### PR TITLE
Make 'hidden' attribute play nicely with TextManipulationController observing

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5660,6 +5660,16 @@ void Element::updateIdForDocument(HTMLDocument& document, const AtomString& oldI
     }
 }
 
+bool Element::shouldNotifyTextManipulationControllerIfDisplayed() const
+{
+    return hasStateFlag(StateFlag::ShouldNotifyTextManipulationControllerIfDisplayed);
+}
+
+void Element::clearShouldNotifyTextManipulationControllerIfDisplayed()
+{
+    clearStateFlag(StateFlag::ShouldNotifyTextManipulationControllerIfDisplayed);
+}
+
 void Element::willModifyAttribute(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue)
 {
     if (name == HTMLNames::idAttr)
@@ -5671,7 +5681,8 @@ void Element::willModifyAttribute(const QualifiedName& name, const AtomString& o
             if (treeScope().shouldCacheLabelsByForAttribute())
                 label->updateLabel(treeScope(), oldValue, newValue);
         }
-    }
+    } else if (name == HTMLNames::hiddenAttr)
+        setStateFlag(StateFlag::ShouldNotifyTextManipulationControllerIfDisplayed);
 
     if (auto recipients = MutationObserverInterestGroup::createForAttributesMutation(*this, name))
         recipients->enqueueMutationRecord(MutationRecord::createAttributes(*this, name, oldValue));

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -917,6 +917,9 @@ public:
 
     void addShadowRoot(Ref<ShadowRoot>&&);
 
+    bool shouldNotifyTextManipulationControllerIfDisplayed() const;
+    void clearShouldNotifyTextManipulationControllerIfDisplayed();
+
 protected:
     Element(const QualifiedName&, Document&, OptionSet<TypeFlag>);
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -662,7 +662,8 @@ protected:
         InLargestContentfulPaintTextContentSet = 1 << 20,
         DidMutateSubtreeAfterSetInnerHTML = 1 << 21,
         WasParsedWithFastPath = 1 << 22,
-        // 9 bits free.
+        ShouldNotifyTextManipulationControllerIfDisplayed = 1 << 23,
+        // 8 bits free.
     };
 
     enum class TabIndexState : uint8_t {

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -107,6 +107,7 @@
 #include "StyleScope.h"
 #include "Styleable.h"
 #include "TextAutoSizing.h"
+#include "TextManipulationController.h"
 #include "ViewTransition.h"
 #include <wtf/MathExtras.h>
 #include <wtf/StackStats.h>
@@ -1067,6 +1068,13 @@ inline void RenderCounter::rendererStyleChanged(RenderElement& renderer, const R
 
 void RenderElement::styleDidChange(Style::Difference diff, const RenderStyle* oldStyle)
 {
+    RefPtr protectedElement = element();
+    if (protectedElement && protectedElement->shouldNotifyTextManipulationControllerIfDisplayed() && !isSkippedContent()) {
+        protectedElement->clearShouldNotifyTextManipulationControllerIfDisplayed();
+        if (auto* textManipulationController = document().textManipulationControllerIfExists())
+            textManipulationController->didAddOrCreateRendererForNode(*protectedElement);
+    }
+
     auto registerImages = [this](auto* style, auto* oldStyle) {
         if (!style && !oldStyle)
             return;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm
@@ -319,6 +319,7 @@ TEST(TextManipulation, StartTextManipulationFindNewlyDisplayedParagraph)
             "<span class='hidden'>Kit</span>"
         "</div>"
         "<div class='hidden'>hey</div>"
+        "<section id='section' hidden='until-found'>there</section>"
         "</body></html>"];
 
     done = false;
@@ -344,7 +345,7 @@ TEST(TextManipulation, StartTextManipulationFindNewlyDisplayedParagraph)
     EXPECT_STREQ("Web", items[1].tokens[0].content.UTF8String);
     EXPECT_STREQ("Kit", items[1].tokens[1].content.UTF8String);
 
-    // This has to happen separately in order to have a deterministic ordering.
+    // These need to happen separately in order to have a deterministic ordering.
     done = false;
     delegate.get().itemCallback = ^(_WKTextManipulationItem *item) {
         done = true;
@@ -355,6 +356,14 @@ TEST(TextManipulation, StartTextManipulationFindNewlyDisplayedParagraph)
     EXPECT_EQ(items.count, 3UL);
     EXPECT_EQ(items[2].tokens.count, 1UL);
     EXPECT_STREQ("hey", items[2].tokens[0].content.UTF8String);
+
+    done = false;
+    [webView stringByEvaluatingJavaScript:@"document.getElementById('section').removeAttribute('hidden');"];
+    TestWebKitAPI::Util::run(&done);
+
+    EXPECT_EQ(items.count, 4UL);
+    EXPECT_EQ(items[3].tokens.count, 1UL);
+    EXPECT_STREQ("there", items[3].tokens[0].content.UTF8String);
 }
 
 TEST(TextManipulation, StartTextManipulationFindSameParagraphWithNewContent)


### PR DESCRIPTION
#### d7e868645091021064481f64f61aef5fe28a43a4
<pre>
Make &apos;hidden&apos; attribute play nicely with TextManipulationController observing
<a href="https://rdar.apple.com/169931473">rdar://169931473</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309226">https://bugs.webkit.org/show_bug.cgi?id=309226</a>

Reviewed by Ryosuke Niwa.

When a TextManipulationController starts observing a Document, parts of the DOM that are not visible are skipped.
If they later become visible, they are then processed.

This is currently handled by the existence of a renderer. When an element without a renderer has something change
(such as its CSS &quot;display&quot; property) that causes a renderer to be created, the TextManipulationController is told.

However some elements can already have a renderer even though they will never display.
This is related to the HTML &quot;hidden&quot; attribute - which is entirely distinct from a hidden style - being removed.

Since they already have a renderer, the TextManipulationController was never told about a renderer being created,
and therefore their newfound visibility went unnoticed.

This patch adds explicit logic around this case. Whenever the `hidden` attribute on an `Element` changes, the
element is flagged for one-time special processing in style recalc so it can be passed to TextManipulationController.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::shouldNotifyTextManipulationControllerIfDisplayed const):
(WebCore::Element::clearShouldNotifyTextManipulationControllerIfDisplayed):
(WebCore::Element::willModifyAttribute):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/Node.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleDidChange):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextManipulation.mm:
(TestWebKitAPI::TEST(TextManipulation, StartTextManipulationFindNewlyDisplayedParagraph)):

Canonical link: <a href="https://commits.webkit.org/308735@main">https://commits.webkit.org/308735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71111f7b9ac77628e6947dd2d3734d20d76f6df4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157007 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7cda3e9c-128a-4018-b7d8-915946d3c749) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150190 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20908 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114356 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c8afaca-9940-4a7e-9f12-996c782d4418) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133176 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95126 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c69a42a2-1823-4894-8611-1e65f712e3f2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15704 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13509 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4437 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125316 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159333 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2468 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12599 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122389 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20801 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122608 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33338 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132898 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76962 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18016 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9644 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20418 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84203 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20150 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20295 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20204 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->