### PR TITLE
Use ASSERT_WITH_SECURITY_IMPLICATION() in ThreadLikeAssertion

### DIFF
--- a/Source/WTF/wtf/RefCountDebugger.h
+++ b/Source/WTF/wtf/RefCountDebugger.h
@@ -127,7 +127,7 @@ public:
             // from both different threads in a way that is likely concurrent and unsafe.
             // Derive from ThreadSafeRefCounted and make sure the destructor is safe on threads
             // that call deref, or ref/deref from a single thread or serial work queue.
-            ASSERT_WITH_SECURITY_IMPLICATION(m_ownerThread.isCurrent()); // Unsafe to ref/deref from different threads.
+            assertIsCurrent(m_ownerThread); // Unsafe to ref/deref from different threads.
         }
 #else
         UNUSED_PARAM(refCount);

--- a/Source/WTF/wtf/ThreadAssertions.h
+++ b/Source/WTF/wtf/ThreadAssertions.h
@@ -107,7 +107,7 @@ public:
     bool isCurrent() const; // Public as used in API tests.
 private:
     constexpr ThreadLikeAssertion(uint32_t uid);
-#if ASSERT_ENABLED
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
     uint32_t m_uid;
 #endif
     friend void assertIsCurrent(const ThreadLikeAssertion&);
@@ -116,7 +116,7 @@ private:
 
 inline ThreadLikeAssertion::ThreadLikeAssertion(CurrentThreadLike)
 {
-#if ASSERT_ENABLED
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
     m_uid = isMainThread() ? mainThreadLike : ThreadLike::currentSequence();
 #endif
 }
@@ -128,7 +128,7 @@ inline ThreadLikeAssertion::ThreadLikeAssertion(ThreadLikeAssertion&& other)
 
 inline ThreadLikeAssertion& ThreadLikeAssertion::operator=(ThreadLikeAssertion&& other)
 {
-#if ASSERT_ENABLED
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
     m_uid = std::exchange(other.m_uid, anyThreadLike);
 #else
     UNUSED_PARAM(other);
@@ -137,18 +137,16 @@ inline ThreadLikeAssertion& ThreadLikeAssertion::operator=(ThreadLikeAssertion&&
 }
 
 inline constexpr ThreadLikeAssertion::ThreadLikeAssertion(uint32_t uid)
-#if ASSERT_ENABLED
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
     : m_uid(uid)
 #endif
 {
-#if !ASSERT_ENABLED
     UNUSED_PARAM(uid);
-#endif
 }
 
 inline bool ThreadLikeAssertion::isCurrent() const
 {
-#if ASSERT_ENABLED
+#if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
     if (m_uid == anyThreadLike)
         return true;
     if (m_uid == mainThreadLike)
@@ -161,7 +159,8 @@ inline bool ThreadLikeAssertion::isCurrent() const
 
 inline void assertIsCurrent(const ThreadLikeAssertion& threadLikeAssertion) WTF_ASSERTS_ACQUIRED_CAPABILITY(threadLikeAssertion)
 {
-    ASSERT_UNUSED(threadLikeAssertion, threadLikeAssertion.isCurrent());
+    UNUSED_PARAM(threadLikeAssertion);
+    ASSERT_WITH_SECURITY_IMPLICATION(threadLikeAssertion.isCurrent());
 }
 
 inline ThreadLikeAssertion ThreadLike::createThreadLikeAssertion(uint32_t uid)


### PR DESCRIPTION
#### 26d7991c939a41bbab5d01263900598b67220208
<pre>
Use ASSERT_WITH_SECURITY_IMPLICATION() in ThreadLikeAssertion
<a href="https://bugs.webkit.org/show_bug.cgi?id=309216">https://bugs.webkit.org/show_bug.cgi?id=309216</a>

Reviewed by Ryosuke Niwa.

Use ASSERT_WITH_SECURITY_IMPLICATION() in ThreadLikeAssertion to help
catch more threading issues.

* Source/WTF/wtf/RefCountDebugger.h:
(WTF::RefCountDebuggerImpl::applyRefDerefThreadingCheck const):
* Source/WTF/wtf/ThreadAssertions.h:
(WTF::ThreadLikeAssertion::ThreadLikeAssertion):
(WTF::ThreadLikeAssertion::operator=):
(WTF::ThreadLikeAssertion::isCurrent const):
(WTF::WTF_ASSERTS_ACQUIRED_CAPABILITY):

Canonical link: <a href="https://commits.webkit.org/308688@main">https://commits.webkit.org/308688@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18ba6e7aff450cfed0b20e4597d184024299b123

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148219 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156902 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/972528bc-2193-496c-b579-fec6351e2017) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20810 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114272 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cce1eed9-c71e-496d-931f-8588c6a7fbc8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95043 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c24664a9-c682-4853-8b6e-f43fbee383d8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15630 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13437 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4339 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140186 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159235 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9006 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2369 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122307 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122526 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/33313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132821 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76863 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22845 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17943 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9561 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179639 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20320 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45992 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20051 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20197 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20106 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->