### PR TITLE
Top scroll stretching should not stop color sampling of top edge

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -269,6 +269,7 @@ void LocalFrameView::reset()
     m_updateEmbeddedObjectsTimer.stop();
     m_lastUserScrollType = std::nullopt;
     m_wasEverScrolledExplicitlyByUser = false;
+    m_wasEverScrolledExplicitlyByUserBelowTopEdge = false;
     m_delayedScrollEventTimer.stop();
     m_shouldScrollToFocusedElement = false;
     m_delayedScrollToFocusedElementTimer.stop();
@@ -5590,14 +5591,17 @@ void LocalFrameView::setLastUserScrollType(std::optional<UserScrollType> userScr
     if (userScrollType && document)
         document->setGotoAnchorNeededAfterStylesheetsLoad(false);
 
+    if (userScrollType == UserScrollType::Explicit) {
+        m_wasEverScrolledExplicitlyByUser = true;
+        if (scrollOffset().y() > minimumScrollOffset().y())
+            m_wasEverScrolledExplicitlyByUserBelowTopEdge = true;
+    }
+
     m_maintainScrollPositionAnchor = nullptr;
     if (m_lastUserScrollType == userScrollType)
         return;
     m_lastUserScrollType = userScrollType;
     adjustTiledBackingCoverage();
-
-    if (userScrollType == UserScrollType::Explicit)
-        m_wasEverScrolledExplicitlyByUser = true;
 }
 
 void LocalFrameView::willPaintContents(GraphicsContext& context, const IntRect&, PaintingState& paintingState, RegionContext* regionContext)

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -403,6 +403,7 @@ public:
 
     WEBCORE_EXPORT bool NODELETE wasScrolledByUser() const;
     bool wasEverScrolledExplicitlyByUser() const { return m_wasEverScrolledExplicitlyByUser; }
+    bool wasEverScrolledExplicitlyByUserBelowTopEdge() const { return m_wasEverScrolledExplicitlyByUserBelowTopEdge; }
 
     enum class UserScrollType : uint8_t { Explicit, Implicit };
     WEBCORE_EXPORT void setLastUserScrollType(std::optional<UserScrollType>);
@@ -1082,6 +1083,7 @@ private:
 
     std::optional<UserScrollType> m_lastUserScrollType;
     bool m_wasEverScrolledExplicitlyByUser { false };
+    bool m_wasEverScrolledExplicitlyByUserBelowTopEdge { false };
 
     bool m_shouldUpdateWhileOffscreen { true };
     bool m_canHaveScrollbars { true };

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5380,7 +5380,7 @@ void Page::updateFixedContainerEdges(BoxSideSet sides)
         auto maximumOffset = frameView->maximumScrollOffset();
 
         bool canSampleTopEdge = settings().topContentInsetBackgroundCanChangeAfterScrolling()
-            || (!frameView->wasEverScrolledExplicitlyByUser() && !m_userHasInteractedSinceLastPageLoadExcludingForcedUserGestures)
+            || (!frameView->wasEverScrolledExplicitlyByUserBelowTopEdge() && !m_userHasInteractedSinceLastPageLoadExcludingForcedUserGestures)
             || document->parsing();
 
         if (scrollOffset.y() < minimumOffset.y() || !canSampleTopEdge)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -187,6 +187,9 @@ typedef NSVisualEffectView _WKPlatformVisualEffectView;
 #endif
 - (void)_cancelFixedColorExtensionFadeAnimationsForTesting;
 
+- (void)_startMonitoringWheelEventsForTesting:(void(^)(void))completionHandler;
+- (void)_waitForWheelEventsToCompleteForTesting:(void(^)(void))completionHandler;
+
 - (unsigned)_forwardedLogsCountForTesting;
 - (bool)_receivedLogsDuringLaunchForTesting;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -1113,6 +1113,28 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 #endif
 }
 
+- (void)_startMonitoringWheelEventsForTesting:(void(^)(void))completionHandler
+{
+    RefPtr pageForTesting = _page->pageForTesting();
+    if (!pageForTesting)
+        return completionHandler();
+
+    pageForTesting->startMonitoringWheelEventsForTesting([completionHandler = makeBlockPtr(completionHandler)] {
+        completionHandler();
+    });
+}
+
+- (void)_waitForWheelEventsToCompleteForTesting:(void(^)(void))completionHandler
+{
+    RefPtr pageForTesting = _page->pageForTesting();
+    if (!pageForTesting)
+        return completionHandler();
+
+    pageForTesting->waitForWheelEventsToCompleteForTesting([completionHandler = makeBlockPtr(completionHandler)] {
+        completionHandler();
+    });
+}
+
 - (unsigned)_forwardedLogsCountForTesting
 {
 #if ENABLE(LOGD_BLOCKING_IN_WEBCONTENT)

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -184,6 +184,24 @@ void WebPageProxyTesting::clearWheelEventTestMonitor()
     send(Messages::WebPageTesting::ClearWheelEventTestMonitor());
 }
 
+void WebPageProxyTesting::startMonitoringWheelEventsForTesting(CompletionHandler<void()>&& completionHandler)
+{
+    if (!protect(page())->hasRunningProcess()) {
+        completionHandler();
+        return;
+    }
+    sendWithAsyncReply(Messages::WebPageTesting::StartMonitoringWheelEventsForTesting(), WTF::move(completionHandler));
+}
+
+void WebPageProxyTesting::waitForWheelEventsToCompleteForTesting(CompletionHandler<void()>&& completionHandler)
+{
+    if (!protect(page())->hasRunningProcess()) {
+        completionHandler();
+        return;
+    }
+    sendWithAsyncReply(Messages::WebPageTesting::WaitForWheelEventsToCompleteForTesting(), WTF::move(completionHandler));
+}
+
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
 void WebPageProxyTesting::setIndexOfGetDisplayMediaDeviceSelectedForTesting(std::optional<unsigned> index)
 {

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.h
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.h
@@ -70,6 +70,8 @@ public:
 #endif
 
     void clearWheelEventTestMonitor();
+    void startMonitoringWheelEventsForTesting(CompletionHandler<void()>&&);
+    void waitForWheelEventsToCompleteForTesting(CompletionHandler<void()>&&);
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     void setIndexOfGetDisplayMediaDeviceSelectedForTesting(std::optional<unsigned>);

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
@@ -43,6 +43,7 @@
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/NotificationController.h>
 #include <WebCore/Page.h>
+#include <WebCore/WheelEventTestMonitor.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
@@ -119,6 +120,32 @@ void WebPageTesting::clearWheelEventTestMonitor()
         return;
 
     page->clearWheelEventTestMonitor();
+}
+
+void WebPageTesting::startMonitoringWheelEventsForTesting(CompletionHandler<void()>&& completionHandler)
+{
+    RefPtr page = m_page ? m_page->corePage() : nullptr;
+    if (!page) {
+        completionHandler();
+        return;
+    }
+
+    page->startMonitoringWheelEvents(true);
+    completionHandler();
+}
+
+void WebPageTesting::waitForWheelEventsToCompleteForTesting(CompletionHandler<void()>&& completionHandler)
+{
+    RefPtr page = m_page ? m_page->corePage() : nullptr;
+    if (!page || !page->isMonitoringWheelEvents()) {
+        completionHandler();
+        return;
+    }
+
+    if (auto wheelEventTestMonitor = page->wheelEventTestMonitor())
+        wheelEventTestMonitor->setTestCallbackAndStartMonitoring(true, false, WTF::move(completionHandler));
+    else
+        completionHandler();
 }
 
 void WebPageTesting::setObscuredContentInsets(float top, float right, float bottom, float left, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.h
@@ -70,6 +70,8 @@ private:
     void setObscuredContentInsets(float top, float right, float bottom, float left, CompletionHandler<void()>&&);
 
     void clearWheelEventTestMonitor();
+    void startMonitoringWheelEventsForTesting(CompletionHandler<void()>&&);
+    void waitForWheelEventsToCompleteForTesting(CompletionHandler<void()>&&);
 
     WeakPtr<WebPage> m_page;
     WebCore::PageIdentifier m_pageIdentifier;

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in
@@ -34,6 +34,8 @@ messages -> WebPageTesting {
 #endif
 
     ClearWheelEventTestMonitor()
+    StartMonitoringWheelEventsForTesting() -> ()
+    WaitForWheelEventsToCompleteForTesting() -> ()
     ResetStateBetweenTests()
     SetObscuredContentInsets(float top, float right, float bottom, float left) -> ()
     ClearCachedBackForwardListCounts() -> ()

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm
@@ -520,6 +520,135 @@ TEST(SampledPageTopColor, TopColorExtensionWhenRubberBanding)
 
 #endif // PLATFORM(IOS_FAMILY) && ENABLE(CONTENT_INSET_BACKGROUND_FILL)
 
+#if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
+
+static void checkColorComponents(CGColorRef color, double minRed, double maxRed, double minGreen, double maxGreen, double minBlue, double maxBlue)
+{
+    auto components = CGColorGetComponents(color);
+    EXPECT_IN_RANGE(components[0], minRed, maxRed);
+    EXPECT_IN_RANGE(components[1], minGreen, maxGreen);
+    EXPECT_IN_RANGE(components[2], minBlue, maxBlue);
+}
+
+static void expectTomato(CGColorRef color)
+{
+    checkColorComponents(color, 0.99, 1.01, 0.38, 0.39, 0.27, 0.28);
+}
+
+static void expectBlue(CGColorRef color)
+{
+    checkColorComponents(color, -0.01, 0.01, -0.01, 0.01, 0.99, 1.01);
+}
+
+TEST(SampledPageTopColor, TopScrollStretchingDoesNotPreventTopEdgeSampling)
+{
+#if PLATFORM(IOS_FAMILY)
+    IPadUserInterfaceSwizzler iPadUserInterface;
+#endif
+
+    RetainPtr webView = createWebViewWithSampledPageTopColorMaxDifference(5);
+#if PLATFORM(MAC)
+    [webView _setTopContentInset:75];
+#else
+    auto insets = UIEdgeInsetsMake(75, 0, 0, 0);
+    auto insetSize = UIEdgeInsetsInsetRect([webView bounds], insets).size;
+    [webView _setObscuredInsets:insets];
+
+    RetainPtr scrollView = [webView scrollView];
+    [scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+    [scrollView setContentInset:insets];
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:insetSize minimumUnobscuredSizeOverride:insetSize maximumUnobscuredSizeOverride:insetSize];
+#endif
+
+    // Part one: check the initial sample.
+    [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
+    [webView waitForNextPresentationUpdate];
+
+    expectTomato([webView _sampledTopFixedPositionContentColor].CGColor);
+
+    // Part two: scroll above the top of the page and change the header color. Verify the sample updates to match.
+#if PLATFORM(MAC)
+    {
+        __block bool done = false;
+        [webView _startMonitoringWheelEventsForTesting:^{
+            done = true;
+        }];
+        TestWebKitAPI::Util::run(&done);
+    }
+    [webView waitForNextPresentationUpdate];
+
+    [webView wheelEventAtPoint:NSMakePoint(400, 300) wheelDelta:CGSizeMake(0, 1) phase:kCGScrollPhaseBegan momentumPhase:kCGMomentumScrollPhaseNone];
+    [webView wheelEventAtPoint:NSMakePoint(400, 300) wheelDelta:CGSizeMake(0, 100) phase:kCGScrollPhaseChanged momentumPhase:kCGMomentumScrollPhaseNone];
+    [webView wheelEventAtPoint:NSMakePoint(400, 300) wheelDelta:CGSizeMake(0, 0) phase:kCGScrollPhaseEnded momentumPhase:kCGMomentumScrollPhaseNone];
+
+    {
+        __block bool done = false;
+        [webView _waitForWheelEventsToCompleteForTesting:^{
+            done = true;
+        }];
+        TestWebKitAPI::Util::run(&done);
+    }
+    [webView waitForNextPresentationUpdate];
+#else
+    auto contentInsetTop = [scrollView contentInset].top;
+
+    [scrollView setContentOffset:CGPointMake(0, -150)];
+    [webView waitForNextVisibleContentRectUpdate];
+    [scrollView setContentOffset:CGPointMake(0, -contentInsetTop)];
+    [webView waitForNextVisibleContentRectUpdate];
+    [webView waitForNextPresentationUpdate];
+#endif
+
+    {
+        bool done = false;
+        RetainPtr topColorObserver = adoptNS([[TestKVOWrapper alloc] initWithObservable:webView.get() keyPath:@"_sampledTopFixedPositionContentColor" callback:[&] {
+            done = true;
+        }]);
+
+        [webView objectByEvaluatingJavaScript:@"document.querySelector('header').style.backgroundColor = 'blue'"];
+        TestWebKitAPI::Util::run(&done);
+    }
+
+    EXPECT_TRUE([webView _fixedContainerEdges] & _WKRectEdgeTop);
+    expectBlue([webView _sampledTopFixedPositionContentColor].CGColor);
+
+    // Part three: scroll below the top of the page and change the header color. Verify that the sample does NOT update.
+#if PLATFORM(MAC)
+    [webView wheelEventAtPoint:NSMakePoint(400, 300) wheelDelta:CGSizeMake(0, -1) phase:kCGScrollPhaseBegan momentumPhase:kCGMomentumScrollPhaseNone];
+    [webView wheelEventAtPoint:NSMakePoint(400, 300) wheelDelta:CGSizeMake(0, -30) phase:kCGScrollPhaseChanged momentumPhase:kCGMomentumScrollPhaseNone];
+    [webView wheelEventAtPoint:NSMakePoint(400, 300) wheelDelta:CGSizeMake(0, 0) phase:kCGScrollPhaseEnded momentumPhase:kCGMomentumScrollPhaseNone];
+
+    {
+        __block bool done = false;
+        [webView _waitForWheelEventsToCompleteForTesting:^{
+            done = true;
+        }];
+        TestWebKitAPI::Util::run(&done);
+    }
+    [webView waitForNextPresentationUpdate];
+#else
+    [scrollView setContentOffset:CGPointMake(0, -contentInsetTop + 30)];
+    [webView waitForNextVisibleContentRectUpdate];
+    [webView waitForNextPresentationUpdate];
+#endif
+
+    {
+        bool colorUpdated = false;
+        RetainPtr colorObserver = adoptNS([[TestKVOWrapper alloc] initWithObservable:webView.get() keyPath:@"_sampledTopFixedPositionContentColor" callback:[&] {
+            colorUpdated = true;
+        }]);
+
+        [webView objectByEvaluatingJavaScript:@"document.querySelector('header').style.backgroundColor = 'green'"];
+        [webView waitForNextPresentationUpdate];
+        [webView waitForNextPresentationUpdate];
+
+        EXPECT_FALSE(colorUpdated);
+        expectBlue([webView _sampledTopFixedPositionContentColor].CGColor);
+    }
+}
+
+#endif
+
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL) && (PLATFORM(MAC) || PLATFORM(IOS) || PLATFORM(MACCATALYST) || PLATFORM(VISION))
 
 TEST(SampledPageTopColor, ForcedUserGestureFromJSInjectionDoesNotPreventTopEdgeSampling)
@@ -544,13 +673,7 @@ TEST(SampledPageTopColor, ForcedUserGestureFromJSInjectionDoesNotPreventTopEdgeS
     [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
     [webView waitForNextPresentationUpdate];
 
-    {
-        auto components = CGColorGetComponents([webView _sampledTopFixedPositionContentColor].CGColor);
-        EXPECT_IN_RANGE(components[0], 0.99, 1.01);
-        EXPECT_IN_RANGE(components[1], 0.38, 0.39);
-        EXPECT_IN_RANGE(components[2], 0.27, 0.28);
-        EXPECT_EQ(components[3], 1);
-    }
+    expectTomato([webView _sampledTopFixedPositionContentColor].CGColor);
 
     [webView objectByEvaluatingJavaScriptWithUserGesture:@"'injected'"];
 
@@ -563,13 +686,7 @@ TEST(SampledPageTopColor, ForcedUserGestureFromJSInjectionDoesNotPreventTopEdgeS
     TestWebKitAPI::Util::run(&done);
     EXPECT_TRUE([webView _fixedContainerEdges] & _WKRectEdgeTop);
 
-    {
-        auto components = CGColorGetComponents([webView _sampledTopFixedPositionContentColor].CGColor);
-        EXPECT_IN_RANGE(components[0], -0.01, 0.01);
-        EXPECT_IN_RANGE(components[1], -0.01, 0.01);
-        EXPECT_IN_RANGE(components[2], 0.99, 1.01);
-        EXPECT_EQ(components[3], 1);
-    }
+    expectBlue([webView _sampledTopFixedPositionContentColor].CGColor);
 
     // Now make sure actual user interaction *does* prevent top edge sampling still.
     [webView objectByEvaluatingJavaScript:@"var btn = document.createElement('button'); btn.id = 'changeColor'; btn.textContent = 'Change'; btn.style.cssText = 'position: absolute; top: 200px; left: 50px'; btn.onclick = function() { document.querySelector('header').style.backgroundColor = 'yellow'; }; document.body.appendChild(btn); void(0)"];
@@ -590,13 +707,7 @@ TEST(SampledPageTopColor, ForcedUserGestureFromJSInjectionDoesNotPreventTopEdgeS
 #endif
     [webView waitForNextPresentationUpdate];
 
-    {
-        auto components = CGColorGetComponents([webView _sampledTopFixedPositionContentColor].CGColor);
-        EXPECT_IN_RANGE(components[0], -0.01, 0.01);
-        EXPECT_IN_RANGE(components[1], -0.01, 0.01);
-        EXPECT_IN_RANGE(components[2], 0.99, 1.01);
-        EXPECT_EQ(components[3], 1);
-    }
+    expectBlue([webView _sampledTopFixedPositionContentColor].CGColor);
 }
 
 #endif

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -252,6 +252,7 @@ class Color;
 - (void)sendClickAtPoint:(NSPoint)pointInWindow;
 - (void)rightClickAtPoint:(NSPoint)pointInWindow;
 - (void)wheelEventAtPoint:(CGPoint)pointInWindow wheelDelta:(CGSize)delta;
+- (void)wheelEventAtPoint:(CGPoint)pointInWindow wheelDelta:(CGSize)delta phase:(CGScrollPhase)phase momentumPhase:(CGMomentumScrollPhase)momentumPhase;
 - (BOOL)acceptsFirstMouseAtPoint:(NSPoint)pointInWindow;
 - (NSWindow *)hostWindow;
 - (void)typeCharacter:(char)character modifiers:(NSEventModifierFlags)modifiers;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -1668,14 +1668,23 @@ static WKContentView *recursiveFindWKContentView(UIView *view)
 
 - (void)wheelEventAtPoint:(CGPoint)pointInWindow wheelDelta:(CGSize)delta
 {
-    RetainPtr<CGEventRef> cgScrollEvent = adoptCF(CGEventCreateScrollWheelEvent(nullptr, kCGScrollEventUnitPixel, 2, delta.height, delta.width, 0));
+    static constexpr auto phase = static_cast<CGScrollPhase>(0);
+    [self wheelEventAtPoint:pointInWindow wheelDelta:delta phase:phase momentumPhase:kCGMomentumScrollPhaseNone];
+}
+
+- (void)wheelEventAtPoint:(CGPoint)pointInWindow wheelDelta:(CGSize)delta phase:(CGScrollPhase)phase momentumPhase:(CGMomentumScrollPhase)momentumPhase
+{
+    RetainPtr cgScrollEvent = adoptCF(CGEventCreateScrollWheelEvent(nullptr, kCGScrollEventUnitPixel, 2, delta.height, delta.width, 0));
+
+    CGEventSetIntegerValueField(cgScrollEvent.get(), kCGScrollWheelEventScrollPhase, phase);
+    CGEventSetIntegerValueField(cgScrollEvent.get(), kCGScrollWheelEventMomentumPhase, momentumPhase);
 
     CGPoint locationInGlobalScreenCoordinates = [[self window] convertPointToScreen:pointInWindow];
     locationInGlobalScreenCoordinates.y = [[[NSScreen screens] objectAtIndex:0] frame].size.height - locationInGlobalScreenCoordinates.y;
     CGEventSetLocation(cgScrollEvent.get(), locationInGlobalScreenCoordinates);
-    
-    NSEvent* event = [NSEvent eventWithCGEvent:cgScrollEvent.get()];
-    [self scrollWheel:event];
+
+    RetainPtr event = [NSEvent eventWithCGEvent:cgScrollEvent.get()];
+    [self scrollWheel:event.get()];
 }
 
 - (NSWindow *)hostWindow


### PR DESCRIPTION
#### aa9d5ddfb18a7595a71e659af04d1ea548a535b4
<pre>
Top scroll stretching should not stop color sampling of top edge
<a href="https://bugs.webkit.org/show_bug.cgi?id=309215">https://bugs.webkit.org/show_bug.cgi?id=309215</a>
<a href="https://rdar.apple.com/171697732">rdar://171697732</a>

Reviewed by Wenson Hsieh, Aditya Keerthi, and Abrar Rahman Protyasha.

To prevent rapid changes in the sampled top color, we stop updating it after
the user scrolls. However, if the user does not scroll into the page and instead
only scrolls into the top scroll stretch area, we should continue to update
the sampled color.

Add new method LocalFrameView::wasEverScrolledExplicitlyByUserBelowTopEdge()
which tracks exactly what it sounds like. In Page::updateFixedContainerEdges,
instead of skipping the top color sample if the user explicitly scrolled,
we only skip if the user expliclitly scrolled below the top of the page (aka
outside of the top scroll stretch area).

Add a new `wheelEventAtPoint:` method to `TestWKWebView.mm` which takes a
scroll phase and momentum phase to allow for simulated scrolls with rubberbanding
to occur on macOS.

Add new methods `_waitForWheelEventsToCompleteForTesting` and
`_startMonitoringWheelEventsForTesting` to track when scrolling completes during
an API test.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::reset):
(WebCore::LocalFrameView::setLastUserScrollType):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateFixedContainerEdges):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _startMonitoringWheelEventsForTesting:]):
(-[WKWebView _waitForWheelEventsToCompleteForTesting:]):
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
(WebKit::WebPageProxyTesting::startMonitoringWheelEventsForTesting):
(WebKit::WebPageProxyTesting::waitForWheelEventsToCompleteForTesting):
* Source/WebKit/UIProcess/WebPageProxyTesting.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp:
(WebKit::WebPageTesting::startMonitoringWheelEventsForTesting):
(WebKit::WebPageTesting::waitForWheelEventsToCompleteForTesting):
* Source/WebKit/WebProcess/WebPage/WebPageTesting.h:
* Source/WebKit/WebProcess/WebPage/WebPageTesting.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm:
(TestWebKitAPI::checkColorComponents):
(TestWebKitAPI::expectTomato):
(TestWebKitAPI::expectBlue):
(TestWebKitAPI::TEST(SampledPageTopColor, TopScrollStretchingDoesNotPreventTopEdgeSampling)):
(TestWebKitAPI::TEST(SampledPageTopColor, ForcedUserGestureFromJSInjectionDoesNotPreventTopEdgeSampling)):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView wheelEventAtPoint:wheelDelta:]):
(-[TestWKWebView wheelEventAtPoint:wheelDelta:phase:momentumPhase:]):

Canonical link: <a href="https://commits.webkit.org/308849@main">https://commits.webkit.org/308849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2fcc965bf198f4c978c60c938df7c29cf911708a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21384 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/14953 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/157356 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150544 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21836 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/21262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/157356 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151631 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/16802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/157356 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/14953 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4791 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/11375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/159691 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/2831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/12897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/159691 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/21262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/159691 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/133169 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22903 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/9931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/20796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->