### PR TITLE
Adopt `LIFETIME_BOUND` annotation in more places in layout & rendering

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1647,14 +1647,15 @@ AXTextRuns AccessibilityRenderObject::textRuns()
         if (text.isEmpty())
             return;
 
-        if (textBox->style().textTransform().contains(Style::TextTransformValue::FullSizeKana)) {
+        CheckedRef textBoxStyle = textBox->style();
+        if (textBoxStyle->textTransform().contains(Style::TextTransformValue::FullSizeKana)) {
             // We don't want to serve transformed kana text to AT since it is a visual affordance.
             // Using the original text from the renderer provides the untransformed string.
             text = textBox->renderer().originalText().substring(textBox->start(), textBox->length());
         }
 
-        bool collapseTabs = textBox->style().collapseWhiteSpace();
-        bool collapseNewlines = !textBox->style().preserveNewline();
+        bool collapseTabs = textBoxStyle->collapseWhiteSpace();
+        bool collapseNewlines = !textBoxStyle->preserveNewline();
 
         auto textRun = textBox->textRun(InlineIterator::TextRunMode::Editing);
         auto lineBox = textBox->lineBox();

--- a/Source/WebCore/editing/ApplyBlockElementCommand.cpp
+++ b/Source/WebCore/editing/ApplyBlockElementCommand.cpp
@@ -189,7 +189,7 @@ static bool isNewLineAtPosition(const Position& position)
     return textNode->data()[offset] == '\n';
 }
 
-const RenderStyle* ApplyBlockElementCommand::renderStyleOfEnclosingTextNode(const Position& position)
+CheckedPtr<const RenderStyle> ApplyBlockElementCommand::renderStyleOfEnclosingTextNode(const Position& position)
 {
     RefPtr node = position.containerNode();
     if (position.anchorType() != Position::PositionIsOffsetInAnchor || !node || !node->isTextNode())

--- a/Source/WebCore/editing/ApplyBlockElementCommand.h
+++ b/Source/WebCore/editing/ApplyBlockElementCommand.h
@@ -47,7 +47,7 @@ protected:
 private:
     void doApply() override;
     virtual void formatRange(const Position& start, const Position& end, const Position& endOfSelection, RefPtr<Element>&) = 0;
-    const RenderStyle* renderStyleOfEnclosingTextNode(const Position&);
+    CheckedPtr<const RenderStyle> renderStyleOfEnclosingTextNode(const Position&);
     void rangeForParagraphSplittingTextNodesIfNeeded(const VisiblePosition&, Position&, Position&);
     VisiblePosition endOfNextParagraphSplittingTextNodesIfNeeded(VisiblePosition&, Position&, Position&);
 

--- a/Source/WebCore/layout/FormattingState.h
+++ b/Source/WebCore/layout/FormattingState.h
@@ -50,10 +50,10 @@ public:
     bool isTableFormattingState() const { return m_type == Type::Table; }
     bool isFlexFormattingState() const { return m_type == Type::Flex; }
 
-    LayoutState& layoutState() const { return m_layoutState; }
+    LayoutState& layoutState() const LIFETIME_BOUND { return m_layoutState; }
 
     // FIXME: We need to find a way to limit access to mutable geometry.
-    BoxGeometry& boxGeometry(const Box& layoutBox);
+    BoxGeometry& boxGeometry(const Box& layoutBox) LIFETIME_BOUND;
 
 protected:
     enum class Type { Block, Table, Flex };

--- a/Source/WebCore/layout/LayoutContext.h
+++ b/Source/WebCore/layout/LayoutContext.h
@@ -60,7 +60,7 @@ public:
 
 private:
     void NODELETE layoutFormattingContextSubtree(const ElementBox&);
-    LayoutState& NODELETE layoutState();
+    LayoutState& NODELETE layoutState() LIFETIME_BOUND;
 
     const CheckedRef<LayoutState> m_layoutState;
 };

--- a/Source/WebCore/layout/LayoutState.h
+++ b/Source/WebCore/layout/LayoutState.h
@@ -70,15 +70,15 @@ public:
 
     void updateQuirksMode(const Document&);
 
-    InlineContentCache& inlineContentCache(const ElementBox& formattingContextRoot);
+    InlineContentCache& inlineContentCache(const ElementBox& formattingContextRoot) LIFETIME_BOUND;
 
-    BlockFormattingState& ensureBlockFormattingState(const ElementBox& formattingContextRoot);
-    TableFormattingState& ensureTableFormattingState(const ElementBox& formattingContextRoot);
+    BlockFormattingState& ensureBlockFormattingState(const ElementBox& formattingContextRoot) LIFETIME_BOUND;
+    TableFormattingState& ensureTableFormattingState(const ElementBox& formattingContextRoot) LIFETIME_BOUND;
 
-    BlockFormattingState& formattingStateForBlockFormattingContext(const ElementBox& blockFormattingContextRoot) const;
-    TableFormattingState& formattingStateForTableFormattingContext(const ElementBox& tableFormattingContextRoot) const;
+    BlockFormattingState& formattingStateForBlockFormattingContext(const ElementBox& blockFormattingContextRoot) const LIFETIME_BOUND;
+    TableFormattingState& formattingStateForTableFormattingContext(const ElementBox& tableFormattingContextRoot) const LIFETIME_BOUND;
 
-    FormattingState& formattingStateForFormattingContext(const ElementBox& formattingRoot) const;
+    FormattingState& formattingStateForFormattingContext(const ElementBox& formattingRoot) const LIFETIME_BOUND;
 
     void destroyBlockFormattingState(const ElementBox& formattingContextRoot);
     void destroyInlineContentCache(const ElementBox& formattingContextRoot);
@@ -90,9 +90,9 @@ public:
     void deregisterFormattingContext(const FormattingContext& formattingContext) { m_formattingContextList.remove(&formattingContext); }
 #endif
 
-    BoxGeometry& geometryForRootBox();
-    BoxGeometry& ensureGeometryForBox(const Box&);
-    const BoxGeometry& geometryForBox(const Box&) const;
+    BoxGeometry& geometryForRootBox() LIFETIME_BOUND;
+    BoxGeometry& ensureGeometryForBox(const Box&) LIFETIME_BOUND;
+    const BoxGeometry& geometryForBox(const Box&) const LIFETIME_BOUND;
 
     bool hasBoxGeometry(const Box&) const;
 
@@ -114,7 +114,7 @@ public:
 
 private:
     void setQuirksMode(QuirksMode quirksMode) { m_quirksMode = quirksMode; }
-    BoxGeometry& ensureGeometryForBoxSlow(const Box&);
+    BoxGeometry& ensureGeometryForBoxSlow(const Box&) LIFETIME_BOUND;
 
     const Type m_type;
 

--- a/Source/WebCore/layout/floats/FloatingContext.h
+++ b/Source/WebCore/layout/floats/FloatingContext.h
@@ -45,7 +45,7 @@ class FloatingContext {
 public:
     FloatingContext(const ElementBox& formattingContextRoot, const LayoutState&, const PlacedFloats&);
 
-    const PlacedFloats& placedFloats() const { return m_placedFloats; }
+    const PlacedFloats& placedFloats() const LIFETIME_BOUND { return m_placedFloats; }
 
     LayoutPoint positionForFloat(const Box&, const BoxGeometry&, const HorizontalConstraints&) const;
     LayoutPoint positionForNonFloatingFloatAvoider(const Box&, const BoxGeometry&) const;
@@ -75,7 +75,7 @@ private:
 
     const ElementBox& root() const { return m_formattingContextRoot; }
     // FIXME: Turn this into an actual geometry cache.
-    const LayoutState& NODELETE containingBlockGeometries() const;
+    const LayoutState& NODELETE containingBlockGeometries() const LIFETIME_BOUND;
 
     void findPositionForFormattingContextRoot(FloatAvoider&, BoxGeometry::HorizontalEdges containingBlockContentBoxEdges) const;
 

--- a/Source/WebCore/layout/floats/PlacedFloats.h
+++ b/Source/WebCore/layout/floats/PlacedFloats.h
@@ -83,8 +83,8 @@ public:
         std::optional<size_t> m_placedByLine;
     };
     using List = Vector<Item>;
-    const List& list() const { return m_list; }
-    const Item* last() const { return list().isEmpty() ? nullptr : &m_list.last(); }
+    const List& list() const LIFETIME_BOUND { return m_list; }
+    const Item* last() const LIFETIME_BOUND { return list().isEmpty() ? nullptr : &m_list.last(); }
 
     void add(Item);
     bool remove(const Box&);

--- a/Source/WebCore/layout/formattingContexts/FormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/FormattingContext.h
@@ -56,8 +56,8 @@ public:
 
     const ElementBox& root() const { return m_root; }
 
-    LayoutState& NODELETE layoutState();
-    const LayoutState& layoutState() const { return const_cast<FormattingContext&>(*this).layoutState(); }
+    LayoutState& NODELETE layoutState() LIFETIME_BOUND;
+    const LayoutState& layoutState() const LIFETIME_BOUND { return const_cast<FormattingContext&>(*this).layoutState(); }
 
     enum class EscapeReason {
         TableQuirkNeedsGeometryFromEstablishedFormattingContext,
@@ -68,8 +68,8 @@ public:
         BodyStretchesToViewportQuirk,
         TableNeedsAccessToTableWrapper
     };
-    const BoxGeometry& geometryForBox(const Box&, std::optional<EscapeReason> = std::nullopt) const;
-    BoxGeometry& geometryForBox(const Box&, std::optional<EscapeReason> = std::nullopt);
+    const BoxGeometry& geometryForBox(const Box&, std::optional<EscapeReason> = std::nullopt) const LIFETIME_BOUND;
+    BoxGeometry& geometryForBox(const Box&, std::optional<EscapeReason> = std::nullopt) LIFETIME_BOUND;
 
     bool isBlockFormattingContext() const { return root().establishesBlockFormattingContext(); }
     bool isTableFormattingContext() const { return root().establishesTableFormattingContext(); }

--- a/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
+++ b/Source/WebCore/layout/formattingContexts/FormattingGeometry.h
@@ -103,8 +103,8 @@ public:
     bool isTableFormattingGeometry() const { return formattingContext().isTableFormattingContext(); }
 
 protected:
-    const LayoutState& layoutState() const { return m_formattingContext.layoutState(); }
-    const FormattingContext& formattingContext() const { return m_formattingContext; }
+    const LayoutState& layoutState() const LIFETIME_BOUND { return m_formattingContext.layoutState(); }
+    const FormattingContext& formattingContext() const LIFETIME_BOUND { return m_formattingContext; }
 
 private:
     VerticalGeometry outOfFlowReplacedVerticalGeometry(const ElementBox&, const HorizontalConstraints&, const VerticalConstraints&, const OverriddenVerticalValues&) const;

--- a/Source/WebCore/layout/formattingContexts/FormattingQuirks.h
+++ b/Source/WebCore/layout/formattingContexts/FormattingQuirks.h
@@ -41,8 +41,8 @@ public:
     bool isTableFormattingQuirks() const { return formattingContext().isTableFormattingContext(); }
 
 protected:
-    const LayoutState& layoutState() const { return m_formattingContext.layoutState(); }
-    const FormattingContext& formattingContext() const { return m_formattingContext; }
+    const LayoutState& layoutState() const LIFETIME_BOUND { return m_formattingContext.layoutState(); }
+    const FormattingContext& formattingContext() const LIFETIME_BOUND { return m_formattingContext; }
 
     const FormattingContext& m_formattingContext;
 };

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingContext.h
@@ -53,9 +53,9 @@ public:
     void layoutOutOfFlowContent(const ConstraintsForOutOfFlowContent&);
     LayoutUnit usedContentHeight() const override;
 
-    const BlockFormattingState& formattingState() const { return m_blockFormattingState; }
-    const BlockFormattingGeometry& formattingGeometry() const { return m_blockFormattingGeometry; }
-    const BlockFormattingQuirks& formattingQuirks() const { return m_blockFormattingQuirks; }
+    const BlockFormattingState& formattingState() const LIFETIME_BOUND { return m_blockFormattingState; }
+    const BlockFormattingGeometry& formattingGeometry() const LIFETIME_BOUND { return m_blockFormattingGeometry; }
+    const BlockFormattingQuirks& formattingQuirks() const LIFETIME_BOUND { return m_blockFormattingQuirks; }
 
 protected:
     struct ConstraintsPair {
@@ -86,7 +86,7 @@ protected:
     void computeOutOfFlowHorizontalGeometry(const Box&, const ConstraintsForOutOfFlowContent&);
     void computeBorderAndPadding(const Box&, const HorizontalConstraints&);
 
-    BlockFormattingState& formattingState() { return m_blockFormattingState; }
+    BlockFormattingState& formattingState() LIFETIME_BOUND { return m_blockFormattingState; }
     BlockMarginCollapse marginCollapse() const;
 
 #if ASSERT_ENABLED

--- a/Source/WebCore/layout/formattingContexts/block/BlockFormattingState.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockFormattingState.h
@@ -40,14 +40,14 @@ public:
     BlockFormattingState(LayoutState&, const ElementBox& blockFormattingContextRoot);
     ~BlockFormattingState();
 
-    const PlacedFloats& placedFloats() const { return m_placedFloats; }
-    PlacedFloats& placedFloats() { return m_placedFloats; }
+    const PlacedFloats& placedFloats() const LIFETIME_BOUND { return m_placedFloats; }
+    PlacedFloats& placedFloats() LIFETIME_BOUND { return m_placedFloats; }
 
     // Since we layout the out-of-flow boxes at the end of the formatting context layout, it's okay to store them in the formatting state -as opposed to the containing block level.
     using OutOfFlowBoxList = Vector<CheckedRef<const Box>>;
     void addOutOfFlowBox(const Box& outOfFlowBox) { m_outOfFlowBoxes.append(outOfFlowBox); }
     void setOutOfFlowBoxes(OutOfFlowBoxList&& outOfFlowBoxes) { m_outOfFlowBoxes = WTF::move(outOfFlowBoxes); }
-    const OutOfFlowBoxList& outOfFlowBoxes() const { return m_outOfFlowBoxes; }
+    const OutOfFlowBoxList& outOfFlowBoxes() const LIFETIME_BOUND { return m_outOfFlowBoxes; }
 
     void setUsedVerticalMargin(const Box& layoutBox, const UsedVerticalMargin& usedVerticalMargin) { m_usedVerticalMargins.set(layoutBox, usedVerticalMargin); }
     UsedVerticalMargin usedVerticalMargin(const Box& layoutBox) const { return m_usedVerticalMargins.get(layoutBox); }

--- a/Source/WebCore/layout/formattingContexts/block/BlockLayoutState.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockLayoutState.h
@@ -91,18 +91,18 @@ public:
 
     BlockLayoutState(PlacedFloats&, MarginState, std::optional<LineClamp> = { }, TextBoxTrim = { }, Style::TextBoxEdge = CSS::Keyword::Auto { }, std::optional<LayoutUnit> intrusiveInitialLetterLogicalBottom = { }, std::optional<LineGrid> lineGrid = { });
 
-    PlacedFloats& placedFloats() { return m_placedFloats; }
-    const PlacedFloats& placedFloats() const { return m_placedFloats; }
+    PlacedFloats& placedFloats() LIFETIME_BOUND { return m_placedFloats; }
+    const PlacedFloats& placedFloats() const LIFETIME_BOUND { return m_placedFloats; }
 
     std::optional<LineClamp> lineClamp() const { return m_lineClamp; }
     TextBoxTrim textBoxTrim() const { return m_textBoxTrim; }
     Style::TextBoxEdge textBoxEdge() const { return m_textBoxEdge; }
 
     std::optional<LayoutUnit> intrusiveInitialLetterLogicalBottom() const { return m_intrusiveInitialLetterLogicalBottom; }
-    const std::optional<LineGrid>& lineGrid() const { return m_lineGrid; }
+    const std::optional<LineGrid>& lineGrid() const LIFETIME_BOUND { return m_lineGrid; }
 
-    MarginState& marginState() { return m_marginState; }
-    const MarginState& marginState() const { return m_marginState; }
+    MarginState& marginState() LIFETIME_BOUND { return m_marginState; }
+    const MarginState& marginState() const LIFETIME_BOUND { return m_marginState; }
 
 private:
     PlacedFloats& m_placedFloats;

--- a/Source/WebCore/layout/formattingContexts/block/BlockMarginCollapse.h
+++ b/Source/WebCore/layout/formattingContexts/block/BlockMarginCollapse.h
@@ -76,8 +76,8 @@ private:
     bool hasClearance(const ElementBox&) const;
 
     bool inQuirksMode() const { return m_inQuirksMode; }
-    const LayoutState& layoutState() const { return m_layoutState; }
-    const BlockFormattingState& formattingState() const { return m_blockFormattingState; }
+    const LayoutState& layoutState() const LIFETIME_BOUND { return m_layoutState; }
+    const BlockFormattingState& formattingState() const LIFETIME_BOUND { return m_blockFormattingState; }
 
     const CheckedRef<const LayoutState> m_layoutState;
     const BlockFormattingState& m_blockFormattingState;

--- a/Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.h
@@ -44,7 +44,7 @@ public:
 
     void setHorizontalConstraintsIgnoringFloats(const HorizontalConstraints& horizontalConstraints) { m_horizontalConstraintsIgnoringFloats = horizontalConstraints; }
 
-    const TableWrapperQuirks& formattingQuirks() const { return m_tableWrapperFormattingQuirks; }
+    const TableWrapperQuirks& formattingQuirks() const LIFETIME_BOUND { return m_tableWrapperFormattingQuirks; }
 
 private:
     void layoutTableBox(const ElementBox& tableBox, const ConstraintsForInFlowContent&);

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingConstraints.h
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingConstraints.h
@@ -38,8 +38,8 @@ struct ConstraintsForFlexContent {
         LayoutUnit startPosition;
     };
     ConstraintsForFlexContent(const AxisGeometry& mainAxis, const AxisGeometry& crossAxis, bool isSizedUnderMinMax);
-    const AxisGeometry& mainAxis() const { return m_mainAxisGeometry; }
-    const AxisGeometry& crossAxis() const { return m_crossAxisGeometry; }
+    const AxisGeometry& mainAxis() const LIFETIME_BOUND { return m_mainAxisGeometry; }
+    const AxisGeometry& crossAxis() const LIFETIME_BOUND { return m_crossAxisGeometry; }
     bool isSizedUnderMinMax() const { return m_isSizedUnderMinMax; }
 
 private:

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.h
@@ -46,12 +46,12 @@ public:
     IntrinsicWidthConstraints NODELETE computedIntrinsicWidthConstraints();
 
     const ElementBox& root() const { return m_flexBox; }
-    const FlexFormattingUtils& formattingUtils() const { return m_flexFormattingUtils; }
+    const FlexFormattingUtils& formattingUtils() const LIFETIME_BOUND { return m_flexFormattingUtils; }
 
-    const BoxGeometry& geometryForFlexItem(const Box&) const;
-    BoxGeometry& geometryForFlexItem(const Box&);
+    const BoxGeometry& geometryForFlexItem(const Box&) const LIFETIME_BOUND;
+    BoxGeometry& geometryForFlexItem(const Box&) LIFETIME_BOUND;
 
-    const IntegrationUtils& integrationUtils() const { return m_integrationUtils; }
+    const IntegrationUtils& integrationUtils() const LIFETIME_BOUND { return m_integrationUtils; }
 
 private:
     FlexLayout::LogicalFlexItems convertFlexItemsToLogicalSpace(const ConstraintsForFlexContent&);

--- a/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.h
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.h
@@ -54,7 +54,7 @@ public:
     LayoutUnit usedSizeInCrossAxis(const LogicalFlexItem&, LayoutUnit maxAxisConstraint) const;
 
 private:
-    const FlexFormattingContext& formattingContext() const { return m_flexFormattingContext; }
+    const FlexFormattingContext& formattingContext() const LIFETIME_BOUND { return m_flexFormattingContext; }
 
 private:
     const FlexFormattingContext& m_flexFormattingContext;

--- a/Source/WebCore/layout/formattingContexts/flex/FlexLayout.h
+++ b/Source/WebCore/layout/formattingContexts/flex/FlexLayout.h
@@ -78,10 +78,10 @@ private:
 
     bool isSingleLineFlexContainer() const { return flexContainer().style().flexWrap() == FlexWrap::NoWrap; }
     const ElementBox& NODELETE flexContainer() const;
-    const RenderStyle& flexContainerStyle() const { return flexContainer().style(); }
+    const RenderStyle& flexContainerStyle() const LIFETIME_BOUND { return flexContainer().style(); }
 
-    const FlexFormattingContext& NODELETE formattingContext() const;
-    const FlexFormattingUtils& NODELETE formattingUtils() const;
+    const FlexFormattingContext& NODELETE formattingContext() const LIFETIME_BOUND;
+    const FlexFormattingUtils& NODELETE formattingUtils() const LIFETIME_BOUND;
 
 private:
     FlexFormattingContext& m_flexFormattingContext;

--- a/Source/WebCore/layout/formattingContexts/flex/LogicalFlexItem.h
+++ b/Source/WebCore/layout/formattingContexts/flex/LogicalFlexItem.h
@@ -72,8 +72,8 @@ public:
     LogicalFlexItem(const ElementBox&, const MainAxisGeometry&, const CrossAxisGeometry&, bool hasAspectRatio, bool isOrthogonal);
     LogicalFlexItem() = default;
 
-    const MainAxisGeometry& mainAxis() const { return m_mainAxisGeometry; }
-    const CrossAxisGeometry& crossAxis() const { return m_crossAxisGeometry; }
+    const MainAxisGeometry& mainAxis() const LIFETIME_BOUND { return m_mainAxisGeometry; }
+    const CrossAxisGeometry& crossAxis() const LIFETIME_BOUND { return m_crossAxisGeometry; }
 
     float growFactor() const { return style().flexGrow().value; }
     float shrinkFactor() const { return style().flexShrink().value; }
@@ -85,7 +85,7 @@ public:
     bool isContentBoxBased() const { return style().boxSizing() == BoxSizing::ContentBox; }
 
     const ElementBox& layoutBox() const { return *m_layoutBox; }
-    const RenderStyle& style() const { return layoutBox().style(); }
+    const RenderStyle& style() const LIFETIME_BOUND { return layoutBox().style(); }
     WritingMode writingMode() const { return style().writingMode(); }
 
 private:

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -86,9 +86,9 @@ public:
 
     const ElementBox& root() const { return m_gridBox; }
 
-    const IntegrationUtils& integrationUtils() const { return m_integrationUtils; }
+    const IntegrationUtils& integrationUtils() const LIFETIME_BOUND { return m_integrationUtils; }
 
-    const BoxGeometry& geometryForGridItem(const ElementBox&) const;
+    const BoxGeometry& geometryForGridItem(const ElementBox&) const LIFETIME_BOUND;
 
     const Style::ZoomFactor zoomFactor() const { return m_gridBox->style().usedZoomForLength(); }
 
@@ -113,11 +113,11 @@ public:
 private:
     UnplacedGridItems constructUnplacedGridItems() const;
 
-    const LayoutState& layoutState() const { return m_globalLayoutState; }
-    BoxGeometry& geometryForGridItem(const ElementBox&);
+    const LayoutState& layoutState() const LIFETIME_BOUND { return m_globalLayoutState; }
+    BoxGeometry& geometryForGridItem(const ElementBox&) LIFETIME_BOUND;
     void setGridItemGeometries(const GridItemRects&);
 
-    const RenderStyle& gridContainerStyle() const { return m_gridBox->style(); }
+    const RenderStyle& gridContainerStyle() const LIFETIME_BOUND { return m_gridBox->style(); }
 
     const CheckedRef<const ElementBox> m_gridBox;
     const CheckedRef<LayoutState> m_globalLayoutState;

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -82,7 +82,7 @@ private:
     BorderBoxPositions performInlineAxisSelfAlignment(const PlacedGridItems&, const Vector<UsedMargins>&, const UsedInlineSizes&, const Vector<LayoutUnit>& gridAreasInlineSizeList);
     BorderBoxPositions performBlockAxisSelfAlignment(const PlacedGridItems&, const Vector<UsedMargins>&, const UsedBlockSizes&, const Vector<LayoutUnit>& gridAreasBlockSizeList);
 
-    const GridFormattingContext& formattingContext() const { return m_gridFormattingContext; }
+    const GridFormattingContext& formattingContext() const LIFETIME_BOUND { return m_gridFormattingContext; }
 
     const GridFormattingContext& m_gridFormattingContext;
 };

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
@@ -52,8 +52,8 @@ class PlacedGridItem {
 public:
     PlacedGridItem(const ElementBox& gridItem, const GridAreaLines&, const BoxGeometry& gridItemGeometry,  const RenderStyle& gridContainerWritingMode);
 
-    const ComputedSizes& inlineAxisSizes() const { return m_inlineAxisSizes; }
-    const ComputedSizes& blockAxisSizes() const { return m_blockAxisSizes; }
+    const ComputedSizes& inlineAxisSizes() const LIFETIME_BOUND { return m_inlineAxisSizes; }
+    const ComputedSizes& blockAxisSizes() const LIFETIME_BOUND { return m_blockAxisSizes; }
 
     size_t columnStartLine() const { return m_gridAreaLines.columnStartLine; }
     size_t columnEndLine() const { return m_gridAreaLines.columnEndLine; }
@@ -61,21 +61,21 @@ public:
     size_t rowEndLine() const { return m_gridAreaLines.rowEndLine; }
 
     const ElementBox& layoutBox() const { return m_layoutBox; }
-    const StyleSelfAlignmentData& inlineAxisAlignment() const { return m_inlineAxisAlignment; }
-    const StyleSelfAlignmentData& blockAxisAlignment() const { return m_blockAxisAlignment; }
+    const StyleSelfAlignmentData& inlineAxisAlignment() const LIFETIME_BOUND { return m_inlineAxisAlignment; }
+    const StyleSelfAlignmentData& blockAxisAlignment() const LIFETIME_BOUND { return m_blockAxisAlignment; }
 
     LayoutUnit usedInlineBorderAndPadding() const { return m_usedInlineBorderAndPadding; }
     LayoutUnit usedBlockBorderAndPadding() const { return m_usedBlockBorderAndPadding; }
 
-    const WritingMode& writingMode() const { return m_writingMode; }
+    const WritingMode& writingMode() const LIFETIME_BOUND { return m_writingMode; }
 
     // FIXME: Add support for grid item's with preferred aspect ratios.
     bool hasPreferredAspectRatio() const { return false; }
     bool isReplacedElement() const { return m_layoutBox->isReplacedBox(); }
 
-    const GridAreaLines& gridAreaLines() const { return m_gridAreaLines; }
+    const GridAreaLines& gridAreaLines() const LIFETIME_BOUND { return m_gridAreaLines; }
 
-    const Style::ZoomFactor& usedZoom() const { return m_usedZoom; }
+    const Style::ZoomFactor& usedZoom() const LIFETIME_BOUND { return m_usedZoom; }
 
 private:
     PlacedGridItem(const ElementBox& gridItem, const GridAreaLines&, const BoxGeometry& gridItemGeometry,  const RenderStyle& gridContainerWritingMode, const RenderStyle& gridItemWritingMode);

--- a/Source/WebCore/layout/formattingContexts/inline/AbstractLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/AbstractLineBuilder.h
@@ -59,17 +59,17 @@ protected:
 
     bool isFirstFormattedLineCandidate() const { return m_isFirstFormattedLineCandidate; }
 
-    InlineContentBreaker& inlineContentBreaker() { return m_inlineContentBreaker; }
+    InlineContentBreaker& inlineContentBreaker() LIFETIME_BOUND { return m_inlineContentBreaker; }
 
-    InlineFormattingContext& formattingContext() { return m_inlineFormattingContext; }
-    const InlineFormattingContext& formattingContext() const { return m_inlineFormattingContext; }
-    const HorizontalConstraints& rootHorizontalConstraints() const { return m_rootHorizontalConstraints; }
-    const InlineLayoutState& NODELETE layoutState() const;
-    InlineLayoutState& NODELETE layoutState();
-    const BlockLayoutState& blockLayoutState() const { return layoutState().parentBlockLayoutState(); }
-    BlockLayoutState& blockLayoutState() { return layoutState().parentBlockLayoutState(); }
+    InlineFormattingContext& formattingContext() LIFETIME_BOUND { return m_inlineFormattingContext; }
+    const InlineFormattingContext& formattingContext() const LIFETIME_BOUND { return m_inlineFormattingContext; }
+    const HorizontalConstraints& rootHorizontalConstraints() const LIFETIME_BOUND { return m_rootHorizontalConstraints; }
+    const InlineLayoutState& NODELETE layoutState() const LIFETIME_BOUND;
+    InlineLayoutState& NODELETE layoutState() LIFETIME_BOUND;
+    const BlockLayoutState& blockLayoutState() const LIFETIME_BOUND { return layoutState().parentBlockLayoutState(); }
+    BlockLayoutState& blockLayoutState() LIFETIME_BOUND { return layoutState().parentBlockLayoutState(); }
     const ElementBox& root() const { return m_rootBox; }
-    const RenderStyle& rootStyle() const;
+    const RenderStyle& rootStyle() const LIFETIME_BOUND;
 
 protected:
     Line m_line;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.h
@@ -123,8 +123,8 @@ public:
             InlineLayoutUnit m_contentWidth { 0 };
         };
         using RunList = Vector<Run, 3>;
-        const RunList& runs() const { return m_runs; }
-        RunList& runs() { return m_runs; }
+        const RunList& runs() const LIFETIME_BOUND { return m_runs; }
+        RunList& runs() LIFETIME_BOUND { return m_runs; }
 
     private:
         void appendToRunList(const InlineItem&, const RenderStyle&, InlineLayoutUnit offset, InlineLayoutUnit contentWidth, InlineLayoutUnit textSpacingAdjustment = 0.f);

--- a/Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h
@@ -39,8 +39,8 @@ class InlineContentCache {
     WTF_MAKE_TZONE_ALLOCATED(InlineContentCache);
 public:
     struct InlineItems {
-        InlineItemList& content() { return m_inlineItemList; }
-        const InlineItemList& content() const { return m_inlineItemList; }
+        InlineItemList& content() LIFETIME_BOUND { return m_inlineItemList; }
+        const InlineItemList& content() const LIFETIME_BOUND { return m_inlineItemList; }
 
         struct ContentAttributes {
             bool requiresVisualReordering { false };
@@ -69,12 +69,12 @@ public:
         InlineItemList m_inlineItemList;
         bool m_isPopulatedFromCache { false };
     };
-    const InlineItems& inlineItems() const { return m_inlineItems; }
-    InlineItems& inlineItems() { return m_inlineItems; }
+    const InlineItems& inlineItems() const LIFETIME_BOUND { return m_inlineItems; }
+    InlineItems& inlineItems() LIFETIME_BOUND { return m_inlineItems; }
 
     void setMaximumIntrinsicWidthLineContent(LineLayoutResult&& lineContent) { m_maximumIntrinsicWidthLineContent = WTF::move(lineContent); }
     void clearMaximumIntrinsicWidthLineContent() { m_maximumIntrinsicWidthLineContent = { }; }
-    std::optional<LineLayoutResult>& maximumIntrinsicWidthLineContent() { return m_maximumIntrinsicWidthLineContent; }
+    std::optional<LineLayoutResult>& maximumIntrinsicWidthLineContent() LIFETIME_BOUND { return m_maximumIntrinsicWidthLineContent; }
 
     void setMinimumContentSize(InlineLayoutUnit minimumContentSize) { m_minimumContentSize = minimumContentSize; }
     void setMaximumContentSize(InlineLayoutUnit maximumContentSize) { m_maximumContentSize = maximumContentSize; }
@@ -82,12 +82,12 @@ public:
     std::optional<InlineLayoutUnit> maximumContentSize() const { return m_maximumContentSize; }
     void resetMinimumMaximumContentSizes();
 
-    const InlineBoxBoundaryTextSpacings& inlineBoxBoundaryTextSpacings() const { return m_textSpacingContext.inlineBoxBoundaryTextSpacings; }
+    const InlineBoxBoundaryTextSpacings& inlineBoxBoundaryTextSpacings() const LIFETIME_BOUND { return m_textSpacingContext.inlineBoxBoundaryTextSpacings; }
     void setInlineBoxBoundaryTextSpacings(InlineBoxBoundaryTextSpacings&& spacings) { m_textSpacingContext.inlineBoxBoundaryTextSpacings = WTF::move(spacings); }
-    const TrimmableTextSpacings& trimmableTextSpacings() const { return m_textSpacingContext.trimmableTextSpacings; }
+    const TrimmableTextSpacings& trimmableTextSpacings() const LIFETIME_BOUND { return m_textSpacingContext.trimmableTextSpacings; }
     void setTrimmableTextSpacings(TrimmableTextSpacings&& spacings) { m_textSpacingContext.trimmableTextSpacings = WTF::move(spacings); }
 
-    const TextSpacingContext& textSpacingContext() const { return m_textSpacingContext; }
+    const TextSpacingContext& textSpacingContext() const LIFETIME_BOUND { return m_textSpacingContext; }
 
 private:
     InlineItems m_inlineItems;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h
@@ -69,20 +69,20 @@ public:
     LayoutUnit maximumContentSize(InlineDamage* = nullptr);
 
     const ElementBox& root() const { return m_rootBlockContainer; }
-    const InlineFormattingUtils& formattingUtils() const { return m_inlineFormattingUtils; }
-    const InlineQuirks& quirks() const { return m_inlineQuirks; }
-    const FloatingContext& floatingContext() const { return m_floatingContext; }
+    const InlineFormattingUtils& formattingUtils() const LIFETIME_BOUND { return m_inlineFormattingUtils; }
+    const InlineQuirks& quirks() const LIFETIME_BOUND { return m_inlineQuirks; }
+    const FloatingContext& floatingContext() const LIFETIME_BOUND { return m_floatingContext; }
 
-    InlineLayoutState& layoutState() { return m_inlineLayoutState; }
-    const InlineLayoutState& layoutState() const { return m_inlineLayoutState; }
+    InlineLayoutState& layoutState() LIFETIME_BOUND { return m_inlineLayoutState; }
+    const InlineLayoutState& layoutState() const LIFETIME_BOUND { return m_inlineLayoutState; }
 
     enum class EscapeReason {
         InkOverflowNeedsInitialContiningBlockForStrokeWidth
     };
-    const BoxGeometry& geometryForBox(const Box&, std::optional<EscapeReason> = std::nullopt) const;
-    BoxGeometry& geometryForBox(const Box&);
+    const BoxGeometry& geometryForBox(const Box&, std::optional<EscapeReason> = std::nullopt) const LIFETIME_BOUND;
+    BoxGeometry& geometryForBox(const Box&) LIFETIME_BOUND;
 
-    const IntegrationUtils& integrationUtils() const { return m_integrationUtils; }
+    const IntegrationUtils& integrationUtils() const LIFETIME_BOUND { return m_integrationUtils; }
 
 private:
     UniqueRef<InlineLayoutResult> lineLayout(AbstractLineBuilder&, const InlineItemList&, InlineItemRange, std::optional<PreviousLine>, const ConstraintsForInlineContent&, const InlineDamage*, bool mayUseSimplifiedDisplayContentBuild = false);
@@ -98,7 +98,7 @@ private:
     void NODELETE initializeInlineLayoutState(const LayoutState&);
     void rebuildInlineItemListIfNeeded(InlineDamage*);
 
-    InlineContentCache& inlineContentCache() { return m_inlineContentCache; }
+    InlineContentCache& inlineContentCache() LIFETIME_BOUND { return m_inlineContentCache; }
 
 private:
     const ElementBox& m_rootBlockContainer;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h
@@ -84,7 +84,7 @@ public:
 private:
     bool isAtSoftWrapOpportunity(const InlineItem& previous, const InlineItem& next) const;
 
-    const InlineFormattingContext& formattingContext() const { return m_inlineFormattingContext; }
+    const InlineFormattingContext& formattingContext() const LIFETIME_BOUND { return m_inlineFormattingContext; }
 
 private:
     const InlineFormattingContext& m_inlineFormattingContext;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLayoutState.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLayoutState.h
@@ -41,14 +41,14 @@ public:
     void setClearGapBeforeFirstLine(InlineLayoutUnit verticalGap) { m_clearGapBeforeFirstLine = verticalGap; }
     InlineLayoutUnit clearGapBeforeFirstLine() const { return m_clearGapBeforeFirstLine; }
 
-    const BlockLayoutState& parentBlockLayoutState() const { return m_parentBlockLayoutState; }
-    BlockLayoutState& parentBlockLayoutState() { return m_parentBlockLayoutState; }
+    const BlockLayoutState& parentBlockLayoutState() const LIFETIME_BOUND { return m_parentBlockLayoutState; }
+    BlockLayoutState& parentBlockLayoutState() LIFETIME_BOUND { return m_parentBlockLayoutState; }
 
-    const PlacedFloats& placedFloats() const { return m_parentBlockLayoutState.placedFloats(); }
-    PlacedFloats& placedFloats() { return m_parentBlockLayoutState.placedFloats(); }
+    const PlacedFloats& placedFloats() const LIFETIME_BOUND { return m_parentBlockLayoutState.placedFloats(); }
+    PlacedFloats& placedFloats() LIFETIME_BOUND { return m_parentBlockLayoutState.placedFloats(); }
 
     void setAvailableLineWidthOverride(AvailableLineWidthOverride availableLineWidthOverride) { m_availableLineWidthOverride = availableLineWidthOverride; }
-    const AvailableLineWidthOverride& availableLineWidthOverride() const { return m_availableLineWidthOverride; }
+    const AvailableLineWidthOverride& availableLineWidthOverride() const LIFETIME_BOUND { return m_availableLineWidthOverride; }
 
     void setLegacyClampedLineIndex(size_t lineIndex) { m_legacyClampedLineIndex = lineIndex; }
     std::optional<size_t> legacyClampedLineIndex() const { return m_legacyClampedLineIndex; }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h
@@ -69,7 +69,7 @@ public:
     void setHasContent();
 
     using VerticalAlignment = Variant<CSS::Keyword::Baseline, CSS::Keyword::Sub, CSS::Keyword::Super, CSS::Keyword::Top, CSS::Keyword::TextTop, CSS::Keyword::Middle, CSS::Keyword::Bottom, CSS::Keyword::TextBottom, CSS::Keyword::WebkitBaselineMiddle, InlineLayoutUnit>;
-    const VerticalAlignment& verticalAlign() const { return m_style.verticalAlignment; }
+    const VerticalAlignment& verticalAlign() const LIFETIME_BOUND { return m_style.verticalAlignment; }
     bool hasLineBoxRelativeAlignment() const;
 
     InlineLayoutUnit preferredLineHeight() const;
@@ -77,7 +77,7 @@ public:
 
     inline bool mayStretchLineBox() const;
 
-    const FontMetrics& primarymetricsOfPrimaryFont() const { return m_style.primaryFontMetrics; }
+    const FontMetrics& primarymetricsOfPrimaryFont() const LIFETIME_BOUND { return m_style.primaryFontMetrics; }
     InlineLayoutUnit fontSize() const { return m_style.primaryFontSize; }
 
     TextBoxTrim textBoxTrim() const { return m_style.textBoxTrim; }
@@ -125,7 +125,7 @@ private:
     friend class InlineFormattingUtils;
     friend class RubyFormattingContext;
 
-    const InlineRect& logicalRect() const { return m_logicalRect; }
+    const InlineRect& logicalRect() const LIFETIME_BOUND { return m_logicalRect; }
     InlineLayoutUnit logicalTop() const { return m_logicalRect.top(); }
     InlineLayoutUnit logicalBottom() const { return m_logicalRect.bottom(); }
     InlineLayoutUnit logicalLeft() const { return m_logicalRect.left(); }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.h
@@ -134,13 +134,13 @@ public:
             size_t length { 0 };
             bool needsHyphen { false };
         };
-        const Text& textContent() const { return m_textContent; }
+        const Text& textContent() const LIFETIME_BOUND { return m_textContent; }
 
         InlineLayoutUnit logicalWidth() const { return m_logicalWidth; }
         InlineLayoutUnit logicalLeft() const { return m_logicalLeft; }
         InlineLayoutUnit logicalRight() const { return logicalLeft() + logicalWidth(); }
 
-        const InlineDisplay::Box::Expansion& expansion() const { return m_expansion; }
+        const InlineDisplay::Box::Expansion& expansion() const LIFETIME_BOUND { return m_expansion; }
 
         bool hasTrailingWhitespace() const { return m_trailingWhitespace.type != TrailingWhitespace::Type::NotApplicable; }
         InlineLayoutUnit trailingWhitespaceWidth() const { return m_trailingWhitespace.width; }
@@ -179,7 +179,7 @@ public:
         Run(const InlineSoftLineBreakItem&, const RenderStyle&, InlineLayoutUnit logicalLeft);
         Run(const InlineItem&, const RenderStyle&, InlineLayoutUnit logicalLeft, InlineLayoutUnit logicalWidth, InlineLayoutUnit textSpacingAdjustment = 0.f);
 
-        const RenderStyle& style() const { return m_style; }
+        const RenderStyle& style() const LIFETIME_BOUND { return m_style; }
         void expand(const InlineTextItem&, InlineLayoutUnit logicalWidth);
         void moveHorizontally(InlineLayoutUnit offset) { m_logicalLeft += offset; }
         void shrinkHorizontally(InlineLayoutUnit width) { m_logicalWidth -= width; }
@@ -224,14 +224,14 @@ public:
         Text m_textContent;
     };
     using RunList = Vector<Run, 1>;
-    const RunList& runs() const { return m_runs; }
-    RunList& runs() { return m_runs; }
+    const RunList& runs() const LIFETIME_BOUND { return m_runs; }
+    RunList& runs() LIFETIME_BOUND { return m_runs; }
     void inflateContentLogicalWidth(InlineLayoutUnit delta) { m_contentLogicalWidth += delta; }
     // FIXME: This is temporary and should be removed when annotation transitions to inline box structure.
     void adjustContentRightWithRubyAlign(InlineLayoutUnit offset) { m_rubyAlignContentRightOffset = offset; }
 
     using InlineBoxListWithClonedDecorationEnd = Vector<const Box*>;
-    const InlineBoxListWithClonedDecorationEnd& inlineBoxListWithClonedDecorationEnd() const { return m_inlineBoxListWithClonedDecorationEnd; }
+    const InlineBoxListWithClonedDecorationEnd& inlineBoxListWithClonedDecorationEnd() const LIFETIME_BOUND { return m_inlineBoxListWithClonedDecorationEnd; }
 
     struct Result {
         RunList runs;
@@ -257,8 +257,7 @@ private:
     bool lineHasVisuallyNonEmptyContent() const;
 
     bool isFirstFormattedLine() const { return m_isFirstFormattedLine; }
-    const InlineFormattingContext& NODELETE formattingContext() const;
-
+    const InlineFormattingContext& NODELETE formattingContext() const LIFETIME_BOUND;
     static bool appendTrailingInlineItemAsTrailingRun(RunList&, InlineLayoutUnit trimmedTrailingWhitespaceWidth, InlineItemRange, const InlineItemList&);
 
     struct TrimmableTrailingContent {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h
@@ -73,17 +73,17 @@ public:
     InlineRect logicalBorderBoxForInlineBox(const Box&, const BoxGeometry&) const;
     InlineRect logicalContentBoxForInlineBox(const Box&) const;
 
-    const InlineLevelBox* inlineLevelBoxFor(const Box& layoutBox) const { return const_cast<LineBox&>(*this).inlineLevelBoxFor(layoutBox); }
-    const InlineLevelBox& inlineLevelBoxFor(const Line::Run& lineRun) const { return const_cast<LineBox&>(*this).inlineLevelBoxFor(lineRun); }
+    const InlineLevelBox* inlineLevelBoxFor(const Box& layoutBox) const LIFETIME_BOUND { return const_cast<LineBox&>(*this).inlineLevelBoxFor(layoutBox); }
+    const InlineLevelBox& inlineLevelBoxFor(const Line::Run& lineRun) const LIFETIME_BOUND { return const_cast<LineBox&>(*this).inlineLevelBoxFor(lineRun); }
 
-    const InlineLevelBox& rootInlineBox() const { return m_rootInlineBox; }
+    const InlineLevelBox& rootInlineBox() const LIFETIME_BOUND { return m_rootInlineBox; }
     using InlineLevelBoxList = Vector<InlineLevelBox>;
-    const InlineLevelBoxList& nonRootInlineLevelBoxes() const { return m_nonRootInlineLevelBoxList; }
+    const InlineLevelBoxList& nonRootInlineLevelBoxes() const LIFETIME_BOUND { return m_nonRootInlineLevelBoxList; }
 
     InlineLayoutUnit alignmentBaseline() const { return logicalRectForRootInlineBox().top() + rootInlineBox().ascent(); }
     FontBaseline baselineType() const { return m_baselineType; }
 
-    const InlineRect& logicalRect() const { return m_logicalRect; }
+    const InlineRect& logicalRect() const LIFETIME_BOUND { return m_logicalRect; }
 
     size_t lineIndex() const { return m_lineIndex; }
 
@@ -95,18 +95,18 @@ private:
     friend class RubyFormattingContext;
 
     void addInlineLevelBox(InlineLevelBox&&);
-    InlineLevelBoxList& nonRootInlineLevelBoxes() { return m_nonRootInlineLevelBoxList; }
+    InlineLevelBoxList& nonRootInlineLevelBoxes() LIFETIME_BOUND { return m_nonRootInlineLevelBoxList; }
 
-    InlineLevelBox& rootInlineBox() { return m_rootInlineBox; }
+    InlineLevelBox& rootInlineBox() LIFETIME_BOUND { return m_rootInlineBox; }
 
-    const InlineLevelBox& parentInlineBox(const InlineLevelBox& inlineLevelBox) const { return const_cast<LineBox&>(*this).parentInlineBox(inlineLevelBox); }
-    InlineLevelBox& parentInlineBox(const InlineLevelBox&);
+    const InlineLevelBox& parentInlineBox(const InlineLevelBox& inlineLevelBox) const LIFETIME_BOUND { return const_cast<LineBox&>(*this).parentInlineBox(inlineLevelBox); }
+    InlineLevelBox& parentInlineBox(const InlineLevelBox&) LIFETIME_BOUND;
 
-    const InlineLevelBox& parentInlineBox(const Line::Run& lineRun) const { return const_cast<LineBox&>(*this).parentInlineBox(lineRun); }
-    InlineLevelBox& parentInlineBox(const Line::Run&);
+    const InlineLevelBox& parentInlineBox(const Line::Run& lineRun) const LIFETIME_BOUND { return const_cast<LineBox&>(*this).parentInlineBox(lineRun); }
+    InlineLevelBox& parentInlineBox(const Line::Run&) LIFETIME_BOUND;
 
-    InlineLevelBox& inlineLevelBoxFor(const Line::Run&);
-    InlineLevelBox* inlineLevelBoxFor(const Box& layoutBox);
+    InlineLevelBox& inlineLevelBoxFor(const Line::Run&) LIFETIME_BOUND;
+    InlineLevelBox* inlineLevelBoxFor(const Box& layoutBox) LIFETIME_BOUND;
 
     InlineRect logicalRectForInlineLevelBox(const Box& layoutBox) const;
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.h
@@ -62,13 +62,13 @@ private:
 
     bool isFirstFormattedLine() const { return lineLayoutResult().isFirstLast.isFirstFormattedLine == IsFirstFormattedLine::Yes; }
     bool isLastLine() const { return lineLayoutResult().isFirstLast.isLastLineWithInlineContent; }
-    const InlineFormattingContext& formattingContext() const { return m_inlineFormattingContext; }
-    const LineLayoutResult& lineLayoutResult() const { return m_lineLayoutResult; }
+    const InlineFormattingContext& formattingContext() const LIFETIME_BOUND { return m_inlineFormattingContext; }
+    const LineLayoutResult& lineLayoutResult() const LIFETIME_BOUND { return m_lineLayoutResult; }
     const ElementBox& rootBox() const { return formattingContext().root(); }
-    const RenderStyle& rootStyle() const { return isFirstFormattedLine() ? rootBox().firstLineStyle() : rootBox().style(); }
+    const RenderStyle& rootStyle() const LIFETIME_BOUND { return isFirstFormattedLine() ? rootBox().firstLineStyle() : rootBox().style(); }
 
-    const InlineLayoutState& layoutState() const { return formattingContext().layoutState(); }
-    const BlockLayoutState& blockLayoutState() const { return layoutState().parentBlockLayoutState(); }
+    const InlineLayoutState& layoutState() const LIFETIME_BOUND { return formattingContext().layoutState(); }
+    const BlockLayoutState& blockLayoutState() const LIFETIME_BOUND { return layoutState().parentBlockLayoutState(); }
 
 private:
     const InlineFormattingContext& m_inlineFormattingContext;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.h
@@ -59,10 +59,10 @@ private:
     enum class IsInlineLevelBoxAlignment : bool { No, Yes };
     InlineLayoutUnit logicalTopOffsetFromParentBaseline(const InlineLevelBox&, const InlineLevelBox& parentInlineBox, IsInlineLevelBoxAlignment = IsInlineLevelBoxAlignment::No) const;
 
-    const InlineFormattingUtils& formattingUtils() const { return formattingContext().formattingUtils(); }
-    const InlineFormattingContext& formattingContext() const { return m_inlineFormattingContext; }
+    const InlineFormattingUtils& formattingUtils() const LIFETIME_BOUND { return formattingContext().formattingUtils(); }
+    const InlineFormattingContext& formattingContext() const LIFETIME_BOUND { return m_inlineFormattingContext; }
     const ElementBox& rootBox() const { return formattingContext().root(); }
-    const InlineLayoutState& layoutState() const { return formattingContext().layoutState(); }
+    const InlineLayoutState& layoutState() const LIFETIME_BOUND { return formattingContext().layoutState(); }
 
 private:
     const InlineFormattingContext& m_inlineFormattingContext;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h
@@ -95,7 +95,7 @@ private:
     bool shouldTryToPlaceFloatBox(const Box& floatBox, LayoutUnit floatBoxMarginBoxWidth, MayOverConstrainLine) const;
 
     bool isLineConstrainedByFloat() const { return !m_lineIsConstrainedByFloat.isEmpty(); }
-    const FloatingContext& floatingContext() const { return m_floatingContext; }
+    const FloatingContext& floatingContext() const LIFETIME_BOUND { return m_floatingContext; }
 
 private:
     const FloatingContext& m_floatingContext;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.h
@@ -47,7 +47,7 @@ public:
     bool shouldCollapseLineBoxHeight(const Line::RunList&, size_t numberOfOutsideListMarkers) const;
 
 private:
-    const InlineFormattingContext& formattingContext() const { return m_inlineFormattingContext; }
+    const InlineFormattingContext& formattingContext() const LIFETIME_BOUND { return m_inlineFormattingContext; }
 
 private:
     const InlineFormattingContext& m_inlineFormattingContext;

--- a/Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.h
+++ b/Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.h
@@ -41,7 +41,7 @@ public:
     InlineLayoutUnit minimumContentSize();
     InlineLayoutUnit maximumContentSize();
 
-    std::optional<LineLayoutResult>& maximumIntrinsicWidthLineContent() { return m_maximumIntrinsicWidthResultForSingleLine; }
+    std::optional<LineLayoutResult>& maximumIntrinsicWidthLineContent() LIFETIME_BOUND { return m_maximumIntrinsicWidthResultForSingleLine; }
 
 private:
     enum class MayCacheLayoutResult : bool { No, Yes };
@@ -49,12 +49,12 @@ private:
     InlineLayoutUnit simplifiedMinimumWidth(const ElementBox& root) const;
     InlineLayoutUnit simplifiedMaximumWidth(MayCacheLayoutResult = MayCacheLayoutResult::No);
 
-    InlineFormattingContext& NODELETE formattingContext();
-    const InlineFormattingContext& NODELETE formattingContext() const;
-    const InlineContentCache& formattingState() const;
+    InlineFormattingContext& NODELETE formattingContext() LIFETIME_BOUND;
+    const InlineFormattingContext& NODELETE formattingContext() const LIFETIME_BOUND;
+    const InlineContentCache& formattingState() const LIFETIME_BOUND;
     const ElementBox& NODELETE formattingContextRoot() const;
     const ElementBox& lineBuilerRoot() const;
-    const InlineItemList& inlineItemList() const { return m_inlineItems.content(); }
+    const InlineItemList& inlineItemList() const LIFETIME_BOUND { return m_inlineItems.content(); }
 
 private:
     InlineFormattingContext& m_inlineFormattingContext;

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h
@@ -118,9 +118,9 @@ struct Box {
     bool isVisibleIgnoringUsedVisibility() const { return !isFullyTruncated() && style().visibility() == Visibility::Visible; }
     bool isFullyTruncated() const { return m_isFullyTruncated; } 
 
-    const FloatRect& visualRectIgnoringBlockDirection() const { return m_unflippedVisualRect; }
+    const FloatRect& visualRectIgnoringBlockDirection() const LIFETIME_BOUND { return m_unflippedVisualRect; }
     static FloatRect visibleRectIgnoringBlockDirection(const Box&, const FloatRect& visibleLineRect);
-    const FloatRect& inkOverflow() const { return m_inkOverflow; }
+    const FloatRect& inkOverflow() const LIFETIME_BOUND { return m_inkOverflow; }
 
     float top() const { return visualRectIgnoringBlockDirection().y(); }
     float bottom() const { return visualRectIgnoringBlockDirection().maxY(); }
@@ -144,8 +144,8 @@ struct Box {
     void setHasContent() { m_hasContent = true; }
     void setIsFullyTruncated() { m_isFullyTruncated = true; }
 
-    Text& text() { ASSERT(isTextOrSoftLineBreak()); return m_text; }
-    const Text& text() const { ASSERT(isTextOrSoftLineBreak()); return m_text; }
+    Text& text() LIFETIME_BOUND { ASSERT(isTextOrSoftLineBreak()); return m_text; }
+    const Text& text() const LIFETIME_BOUND { ASSERT(isTextOrSoftLineBreak()); return m_text; }
 
     struct Expansion {
         ExpansionBehavior behavior { ExpansionBehavior::defaultBehavior() };
@@ -155,7 +155,7 @@ struct Box {
     Expansion expansion() const { return { m_expansionBehavior, m_horizontalExpansion }; }
 
     const Layout::Box& layoutBox() const { return m_layoutBox; }
-    const RenderStyle& style() const { return isFirstFormattedLine() ? layoutBox().firstLineStyle() : layoutBox().style(); }
+    const RenderStyle& style() const LIFETIME_BOUND { return isFirstFormattedLine() ? layoutBox().firstLineStyle() : layoutBox().style(); }
     WritingMode writingMode() const { return style().writingMode(); }
 
     void moveToLine(unsigned lineIndex) { m_lineIndex = lineIndex; }

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h
@@ -84,13 +84,13 @@ private:
 
     bool isFirstFormattedLine() const { return lineBox().isFirstFormattedLine(); }
 
-    const LineBox& lineBox() const { return m_lineBox; }
+    const LineBox& lineBox() const LIFETIME_BOUND { return m_lineBox; }
     size_t lineIndex() const { return lineBox().lineIndex(); }
-    const ConstraintsForInlineContent& constraints() const { return m_constraints; }
+    const ConstraintsForInlineContent& constraints() const LIFETIME_BOUND { return m_constraints; }
     const ElementBox& root() const { return m_formattingContext.root(); }
-    const RenderStyle& rootStyle() const { return lineIndex() ? root().style() : root().firstLineStyle(); }
-    InlineFormattingContext& formattingContext() { return m_formattingContext; }
-    const InlineFormattingContext& formattingContext() const { return m_formattingContext; }
+    const RenderStyle& rootStyle() const LIFETIME_BOUND { return lineIndex() ? root().style() : root().firstLineStyle(); }
+    InlineFormattingContext& formattingContext() LIFETIME_BOUND { return m_formattingContext; }
+    const InlineFormattingContext& formattingContext() const LIFETIME_BOUND { return m_formattingContext; }
 
 private:
     InlineFormattingContext& m_formattingContext;

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h
@@ -61,10 +61,10 @@ public:
     float lineBoxHeight() const { return m_lineBoxRect.height(); }
     float lineBoxWidth() const { return m_lineBoxRect.width(); }
 
-    const FloatRect& lineBoxRect() const { return m_lineBoxRect; }
-    const FloatRect& lineBoxLogicalRect() const { return m_lineBoxLogicalRect; }
-    const FloatRect& scrollableOverflow() const { return m_scrollableOverflow; }
-    const FloatRect& inkOverflow() const { return m_inkOverflow; }
+    const FloatRect& lineBoxRect() const LIFETIME_BOUND { return m_lineBoxRect; }
+    const FloatRect& lineBoxLogicalRect() const LIFETIME_BOUND { return m_lineBoxLogicalRect; }
+    const FloatRect& scrollableOverflow() const LIFETIME_BOUND { return m_scrollableOverflow; }
+    const FloatRect& inkOverflow() const LIFETIME_BOUND { return m_inkOverflow; }
 
     float enclosingContentLogicalTop() const { return m_enclosingLogicalTopAndBottom.top; }
     float enclosingContentLogicalBottom() const { return m_enclosingLogicalTopAndBottom.bottom; }

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.h
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.h
@@ -53,9 +53,9 @@ private:
     };
     EnclosingLineGeometry collectEnclosingLineGeometry(const LineLayoutResult&, const LineBox&, const InlineRect& lineBoxRect) const;
 
-    const ConstraintsForInlineContent& constraints() const { return m_constraints; }
-    const InlineFormattingContext& formattingContext() const { return m_inlineFormattingContext; }
-    InlineFormattingContext& formattingContext() { return m_inlineFormattingContext; }
+    const ConstraintsForInlineContent& constraints() const LIFETIME_BOUND { return m_constraints; }
+    const InlineFormattingContext& formattingContext() const LIFETIME_BOUND { return m_inlineFormattingContext; }
+    InlineFormattingContext& formattingContext() LIFETIME_BOUND { return m_inlineFormattingContext; }
     const Box& root() const { return formattingContext().root(); }
 
 private:

--- a/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.h
+++ b/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.h
@@ -64,8 +64,8 @@ private:
     enum class ShouldApplyRangeLayout : bool { No, Yes };
     bool updateInlineDamage(const InvalidatedLine&, InlineDamage::Reason, ShouldApplyRangeLayout = ShouldApplyRangeLayout::No, LayoutUnit restartPaginationAdjustment = 0_lu);
     bool setFullLayoutIfNeeded(const Box&);
-    const InlineDisplay::Boxes& displayBoxes() const { return m_displayContent.boxes; }
-    const InlineDisplay::Lines& displayLines() const { return m_displayContent.lines; }
+    const InlineDisplay::Boxes& displayBoxes() const LIFETIME_BOUND { return m_displayContent.boxes; }
+    const InlineDisplay::Lines& displayLines() const LIFETIME_BOUND { return m_displayContent.lines; }
 
     InlineDamage& m_inlineDamage;
 

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingContext.h
@@ -45,9 +45,9 @@ public:
     void layoutInFlowContent(const ConstraintsForInFlowContent&) override;
     LayoutUnit usedContentHeight() const override;
 
-    const TableFormattingGeometry& formattingGeometry() const { return m_tableFormattingGeometry; }
-    const TableFormattingQuirks& formattingQuirks() const { return m_tableFormattingQuirks; }
-    const TableFormattingState& formattingState() const { return m_tableFormattingState; }
+    const TableFormattingGeometry& formattingGeometry() const LIFETIME_BOUND { return m_tableFormattingGeometry; }
+    const TableFormattingQuirks& formattingQuirks() const LIFETIME_BOUND { return m_tableFormattingQuirks; }
+    const TableFormattingState& formattingState() const LIFETIME_BOUND { return m_tableFormattingState; }
 
 private:
     class TableLayout {
@@ -59,7 +59,7 @@ private:
         DistributedSpaces distributedVerticalSpace(std::optional<LayoutUnit> availableVerticalSpace);
 
     private:
-        const TableFormattingContext& formattingContext() const { return m_formattingContext; }
+        const TableFormattingContext& formattingContext() const LIFETIME_BOUND { return m_formattingContext; }
 
         const TableFormattingContext& m_formattingContext;
         const TableGrid& m_grid;
@@ -75,7 +75,7 @@ private:
     IntrinsicWidthConstraints computedPreferredWidthForColumns();
     void computeAndDistributeExtraSpace(LayoutUnit availableHorizontalSpace, std::optional<LayoutUnit> availableVerticalSpace);
 
-    TableFormattingState& formattingState() { return m_tableFormattingState; }
+    TableFormattingState& formattingState() LIFETIME_BOUND { return m_tableFormattingState; }
 
     TableFormattingState& m_tableFormattingState;
     const TableFormattingGeometry m_tableFormattingGeometry;

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingGeometry.h
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingGeometry.h
@@ -46,7 +46,7 @@ public:
     LayoutUnit verticalSpaceForCellContent(const TableGridCell&, std::optional<LayoutUnit> availableVerticalSpace) const;
 
 private:
-    const TableFormattingContext& formattingContext() const { return downcast<TableFormattingContext>(FormattingGeometry::formattingContext()); }
+    const TableFormattingContext& formattingContext() const LIFETIME_BOUND { return downcast<TableFormattingContext>(FormattingGeometry::formattingContext()); }
 };
 
 }

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingQuirks.h
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingQuirks.h
@@ -40,7 +40,7 @@ public:
     LayoutUnit heightValueOfNearestContainingBlockWithFixedHeight(const Box&) const final;
 
 private:
-    const TableFormattingContext& formattingContext() const { return downcast<TableFormattingContext>(FormattingQuirks::formattingContext()); }
+    const TableFormattingContext& formattingContext() const LIFETIME_BOUND { return downcast<TableFormattingContext>(FormattingQuirks::formattingContext()); }
 
 };
 

--- a/Source/WebCore/layout/formattingContexts/table/TableFormattingState.h
+++ b/Source/WebCore/layout/formattingContexts/table/TableFormattingState.h
@@ -40,8 +40,8 @@ public:
     TableFormattingState(LayoutState&, const ElementBox& tableBox);
     ~TableFormattingState();
 
-    TableGrid& tableGrid() { return m_tableGrid; }
-    const TableGrid& tableGrid() const { return m_tableGrid; }
+    TableGrid& tableGrid() LIFETIME_BOUND { return m_tableGrid; }
+    const TableGrid& tableGrid() const LIFETIME_BOUND { return m_tableGrid; }
 
 private:
     const UniqueRef<TableGrid> m_tableGrid;

--- a/Source/WebCore/layout/formattingContexts/table/TableGrid.h
+++ b/Source/WebCore/layout/formattingContexts/table/TableGrid.h
@@ -107,7 +107,7 @@ public:
         LayoutUnit usedLogicalWidth() const;
 
         void setComputedLogicalWidth(ComputedLogicalWidth&&);
-        const ComputedLogicalWidth& computedLogicalWidth() const { return m_computedLogicalWidth; }
+        const ComputedLogicalWidth& computedLogicalWidth() const LIFETIME_BOUND { return m_computedLogicalWidth; }
 
         const ElementBox* box() const { return m_layoutBox.get(); }
 
@@ -126,8 +126,8 @@ public:
     class Columns {
     public:
         using ColumnList = Vector<Column>;
-        ColumnList& list() { return m_columnList; }
-        const ColumnList& list() const { return m_columnList; }
+        ColumnList& list() LIFETIME_BOUND { return m_columnList; }
+        const ColumnList& list() const LIFETIME_BOUND { return m_columnList; }
         size_t size() const { return m_columnList.size(); }
 
         void addColumn(const ElementBox&);
@@ -165,8 +165,8 @@ public:
     class Rows {
     public:
         using RowList = Vector<Row>;
-        RowList& list() { return m_rowList; }
-        const RowList& list() const { return m_rowList; }
+        RowList& list() LIFETIME_BOUND { return m_rowList; }
+        const RowList& list() const LIFETIME_BOUND { return m_rowList; }
 
         void addRow(const ElementBox&);
 
@@ -182,10 +182,10 @@ public:
         Slot() = default;
         Slot(TableGridCell&, bool isColumnSpanned, bool isRowSpanned);
 
-        const TableGridCell& cell() const { return *m_cell; }
-        TableGridCell& cell() { return *m_cell; }
+        const TableGridCell& cell() const LIFETIME_BOUND { return *m_cell; }
+        TableGridCell& cell() LIFETIME_BOUND { return *m_cell; }
 
-        const IntrinsicWidthConstraints& widthConstraints() const { return m_widthConstraints; }
+        const IntrinsicWidthConstraints& widthConstraints() const LIFETIME_BOUND { return m_widthConstraints; }
         void setWidthConstraints(const IntrinsicWidthConstraints& widthConstraints) { m_widthConstraints = widthConstraints; }
 
         // Initial slot position for a spanning cell.
@@ -206,17 +206,17 @@ public:
         IntrinsicWidthConstraints m_widthConstraints;
     };
 
-    const Columns& columns() const { return m_columns; }
-    Columns& columns() { return m_columns; }
+    const Columns& columns() const LIFETIME_BOUND { return m_columns; }
+    Columns& columns() LIFETIME_BOUND { return m_columns; }
 
-    const Rows& rows() const { return m_rows; }
-    Rows& rows() { return m_rows; }
+    const Rows& rows() const LIFETIME_BOUND { return m_rows; }
+    Rows& rows() LIFETIME_BOUND { return m_rows; }
 
     using Cells = ListHashSet<std::unique_ptr<TableGridCell>>;
-    Cells& cells() { return m_cells; }
+    Cells& cells() LIFETIME_BOUND { return m_cells; }
 
-    Slot* slot(SlotPosition);
-    const Slot* slot(SlotPosition position) const { return m_slotMap.get(position); }
+    Slot* slot(SlotPosition) LIFETIME_BOUND;
+    const Slot* slot(SlotPosition position) const LIFETIME_BOUND { return m_slotMap.get(position); }
     bool isSpanned(SlotPosition);
 
 private:

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -93,7 +93,8 @@ static LayoutUnit snapToInt(LayoutUnit value, const RenderObject& renderer, Snap
 
 static float ascent(const RenderObject& renderer)
 {
-    auto& fontMetrics = renderer.firstLineStyle().metricsOfPrimaryFont();
+    CheckedRef style = renderer.firstLineStyle();
+    auto& fontMetrics = style->metricsOfPrimaryFont();
     return renderer.settings().subpixelInlineLayoutEnabled() ? fontMetrics.ascent() : fontMetrics.intAscent();
 }
 

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h
@@ -70,8 +70,8 @@ private:
     Layout::BoxGeometry::Edges logicalBorder(const RenderBoxModelObject&, WritingMode, bool isIntrinsicWidthMode = false, bool retainBorderStart = true, bool retainBorderEnd = true);
     Layout::BoxGeometry::Edges logicalPadding(const RenderBoxModelObject&, std::optional<LayoutUnit> availableWidth, WritingMode, bool retainPaddingStart = true, bool retainPaddingEnd = true);
 
-    Layout::LayoutState& layoutState() { return *m_layoutState; }
-    const Layout::LayoutState& layoutState() const { return *m_layoutState; }
+    Layout::LayoutState& layoutState() LIFETIME_BOUND { return *m_layoutState; }
+    const Layout::LayoutState& layoutState() const LIFETIME_BOUND { return *m_layoutState; }
     const Layout::ElementBox& NODELETE rootLayoutBox() const;
     const RenderBlock& rootRenderer() const;
     inline WritingMode writingMode() const;

--- a/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h
+++ b/Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h
@@ -71,8 +71,8 @@ private:
     const RenderFlexibleBox& flexBoxRenderer() const { return downcast<RenderFlexibleBox>(*m_flexBox->rendererForIntegration()); }
     RenderFlexibleBox& flexBoxRenderer() { return downcast<RenderFlexibleBox>(*m_flexBox->rendererForIntegration()); }
 
-    Layout::LayoutState& layoutState() { return *m_layoutState; }
-    const Layout::LayoutState& layoutState() const { return *m_layoutState; }
+    Layout::LayoutState& layoutState() LIFETIME_BOUND { return *m_layoutState; }
+    const Layout::LayoutState& layoutState() const LIFETIME_BOUND { return *m_layoutState; }
 
     CheckedPtr<Layout::ElementBox> m_flexBox;
     WeakPtr<Layout::LayoutState> m_layoutState;

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -145,7 +145,8 @@ void GridLayout::updateGridItemRenderers()
 {
     for (CheckedRef layoutBox : formattingContextBoxes(gridBox())) {
         CheckedRef renderer = downcast<RenderBox>(*layoutBox->rendererForIntegration());
-        auto& gridItemGeometry = CheckedRef { layoutState() }->geometryForBox(layoutBox);
+        CheckedRef layoutState = this->layoutState();
+        auto& gridItemGeometry = layoutState->geometryForBox(layoutBox);
         auto borderBoxRect = Layout::BoxGeometry::borderBoxRect(gridItemGeometry);
 
         renderer->setLocation(borderBoxRect.topLeft());

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
@@ -66,8 +66,8 @@ private:
     const RenderGrid& gridBoxRenderer() const { return downcast<RenderGrid>(*m_gridBox->rendererForIntegration()); }
     RenderGrid& gridBoxRenderer() { return downcast<RenderGrid>(*m_gridBox->rendererForIntegration()); }
 
-    Layout::LayoutState& layoutState() { return m_layoutState; }
-    const Layout::LayoutState& layoutState() const { return m_layoutState; }
+    Layout::LayoutState& layoutState() LIFETIME_BOUND { return m_layoutState; }
+    const Layout::LayoutState& layoutState() const LIFETIME_BOUND { return m_layoutState; }
 
     const CheckedPtr<Layout::ElementBox> m_gridBox;
     CheckedRef<Layout::LayoutState> m_layoutState;

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBox.h
@@ -94,12 +94,12 @@ public:
 
     const RenderObject& renderer() const;
     const RenderBlockFlow& formattingContextRoot() const;
-    const RenderStyle& style() const;
-    WritingMode writingMode() const { return style().writingMode(); }
+    CheckedRef<const RenderStyle> style() const;
+    WritingMode writingMode() const { return style()->writingMode(); }
 
     // FIXME: Remove. For intermediate porting steps only.
-    const LegacyInlineBox* legacyInlineBox() const;
-    const InlineDisplay::Box* inlineBox() const;
+    const LegacyInlineBox* legacyInlineBox() const LIFETIME_BOUND;
+    const InlineDisplay::Box* inlineBox() const LIFETIME_BOUND;
 
     // Text-relative left/right
     LeafBoxIterator nextLineRightwardOnLine() const;
@@ -118,8 +118,8 @@ public:
     LineBoxIterator lineBox() const;
     size_t lineIndex() const;
 
-    const BoxModernPath& modernPath() const;
-    const BoxLegacyPath& legacyPath() const;
+    const BoxModernPath& modernPath() const LIFETIME_BOUND;
+    const BoxLegacyPath& legacyPath() const LIFETIME_BOUND;
 
 protected:
     friend class BoxIterator;
@@ -144,8 +144,8 @@ public:
     bool operator==(const BoxIterator&) const;
     bool operator==(EndIterator) const { return atEnd(); }
 
-    const Box& operator*() const { return m_box; }
-    const Box* operator->() const { return &m_box; }
+    const Box& operator*() const LIFETIME_BOUND { return m_box; }
+    const Box* operator->() const LIFETIME_BOUND { return &m_box; }
 
     BoxIterator& traverseLineRightwardOnLine();
     BoxIterator& traverseLineRightwardOnLineSkippingChildren();
@@ -305,9 +305,9 @@ inline const RenderBlockFlow& Box::formattingContextRoot() const
     });
 }
 
-inline const RenderStyle& Box::style() const
+inline CheckedRef<const RenderStyle> Box::style() const
 {
-    return WTF::switchOn(m_pathVariant, [](auto& path) -> const RenderStyle& {
+    return WTF::switchOn(m_pathVariant, [](auto& path) -> CheckedRef<const RenderStyle> {
         return path.style();
     });
 }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h
@@ -97,7 +97,7 @@ public:
         return m_inlineBox->root().blockFlow();
     }
 
-    const RenderStyle& style() const
+    CheckedRef<const RenderStyle> style() const
     {
         return m_inlineBox->lineStyle();
     }

--- a/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.cpp
@@ -43,9 +43,9 @@ RectEdges<bool> InlineBox::closedEdges() const
 {
     // FIXME: Layout knows the answer to this question so we should consult it.
     RectEdges<bool> closedEdges { true };
-    if (style().boxDecorationBreak() == BoxDecorationBreak::Clone)
+    if (style()->boxDecorationBreak() == BoxDecorationBreak::Clone)
         return closedEdges;
-    auto writingMode = style().writingMode();
+    auto writingMode = style()->writingMode();
     bool isFirst = !nextInlineBoxLineLeftward() && !renderer().isContinuation();
     bool isLast = !nextInlineBoxLineRightward() && !renderer().continuation();
     closedEdges.setStart(isFirst, writingMode);

--- a/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.h
@@ -42,7 +42,7 @@ public:
     RectEdges<bool> closedEdges() const;
 
     // FIXME: Remove. For intermediate porting steps only.
-    const LegacyInlineFlowBox* legacyInlineBox() const { return downcast<LegacyInlineFlowBox>(Box::legacyInlineBox()); }
+    const LegacyInlineFlowBox* legacyInlineBox() const LIFETIME_BOUND { return downcast<LegacyInlineFlowBox>(Box::legacyInlineBox()); }
 
     InlineBoxIterator nextInlineBoxLineRightward() const;
     InlineBoxIterator nextInlineBoxLineLeftward() const;
@@ -62,14 +62,14 @@ public:
     InlineBoxIterator(Box::PathVariant&&);
     InlineBoxIterator(const Box&);
 
-    const InlineBox& operator*() const { return get(); }
-    const InlineBox* operator->() const { return &get(); }
+    const InlineBox& operator*() const LIFETIME_BOUND { return get(); }
+    const InlineBox* operator->() const LIFETIME_BOUND { return &get(); }
 
     InlineBoxIterator& traverseInlineBoxLineRightward();
     InlineBoxIterator& traverseInlineBoxLineLeftward();
 
 private:
-    const InlineBox& get() const { return downcast<InlineBox>(m_box); }
+    const InlineBox& get() const LIFETIME_BOUND { return downcast<InlineBox>(m_box); }
 };
 
 InlineBoxIterator lineLeftmostInlineBoxFor(const RenderInline&);

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h
@@ -71,7 +71,7 @@ public:
     float scrollableOverflowTop() const;
     float scrollableOverflowBottom() const;
 
-    const RenderStyle& style() const { return isFirst() ? formattingContextRoot().firstLineStyle() : formattingContextRoot().style(); }
+    const RenderStyle& style() const LIFETIME_BOUND { return isFirst() ? formattingContextRoot().firstLineStyle() : formattingContextRoot().style(); }
 
     bool hasEllipsis() const;
     enum AdjustedForSelection : bool { No, Yes };
@@ -125,8 +125,8 @@ public:
     bool operator==(const LineBoxIterator&) const;
     bool operator==(EndLineBoxIterator) const { return atEnd(); }
 
-    const LineBox& operator*() const { return m_lineBox; }
-    const LineBox* operator->() const { return &m_lineBox; }
+    const LineBox& operator*() const LIFETIME_BOUND { return m_lineBox; }
+    const LineBox* operator->() const LIFETIME_BOUND { return &m_lineBox; }
 
     bool atEnd() const;
 

--- a/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h
@@ -140,8 +140,8 @@ public:
 private:
     void setAtEnd() { m_lineIndex = lines().size(); }
 
-    const InlineDisplay::Lines& lines() const { return m_inlineContent->displayContent().lines; }
-    const InlineDisplay::Line& line() const { return lines()[m_lineIndex]; }
+    const InlineDisplay::Lines& lines() const LIFETIME_BOUND { return m_inlineContent->displayContent().lines; }
+    const InlineDisplay::Line& line() const LIFETIME_BOUND { return lines()[m_lineIndex]; }
     InlineDisplay::Line::Ellipsis lineEllipsis() const { return *m_inlineContent->displayContent().lineEllipsis(m_lineIndex); }
 
     WeakPtr<const LayoutIntegration::InlineContent> m_inlineContent;

--- a/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h
@@ -46,7 +46,7 @@ public:
 
     const RenderSVGInlineText& renderer() const { return downcast<RenderSVGInlineText>(TextBox::renderer()); }
 
-    const SVGInlineTextBox* legacyInlineBox() const;
+    const SVGInlineTextBox* legacyInlineBox() const LIFETIME_BOUND;
 
     using Key = std::pair<const RenderSVGInlineText*, unsigned>;
 };
@@ -59,11 +59,11 @@ public:
 
     SVGTextBoxIterator& operator++() { return downcast<SVGTextBoxIterator>(traverseNextTextBox()); }
 
-    const SVGTextBox& operator*() const { return get(); }
-    const SVGTextBox* operator->() const { return &get(); }
+    const SVGTextBox& operator*() const LIFETIME_BOUND { return get(); }
+    const SVGTextBox* operator->() const LIFETIME_BOUND { return &get(); }
 
 private:
-    const SVGTextBox& get() const { return downcast<SVGTextBox>(m_box); }
+    const SVGTextBox& get() const LIFETIME_BOUND { return downcast<SVGTextBox>(m_box); }
 };
 
 SVGTextBoxIterator firstSVGTextBoxFor(const RenderSVGInlineText&);

--- a/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp
@@ -47,7 +47,7 @@ const FontCascade& TextBox::fontCascade() const
     if (CheckedPtr renderer = dynamicDowncast<RenderCombineText>(this->renderer()); renderer && renderer->isCombined())
         return renderer->textCombineFont();
 
-    return style().fontCascade();
+    return style()->fontCascade();
 }
 
 TextBoxIterator::TextBoxIterator(Box::PathVariant&& pathVariant)

--- a/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h
@@ -66,8 +66,8 @@ public:
 
     TextBoxIterator& operator++() { return traverseNextTextBox(); }
 
-    const TextBox& operator*() const { return get(); }
-    const TextBox* operator->() const { return &get(); }
+    const TextBox& operator*() const LIFETIME_BOUND { return get(); }
+    const TextBox* operator->() const LIFETIME_BOUND { return &get(); }
 
     // This traverses to the next text box generated for the same RenderText/Layout::InlineTextBox.
     TextBoxIterator& traverseNextTextBox();
@@ -78,7 +78,7 @@ private:
     BoxIterator& traverseLineRightwardOnLineIgnoringLineBreak() = delete;
     BoxIterator& traverseLineLeftwardOnLineIgnoringLineBreak() = delete;
 
-    const TextBox& get() const { return downcast<TextBox>(m_box); }
+    const TextBox& get() const LIFETIME_BOUND { return downcast<TextBox>(m_box); }
 };
 
 TextBoxIterator lineLeftmostTextBoxFor(const RenderText&);

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
@@ -67,8 +67,8 @@ class InlineContent : public CanMakeWeakPtr<InlineContent> {
 public:
     InlineContent(const RenderBlockFlow& formattingContextRoot);
 
-    InlineDisplay::Content& displayContent() { return m_displayContent; }
-    const InlineDisplay::Content& displayContent() const { return m_displayContent; }
+    InlineDisplay::Content& displayContent()  LIFETIME_BOUND { return m_displayContent; }
+    const InlineDisplay::Content& displayContent() const LIFETIME_BOUND { return m_displayContent; }
     bool NODELETE hasContentfulInFlowBox() const;
     bool NODELETE hasContentfulInlineLevelBox() const;
 
@@ -85,21 +85,21 @@ public:
 
     IteratorRange<const InlineDisplay::Box*> boxesForRect(const LayoutRect&) const;
 
-    const InlineDisplay::Line& lineForBox(const InlineDisplay::Box& box) const { return displayContent().lines[box.lineIndex()]; }
+    const InlineDisplay::Line& lineForBox(const InlineDisplay::Box& box) const LIFETIME_BOUND { return displayContent().lines[box.lineIndex()]; }
     size_t NODELETE indexForBox(const InlineDisplay::Box&) const;
-    const InlineDisplay::Box* firstBoxForLayoutBox(const Layout::Box&) const;
+    const InlineDisplay::Box* firstBoxForLayoutBox(const Layout::Box&) const LIFETIME_BOUND;
     std::optional<size_t> firstBoxIndexForLayoutBox(const Layout::Box&) const;
 
     // Returns a block level box if the line is for block-in-inline.
-    const InlineDisplay::Box* NODELETE blockLevelBoxForLine(const InlineDisplay::Line&) const;
+    const InlineDisplay::Box* NODELETE blockLevelBoxForLine(const InlineDisplay::Line&) const LIFETIME_BOUND;
     bool NODELETE isInlineBoxWrapperForBlockLevelBox(const InlineDisplay::Box&) const;
 
     template<typename Function> void traverseNonRootInlineBoxes(const Layout::Box&, Function&&);
 
     const RenderBlockFlow& NODELETE formattingContextRoot() const;
 
-    const Vector<SVGTextFragment>& NODELETE svgTextFragments(size_t boxIndex) const;
-    Vector<Vector<SVGTextFragment>>& svgTextFragmentsForBoxes() { return m_svgTextFragmentsForBoxes; }
+    const Vector<SVGTextFragment>& NODELETE svgTextFragments(size_t boxIndex) const LIFETIME_BOUND;
+    Vector<Vector<SVGTextFragment>>& svgTextFragmentsForBoxes() LIFETIME_BOUND { return m_svgTextFragmentsForBoxes; }
 
     void shrinkToFit();
     void releaseCaches();
@@ -117,7 +117,7 @@ private:
     void setHasBlockLevelBoxes() { m_hasBlockLevelBoxes = true; }
     void setHasPaintedInlineLevelBoxes() { m_hasPaintedInlineLevelBoxes = true; }
 
-    const Vector<size_t>& nonRootInlineBoxIndexesForLayoutBox(const Layout::Box&) const;
+    const Vector<size_t>& nonRootInlineBoxIndexesForLayoutBox(const Layout::Box&) const LIFETIME_BOUND;
 
     CheckedRef<const RenderBlockFlow> m_formattingContextRoot;
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h
@@ -139,7 +139,7 @@ public:
     // This is temporary, required by partial bailout check.
     bool NODELETE contentNeedsVisualReordering() const;
     bool isDamaged() const { return !!m_lineDamage; }
-    const Layout::InlineDamage* damage() const { return m_lineDamage.get(); }
+    const Layout::InlineDamage* damage() const LIFETIME_BOUND { return m_lineDamage.get(); }
 #ifndef NDEBUG
     bool hasDetachedContent() const { return m_lineDamage && m_lineDamage->hasDetachedContent(); }
 #endif
@@ -154,12 +154,12 @@ private:
     Vector<LineAdjustment> adjustContentForPagination(const Layout::BlockLayoutState&, bool isPartialLayout);
     void updateRenderTreePositions(const Vector<LineAdjustment>&, const Layout::InlineLayoutState&, bool didDiscardContent);
 
-    InlineContent& ensureInlineContent();
+    InlineContent& ensureInlineContent() LIFETIME_BOUND;
 
-    Layout::LayoutState& layoutState() { return *m_layoutState; }
-    const Layout::LayoutState& layoutState() const { return *m_layoutState; }
+    Layout::LayoutState& layoutState() LIFETIME_BOUND { return *m_layoutState; }
+    const Layout::LayoutState& layoutState() const LIFETIME_BOUND { return *m_layoutState; }
 
-    Layout::InlineDamage& ensureLineDamage();
+    Layout::InlineDamage& ensureLineDamage() LIFETIME_BOUND;
 
     const Layout::ElementBox& rootLayoutBox() const { return *m_rootLayoutBox; }
     Layout::ElementBox& rootLayoutBox() { return *m_rootLayoutBox; }

--- a/Source/WebCore/layout/layouttree/LayoutBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutBox.h
@@ -182,8 +182,8 @@ public:
     bool NODELETE isOverflowVisible() const;
 
     void updateStyle(RenderStyle&& newStyle, std::unique_ptr<RenderStyle>&& newFirstLineStyle);
-    const RenderStyle& style() const { return m_style; }
-    const RenderStyle& firstLineStyle() const { return hasRareData() && rareData().firstLineStyle ? *rareData().firstLineStyle : m_style; }
+    const RenderStyle& style() const LIFETIME_BOUND { return m_style; }
+    const RenderStyle& firstLineStyle() const LIFETIME_BOUND { return hasRareData() && rareData().firstLineStyle ? *rareData().firstLineStyle : m_style; }
     WritingMode writingMode() const { return style().writingMode(); }
 
     // FIXME: Find a better place for random DOM things.

--- a/Source/WebCore/layout/layouttree/LayoutInlineTextBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutInlineTextBox.h
@@ -47,7 +47,7 @@ public:
     InlineTextBox(String, bool isCombined, EnumSet<ContentCharacteristic>, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle = nullptr);
     virtual ~InlineTextBox() = default;
 
-    const String& content() const { return m_content; }
+    const String& content() const LIFETIME_BOUND { return m_content; }
     bool isCombined() const { return m_isCombined; }
     // FIXME: This should not be a box's property.
     bool canUseSimplifiedContentMeasuring() const { return m_contentCharacteristicSet.contains(ContentCharacteristic::CanUseSimplifiedContentMeasuring); }

--- a/Source/WebCore/rendering/BidiRun.h
+++ b/Source/WebCore/rendering/BidiRun.h
@@ -40,7 +40,7 @@ public:
     ~BidiRun();
 
     RenderObject& renderer() { return m_renderer; }
-    LegacyInlineBox* box() { return m_box; }
+    LegacyInlineBox* box() LIFETIME_BOUND { return m_box; }
     void setBox(LegacyInlineBox* box) { m_box = box; }
 
 private:

--- a/Source/WebCore/rendering/BorderEdge.h
+++ b/Source/WebCore/rendering/BorderEdge.h
@@ -45,7 +45,7 @@ public:
 
     BorderStyle style() const { return m_style; }
     LayoutUnit width() const { return m_width; }
-    const Color& color() const { return m_color; }
+    const Color& color() const LIFETIME_BOUND { return m_color; }
     bool isTransparent() const { return m_isTransparent; }
     bool isPresent() const { return m_isPresent; }
 

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -68,7 +68,7 @@ public:
     LayoutRect innerEdgeRect() const { return m_innerEdgeRect.rect(); }
 
     // Takes `closedEdges` into account.
-    const RectEdges<LayoutUnit>& borderWidths() const { return m_borderWidths; }
+    const RectEdges<LayoutUnit>& borderWidths() const LIFETIME_BOUND { return m_borderWidths; }
 
     LayoutRoundedRect NODELETE deprecatedRoundedRect() const;
     LayoutRoundedRect NODELETE deprecatedInnerRoundedRect() const;
@@ -83,11 +83,11 @@ public:
     // meaning border painting can use simpler rectangular paths.
     bool allCornersClippedOut(const LayoutRect&) const;
 
-    const LayoutRoundedRectRadii& radii() const { return m_borderRect.radii(); }
+    const LayoutRoundedRectRadii& radii() const LIFETIME_BOUND { return m_borderRect.radii(); }
     void setRadii(const LayoutRoundedRectRadii& radii) { m_borderRect.setRadii(radii); }
 
     // Note that the inner edge isn't necessarily a rounded rect, but the radii still represent where the straight edge sections terminate.
-    const LayoutRoundedRectRadii& innerEdgeRadii() const { return m_innerEdgeRect.radii(); }
+    const LayoutRoundedRectRadii& innerEdgeRadii() const LIFETIME_BOUND { return m_innerEdgeRect.radii(); }
 
     FloatRect snappedOuterRect(float deviceScaleFactor) const;
     FloatRect snappedInnerRect(float deviceScaleFactor) const;

--- a/Source/WebCore/rendering/CSSFilterRenderer.h
+++ b/Source/WebCore/rendering/CSSFilterRenderer.h
@@ -47,7 +47,7 @@ public:
     WEBCORE_EXPORT static Ref<CSSFilterRenderer> create(Vector<Ref<FilterFunction>>&&);
     WEBCORE_EXPORT static Ref<CSSFilterRenderer> create(Vector<Ref<FilterFunction>>&&, const FilterGeometry&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, bool showDebugOverlay);
 
-    const Vector<Ref<FilterFunction>>& functions() const { return m_functions; }
+    const Vector<Ref<FilterFunction>>& functions() const LIFETIME_BOUND { return m_functions; }
     void setFilterRegion(const FloatRect&);
 
     bool hasFilterThatMovesPixels() const { return m_hasFilterThatMovesPixels; }

--- a/Source/WebCore/rendering/ClipRect.h
+++ b/Source/WebCore/rendering/ClipRect.h
@@ -44,7 +44,7 @@ public:
     {
     }
     
-    const LayoutRect& rect() const { return m_rect; }
+    const LayoutRect& rect() const LIFETIME_BOUND { return m_rect; }
 
     void reset() { m_rect = LayoutRect::infiniteRect(); }
 

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -137,22 +137,22 @@ public:
     bool contains(const IntRect& rect) const { return m_region.contains(rect); }
     bool intersects(const IntRect& rect) const { return m_region.intersects(rect); }
 
-    const Region& region() const { return m_region; }
+    const Region& region() const LIFETIME_BOUND { return m_region; }
 
 #if ENABLE(TOUCH_ACTION_REGIONS)
     bool hasTouchActions() const { return !m_touchActionRegions.isEmpty(); }
     WEBCORE_EXPORT OptionSet<TouchAction> touchActionsForPoint(const IntPoint&) const;
-    const Region* regionForTouchAction(TouchAction) const;
+    const Region* regionForTouchAction(TouchAction) const LIFETIME_BOUND;
 #endif
 
 #if ENABLE(TOUCH_EVENT_REGIONS)
     WEBCORE_EXPORT TrackingType eventTrackingTypeForPoint(EventTrackingRegionsEventType, const IntPoint&) const;
-    const EventTrackingRegions& touchEventListenerRegion() const { return m_touchEventListenerRegion; }
+    const EventTrackingRegions& touchEventListenerRegion() const LIFETIME_BOUND { return m_touchEventListenerRegion; }
 #endif
 
 #if ENABLE(WHEEL_EVENT_REGIONS)
     WEBCORE_EXPORT OptionSet<EventListenerRegionType> eventListenerRegionTypesForPoint(const IntPoint&) const;
-    const Region& NODELETE eventListenerRegionForType(EventListenerRegionType) const;
+    const Region& NODELETE eventListenerRegionForType(EventListenerRegionType) const LIFETIME_BOUND;
 #endif
 
 #if ENABLE(EDITABLE_REGION)
@@ -165,7 +165,7 @@ public:
     void dump(TextStream&) const;
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    const Vector<InteractionRegion>& interactionRegions() const { return m_interactionRegions; }
+    const Vector<InteractionRegion>& interactionRegions() const LIFETIME_BOUND { return m_interactionRegions; }
     void appendInteractionRegions(const Vector<InteractionRegion>&);
     void clearInteractionRegions();
 #endif

--- a/Source/WebCore/rendering/FloatingObjects.h
+++ b/Source/WebCore/rendering/FloatingObjects.h
@@ -74,7 +74,7 @@ public:
 
     void setMarginOffset(LayoutSize offset) { ASSERT(!isInPlacedTree()); m_marginOffset = offset; }
 
-    const LayoutRect& frameRect() const { ASSERT(isPlaced()); return m_frameRect; }
+    const LayoutRect& frameRect() const LIFETIME_BOUND { ASSERT(isPlaced()); return m_frameRect; }
     void setFrameRect(const LayoutRect& frameRect) { ASSERT(!isInPlacedTree()); m_frameRect = frameRect; }
 
     LayoutUnit paginationStrut() const { return m_paginationStrut; }
@@ -164,7 +164,7 @@ public:
 
     bool hasLeftObjects() const { return m_leftObjectsCount > 0; }
     bool hasRightObjects() const { return m_rightObjectsCount > 0; }
-    const FloatingObjectSet& set() const { return m_set; }
+    const FloatingObjectSet& set() const LIFETIME_BOUND { return m_set; }
 
     LayoutUnit logicalLeftOffset(LayoutUnit fixedOffset, LayoutUnit logicalTop, LayoutUnit logicalHeight);
     LayoutUnit logicalRightOffset(LayoutUnit fixedOffset, LayoutUnit logicalTop, LayoutUnit logicalHeight);

--- a/Source/WebCore/rendering/GapRects.h
+++ b/Source/WebCore/rendering/GapRects.h
@@ -27,9 +27,9 @@
 namespace WebCore {
 
     struct GapRects {
-        const LayoutRect& left() const { return m_left; }
-        const LayoutRect& center() const { return m_center; }
-        const LayoutRect& right() const { return m_right; }
+        const LayoutRect& left() const LIFETIME_BOUND { return m_left; }
+        const LayoutRect& center() const LIFETIME_BOUND { return m_center; }
+        const LayoutRect& right() const LIFETIME_BOUND { return m_right; }
         
         void uniteLeft(const LayoutRect& r) { m_left.unite(r); }
         void uniteCenter(const LayoutRect& r) { m_center.unite(r); }

--- a/Source/WebCore/rendering/Grid.h
+++ b/Source/WebCore/rendering/Grid.h
@@ -63,7 +63,7 @@ public:
     GridSpan gridItemSpan(const RenderBox&, Style::GridTrackSizingDirection) const;
     GridSpan gridItemSpanIgnoringCollapsedTracks(const RenderBox&, Style::GridTrackSizingDirection) const;
 
-    const GridCell& NODELETE cell(unsigned row, unsigned column) const;
+    const GridCell& NODELETE cell(unsigned row, unsigned column) const LIFETIME_BOUND;
 
     unsigned NODELETE explicitGridStart(Style::GridTrackSizingDirection) const;
     void NODELETE setExplicitGridStart(unsigned rowStart, unsigned columnStart);
@@ -82,10 +82,10 @@ public:
     bool NODELETE hasAutoRepeatEmptyTracks(Style::GridTrackSizingDirection) const;
     bool isEmptyAutoRepeatTrack(Style::GridTrackSizingDirection, unsigned) const;
 
-    OrderedTrackIndexSet* NODELETE autoRepeatEmptyTracks(Style::GridTrackSizingDirection) const;
+    OrderedTrackIndexSet* NODELETE autoRepeatEmptyTracks(Style::GridTrackSizingDirection) const LIFETIME_BOUND;
 
-    OrderIterator& orderIterator() { return m_orderIterator; }
-    const OrderIterator& orderIterator() const { return m_orderIterator; }
+    OrderIterator& orderIterator() LIFETIME_BOUND { return m_orderIterator; }
+    const OrderIterator& orderIterator() const LIFETIME_BOUND { return m_orderIterator; }
 
     void setNeedsItemsPlacement(bool);
     bool needsItemsPlacement() const { return m_needsItemsPlacement; };

--- a/Source/WebCore/rendering/GridBaselineAlignment.h
+++ b/Source/WebCore/rendering/GridBaselineAlignment.h
@@ -63,7 +63,7 @@ public:
     void clear(Style::GridTrackSizingDirection alignmentContextType);
 
 private:
-    const BaselineGroup& baselineGroupForGridItem(ItemPosition, unsigned sharedContext, const RenderBox&, Style::GridTrackSizingDirection alignmentContextType) const;
+    const BaselineGroup& baselineGroupForGridItem(ItemPosition, unsigned sharedContext, const RenderBox&, Style::GridTrackSizingDirection alignmentContextType) const LIFETIME_BOUND;
     LayoutUnit marginOverForGridItem(const RenderBox&, Style::GridTrackSizingDirection alignmentContextType) const;
     LayoutUnit marginUnderForGridItem(const RenderBox&, Style::GridTrackSizingDirection alignmentContextType) const;
     LayoutUnit logicalAscentForGridItem(const RenderBox&, Style::GridTrackSizingDirection alignmentContextType, ItemPosition) const;

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -74,17 +74,17 @@ public:
     LayoutUnit NODELETE unclampedBaseSize() const;
     void setBaseSize(LayoutUnit);
 
-    const LayoutUnit& NODELETE growthLimit() const;
+    const LayoutUnit& NODELETE growthLimit() const LIFETIME_BOUND;
     bool growthLimitIsInfinite() const { return m_growthLimit == infinity; }
     void setGrowthLimit(LayoutUnit);
 
     bool infiniteGrowthPotential() const { return growthLimitIsInfinite() || m_infinitelyGrowable; }
     LayoutUnit growthLimitIfNotInfinite() const;
 
-    const LayoutUnit& plannedSize() const { return m_plannedSize; }
+    const LayoutUnit& plannedSize() const LIFETIME_BOUND { return m_plannedSize; }
     void setPlannedSize(LayoutUnit plannedSize) { m_plannedSize = plannedSize; }
 
-    const LayoutUnit& tempSize() const { return m_tempSize; }
+    const LayoutUnit& tempSize() const LIFETIME_BOUND { return m_tempSize; }
     void NODELETE setTempSize(const LayoutUnit&);
     void NODELETE growTempSize(const LayoutUnit&);
 
@@ -94,7 +94,7 @@ public:
     void NODELETE setGrowthLimitCap(std::optional<LayoutUnit>);
     std::optional<LayoutUnit> growthLimitCap() const { return m_growthLimitCap; }
 
-    const Style::GridTrackSize& NODELETE cachedTrackSize() const;
+    const Style::GridTrackSize& NODELETE cachedTrackSize() const LIFETIME_BOUND;
     void setCachedTrackSize(const Style::GridTrackSize&);
 
 private:
@@ -124,7 +124,7 @@ public:
     void reset();
 
     // Required by RenderGrid. Try to minimize the exposed surface.
-    const Grid& grid() const { return m_grid; }
+    const Grid& grid() const LIFETIME_BOUND { return m_grid; }
 
     const RenderGrid* renderGrid() const { return m_renderGrid; };
 
@@ -141,8 +141,8 @@ public:
     void cacheBaselineAlignedItem(const RenderBox&, Style::GridTrackSizingDirection alignmentContextType, bool cachingRowSubgridsForRootGrid);
     void clearBaselineItemsCache();
 
-    Vector<UniqueRef<GridTrack>>& tracks(Style::GridTrackSizingDirection direction) { return direction == Style::GridTrackSizingDirection::Columns ? m_columns : m_rows; }
-    const Vector<UniqueRef<GridTrack>>& tracks(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? m_columns : m_rows; }
+    Vector<UniqueRef<GridTrack>>& tracks(Style::GridTrackSizingDirection direction) LIFETIME_BOUND { return direction == Style::GridTrackSizingDirection::Columns ? m_columns : m_rows; }
+    const Vector<UniqueRef<GridTrack>>& tracks(Style::GridTrackSizingDirection direction) const LIFETIME_BOUND { return direction == Style::GridTrackSizingDirection::Columns ? m_columns : m_rows; }
 
     std::optional<LayoutUnit> freeSpace(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? m_freeSpaceColumns : m_freeSpaceRows; }
     void NODELETE setFreeSpace(Style::GridTrackSizingDirection, std::optional<LayoutUnit>);

--- a/Source/WebCore/rendering/HitTestLocation.h
+++ b/Source/WebCore/rendering/HitTestLocation.h
@@ -40,7 +40,7 @@ public:
     WEBCORE_EXPORT ~HitTestLocation();
     HitTestLocation& operator=(const HitTestLocation&);
 
-    const LayoutPoint& point() const { return m_point; }
+    const LayoutPoint& point() const LIFETIME_BOUND { return m_point; }
     IntPoint roundedPoint() const { return roundedIntPoint(m_point); }
 
     // Rect-based hit test related methods.
@@ -52,8 +52,8 @@ public:
     bool intersects(const FloatRect&) const;
     bool intersects(const LayoutRoundedRect&) const;
 
-    const FloatPoint& transformedPoint() const { return m_transformedPoint; }
-    const FloatQuad& transformedRect() const { return m_transformedRect; }
+    const FloatPoint& transformedPoint() const LIFETIME_BOUND { return m_transformedPoint; }
+    const FloatQuad& transformedRect() const LIFETIME_BOUND { return m_transformedRect; }
 
 private:
     template<typename RectType> bool intersectsRect(const RectType&) const;

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -86,22 +86,22 @@ public:
     bool isRectBasedTest() const { return m_hitTestLocation.isRectBasedTest(); }
 
     // The hit-tested point in the coordinates of the main frame.
-    const LayoutPoint& pointInMainFrame() const { return m_hitTestLocation.point(); }
+    const LayoutPoint& pointInMainFrame() const LIFETIME_BOUND { return m_hitTestLocation.point(); }
     IntPoint roundedPointInMainFrame() const { return roundedIntPoint(pointInMainFrame()); }
 
     // The hit-tested point in the coordinates of the innerNode frame, the frame containing innerNode.
     const LayoutPoint pointInInnerNodeFrame() const { return LayoutPoint(m_doublePointInInnerNodeFrame); }
-    const DoublePoint& doublePointInInnerNodeFrame() const { return m_doublePointInInnerNodeFrame; }
+    const DoublePoint& doublePointInInnerNodeFrame() const LIFETIME_BOUND { return m_doublePointInInnerNodeFrame; }
     IntPoint roundedPointInInnerNodeFrame() const { return roundedIntPoint(pointInInnerNodeFrame()); }
     WEBCORE_EXPORT LocalFrame* NODELETE innerNodeFrame() const;
 
     // The hit-tested point in the coordinates of the inner node.
-    const LayoutPoint& localPoint() const { return m_localPoint; }
+    const LayoutPoint& localPoint() const LIFETIME_BOUND { return m_localPoint; }
     void NODELETE setLocalPoint(const LayoutPoint&);
 
     WEBCORE_EXPORT void setToNonUserAgentShadowAncestor();
 
-    const HitTestLocation& hitTestLocation() const { return m_hitTestLocation; }
+    const HitTestLocation& hitTestLocation() const LIFETIME_BOUND { return m_hitTestLocation; }
 
     WEBCORE_EXPORT LocalFrame* NODELETE frame() const;
     WEBCORE_EXPORT RefPtr<Frame> targetFrame() const;
@@ -165,7 +165,7 @@ public:
     // If m_listBasedTestResult is 0 then set it to a new NodeSet. Return *m_listBasedTestResult. Lazy allocation makes
     // sense because the NodeSet is seldom necessary, and it's somewhat expensive to allocate and initialize. This method does
     // the same thing as mutableListBasedTestResult(), but here the return value is const.
-    WEBCORE_EXPORT const NodeSet& listBasedTestResult() const;
+    WEBCORE_EXPORT const NodeSet& listBasedTestResult() const LIFETIME_BOUND;
 
     Vector<String> dictationAlternatives() const;
 
@@ -173,7 +173,7 @@ public:
     WEBCORE_EXPORT Element* targetElement() const;
 
 private:
-    NodeSet& mutableListBasedTestResult(); // See above.
+    NodeSet& mutableListBasedTestResult() LIFETIME_BOUND; // See above.
 
     template<typename RectType> HitTestProgress addNodeToListBasedTestResultCommon(Node*, const HitTestRequest&, const HitTestLocation&, const RectType&);
 

--- a/Source/WebCore/rendering/LayerAncestorClippingStack.h
+++ b/Source/WebCore/rendering/LayerAncestorClippingStack.h
@@ -98,8 +98,8 @@ public:
         }
     };
 
-    Vector<ClippingStackEntry>& stack() { return m_stack; }
-    const Vector<ClippingStackEntry>& stack() const { return m_stack; }
+    Vector<ClippingStackEntry>& stack() LIFETIME_BOUND { return m_stack; }
+    const Vector<ClippingStackEntry>& stack() const LIFETIME_BOUND { return m_stack; }
 
 private:
     // Order is ancestors to descendants.

--- a/Source/WebCore/rendering/LayerOverlapMap.h
+++ b/Source/WebCore/rendering/LayerOverlapMap.h
@@ -62,10 +62,10 @@ public:
     void confirmSpeculativeCompositingContainer();
     bool maybePopSpeculativeCompositingContainer();
 
-    const RenderGeometryMap& geometryMap() const { return m_geometryMap; }
-    RenderGeometryMap& geometryMap() { return m_geometryMap; }
+    const RenderGeometryMap& geometryMap() const LIFETIME_BOUND { return m_geometryMap; }
+    RenderGeometryMap& geometryMap() LIFETIME_BOUND { return m_geometryMap; }
 
-    const Vector<std::unique_ptr<OverlapMapContainer>>& overlapStack() const { return m_overlapStack; }
+    const Vector<std::unique_ptr<OverlapMapContainer>>& overlapStack() const LIFETIME_BOUND { return m_overlapStack; }
 
 private:
     Vector<std::unique_ptr<OverlapMapContainer>> m_overlapStack;

--- a/Source/WebCore/rendering/LegacyInlineBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineBox.cpp
@@ -85,9 +85,9 @@ void LegacyInlineBox::invalidateParentChildList()
 
 #endif
 
-const RenderStyle& LegacyInlineBox::lineStyle() const
+CheckedRef<const RenderStyle> LegacyInlineBox::lineStyle() const
 {
-    return m_bitfields.firstLine() ? renderer().firstLineStyle() : renderer().style();
+    return m_bitfields.firstLine() ? renderer().firstLineStyle() : CheckedRef { renderer().style() };
 }
 
 void LegacyInlineBox::removeFromParent()
@@ -139,13 +139,13 @@ float LegacyInlineBox::logicalHeight() const
     if (hasVirtualLogicalHeight())
         return virtualLogicalHeight();
 
-    const RenderStyle& lineStyle = this->lineStyle();
+    CheckedRef lineStyle = this->lineStyle();
     if (renderer().isRenderTextOrLineBreak())
-        return lineStyle.metricsOfPrimaryFont().intHeight();
+        return lineStyle->metricsOfPrimaryFont().intHeight();
 
     ASSERT(isInlineFlowBox());
     RenderBoxModelObject* flowObject = boxModelObject();
-    const FontMetrics& fontMetrics = lineStyle.metricsOfPrimaryFont();
+    const FontMetrics& fontMetrics = lineStyle->metricsOfPrimaryFont();
     float result = fontMetrics.intHeight();
     if (parent())
         result += flowObject->borderAndPaddingLogicalHeight();

--- a/Source/WebCore/rendering/LegacyInlineBox.h
+++ b/Source/WebCore/rendering/LegacyInlineBox.h
@@ -109,8 +109,8 @@ public:
 
     void removeFromParent();
 
-    LegacyInlineBox* nextOnLine() const { return m_nextOnLine; }
-    LegacyInlineBox* previousOnLine() const { return m_previousOnLine; }
+    LegacyInlineBox* nextOnLine() const LIFETIME_BOUND { return m_nextOnLine; }
+    LegacyInlineBox* previousOnLine() const LIFETIME_BOUND { return m_previousOnLine; }
     void setNextOnLine(LegacyInlineBox* next)
     {
         ASSERT(m_parent || !next);
@@ -126,13 +126,13 @@ public:
 
     virtual bool isLeaf() const { return true; }
     
-    LegacyInlineBox* nextLeafOnLine() const;
-    LegacyInlineBox* previousLeafOnLine() const;
+    LegacyInlineBox* nextLeafOnLine() const LIFETIME_BOUND;
+    LegacyInlineBox* previousLeafOnLine() const LIFETIME_BOUND;
 
     // FIXME: Hide this once all callers are using tighter types.
     RenderObject& renderer() const { return *m_renderer; }
 
-    LegacyInlineFlowBox* parent() const
+    LegacyInlineFlowBox* parent() const LIFETIME_BOUND
     {
         assertNotDeleted();
         ASSERT_WITH_SECURITY_IMPLICATION(!m_hasBadParent);
@@ -153,7 +153,7 @@ public:
     float y() const { return m_topLeft.y(); }
     float top() const { return m_topLeft.y(); }
 
-    const FloatPoint& topLeft() const { return m_topLeft; }
+    const FloatPoint& topLeft() const LIFETIME_BOUND { return m_topLeft; }
 
     float width() const { return isHorizontal() ? logicalWidth() : logicalHeight(); }
     float height() const { return isHorizontal() ? logicalHeight() : logicalWidth(); }
@@ -215,9 +215,9 @@ public:
     void invalidateParentChildList();
 #endif
 
-    const RenderStyle& lineStyle() const;
+    CheckedRef<const RenderStyle> lineStyle() const;
     
-    const Style::VerticalAlign& verticalAlign() const { return lineStyle().verticalAlign(); }
+    const Style::VerticalAlign& verticalAlign() const LIFETIME_BOUND { return lineStyle()->verticalAlign(); }
 
     // Use with caution! The type is not checked!
     RenderBoxModelObject* boxModelObject() const

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
@@ -109,9 +109,8 @@ void LegacyInlineFlowBox::addToLine(LegacyInlineBox* child)
             setHasTextDescendantsOnAncestors(this);
     }
 
-    const RenderStyle& childStyle = child->lineStyle();
+    CheckedRef childStyle = child->lineStyle();
     if (child->isInlineTextBox()) {
-        const RenderStyle* childStyle = &child->lineStyle();
         bool hasMarkers = false;
         if (auto* textBox = dynamicDowncast<LegacyInlineTextBox>(*child))
             hasMarkers = textBox->hasMarkers();
@@ -119,7 +118,7 @@ void LegacyInlineFlowBox::addToLine(LegacyInlineBox* child)
             child->clearKnownToHaveNoOverflow();
     } else if (child->boxModelObject()->hasSelfPaintingLayer())
         child->clearKnownToHaveNoOverflow();
-    else if (childStyle.hasOutlineInVisualOverflow())
+    else if (childStyle->hasOutlineInVisualOverflow())
         child->clearKnownToHaveNoOverflow();
 
     if (lineStyle().hasOutlineInVisualOverflow())

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.h
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.h
@@ -53,20 +53,20 @@ public:
 #endif
 
     RenderBoxModelObject& renderer() const { return downcast<RenderBoxModelObject>(LegacyInlineBox::renderer()); }
-    const RenderStyle& lineStyle() const { return isFirstLine() ? renderer().firstLineStyle() : renderer().style(); }
+    const RenderStyle& lineStyle() const LIFETIME_BOUND { return isFirstLine() ? renderer().firstLineStyle() : renderer().style(); }
 
-    LegacyInlineFlowBox* prevLineBox() const { return m_prevLineBox; }
-    LegacyInlineFlowBox* nextLineBox() const { return m_nextLineBox; }
+    LegacyInlineFlowBox* prevLineBox() const LIFETIME_BOUND { return m_prevLineBox; }
+    LegacyInlineFlowBox* nextLineBox() const LIFETIME_BOUND { return m_nextLineBox; }
     void setNextLineBox(LegacyInlineFlowBox* n) { m_nextLineBox = n; }
     void setPreviousLineBox(LegacyInlineFlowBox* p) { m_prevLineBox = p; }
 
-    LegacyInlineBox* firstChild() const { checkConsistency(); return m_firstChild; }
-    LegacyInlineBox* lastChild() const { checkConsistency(); return m_lastChild; }
+    LegacyInlineBox* firstChild() const LIFETIME_BOUND { checkConsistency(); return m_firstChild; }
+    LegacyInlineBox* lastChild() const LIFETIME_BOUND { checkConsistency(); return m_lastChild; }
 
     bool isLeaf() const final { return false; }
     
-    LegacyInlineBox* firstLeafDescendant() const;
-    LegacyInlineBox* lastLeafDescendant() const;
+    LegacyInlineBox* firstLeafDescendant() const LIFETIME_BOUND;
+    LegacyInlineBox* lastLeafDescendant() const LIFETIME_BOUND;
 
     void setConstructed() final
     {

--- a/Source/WebCore/rendering/LegacyInlineTextBox.h
+++ b/Source/WebCore/rendering/LegacyInlineTextBox.h
@@ -42,10 +42,10 @@ public:
     virtual ~LegacyInlineTextBox();
 
     RenderSVGInlineText& NODELETE renderer() const;
-    const RenderStyle& lineStyle() const;
+    const RenderStyle& lineStyle() const LIFETIME_BOUND;
 
-    LegacyInlineTextBox* prevTextBox() const { return m_prevTextBox; }
-    LegacyInlineTextBox* nextTextBox() const { return m_nextTextBox; }
+    LegacyInlineTextBox* prevTextBox() const LIFETIME_BOUND { return m_prevTextBox; }
+    LegacyInlineTextBox* nextTextBox() const LIFETIME_BOUND { return m_nextTextBox; }
     void setNextTextBox(LegacyInlineTextBox* n) { m_nextTextBox = n; }
     void setPreviousTextBox(LegacyInlineTextBox* p) { m_prevTextBox = p; }
 

--- a/Source/WebCore/rendering/LegacyLineLayout.h
+++ b/Source/WebCore/rendering/LegacyLineLayout.h
@@ -82,7 +82,7 @@ private:
     void layoutRunsAndFloats(bool hasInlineChild);
     void layoutRunsAndFloatsInRange(InlineBidiResolver&);
 
-    const RenderStyle& NODELETE style() const;
+    const RenderStyle& NODELETE style() const LIFETIME_BOUND;
     const LocalFrameViewLayoutContext& NODELETE layoutContext() const;
 
     RenderBlockFlow& m_flow;

--- a/Source/WebCore/rendering/LegacyRootInlineBox.h
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.h
@@ -73,8 +73,8 @@ public:
     }
 
     RenderObject::HighlightState selectionState() const final;
-    const LegacyInlineBox* firstSelectedBox() const;
-    const LegacyInlineBox* lastSelectedBox() const;
+    const LegacyInlineBox* firstSelectedBox() const LIFETIME_BOUND;
+    const LegacyInlineBox* lastSelectedBox() const LIFETIME_BOUND;
 
     void NODELETE removeLineBoxFromRenderObject() final;
 

--- a/Source/WebCore/rendering/LogicalSelectionOffsetCaches.h
+++ b/Source/WebCore/rendering/LogicalSelectionOffsetCaches.h
@@ -39,7 +39,7 @@ public:
         inline LayoutUnit logicalRightSelectionOffset(RenderBlock&, LayoutUnit) const;
 
         RenderBlock* block() const { return m_block; }
-        const LogicalSelectionOffsetCaches* cache() const { return m_cache; }
+        const LogicalSelectionOffsetCaches* cache() const LIFETIME_BOUND { return m_cache; }
         bool hasFloatsOrFragmentedFlows() const { return m_hasFloatsOrFragmentedFlows; }
 
     private:
@@ -55,7 +55,7 @@ public:
     inline explicit LogicalSelectionOffsetCaches(RenderBlock&);
     inline LogicalSelectionOffsetCaches(RenderBlock&, const LogicalSelectionOffsetCaches&);
 
-    inline const ContainingBlockInfo& containingBlockInfo(RenderBlock&) const;
+    inline const ContainingBlockInfo& containingBlockInfo(RenderBlock&) const LIFETIME_BOUND;
 
 private:
     ContainingBlockInfo m_containingBlockForFixedPosition;

--- a/Source/WebCore/rendering/PaintInfo.h
+++ b/Source/WebCore/rendering/PaintInfo.h
@@ -69,7 +69,7 @@ struct PaintInfo {
     {
     }
 
-    GraphicsContext& context() const
+    GraphicsContext& context() const LIFETIME_BOUND
     {
         ASSERT(m_context);
         return *m_context;

--- a/Source/WebCore/rendering/PathOperation.h
+++ b/Source/WebCore/rendering/PathOperation.h
@@ -93,8 +93,8 @@ public:
 
     Ref<PathOperation> clone() const final;
 
-    const Style::URL& url() const { return m_url; }
-    const AtomString& fragment() const { return m_fragment; }
+    const Style::URL& url() const LIFETIME_BOUND { return m_url; }
+    const AtomString& fragment() const LIFETIME_BOUND { return m_fragment; }
 
     std::optional<Path> getPath(const TransformOperationData&, Style::ZoomFactor) const final { return m_path; }
     std::optional<Path> path() const { return m_path; }
@@ -129,7 +129,7 @@ public:
     bool canBlend(const PathOperation&) const final;
     RefPtr<PathOperation> blend(const PathOperation*, const BlendingContext&) const final;
 
-    const Style::BasicShape& shape() const { return m_shape; }
+    const Style::BasicShape& shape() const LIFETIME_BOUND { return m_shape; }
     WindRule windRule() const { return Style::windRule(m_shape); }
     Path pathForReferenceRect(const FloatRect& boundingRect, Style::ZoomFactor zoom) const { return Style::path(m_shape, boundingRect, zoom); }
 
@@ -192,7 +192,7 @@ public:
 
     Ref<PathOperation> clone() const final;
 
-    const Style::RayFunction& ray() const { return m_ray; }
+    const Style::RayFunction& ray() const LIFETIME_BOUND { return m_ray; }
 
     WEBCORE_EXPORT bool canBlend(const PathOperation&) const final;
     RefPtr<PathOperation> blend(const PathOperation*, const BlendingContext&) const final;

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -56,7 +56,7 @@ public:
 
     bool NODELETE needsAnchor() const;
     const RenderBoxModelObject* defaultAnchorBox() const { return m_defaultAnchorBox.get(); }
-    const StyleSelfAlignmentData& alignment() const { return m_alignment; }
+    const StyleSelfAlignmentData& alignment() const LIFETIME_BOUND { return m_alignment; }
     ItemPosition resolveAlignmentValue() const; // Convert auto/normal as necessary.
     bool NODELETE alignmentAppliesStretch(ItemPosition normalAlignment) const;
 

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -76,7 +76,7 @@ public:
     enum class ContainingBlockState : bool { NewContainingBlock, SameContainingBlock };
     void removeOutOfFlowBoxes(const RenderBlock*, ContainingBlockState = ContainingBlockState::SameContainingBlock);
 
-    TrackedRendererListHashSet* outOfFlowBoxes() const;
+    TrackedRendererListHashSet* outOfFlowBoxes() const LIFETIME_BOUND;
     bool hasOutOfFlowBoxes() const
     {
         auto* renderers = outOfFlowBoxes();
@@ -84,7 +84,7 @@ public:
     }
     void addPercentHeightDescendant(RenderBox&);
     static void removePercentHeightDescendant(RenderBox&);
-    TrackedRendererListHashSet* percentHeightDescendants() const;
+    TrackedRendererListHashSet* percentHeightDescendants() const LIFETIME_BOUND;
     bool hasPercentHeightDescendants() const
     {
         auto* renderers = percentHeightDescendants();
@@ -326,8 +326,8 @@ protected:
 
     virtual void computeChildIntrinsicLogicalWidths(RenderBox&, LayoutUnit& minPreferredLogicalWidth, LayoutUnit& maxPreferredLogicalWidth) const;
 
-    RenderBlockRareData& ensureBlockRareData();
-    RenderBlockRareData* blockRareData() const;
+    RenderBlockRareData& ensureBlockRareData() LIFETIME_BOUND;
+    RenderBlockRareData* blockRareData() const LIFETIME_BOUND;
     bool recomputeLogicalWidth();
 
 private:
@@ -362,7 +362,7 @@ private:
     void computeBlockPreferredLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const;
     
     LayoutRect rectWithOutlineForRepaint(const RenderLayerModelObject* repaintContainer, LayoutUnit outlineWidth) const final;
-    const RenderStyle& outlineStyleForRepaint() const final;
+    const RenderStyle& outlineStyleForRepaint() const LIFETIME_BOUND final;
 
     LayoutRect selectionRectForRepaint(const RenderLayerModelObject* repaintContainer, bool /*clipToVisibleContent*/) final
     {

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -293,7 +293,7 @@ public:
     void markAllDescendantsWithFloatsForLayout(RenderBox* floatToRemove = nullptr, bool inLayout = true);
     void markSiblingsWithFloatsForLayout(RenderBox* floatToRemove = nullptr);
 
-    const FloatingObjectSet* floatingObjectSet() const { return m_floatingObjects ? &m_floatingObjects->set() : nullptr; }
+    const FloatingObjectSet* floatingObjectSet() const LIFETIME_BOUND { return m_floatingObjects ? &m_floatingObjects->set() : nullptr; }
 
     FloatingObject& insertFloatingBox(RenderBox&);
 
@@ -561,8 +561,8 @@ public:
     bool relayoutForPagination();
 
     bool hasRareBlockFlowData() const { return m_rareBlockFlowData.get(); }
-    RenderBlockFlowRareData* rareBlockFlowData() const { ASSERT_WITH_SECURITY_IMPLICATION(hasRareBlockFlowData()); return m_rareBlockFlowData.get(); }
-    RenderBlockFlowRareData& ensureRareBlockFlowData();
+    RenderBlockFlowRareData* rareBlockFlowData() const LIFETIME_BOUND { ASSERT_WITH_SECURITY_IMPLICATION(hasRareBlockFlowData()); return m_rareBlockFlowData.get(); }
+    RenderBlockFlowRareData& ensureRareBlockFlowData() LIFETIME_BOUND;
     void materializeRareBlockFlowData();
 
 #if ENABLE(TEXT_AUTOSIZING)

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -232,7 +232,7 @@ public:
     virtual void setScrollTop(int, const ScrollPositionChangeOptions&);
     virtual void setScrollPosition(const ScrollPosition&, const ScrollPositionChangeOptions&);
 
-    const LayoutBoxExtent& marginBox() const { return m_marginBox; }
+    const LayoutBoxExtent& marginBox() const LIFETIME_BOUND { return m_marginBox; }
     LayoutUnit marginTop() const override { return m_marginBox.top(); }
     LayoutUnit marginBottom() const override { return m_marginBox.bottom(); }
     LayoutUnit marginLeft() const override { return m_marginBox.left(); }
@@ -616,7 +616,7 @@ public:
 
     bool computeHasTransformRelatedProperty(const RenderStyle&) const;
 
-    ShapeOutsideInfo* shapeOutsideInfo() const;
+    ShapeOutsideInfo* shapeOutsideInfo() const LIFETIME_BOUND;
 
     LayoutUnit computeIntrinsicLogicalWidthUsing(CSS::Keyword::WebkitFillAvailable, LayoutUnit availableLogicalWidth, LayoutUnit borderAndPadding) const;
     LayoutUnit computeIntrinsicLogicalWidthUsing(CSS::Keyword::MinIntrinsic, LayoutUnit availableLogicalWidth, LayoutUnit borderAndPadding) const;

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -264,7 +264,7 @@ public:
         void NODELETE insertAfter(ContinuationChainNode&);
     };
 
-    ContinuationChainNode* continuationChainNode() const;
+    ContinuationChainNode* continuationChainNode() const LIFETIME_BOUND;
 
 protected:
     LayoutUnit resolveLengthPercentageUsingContainerLogicalWidth(const auto&) const;
@@ -274,7 +274,7 @@ protected:
     void collectAbsoluteQuadsForContinuation(Vector<FloatQuad>& quads, bool* wasFixed) const;
 
 private:
-    ContinuationChainNode& ensureContinuationChainNode();
+    ContinuationChainNode& ensureContinuationChainNode() LIFETIME_BOUND;
 
     virtual LayoutRect frameRectForStickyPositioning() const = 0;
 

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -74,12 +74,12 @@ public:
 
     bool hasInitializedStyle() const { return m_hasInitializedStyle; }
 
-    const RenderStyle& style() const { return m_style; }
-    const RenderStyle* parentStyle() const { return !m_parent ? nullptr : &m_parent->style(); }
-    const RenderStyle& firstLineStyle() const;
+    const RenderStyle& style() const LIFETIME_BOUND { return m_style; }
+    const RenderStyle* parentStyle() const LIFETIME_BOUND { return !m_parent ? nullptr : &m_parent->style(); }
+    const RenderStyle& firstLineStyle() const LIFETIME_BOUND;
 
     // FIXME: Style shouldn't be mutated.
-    RenderStyle& mutableStyle() { return m_style; }
+    RenderStyle& mutableStyle() LIFETIME_BOUND { return m_style; }
 
     void initializeStyle();
 
@@ -91,7 +91,7 @@ public:
     // The pseudo element style can be cached or uncached. Use the uncached method if the pseudo element
     // has the concept of changing state (like ::-webkit-scrollbar-thumb:hover), or if it takes additional
     // parameters (like ::highlight(name)).
-    const RenderStyle* getCachedPseudoStyle(const Style::PseudoElementIdentifier&, const RenderStyle* parentStyle = nullptr) const;
+    const RenderStyle* getCachedPseudoStyle(const Style::PseudoElementIdentifier&, const RenderStyle* parentStyle = nullptr) const LIFETIME_BOUND;
     std::unique_ptr<RenderStyle> getUncachedPseudoStyle(const Style::PseudoElementRequest&, const RenderStyle* parentStyle = nullptr, const RenderStyle* ownStyle = nullptr) const;
 
     // This is null for anonymous renderers.
@@ -129,9 +129,9 @@ public:
     Color selectionForegroundColor() const;
     Color selectionEmphasisMarkColor() const;
 
-    const RenderStyle* spellingErrorPseudoStyle() const;
-    const RenderStyle* grammarErrorPseudoStyle() const;
-    const RenderStyle* targetTextPseudoStyle() const;
+    const RenderStyle* spellingErrorPseudoStyle() const LIFETIME_BOUND;
+    const RenderStyle* grammarErrorPseudoStyle() const LIFETIME_BOUND;
+    const RenderStyle* targetTextPseudoStyle() const LIFETIME_BOUND;
 
     virtual bool isChildAllowed(const RenderObject&, const RenderStyle&) const { return true; }
     void didAttachChild(RenderObject& child, RenderObject* beforeChild);
@@ -443,7 +443,7 @@ private:
     void updateReferencedSVGResources();
     void clearReferencedSVGResources();
 
-    const RenderStyle* textSegmentPseudoStyle(PseudoElementType) const;
+    const RenderStyle* textSegmentPseudoStyle(PseudoElementType) const LIFETIME_BOUND;
 
     template<typename> Color selectionColor() const;
 

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -192,7 +192,7 @@ void RenderFileUploadControl::paintControl(PaintInfo& paintInfo, const LayoutPoi
                         textVisualRect.setLocation(buttonTextRenderer->localToContainerPoint(textVisualRect.location(), this));
                         textVisualRect.moveBy(roundPointToDevicePixels(paintOffset, document().deviceScaleFactor()));
 
-                        auto metrics = textBox->style().fontCascade().metricsOfPrimaryFont();
+                        auto metrics = textBox->style()->fontCascade().metricsOfPrimaryFont();
 
                         if (!isHorizontalWritingMode) {
                             if (isBlockFlipped)

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -67,7 +67,7 @@ public:
     bool NODELETE isHorizontalFlow() const;
     Direction NODELETE crossAxisDirection() const;
 
-    const OrderIterator& orderIterator() const { return m_orderIterator; }
+    const OrderIterator& orderIterator() const LIFETIME_BOUND { return m_orderIterator; }
 
     LayoutOptionalOutsets allowedLayoutOverflow() const override;
 
@@ -119,7 +119,7 @@ private:
         LayoutUnit NODELETE hypotheticalMainAxisMarginBoxSize() const;
         LayoutUnit NODELETE flexBaseMarginBoxSize() const;
         LayoutUnit NODELETE flexedMarginBoxSize() const;
-        const RenderStyle& NODELETE style() const;
+        const RenderStyle& NODELETE style() const LIFETIME_BOUND;
         LayoutUnit constrainSizeByMinMax(const LayoutUnit size) const;
 
         CheckedRef<RenderBox> renderer;
@@ -153,12 +153,12 @@ private:
     bool NODELETE isLeftToRightFlow() const;
     bool NODELETE isMultiline() const;
     Style::FlexBasis flexBasisForFlexItem(const RenderBox& flexItem) const;
-    const Style::PreferredSize& NODELETE preferredMainSizeLengthForFlexItem(const RenderBox&) const;
-    const Style::MinimumSize& NODELETE minMainSizeLengthForFlexItem(const RenderBox&) const;
-    const Style::MaximumSize& NODELETE maxMainSizeLengthForFlexItem(const RenderBox&) const;
-    const Style::PreferredSize& NODELETE preferredCrossSizeLengthForFlexItem(const RenderBox&) const;
-    const Style::MinimumSize& NODELETE minCrossSizeLengthForFlexItem(const RenderBox&) const;
-    const Style::MaximumSize& NODELETE maxCrossSizeLengthForFlexItem(const RenderBox&) const;
+    const Style::PreferredSize& NODELETE preferredMainSizeLengthForFlexItem(const RenderBox&) const LIFETIME_BOUND;
+    const Style::MinimumSize& NODELETE minMainSizeLengthForFlexItem(const RenderBox&) const LIFETIME_BOUND;
+    const Style::MaximumSize& NODELETE maxMainSizeLengthForFlexItem(const RenderBox&) const LIFETIME_BOUND;
+    const Style::PreferredSize& NODELETE preferredCrossSizeLengthForFlexItem(const RenderBox&) const LIFETIME_BOUND;
+    const Style::MinimumSize& NODELETE minCrossSizeLengthForFlexItem(const RenderBox&) const LIFETIME_BOUND;
+    const Style::MaximumSize& NODELETE maxCrossSizeLengthForFlexItem(const RenderBox&) const LIFETIME_BOUND;
     bool shouldApplyMinSizeAutoForFlexItem(const RenderBox&) const;
     LayoutUnit NODELETE crossAxisExtentForFlexItem(const RenderBox& flexItem) const;
     LayoutUnit crossAxisIntrinsicExtentForFlexItem(RenderBox& flexItem);

--- a/Source/WebCore/rendering/RenderFragmentedFlow.h
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.h
@@ -70,7 +70,7 @@ public:
 
     virtual void addFragmentToThread(RenderFragmentContainer*) = 0;
     void removeFragmentFromThread(RenderFragmentContainer&);
-    const RenderFragmentContainerList& renderFragmentContainerList() const { return m_fragmentList; }
+    const RenderFragmentContainerList& renderFragmentContainerList() const LIFETIME_BOUND { return m_fragmentList; }
 
     void updateLogicalWidth() final;
     LogicalExtentComputedValues computeLogicalHeight(LayoutUnit logicalHeight, LayoutUnit logicalTop) const override;

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -90,9 +90,9 @@ public:
     void setNeedsItemPlacement(SubgridDidChange descendantSubgridsNeedItemPlacement = SubgridDidChange::No);
     Vector<LayoutUnit> trackSizesForComputedStyle(Style::GridTrackSizingDirection) const;
 
-    const Vector<LayoutUnit>& columnPositions() const { return m_columnPositions; }
-    const Vector<LayoutUnit>& rowPositions() const { return m_rowPositions; }
-    const Vector<LayoutUnit>& positions(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? columnPositions() : rowPositions(); }
+    const Vector<LayoutUnit>& columnPositions() const LIFETIME_BOUND { return m_columnPositions; }
+    const Vector<LayoutUnit>& rowPositions() const LIFETIME_BOUND { return m_rowPositions; }
+    const Vector<LayoutUnit>& positions(Style::GridTrackSizingDirection direction) const LIFETIME_BOUND { return direction == Style::GridTrackSizingDirection::Columns ? columnPositions() : rowPositions(); }
 
     unsigned autoRepeatCountForDirection(Style::GridTrackSizingDirection direction) const { return currentGrid().autoRepeatTracks(direction); }
     unsigned explicitGridStartForDirection(Style::GridTrackSizingDirection direction) const { return currentGrid().explicitGridStart(direction); }
@@ -138,8 +138,8 @@ public:
     bool areMasonryRows() const { return isMasonry(Style::GridTrackSizingDirection::Rows); }
     bool areMasonryColumns() const { return isMasonry(Style::GridTrackSizingDirection::Columns); }
 
-    const Grid& NODELETE currentGrid() const;
-    Grid& currentGrid();
+    const Grid& NODELETE currentGrid() const LIFETIME_BOUND;
+    Grid& currentGrid() LIFETIME_BOUND;
 
     unsigned numTracks(Style::GridTrackSizingDirection) const;
 
@@ -152,7 +152,7 @@ public:
     LayoutUnit NODELETE masonryContentSize() const;
 
     void updateIntrinsicLogicalHeightsForRowSizingFirstPassCacheAvailability();
-    std::optional<GridItemSizeCache>& NODELETE intrinsicLogicalHeightsForRowSizingFirstPass() const;
+    std::optional<GridItemSizeCache>& NODELETE intrinsicLogicalHeightsForRowSizingFirstPass() const LIFETIME_BOUND;
 
     bool shouldCheckExplicitIntrinsicInnerLogicalSize(Style::GridTrackSizingDirection) const;
 
@@ -274,10 +274,10 @@ private:
 
     AutoRepeatType autoRepeatType(Style::GridTrackSizingDirection) const;
 
-    Vector<LayoutUnit>& positions(Style::GridTrackSizingDirection direction) { return direction == Style::GridTrackSizingDirection::Columns ? m_columnPositions : m_rowPositions; }
+    Vector<LayoutUnit>& positions(Style::GridTrackSizingDirection direction) LIFETIME_BOUND { return direction == Style::GridTrackSizingDirection::Columns ? m_columnPositions : m_rowPositions; }
 
-    ContentAlignmentData& offsetBetweenTracks(Style::GridTrackSizingDirection direction) { return direction == Style::GridTrackSizingDirection::Columns ? m_offsetBetweenColumns : m_offsetBetweenRows; }
-    const ContentAlignmentData& offsetBetweenTracks(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? m_offsetBetweenColumns : m_offsetBetweenRows; }
+    ContentAlignmentData& offsetBetweenTracks(Style::GridTrackSizingDirection direction) LIFETIME_BOUND { return direction == Style::GridTrackSizingDirection::Columns ? m_offsetBetweenColumns : m_offsetBetweenRows; }
+    const ContentAlignmentData& offsetBetweenTracks(Style::GridTrackSizingDirection direction) const LIFETIME_BOUND { return direction == Style::GridTrackSizingDirection::Columns ? m_offsetBetweenColumns : m_offsetBetweenRows; }
 
     bool canCreateIntrinsicLogicalHeightsForRowSizingFirstPassCache() const;
 

--- a/Source/WebCore/rendering/RenderHighlight.h
+++ b/Source/WebCore/rendering/RenderHighlight.h
@@ -88,7 +88,7 @@ public:
 
     void NODELETE setRenderRange(const RenderRange&);
     bool setRenderRange(const HighlightRange&); // Returns true if successful.
-    const RenderRange& get() const { return m_renderRange; }
+    const RenderRange& get() const LIFETIME_BOUND { return m_renderRange; }
 
     RenderObject* start() const { return m_renderRange.start(); }
     RenderObject* end() const { return m_renderRange.end(); }

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -63,7 +63,7 @@ public:
 
     bool isGeneratedContent() const { return m_isGeneratedContent; }
 
-    const String& altText() const { return m_altText; }
+    const String& altText() const LIFETIME_BOUND { return m_altText; }
     void setAltText(const String& altText) { m_altText = altText; }
 
     void setImageDevicePixelRatio(float factor);

--- a/Source/WebCore/rendering/RenderInline.h
+++ b/Source/WebCore/rendering/RenderInline.h
@@ -70,11 +70,11 @@ public:
 
     LegacyInlineFlowBox* createAndAppendInlineFlowBox();
 
-    RenderLineBoxList& legacyLineBoxes() { return m_legacyLineBoxes; }
-    const RenderLineBoxList& legacyLineBoxes() const { return m_legacyLineBoxes; }
+    RenderLineBoxList& legacyLineBoxes() LIFETIME_BOUND { return m_legacyLineBoxes; }
+    const RenderLineBoxList& legacyLineBoxes() const LIFETIME_BOUND { return m_legacyLineBoxes; }
     void deleteLegacyLineBoxes();
-    LegacyInlineFlowBox* firstLegacyInlineBox() const { return m_legacyLineBoxes.firstLegacyLineBox(); }
-    LegacyInlineFlowBox* lastLegacyInlineBox() const { return m_legacyLineBoxes.lastLegacyLineBox(); }
+    LegacyInlineFlowBox* firstLegacyInlineBox() const LIFETIME_BOUND { return m_legacyLineBoxes.firstLegacyLineBox(); }
+    LegacyInlineFlowBox* lastLegacyInlineBox() const LIFETIME_BOUND { return m_legacyLineBoxes.lastLegacyLineBox(); }
 
 #if PLATFORM(IOS_FAMILY)
     void absoluteQuadsForSelection(Vector<FloatQuad>& quads) const override;

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -189,11 +189,11 @@ public:
     RenderLayerModelObject& renderer() const { return m_renderer; }
     RenderBox* renderBox() const { return dynamicDowncast<RenderBox>(renderer()); }
 
-    RenderLayer* parent() const { return m_parent.get(); }
-    RenderLayer* previousSibling() const { return m_previous.get(); }
-    RenderLayer* nextSibling() const { return m_next.get(); }
-    RenderLayer* firstChild() const { return m_first.get(); }
-    RenderLayer* lastChild() const { return m_last.get(); }
+    RenderLayer* parent() const LIFETIME_BOUND { return m_parent.get(); }
+    RenderLayer* previousSibling() const LIFETIME_BOUND { return m_previous.get(); }
+    RenderLayer* nextSibling() const LIFETIME_BOUND { return m_next.get(); }
+    RenderLayer* firstChild() const LIFETIME_BOUND { return m_first.get(); }
+    RenderLayer* lastChild() const LIFETIME_BOUND { return m_last.get(); }
     bool NODELETE isDescendantOf(const RenderLayer&) const;
     WEBCORE_EXPORT RenderLayer* commonAncestorWithLayer(const RenderLayer&) const;
 
@@ -479,10 +479,10 @@ public:
     RenderLayer* NODELETE reflectionLayer() const;
     bool NODELETE isReflectionLayer(const RenderLayer&) const;
 
-    inline const LayoutPoint& location() const;
+    inline const LayoutPoint& location() const LIFETIME_BOUND;
     void setLocation(const LayoutPoint& p) { m_topLeft = p; }
 
-    inline const IntSize& size() const;
+    inline const IntSize& size() const LIFETIME_BOUND;
     void setSize(const IntSize& size) { m_layerSize = size; } // Only public for RenderTreeAsText.
 
     inline LayoutRect rect() const;
@@ -540,7 +540,7 @@ public:
 
     bool hasCompositedLayerInEnclosingPaginationChain() const;
     enum PaginationInclusionMode { ExcludeCompositedPaginatedLayers, IncludeCompositedPaginatedLayers };
-    RenderLayer* enclosingPaginationLayer(PaginationInclusionMode mode) const
+    RenderLayer* enclosingPaginationLayer(PaginationInclusionMode mode) const LIFETIME_BOUND
     {
         if (mode == ExcludeCompositedPaginatedLayers && hasCompositedLayerInEnclosingPaginationChain())
             return nullptr;
@@ -552,7 +552,7 @@ public:
     void updateBlendMode();
     void NODELETE willRemoveChildWithBlendMode();
 
-    const LayoutSize& offsetForInFlowPosition() const { return m_offsetForPosition; }
+    const LayoutSize& offsetForInFlowPosition() const LIFETIME_BOUND { return m_offsetForPosition; }
 
     void clearClipRectsIncludingDescendants(ClipRectsType typeToClear = AllClipRectTypes);
     void clearClipRects(ClipRectsType typeToClear = AllClipRectTypes);
@@ -807,7 +807,7 @@ public:
 
     inline bool isTransformed() const;
     // Note that this transform has the transform-origin baked in.
-    TransformationMatrix* transform() const { return m_transform.get(); }
+    TransformationMatrix* transform() const LIFETIME_BOUND { return m_transform.get(); }
     // updateTransformFromStyle computes a transform according to the passed options (e.g. transform-origin baked in or excluded) and the given style.
     void updateTransformFromStyle(TransformationMatrix&, const RenderStyle&, OptionSet<Style::TransformResolverOption>) const;
     // currentTransform computes a transform which takes accelerated animations into account. The
@@ -878,19 +878,19 @@ public:
     void clearHasDescendantNeedingEventRegionUpdate() { m_hasDescendantNeedingEventRegionUpdate = false; }
 
     // If non-null, a non-ancestor composited layer that this layer paints into (it is sharing its backing store with this layer).
-    RenderLayer* backingProviderLayer() const { return m_backingProviderLayer.get(); }
+    RenderLayer* backingProviderLayer() const LIFETIME_BOUND { return m_backingProviderLayer.get(); }
     void setBackingProviderLayer(RenderLayer*, OptionSet<UpdateBackingSharingFlags>);
     void disconnectFromBackingProviderLayer(OptionSet<UpdateBackingSharingFlags>);
 
     bool paintsIntoProvidedBacking() const { return !!m_backingProviderLayer; }
 
-    RenderLayer* backingProviderLayerAtEndOfCompositingUpdate() const { return m_backingProviderLayerAtEndOfCompositingUpdate.get(); }
+    RenderLayer* backingProviderLayerAtEndOfCompositingUpdate() const LIFETIME_BOUND { return m_backingProviderLayerAtEndOfCompositingUpdate.get(); }
     void setBackingProviderLayerAtEndOfCompositingUpdate(RenderLayer* provider) { m_backingProviderLayerAtEndOfCompositingUpdate = provider; }
     RenderLayerModelObject* repaintContainer() const { return m_repaintContainer.get(); }
     void clearRepaintContainer() { m_repaintContainer = nullptr; }
 
-    RenderLayerBacking* backing() const { return m_backing.get(); }
-    RenderLayerBacking* ensureBacking();
+    RenderLayerBacking* backing() const LIFETIME_BOUND { return m_backing.get(); }
+    RenderLayerBacking* ensureBacking() LIFETIME_BOUND;
     void clearBacking(OptionSet<UpdateBackingSharingFlags>, bool layerBeingDestroyed = false);
 
     bool hasCompositedScrollingAncestor() const { return m_hasCompositedScrollingAncestor; }

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -83,7 +83,7 @@ public:
     RenderLayer& owningLayer() const { return m_owningLayer; }
 
     // Included layers are non-z-order descendant layers that are painted into this backing.
-    const InlineWeakKeyListHashSet<RenderLayer>& backingSharingLayers() const { return m_backingSharingLayers; }
+    const InlineWeakKeyListHashSet<RenderLayer>& backingSharingLayers() const LIFETIME_BOUND { return m_backingSharingLayers; }
     void setBackingSharingLayers(InlineWeakKeyListHashSet<RenderLayer>&&);
 
     bool hasBackingSharingLayers() const { return !m_backingSharingLayers.isEmptyIgnoringNullReferences(); }
@@ -114,11 +114,11 @@ public:
     GraphicsLayer* clippingLayer() const { return !m_isFrameLayerWithTiledBacking ? m_childContainmentLayer.get() : nullptr; }
 
     bool hasAncestorClippingLayers() const { return !!m_ancestorClippingStack; }
-    LayerAncestorClippingStack* ancestorClippingStack() const { return m_ancestorClippingStack.get(); }
+    LayerAncestorClippingStack* ancestorClippingStack() const LIFETIME_BOUND { return m_ancestorClippingStack.get(); }
     bool updateAncestorClippingStack(Vector<CompositedClipData>&&);
 
     void ensureOverflowControlsHostLayerAncestorClippingStack(const RenderLayer* compositedAncestor);
-    LayerAncestorClippingStack* overflowControlsHostLayerAncestorClippingStack() const { return m_overflowControlsHostLayerAncestorClippingStack.get(); }
+    LayerAncestorClippingStack* overflowControlsHostLayerAncestorClippingStack() const LIFETIME_BOUND { return m_overflowControlsHostLayerAncestorClippingStack.get(); }
 
     GraphicsLayer* contentsContainmentLayer() const { return m_contentsContainmentLayer.get(); }
     GraphicsLayer* viewportAnchorLayer() const { return m_viewportAnchorLayer.get(); }

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -410,7 +410,7 @@ public:
     
     void didPaintBacking(RenderLayerBacking*);
 
-    const Color& rootExtendedBackgroundColor() const { return m_rootExtendedBackgroundColor; }
+    const Color& rootExtendedBackgroundColor() const LIFETIME_BOUND { return m_rootExtendedBackgroundColor; }
 
     void updateRootContentLayerClipping();
 

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -57,7 +57,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    const LayoutRect& dirtySourceRect() const { return m_dirtySourceRect; }
+    const LayoutRect& dirtySourceRect() const LIFETIME_BOUND { return m_dirtySourceRect; }
     void expandDirtySourceRect(const LayoutRect& rect) { m_dirtySourceRect.unite(rect); }
 
     CSSFilterRenderer* filter() const { return m_filter.get(); }

--- a/Source/WebCore/rendering/RenderLayerInlines.h
+++ b/Source/WebCore/rendering/RenderLayerInlines.h
@@ -95,13 +95,13 @@ inline RenderSVGHiddenContainer* RenderLayer::enclosingSVGHiddenOrResourceContai
     return m_enclosingSVGHiddenOrResourceContainer.get();
 }
 
-inline const LayoutPoint& RenderLayer::location() const
+inline const LayoutPoint& RenderLayer::location() const LIFETIME_BOUND
 {
     ASSERT(!renderer().view().frameView().layerAccessPrevented());
     return m_topLeft;
 }
 
-inline const IntSize& RenderLayer::size() const
+inline const IntSize& RenderLayer::size() const LIFETIME_BOUND
 {
     ASSERT(!renderer().view().frameView().layerAccessPrevented());
     return m_layerSize;

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -54,7 +54,7 @@ public:
     void destroyLayer();
 
     bool NODELETE hasSelfPaintingLayer() const;
-    RenderLayer* layer() const { return m_layer.get(); }
+    RenderLayer* layer() const LIFETIME_BOUND { return m_layer.get(); }
 
     void styleWillChange(Style::Difference, const RenderStyle& newStyle) override;
     void styleDidChange(Style::Difference, const RenderStyle* oldStyle) override;

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -67,7 +67,7 @@ public:
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
     void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
 
-    RenderLayer& layer() { return m_layer; }
+    RenderLayer& layer() LIFETIME_BOUND { return m_layer; }
 
     void clear();
 

--- a/Source/WebCore/rendering/RenderLineBoxList.h
+++ b/Source/WebCore/rendering/RenderLineBoxList.h
@@ -47,8 +47,8 @@ public:
     ~RenderLineBoxList();
 #endif
 
-    LegacyInlineFlowBox* firstLegacyLineBox() const { return m_firstLineBox; }
-    LegacyInlineFlowBox* lastLegacyLineBox() const { return m_lastLineBox; }
+    LegacyInlineFlowBox* firstLegacyLineBox() const LIFETIME_BOUND { return m_firstLineBox; }
+    LegacyInlineFlowBox* lastLegacyLineBox() const LIFETIME_BOUND { return m_lastLineBox; }
 
     void checkConsistency() const;
 

--- a/Source/WebCore/rendering/RenderMultiColumnFlow.h
+++ b/Source/WebCore/rendering/RenderMultiColumnFlow.h
@@ -97,7 +97,7 @@ public:
     bool shouldCheckColumnBreaks() const override;
 
     using SpannerMap = SingleThreadWeakHashMap<const RenderBox, SingleThreadWeakPtr<RenderMultiColumnSpannerPlaceholder>>;
-    SpannerMap& spannerMap() { return m_spannerMap; }
+    SpannerMap& spannerMap() LIFETIME_BOUND { return m_spannerMap; }
 
 private:
     ASCIILiteral renderName() const override;

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -647,7 +647,7 @@ public:
 
     // Returns the full transform mapping from local coordinates to local coords for the parent SVG renderer
     // This includes any viewport transforms and x/y offsets as well as the transform="" value off the element.
-    virtual const AffineTransform& localToParentTransform() const;
+    virtual const AffineTransform& localToParentTransform() const LIFETIME_BOUND;
 
     // SVG uses FloatPoint precise hit testing, and passes the point in parent
     // coordinates instead of in repaint container coordinates.  Eventually the
@@ -859,14 +859,14 @@ public:
     // the rect that will be painted if this object is passed as the paintingRoot
     WEBCORE_EXPORT LayoutRect paintingRootRect(LayoutRect& topLevelRect);
 
-    inline const RenderStyle& style() const; // Defined in RenderObjectStyle.h.
-    inline const RenderStyle& firstLineStyle() const;
+    inline const RenderStyle& style() const LIFETIME_BOUND; // Defined in RenderObjectStyle.h.
+    inline CheckedRef<const RenderStyle> firstLineStyle() const LIFETIME_BOUND;
     inline WritingMode writingMode() const; // Defined in RenderObjectStyle.h.
     // writingMode().isHorizontal() is cached by isHorizontalWritingMode() above.
 
     // Anonymous blocks that are part of of a continuation chain will return their inline continuation's outline style instead.
     // This is typically only relevant when repainting.
-    virtual const RenderStyle& outlineStyleForRepaint() const;
+    virtual const RenderStyle& outlineStyleForRepaint() const LIFETIME_BOUND;
 
     virtual CursorDirective getCursor(const LayoutPoint&, Cursor&) const;
 

--- a/Source/WebCore/rendering/RenderObjectInlines.h
+++ b/Source/WebCore/rendering/RenderObjectInlines.h
@@ -63,7 +63,7 @@ inline TreeScope& RenderObject::treeScopeForSVGReferences() const
     return Ref { m_node.get() }->treeScopeForSVGReferences();
 }
 
-inline const RenderStyle& RenderObject::firstLineStyle() const
+inline CheckedRef<const RenderStyle> RenderObject::firstLineStyle() const
 {
     if (isRenderText())
         return protect(parent())->firstLineStyle();

--- a/Source/WebCore/rendering/RenderSelectionGeometry.h
+++ b/Source/WebCore/rendering/RenderSelectionGeometry.h
@@ -58,7 +58,7 @@ public:
     RenderSelectionGeometry(RenderObject& renderer, bool clipToVisibleContent);
 
     void repaint();
-    const Vector<FloatQuad>& collectedSelectionQuads() const { return m_collectedSelectionQuads; }
+    const Vector<FloatQuad>& collectedSelectionQuads() const LIFETIME_BOUND { return m_collectedSelectionQuads; }
     LayoutRect rect() const { return m_rect; }
 
 private:

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -94,8 +94,8 @@ public:
     struct ColumnStruct {
         unsigned span { 1 };
     };
-    const Vector<ColumnStruct>& columns() const { return m_columns; }
-    const Vector<LayoutUnit>& columnPositions() const { return m_columnPos; }
+    const Vector<ColumnStruct>& columns() const LIFETIME_BOUND { return m_columns; }
+    const Vector<LayoutUnit>& columnPositions() const LIFETIME_BOUND { return m_columnPos; }
     void setColumnPosition(unsigned index, LayoutUnit position)
     {
         // Note that if our horizontal border-spacing changed, our position will change but not
@@ -189,7 +189,7 @@ public:
     void invalidateCollapsedBorders(RenderTableCell* cellWithStyleChange = nullptr);
     void invalidateCollapsedBordersAfterStyleChangeIfNeeded(const RenderStyle& oldStyle, const RenderStyle& newStyle, RenderTableCell* cellWithStyleChange = nullptr);
     void collapsedEmptyBorderIsPresent() { m_collapsedEmptyBorderIsPresent = true; }
-    const CollapsedBorderValue* currentBorderValue() const { return m_currentBorder; }
+    const CollapsedBorderValue* currentBorderValue() const LIFETIME_BOUND { return m_currentBorder; }
     
     bool hasSections() const { return m_head || m_foot || m_firstBody; }
 

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -120,10 +120,10 @@ public:
     // Table layout always uses the table's writing mode.
     const WritingMode tableWritingMode() const { return table()->writingMode(); }
 
-    inline const BorderValue& borderAdjoiningTableStart() const;
-    inline const BorderValue& borderAdjoiningTableEnd() const;
-    inline const BorderValue& borderAdjoiningCellBefore(const RenderTableCell&);
-    inline const BorderValue& borderAdjoiningCellAfter(const RenderTableCell&);
+    inline const BorderValue& borderAdjoiningTableStart() const LIFETIME_BOUND;
+    inline const BorderValue& borderAdjoiningTableEnd() const LIFETIME_BOUND;
+    inline const BorderValue& borderAdjoiningCellBefore(const RenderTableCell&) LIFETIME_BOUND;
+    inline const BorderValue& borderAdjoiningCellAfter(const RenderTableCell&) LIFETIME_BOUND;
 
     using RenderBlockFlow::nodeAtPoint;
 #if ASSERT_ENABLED

--- a/Source/WebCore/rendering/RenderTableCol.cpp
+++ b/Source/WebCore/rendering/RenderTableCol.cpp
@@ -216,26 +216,26 @@ RenderTableCol* RenderTableCol::nextColumn() const
 
 const BorderValue& RenderTableCol::borderAdjoiningCellStartBorder() const
 {
-    return protect(style())->borderStart(table()->writingMode());
+    return style().borderStart(table()->writingMode());
 }
 
 const BorderValue& RenderTableCol::borderAdjoiningCellEndBorder() const
 {
-    return protect(style())->borderEnd(table()->writingMode());
+    return style().borderEnd(table()->writingMode());
 }
 
 const BorderValue& RenderTableCol::borderAdjoiningCellBefore(const RenderTableCell& cell) const
 {
     CheckedPtr table = this->table();
     ASSERT_UNUSED(cell, table->colElement(cell.col() + cell.colSpan()) == this);
-    return protect(style())->borderStart(table->writingMode());
+    return style().borderStart(table->writingMode());
 }
 
 const BorderValue& RenderTableCol::borderAdjoiningCellAfter(const RenderTableCell& cell) const
 {
     CheckedPtr table = this->table();
     ASSERT_UNUSED(cell, table->colElement(cell.col() - 1) == this);
-    return protect(style())->borderEnd(table->writingMode());
+    return style().borderEnd(table->writingMode());
 }
 
 LayoutUnit RenderTableCol::offsetLeft() const

--- a/Source/WebCore/rendering/RenderTableRow.h
+++ b/Source/WebCore/rendering/RenderTableRow.h
@@ -54,10 +54,10 @@ public:
     bool rowIndexWasSet() const { return m_rowIndex != unsetRowIndex; }
     unsigned rowIndex() const;
 
-    inline const BorderValue& borderAdjoiningTableStart() const;
-    inline const BorderValue& borderAdjoiningTableEnd() const;
-    const BorderValue& borderAdjoiningStartCell(const RenderTableCell&) const;
-    const BorderValue& borderAdjoiningEndCell(const RenderTableCell&) const;
+    inline const BorderValue& borderAdjoiningTableStart() const LIFETIME_BOUND;
+    inline const BorderValue& borderAdjoiningTableEnd() const LIFETIME_BOUND;
+    const BorderValue& borderAdjoiningStartCell(const RenderTableCell&) const LIFETIME_BOUND;
+    const BorderValue& borderAdjoiningEndCell(const RenderTableCell&) const LIFETIME_BOUND;
 
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;
 

--- a/Source/WebCore/rendering/RenderTableRowInlines.h
+++ b/Source/WebCore/rendering/RenderTableRowInlines.h
@@ -24,7 +24,7 @@
 
 namespace WebCore {
 
-inline const BorderValue& RenderTableRow::borderAdjoiningTableStart() const { return protect(style())->borderStart(table()->writingMode()); }
-inline const BorderValue& RenderTableRow::borderAdjoiningTableEnd() const { return protect(style())->borderEnd(table()->writingMode()); }
+inline const BorderValue& RenderTableRow::borderAdjoiningTableStart() const { return style().borderStart(table()->writingMode()); }
+inline const BorderValue& RenderTableRow::borderAdjoiningTableEnd() const { return style().borderEnd(table()->writingMode()); }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderTableSection.h
+++ b/Source/WebCore/rendering/RenderTableSection.h
@@ -94,13 +94,13 @@ public:
         Style::PreferredSize logicalHeight { CSS::Keyword::Auto { } };
     };
 
-    inline const BorderValue& borderAdjoiningTableStart() const;
-    inline const BorderValue& borderAdjoiningTableEnd() const;
-    const BorderValue& borderAdjoiningStartCell(const RenderTableCell&) const;
-    const BorderValue& borderAdjoiningEndCell(const RenderTableCell&) const;
+    inline const BorderValue& borderAdjoiningTableStart() const LIFETIME_BOUND;
+    inline const BorderValue& borderAdjoiningTableEnd() const LIFETIME_BOUND;
+    const BorderValue& borderAdjoiningStartCell(const RenderTableCell&) const LIFETIME_BOUND;
+    const BorderValue& borderAdjoiningEndCell(const RenderTableCell&) const LIFETIME_BOUND;
 
-    CellStruct& cellAt(unsigned row,  unsigned col);
-    const CellStruct& cellAt(unsigned row, unsigned col) const;
+    CellStruct& cellAt(unsigned row,  unsigned col) LIFETIME_BOUND;
+    const CellStruct& cellAt(unsigned row, unsigned col) const LIFETIME_BOUND;
     RenderTableCell* primaryCellAt(unsigned row, unsigned col);
     RenderTableRow* rowRendererAt(unsigned row) const;
 

--- a/Source/WebCore/rendering/RenderTableSectionInlines.h
+++ b/Source/WebCore/rendering/RenderTableSectionInlines.h
@@ -24,8 +24,8 @@
 
 namespace WebCore {
 
-inline const BorderValue& RenderTableSection::borderAdjoiningTableEnd() const { return protect(style())->borderEnd(table()->writingMode()); }
-inline const BorderValue& RenderTableSection::borderAdjoiningTableStart() const { return protect(style())->borderStart(table()->writingMode()); }
+inline const BorderValue& RenderTableSection::borderAdjoiningTableEnd() const { return style().borderEnd(table()->writingMode()); }
+inline const BorderValue& RenderTableSection::borderAdjoiningTableStart() const { return style().borderStart(table()->writingMode()); }
 
 inline LayoutUnit RenderTableSection::outerBorderBottom(const WritingMode writingMode) const
 {

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -62,24 +62,24 @@ public:
 
     WEBCORE_EXPORT Text* NODELETE textNode() const;
 
-    const RenderStyle& style() const;
+    const RenderStyle& style() const LIFETIME_BOUND;
 
-    const RenderStyle& firstLineStyle() const;
-    const RenderStyle* getCachedPseudoStyle(const Style::PseudoElementIdentifier&, const RenderStyle* parentStyle = nullptr) const;
+    const RenderStyle& firstLineStyle() const LIFETIME_BOUND;
+    const RenderStyle* getCachedPseudoStyle(const Style::PseudoElementIdentifier&, const RenderStyle* parentStyle = nullptr) const LIFETIME_BOUND;
 
     Color selectionBackgroundColor() const;
     Color selectionForegroundColor() const;
     Color selectionEmphasisMarkColor() const;
     std::unique_ptr<RenderStyle> selectionPseudoStyle() const;
 
-    const RenderStyle* spellingErrorPseudoStyle() const;
-    const RenderStyle* grammarErrorPseudoStyle() const;
-    const RenderStyle* targetTextPseudoStyle() const;
+    const RenderStyle* spellingErrorPseudoStyle() const LIFETIME_BOUND;
+    const RenderStyle* grammarErrorPseudoStyle() const LIFETIME_BOUND;
+    const RenderStyle* targetTextPseudoStyle() const LIFETIME_BOUND;
 
     virtual String originalText() const;
 
 
-    const String& text() const { return m_text; }
+    const String& text() const LIFETIME_BOUND { return m_text; }
     String textWithoutConvertingBackslashToYenSymbol() const;
 
     void boundingRects(Vector<LayoutRect>&, const LayoutPoint& accumulatedOffset) const final;

--- a/Source/WebCore/rendering/RenderTextFragment.h
+++ b/Source/WebCore/rendering/RenderTextFragment.h
@@ -54,7 +54,7 @@ public:
     void setContentString(const String& text);
     StringImpl* contentString() const { return m_contentString.impl(); }
 
-    const String& altText() const { return m_altText; }
+    const String& altText() const LIFETIME_BOUND { return m_altText; }
     void setAltText(const String& altText) { m_altText = altText; }
     
 private:

--- a/Source/WebCore/rendering/RenderTextLineBoxes.h
+++ b/Source/WebCore/rendering/RenderTextLineBoxes.h
@@ -37,8 +37,8 @@ class RenderTextLineBoxes {
 public:
     RenderTextLineBoxes();
 
-    LegacyInlineTextBox* first() const { return m_first; }
-    LegacyInlineTextBox* last() const { return m_last; }
+    LegacyInlineTextBox* first() const LIFETIME_BOUND { return m_first; }
+    LegacyInlineTextBox* last() const LIFETIME_BOUND { return m_last; }
 
     LegacyInlineTextBox* createAndAppendLineBox(RenderSVGInlineText&);
 

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -97,7 +97,7 @@ public:
     // Return the renderer whose background style is used to paint the root background.
     RenderElement* rendererForRootBackground() const;
 
-    RenderSelection& selection() { return m_selection; }
+    RenderSelection& selection() LIFETIME_BOUND { return m_selection; }
 
     bool printing() const;
 
@@ -130,7 +130,7 @@ public:
         m_legacyPrinting.m_truncatorWidth = 0;
         m_legacyPrinting.m_forcedPageBreak = false;
     }
-    const IntRect& printRect() const { return m_legacyPrinting.m_printRect; }
+    const IntRect& printRect() const LIFETIME_BOUND { return m_legacyPrinting.m_printRect; }
     void setPrintRect(const IntRect& r) { m_legacyPrinting.m_printRect = r; }
     // End deprecated functions.
 
@@ -167,7 +167,7 @@ public:
     void decrementRendersWithOutline() { ASSERT(m_renderersWithOutlineCount > 0); --m_renderersWithOutlineCount; }
     bool hasRenderersWithOutline() const { return m_renderersWithOutlineCount; }
 
-    ImageQualityController& imageQualityController();
+    ImageQualityController& imageQualityController() LIFETIME_BOUND;
 
     void setHasSoftwareFilters(bool hasSoftwareFilters) { m_hasSoftwareFilters = hasSoftwareFilters; }
     bool hasSoftwareFilters() const { return m_hasSoftwareFilters; }
@@ -201,19 +201,19 @@ public:
 
     void registerBoxWithScrollSnapPositions(const RenderBox&);
     void unregisterBoxWithScrollSnapPositions(const RenderBox&);
-    const SingleThreadWeakHashSet<const RenderBox>& boxesWithScrollSnapPositions() { return m_boxesWithScrollSnapPositions; }
+    const SingleThreadWeakHashSet<const RenderBox>& boxesWithScrollSnapPositions() LIFETIME_BOUND { return m_boxesWithScrollSnapPositions; }
 
     void registerContainerQueryBox(const RenderBox&);
     void unregisterContainerQueryBox(const RenderBox&);
-    const SingleThreadWeakHashSet<const RenderBox>& containerQueryBoxes() const { return m_containerQueryBoxes; }
+    const SingleThreadWeakHashSet<const RenderBox>& containerQueryBoxes() const LIFETIME_BOUND { return m_containerQueryBoxes; }
 
     void registerAnchor(const RenderBoxModelObject&);
     void unregisterAnchor(const RenderBoxModelObject&);
-    const SingleThreadWeakHashSet<const RenderBoxModelObject>& anchors() const { return m_anchors; }
+    const SingleThreadWeakHashSet<const RenderBoxModelObject>& anchors() const LIFETIME_BOUND { return m_anchors; }
 
     void registerPositionTryBox(const RenderBox&);
     void unregisterPositionTryBox(const RenderBox&);
-    const SingleThreadWeakHashSet<const RenderBox>& positionTryBoxes() const { return m_positionTryBoxes; }
+    const SingleThreadWeakHashSet<const RenderBox>& positionTryBoxes() const LIFETIME_BOUND { return m_positionTryBoxes; }
 
     SingleThreadWeakPtr<RenderBlockFlow> NODELETE viewTransitionContainingBlock() const;
     void setViewTransitionContainingBlock(RenderBlockFlow& renderer);

--- a/Source/WebCore/rendering/TextAutoSizing.h
+++ b/Source/WebCore/rendering/TextAutoSizing.h
@@ -47,7 +47,7 @@ public:
     explicit TextAutoSizingKey(DeletedTag);
     TextAutoSizingKey(const RenderStyle&, unsigned hash);
 
-    const RenderStyle* style() const { ASSERT(!isDeleted()); return m_style.get(); }
+    const RenderStyle* style() const LIFETIME_BOUND { ASSERT(!isDeleted()); return m_style.get(); }
     bool isDeleted() const { return HashTraits<std::unique_ptr<RenderStyle>>::isDeletedValue(m_style); }
     static constexpr bool safeToCompareToHashTableEmptyOrDeletedValue = true;
 

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -759,7 +759,7 @@ static inline Style::TextDecorationLine computedTextDecorationType(const RenderS
     return textDecorations;
 }
 
-static inline const RenderStyle& decoratingBoxStyleForInlineBox(const InlineIterator::InlineBox& inlineBox, bool isFirstLine)
+static inline CheckedRef<const RenderStyle> decoratingBoxStyleForInlineBox(const InlineIterator::InlineBox& inlineBox, bool isFirstLine)
 {
     if (!inlineBox.isRootInlineBox())
         return inlineBox.style();
@@ -807,10 +807,10 @@ void TextBoxPainter::collectDecoratingBoxesForBackgroundPainting(DecoratingBoxLi
 
     enum UseOverriderDecorationStyle : bool { No, Yes };
     auto appendIfIsDecoratingBoxForBackground = [&] (auto& inlineBox, auto useOverriderDecorationStyle) {
-        auto& style = decoratingBoxStyleForInlineBox(*inlineBox, m_isFirstLine);
+        CheckedRef style = decoratingBoxStyleForInlineBox(*inlineBox, m_isFirstLine);
 
         auto computedDecorationStyle = [&] {
-            return TextDecorationPainter::stylesForRenderer(inlineBox->renderer(), style.textDecorationLineInEffect(), m_isFirstLine);
+            return TextDecorationPainter::stylesForRenderer(inlineBox->renderer(), style->textDecorationLineInEffect(), m_isFirstLine);
         };
         if (!isDecoratingBoxForBackground(*inlineBox, style)) {
             // Some cases even non-decoration boxes may have some decoration pieces coming from the marked text (e.g. highlight).
@@ -896,7 +896,7 @@ void TextBoxPainter::paintBackgroundDecorations(TextDecorationPainter& decoratio
         m_paintInfo.context().concatCTM(rotation(m_paintRect, RotationDirection::Counterclockwise));
 }
 
-static const RenderStyle& decoratingBoxStyle(const InlineIterator::TextBoxIterator& textBox)
+static CheckedRef<const RenderStyle> decoratingBoxStyle(const InlineIterator::TextBoxIterator& textBox)
 {
     if (auto parentInlineBox = textBox->parentInlineBox())
         return parentInlineBox->style();
@@ -907,9 +907,9 @@ static const RenderStyle& decoratingBoxStyle(const InlineIterator::TextBoxIterat
 void TextBoxPainter::paintForegroundDecorations(TextDecorationPainter& decorationPainter, const StyledMarkedText& markedText, const FloatRect& textBoxPaintRect)
 {
     auto textBox = makeIterator();
-    auto& styleForDecoration = decoratingBoxStyle(textBox);
+    CheckedRef styleForDecoration = decoratingBoxStyle(textBox);
     auto computedTextDecorationType = [&] {
-        auto textDecorations = styleForDecoration.textDecorationLineInEffect();
+        auto textDecorations = styleForDecoration->textDecorationLineInEffect();
         textDecorations.addOrReplaceIfNotNone(TextDecorationPainter::textDecorationsInEffectForStyle(markedText.style.textDecorationStyles));
         return textDecorations;
     }();
@@ -927,7 +927,7 @@ void TextBoxPainter::paintForegroundDecorations(TextDecorationPainter& decoratio
         , textBoxPaintRect.width()
         , textDecorationThickness
         , linethroughCenter
-        , wavyStrokeParameters(styleForDecoration.computedFontSize()) }, markedText.style.textDecorationStyles);
+        , wavyStrokeParameters(styleForDecoration->computedFontSize()) }, markedText.style.textDecorationStyles);
 
     if (m_isCombinedText)
         m_paintInfo.context().concatCTM(rotation(m_paintRect, RotationDirection::Counterclockwise));

--- a/Source/WebCore/rendering/TextBoxPainter.h
+++ b/Source/WebCore/rendering/TextBoxPainter.h
@@ -57,7 +57,7 @@ public:
     static inline FloatSize rotateShadowOffset(const SpaceSeparatedPoint<Style::Length<CSS::AllUnzoomed>>& offset, WritingMode, const Style::ZoomFactor&);
 
 protected:
-    auto& textBox() const { return m_textBox; }
+    auto& textBox() const LIFETIME_BOUND { return m_textBox; }
     InlineIterator::TextBoxIterator makeIterator() const;
 
     void paintBackgroundFill();

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -346,19 +346,19 @@ static void collectStylesForRenderer(TextDecorationPainter::Styles& result, cons
         }
     };
 
-    auto styleForRenderer = [&] (const RenderObject& renderer) -> const RenderStyle& {
+    auto styleForRenderer = [&] (const RenderObject& renderer) -> CheckedRef<const RenderStyle> {
         if (pseudoElementType && renderer.style().hasPseudoStyle(*pseudoElementType)) {
             if (auto textRenderer = dynamicDowncast<RenderText>(renderer))
                 return *textRenderer->getCachedPseudoStyle({ *pseudoElementType });
             return *downcast<RenderElement>(renderer).getCachedPseudoStyle({ *pseudoElementType });
         }
-        return firstLineStyle ? renderer.firstLineStyle() : renderer.style();
+        return firstLineStyle ? renderer.firstLineStyle() : CheckedRef { renderer.style() };
     };
 
     auto* current = &renderer;
     do {
-        const auto& style = styleForRenderer(*current);
-        extractDecorations(style, style.textDecorationLine());
+        CheckedRef style = styleForRenderer(*current);
+        extractDecorations(style, style->textDecorationLine());
 
         if (current->style().display() == Style::DisplayType::RubyText)
             return;

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -84,7 +84,7 @@ public:
 
     RenderObject* currentObject() { return m_current.renderer(); }
     LegacyInlineIterator lineBreak() { return m_lineBreak; }
-    LineWidth& lineWidth() { return m_width; }
+    LineWidth& lineWidth() LIFETIME_BOUND { return m_width; }
     bool atEnd() { return m_atEnd; }
     
     bool fitsOnLineOrHangsAtEnd() const { return m_width.fitsOnLine() || m_hangsAtEnd; }
@@ -342,25 +342,25 @@ inline bool BreakingContext::handleText()
     if (m_autoWrap && m_lastObjectTextWrap == TextWrapMode::NoWrap && m_ignoringSpaces)
         commitLineBreakAtCurrentWidth(renderer);
 
-    const RenderStyle& style = lineStyle(renderer, m_lineInfo);
-    const FontCascade& font = style.fontCascade();
-    bool canHangPunctuationAtStart = style.hangingPunctuation().contains(Style::HangingPunctuationValue::First);
-    bool canHangPunctuationAtEnd = style.hangingPunctuation().contains(Style::HangingPunctuationValue::Last);
-    bool canHangStopOrCommaAtLineEnd = style.hangingPunctuation().contains(Style::HangingPunctuationValue::AllowEnd);
+    CheckedRef style = lineStyle(renderer, m_lineInfo);
+    const FontCascade& font = style->fontCascade();
+    bool canHangPunctuationAtStart = style->hangingPunctuation().contains(Style::HangingPunctuationValue::First);
+    bool canHangPunctuationAtEnd = style->hangingPunctuation().contains(Style::HangingPunctuationValue::Last);
+    bool canHangStopOrCommaAtLineEnd = style->hangingPunctuation().contains(Style::HangingPunctuationValue::AllowEnd);
     int endPunctuationIndex = canHangPunctuationAtEnd && m_collapseWhiteSpace ? renderer.lastCharacterIndexStrippingSpaces() : renderer.text().length() - 1;
 
     float wrapWidthOffset = m_width.uncommittedWidth() + inlineLogicalWidth(renderer, !m_appliedStartWidth, true);
     float wrapW = wrapWidthOffset;
     float charWidth = 0;
-    bool breakNBSP = m_autoWrap && style.nbspMode() == NBSPMode::Space;
+    bool breakNBSP = m_autoWrap && style->nbspMode() == NBSPMode::Space;
     // Auto-wrapping text should wrap in the middle of a word only if it could not wrap before the word,
     // which is only possible if the word is the first thing on the line.
     auto isWrappingAllowed = m_currentTextWrap != TextWrapMode::NoWrap;
-    bool breakWords = isWrappingAllowed && style.breakWords() && !m_width.committedWidth() && !m_width.hasCommittedReplaced();
+    bool breakWords = isWrappingAllowed && style->breakWords() && !m_width.committedWidth() && !m_width.hasCommittedReplaced();
     bool midWordBreak = false;
-    bool breakAnywhere = style.lineBreak() == LineBreak::Anywhere && m_autoWrap;
-    bool breakAll = (style.wordBreak() == WordBreak::BreakAll || breakAnywhere) && m_autoWrap;
-    bool keepAllWords = style.wordBreak() == WordBreak::KeepAll;
+    bool breakAnywhere = style->lineBreak() == LineBreak::Anywhere && m_autoWrap;
+    bool breakAll = (style->wordBreak() == WordBreak::BreakAll || breakAnywhere) && m_autoWrap;
+    bool keepAllWords = style->wordBreak() == WordBreak::KeepAll;
     auto iteratorMode = mapLineBreakToIteratorMode(m_blockStyle.lineBreak());
     auto contentAnalysis = mapWordBreakToContentAnalysis(m_blockStyle.wordBreak());
     bool canUseLineBreakShortcut = iteratorMode == TextBreakIterator::LineMode::Behavior::Default
@@ -375,7 +375,7 @@ inline bool BreakingContext::handleText()
         m_renderTextInfo.text = &renderer;
         m_renderTextInfo.font = &font;
         m_renderTextInfo.layout = font.createLayout(renderer, m_width.currentWidth(), m_collapseWhiteSpace);
-        m_renderTextInfo.lineBreakIteratorFactory.resetStringAndReleaseIterator(renderer.text(), Style::toPlatform(style.computedLocale()), iteratorMode, contentAnalysis);
+        m_renderTextInfo.lineBreakIteratorFactory.resetStringAndReleaseIterator(renderer.text(), Style::toPlatform(style->computedLocale()), iteratorMode, contentAnalysis);
     } else if (m_renderTextInfo.layout && m_renderTextInfo.font != &font) {
         m_renderTextInfo.font = &font;
         m_renderTextInfo.layout = font.createLayout(renderer, m_width.currentWidth(), m_collapseWhiteSpace);
@@ -483,7 +483,7 @@ inline bool BreakingContext::handleText()
                 // as candidate width for this line.
                 bool lineWasTooWide = false;
                 auto mayBreakSpaces = m_currentWhitespaceCollapse == WhiteSpaceCollapse::BreakSpaces && m_currentTextWrap == TextWrapMode::Wrap;
-                if (fitsOnLineOrHangsAtEnd() && m_currentCharacterIsWS && style.breakOnlyAfterWhiteSpace() && (!midWordBreak || mayBreakSpaces)) {
+                if (fitsOnLineOrHangsAtEnd() && m_currentCharacterIsWS && style->breakOnlyAfterWhiteSpace() && (!midWordBreak || mayBreakSpaces)) {
                     float charWidth = 0;
                     // Check if line is too big even without the extra space
                     // at the end of the line. If it is not, do nothing.
@@ -543,7 +543,7 @@ inline bool BreakingContext::handleText()
                 midWordBreak &= canBreakMidWord;
             }
 
-            if (!m_ignoringSpaces && style.collapseWhiteSpace()) {
+            if (!m_ignoringSpaces && style->collapseWhiteSpace()) {
                 // If we encounter a newline, or if we encounter a second space,
                 // we need to break up this run and enter a mode where we start collapsing spaces.
                 if (m_currentCharacterIsSpace && previousCharacterIsSpace) {
@@ -593,13 +593,13 @@ inline bool BreakingContext::handleText()
         }
 
         if (!m_currentCharacterIsWS && previousCharacterIsWS) {
-            if (m_autoWrap && style.breakOnlyAfterWhiteSpace())
+            if (m_autoWrap && style->breakOnlyAfterWhiteSpace())
                 m_lineBreak.moveTo(renderer, m_current.offset(), m_current.nextBreakablePosition());
         }
 
         if (m_collapseWhiteSpace && m_currentCharacterIsSpace && !m_ignoringSpaces)
             m_trailingObjects.setTrailingWhitespace(renderer);
-        else if (!style.collapseWhiteSpace() || !m_currentCharacterIsSpace)
+        else if (!style->collapseWhiteSpace() || !m_currentCharacterIsSpace)
             m_trailingObjects.clear();
 
         m_atStart = false;

--- a/Source/WebCore/rendering/line/LineInlineHeaders.h
+++ b/Source/WebCore/rendering/line/LineInlineHeaders.h
@@ -33,20 +33,20 @@ namespace WebCore {
 
 enum WhitespacePosition : bool { LeadingWhitespace, TrailingWhitespace };
 
-inline const RenderStyle& lineStyle(const RenderObject& renderer, const LineInfo& lineInfo)
+inline CheckedRef<const RenderStyle> lineStyle(const RenderObject& renderer, const LineInfo& lineInfo)
 {
-    return lineInfo.isFirstLine() ? renderer.firstLineStyle() : renderer.style();
+    return lineInfo.isFirstLine() ? renderer.firstLineStyle() : CheckedRef { renderer.style() };
 }
 
 inline bool requiresLineBoxForContent(const RenderInline& flow, const LineInfo& lineInfo)
 {
     RenderElement* parent = flow.parent();
     if (flow.document().inNoQuirksMode()) {
-        const RenderStyle& flowStyle = lineStyle(flow, lineInfo);
-        const RenderStyle& parentStyle = lineStyle(*parent, lineInfo);
-        if (flowStyle.lineHeight() != parentStyle.lineHeight()
-            || flowStyle.verticalAlign() != parentStyle.verticalAlign()
-            || !parentStyle.fontCascade().metricsOfPrimaryFont().hasIdenticalAscentDescentAndLineGap(flowStyle.fontCascade().metricsOfPrimaryFont()))
+        CheckedRef flowStyle = lineStyle(flow, lineInfo);
+        CheckedRef parentStyle = lineStyle(*parent, lineInfo);
+        if (flowStyle->lineHeight() != parentStyle->lineHeight()
+            || flowStyle->verticalAlign() != parentStyle->verticalAlign()
+            || !parentStyle->fontCascade().metricsOfPrimaryFont().hasIdenticalAscentDescentAndLineGap(flowStyle->fontCascade().metricsOfPrimaryFont()))
         return true;
     }
     return false;

--- a/Source/WebCore/rendering/shapes/PolygonLayoutShape.h
+++ b/Source/WebCore/rendering/shapes/PolygonLayoutShape.h
@@ -43,8 +43,8 @@ public:
     {
     }
 
-    const FloatPoint& vertex1() const override { return m_vertex1; }
-    const FloatPoint& vertex2() const override { return m_vertex2; }
+    const FloatPoint& vertex1() const LIFETIME_BOUND override { return m_vertex1; }
+    const FloatPoint& vertex2() const LIFETIME_BOUND override { return m_vertex2; }
 
     bool isWithinYRange(float y1, float y2) const { return y1 <= minY() && y2 >= maxY(); }
     bool overlapsYRange(float y1, float y2) const { return y2 >= minY() && y1 <= maxY(); }

--- a/Source/WebCore/rendering/shapes/RasterLayoutShape.h
+++ b/Source/WebCore/rendering/shapes/RasterLayoutShape.h
@@ -48,16 +48,16 @@ public:
     }
 
     void initializeBounds();
-    const IntRect& bounds() const { return m_bounds; }
+    const IntRect& bounds() const LIFETIME_BOUND { return m_bounds; }
     bool isEmpty() const { return m_bounds.isEmpty(); }
 
-    IntShapeInterval& intervalAt(int y)
+    IntShapeInterval& intervalAt(int y) LIFETIME_BOUND
     {
         ASSERT(y + m_offset >= 0 && static_cast<unsigned>(y + m_offset) < m_intervals.size());
         return m_intervals[y + m_offset];
     }
 
-    const IntShapeInterval& intervalAt(int y) const
+    const IntShapeInterval& intervalAt(int y) const LIFETIME_BOUND
     {
         ASSERT(y + m_offset >= 0 && static_cast<unsigned>(y + m_offset) < m_intervals.size());
         return m_intervals[y + m_offset];
@@ -99,7 +99,7 @@ public:
     }
 
 private:
-    const RasterShapeIntervals& marginIntervals() const;
+    const RasterShapeIntervals& marginIntervals() const LIFETIME_BOUND;
 
     const std::unique_ptr<RasterShapeIntervals> m_intervals;
     const std::unique_ptr<RasterShapeIntervals> m_marginIntervals;

--- a/Source/WebCore/rendering/style/BorderData.h
+++ b/Source/WebCore/rendering/style/BorderData.h
@@ -98,30 +98,30 @@ struct BorderData {
     BorderStylesView<false> styles() { return { .data = *this }; }
     BorderStylesView<true> styles() const { return { .data = *this }; }
 
-    BorderValue& left() { return edges.left(); }
-    BorderValue& right() { return edges.right(); }
-    BorderValue& top() { return edges.top(); }
-    BorderValue& bottom() { return edges.bottom(); }
+    BorderValue& left() LIFETIME_BOUND { return edges.left(); }
+    BorderValue& right() LIFETIME_BOUND { return edges.right(); }
+    BorderValue& top() LIFETIME_BOUND { return edges.top(); }
+    BorderValue& bottom() LIFETIME_BOUND { return edges.bottom(); }
 
-    const BorderValue& left() const { return edges.left(); }
-    const BorderValue& right() const { return edges.right(); }
-    const BorderValue& top() const { return edges.top(); }
-    const BorderValue& bottom() const { return edges.bottom(); }
+    const BorderValue& left() const LIFETIME_BOUND { return edges.left(); }
+    const BorderValue& right() const LIFETIME_BOUND { return edges.right(); }
+    const BorderValue& top() const LIFETIME_BOUND { return edges.top(); }
+    const BorderValue& bottom() const LIFETIME_BOUND { return edges.bottom(); }
 
-    Style::BorderRadiusValue& topLeftRadius() { return radii.topLeft(); }
-    Style::BorderRadiusValue& topRightRadius() { return radii.topRight(); }
-    Style::BorderRadiusValue& bottomLeftRadius() { return radii.bottomLeft(); }
-    Style::BorderRadiusValue& bottomRightRadius() { return radii.bottomRight(); }
+    Style::BorderRadiusValue& topLeftRadius() LIFETIME_BOUND { return radii.topLeft(); }
+    Style::BorderRadiusValue& topRightRadius() LIFETIME_BOUND { return radii.topRight(); }
+    Style::BorderRadiusValue& bottomLeftRadius() LIFETIME_BOUND { return radii.bottomLeft(); }
+    Style::BorderRadiusValue& bottomRightRadius() LIFETIME_BOUND { return radii.bottomRight(); }
 
-    const Style::BorderRadiusValue& topLeftRadius() const { return radii.topLeft(); }
-    const Style::BorderRadiusValue& topRightRadius() const { return radii.topRight(); }
-    const Style::BorderRadiusValue& bottomLeftRadius() const { return radii.bottomLeft(); }
-    const Style::BorderRadiusValue& bottomRightRadius() const { return radii.bottomRight(); }
+    const Style::BorderRadiusValue& topLeftRadius() const LIFETIME_BOUND { return radii.topLeft(); }
+    const Style::BorderRadiusValue& topRightRadius() const LIFETIME_BOUND { return radii.topRight(); }
+    const Style::BorderRadiusValue& bottomLeftRadius() const LIFETIME_BOUND { return radii.bottomLeft(); }
+    const Style::BorderRadiusValue& bottomRightRadius() const LIFETIME_BOUND { return radii.bottomRight(); }
 
-    const Style::CornerShapeValue& topLeftCornerShape() const { return cornerShapes.topLeft(); }
-    const Style::CornerShapeValue& topRightCornerShape() const { return cornerShapes.topRight(); }
-    const Style::CornerShapeValue& bottomLeftCornerShape() const { return cornerShapes.bottomLeft(); }
-    const Style::CornerShapeValue& bottomRightCornerShape() const { return cornerShapes.bottomRight(); }
+    const Style::CornerShapeValue& topLeftCornerShape() const LIFETIME_BOUND { return cornerShapes.topLeft(); }
+    const Style::CornerShapeValue& topRightCornerShape() const LIFETIME_BOUND { return cornerShapes.topRight(); }
+    const Style::CornerShapeValue& bottomLeftCornerShape() const LIFETIME_BOUND { return cornerShapes.bottomLeft(); }
+    const Style::CornerShapeValue& bottomRightCornerShape() const LIFETIME_BOUND { return cornerShapes.bottomRight(); }
 
     bool containsCurrentColor() const;
 

--- a/Source/WebCore/rendering/style/CollapsedBorderValue.h
+++ b/Source/WebCore/rendering/style/CollapsedBorderValue.h
@@ -51,7 +51,7 @@ public:
     LayoutUnit width() const { return isVisibleBorderStyle(style()) ? m_width : 0_lu; }
     BorderStyle style() const { return static_cast<BorderStyle>(m_style); }
     bool exists() const { return precedence() != BorderPrecedence::Off; }
-    const Color& color() const { return m_color; }
+    const Color& color() const LIFETIME_BOUND { return m_color; }
     bool isTransparent() const { return m_transparent; }
     BorderPrecedence precedence() const { return static_cast<BorderPrecedence>(m_precedence); }
 

--- a/Source/WebCore/rendering/style/GridArea.h
+++ b/Source/WebCore/rendering/style/GridArea.h
@@ -59,7 +59,7 @@ public:
     GridSpan columns;
     GridSpan rows;
 
-    const GridSpan& span(Style::GridTrackSizingDirection direction) const
+    const GridSpan& span(Style::GridTrackSizingDirection direction) const LIFETIME_BOUND
     {
         return direction == Style::GridTrackSizingDirection::Columns ? columns : rows;
     }

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -200,7 +200,7 @@ public:
     // MARK: - Pseudo element/style
 
     std::optional<PseudoElementType> pseudoElementType() const;
-    const AtomString& pseudoElementNameArgument() const;
+    const AtomString& pseudoElementNameArgument() const LIFETIME_BOUND;
 
     std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier() const;
     inline void setPseudoElementIdentifier(std::optional<Style::PseudoElementIdentifier>&&);
@@ -209,17 +209,17 @@ public:
     inline bool hasPseudoStyle(PseudoElementType) const;
     inline void setHasPseudoStyles(EnumSet<PseudoElementType>);
 
-    RenderStyle* getCachedPseudoStyle(const Style::PseudoElementIdentifier&) const;
-    RenderStyle* addCachedPseudoStyle(std::unique_ptr<RenderStyle>);
+    RenderStyle* getCachedPseudoStyle(const Style::PseudoElementIdentifier&) const LIFETIME_BOUND;
+    RenderStyle* addCachedPseudoStyle(std::unique_ptr<RenderStyle>) LIFETIME_BOUND;
 
     bool hasCachedPseudoStyles() const { return m_computedStyle.hasCachedPseudoStyles(); }
-    const Style::PseudoStyleCache& cachedPseudoStyles() const { return m_computedStyle.cachedPseudoStyles(); }
+    const Style::PseudoStyleCache& cachedPseudoStyles() const LIFETIME_BOUND { return m_computedStyle.cachedPseudoStyles(); }
 
     // MARK: - Custom properties
 
-    inline const Style::CustomPropertyData& inheritedCustomProperties() const;
-    inline const Style::CustomPropertyData& nonInheritedCustomProperties() const;
-    const Style::CustomProperty* customPropertyValue(const AtomString&) const;
+    inline const Style::CustomPropertyData& inheritedCustomProperties() const LIFETIME_BOUND;
+    inline const Style::CustomPropertyData& nonInheritedCustomProperties() const LIFETIME_BOUND;
+    const Style::CustomProperty* customPropertyValue(const AtomString&) const LIFETIME_BOUND;
     void setCustomPropertyValue(Ref<const Style::CustomProperty>&&, bool isInherited);
     bool customPropertyValueEqual(const RenderStyle&, const AtomString&) const;
     bool customPropertiesEqual(const RenderStyle&) const;
@@ -248,16 +248,16 @@ public:
     inline FontCascade& mutableFontCascadeWithoutUpdate();
     inline void setFontCascade(FontCascade&&);
 
-    inline const FontCascadeDescription& fontDescription() const;
-    inline FontCascadeDescription& mutableFontDescriptionWithoutUpdate();
+    inline const FontCascadeDescription& fontDescription() const LIFETIME_BOUND;
+    inline FontCascadeDescription& mutableFontDescriptionWithoutUpdate() LIFETIME_BOUND;
     inline void setFontDescription(FontCascadeDescription&&);
     inline bool setFontDescriptionWithoutUpdate(FontCascadeDescription&&);
 
-    inline const FontMetrics& metricsOfPrimaryFont() const;
+    inline const FontMetrics& metricsOfPrimaryFont() const LIFETIME_BOUND;
     inline std::pair<FontOrientation, NonCJKGlyphOrientation> fontAndGlyphOrientation();
     inline float computedFontSize() const;
     inline Style::WebkitLocale computedLocale() const;
-    inline const Style::LineHeight& specifiedLineHeight() const;
+    inline const Style::LineHeight& specifiedLineHeight() const LIFETIME_BOUND;
 #if ENABLE(TEXT_AUTOSIZING)
     inline void setSpecifiedLineHeight(Style::LineHeight&&);
 #endif
@@ -275,7 +275,7 @@ public:
 
     // MARK: - Used Counter Directives
 
-    inline const CounterDirectiveMap& usedCounterDirectives() const;
+    inline const CounterDirectiveMap& usedCounterDirectives() const LIFETIME_BOUND;
 
     // MARK: - Writing Modes
 
@@ -285,34 +285,34 @@ public:
 
     // MARK: - Aggregates
 
-    inline Style::Animations& ensureAnimations();
-    inline Style::BackgroundLayers& ensureBackgroundLayers();
-    inline Style::MaskLayers& ensureMaskLayers();
-    inline Style::Transitions& ensureTransitions();
-    inline Style::ScrollTimelines& ensureScrollTimelines();
-    inline Style::ViewTimelines& ensureViewTimelines();
+    inline Style::Animations& ensureAnimations() LIFETIME_BOUND;
+    inline Style::BackgroundLayers& ensureBackgroundLayers() LIFETIME_BOUND;
+    inline Style::MaskLayers& ensureMaskLayers() LIFETIME_BOUND;
+    inline Style::Transitions& ensureTransitions() LIFETIME_BOUND;
+    inline Style::ScrollTimelines& ensureScrollTimelines() LIFETIME_BOUND;
+    inline Style::ViewTimelines& ensureViewTimelines() LIFETIME_BOUND;
 
-    inline const BorderData& border() const;
-    inline const BorderValue& borderBottom() const;
-    inline const BorderValue& borderLeft() const;
-    inline const BorderValue& borderRight() const;
-    inline const BorderValue& borderTop() const;
-    inline const Style::Animations& animations() const;
-    inline const Style::BackgroundLayers& backgroundLayers() const;
-    inline const Style::BorderImage& borderImage() const;
-    inline const Style::BorderRadius& borderRadii() const;
-    inline const Style::InsetBox& insetBox() const;
-    inline const Style::MarginBox& marginBox() const;
-    inline const Style::MaskBorder& maskBorder() const;
-    inline const Style::MaskLayers& maskLayers() const;
-    inline const Style::PaddingBox& paddingBox() const;
-    inline const Style::PerspectiveOrigin& perspectiveOrigin() const;
-    inline const Style::ScrollMarginBox& scrollMarginBox() const;
-    inline const Style::ScrollPaddingBox& scrollPaddingBox() const;
-    inline const Style::ScrollTimelines& scrollTimelines() const;
-    inline const Style::TransformOrigin& transformOrigin() const;
-    inline const Style::Transitions& transitions() const;
-    inline const Style::ViewTimelines& viewTimelines() const;
+    inline const BorderData& border() const LIFETIME_BOUND;
+    inline const BorderValue& borderBottom() const LIFETIME_BOUND;
+    inline const BorderValue& borderLeft() const LIFETIME_BOUND;
+    inline const BorderValue& borderRight() const LIFETIME_BOUND;
+    inline const BorderValue& borderTop() const LIFETIME_BOUND;
+    inline const Style::Animations& animations() const LIFETIME_BOUND;
+    inline const Style::BackgroundLayers& backgroundLayers() const LIFETIME_BOUND;
+    inline const Style::BorderImage& borderImage() const LIFETIME_BOUND;
+    inline const Style::BorderRadius& borderRadii() const LIFETIME_BOUND;
+    inline const Style::InsetBox& insetBox() const LIFETIME_BOUND;
+    inline const Style::MarginBox& marginBox() const LIFETIME_BOUND;
+    inline const Style::MaskBorder& maskBorder() const LIFETIME_BOUND;
+    inline const Style::MaskLayers& maskLayers() const LIFETIME_BOUND;
+    inline const Style::PaddingBox& paddingBox() const LIFETIME_BOUND;
+    inline const Style::PerspectiveOrigin& perspectiveOrigin() const LIFETIME_BOUND;
+    inline const Style::ScrollMarginBox& scrollMarginBox() const LIFETIME_BOUND;
+    inline const Style::ScrollPaddingBox& scrollPaddingBox() const LIFETIME_BOUND;
+    inline const Style::ScrollTimelines& scrollTimelines() const LIFETIME_BOUND;
+    inline const Style::TransformOrigin& transformOrigin() const LIFETIME_BOUND;
+    inline const Style::Transitions& transitions() const LIFETIME_BOUND;
+    inline const Style::ViewTimelines& viewTimelines() const LIFETIME_BOUND;
 
     inline void setBackgroundLayers(Style::BackgroundLayers&&);
     inline void setBorderImage(Style::BorderImage&&);
@@ -335,7 +335,7 @@ public:
     inline CursorType cursorType() const;
 
     // `@page size`
-    inline const Style::PageSize& pageSize() const;
+    inline const Style::PageSize& pageSize() const LIFETIME_BOUND;
     inline void setPageSize(Style::PageSize&&);
 
     // MARK: - Style reset utilities
@@ -353,20 +353,20 @@ public:
     // MARK: - Logical Values
 
     // Logical Inset aliases
-    inline const Style::InsetEdge& logicalLeft() const;
-    inline const Style::InsetEdge& logicalRight() const;
-    inline const Style::InsetEdge& logicalTop() const;
-    inline const Style::InsetEdge& logicalBottom() const;
+    inline const Style::InsetEdge& logicalLeft() const LIFETIME_BOUND;
+    inline const Style::InsetEdge& logicalRight() const LIFETIME_BOUND;
+    inline const Style::InsetEdge& logicalTop() const LIFETIME_BOUND;
+    inline const Style::InsetEdge& logicalBottom() const LIFETIME_BOUND;
 
     // Logical Border (aggregate)
-    const BorderValue& NODELETE borderBefore(const WritingMode) const;
-    const BorderValue& NODELETE borderAfter(const WritingMode) const;
-    const BorderValue& NODELETE borderStart(const WritingMode) const;
-    const BorderValue& NODELETE borderEnd(const WritingMode) const;
-    inline const BorderValue& borderBefore() const;
-    inline const BorderValue& borderAfter() const;
-    inline const BorderValue& borderStart() const;
-    inline const BorderValue& borderEnd() const;
+    const BorderValue& NODELETE borderBefore(const WritingMode) const LIFETIME_BOUND;
+    const BorderValue& NODELETE borderAfter(const WritingMode) const LIFETIME_BOUND;
+    const BorderValue& NODELETE borderStart(const WritingMode) const LIFETIME_BOUND;
+    const BorderValue& NODELETE borderEnd(const WritingMode) const LIFETIME_BOUND;
+    inline const BorderValue& borderBefore() const LIFETIME_BOUND;
+    inline const BorderValue& borderAfter() const LIFETIME_BOUND;
+    inline const BorderValue& borderStart() const LIFETIME_BOUND;
+    inline const BorderValue& borderEnd() const LIFETIME_BOUND;
 
     // Logical Aspect Ratio
     inline Style::Number<CSS::Nonnegative> aspectRatioLogicalWidth() const;
@@ -375,11 +375,11 @@ public:
     inline BoxSizing boxSizingForAspectRatio() const;
 
     // Logical Grid
-    inline const Style::GridTrackSizes& gridAutoList(Style::GridTrackSizingDirection) const;
-    inline const Style::GridTemplateList& gridTemplateList(Style::GridTrackSizingDirection) const;
-    inline const Style::GridPosition& gridItemStart(Style::GridTrackSizingDirection) const;
-    inline const Style::GridPosition& gridItemEnd(Style::GridTrackSizingDirection) const;
-    inline const Style::GapGutter& gap(Style::GridTrackSizingDirection) const;
+    inline const Style::GridTrackSizes& gridAutoList(Style::GridTrackSizingDirection) const LIFETIME_BOUND;
+    inline const Style::GridTemplateList& gridTemplateList(Style::GridTrackSizingDirection) const LIFETIME_BOUND;
+    inline const Style::GridPosition& gridItemStart(Style::GridTrackSizingDirection) const LIFETIME_BOUND;
+    inline const Style::GridPosition& gridItemEnd(Style::GridTrackSizingDirection) const LIFETIME_BOUND;
+    inline const Style::GapGutter& gap(Style::GridTrackSizingDirection) const LIFETIME_BOUND;
 
     // MARK: - Derived Values
 
@@ -393,7 +393,7 @@ public:
 
     // MARK: - Used Values
 
-    const AtomString& hyphenString() const;
+    const AtomString& hyphenString() const LIFETIME_BOUND;
     float usedStrokeWidth(const IntSize& viewportSize) const;
     Color usedStrokeColor() const;
     Color usedStrokeColorApplyingColorFilter() const;
@@ -487,8 +487,8 @@ public:
 
     // MARK: - Underlying ComputedStyle
 
-    Style::ComputedStyle& computedStyle() { return m_computedStyle; }
-    const Style::ComputedStyle& computedStyle() const { return m_computedStyle; }
+    Style::ComputedStyle& computedStyle() LIFETIME_BOUND { return m_computedStyle; }
+    const Style::ComputedStyle& computedStyle() const LIFETIME_BOUND { return m_computedStyle; }
 
 private:
     friend class Style::DifferenceFunctions;
@@ -496,12 +496,12 @@ private:
     // This constructor is used to implement the replace operation.
     RenderStyle(RenderStyle&, RenderStyle&&);
 
-    const Style::NonInheritedData& nonInheritedData() const { return computedStyle().nonInheritedData(); }
-    const Style::ComputedStyle::NonInheritedFlags& nonInheritedFlags() const { return computedStyle().nonInheritedFlags(); }
-    const Style::InheritedRareData& inheritedRareData() const { return computedStyle().inheritedRareData(); }
-    const Style::InheritedData& inheritedData() const { return computedStyle().inheritedData(); }
-    const Style::ComputedStyle::InheritedFlags& inheritedFlags() const { return computedStyle().inheritedFlags(); }
-    const Style::SVGData& svgData() const { return computedStyle().svgData(); }
+    const Style::NonInheritedData& nonInheritedData() const LIFETIME_BOUND { return computedStyle().nonInheritedData(); }
+    const Style::ComputedStyle::NonInheritedFlags& nonInheritedFlags() const LIFETIME_BOUND { return computedStyle().nonInheritedFlags(); }
+    const Style::InheritedRareData& inheritedRareData() const LIFETIME_BOUND { return computedStyle().inheritedRareData(); }
+    const Style::InheritedData& inheritedData() const LIFETIME_BOUND { return computedStyle().inheritedData(); }
+    const Style::ComputedStyle::InheritedFlags& inheritedFlags() const LIFETIME_BOUND { return computedStyle().inheritedFlags(); }
+    const Style::SVGData& svgData() const LIFETIME_BOUND { return computedStyle().svgData(); }
 };
 
 constexpr BorderStyle collapsedBorderStyle(BorderStyle);

--- a/Source/WebCore/rendering/svg/RenderSVGInlineText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGInlineText.h
@@ -41,8 +41,8 @@ public:
     Text& textNode() const { return downcast<Text>(nodeForNonAnonymous()); }
 
     bool characterStartsNewTextChunk(int position) const;
-    SVGTextLayoutAttributes* layoutAttributes() { return &m_layoutAttributes; }
-    const SVGTextLayoutAttributes* layoutAttributes() const { return &m_layoutAttributes; }
+    SVGTextLayoutAttributes* layoutAttributes() LIFETIME_BOUND { return &m_layoutAttributes; }
+    const SVGTextLayoutAttributes* layoutAttributes() const LIFETIME_BOUND { return &m_layoutAttributes; }
 
     // computeScalingFactor() returns the font-size scaling factor, ignoring the text-rendering mode.
     // scalingFactor() takes it into account, and thus returns 1 whenever text-rendering is set to 'geometricPrecision'.

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -79,7 +79,7 @@ public:
     FloatPoint getPointAtLength(float distance) const;
 
     bool hasPath() const { return m_path.get(); }
-    Path& path() const
+    Path& path() const LIFETIME_BOUND
     {
         ASSERT(m_path);
         return *m_path;
@@ -103,7 +103,7 @@ public:
 protected:
     void element() const = delete;
 
-    Path& ensurePath();
+    Path& ensurePath() LIFETIME_BOUND;
 
     virtual void updateShapeFromElement() = 0;
     virtual bool NODELETE isEmpty() const;

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -60,7 +60,7 @@ public:
     static const RenderSVGText* locateRenderSVGTextAncestor(const RenderObject&);
 
     bool needsReordering() const { return m_needsReordering; }
-    Vector<SVGTextLayoutAttributes*>& layoutAttributes() { return m_layoutAttributes; }
+    Vector<SVGTextLayoutAttributes*>& layoutAttributes() LIFETIME_BOUND { return m_layoutAttributes; }
 
     void subtreeChildWasAdded(RenderObject*);
     void subtreeChildWillBeRemoved(RenderObject*, Vector<SVGTextLayoutAttributes*, 2>& affectedAttributes);
@@ -115,7 +115,7 @@ private:
 
     // FIXME: [LBSE] Begin code only needed for legacy SVG engine.
     bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint& pointInParent, HitTestAction) override;
-    const AffineTransform& localToParentTransform() const override { return m_localTransform; }
+    const AffineTransform& localToParentTransform() const LIFETIME_BOUND override { return m_localTransform; }
     AffineTransform localTransform() const override { return m_localTransform; }
     // FIXME: [LBSE] End code only needed for legacy SVG engine.
 

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.h
@@ -40,7 +40,7 @@ public:
     SVGGeometryElement* targetElement() const;
 
     Path layoutPath() const;
-    const SVGLengthValue& NODELETE startOffset() const;
+    const SVGLengthValue& NODELETE startOffset() const LIFETIME_BOUND;
 
 private:
     void graphicsElement() const = delete;

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.h
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.h
@@ -42,7 +42,7 @@ public:
 
     FloatRect calculateBoundaries() const;
 
-    const Vector<SVGTextFragment>& textFragments() const { return m_textFragments; }
+    const Vector<SVGTextFragment>& textFragments() const LIFETIME_BOUND { return m_textFragments; }
     void setTextFragments(Vector<SVGTextFragment>&&);
 
     void dirtyOwnLineBoxes() override;

--- a/Source/WebCore/rendering/svg/SVGPaintServerHandling.h
+++ b/Source/WebCore/rendering/svg/SVGPaintServerHandling.h
@@ -44,7 +44,7 @@ public:
 
     ~SVGPaintServerHandling() = default;
 
-    GraphicsContext& context() const { return m_context; }
+    GraphicsContext& context() const LIFETIME_BOUND { return m_context; }
 
     enum class Operation : bool { Fill, Stroke };
     enum class URIResolving : bool { Disabled, Enabled };

--- a/Source/WebCore/rendering/svg/SVGTextChunkBuilder.h
+++ b/Source/WebCore/rendering/svg/SVGTextChunkBuilder.h
@@ -41,7 +41,7 @@ public:
     SVGTextChunkBuilder(SVGTextChunkBuilder&&) = default;
     SVGTextChunkBuilder(const SVGTextChunkBuilder&) = delete;
 
-    const Vector<SVGTextChunk>& textChunks() const { return m_textChunks; }
+    const Vector<SVGTextChunk>& textChunks() const LIFETIME_BOUND { return m_textChunks; }
     unsigned NODELETE totalCharacters() const;
     float totalLength() const;
     float totalAnchorShift() const;

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.h
@@ -55,11 +55,11 @@ public:
     RenderSVGInlineText& NODELETE context();
     const RenderSVGInlineText& context() const;
     
-    SVGCharacterDataMap& characterDataMap() { return m_characterDataMap; }
-    const SVGCharacterDataMap& characterDataMap() const { return m_characterDataMap; }
+    SVGCharacterDataMap& characterDataMap() LIFETIME_BOUND { return m_characterDataMap; }
+    const SVGCharacterDataMap& characterDataMap() const LIFETIME_BOUND { return m_characterDataMap; }
 
-    Vector<SVGTextMetrics>& textMetricsValues() { return m_textMetricsValues; }
-    const Vector<SVGTextMetrics>& textMetricsValues() const { return m_textMetricsValues; }
+    Vector<SVGTextMetrics>& textMetricsValues() LIFETIME_BOUND { return m_textMetricsValues; }
+    const Vector<SVGTextMetrics>& textMetricsValues() const LIFETIME_BOUND { return m_textMetricsValues; }
 
 private:
     SingleThreadWeakRef<RenderSVGInlineText> m_context;

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
@@ -48,7 +48,7 @@ public:
     SVGTextLayoutEngine(SVGTextLayoutEngine&&) = default;
     SVGTextLayoutEngine(const SVGTextLayoutEngine&) = delete;
 
-    Vector<SVGTextLayoutAttributes*>& layoutAttributes() { return m_layoutAttributes; }
+    Vector<SVGTextLayoutAttributes*>& layoutAttributes() LIFETIME_BOUND { return m_layoutAttributes; }
 
     void beginTextPathLayout(const RenderSVGTextPath&, SVGTextLayoutEngine& lineLayout);
     void endTextPathLayout();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h
@@ -60,7 +60,7 @@ private:
     void updateLogicalWidth() override;
     LogicalExtentComputedValues computeLogicalHeight(LayoutUnit logicalHeight, LayoutUnit logicalTop) const override;
 
-    const AffineTransform& localToParentTransform() const override;
+    const AffineTransform& localToParentTransform() const LIFETIME_BOUND override;
     AffineTransform localTransform() const override { return m_localTransform; }
 
     LayoutSize offsetFromContainer(const RenderElement&, const LayoutPoint&, bool* offsetDependsOnPoint = nullptr) const override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
@@ -61,7 +61,7 @@ private:
     ASCIILiteral renderName() const override { return "RenderSVGImage"_s; }
     bool canHaveChildren() const override { return false; }
 
-    const AffineTransform& localToParentTransform() const override { return m_localTransform; }
+    const AffineTransform& localToParentTransform() const LIFETIME_BOUND override { return m_localTransform; }
 
     void notifyFinished(CachedResource& newImage, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess) override;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h
@@ -50,7 +50,7 @@ public:
     void layout() override;
     void calcViewport() override;
 
-    const AffineTransform& localToParentTransform() const override;
+    const AffineTransform& localToParentTransform() const LIFETIME_BOUND override;
     AffineTransform markerTransformation(const FloatPoint& origin, float angle, float strokeWidth) const;
 
     OptionSet<ApplyResult> applyResource(RenderElement&, const RenderStyle&, GraphicsContext*&, OptionSet<RenderSVGResourceMode>) override { return { }; }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.h
@@ -45,7 +45,7 @@ public:
 
     RenderSVGResourceType resourceType() const override { return SolidColorResourceType; }
 
-    const Color& color() const { return m_color; }
+    const Color& color() const LIFETIME_BOUND { return m_color; }
     void setColor(const Color& color) { m_color = color; }
 
 private:

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -60,7 +60,7 @@ public:
     bool hasRelativeDimensions() const override;
 
     // localToBorderBoxTransform maps local SVG viewport coordinates to local CSS box coordinates.  
-    const AffineTransform& localToBorderBoxTransform() const { return m_localToBorderBoxTransform; }
+    const AffineTransform& localToBorderBoxTransform() const LIFETIME_BOUND { return m_localToBorderBoxTransform; }
 
     // The flag is cleared at the beginning of each layout() pass. Elements then call this
     // method during layout when they are invalidated by a filter.
@@ -91,7 +91,7 @@ private:
 
     void styleDidChange(Style::Difference, const RenderStyle* oldStyle) override;
 
-    const AffineTransform& localToParentTransform() const override;
+    const AffineTransform& localToParentTransform() const LIFETIME_BOUND override;
 
     FloatRect objectBoundingBox() const override { return m_objectBoundingBox.value_or(FloatRect()); }
     FloatRect strokeBoundingBox() const override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
@@ -77,7 +77,7 @@ public:
     FloatPoint getPointAtLength(float distance) const;
 
     bool hasPath() const { return m_path.get(); }
-    Path& path() const
+    Path& path() const LIFETIME_BOUND
     {
         ASSERT(m_path);
         return *m_path;
@@ -89,7 +89,7 @@ public:
 protected:
     void element() const = delete;
 
-    Path& ensurePath();
+    Path& ensurePath() LIFETIME_BOUND;
 
     virtual void updateShapeFromElement() = 0;
     virtual bool NODELETE isEmpty() const;
@@ -116,7 +116,7 @@ private:
 
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final;
     FloatRect decoratedBoundingBox() const final;
-    const AffineTransform& localToParentTransform() const final { return m_localTransform; }
+    const AffineTransform& localToParentTransform() const LIFETIME_BOUND final { return m_localTransform; }
     AffineTransform localTransform() const final { return m_localTransform; }
 
     bool canHaveChildren() const final { return false; }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h
@@ -34,11 +34,11 @@ public:
     LegacyRenderSVGTransformableContainer(SVGGraphicsElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGTransformableContainer();
 
-    const AffineTransform& localToParentTransform() const override { return m_localTransform; }
+    const AffineTransform& localToParentTransform() const LIFETIME_BOUND override { return m_localTransform; }
     void setNeedsTransformUpdate() override { m_needsTransformUpdate = true; }
     bool didTransformToRootUpdate() override { return m_didTransformToRootUpdate; }
 
-    const FloatSize& additionalTranslation() const { return m_additionalTranslation; }
+    const FloatSize& additionalTranslation() const LIFETIME_BOUND { return m_additionalTranslation; }
 
 private:
     SVGGraphicsElement& NODELETE graphicsElement();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h
@@ -53,7 +53,7 @@ private:
     ASCIILiteral renderName() const override { return "RenderSVGViewportContainer"_s; }
 
     AffineTransform viewportTransform() const;
-    const AffineTransform& localToParentTransform() const override { return m_localToParentTransform; }
+    const AffineTransform& localToParentTransform() const LIFETIME_BOUND override { return m_localToParentTransform; }
 
     void calcViewport() override;
     bool calculateLocalTransform() override;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.h
@@ -121,20 +121,20 @@ private:
 #endif
     class Continuation;
 
-    FirstLetter& firstLetterBuilder() { return m_firstLetterBuilder; }
-    List& listBuilder() { return m_listBuilder; }
-    MultiColumn& multiColumnBuilder() { return m_multiColumnBuilder; }
-    Table& tableBuilder() { return m_tableBuilder; }
-    Ruby& rubyBuilder() { return m_rubyBuilder; }
-    FormControls& formControlsBuilder() { return m_formControlsBuilder; }
-    Block& blockBuilder() { return m_blockBuilder; }
-    BlockFlow& blockFlowBuilder() { return m_blockFlowBuilder; }
-    Inline& inlineBuilder() { return m_inlineBuilder; }
-    SVG& svgBuilder() { return m_svgBuilder; }
+    FirstLetter& firstLetterBuilder() LIFETIME_BOUND { return m_firstLetterBuilder; }
+    List& listBuilder() LIFETIME_BOUND { return m_listBuilder; }
+    MultiColumn& multiColumnBuilder() LIFETIME_BOUND { return m_multiColumnBuilder; }
+    Table& tableBuilder() LIFETIME_BOUND { return m_tableBuilder; }
+    Ruby& rubyBuilder() LIFETIME_BOUND { return m_rubyBuilder; }
+    FormControls& formControlsBuilder() LIFETIME_BOUND { return m_formControlsBuilder; }
+    Block& blockBuilder() LIFETIME_BOUND { return m_blockBuilder; }
+    BlockFlow& blockFlowBuilder() LIFETIME_BOUND { return m_blockFlowBuilder; }
+    Inline& inlineBuilder() LIFETIME_BOUND { return m_inlineBuilder; }
+    SVG& svgBuilder() LIFETIME_BOUND { return m_svgBuilder; }
 #if ENABLE(MATHML)
-    MathML& mathMLBuilder() { return m_mathMLBuilder; }
+    MathML& mathMLBuilder() LIFETIME_BOUND { return m_mathMLBuilder; }
 #endif
-    Continuation& continuationBuilder() { return m_continuationBuilder; }
+    Continuation& continuationBuilder() LIFETIME_BOUND { return m_continuationBuilder; }
 
     WidgetHierarchyUpdatesSuspensionScope m_widgetHierarchyUpdatesSuspensionScope;
     RenderView& m_view;

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.h
@@ -85,12 +85,12 @@ private:
         Parent(ContainerNode& root);
         Parent(Element&, const Style::ElementUpdate*);
     };
-    Parent& parent() { return m_parentStack.last(); }
+    Parent& parent() LIFETIME_BOUND { return m_parentStack.last(); }
     Parent& NODELETE renderingParent();
     RenderTreePosition& NODELETE renderTreePosition();
 
-    GeneratedContent& generatedContent() { return m_generatedContent; }
-    ViewTransition& viewTransition() { return m_viewTransition; }
+    GeneratedContent& generatedContent() LIFETIME_BOUND { return m_generatedContent; }
+    ViewTransition& viewTransition() LIFETIME_BOUND { return m_viewTransition; }
 
     void pushParent(Element&, const Style::ElementUpdate*);
     void popParent();

--- a/Source/WebCore/style/InlineTextBoxStyle.cpp
+++ b/Source/WebCore/style/InlineTextBoxStyle.cpp
@@ -69,13 +69,14 @@ static float minLogicalTopForTextDecorationLineUnder(const InlineIterator::LineB
         if (run->renderer().isOutOfFlowPositioned())
             continue; // Positioned placeholders don't affect calculations.
 
-        if (!run->style().textDecorationLineInEffect().hasUnderline())
+        CheckedRef runStyle = run->style();
+        if (!runStyle->textDecorationLineInEffect().hasUnderline())
             continue; // If the text decoration isn't in effect on the child, then it must be outside of |decoratingBoxRendererForUnderline|'s hierarchy.
 
         if (auto* renderInline = dynamicDowncast<RenderInline>(decoratingBoxRendererForUnderline); renderInline && !isAncestorAndWithinBlock(*renderInline, &run->renderer()))
             continue;
 
-        if (run->isText() || run->style().textDecorationSkipInk() == TextDecorationSkipInk::None)
+        if (run->isText() || runStyle->textDecorationSkipInk() == TextDecorationSkipInk::None)
             minLogicalTop = std::min<float>(minLogicalTop, run->logicalTop());
     }
     return minLogicalTop;
@@ -88,13 +89,14 @@ static float maxLogicalBottomForTextDecorationLineUnder(const InlineIterator::Li
         if (run->renderer().isOutOfFlowPositioned())
             continue; // Positioned placeholders don't affect calculations.
 
-        if (!run->style().textDecorationLineInEffect().hasUnderline())
+        CheckedRef runStyle = run->style();
+        if (!runStyle->textDecorationLineInEffect().hasUnderline())
             continue; // If the text decoration isn't in effect on the child, then it must be outside of |decoratingBoxRendererForUnderline|'s hierarchy.
 
         if (auto* renderInline = dynamicDowncast<RenderInline>(decoratingBoxRendererForUnderline); renderInline && !isAncestorAndWithinBlock(*renderInline, &run->renderer()))
             continue;
 
-        if (run->isText() || run->style().textDecorationSkipInk() == TextDecorationSkipInk::None)
+        if (run->isText() || runStyle->textDecorationSkipInk() == TextDecorationSkipInk::None)
             maxLogicalBottom = std::max<float>(maxLogicalBottom, run->logicalBottom());
     }
     return maxLogicalBottom;


### PR DESCRIPTION
#### 49805299ef532e6944fdc72c9b7ec6c39e4ad291
<pre>
Adopt `LIFETIME_BOUND` annotation in more places in layout &amp; rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=309211">https://bugs.webkit.org/show_bug.cgi?id=309211</a>

Reviewed by Alan Baradlay.

Also fix issues reported by the compiler after the LIFETIME_BOUND adoption.

* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::textRuns):
* Source/WebCore/layout/FormattingState.h:
(WebCore::Layout::FormattingState::layoutState const): Deleted.
* Source/WebCore/layout/LayoutContext.h:
* Source/WebCore/layout/LayoutState.h:
* Source/WebCore/layout/floats/FloatingContext.h:
(WebCore::Layout::FloatingContext::placedFloats const): Deleted.
* Source/WebCore/layout/floats/PlacedFloats.h:
(WebCore::Layout::PlacedFloats::list const): Deleted.
(WebCore::Layout::PlacedFloats::last const): Deleted.
* Source/WebCore/layout/formattingContexts/FormattingContext.h:
(WebCore::Layout::FormattingContext::layoutState const): Deleted.
* Source/WebCore/layout/formattingContexts/FormattingGeometry.h:
(WebCore::Layout::FormattingGeometry::layoutState const): Deleted.
(WebCore::Layout::FormattingGeometry::formattingContext const): Deleted.
* Source/WebCore/layout/formattingContexts/FormattingQuirks.h:
(WebCore::Layout::FormattingQuirks::layoutState const): Deleted.
(WebCore::Layout::FormattingQuirks::formattingContext const): Deleted.
* Source/WebCore/layout/formattingContexts/block/BlockFormattingContext.h:
(WebCore::Layout::BlockFormattingContext::formattingState const): Deleted.
(WebCore::Layout::BlockFormattingContext::formattingGeometry const): Deleted.
(WebCore::Layout::BlockFormattingContext::formattingQuirks const): Deleted.
(WebCore::Layout::BlockFormattingContext::formattingState): Deleted.
* Source/WebCore/layout/formattingContexts/block/BlockFormattingState.h:
(WebCore::Layout::BlockFormattingState::placedFloats const): Deleted.
(WebCore::Layout::BlockFormattingState::placedFloats): Deleted.
(WebCore::Layout::BlockFormattingState::outOfFlowBoxes const): Deleted.
* Source/WebCore/layout/formattingContexts/block/BlockLayoutState.h:
(WebCore::Layout::BlockLayoutState::placedFloats): Deleted.
(WebCore::Layout::BlockLayoutState::placedFloats const): Deleted.
(WebCore::Layout::BlockLayoutState::lineGrid const): Deleted.
(WebCore::Layout::BlockLayoutState::marginState): Deleted.
(WebCore::Layout::BlockLayoutState::marginState const): Deleted.
* Source/WebCore/layout/formattingContexts/block/BlockMarginCollapse.h:
(WebCore::Layout::BlockMarginCollapse::layoutState const): Deleted.
(WebCore::Layout::BlockMarginCollapse::formattingState const): Deleted.
* Source/WebCore/layout/formattingContexts/block/tablewrapper/TableWrapperBlockFormattingContext.h:
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingConstraints.h:
(WebCore::Layout::ConstraintsForFlexContent::mainAxis const): Deleted.
(WebCore::Layout::ConstraintsForFlexContent::crossAxis const): Deleted.
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingContext.h:
(WebCore::Layout::FlexFormattingContext::formattingUtils const): Deleted.
(WebCore::Layout::FlexFormattingContext::integrationUtils const): Deleted.
* Source/WebCore/layout/formattingContexts/flex/FlexFormattingUtils.h:
(WebCore::Layout::FlexFormattingUtils::formattingContext const): Deleted.
* Source/WebCore/layout/formattingContexts/flex/FlexLayout.h:
(WebCore::Layout::FlexLayout::flexContainerStyle const): Deleted.
* Source/WebCore/layout/formattingContexts/flex/LogicalFlexItem.h:
(WebCore::Layout::LogicalFlexItem::mainAxis const): Deleted.
(WebCore::Layout::LogicalFlexItem::crossAxis const): Deleted.
(WebCore::Layout::LogicalFlexItem::style const): Deleted.
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h:
(WebCore::Layout::GridFormattingContext::integrationUtils const): Deleted.
(WebCore::Layout::GridFormattingContext::layoutState const): Deleted.
(WebCore::Layout::GridFormattingContext::gridContainerStyle const): Deleted.
* Source/WebCore/layout/formattingContexts/grid/GridLayout.h:
(WebCore::Layout::GridLayout::formattingContext const): Deleted.
* Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h:
(WebCore::Layout::PlacedGridItem::inlineAxisSizes const): Deleted.
(WebCore::Layout::PlacedGridItem::blockAxisSizes const): Deleted.
(WebCore::Layout::PlacedGridItem::inlineAxisAlignment const): Deleted.
(WebCore::Layout::PlacedGridItem::blockAxisAlignment const): Deleted.
(WebCore::Layout::PlacedGridItem::writingMode const): Deleted.
(WebCore::Layout::PlacedGridItem::gridAreaLines const): Deleted.
(WebCore::Layout::PlacedGridItem::usedZoom const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/AbstractLineBuilder.h:
(WebCore::Layout::AbstractLineBuilder::inlineContentBreaker): Deleted.
(WebCore::Layout::AbstractLineBuilder::formattingContext): Deleted.
(WebCore::Layout::AbstractLineBuilder::formattingContext const): Deleted.
(WebCore::Layout::AbstractLineBuilder::rootHorizontalConstraints const): Deleted.
(WebCore::Layout::AbstractLineBuilder::blockLayoutState const): Deleted.
(WebCore::Layout::AbstractLineBuilder::blockLayoutState): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineContentBreaker.h:
(WebCore::Layout::InlineContentBreaker::ContinuousContent::runs const): Deleted.
(WebCore::Layout::InlineContentBreaker::ContinuousContent::runs): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineContentCache.h:
(WebCore::Layout::InlineContentCache::InlineItems::content): Deleted.
(WebCore::Layout::InlineContentCache::InlineItems::content const): Deleted.
(WebCore::Layout::InlineContentCache::inlineItems const): Deleted.
(WebCore::Layout::InlineContentCache::inlineItems): Deleted.
(WebCore::Layout::InlineContentCache::maximumIntrinsicWidthLineContent): Deleted.
(WebCore::Layout::InlineContentCache::inlineBoxBoundaryTextSpacings const): Deleted.
(WebCore::Layout::InlineContentCache::trimmableTextSpacings const): Deleted.
(WebCore::Layout::InlineContentCache::textSpacingContext const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingContext.h:
(WebCore::Layout::InlineFormattingContext::formattingUtils const): Deleted.
(WebCore::Layout::InlineFormattingContext::quirks const): Deleted.
(WebCore::Layout::InlineFormattingContext::floatingContext const): Deleted.
(WebCore::Layout::InlineFormattingContext::layoutState): Deleted.
(WebCore::Layout::InlineFormattingContext::layoutState const): Deleted.
(WebCore::Layout::InlineFormattingContext::integrationUtils const): Deleted.
(WebCore::Layout::InlineFormattingContext::inlineContentCache): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineFormattingUtils.h:
(WebCore::Layout::InlineFormattingUtils::formattingContext const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineLayoutState.h:
(WebCore::Layout::InlineLayoutState::parentBlockLayoutState const): Deleted.
(WebCore::Layout::InlineLayoutState::parentBlockLayoutState): Deleted.
(WebCore::Layout::InlineLayoutState::placedFloats const): Deleted.
(WebCore::Layout::InlineLayoutState::placedFloats): Deleted.
(WebCore::Layout::InlineLayoutState::availableLineWidthOverride const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineLevelBox.h:
(WebCore::Layout::InlineLevelBox::verticalAlign const): Deleted.
(WebCore::Layout::InlineLevelBox::primarymetricsOfPrimaryFont const): Deleted.
(WebCore::Layout::InlineLevelBox::logicalRect const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineLine.h:
(WebCore::Layout::Line::Run::textContent const): Deleted.
(WebCore::Layout::Line::Run::expansion const): Deleted.
(WebCore::Layout::Line::Run::style const): Deleted.
(WebCore::Layout::Line::runs const): Deleted.
(WebCore::Layout::Line::runs): Deleted.
(WebCore::Layout::Line::inlineBoxListWithClonedDecorationEnd const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineLineBox.h:
(WebCore::Layout::LineBox::inlineLevelBoxFor const): Deleted.
(WebCore::Layout::LineBox::rootInlineBox const): Deleted.
(WebCore::Layout::LineBox::nonRootInlineLevelBoxes const): Deleted.
(WebCore::Layout::LineBox::logicalRect const): Deleted.
(WebCore::Layout::LineBox::nonRootInlineLevelBoxes): Deleted.
(WebCore::Layout::LineBox::rootInlineBox): Deleted.
(WebCore::Layout::LineBox::parentInlineBox const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxBuilder.h:
(WebCore::Layout::LineBoxBuilder::formattingContext const): Deleted.
(WebCore::Layout::LineBoxBuilder::lineLayoutResult const): Deleted.
(WebCore::Layout::LineBoxBuilder::rootStyle const): Deleted.
(WebCore::Layout::LineBoxBuilder::layoutState const): Deleted.
(WebCore::Layout::LineBoxBuilder::blockLayoutState const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineLineBoxVerticalAligner.h:
(WebCore::Layout::LineBoxVerticalAligner::formattingUtils const): Deleted.
(WebCore::Layout::LineBoxVerticalAligner::formattingContext const): Deleted.
(WebCore::Layout::LineBoxVerticalAligner::layoutState const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.h:
* Source/WebCore/layout/formattingContexts/inline/InlineQuirks.h:
(WebCore::Layout::InlineQuirks::formattingContext const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/IntrinsicWidthHandler.h:
(WebCore::Layout::IntrinsicWidthHandler::maximumIntrinsicWidthLineContent): Deleted.
(WebCore::Layout::IntrinsicWidthHandler::inlineItemList const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayBox.h:
(WebCore::InlineDisplay::Box::visualRectIgnoringBlockDirection const): Deleted.
(WebCore::InlineDisplay::Box::inkOverflow const): Deleted.
(WebCore::InlineDisplay::Box::text): Deleted.
(WebCore::InlineDisplay::Box::text const): Deleted.
(WebCore::InlineDisplay::Box::style const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.h:
(WebCore::Layout::InlineDisplayContentBuilder::lineBox const): Deleted.
(WebCore::Layout::InlineDisplayContentBuilder::constraints const): Deleted.
(WebCore::Layout::InlineDisplayContentBuilder::rootStyle const): Deleted.
(WebCore::Layout::InlineDisplayContentBuilder::formattingContext): Deleted.
(WebCore::Layout::InlineDisplayContentBuilder::formattingContext const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLine.h:
(WebCore::InlineDisplay::Line::lineBoxRect const): Deleted.
(WebCore::InlineDisplay::Line::lineBoxLogicalRect const): Deleted.
(WebCore::InlineDisplay::Line::scrollableOverflow const): Deleted.
(WebCore::InlineDisplay::Line::inkOverflow const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayLineBuilder.h:
(WebCore::Layout::InlineDisplayLineBuilder::constraints const): Deleted.
(WebCore::Layout::InlineDisplayLineBuilder::formattingContext const): Deleted.
(WebCore::Layout::InlineDisplayLineBuilder::formattingContext): Deleted.
* Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.h:
(WebCore::Layout::InlineInvalidation::displayBoxes const): Deleted.
(WebCore::Layout::InlineInvalidation::displayLines const): Deleted.
* Source/WebCore/layout/formattingContexts/table/TableFormattingContext.h:
* Source/WebCore/layout/formattingContexts/table/TableFormattingGeometry.h:
(WebCore::Layout::TableFormattingGeometry::formattingContext const): Deleted.
* Source/WebCore/layout/formattingContexts/table/TableFormattingQuirks.h:
(WebCore::Layout::TableFormattingQuirks::formattingContext const): Deleted.
* Source/WebCore/layout/formattingContexts/table/TableFormattingState.h:
(WebCore::Layout::TableFormattingState::tableGrid): Deleted.
(WebCore::Layout::TableFormattingState::tableGrid const): Deleted.
* Source/WebCore/layout/formattingContexts/table/TableGrid.h:
(WebCore::Layout::TableGrid::Column::computedLogicalWidth const): Deleted.
(WebCore::Layout::TableGrid::Columns::list): Deleted.
(WebCore::Layout::TableGrid::Columns::list const): Deleted.
(WebCore::Layout::TableGrid::Rows::list): Deleted.
(WebCore::Layout::TableGrid::Rows::list const): Deleted.
(WebCore::Layout::TableGrid::Slot::cell const): Deleted.
(WebCore::Layout::TableGrid::Slot::cell): Deleted.
(WebCore::Layout::TableGrid::Slot::widthConstraints const): Deleted.
(WebCore::Layout::TableGrid::columns const): Deleted.
(WebCore::Layout::TableGrid::columns): Deleted.
(WebCore::Layout::TableGrid::rows const): Deleted.
(WebCore::Layout::TableGrid::rows): Deleted.
(WebCore::Layout::TableGrid::cells): Deleted.
(WebCore::Layout::TableGrid::slot const): Deleted.
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
(WebCore::LayoutIntegration::ascent):
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h:
(WebCore::LayoutIntegration::BoxGeometryUpdater::layoutState): Deleted.
(WebCore::LayoutIntegration::BoxGeometryUpdater::layoutState const): Deleted.
* Source/WebCore/layout/integration/flex/LayoutIntegrationFlexLayout.h:
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h:
(WebCore::LayoutIntegration::GridLayout::layoutState): Deleted.
(WebCore::LayoutIntegration::GridLayout::layoutState const): Deleted.
* Source/WebCore/layout/integration/inline/InlineIteratorBox.h:
(WebCore::InlineIterator::Box::writingMode const):
(WebCore::InlineIterator::Box::style const):
(WebCore::InlineIterator::BoxIterator::operator* const): Deleted.
(WebCore::InlineIterator::BoxIterator::operator-&gt; const): Deleted.
* Source/WebCore/layout/integration/inline/InlineIteratorBoxLegacyPath.h:
(WebCore::InlineIterator::BoxLegacyPath::style const):
* Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.cpp:
(WebCore::InlineIterator::InlineBox::closedEdges const):
* Source/WebCore/layout/integration/inline/InlineIteratorInlineBox.h:
(WebCore::InlineIterator::InlineBox::legacyInlineBox const): Deleted.
(WebCore::InlineIterator::InlineBoxIterator::operator* const): Deleted.
(WebCore::InlineIterator::InlineBoxIterator::operator-&gt; const): Deleted.
(WebCore::InlineIterator::InlineBoxIterator::get const): Deleted.
* Source/WebCore/layout/integration/inline/InlineIteratorLineBox.h:
(WebCore::InlineIterator::LineBox::style const): Deleted.
(WebCore::InlineIterator::LineBoxIterator::operator* const): Deleted.
(WebCore::InlineIterator::LineBoxIterator::operator-&gt; const): Deleted.
* Source/WebCore/layout/integration/inline/InlineIteratorLineBoxModernPath.h:
(WebCore::InlineIterator::LineBoxIteratorModernPath::lines const): Deleted.
(WebCore::InlineIterator::LineBoxIteratorModernPath::line const): Deleted.
* Source/WebCore/layout/integration/inline/InlineIteratorSVGTextBox.h:
(WebCore::InlineIterator::SVGTextBoxIterator::operator* const): Deleted.
(WebCore::InlineIterator::SVGTextBoxIterator::operator-&gt; const): Deleted.
(WebCore::InlineIterator::SVGTextBoxIterator::get const): Deleted.
* Source/WebCore/layout/integration/inline/InlineIteratorTextBox.cpp:
(WebCore::InlineIterator::TextBox::fontCascade const):
* Source/WebCore/layout/integration/inline/InlineIteratorTextBox.h:
(WebCore::InlineIterator::TextBoxIterator::operator* const): Deleted.
(WebCore::InlineIterator::TextBoxIterator::operator-&gt; const): Deleted.
(WebCore::InlineIterator::TextBoxIterator::get const): Deleted.
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h:
(WebCore::LayoutIntegration::InlineContent::displayContent): Deleted.
(WebCore::LayoutIntegration::InlineContent::displayContent const): Deleted.
(WebCore::LayoutIntegration::InlineContent::lineForBox const): Deleted.
(WebCore::LayoutIntegration::InlineContent::svgTextFragmentsForBoxes): Deleted.
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.h:
* Source/WebCore/layout/layouttree/LayoutBox.h:
(WebCore::Layout::Box::style const): Deleted.
(WebCore::Layout::Box::firstLineStyle const): Deleted.
* Source/WebCore/layout/layouttree/LayoutInlineTextBox.h:
(WebCore::Layout::InlineTextBox::content const): Deleted.
* Source/WebCore/rendering/BidiRun.h:
(WebCore::BidiRun::box): Deleted.
* Source/WebCore/rendering/BorderEdge.h:
(WebCore::BorderEdge::color const): Deleted.
* Source/WebCore/rendering/BorderShape.h:
(WebCore::BorderShape::borderWidths const): Deleted.
(WebCore::BorderShape::radii const): Deleted.
(WebCore::BorderShape::innerEdgeRadii const): Deleted.
* Source/WebCore/rendering/CSSFilterRenderer.h:
* Source/WebCore/rendering/ClipRect.h:
(WebCore::ClipRect::rect const): Deleted.
* Source/WebCore/rendering/EventRegion.h:
(WebCore::EventRegion::region const): Deleted.
(WebCore::EventRegion::touchEventListenerRegion const): Deleted.
(WebCore::EventRegion::interactionRegions const): Deleted.
* Source/WebCore/rendering/FloatingObjects.h:
(WebCore::FloatingObject::frameRect const): Deleted.
(WebCore::FloatingObjects::set const): Deleted.
* Source/WebCore/rendering/GapRects.h:
(WebCore::GapRects::left const): Deleted.
(WebCore::GapRects::center const): Deleted.
(WebCore::GapRects::right const): Deleted.
* Source/WebCore/rendering/Grid.h:
* Source/WebCore/rendering/GridBaselineAlignment.h:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
* Source/WebCore/rendering/HitTestLocation.h:
(WebCore::HitTestLocation::point const): Deleted.
(WebCore::HitTestLocation::transformedPoint const): Deleted.
(WebCore::HitTestLocation::transformedRect const): Deleted.
* Source/WebCore/rendering/HitTestResult.h:
(WebCore::HitTestResult::pointInMainFrame const): Deleted.
(WebCore::HitTestResult::doublePointInInnerNodeFrame const): Deleted.
(WebCore::HitTestResult::localPoint const): Deleted.
(WebCore::HitTestResult::hitTestLocation const): Deleted.
* Source/WebCore/rendering/LayerAncestorClippingStack.h:
(WebCore::LayerAncestorClippingStack::stack): Deleted.
(WebCore::LayerAncestorClippingStack::stack const): Deleted.
* Source/WebCore/rendering/LayerOverlapMap.h:
(WebCore::LayerOverlapMap::geometryMap const): Deleted.
(WebCore::LayerOverlapMap::geometryMap): Deleted.
(WebCore::LayerOverlapMap::overlapStack const): Deleted.
* Source/WebCore/rendering/LegacyInlineBox.cpp:
(WebCore::LegacyInlineBox::lineStyle const):
(WebCore::LegacyInlineBox::logicalHeight const):
* Source/WebCore/rendering/LegacyInlineBox.h:
(WebCore::LegacyInlineBox::nextOnLine const): Deleted.
(WebCore::LegacyInlineBox::previousOnLine const): Deleted.
(WebCore::LegacyInlineBox::parent const): Deleted.
(WebCore::LegacyInlineBox::topLeft const): Deleted.
(WebCore::LegacyInlineBox::verticalAlign const): Deleted.
* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
(WebCore::LegacyInlineFlowBox::addToLine):
* Source/WebCore/rendering/LegacyInlineFlowBox.h:
(WebCore::LegacyInlineFlowBox::lineStyle const): Deleted.
(WebCore::LegacyInlineFlowBox::prevLineBox const): Deleted.
(WebCore::LegacyInlineFlowBox::nextLineBox const): Deleted.
(WebCore::LegacyInlineFlowBox::firstChild const): Deleted.
(WebCore::LegacyInlineFlowBox::lastChild const): Deleted.
* Source/WebCore/rendering/LegacyInlineTextBox.h:
(WebCore::LegacyInlineTextBox::prevTextBox const): Deleted.
(WebCore::LegacyInlineTextBox::nextTextBox const): Deleted.
* Source/WebCore/rendering/LegacyLineLayout.h:
* Source/WebCore/rendering/LegacyRootInlineBox.h:
* Source/WebCore/rendering/LogicalSelectionOffsetCaches.h:
(WebCore::LogicalSelectionOffsetCaches::ContainingBlockInfo::cache const): Deleted.
* Source/WebCore/rendering/PaintInfo.h:
(WebCore::PaintInfo::context const): Deleted.
* Source/WebCore/rendering/PathOperation.h:
* Source/WebCore/rendering/PositionedLayoutConstraints.h:
(WebCore::PositionedLayoutConstraints::alignment const): Deleted.
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBlockFlow.h:
(WebCore::RenderBlockFlow::floatingObjectSet const): Deleted.
(WebCore::RenderBlockFlow::rareBlockFlowData const): Deleted.
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::marginBox const): Deleted.
* Source/WebCore/rendering/RenderBoxModelObject.h:
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::style const): Deleted.
(WebCore::RenderElement::parentStyle const): Deleted.
(WebCore::RenderElement::mutableStyle): Deleted.
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::RenderFileUploadControl::paintControl):
* Source/WebCore/rendering/RenderFlexibleBox.h:
(WebCore::RenderFlexibleBox::orderIterator const): Deleted.
* Source/WebCore/rendering/RenderFragmentedFlow.h:
(WebCore::RenderFragmentedFlow::renderFragmentContainerList const): Deleted.
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/RenderHighlight.h:
(WebCore::RenderHighlight::get const): Deleted.
* Source/WebCore/rendering/RenderImage.h:
(WebCore::RenderImage::altText const): Deleted.
* Source/WebCore/rendering/RenderInline.h:
(WebCore::RenderInline::legacyLineBoxes): Deleted.
(WebCore::RenderInline::legacyLineBoxes const): Deleted.
(WebCore::RenderInline::firstLegacyInlineBox const): Deleted.
(WebCore::RenderInline::lastLegacyInlineBox const): Deleted.
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderLayerFilters.h:
* Source/WebCore/rendering/RenderLayerInlines.h:
(WebCore::RenderLayer::location const): Deleted.
(WebCore::RenderLayer::size const): Deleted.
* Source/WebCore/rendering/RenderLayerModelObject.h:
(WebCore::RenderLayerModelObject::layer const): Deleted.
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebCore/rendering/RenderLineBoxList.h:
(WebCore::RenderLineBoxList::firstLegacyLineBox const): Deleted.
(WebCore::RenderLineBoxList::lastLegacyLineBox const): Deleted.
* Source/WebCore/rendering/RenderMultiColumnFlow.h:
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderObjectInlines.h:
(WebCore::RenderObject::firstLineStyle const):
* Source/WebCore/rendering/RenderSelectionGeometry.h:
(WebCore::RenderSelectionGeometry::collectedSelectionQuads const): Deleted.
* Source/WebCore/rendering/RenderTable.h:
(WebCore::RenderTable::columns const): Deleted.
(WebCore::RenderTable::columnPositions const): Deleted.
(WebCore::RenderTable::currentBorderValue const): Deleted.
* Source/WebCore/rendering/RenderTableCell.h:
* Source/WebCore/rendering/RenderTableCol.cpp:
(WebCore::RenderTableCol::borderAdjoiningCellStartBorder const):
(WebCore::RenderTableCol::borderAdjoiningCellEndBorder const):
(WebCore::RenderTableCol::borderAdjoiningCellBefore const):
(WebCore::RenderTableCol::borderAdjoiningCellAfter const):
* Source/WebCore/rendering/RenderTableRow.h:
* Source/WebCore/rendering/RenderTableRowInlines.h:
(WebCore::RenderTableRow::borderAdjoiningTableStart const):
(WebCore::RenderTableRow::borderAdjoiningTableEnd const):
* Source/WebCore/rendering/RenderTableSection.h:
* Source/WebCore/rendering/RenderTableSectionInlines.h:
(WebCore::RenderTableSection::borderAdjoiningTableEnd const):
(WebCore::RenderTableSection::borderAdjoiningTableStart const):
* Source/WebCore/rendering/RenderText.h:
(WebCore::RenderText::text const): Deleted.
* Source/WebCore/rendering/RenderTextFragment.h:
* Source/WebCore/rendering/RenderTextLineBoxes.h:
(WebCore::RenderTextLineBoxes::first const): Deleted.
(WebCore::RenderTextLineBoxes::last const): Deleted.
* Source/WebCore/rendering/RenderView.h:
* Source/WebCore/rendering/TextAutoSizing.h:
(WebCore::TextAutoSizingKey::style const): Deleted.
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::decoratingBoxStyleForInlineBox):
(WebCore::TextBoxPainter::collectDecoratingBoxesForBackgroundPainting):
(WebCore::decoratingBoxStyle):
(WebCore::TextBoxPainter::paintForegroundDecorations):
* Source/WebCore/rendering/TextBoxPainter.h:
(WebCore::TextBoxPainter::textBox const): Deleted.
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::collectStylesForRenderer):
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::handleText):
(WebCore::BreakingContext::lineWidth): Deleted.
* Source/WebCore/rendering/line/LineInlineHeaders.h:
(WebCore::lineStyle):
(WebCore::requiresLineBoxForContent):
* Source/WebCore/rendering/shapes/PolygonLayoutShape.h:
* Source/WebCore/rendering/shapes/RasterLayoutShape.h:
(WebCore::RasterShapeIntervals::bounds const): Deleted.
(WebCore::RasterShapeIntervals::intervalAt): Deleted.
(WebCore::RasterShapeIntervals::intervalAt const): Deleted.
* Source/WebCore/rendering/style/BorderData.h:
(WebCore::BorderData::left): Deleted.
(WebCore::BorderData::right): Deleted.
(WebCore::BorderData::top): Deleted.
(WebCore::BorderData::bottom): Deleted.
(WebCore::BorderData::left const): Deleted.
(WebCore::BorderData::right const): Deleted.
(WebCore::BorderData::top const): Deleted.
(WebCore::BorderData::bottom const): Deleted.
(WebCore::BorderData::topLeftRadius): Deleted.
(WebCore::BorderData::topRightRadius): Deleted.
(WebCore::BorderData::bottomLeftRadius): Deleted.
(WebCore::BorderData::bottomRightRadius): Deleted.
(WebCore::BorderData::topLeftRadius const): Deleted.
(WebCore::BorderData::topRightRadius const): Deleted.
(WebCore::BorderData::bottomLeftRadius const): Deleted.
(WebCore::BorderData::bottomRightRadius const): Deleted.
(WebCore::BorderData::topLeftCornerShape const): Deleted.
(WebCore::BorderData::topRightCornerShape const): Deleted.
(WebCore::BorderData::bottomLeftCornerShape const): Deleted.
(WebCore::BorderData::bottomRightCornerShape const): Deleted.
* Source/WebCore/rendering/style/CollapsedBorderValue.h:
(WebCore::CollapsedBorderValue::color const): Deleted.
* Source/WebCore/rendering/style/GridArea.h:
(WebCore::GridArea::span const): Deleted.
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/svg/RenderSVGInlineText.h:
* Source/WebCore/rendering/svg/RenderSVGShape.h:
(WebCore::RenderSVGShape::path const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/rendering/svg/RenderSVGTextPath.h:
* Source/WebCore/rendering/svg/SVGInlineTextBox.h:
* Source/WebCore/rendering/svg/SVGPaintServerHandling.h:
(WebCore::SVGPaintServerHandling::context const): Deleted.
* Source/WebCore/rendering/svg/SVGTextChunkBuilder.h:
(WebCore::SVGTextChunkBuilder::textChunks const): Deleted.
* Source/WebCore/rendering/svg/SVGTextLayoutAttributes.h:
(WebCore::SVGTextLayoutAttributes::characterDataMap): Deleted.
(WebCore::SVGTextLayoutAttributes::characterDataMap const): Deleted.
(WebCore::SVGTextLayoutAttributes::textMetricsValues): Deleted.
(WebCore::SVGTextLayoutAttributes::textMetricsValues const): Deleted.
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceSolidColor.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h:
(WebCore::LegacyRenderSVGShape::path const): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h:
* Source/WebCore/rendering/updating/RenderTreeBuilder.h:
(WebCore::RenderTreeBuilder::firstLetterBuilder): Deleted.
(WebCore::RenderTreeBuilder::listBuilder): Deleted.
(WebCore::RenderTreeBuilder::multiColumnBuilder): Deleted.
(WebCore::RenderTreeBuilder::tableBuilder): Deleted.
(WebCore::RenderTreeBuilder::rubyBuilder): Deleted.
(WebCore::RenderTreeBuilder::formControlsBuilder): Deleted.
(WebCore::RenderTreeBuilder::blockBuilder): Deleted.
(WebCore::RenderTreeBuilder::blockFlowBuilder): Deleted.
(WebCore::RenderTreeBuilder::inlineBuilder): Deleted.
(WebCore::RenderTreeBuilder::svgBuilder): Deleted.
(WebCore::RenderTreeBuilder::mathMLBuilder): Deleted.
(WebCore::RenderTreeBuilder::continuationBuilder): Deleted.
* Source/WebCore/rendering/updating/RenderTreeUpdater.h:
(WebCore::RenderTreeUpdater::parent): Deleted.
(WebCore::RenderTreeUpdater::generatedContent): Deleted.
(WebCore::RenderTreeUpdater::viewTransition): Deleted.
* Source/WebCore/style/InlineTextBoxStyle.cpp:
(WebCore::minLogicalTopForTextDecorationLineUnder):
(WebCore::maxLogicalBottomForTextDecorationLineUnder):

Canonical link: <a href="https://commits.webkit.org/308784@main">https://commits.webkit.org/308784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec316dea0ba90c8c38d42cbf4d8ec6121538c12c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148433 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21119 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157117 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150306 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21024 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114437 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d2c3c619-6228-4100-8e8a-e6210ac54cd7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133262 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95207 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/539b1551-5915-4f6d-9ef2-db7c65a00c7c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15762 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13589 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4553 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159450 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2584 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122473 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17566 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122695 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33365 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20926 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/132982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77078 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/18070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9731 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20534 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84319 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20266 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20411 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20320 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->