### PR TITLE
KeyframeEffect's m_document can become null

### DIFF
--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -770,7 +770,7 @@ static inline ExceptionOr<void> processPropertyIndexedKeyframes(JSGlobalObject& 
 
 ExceptionOr<Ref<KeyframeEffect>> KeyframeEffect::create(JSGlobalObject& lexicalGlobalObject, Document& document, Element* target, Strong<JSObject>&& keyframes, Variant<double, KeyframeEffectOptions>&& options)
 {
-    Ref keyframeEffect = adoptRef(*new KeyframeEffect(target ? target->document() : document, target, { }));
+    Ref keyframeEffect = adoptRef(*new KeyframeEffect(target ? &target->document() : &document, target, { }));
 
     auto timing = WTF::switchOn(WTF::move(options),
         [&](double duration) -> ExceptionOr<OptionalEffectTiming> {
@@ -825,10 +825,10 @@ Ref<KeyframeEffect> KeyframeEffect::create(Ref<KeyframeEffect>&& source)
 
 Ref<KeyframeEffect> KeyframeEffect::create(const Element& target, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
 {
-    return adoptRef(*new KeyframeEffect(target.document(), const_cast<Element*>(&target), pseudoElementIdentifier));
+    return adoptRef(*new KeyframeEffect(&target.document(), const_cast<Element*>(&target), pseudoElementIdentifier));
 }
 
-KeyframeEffect::KeyframeEffect(Document& document, Element* target, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
+KeyframeEffect::KeyframeEffect(Document* document, Element* target, const std::optional<Style::PseudoElementIdentifier>& pseudoElementIdentifier)
     : m_document(document)
     , m_target(target)
     , m_pseudoElementIdentifier(pseudoElementIdentifier)
@@ -1304,7 +1304,8 @@ bool KeyframeEffect::forceLayoutIfNeeded()
     if (CheckedPtr renderer = this->renderer(); !renderer || !renderer->parent())
         return false;
 
-    RefPtr frameView = document().view();
+    ASSERT(document());
+    RefPtr frameView = document()->view();
     if (!frameView)
         return false;
 
@@ -1349,7 +1350,8 @@ void KeyframeEffect::analyzeAcceleratedProperties()
     m_acceleratedProperties.clear();
     m_acceleratedPropertiesWithImplicitKeyframe.clear();
 
-    auto& settings = document().settings();
+    ASSERT(document());
+    auto& settings = document()->settings();
     for (auto& property : m_blendingKeyframes.properties()) {
         if (!Style::Interpolation::isAccelerated(property, settings))
             continue;
@@ -1422,7 +1424,7 @@ void KeyframeEffect::computeCSSAnimationBlendingKeyframes(const RenderStyle& una
         // Ensure resource loads for all the frames.
         for (auto& keyframe : blendingKeyframes) {
             if (CheckedPtr style = const_cast<RenderStyle*>(keyframe.style()))
-                Style::loadPendingResources(*style, document(), m_target.get());
+                Style::loadPendingResources(*style, *document(), m_target.get());
         }
     }
 
@@ -1439,7 +1441,7 @@ void KeyframeEffect::computeCSSTransitionBlendingKeyframes(const RenderStyle& ol
 
     auto toStyle = RenderStyle::clonePtr(newStyle);
     if (m_target)
-        Style::loadPendingResources(*toStyle, document(), m_target.get());
+        Style::loadPendingResources(*toStyle, *document(), m_target.get());
 
     BlendingKeyframes blendingKeyframes(m_blendingKeyframes.identifier());
 
@@ -1575,7 +1577,7 @@ const String KeyframeEffect::pseudoElement() const
 ExceptionOr<void> KeyframeEffect::setPseudoElement(const String& pseudoElement)
 {
     // https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-pseudoelement
-    auto [parsed, pseudoElementIdentifier] = pseudoElementIdentifierFromString(pseudoElement, CSSSelectorParserContext { document() });
+    auto [parsed, pseudoElementIdentifier] = pseudoElementIdentifierFromString(pseudoElement, CSSSelectorParserContext { *document() });
     if (!parsed)
         return Exception { ExceptionCode::SyntaxError, "Parsing pseudo-element selector failed"_s };
 
@@ -1695,7 +1697,8 @@ bool KeyframeEffect::isRunningAcceleratedAnimationForProperty(CSSPropertyID prop
     if (!isRunningAccelerated())
         return false;
 
-    return Style::Interpolation::isAccelerated(property, document().settings()) && m_blendingKeyframes.properties().contains(property);
+    ASSERT(document());
+    return Style::Interpolation::isAccelerated(property, document()->settings()) && m_blendingKeyframes.properties().contains(property);
 }
 
 bool KeyframeEffect::isRunningAcceleratedTransformRelatedAnimation() const
@@ -1714,23 +1717,25 @@ void KeyframeEffect::computeAcceleratedPropertiesState()
     bool hasSomeAcceleratedProperties = false;
     bool hasSomeUnacceleratedProperties = false;
 
-    auto& settings = document().settings();
-    auto isMarker = m_pseudoElementIdentifier && m_pseudoElementIdentifier->type == PseudoElementType::Marker;
+    if (RefPtr document = this->document()) {
+        auto& settings = document->settings();
+        auto isMarker = m_pseudoElementIdentifier && m_pseudoElementIdentifier->type == PseudoElementType::Marker;
 
-    auto isAcceleratedProperty = [&](AnimatableCSSProperty property) {
-        if (isMarker && std::holds_alternative<CSSPropertyID>(property) && !Style::isValidMarkerStyleProperty(std::get<CSSPropertyID>(property)))
-            return false;
-        return Style::Interpolation::isAccelerated(property, settings);
-    };
+        auto isAcceleratedProperty = [&](AnimatableCSSProperty property) {
+            if (isMarker && std::holds_alternative<CSSPropertyID>(property) && !Style::isValidMarkerStyleProperty(std::get<CSSPropertyID>(property)))
+                return false;
+            return Style::Interpolation::isAccelerated(property, settings);
+        };
 
-    for (auto property : m_blendingKeyframes.properties()) {
-        // If any animated property can be accelerated, then the animation should run accelerated.
-        if (isAcceleratedProperty(property))
-            hasSomeAcceleratedProperties = true;
-        else
-            hasSomeUnacceleratedProperties = true;
-        if (hasSomeAcceleratedProperties && hasSomeUnacceleratedProperties)
-            break;
+        for (auto property : m_blendingKeyframes.properties()) {
+            // If any animated property can be accelerated, then the animation should run accelerated.
+            if (isAcceleratedProperty(property))
+                hasSomeAcceleratedProperties = true;
+            else
+                hasSomeUnacceleratedProperties = true;
+            if (hasSomeAcceleratedProperties && hasSomeUnacceleratedProperties)
+                break;
+        }
     }
 
     if (!hasSomeAcceleratedProperties)
@@ -1961,8 +1966,10 @@ bool KeyframeEffect::canBeAccelerated(AccountForTimelineAccelerationAbility acco
     if (!m_needsComputedKeyframeOffsetsUpdate && m_blendingKeyframes.hasKeyframeWithUnresolvedComputedOffset())
         return false;
 
-    if (document().quirks().shouldPreventKeyframeEffectAcceleration(*this))
-        return false;
+    if (RefPtr document = this->document()) {
+        if (document->quirks().shouldPreventKeyframeEffectAcceleration(*this))
+            return false;
+    }
 
 #if ENABLE(THREADED_ANIMATIONS)
     if (canHaveAcceleratedRepresentation())
@@ -2438,8 +2445,9 @@ void KeyframeEffect::applyPendingAcceleratedActions()
                 renderer->animationPaused(timeOffset(), m_blendingKeyframes);
             break;
         case AcceleratedAction::Stop:
+            ASSERT(document());
             renderer->animationFinished(m_blendingKeyframes);
-            if (!document().renderTreeBeingDestroyed())
+            if (!document()->renderTreeBeingDestroyed())
                 m_target->invalidateStyleAndLayerComposition();
             m_runningAccelerated = canBeAccelerated() ? RunningAccelerated::NotStarted : RunningAccelerated::Prevented;
             break;
@@ -2694,8 +2702,9 @@ Seconds KeyframeEffect::timeToNextTick(const BasicEffectTiming& timing)
     // We only do this in case any CSS Animation event was registered since, in the general case, there's
     // a good chance that no such event listeners were registered and we can avoid some unnecessary
     // animation resolution scheduling.
+    ASSERT(document());
     if (timing.phase == AnimationEffectPhase::Active && is<CSSAnimation>(animation())
-        && document().hasListenerType(Document::ListenerType::CSSAnimation)
+        && document()->hasListenerType(Document::ListenerType::CSSAnimation)
         && !ticksContinuouslyWhileActive()) {
         if (auto iterationProgress = getComputedTiming().simpleIterationProgress)
             return iterationDuration() * (1 - *iterationProgress);
@@ -2748,7 +2757,8 @@ void KeyframeEffect::computeHasImplicitKeyframeForAcceleratedProperty()
         if (m_acceleratedPropertiesState == AcceleratedProperties::None)
             return false;
 
-        auto& settings = document().settings();
+        ASSERT(document());
+        auto& settings = document()->settings();
 
         if (!m_blendingKeyframes.isEmpty()) {
             // We make a list of all animated properties and consider them all
@@ -2824,7 +2834,8 @@ void KeyframeEffect::computeHasKeyframeComposingAcceleratedProperty()
         if (m_acceleratedPropertiesState == AcceleratedProperties::None)
             return false;
 
-        auto& settings = document().settings();
+        ASSERT(document());
+        auto& settings = document()->settings();
 
         if (!m_blendingKeyframes.isEmpty()) {
             for (auto& keyframe : m_blendingKeyframes) {
@@ -2951,9 +2962,11 @@ void KeyframeEffect::effectStackNoLongerAllowsAccelerationDuringAcceleratedActio
 #if ENABLE(THREADED_ANIMATIONS)
     if (canHaveAcceleratedRepresentation()) {
         ASSERT([&] {
-            Ref settings = document().settings();
-            if (settings->threadedScrollDrivenAnimationsEnabled() && settings->threadedTimeBasedAnimationsEnabled())
-                return false;
+            if (RefPtr document = this->document()) {
+                Ref settings = document->settings();
+                if (settings->threadedScrollDrivenAnimationsEnabled() && settings->threadedTimeBasedAnimationsEnabled())
+                    return false;
+            }
             return true;
         }());
         scheduleAssociatedAcceleratedEffectStackUpdate();
@@ -3077,7 +3090,8 @@ void KeyframeEffect::lastStyleChangeEventStyleDidChange(const RenderStyle* previ
             return;
         }
 
-        auto& settings = document().settings();
+        ASSERT(document());
+        auto& settings = document()->settings();
 
         ASSERT(previousStyle && currentStyle);
         for (auto property : CSSProperty::allAcceleratedAnimationProperties(settings)) {
@@ -3104,7 +3118,7 @@ bool KeyframeEffect::preventsAnimationReadiness() const
     // https://drafts.csswg.org/web-animations-1/#ready
     // An animation cannot be ready if it's associated with a document that does not have a browsing
     // context since this will prevent the first frame of the animmation from being rendered.
-    return !document().hasBrowsingContext();
+    return document() && !document()->hasBrowsingContext();
 }
 
 #if ENABLE(THREADED_ANIMATIONS)
@@ -3135,11 +3149,13 @@ KeyframeEffect::StackMembershipMutationScope::~StackMembershipMutationScope()
 
 bool KeyframeEffect::canHaveAcceleratedRepresentation() const
 {
-    Ref settings = document().settings();
-    if (m_isAssociatedWithProgressBasedTimeline && settings->threadedScrollDrivenAnimationsEnabled())
-        return true;
-    if (!m_isAssociatedWithProgressBasedTimeline && settings->threadedTimeBasedAnimationsEnabled())
-        return true;
+    if (RefPtr document = this->document()) {
+        Ref settings = document->settings();
+        if (m_isAssociatedWithProgressBasedTimeline && settings->threadedScrollDrivenAnimationsEnabled())
+            return true;
+        if (!m_isAssociatedWithProgressBasedTimeline && settings->threadedTimeBasedAnimationsEnabled())
+            return true;
+    }
 
     return false;
 }
@@ -3149,10 +3165,11 @@ void KeyframeEffect::scheduleAssociatedAcceleratedEffectStackUpdate(const std::o
     if (!canHaveAcceleratedRepresentation())
         return;
 
-    if (!document().page())
+    ASSERT(document());
+    if (!document()->page())
         return;
 
-    CheckedPtr timelinesController = document().timelinesController();
+    CheckedPtr timelinesController = document()->timelinesController();
     ASSERT(timelinesController);
     if (previousTarget)
         timelinesController->scheduleAcceleratedEffectStackUpdateForTarget(*previousTarget);

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -146,7 +146,7 @@ public:
 
     void willChangeRenderer();
 
-    Document& document() const final { return m_document; }
+    Document* document() const final { return m_document; }
     RenderElement* renderer() const final;
     const RenderStyle& currentStyle() const final;
     bool triggersStackingContext() const { return m_triggersStackingContext; }
@@ -198,7 +198,7 @@ public:
 #endif
 
 private:
-    KeyframeEffect(Document&, Element*, const std::optional<Style::PseudoElementIdentifier>&);
+    KeyframeEffect(Document*, Element*, const std::optional<Style::PseudoElementIdentifier>&);
     ~KeyframeEffect();
 
     enum class AcceleratedAction : uint8_t { Play, Pause, UpdateProperties, TransformChange, Stop };
@@ -299,7 +299,7 @@ private:
     const TimingFunction* timingFunctionForKeyframe(const KeyframeInterpolation::Keyframe&) const final;
     bool isPropertyAdditiveOrCumulative(KeyframeInterpolation::Property) const final;
 
-    WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
+    WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
 
     BlendingKeyframes m_blendingKeyframes { };
     HashSet<AnimatableCSSProperty> m_animatedProperties;

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -238,7 +238,8 @@ AcceleratedEffect::AcceleratedEffect(const KeyframeEffect& effect, const IntRect
         }
     }
 
-    auto& settings = effect.document().settings();
+    ASSERT(effect.document());
+    auto& settings = effect.document()->settings();
     CheckedPtr renderLayerModelObject = dynamicDowncast<RenderLayerModelObject>(effect.renderer());
 
     OptionSet<AcceleratedEffectProperty> propertiesReplacedByZeroKeyframe;

--- a/Source/WebCore/style/StyleInterpolation.cpp
+++ b/Source/WebCore/style/StyleInterpolation.cpp
@@ -187,7 +187,7 @@ static void interpolateCustomProperty(const AtomString& customProperty, RenderSt
     if (!fromValue || !toValue)
         return;
 
-    bool isInherited = client.document().customPropertyRegistry().isInherited(customProperty);
+    bool isInherited = client.document()->customPropertyRegistry().isInherited(customProperty);
     destination.setCustomPropertyValue(interpolatedCustomProperty(from, to, *fromValue, *toValue, context), isInherited);
 }
 

--- a/Source/WebCore/style/StyleInterpolationClient.h
+++ b/Source/WebCore/style/StyleInterpolationClient.h
@@ -37,7 +37,7 @@ namespace Style::Interpolation {
 
 class Client {
 public:
-    virtual Document& document() const = 0;
+    virtual Document* document() const = 0;
     virtual RenderElement* renderer() const = 0;
     virtual const RenderStyle& currentStyle() const = 0;
     virtual std::optional<unsigned> transformFunctionListPrefix() const = 0;

--- a/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
+++ b/Source/WebCore/style/values/backgrounds/StyleLineWidth.cpp
@@ -93,7 +93,9 @@ auto CSSValueConversion<LineWidth>::operator()(BuilderState& state, const CSSVal
 auto Blending<LineWidth>::blend(const LineWidth& a, const LineWidth& b, const RenderStyle& aStyle, const RenderStyle& bStyle, const Interpolation::Context& context) -> LineWidth
 {
     auto blendedValue = Style::blend(a.value, b.value, aStyle, bStyle, context);
-    return LineWidth::snapLengthAsBorderWidth(blendedValue, protect(context.client.document())->deviceScaleFactor());
+    if (RefPtr document = context.client.document())
+        return LineWidth::snapLengthAsBorderWidth(blendedValue, document->deviceScaleFactor());
+    return blendedValue;
 }
 
 // MARK: - Evaluate


### PR DESCRIPTION
#### 986dd62d92a9851728efd84e6717d476b14a9b55
<pre>
KeyframeEffect&apos;s m_document can become null
<a href="https://bugs.webkit.org/show_bug.cgi?id=309229">https://bugs.webkit.org/show_bug.cgi?id=309229</a>
<a href="https://rdar.apple.com/171630960">rdar://171630960</a>

Reviewed by NOBODY (OOPS!).

When creating a KeyFrameEffect we have a non-null document, but in edge
cases the KeyFrameEffect can outlive the document. So selectively
revert some changes <a href="https://commits.webkit.org/308181@main">308181@main</a> made to account for that reality.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/986dd62d92a9851728efd84e6717d476b14a9b55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101671 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1574f92e-944e-4e85-b8c2-e75b1b713902) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150116 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114292 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81462 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/001523bd-ad45-41e1-9ce7-8d5708555357) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133113 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95063 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/82a1fdee-df2c-44e8-ab3e-dc97e650302e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15651 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13455 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4363 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125255 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159259 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2394 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12534 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122325 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20727 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122545 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132840 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76887 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17959 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9580 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20344 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84129 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20075 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20221 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20130 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->