### PR TITLE
Parse media controls UA stylesheets once per document using adoptedStyleSheets

### DIFF
--- a/LayoutTests/media/modern-media-controls/media-controller/media-controller-single-container-expected.txt
+++ b/LayoutTests/media/modern-media-controls/media-controller/media-controller-single-container-expected.txt
@@ -3,8 +3,7 @@ Testing the MediaController has a single container for captions and media contro
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS shadowRoot.childElementCount is >= 2
-PASS shadowRoot.firstElementChild.localName is "style"
+PASS shadowRoot.childElementCount is 1
 PASS shadowRoot.lastElementChild.localName is "div"
 PASS shadowRoot.lastElementChild.className is "media-controls-container"
 PASS shadowRoot.lastElementChild.childElementCount is 2

--- a/LayoutTests/media/modern-media-controls/media-controller/media-controller-single-container.html
+++ b/LayoutTests/media/modern-media-controls/media-controller/media-controller-single-container.html
@@ -9,8 +9,7 @@ description("Testing the <code>MediaController</code> has a single container for
 const media = document.querySelector("video");
 const shadowRoot = window.internals.shadowRoot(media);
 
-shouldBeGreaterThanOrEqual("shadowRoot.childElementCount", "2");
-shouldBeEqualToString("shadowRoot.firstElementChild.localName", "style");
+shouldBe("shadowRoot.childElementCount", "1");
 shouldBeEqualToString("shadowRoot.lastElementChild.localName", "div");
 shouldBeEqualToString("shadowRoot.lastElementChild.className", "media-controls-container");
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2638,6 +2638,7 @@ set(MODERN_MEDIA_CONTROLS_SCRIPTS
     "${WEBCORE_DIR}/Modules/modern-media-controls/controls/adwaita-fullscreen-media-controls.js"
     "${WEBCORE_DIR}/Modules/modern-media-controls/controls/adwaita-layout-traits.js"
     "${WEBCORE_DIR}/Modules/modern-media-controls/media/media-controller-support.js"
+    "${WEBCORE_DIR}/Modules/modern-media-controls/media/stylesheet-support.js"
     "${WEBCORE_DIR}/Modules/modern-media-controls/media/airplay-support.js"
     "${WEBCORE_DIR}/Modules/modern-media-controls/media/audio-support.js"
     "${WEBCORE_DIR}/Modules/modern-media-controls/media/close-support.js"

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -772,6 +772,7 @@ $(PROJECT_DIR)/Modules/modern-media-controls/media/close-support.js
 $(PROJECT_DIR)/Modules/modern-media-controls/media/controls-visibility-support.js
 $(PROJECT_DIR)/Modules/modern-media-controls/media/fullscreen-support.js
 $(PROJECT_DIR)/Modules/modern-media-controls/media/media-controller-support.js
+$(PROJECT_DIR)/Modules/modern-media-controls/media/stylesheet-support.js
 $(PROJECT_DIR)/Modules/modern-media-controls/media/media-controller.js
 $(PROJECT_DIR)/Modules/modern-media-controls/media/media-document-controller.js
 $(PROJECT_DIR)/Modules/modern-media-controls/media/metadata-support.js

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -2307,6 +2307,7 @@ MODERN_MEDIA_CONTROLS_SCRIPTS = \
     $(WebCore)/Modules/modern-media-controls/controls/watchos-media-controls.js \
     $(WebCore)/Modules/modern-media-controls/controls/watchos-layout-traits.js \
     $(WebCore)/Modules/modern-media-controls/media/media-controller-support.js \
+    $(WebCore)/Modules/modern-media-controls/media/stylesheet-support.js \
     $(WebCore)/Modules/modern-media-controls/media/airplay-support.js \
     $(WebCore)/Modules/modern-media-controls/media/audio-support.js \
     $(WebCore)/Modules/modern-media-controls/media/close-support.js \

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -31,6 +31,7 @@
 
 #include "AbortSignal.h"
 #include "AudioTrackList.h"
+#include "CSSStyleSheet.h"
 #include "CaptionUserPreferences.h"
 #include "Chrome.h"
 #include "ChromeClient.h"
@@ -38,6 +39,7 @@
 #include "ContextMenuController.h"
 #include "ContextMenuItem.h"
 #include "ContextMenuProvider.h"
+#include "DocumentMediaElement.h"
 #include "DocumentPage.h"
 #include "DocumentQuirks.h"
 #include "Event.h"
@@ -75,6 +77,7 @@
 #include <wtf/JSONValues.h>
 #include <wtf/Scope.h>
 #include <wtf/UUID.h>
+#include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
 
@@ -422,6 +425,40 @@ String MediaControlsHost::generateUUID()
 Vector<String, 2> MediaControlsHost::shadowRootStyleSheets() const
 {
     return RenderTheme::singleton().mediaControlsStyleSheets(protect(m_mediaElement));
+}
+
+Vector<Ref<CSSStyleSheet>> MediaControlsHost::uaStyleSheets() const
+{
+    Ref mediaElement = m_mediaElement.get();
+    return DocumentMediaElement::from(protect(mediaElement->document())).ensureMediaControlsStyleSheets(mediaElement);
+}
+
+String MediaControlsHost::captionPreferencesStyleSheet() const
+{
+    if (RefPtr page = protect(m_mediaElement)->document().page())
+        return page->captionUserPreferencesStyleSheet();
+    return String();
+}
+
+Vector<String> MediaControlsHost::showingTextTrackStyleSheets() const
+{
+    Vector<String> result;
+    RefPtr tracks = protect(m_mediaElement)->textTracks();
+    if (!tracks)
+        return result;
+    for (unsigned i = 0; i < tracks->length(); ++i) {
+        RefPtr track = tracks->item(i);
+        if (!track || track->mode() != TextTrack::Mode::Showing)
+            continue;
+        if (const auto& sheets = track->styleSheets()) {
+            StringBuilder builder;
+            for (const auto& css : *sheets)
+                builder.append(css);
+            if (!builder.isEmpty())
+                result.append(builder.toString());
+        }
+    }
+    return result;
 }
 
 String MediaControlsHost::base64StringForIconNameAndType(const String& iconName, const String& iconType)

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -39,6 +39,7 @@ namespace WebCore {
 
 class AudioTrack;
 class AudioTrackList;
+class CSSStyleSheet;
 class ContextMenuItem;
 class DOMPromise;
 class Element;
@@ -130,6 +131,9 @@ public:
     static String generateUUID();
 
     Vector<String, 2> shadowRootStyleSheets() const;
+    Vector<Ref<CSSStyleSheet>> uaStyleSheets() const;
+    String captionPreferencesStyleSheet() const;
+    Vector<String> showingTextTrackStyleSheets() const;
     static String base64StringForIconNameAndType(const String& iconName, const String& iconType);
 
 #if ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
@@ -86,6 +86,9 @@ enum DeviceType {
     readonly attribute SourceType? sourceType;
 
     readonly attribute sequence<DOMString> shadowRootStyleSheets;
+    readonly attribute sequence<CSSStyleSheet> uaStyleSheets;
+    readonly attribute DOMString captionPreferencesStyleSheet;
+    readonly attribute sequence<DOMString> showingTextTrackStyleSheets;
     DOMString base64StringForIconNameAndType(DOMString iconName, DOMString iconType);
     [Conditional=MEDIA_CONTROLS_CONTEXT_MENUS, EnabledBySetting=MediaControlsContextMenusEnabled] boolean showMediaControlsContextMenu(HTMLElement target, JSON options, VoidCallback callback);
     [Conditional=MEDIA_CONTROLS_CONTEXT_MENUS, EnabledBySetting=MediaControlsContextMenusEnabled, ImplementedAs=mediaControlsContextMenuItemsForBindings] sequence<MediaControlsContextMenuItem> mediaControlsContextMenuItems(JSON options);

--- a/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-video::-webkit-media-text-track-container {
+[useragentpart="-webkit-media-text-track-container"] {
     overflow: hidden;
     padding-bottom: 0;
     z-index: 0;
@@ -43,7 +43,7 @@ video::-webkit-media-text-track-container {
     flex: 1 1 auto;
 }
 
-video[controls]::-webkit-media-text-track-container.visible-controls-bar {
+:host(video[controls]) [useragentpart="-webkit-media-text-track-container"].visible-controls-bar {
     height: calc(100% - var(--inline-controls-bar-height) - var(--inline-controls-inside-margin));
 }
 

--- a/Source/WebCore/Modules/modern-media-controls/js-files
+++ b/Source/WebCore/Modules/modern-media-controls/js-files
@@ -52,6 +52,7 @@ controls/watchos-activity-indicator.js
 controls/watchos-media-controls.js
 controls/watchos-layout-traits.js
 media/media-controller-support.js
+media/stylesheet-support.js
 media/airplay-support.js
 media/audio-support.js
 media/close-support.js

--- a/Source/WebCore/Modules/modern-media-controls/main.js
+++ b/Source/WebCore/Modules/modern-media-controls/main.js
@@ -38,11 +38,6 @@ if (!window.utils) {
 // This is called from HTMLMediaElement::ensureMediaControls().
 function createControls(shadowRoot, media, host)
 {
-    if (host) {
-        for (let styleSheet of host.shadowRootStyleSheets)
-            shadowRoot.appendChild(document.createElement("style")).textContent = styleSheet;
-    }
-
     controller = new MediaController(shadowRoot, media, host);
     if (host)
         host.controller = controller;

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -83,6 +83,9 @@ class MediaController
 
         this.hasPlayed = !media.paused || !!media.played.length;
 
+        if (host)
+            this._stylesheetSupport = new StyleSheetSupport(this);
+
         this.container = shadowRoot.appendChild(document.createElement("div"));
 
         this._updateControlsIfNeeded();
@@ -362,6 +365,12 @@ class MediaController
         if (this.controls)
             this.controls.disable();
         return true;
+    }
+
+    captionStyleSheetsDidChange()
+    {
+        if (this._stylesheetSupport)
+            this._stylesheetSupport.captionStyleSheetsDidChange();
     }
 
     reinitialize(shadowRoot, media, host)

--- a/Source/WebCore/Modules/modern-media-controls/media/stylesheet-support.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/stylesheet-support.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+class StyleSheetSupport extends MediaControllerSupport
+{
+
+    constructor(mediaController)
+    {
+        super(mediaController);
+        this._captionSheet = null;
+        this._cachedCaptionCSS = "";
+        this._trackSheets = [];
+        this._cachedTrackCSS = [];
+        this._syncAdoptedStyleSheets();
+    }
+
+    // Protected
+
+    get control()
+    {
+        return null;
+    }
+
+    get mediaEvents()
+    {
+        return ["loadedmetadata"];
+    }
+
+    get tracksToMonitor()
+    {
+        return [this.mediaController.media.textTracks];
+    }
+
+    handleEvent(event)
+    {
+        this._syncAdoptedStyleSheets();
+    }
+
+    // Public
+
+    captionStyleSheetsDidChange()
+    {
+        this._syncAdoptedStyleSheets();
+    }
+
+    // Private
+
+    _syncAdoptedStyleSheets()
+    {
+        const host = this.mediaController.host;
+        const shadowRoot = this.mediaController.shadowRoot;
+        if (!host || !shadowRoot)
+            return;
+
+        const sheets = [...host.uaStyleSheets];
+
+        const captionCSS = host.captionPreferencesStyleSheet || "";
+        if (captionCSS !== this._cachedCaptionCSS) {
+            if (captionCSS) {
+                if (!this._captionSheet)
+                    this._captionSheet = new CSSStyleSheet();
+                this._captionSheet.replaceSync(captionCSS);
+            } else
+                this._captionSheet = null;
+            this._cachedCaptionCSS = captionCSS;
+        }
+        if (this._captionSheet)
+            sheets.push(this._captionSheet);
+
+        const trackCSSList = host.showingTextTrackStyleSheets;
+        for (let i = 0; i < trackCSSList.length; i++) {
+            if (i >= this._trackSheets.length)
+                this._trackSheets.push(new CSSStyleSheet());
+            if (trackCSSList[i] !== this._cachedTrackCSS[i])
+                this._trackSheets[i].replaceSync(trackCSSList[i]);
+            sheets.push(this._trackSheets[i]);
+        }
+        this._trackSheets.length = trackCSSList.length;
+        this._cachedTrackCSS = [...trackCSSList];
+
+        shadowRoot.adoptedStyleSheets = sheets;
+    }
+}

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -120,6 +120,11 @@ ExceptionOr<Ref<CSSStyleSheet>> CSSStyleSheet::create(Document& document, Init&&
     return adoptRef(*new CSSStyleSheet(StyleSheetContents::create(parserContext), document, WTF::move(init)));
 }
 
+Ref<CSSStyleSheet> CSSStyleSheet::createFromContents(Ref<StyleSheetContents>&& contents, Document& document)
+{
+    return adoptRef(*new CSSStyleSheet(WTF::move(contents), document, Init { }));
+}
+
 CSSStyleSheet::CSSStyleSheet(Ref<StyleSheetContents>&& contents, CSSImportRule* ownerRule, std::optional<bool> isOriginClean)
     : m_contents(WTF::move(contents))
     , m_isOriginClean(isOriginClean)

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -68,6 +68,7 @@ public:
     static Ref<CSSStyleSheet> create(Ref<StyleSheetContents>&&, Node& ownerNode, const std::optional<bool>& isOriginClean = std::nullopt);
     static Ref<CSSStyleSheet> createInline(Ref<StyleSheetContents>&&, Element& owner, const TextPosition& startPosition);
     static ExceptionOr<Ref<CSSStyleSheet>> create(Document&, Init&&);
+    static Ref<CSSStyleSheet> createFromContents(Ref<StyleSheetContents>&&, Document&);
 
     virtual ~CSSStyleSheet();
 

--- a/Source/WebCore/dom/DocumentMediaElement.cpp
+++ b/Source/WebCore/dom/DocumentMediaElement.cpp
@@ -35,6 +35,7 @@
 #include "RenderTheme.h"
 #include "ScriptController.h"
 #include "ScriptSourceCode.h"
+#include "StyleSheetContents.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/TopExceptionScope.h>
@@ -174,6 +175,23 @@ bool DocumentMediaElement::setupAndCallJS(NOESCAPE const JSSetupFunction& task, 
     return result;
 }
 
+Vector<Ref<CSSStyleSheet>>& DocumentMediaElement::ensureMediaControlsStyleSheets(const HTMLMediaElement& element)
+{
+    if (!m_cachedMediaControlsStyleSheets.isEmpty())
+        return m_cachedMediaControlsStyleSheets;
+
+    auto styleSheetTexts = RenderTheme::singleton().mediaControlsStyleSheets(element);
+    // Use UASheetMode so UA-gated values like display: ruby are not dropped.
+    CSSParserContext parserContext(UASheetMode);
+    Ref protectedDocument = document();
+    for (auto& cssText : styleSheetTexts) {
+        Ref contents = StyleSheetContents::create(parserContext);
+        contents->parseString(cssText);
+        m_cachedMediaControlsStyleSheets.append(CSSStyleSheet::createFromContents(WTF::move(contents), protectedDocument));
+    }
+    return m_cachedMediaControlsStyleSheets;
 }
+
+} // namespace WebCore
 
 #endif

--- a/Source/WebCore/dom/DocumentMediaElement.h
+++ b/Source/WebCore/dom/DocumentMediaElement.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(VIDEO)
 
+#include "CSSStyleSheet.h"
 #include <WebCore/Supplementable.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -40,6 +41,7 @@ namespace WebCore {
 
 class DOMWrapperWorld;
 class Document;
+class HTMLMediaElement;
 class JSDOMGlobalObject;
 class ScriptController;
 
@@ -53,6 +55,8 @@ public:
     using JSSetupFunction = Function<bool(JSDOMGlobalObject&, JSC::JSGlobalObject&, ScriptController&, DOMWrapperWorld&)>;
     bool setupAndCallMediaControlsJS(NOESCAPE const JSSetupFunction&);
     bool setupAndCallYouTubeQuirkJS(NOESCAPE const JSSetupFunction&);
+
+    Vector<Ref<CSSStyleSheet>>& ensureMediaControlsStyleSheets(const HTMLMediaElement&);
 
 private:
     bool isDocumentMediaElement() const final { return true; }
@@ -68,6 +72,7 @@ private:
 
     CheckedRef<Document> m_document;
     RefPtr<DOMWrapperWorld> m_isolatedWorld;
+    Vector<Ref<CSSStyleSheet>> m_cachedMediaControlsStyleSheets;
     bool m_haveParsedMediaControlsScript { false };
     bool m_haveParsedYouTubeQuirkScript { false };
 };

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7940,8 +7940,10 @@ void HTMLMediaElement::configureTextTrackDisplay(TextTrackVisibilityCheckType ch
 
 void HTMLMediaElement::updateTextTrackDisplay()
 {
-    if (ensureMediaControls())
+    if (ensureMediaControls()) {
+        callControllerJSMethod("captionStyleSheetsDidChange"_s);
         m_mediaControlsHost->updateTextTrackContainer();
+    }
 }
 
 void HTMLMediaElement::updateTextTrackRepresentationImageIfNeeded()
@@ -8111,6 +8113,8 @@ void HTMLMediaElement::captionPreferencesChanged()
 
     if (RefPtr mediaControlsHost = m_mediaControlsHost.get())
         mediaControlsHost->captionPreferencesChanged();
+
+    callControllerJSMethod("captionStyleSheetsDidChange"_s);
 
     if (RefPtr player = m_player)
         player->tracksChanged();
@@ -8942,6 +8946,38 @@ void HTMLMediaElement::setControllerJSProperty(ASCIILiteral propertyName, JSC::J
     });
 }
 
+void HTMLMediaElement::callControllerJSMethod(ASCIILiteral methodName)
+{
+    DocumentMediaElement::from(protect(document())).setupAndCallMediaControlsJS([this, methodName](JSDOMGlobalObject& globalObject, JSC::JSGlobalObject& lexicalGlobalObject, ScriptController&, DOMWrapperWorld&) {
+        auto& vm = globalObject.vm();
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        if (!m_mediaControlsHost)
+            return false;
+
+        auto controllerValue = m_mediaControlsHost->controllerWrapper().getValue();
+        RETURN_IF_EXCEPTION(scope, false);
+        auto* controllerObject = controllerValue.toObject(&lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, false);
+
+        auto functionValue = controllerObject->get(&lexicalGlobalObject, JSC::Identifier::fromString(vm, methodName));
+        if (scope.exception()) [[unlikely]]
+            return false;
+        if (functionValue.isUndefinedOrNull())
+            return false;
+
+        auto* function = functionValue.toObject(&lexicalGlobalObject);
+        RETURN_IF_EXCEPTION(scope, false);
+
+        auto callData = JSC::getCallData(function);
+        if (callData.type == JSC::CallData::Type::None)
+            return false;
+
+        JSC::call(&lexicalGlobalObject, function, callData, controllerObject, JSC::MarkedArgumentBuffer());
+        RETURN_IF_EXCEPTION(scope, false);
+        return true;
+    });
+}
+
 bool HTMLMediaElement::ensureMediaControls()
 {
     if (m_controlsState == ControlsState::Ready)
@@ -8981,8 +9017,10 @@ bool HTMLMediaElement::ensureMediaControls()
             auto mediaJSWrapper = toJS(&lexicalGlobalObject, &globalObject, *this);
             auto mediaControlsHostJSWrapper = toJS(&lexicalGlobalObject, &globalObject, *m_mediaControlsHost);
 
+            Ref shadowRoot = ensureUserAgentShadowRoot();
+
             JSC::MarkedArgumentBuffer argList;
-            argList.append(toJS(&lexicalGlobalObject, &globalObject, Ref { ensureUserAgentShadowRoot() }));
+            argList.append(toJS(&lexicalGlobalObject, &globalObject, shadowRoot));
             argList.append(mediaJSWrapper);
             argList.append(mediaControlsHostJSWrapper);
             ASSERT(!argList.hasOverflowed());

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1131,6 +1131,7 @@ private:
     void updatePageScaleFactorJSProperty();
     void updateUsesLTRUserInterfaceLayoutDirectionJSProperty();
     void setControllerJSProperty(ASCIILiteral, JSC::JSValue);
+    void callControllerJSMethod(ASCIILiteral);
 
     void addBehaviorRestrictionsOnEndIfNecessary();
     void handleSeekToPlaybackPosition(double);

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -39,12 +39,10 @@
 #include "CSSValuePool.h"
 #include "CommonAtomStrings.h"
 #include "DocumentFragment.h"
-#include "DocumentPage.h"
 #include "ElementInlines.h"
 #include "Event.h"
 #include "HTMLDivElement.h"
 #include "HTMLSpanElement.h"
-#include "HTMLStyleElement.h"
 #include "JSVTTCue.h"
 #include "Logging.h"
 #include "NodeTraversal.h"
@@ -968,22 +966,6 @@ void VTTCue::obtainCSSBoxes()
         displayTree->applyCSSPropertiesWithRegion();
     else
         displayTree->applyCSSProperties();
-
-    Ref document = displayTree->document();
-    if (RefPtr page = document->page()) {
-        auto cssString = page->captionUserPreferencesStyleSheet();
-        Ref style = HTMLStyleElement::create(HTMLNames::styleTag, document.get(), false);
-        style->setTextContent(WTF::move(cssString));
-        displayTree->appendChild(WTF::move(style));
-    }
-
-    if (const auto& styleSheets = track()->styleSheets()) {
-        for (const auto& cssString : *styleSheets) {
-            auto style = HTMLStyleElement::create(HTMLNames::styleTag, document.get(), false);
-            style->setTextContent(String { cssString });
-            displayTree->appendChild(WTF::move(style));
-        }
-    }
 }
 
 void VTTCue::markFutureAndPastNodes(ContainerNode* root, const MediaTime& previousTimestamp, const MediaTime& movieTime)


### PR DESCRIPTION
#### 5c180c290003e2549b9ece2d9f32def732444b70
<pre>
Parse media controls UA stylesheets once per document using adoptedStyleSheets
<a href="https://bugs.webkit.org/show_bug.cgi?id=309214">https://bugs.webkit.org/show_bug.cgi?id=309214</a>
<a href="https://rdar.apple.com/171764828">rdar://171764828</a>

Reviewed by NOBODY (OOPS!).

Media controls stylesheets were injected as inline &lt;style&gt; elements in the UA shadow root, causing the
same CSS to be re-parsed for every media element. Parse them once per document in C++ and share the
result across all media elements via adoptedStyleSheets on the shadow root.

Parse in C++ with UASheetMode rather than constructing stylesheets from JS, which uses HTMLStandardMode.
In HTMLStandardMode, CSS values like display: ruby and display: ruby-text are gated behind
cssRubyDisplayTypesInAuthorStylesEnabled and silently dropped. There is no equivalent mechanism for
adopted stylesheets created from JS, so parsing in C++ allows the parser mode to be set explicitly.

Expose the pre-parsed sheets to JS via host.uaStyleSheets, and let a new StyleSheetSupport class in
JavaScript manage the shadowRoot.adoptedStyleSheets list. This keeps the logic (caching,
diffing, assembling the sheet list) in JS along with the rest of the media controls UI code, while C++
handles the UASheetMode parse and exposes the data to JS through IDL getters.

Caption user preference overrides and VTT track-level stylesheets are managed in JS using
constructed stylesheets (new CSSStyleSheet() + replaceSync()). These do not need UASheetMode because
they are author CSS. Adopted stylesheets take precedence over inline &lt;style&gt; elements in the cascade,
so caption and track sheets must also be adopted stylesheets to still be able to override the
UA rules. JS reacts to text track change events and a C++ notification (captionStyleSheetsDidChange)
when system caption preferences change.

Adopted stylesheets cannot match pseudo-elements in the shadow tree the way inline &lt;style&gt; elements
can, so change text track CSS selectors from pseudo-element selectors
(e.g. video::-webkit-media-text-track-container) to attribute selectors (e.g. [useragentpart=&quot;...&quot;]).

When running the VideoElementWithControlsCreation micro benchmark  before vs after this commit, the median
time improved from 193ms to 94ms per iteration (51% faster). Memory usage decreased from ~327MB to
~260MB per iteration (20% less memory).

No new tests because this performance change should not affect correctness.
VideoElementWithControlsCreation.html stresses this code change already.

Original PR credits and optimization idea go to Ryan Reno.

* LayoutTests/media/modern-media-controls/media-controller/media-controller-single-container-expected.txt:
* LayoutTests/media/modern-media-controls/media-controller/media-controller-single-container.html:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::uaStyleSheets const):
(WebCore::MediaControlsHost::captionPreferencesStyleSheet const):
(WebCore::MediaControlsHost::showingTextTrackStyleSheets const):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl:
* Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css:
([useragentpart=&quot;-webkit-media-text-track-container&quot;]):
(:host(video[controls]) [useragentpart=&quot;-webkit-media-text-track-container&quot;].visible-controls-bar):
(video::-webkit-media-text-track-container): Deleted.
(video[controls]::-webkit-media-text-track-container.visible-controls-bar): Deleted.
* Source/WebCore/Modules/modern-media-controls/js-files:
* Source/WebCore/Modules/modern-media-controls/main.js:
(createControls):
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController):
(MediaController.prototype.captionStyleSheetsDidChange):
* Source/WebCore/Modules/modern-media-controls/media/stylesheet-support.js: Added.
(StyleSheetSupport):
(StyleSheetSupport.prototype.get control):
(StyleSheetSupport.prototype.get mediaEvents):
(StyleSheetSupport.prototype.get tracksToMonitor):
(StyleSheetSupport.prototype.handleEvent):
(StyleSheetSupport.prototype.captionStyleSheetsDidChange):
(StyleSheetSupport.prototype._syncAdoptedStyleSheets):
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::createFromContents):
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/dom/DocumentMediaElement.cpp:
(WebCore::DocumentMediaElement::ensureMediaControlsStyleSheets):
* Source/WebCore/dom/DocumentMediaElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::updateTextTrackDisplay):
(WebCore::HTMLMediaElement::captionPreferencesChanged):
(WebCore::HTMLMediaElement::callControllerJSMethod):
(WebCore::HTMLMediaElement::ensureMediaControls):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::obtainCSSBoxes):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c180c290003e2549b9ece2d9f32def732444b70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161918 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35392 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28495 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118289 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163787 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125629 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88531 "17 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106225 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27004 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25518 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18542 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23192 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173310 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20405 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24833 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133931 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133936 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35050 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144987 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97145 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28469 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21812 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34560 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102045 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34061 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34303 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34209 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->