### PR TITLE
Use shouldBe assertions instead of console.log(FAIL) in mixed content and CSP upgrade-insecure-requests tests

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-insecure-css-in-iframe-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-insecure-css-in-iframe-expected.txt
@@ -1,3 +1,4 @@
+PASS window.data is 'done'
 This test loads a secure iframe that loads an insecure style sheet. We should upgrade the CSS request to HTTPS, and thereby avoid triggering a mixed content callback.
 
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-insecure-css-in-iframe.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-insecure-css-in-iframe.html
@@ -1,15 +1,17 @@
 <!DOCTYPE html>
 <html>
 <body>
+<script src="../../../../resources/js-test-pre.js"></script>
 <script>
 if (window.testRunner) {
     testRunner.waitUntilDone();
     testRunner.dumpAsText();
 }
 
+window.data = null;
 window.addEventListener("message", function (e) {
-    if (e.data !== 'done')
-        console.log('FAIL: Insecure CSS was NOT upgraded');
+    window.data = e.data;
+    shouldBe("window.data", "'done'");
 
     if (window.testRunner)
         testRunner.notifyDone();

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-redirect-http-to-https-script-in-iframe-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-redirect-http-to-https-script-in-iframe-expected.txt
@@ -1,3 +1,4 @@
+PASS window.data is 'done'
 This test loads a secure iframe that loads an insecure script (but with a tricky redirect). We should upgrade the script request, and thereby avoid triggering a mixed content callback.
 
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-redirect-http-to-https-script-in-iframe.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-redirect-http-to-https-script-in-iframe.html
@@ -1,16 +1,17 @@
 <!DOCTYPE html>
 <html>
 <body>
+<script src="../../../../resources/js-test-pre.js"></script>
 <script>
 if (window.testRunner) {
     testRunner.waitUntilDone();
     testRunner.dumpAsText();
 }
 
-window.addEventListener("message", function (e)
-{
-    if (e.data !== 'done')
-        console.log('FAIL: Insecure script was NOT upgraded');
+window.data = null;
+window.addEventListener("message", function (e) {
+    window.data = e.data;
+    shouldBe("window.data", "'done'");
 
     if (window.testRunner)
         testRunner.notifyDone();

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-redirect-https-to-http-script-in-iframe-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-redirect-https-to-http-script-in-iframe-expected.txt
@@ -1,3 +1,4 @@
+PASS window.data is 'done'
 This test loads a secure iframe that loads an insecure script (but with a tricky redirect). We should upgrade the relevant requests.
 
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-redirect-https-to-http-script-in-iframe.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-redirect-https-to-http-script-in-iframe.html
@@ -1,15 +1,17 @@
 <!DOCTYPE html>
 <html>
 <body>
+<script src="../../../../resources/js-test-pre.js"></script>
 <script>
 if (window.testRunner) {
     testRunner.waitUntilDone();
     testRunner.dumpAsText();
 }
-window.addEventListener("message", function (e)
-{
-    if (e.data !== 'done')
-        console.log('FAIL: Insecure script was NOT upgraded');
+
+window.data = null;
+window.addEventListener("message", function (e) {
+    window.data = e.data;
+    shouldBe("window.data", "'done'");
 
     if (window.testRunner)
         testRunner.notifyDone();

--- a/LayoutTests/http/tests/security/mixedContent/insecure-css-in-iframe-expected.txt
+++ b/LayoutTests/http/tests/security/mixedContent/insecure-css-in-iframe-expected.txt
@@ -1,5 +1,6 @@
 CONSOLE MESSAGE: [blocked] The page at https://127.0.0.1:8443/security/mixedContent/resources/frame-with-insecure-css.html requested insecure content from http://127.0.0.1:8080/security/mixedContent/resources/style.css. This content was blocked and must be served over HTTPS.
 
+PASS window.data is 'blocked'
 This test loads a secure iframe that loads an insecure style sheet. We should trigger a mixed content callback because an active network attacker can use CSS3 to breach the confidentiality of the HTTPS security origin.
 
 

--- a/LayoutTests/http/tests/security/mixedContent/insecure-css-in-iframe.html
+++ b/LayoutTests/http/tests/security/mixedContent/insecure-css-in-iframe.html
@@ -1,14 +1,16 @@
 <html>
 <body>
+<script src="../../resources/js-test-pre.js"></script>
 <script>
 if (window.testRunner) {
     testRunner.waitUntilDone();
     testRunner.dumpAsText();
 }
 
+window.data = null;
 window.addEventListener("message", function (e) {
-    if (e.data !== 'blocked')
-        console.log('FAIL: Insecure CSS was NOT blocked');
+    window.data = e.data;
+    shouldBe("window.data", "'blocked'");
 
     if (window.testRunner)
         testRunner.notifyDone();

--- a/LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-iframe-expected.txt
+++ b/LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-iframe-expected.txt
@@ -1,5 +1,6 @@
 CONSOLE MESSAGE: [blocked] The page at https://127.0.0.1:8443/security/mixedContent/resources/frame-with-insecure-iframe.html requested insecure content from http://127.0.0.1:8080/security/mixedContent/resources/boring.html. This content was blocked and must be served over HTTPS.
 
+PASS window.data is 'blocked'
 This test loads a secure iframe that loads an insecure iframe. We should get a mixed content callback becase the secure inner frame should block mixed content.
 
 

--- a/LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-iframe.html
+++ b/LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-iframe.html
@@ -1,14 +1,16 @@
 <html>
 <body>
+<script src="../../resources/js-test-pre.js"></script>
 <script>
 if (window.testRunner) {
     testRunner.waitUntilDone();
     testRunner.dumpAsText();
 }
 
+window.data = null;
 window.addEventListener("message", function (e) {
-    if (e.data !== 'blocked')
-        console.log('FAIL: Insecure nested iframe was NOT blocked');
+    window.data = e.data;
+    shouldBe("window.data", "'blocked'");
 
     if (window.testRunner)
         testRunner.notifyDone();

--- a/LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-main-frame-UpgradeMixedContent-expected.txt
+++ b/LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-main-frame-UpgradeMixedContent-expected.txt
@@ -1,3 +1,4 @@
 CONSOLE MESSAGE: [blocked] The page at https://127.0.0.1:8443/security/mixedContent/resources/frame-with-insecure-frame.html requested insecure content from http://127.0.0.1:8080/security/mixedContent/resources/boring.html. This content was blocked and must be served over HTTPS.
 
+PASS window.data is 'blocked'
 This test opens a window that loads an insecure iframe. We should trigger a mixed content callback and block the request because the main frame in the window is HTTPS but is displaying insecure content.

--- a/LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-main-frame-UpgradeMixedContent.html
+++ b/LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-main-frame-UpgradeMixedContent.html
@@ -1,15 +1,17 @@
 <!doctype html>
 <html>
 <body>
+<script src="../../resources/js-test-pre.js"></script>
 <script>
 if (window.testRunner) {
     testRunner.waitUntilDone();
     testRunner.dumpAsText();
 }
 
+window.data = null;
 window.addEventListener("message", function (e) {
-    if (e.data !== 'blocked')
-        console.log('FAIL: Insecure iframe was NOT blocked');
+    window.data = e.data;
+    shouldBe("window.data", "'blocked'");
 
     if (window.testRunner)
         testRunner.notifyDone();

--- a/LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-sandboxed-iframe-UpgradeMixedContent-expected.txt
+++ b/LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-sandboxed-iframe-UpgradeMixedContent-expected.txt
@@ -1,5 +1,6 @@
 CONSOLE MESSAGE: [blocked] The page at https://127.0.0.1:8443/security/mixedContent/resources/frame-with-insecure-iframe.html requested insecure content from http://127.0.0.1:8080/security/mixedContent/resources/boring.html. This content was blocked and must be served over HTTPS.
 
+PASS window.data is 'blocked'
 This test embeds a secure iframe which tries to open mixed content. We should block mixed content even though the parent frame is insecure because the middle frame is HTTPS.
 
 

--- a/LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-sandboxed-iframe-UpgradeMixedContent.html
+++ b/LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-sandboxed-iframe-UpgradeMixedContent.html
@@ -1,14 +1,16 @@
 <!DOCTYPE html>
 <body>
+<script src="../../resources/js-test-pre.js"></script>
 <script>
 if (window.testRunner) {
     testRunner.waitUntilDone();
     testRunner.dumpAsText();
 }
 
+window.data = null;
 window.addEventListener("message", function(e) {
-    if (e.data !== 'blocked')
-        console.log('FAIL: Insecure nested iframe was NOT blocked');
+    window.data = e.data;
+    shouldBe("window.data", "'blocked'");
 
     if (window.testRunner)
         testRunner.notifyDone();

--- a/LayoutTests/http/tests/security/mixedContent/redirect-http-to-https-iframe-in-main-frame-expected.txt
+++ b/LayoutTests/http/tests/security/mixedContent/redirect-http-to-https-iframe-in-main-frame-expected.txt
@@ -1,3 +1,4 @@
 CONSOLE MESSAGE: [blocked] The page at https://127.0.0.1:8443/security/mixedContent/resources/frame-with-redirect-http-to-https-frame.html requested insecure content from http://127.0.0.1:8080/resources/redirect.py?url=https://127.0.0.1:8443/security/mixedContent/resources/boring.html. This content was blocked and must be served over HTTPS.
 
+PASS window.data is 'blocked'
 This test opens a window that loads an insecure iframe (via a tricky redirect). We should trigger a mixed content callback because the main frame in the window is HTTPS but is displaying content that can be controlled by an active network attacker.

--- a/LayoutTests/http/tests/security/mixedContent/redirect-http-to-https-iframe-in-main-frame.html
+++ b/LayoutTests/http/tests/security/mixedContent/redirect-http-to-https-iframe-in-main-frame.html
@@ -1,14 +1,16 @@
 <html>
 <body>
+<script src="../../resources/js-test-pre.js"></script>
 <script>
 if (window.testRunner) {
     testRunner.waitUntilDone();
     testRunner.dumpAsText();
 }
 
+window.data = null;
 window.addEventListener("message", function (e) {
-    if (e.data !== 'blocked')
-        console.log('FAIL: Insecure iframe was NOT blocked');
+    window.data = e.data;
+    shouldBe("window.data", "'blocked'");
 
     if (window.testRunner)
         testRunner.notifyDone();


### PR DESCRIPTION
#### 2a0eaea832457e1870819766ffe623e62afb9bdb
<pre>
Use shouldBe assertions instead of console.log(FAIL) in mixed content and CSP upgrade-insecure-requests tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=309225">https://bugs.webkit.org/show_bug.cgi?id=309225</a>
<a href="https://rdar.apple.com/171783151">rdar://171783151</a>

Reviewed by Sihui Liu.

Replace ad-hoc console.log(&apos;FAIL: ...&apos;) patterns with shouldBe() assertions
from js-test-pre.js in 8 mixed content and CSP upgrade-insecure-requests layout
tests. This brings these tests in line with the standard test assertion pattern
already used by insecure-css-in-main-frame.html and other tests in the same
directories.

No new behavior so no new tests.

* LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-insecure-css-in-iframe-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-insecure-css-in-iframe.html:
* LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-redirect-http-to-https-script-in-iframe-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-redirect-http-to-https-script-in-iframe.html:
* LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-redirect-https-to-http-script-in-iframe-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/upgrade-insecure-requests/upgrade-redirect-https-to-http-script-in-iframe.html:
* LayoutTests/http/tests/security/mixedContent/insecure-css-in-iframe-expected.txt:
* LayoutTests/http/tests/security/mixedContent/insecure-css-in-iframe.html:
* LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-iframe-expected.txt:
* LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-iframe.html:
* LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-main-frame-UpgradeMixedContent-expected.txt:
* LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-main-frame-UpgradeMixedContent.html:
* LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-sandboxed-iframe-UpgradeMixedContent-expected.txt:
* LayoutTests/http/tests/security/mixedContent/insecure-iframe-in-sandboxed-iframe-UpgradeMixedContent.html:
* LayoutTests/http/tests/security/mixedContent/redirect-http-to-https-iframe-in-main-frame-expected.txt:
* LayoutTests/http/tests/security/mixedContent/redirect-http-to-https-iframe-in-main-frame.html:

Canonical link: <a href="https://commits.webkit.org/308765@main">https://commits.webkit.org/308765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dbb0cff7f17580e075b6faae68f4b487901f7cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148236 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156919 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bbf94efd-59e3-4bc3-b3c2-728698dbe28c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114283 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/28b2db4e-60f9-4ca8-8a48-5111e35960ed) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95054 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4dd0f24a-3c05-4f3d-9fe6-e1084dd52b49) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15638 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13447 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4356 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125242 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159252 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122317 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122537 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33351 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132831 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76880 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17950 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9571 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20337 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20068 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20214 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20123 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->