### PR TITLE
Adopt `LIFETIME_BOUND` annotation in more places in WebCore/workers & WebCore/worklets

### DIFF
--- a/Source/WebCore/loader/WorkerThreadableLoader.cpp
+++ b/Source/WebCore/loader/WorkerThreadableLoader.cpp
@@ -72,7 +72,8 @@ WorkerThreadableLoader::~WorkerThreadableLoader()
 
 void WorkerThreadableLoader::loadResourceSynchronously(WorkerOrWorkletGlobalScope& workerOrWorkletGlobalScope, ResourceRequest&& request, ThreadableLoaderClient& client, const ThreadableLoaderOptions& options)
 {
-    WorkerRunLoop& runLoop = workerOrWorkletGlobalScope.workerOrWorkletThread()->runLoop();
+    RefPtr workerOrWorkletThread = workerOrWorkletGlobalScope.workerOrWorkletThread();
+    auto& runLoop = workerOrWorkletThread->runLoop();
 
     // Create a unique mode just for this synchronous resource load.
     auto mode = makeString("loadResourceSynchronouslyMode"_s, runLoop.createUniqueId());

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.h
@@ -69,7 +69,7 @@ public:
     static Ref<DedicatedWorkerGlobalScope> create(const WorkerParameters&, Ref<SecurityOrigin>&&, DedicatedWorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<WorkerClient>&&);
     virtual ~DedicatedWorkerGlobalScope();
 
-    const String& name() const { return m_name; }
+    const String& name() const LIFETIME_BOUND { return m_name; }
 
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, StructuredSerializeOptions&&);
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, Vector<JSC::Strong<JSC::JSObject>>&&);

--- a/Source/WebCore/workers/ScriptBuffer.h
+++ b/Source/WebCore/workers/ScriptBuffer.h
@@ -44,7 +44,7 @@ public:
     static ScriptBuffer empty();
 
     String toString() const;
-    const SharedBufferBuilder& bufferBuilder() const { return m_buffer; }
+    const SharedBufferBuilder& bufferBuilder() const LIFETIME_BOUND { return m_buffer; }
     const FragmentedSharedBuffer* buffer() const { return m_buffer.buffer(); }
     RefPtr<const FragmentedSharedBuffer> bufferForSerialization() const { return m_buffer.buffer(); }
     size_t size() const { return m_buffer.size(); }

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -76,7 +76,7 @@ public:
     bool wasTerminated() const { return m_wasTerminated; }
 
     String identifier() const { return m_identifier; }
-    const String& name() const { return m_options.name; }
+    const String& name() const LIFETIME_BOUND { return m_options.name; }
 
     ScriptExecutionContext* scriptExecutionContext() const final;
 

--- a/Source/WebCore/workers/WorkerFontLoadRequest.h
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.h
@@ -56,7 +56,7 @@ public:
 private:
     WorkerFontLoadRequest(URL&&, LoadedFromOpaqueSource);
 
-    const URL& url() const final { return m_url; }
+    const URL& url() const LIFETIME_BOUND final { return m_url; }
     bool isPending() const final { return !m_isLoading && !m_errorOccurred && !m_data; }
     bool isLoading() const final { return m_isLoading; }
     bool errorOccurred() const final { return m_errorOccurred; }

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -90,11 +90,11 @@ public:
     enum class Type : uint8_t { DedicatedWorker, ServiceWorker, SharedWorker };
     virtual Type type() const = 0;
 
-    const URL& url() const final { return m_url; }
-    const URL& cookieURL() const final { return url(); }
-    const URL& ownerURL() const { return m_ownerURL; }
+    const URL& url() const LIFETIME_BOUND final { return m_url; }
+    const URL& cookieURL() const LIFETIME_BOUND final { return url(); }
+    const URL& ownerURL() const LIFETIME_BOUND { return m_ownerURL; }
     String origin() const;
-    const String& inspectorIdentifier() const { return m_inspectorIdentifier; }
+    const String& inspectorIdentifier() const LIFETIME_BOUND { return m_inspectorIdentifier; }
 
     IDBClient::IDBConnectionProxy* NODELETE idbConnectionProxy() final;
     void suspend() final;
@@ -160,7 +160,7 @@ public:
     RefPtr<FontLoadRequest> fontLoadRequest(const String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource) final;
     void beginLoadingFontSoon(FontLoadRequest&) final;
 
-    const SettingsValues& settingsValues() const final { return m_settingsValues; }
+    const SettingsValues& settingsValues() const LIFETIME_BOUND final { return m_settingsValues; }
 
     FetchOptions::Credentials credentials() const { return m_credentials; }
 
@@ -173,7 +173,7 @@ public:
 
     ClientOrigin clientOrigin() const { return { topOrigin().data(), securityOrigin()->data() }; }
 
-    WorkerClient* workerClient() { return m_workerClient.get(); }
+    WorkerClient* workerClient() LIFETIME_BOUND { return m_workerClient.get(); }
 
     void reportErrorToWorkerObject(const String&);
 

--- a/Source/WebCore/workers/WorkerInspectorProxy.h
+++ b/Source/WebCore/workers/WorkerInspectorProxy.h
@@ -74,9 +74,9 @@ public:
     static Vector<Ref<WorkerInspectorProxy>> proxiesForPage(PageIdentifier);
     static Vector<Ref<WorkerInspectorProxy>> proxiesForWorkerGlobalScope(ScriptExecutionContextIdentifier);
 
-    const URL& url() const { return m_url; }
-    const String& name() const { return m_name; }
-    const String& identifier() const { return m_identifier; }
+    const URL& url() const LIFETIME_BOUND { return m_url; }
+    const String& name() const LIFETIME_BOUND { return m_name; }
+    const String& identifier() const LIFETIME_BOUND { return m_identifier; }
     ScriptExecutionContext* scriptExecutionContext() const { return m_scriptExecutionContext.get(); }
 
     WorkerThreadStartMode workerStartMode(ScriptExecutionContext&);

--- a/Source/WebCore/workers/WorkerLocation.h
+++ b/Source/WebCore/workers/WorkerLocation.h
@@ -37,7 +37,7 @@ class WorkerLocation : public RefCounted<WorkerLocation> {
 public:
     static Ref<WorkerLocation> create(URL&& url, String&& origin) { return adoptRef(*new WorkerLocation(WTF::move(url), WTF::move(origin))); }
 
-    const URL& url() const { return m_url; }
+    const URL& url() const LIFETIME_BOUND { return m_url; }
     String href() const;
 
     // URI decomposition attributes

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
@@ -62,7 +62,7 @@ public:
     JSC::VM* vmIfExists() const final;
     WorkerInspectorController& inspectorController() const { return m_inspectorController; }
 
-    ScriptModuleLoader& moduleLoader() { return m_moduleLoader; }
+    ScriptModuleLoader& moduleLoader() LIFETIME_BOUND { return m_moduleLoader; }
 
     // ScriptExecutionContext.
     EventLoopTaskGroup& eventLoop() final;

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
@@ -417,7 +417,8 @@ bool WorkerOrWorkletScriptController::loadModuleSynchronously(WorkerScriptFetche
     globalScope->eventLoop().performMicrotaskCheckpoint(*m_vm);
 
     // Drive RunLoop until we get either of "Worker is terminated", "Loading is done", or "Loading is failed".
-    WorkerRunLoop& runLoop = globalScope->workerOrWorkletThread()->runLoop();
+    RefPtr workerOrWorkletThread = globalScope->workerOrWorkletThread();
+    auto& runLoop = workerOrWorkletThread->runLoop();
 
     // We do not want to receive messages that are not related to asynchronous resource loading.
     // Otherwise, a worker discards some messages from the main thread here in a racy way.

--- a/Source/WebCore/workers/WorkerOrWorkletThread.h
+++ b/Source/WebCore/workers/WorkerOrWorkletThread.h
@@ -62,7 +62,7 @@ public:
     virtual WorkerLoaderProxy* workerLoaderProxy() const = 0;
 
     WorkerOrWorkletGlobalScope* globalScope() const { return m_globalScope.get(); }
-    WorkerRunLoop& runLoop() { return m_runLoop; }
+    WorkerRunLoop& runLoop() LIFETIME_BOUND { return m_runLoop; }
 
     void start(Function<void(const String&)>&& evaluateCallback = { });
     void stop(Function<void()>&& terminatedCallback = { });
@@ -73,7 +73,7 @@ public:
     void suspend();
     void resume();
 
-    const String& inspectorIdentifier() const { return m_inspectorIdentifier; }
+    const String& inspectorIdentifier() const LIFETIME_BOUND { return m_inspectorIdentifier; }
 
     static ThreadSafeWeakHashSet<WorkerOrWorkletThread>& workerOrWorkletThreads();
     static void releaseFastMallocFreeMemoryInAllThreads();

--- a/Source/WebCore/workers/WorkerRunLoop.h
+++ b/Source/WebCore/workers/WorkerRunLoop.h
@@ -94,7 +94,7 @@ public:
         WTF_MAKE_NONCOPYABLE(Task);
     public:
         Task(ScriptExecutionContext::Task&&, const String& mode);
-        const String& mode() const { return m_mode; }
+        const String& mode() const LIFETIME_BOUND { return m_mode; }
 
     private:
         void performTask(WorkerOrWorkletGlobalScope*);

--- a/Source/WebCore/workers/WorkerScriptLoader.h
+++ b/Source/WebCore/workers/WorkerScriptLoader.h
@@ -79,20 +79,20 @@ public:
 
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const { return m_advancedPrivacyProtections; }
 
-    const ScriptBuffer& script() const { return m_script; }
-    const ContentSecurityPolicyResponseHeaders& contentSecurityPolicy() const { return m_contentSecurityPolicy; }
-    const String& referrerPolicy() const { return m_referrerPolicy; }
-    const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy() const { return m_crossOriginEmbedderPolicy; }
-    const URL& url() const { return m_url; }
+    const ScriptBuffer& script() const LIFETIME_BOUND { return m_script; }
+    const ContentSecurityPolicyResponseHeaders& contentSecurityPolicy() const LIFETIME_BOUND { return m_contentSecurityPolicy; }
+    const String& referrerPolicy() const LIFETIME_BOUND { return m_referrerPolicy; }
+    const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy() const LIFETIME_BOUND { return m_crossOriginEmbedderPolicy; }
+    const URL& url() const LIFETIME_BOUND { return m_url; }
     const URL& responseURL() const;
     ResourceResponse::Source responseSource() const { return m_responseSource; }
     bool isRedirected() const { return m_isRedirected; }
-    const CertificateInfo& certificateInfo() const { return m_certificateInfo; }
-    const String& responseMIMEType() const { return m_responseMIMEType; }
+    const CertificateInfo& certificateInfo() const LIFETIME_BOUND { return m_certificateInfo; }
+    const String& responseMIMEType() const LIFETIME_BOUND { return m_responseMIMEType; }
     ResourceResponse::Tainting responseTainting() const { return m_responseTainting; }
     bool failed() const { return m_failed; }
     ResourceLoaderIdentifier identifier() const { return *m_identifier; }
-    const ResourceError& error() const { return m_error; }
+    const ResourceError& error() const LIFETIME_BOUND { return m_error; }
 
     WorkerFetchResult fetchResult() const;
 
@@ -129,7 +129,7 @@ public:
     WEBCORE_EXPORT static RefPtr<ServiceWorkerDataManager> serviceWorkerDataManagerFromIdentifier(ScriptExecutionContextIdentifier);
 
     std::optional<ScriptExecutionContextIdentifier> clientIdentifier() const { return m_clientIdentifier; }
-    const String& userAgentForSharedWorker() const { return m_userAgentForSharedWorker; }
+    const String& userAgentForSharedWorker() const LIFETIME_BOUND { return m_userAgentForSharedWorker; }
 
 private:
     friend class RefCounted<WorkerScriptLoader>;

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.h
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.h
@@ -67,14 +67,14 @@ public:
 
     ~ExtendableMessageEvent();
 
-    JSValueInWrappedObject& data() { return m_data; }
-    JSValueInWrappedObject& cachedPorts() { return m_cachedPorts; }
+    JSValueInWrappedObject& data() LIFETIME_BOUND { return m_data; }
+    JSValueInWrappedObject& cachedPorts() LIFETIME_BOUND { return m_cachedPorts; }
 
     String origin() const;
     const RefPtr<SecurityOrigin> securityOrigin() const;
-    const String& lastEventId() const { return m_lastEventId; }
-    const std::optional<ExtendableMessageEventSource>& source() const { return m_source; }
-    const Vector<Ref<MessagePort>>& ports() const { return m_ports; }
+    const String& lastEventId() const LIFETIME_BOUND { return m_lastEventId; }
+    const std::optional<ExtendableMessageEventSource>& source() const LIFETIME_BOUND { return m_source; }
+    const Vector<Ref<MessagePort>>& ports() const LIFETIME_BOUND { return m_ports; }
 
 private:
     ExtendableMessageEvent(const AtomString&, const Init&, IsTrusted);

--- a/Source/WebCore/workers/service/FetchEvent.h
+++ b/Source/WebCore/workers/service/FetchEvent.h
@@ -67,8 +67,8 @@ public:
     WEBCORE_EXPORT void onResponse(ResponseCallback&&);
 
     FetchRequest& request() { return m_request.get(); }
-    const String& clientId() const { return m_clientId; }
-    const String& resultingClientId() const { return m_resultingClientId; }
+    const String& clientId() const LIFETIME_BOUND { return m_clientId; }
+    const String& resultingClientId() const LIFETIME_BOUND { return m_resultingClientId; }
     DOMPromise& handled() const { return m_handled.get(); }
 
     bool respondWithEntered() const { return m_respondWithEntered; }

--- a/Source/WebCore/workers/service/RouterCondition.h
+++ b/Source/WebCore/workers/service/RouterCondition.h
@@ -40,7 +40,7 @@ class RouterNotCondition {
 public:
     RouterNotCondition(RouterCondition&&);
 
-    RouterCondition& value() & { return m_value.get(); }
+    RouterCondition& value() & LIFETIME_BOUND { return m_value.get(); }
     RouterCondition&& value() && { return WTF::move(m_value.get()); }
 
 private:

--- a/Source/WebCore/workers/service/ServiceWorker.h
+++ b/Source/WebCore/workers/service/ServiceWorker.h
@@ -60,7 +60,7 @@ public:
     void deref() const final { RefCounted::deref(); }
     USING_CAN_MAKE_WEAKPTR(EventTarget);
 
-    const URL& scriptURL() const { return m_data.scriptURL; }
+    const URL& scriptURL() const LIFETIME_BOUND { return m_data.scriptURL; }
 
     State state() const { return m_data.state; }
     
@@ -73,7 +73,7 @@ public:
     ServiceWorkerRegistrationIdentifier registrationIdentifier() const { return m_data.registrationIdentifier; }
     WorkerType workerType() const { return m_data.type; }
 
-    const ServiceWorkerData& data() const { return m_data; }
+    const ServiceWorkerData& data() const LIFETIME_BOUND { return m_data; }
 
 private:
     ServiceWorker(ScriptExecutionContext&, ServiceWorkerData&&);

--- a/Source/WebCore/workers/service/ServiceWorkerClient.h
+++ b/Source/WebCore/workers/service/ServiceWorkerClient.h
@@ -69,7 +69,7 @@ public:
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, StructuredSerializeOptions&&);
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message, Vector<JSC::Strong<JSC::JSObject>>&&);
 
-    const ServiceWorkerClientData& data() const { return m_data; }
+    const ServiceWorkerClientData& data() const LIFETIME_BOUND { return m_data; }
 
 protected:
     ServiceWorkerClient(ServiceWorkerGlobalScope&, ServiceWorkerClientData&&);

--- a/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
+++ b/Source/WebCore/workers/service/ServiceWorkerGlobalScope.h
@@ -84,8 +84,8 @@ public:
 
     void didSaveScriptsToDisk(ScriptBuffer&&, HashMap<URL, ScriptBuffer>&& importedScripts);
 
-    const ServiceWorkerContextData& contextData() const { return m_contextData; }
-    const CertificateInfo& certificateInfo() const { return m_contextData.certificateInfo; }
+    const ServiceWorkerContextData& contextData() const LIFETIME_BOUND { return m_contextData; }
+    const CertificateInfo& certificateInfo() const LIFETIME_BOUND { return m_contextData.certificateInfo; }
 
     FetchOptions::Destination destination() const final { return FetchOptions::Destination::Serviceworker; }
 
@@ -137,7 +137,7 @@ private:
     Type type() const final { return Type::ServiceWorker; }
     bool hasPendingEvents() const { return !m_extendedEvents.isEmpty(); }
 
-    NotificationClient* notificationClient() final { return m_notificationClient.get(); }
+    NotificationClient* notificationClient() LIFETIME_BOUND final { return m_notificationClient.get(); }
 
     void resetUserGesture() { m_isProcessingUserGesture = false; }
 

--- a/Source/WebCore/workers/service/ServiceWorkerJob.h
+++ b/Source/WebCore/workers/service/ServiceWorkerJob.h
@@ -64,12 +64,12 @@ public:
     using Identifier = ServiceWorkerJobIdentifier;
     Identifier identifier() const { return m_jobData.identifier().jobIdentifier; }
 
-    const ServiceWorkerJobData& data() const { return m_jobData; }
+    const ServiceWorkerJobData& data() const LIFETIME_BOUND { return m_jobData; }
     Ref<DeferredPromise> takePromise();
 
     void fetchScriptWithContext(ScriptExecutionContext&, FetchOptions::Cache);
 
-    const ServiceWorkerOrClientIdentifier& contextIdentifier() { return m_contextIdentifier; }
+    const ServiceWorkerOrClientIdentifier& contextIdentifier() LIFETIME_BOUND { return m_contextIdentifier; }
 
     bool cancelPendingLoad();
 

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.h
@@ -95,7 +95,7 @@ public:
     void getPushSubscription(DOMPromiseDeferred<IDLNullable<IDLInterface<PushSubscription>>>&&);
     void getPushPermissionState(DOMPromiseDeferred<IDLEnumeration<PushPermissionState>>&&);
 
-    const ServiceWorkerRegistrationData& data() const { return m_registrationData; }
+    const ServiceWorkerRegistrationData& data() const LIFETIME_BOUND { return m_registrationData; }
 
     void updateStateFromServer(ServiceWorkerRegistrationState, RefPtr<ServiceWorker>&&);
     void queueTaskToFireUpdateFoundEvent();

--- a/Source/WebCore/workers/service/ServiceWorkerRegistrationKey.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistrationKey.h
@@ -48,9 +48,9 @@ public:
     size_t scopeLength() const { return m_scope.string().length(); }
 
     WEBCORE_EXPORT ClientOrigin clientOrigin() const;
-    const SecurityOriginData& topOrigin() const { return m_topOrigin; }
+    const SecurityOriginData& topOrigin() const LIFETIME_BOUND { return m_topOrigin; }
     WEBCORE_EXPORT RegistrableDomain firstPartyForCookies() const;
-    const URL& scope() const { return m_scope; }
+    const URL& scope() const LIFETIME_BOUND { return m_scope; }
     void setScope(URL&& scope) { m_scope = WTF::move(scope); }
 
     bool relatesToOrigin(const SecurityOriginData&) const;

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetch.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetch.h
@@ -70,8 +70,8 @@ public:
 
     String identifier() const { return m_identifier; }
     WEBCORE_EXPORT BackgroundFetchInformation information() const;
-    const ServiceWorkerRegistrationKey& registrationKey() const { return m_registrationKey; }
-    const BackgroundFetchOptions& options() const { return m_options; }
+    const ServiceWorkerRegistrationKey& registrationKey() const LIFETIME_BOUND { return m_registrationKey; }
+    const BackgroundFetchOptions& options() const LIFETIME_BOUND { return m_options; }
 
     using RetrieveRecordResponseCallback = CompletionHandler<void(Expected<ResourceResponse, ExceptionData>&&)>;
     using RetrieveRecordResponseBodyCallback = Function<void(Expected<RefPtr<SharedBuffer>, ResourceError>&&)>;
@@ -97,8 +97,8 @@ public:
         void setAsCompleted() { m_isCompleted = true; }
         bool isCompleted() const { return m_isCompleted; }
 
-        const BackgroundFetchRequest& request() const { return m_request; }
-        const ResourceResponse& response() const { return m_response; }
+        const BackgroundFetchRequest& request() const LIFETIME_BOUND { return m_request; }
+        const ResourceResponse& response() const LIFETIME_BOUND { return m_response; }
 
         uint64_t responseDataSize() const { return m_responseDataSize; }
         void clearResponseDataSize() { m_responseDataSize = 0; }
@@ -138,7 +138,7 @@ public:
     void perform(const CreateLoaderCallback&);
 
     bool isActive() const { return m_isActive; }
-    const ClientOrigin& origin() const { return m_origin; }
+    const ClientOrigin& origin() const LIFETIME_BOUND { return m_origin; }
     uint64_t downloadTotal() const { return  m_options.downloadTotal; }
     uint64_t uploadTotal() const { return m_uploadTotal; }
 

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRecord.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRecord.h
@@ -42,7 +42,7 @@ public:
     ~BackgroundFetchRecord();
     
     using ResponseReadyPromise = DOMPromiseProxy<IDLInterface<FetchResponse>>;
-    ResponseReadyPromise& responseReady() { return m_responseReadyPromise; }
+    ResponseReadyPromise& responseReady() LIFETIME_BOUND { return m_responseReadyPromise; }
     FetchRequest& request() { return m_request; }
 
     void settleResponseReadyPromise(ExceptionOr<Ref<FetchResponse>>&&);

--- a/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h
+++ b/Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h
@@ -54,7 +54,7 @@ public:
 
     static void updateIfExisting(ScriptExecutionContext&, const BackgroundFetchInformation&);
 
-    const String& id() const { return m_information.identifier; }
+    const String& id() const LIFETIME_BOUND { return m_information.identifier; }
     uint64_t uploadTotal() const { return m_information.uploadTotal; }
     uint64_t uploaded() const { return m_information.uploaded; }
     uint64_t downloadTotal() const { return m_information.downloadTotal; }

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -67,14 +67,14 @@ public:
 
     ServiceWorkerIdentifier identifier() const { return m_serviceWorkerThread->identifier(); }
     ServiceWorkerThread& thread() { return m_serviceWorkerThread.get(); }
-    ServiceWorkerInspectorProxy& inspectorProxy() { return m_inspectorProxy; }
+    ServiceWorkerInspectorProxy& inspectorProxy() LIFETIME_BOUND { return m_inspectorProxy; }
 
     bool isTerminatingOrTerminated() const { return m_isTerminatingOrTerminated; }
     void setAsTerminatingOrTerminated() { m_isTerminatingOrTerminated = true; }
 
     WEBCORE_EXPORT RefPtr<FetchLoader> createBlobLoader(FetchLoaderClient&, const URL&);
 
-    const URL& scriptURL() const { return m_document->url(); }
+    const URL& scriptURL() const LIFETIME_BOUND { return m_document->url(); }
 
     WEBCORE_EXPORT void notifyNetworkStateChange(bool isOnline);
 

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -207,10 +207,10 @@ public:
     WEBCORE_EXPORT void removeConnection(SWServerConnectionIdentifier);
     Connection* connection(SWServerConnectionIdentifier identifier) const { return m_connections.get(identifier); }
 
-    const HashMap<SWServerConnectionIdentifier, Ref<Connection>>& connections() const { return m_connections; }
+    const HashMap<SWServerConnectionIdentifier, Ref<Connection>>& connections() const LIFETIME_BOUND { return m_connections; }
     WEBCORE_EXPORT bool canHandleScheme(StringView) const;
 
-    SWOriginStore& originStore() { return m_originStore; }
+    SWOriginStore& originStore() LIFETIME_BOUND { return m_originStore; }
 
     void refreshImportedScriptsFinished(const ServiceWorkerJobDataIdentifier&, const ServiceWorkerRegistrationKey&, const Vector<std::pair<URL, ScriptBuffer>>&, const std::optional<ProcessIdentifier>&);
     void scriptContextFailedToStart(const std::optional<ServiceWorkerJobDataIdentifier>&, SWServerWorker&, const String& message);

--- a/Source/WebCore/workers/service/server/SWServerJobQueue.h
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.h
@@ -47,8 +47,8 @@ public:
     SWServerJobQueue(const SWServerRegistration&) = delete;
     ~SWServerJobQueue();
 
-    const ServiceWorkerJobData& firstJob() const { return m_jobQueue.first(); }
-    const ServiceWorkerJobData& lastJob() const { return m_jobQueue.last(); }
+    const ServiceWorkerJobData& firstJob() const LIFETIME_BOUND { return m_jobQueue.first(); }
+    const ServiceWorkerJobData& lastJob() const LIFETIME_BOUND { return m_jobQueue.last(); }
     void enqueueJob(ServiceWorkerJobData&& jobData) { m_jobQueue.append(WTF::move(jobData)); }
     size_t size() const { return m_jobQueue.size(); }
 

--- a/Source/WebCore/workers/service/server/SWServerRegistration.h
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.h
@@ -59,7 +59,7 @@ public:
     static Ref<SWServerRegistration> create(SWServer&, const ServiceWorkerRegistrationKey&, ServiceWorkerUpdateViaCache, const URL& scopeURL, const URL& scriptURL, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, NavigationPreloadState&&);
     WEBCORE_EXPORT ~SWServerRegistration();
 
-    const ServiceWorkerRegistrationKey& key() const { return m_registrationKey; }
+    const ServiceWorkerRegistrationKey& key() const LIFETIME_BOUND { return m_registrationKey; }
 
     SWServerWorker* getNewestWorker();
     WEBCORE_EXPORT ServiceWorkerRegistrationData data() const;
@@ -116,7 +116,7 @@ public:
     WEBCORE_EXPORT std::optional<ExceptionData> enableNavigationPreload();
     WEBCORE_EXPORT std::optional<ExceptionData> disableNavigationPreload();
     WEBCORE_EXPORT std::optional<ExceptionData> setNavigationPreloadHeaderValue(String&&);
-    const NavigationPreloadState& navigationPreloadState() const { return m_preloadState; }
+    const NavigationPreloadState& navigationPreloadState() const LIFETIME_BOUND { return m_preloadState; }
 
     WEBCORE_EXPORT void addCookieChangeSubscriptions(Vector<CookieChangeSubscription>&&);
     WEBCORE_EXPORT void removeCookieChangeSubscriptions(Vector<CookieChangeSubscription>&&);

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -95,8 +95,8 @@ public:
     using OpenWindowCallback = CompletionHandler<void(Expected<std::optional<ServiceWorkerClientData>, ExceptionData>&&)>;
     virtual void openWindow(ServiceWorkerIdentifier, const URL&, OpenWindowCallback&&) = 0;
 
-    const RegistrableDomain& registrableDomain() const { return m_site.domain(); }
-    const Site& site() const { return m_site; }
+    const RegistrableDomain& registrableDomain() const LIFETIME_BOUND { return m_site.domain(); }
+    const Site& site() const LIFETIME_BOUND { return m_site; }
     std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier() const { return m_serviceWorkerPageIdentifier; }
 
     virtual void connectionIsNoLongerNeeded() = 0;

--- a/Source/WebCore/workers/service/server/SWServerWorker.h
+++ b/Source/WebCore/workers/service/server/SWServerWorker.h
@@ -85,11 +85,11 @@ public:
     void setState(State);
 
     SWServer* server() const { return m_server.get(); }
-    const ServiceWorkerRegistrationKey& registrationKey() const { return m_registrationKey; }
+    const ServiceWorkerRegistrationKey& registrationKey() const LIFETIME_BOUND { return m_registrationKey; }
     RegistrableDomain firstPartyForCookies() const { return m_registrationKey.firstPartyForCookies(); }
-    const URL& scriptURL() const { return m_data.scriptURL; }
-    const ScriptBuffer& script() const { return m_script; }
-    const CertificateInfo& certificateInfo() const { return m_certificateInfo; }
+    const URL& scriptURL() const LIFETIME_BOUND { return m_data.scriptURL; }
+    const ScriptBuffer& script() const LIFETIME_BOUND { return m_script; }
+    const CertificateInfo& certificateInfo() const LIFETIME_BOUND { return m_certificateInfo; }
     WorkerType type() const { return m_data.type; }
 
     ServiceWorkerIdentifier identifier() const { return m_data.identifier; }
@@ -119,12 +119,12 @@ public:
     WEBCORE_EXPORT static SWServerWorker* existingWorkerForIdentifier(ServiceWorkerIdentifier);
     static HashMap<ServiceWorkerIdentifier, WeakRef<SWServerWorker>>& allWorkers();
 
-    const ServiceWorkerData& data() const { return m_data; }
+    const ServiceWorkerData& data() const LIFETIME_BOUND { return m_data; }
     ServiceWorkerContextData contextData() const;
 
     WEBCORE_EXPORT const ClientOrigin& origin() const;
-    const RegistrableDomain& topRegistrableDomain() const { return m_topSite.domain(); }
-    const Site& topSite() const { return m_topSite; }
+    const RegistrableDomain& topRegistrableDomain() const LIFETIME_BOUND { return m_topSite.domain(); }
+    const Site& topSite() const LIFETIME_BOUND { return m_topSite; }
     WEBCORE_EXPORT std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier() const;
 
     WEBCORE_EXPORT SWServerToContextConnection* contextConnection();
@@ -152,7 +152,7 @@ public:
     WEBCORE_EXPORT bool isClientActiveServiceWorker(ScriptExecutionContextIdentifier) const;
 
     Vector<URL> importedScriptURLs() const;
-    const MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript>& scriptResourceMap() const { return m_scriptResourceMap; }
+    const MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript>& scriptResourceMap() const LIFETIME_BOUND { return m_scriptResourceMap; }
     bool matchingImportedScripts(const Vector<std::pair<URL, ScriptBuffer>>&) const;
 
     void markActivateEventAsFired() { m_isActivateEventFired = true; }

--- a/Source/WebCore/workers/shared/SharedWorker.h
+++ b/Source/WebCore/workers/shared/SharedWorker.h
@@ -57,7 +57,7 @@ public:
     static SharedWorker* fromIdentifier(SharedWorkerObjectIdentifier);
     MessagePort& port() const { return m_port.get(); }
 
-    const String& identifierForInspector() const { return m_identifierForInspector; }
+    const String& identifierForInspector() const LIFETIME_BOUND { return m_identifierForInspector; }
 
     void didFinishLoading(const ResourceError&);
 

--- a/Source/WebCore/workers/shared/SharedWorkerGlobalScope.h
+++ b/Source/WebCore/workers/shared/SharedWorkerGlobalScope.h
@@ -44,7 +44,7 @@ public:
     ~SharedWorkerGlobalScope();
 
     Type type() const final { return Type::SharedWorker; }
-    const String& name() const { return m_name; }
+    const String& name() const LIFETIME_BOUND { return m_name; }
     Ref<SharedWorkerThread> thread();
 
     void postConnectEvent(TransferredMessagePort&&, const SecurityOriginData&);

--- a/Source/WebCore/workers/shared/SharedWorkerScriptLoader.h
+++ b/Source/WebCore/workers/shared/SharedWorkerScriptLoader.h
@@ -53,9 +53,9 @@ public:
 
     void load(CompletionHandler<void(WorkerFetchResult&&, WorkerInitializationData&&)>&&);
 
-    const URL& url() const { return m_url; }
+    const URL& url() const LIFETIME_BOUND { return m_url; }
     SharedWorker& worker() { return m_worker.get(); }
-    const WorkerOptions& options() const { return m_options; }
+    const WorkerOptions& options() const LIFETIME_BOUND { return m_options; }
 
 private:
     SharedWorkerScriptLoader(URL&&, SharedWorker&, WorkerOptions&&);

--- a/Source/WebCore/worklets/PaintWorkletGlobalScope.h
+++ b/Source/WebCore/worklets/PaintWorkletGlobalScope.h
@@ -64,7 +64,7 @@ public:
     double devicePixelRatio() const;
 
     HashMap<String, std::unique_ptr<PaintDefinition>>& paintDefinitionMap() WTF_REQUIRES_LOCK(m_paintDefinitionLock);
-    Lock& paintDefinitionLock() WTF_RETURNS_LOCK(m_paintDefinitionLock) { return m_paintDefinitionLock; }
+    Lock& paintDefinitionLock() LIFETIME_BOUND WTF_RETURNS_LOCK(m_paintDefinitionLock) { return m_paintDefinitionLock; }
 
     void prepareForDestruction() final
     {

--- a/Source/WebCore/worklets/Worklet.h
+++ b/Source/WebCore/worklets/Worklet.h
@@ -54,8 +54,8 @@ public:
     void finishPendingTasks(WorkletPendingTasks&);
     Document* NODELETE document();
 
-    const Vector<Ref<WorkletGlobalScopeProxy>>& proxies() const { return m_proxies; }
-    const String& identifier() const { return m_identifier; }
+    const Vector<Ref<WorkletGlobalScopeProxy>>& proxies() const LIFETIME_BOUND { return m_proxies; }
+    const String& identifier() const LIFETIME_BOUND { return m_identifier; }
 
     virtual bool isAudioWorklet() const { return false; }
 

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -67,8 +67,8 @@ public:
 
     MessagePortChannelProvider& messagePortChannelProvider();
 
-    const URL& url() const final { return m_url; }
-    const URL& cookieURL() const final { return url(); }
+    const URL& url() const LIFETIME_BOUND final { return m_url; }
+    const URL& cookieURL() const LIFETIME_BOUND final { return url(); }
 
     void evaluate();
 
@@ -111,7 +111,7 @@ private:
     std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>&) final { RELEASE_ASSERT_NOT_REACHED(); return std::nullopt; }
     URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final;
     String userAgent(const URL&) const final;
-    const SettingsValues& settingsValues() const final { return m_settingsValues; }
+    const SettingsValues& settingsValues() const LIFETIME_BOUND final { return m_settingsValues; }
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 


### PR DESCRIPTION
#### 6fa60849e6a4a1dbf191c93ab571c8059ec03cc9
<pre>
Adopt `LIFETIME_BOUND` annotation in more places in WebCore/workers &amp; WebCore/worklets
<a href="https://bugs.webkit.org/show_bug.cgi?id=309227">https://bugs.webkit.org/show_bug.cgi?id=309227</a>

Reviewed by Geoffrey Garen.

* Source/WebCore/loader/WorkerThreadableLoader.cpp:
(WebCore::WorkerThreadableLoader::loadResourceSynchronously):
* Source/WebCore/workers/DedicatedWorkerGlobalScope.h:
* Source/WebCore/workers/ScriptBuffer.h:
(WebCore::ScriptBuffer::bufferBuilder const): Deleted.
* Source/WebCore/workers/Worker.h:
* Source/WebCore/workers/WorkerFontLoadRequest.h:
* Source/WebCore/workers/WorkerGlobalScope.h:
(WebCore::WorkerGlobalScope::ownerURL const): Deleted.
(WebCore::WorkerGlobalScope::inspectorIdentifier const): Deleted.
(WebCore::WorkerGlobalScope::workerClient): Deleted.
* Source/WebCore/workers/WorkerInspectorProxy.h:
(WebCore::WorkerInspectorProxy::url const): Deleted.
(WebCore::WorkerInspectorProxy::name const): Deleted.
(WebCore::WorkerInspectorProxy::identifier const): Deleted.
* Source/WebCore/workers/WorkerLocation.h:
(WebCore::WorkerLocation::url const): Deleted.
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.h:
(WebCore::WorkerOrWorkletGlobalScope::moduleLoader): Deleted.
* Source/WebCore/workers/WorkerOrWorkletScriptController.cpp:
(WebCore::WorkerOrWorkletScriptController::loadModuleSynchronously):
* Source/WebCore/workers/WorkerOrWorkletThread.h:
(WebCore::WorkerOrWorkletThread::runLoop): Deleted.
(WebCore::WorkerOrWorkletThread::inspectorIdentifier const): Deleted.
* Source/WebCore/workers/WorkerRunLoop.h:
* Source/WebCore/workers/WorkerScriptLoader.h:
* Source/WebCore/workers/service/ExtendableMessageEvent.h:
* Source/WebCore/workers/service/FetchEvent.h:
* Source/WebCore/workers/service/RouterCondition.h:
* Source/WebCore/workers/service/ServiceWorker.h:
* Source/WebCore/workers/service/ServiceWorkerClient.h:
(WebCore::ServiceWorkerClient::data const): Deleted.
* Source/WebCore/workers/service/ServiceWorkerGlobalScope.h:
* Source/WebCore/workers/service/ServiceWorkerJob.h:
* Source/WebCore/workers/service/ServiceWorkerRegistration.h:
* Source/WebCore/workers/service/ServiceWorkerRegistrationKey.h:
(WebCore::ServiceWorkerRegistrationKey::topOrigin const): Deleted.
(WebCore::ServiceWorkerRegistrationKey::scope const): Deleted.
* Source/WebCore/workers/service/background-fetch/BackgroundFetch.h:
(WebCore::BackgroundFetch::registrationKey const): Deleted.
(WebCore::BackgroundFetch::options const): Deleted.
(WebCore::BackgroundFetch::origin const): Deleted.
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRecord.h:
(WebCore::BackgroundFetchRecord::responseReady): Deleted.
* Source/WebCore/workers/service/background-fetch/BackgroundFetchRegistration.h:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebCore/workers/service/server/SWServer.h:
(WebCore::SWServer::connections const): Deleted.
(WebCore::SWServer::originStore): Deleted.
* Source/WebCore/workers/service/server/SWServerJobQueue.h:
* Source/WebCore/workers/service/server/SWServerRegistration.h:
(WebCore::SWServerRegistration::key const): Deleted.
(WebCore::SWServerRegistration::navigationPreloadState const): Deleted.
* Source/WebCore/workers/service/server/SWServerToContextConnection.h:
* Source/WebCore/workers/service/server/SWServerWorker.h:
(WebCore::SWServerWorker::registrationKey const): Deleted.
(WebCore::SWServerWorker::scriptURL const): Deleted.
(WebCore::SWServerWorker::script const): Deleted.
(WebCore::SWServerWorker::certificateInfo const): Deleted.
(WebCore::SWServerWorker::data const): Deleted.
(WebCore::SWServerWorker::topRegistrableDomain const): Deleted.
(WebCore::SWServerWorker::topSite const): Deleted.
(WebCore::SWServerWorker::scriptResourceMap const): Deleted.
* Source/WebCore/workers/shared/SharedWorker.h:
* Source/WebCore/workers/shared/SharedWorkerGlobalScope.h:
* Source/WebCore/workers/shared/SharedWorkerScriptLoader.h:
* Source/WebCore/worklets/PaintWorkletGlobalScope.h:
* Source/WebCore/worklets/Worklet.h:
(WebCore::Worklet::proxies const): Deleted.
(WebCore::Worklet::identifier const): Deleted.
* Source/WebCore/worklets/WorkletGlobalScope.h:

Canonical link: <a href="https://commits.webkit.org/308748@main">https://commits.webkit.org/308748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa58c58c349a8e81f232ad90dcc9fcf0a7fc9ca7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156921 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f5721c1-d544-4356-b823-135f437881df) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150111 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20829 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114285 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2bb67649-e669-455a-8897-8aba0a00c2f6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16523 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95056 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15645 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13449 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4358 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125249 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11011 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159254 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2388 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12529 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122322 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20722 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122542 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33343 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132835 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76882 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17952 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9575 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20339 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84124 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20070 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20216 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20125 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->