### PR TITLE
[JSC] Tolerant againt non-Unicode BCP 47 extensions + maximize / minimize

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlLocale.cpp
+++ b/Source/JavaScriptCore/runtime/IntlLocale.cpp
@@ -230,6 +230,61 @@ String IntlLocale::keywordValue(ASCIILiteral key, bool isBoolean) const
     return result;
 }
 
+// Build an ICU locale ID from the given source, keeping only multi-character
+// keywords (Unicode/Transform extensions). Single-character keywords (from
+// non-Unicode BCP 47 extensions like -a- or -x-) are stripped because
+// uloc_toLanguageTag cannot handle them on some ICU versions.
+static Vector<char, 64> buildLocaleIDWithUnicodeKeywords(const char* localeID)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    Vector<char, 32> baseName(32);
+    auto baseLen = uloc_getBaseName(localeID, baseName.mutableSpan().data(), baseName.size(), &status);
+    if (needsToGrowToProduceCString(status)) {
+        baseName.grow(baseLen + 1);
+        status = U_ZERO_ERROR;
+        uloc_getBaseName(localeID, baseName.mutableSpan().data(), baseName.size(), &status);
+    }
+    ASSERT(U_SUCCESS(status));
+
+    Vector<char, 64> result;
+    result.append(baseName.span().first(baseLen));
+    result.append('\0');
+    result.grow(std::max<size_t>(result.size(), 64));
+
+    status = U_ZERO_ERROR;
+    auto keywords = std::unique_ptr<UEnumeration, ICUDeleter<uenum_close>>(uloc_openKeywords(localeID, &status));
+    if (U_SUCCESS(status) && keywords) {
+        int32_t keyLen;
+        while (const char* key = uenum_next(keywords.get(), &keyLen, &status)) {
+            if (U_FAILURE(status))
+                break;
+            // Skip single-character keywords (non-Unicode BCP 47 extensions).
+            if (keyLen <= 1)
+                continue;
+
+            UErrorCode valStatus = U_ZERO_ERROR;
+            Vector<char, 32> value(32);
+            auto valLen = uloc_getKeywordValue(localeID, key, value.mutableSpan().data(), value.size(), &valStatus);
+            if (needsToGrowToProduceCString(valStatus)) {
+                value.grow(valLen + 1);
+                valStatus = U_ZERO_ERROR;
+                uloc_getKeywordValue(localeID, key, value.mutableSpan().data(), value.size(), &valStatus);
+            }
+            if (U_FAILURE(valStatus))
+                continue;
+
+            UErrorCode setStatus = U_ZERO_ERROR;
+            auto newLen = uloc_setKeywordValue(key, value.span().data(), result.mutableSpan().data(), result.size(), &setStatus);
+            if (needsToGrowToProduceBuffer(setStatus)) {
+                result.grow(newLen + 1);
+                setStatus = U_ZERO_ERROR;
+                uloc_setKeywordValue(key, value.span().data(), result.mutableSpan().data(), result.size(), &setStatus);
+            }
+        }
+    }
+    return result;
+}
+
 // https://tc39.es/ecma402/#sec-Intl.Locale
 void IntlLocale::initializeLocale(JSGlobalObject* globalObject, JSValue tagValue, JSValue optionsValue)
 {
@@ -278,6 +333,11 @@ void IntlLocale::initializeLocale(JSGlobalObject* globalObject, const String& ta
         throwRangeError(globalObject, scope, "invalid language tag"_s);
         return;
     }
+
+    // Store non-Unicode BCP 47 extensions (like -a- and -x-) for fallback when
+    // ICU's uloc_toLanguageTag fails on non-Unicode keywords. Unicode (-u-) and
+    // Transform (-t-) extensions are handled as ICU keywords and don't need this.
+    m_nonUnicodeExtensions = extractNonUnicodeBCP47Extensions(tag);
 
     String language = intlStringOption(globalObject, options, vm.propertyNames->language, { }, { }, { });
     RETURN_IF_EXCEPTION(scope, void());
@@ -403,48 +463,72 @@ void IntlLocale::initializeLocale(JSGlobalObject* globalObject, const String& ta
 const String& IntlLocale::maximal()
 {
     if (m_maximal.isNull()) {
-        // ICU has a serious bug that it fails to perform uloc_addLikelySubtags when the input localeID is longer than ULOC_FULLNAME_CAPACITY,
-        // and that can be achieved if we add many unicode extensions. While ICU needs to be fixed, we work-around this bug for now: We pass
-        // non-keyword part of ICU locale ID and later, concatenate keyword part to the output.
-        // Note that ICU locale ID consists of Language, Script, Country (unicode language tag's region.
+        // Always maximize only the base name (without keywords/extensions), then
+        // merge extensions back. This avoids ICU issues with long locale IDs
+        // (ULOC_FULLNAME_CAPACITY limitation) and also works around uloc_toLanguageTag
+        // failures with non-Unicode keywords on some ICU versions.
         // FIXME: ICU tracking bug https://unicode-org.atlassian.net/browse/ICU-21639.
+
+        // Extract base name (no keywords).
         UErrorCode status = U_ZERO_ERROR;
-        Vector<char, 32> buffer(32);
-        auto bufferLength = uloc_addLikelySubtags(m_localeID.data(), buffer.mutableSpan().data(), buffer.size(), &status);
+        Vector<char, 32> baseNameID(32);
+        auto baseLen = uloc_getBaseName(m_localeID.data(), baseNameID.mutableSpan().data(), baseNameID.size(), &status);
         if (needsToGrowToProduceCString(status)) {
-            buffer.grow(bufferLength + 1);
+            baseNameID.grow(baseLen + 1);
             status = U_ZERO_ERROR;
-            uloc_addLikelySubtags(m_localeID.data(), buffer.mutableSpan().data(), buffer.size(), &status);
+            uloc_getBaseName(m_localeID.data(), baseNameID.mutableSpan().data(), baseNameID.size(), &status);
+        }
+        ASSERT(U_SUCCESS(status));
+
+        // Maximize base name.
+        status = U_ZERO_ERROR;
+        Vector<char, 32> maxBase(32);
+        auto maxLen = uloc_addLikelySubtags(baseNameID.span().data(), maxBase.mutableSpan().data(), maxBase.size(), &status);
+        if (needsToGrowToProduceCString(status)) {
+            maxBase.grow(maxLen + 1);
+            status = U_ZERO_ERROR;
+            uloc_addLikelySubtags(baseNameID.span().data(), maxBase.mutableSpan().data(), maxBase.size(), &status);
+        }
+        if (U_FAILURE(status)) {
+            m_maximal = toString();
+            return m_maximal;
         }
 
-        if (U_SUCCESS(status))
-            m_maximal = languageTagForLocaleID(buffer.span().data());
-        else {
-            status = U_ZERO_ERROR;
-            Vector<char, 32> baseNameID;
-            auto bufferLength = uloc_getBaseName(m_localeID.data(), baseNameID.mutableSpan().data(), baseNameID.size(), &status);
-            if (needsToGrowToProduceCString(status)) {
-                baseNameID.grow(bufferLength + 1);
-                status = U_ZERO_ERROR;
-                uloc_getBaseName(m_localeID.data(), baseNameID.mutableSpan().data(), baseNameID.size(), &status);
-            }
-            ASSERT(U_SUCCESS(status));
+        // If base name didn't change, return original unchanged.
+        if (equalSpans(baseNameID.span().first(baseLen), maxBase.span().first(maxLen))) {
+            m_maximal = toString();
+            return m_maximal;
+        }
 
-            Vector<char, 32> maximal;
-            status = callBufferProducingFunction(uloc_addLikelySubtags, baseNameID.span().data(), maximal);
-            // We fail if,
-            // 1. uloc_addLikelySubtags still fails.
-            // 2. New maximal locale ID includes newly-added keywords.
-            if (!U_SUCCESS(status) || maximal.find(ULOC_KEYWORD_SEPARATOR) != notFound) {
+        // If no keywords, just convert maximized base to BCP 47.
+        auto keywordSepPos = WTF::find(m_localeID.span(), ULOC_KEYWORD_SEPARATOR);
+        if (keywordSepPos == notFound) {
+            m_maximal = languageTagForLocaleID(maxBase.span().data());
+            if (m_maximal.isNull())
                 m_maximal = toString();
-                return m_maximal;
-            }
+            return m_maximal;
+        }
 
-            auto endOfLanguageScriptRegionVariant = WTF::find(m_localeID.span(), ULOC_KEYWORD_SEPARATOR);
-            if (endOfLanguageScriptRegionVariant != notFound)
-                maximal.appendRange(m_localeID.data() + endOfLanguageScriptRegionVariant, m_localeID.data() + m_localeID.length());
-            maximal.append('\0');
-            m_maximal = languageTagForLocaleID(maximal.span().data());
+        // Has keywords — merge maximized base with original keywords.
+        auto keywords = m_localeID.span().subspan(keywordSepPos);
+        Vector<char, 64> merged;
+        merged.append(maxBase.span().first(maxLen));
+        merged.append(keywords);
+        merged.append('\0');
+
+        m_maximal = languageTagForLocaleID(merged.span().data());
+        if (m_maximal.isNull()) {
+            // uloc_toLanguageTag failed — non-Unicode keywords caused the failure.
+            // Strip non-Unicode (single-char) keywords, convert to BCP 47 (preserving
+            // Unicode extensions like -u-), then append stored non-Unicode extensions.
+            auto cleanID = buildLocaleIDWithUnicodeKeywords(merged.span().data());
+            m_maximal = languageTagForLocaleID(cleanID.span().data());
+            if (m_maximal.isNull())
+                m_maximal = languageTagForLocaleID(maxBase.span().data());
+            if (m_maximal.isNull())
+                m_maximal = baseName();
+            if (!m_nonUnicodeExtensions.isNull())
+                m_maximal = makeString(m_maximal, m_nonUnicodeExtensions);
         }
     }
     return m_maximal;
@@ -454,48 +538,61 @@ const String& IntlLocale::maximal()
 const String& IntlLocale::minimal()
 {
     if (m_minimal.isNull()) {
-        // ICU has a serious bug that it fails to perform uloc_minimizeSubtags when the input localeID is longer than ULOC_FULLNAME_CAPACITY,
-        // and that can be achieved if we add many unicode extensions. While ICU needs to be fixed, we work-around this bug for now: We pass
-        // non-keyword part of ICU locale ID and later, concatenate keyword part to the output.
-        // Note that ICU locale ID consists of Language, Script, Country (unicode language tag's region.
+        // Same approach as maximal(): minimize only the base name, then merge extensions.
         // FIXME: ICU tracking bug https://unicode-org.atlassian.net/browse/ICU-21639.
+
         UErrorCode status = U_ZERO_ERROR;
-        Vector<char, 32> buffer(32);
-        auto bufferLength = uloc_minimizeSubtags(m_localeID.data(), buffer.mutableSpan().data(), buffer.size(), &status);
+        Vector<char, 32> baseNameID(32);
+        auto baseLen = uloc_getBaseName(m_localeID.data(), baseNameID.mutableSpan().data(), baseNameID.size(), &status);
         if (needsToGrowToProduceCString(status)) {
-            buffer.grow(bufferLength + 1);
+            baseNameID.grow(baseLen + 1);
             status = U_ZERO_ERROR;
-            uloc_minimizeSubtags(m_localeID.data(), buffer.mutableSpan().data(), buffer.size(), &status);
+            uloc_getBaseName(m_localeID.data(), baseNameID.mutableSpan().data(), baseNameID.size(), &status);
+        }
+        ASSERT(U_SUCCESS(status));
+
+        status = U_ZERO_ERROR;
+        Vector<char, 32> minBase(32);
+        auto minLen = uloc_minimizeSubtags(baseNameID.span().data(), minBase.mutableSpan().data(), minBase.size(), &status);
+        if (needsToGrowToProduceCString(status)) {
+            minBase.grow(minLen + 1);
+            status = U_ZERO_ERROR;
+            uloc_minimizeSubtags(baseNameID.span().data(), minBase.mutableSpan().data(), minBase.size(), &status);
+        }
+        if (U_FAILURE(status)) {
+            m_minimal = toString();
+            return m_minimal;
         }
 
-        if (U_SUCCESS(status))
-            m_minimal = languageTagForLocaleID(buffer.span().data());
-        else {
-            status = U_ZERO_ERROR;
-            Vector<char, 32> baseNameID;
-            auto bufferLength = uloc_getBaseName(m_localeID.data(), baseNameID.mutableSpan().data(), baseNameID.size(), &status);
-            if (needsToGrowToProduceCString(status)) {
-                baseNameID.grow(bufferLength + 1);
-                status = U_ZERO_ERROR;
-                uloc_getBaseName(m_localeID.data(), baseNameID.mutableSpan().data(), baseNameID.size(), &status);
-            }
-            ASSERT(U_SUCCESS(status));
+        if (equalSpans(baseNameID.span().first(baseLen), minBase.span().first(minLen))) {
+            m_minimal = toString();
+            return m_minimal;
+        }
 
-            Vector<char, 32> minimal;
-            auto status = callBufferProducingFunction(uloc_minimizeSubtags, baseNameID.span().data(), minimal);
-            // We fail if,
-            // 1. uloc_minimizeSubtags still fails.
-            // 2. New minimal locale ID includes newly-added keywords.
-            if (!U_SUCCESS(status) || minimal.find(ULOC_KEYWORD_SEPARATOR) != notFound) {
+        auto keywordSepPos = WTF::find(m_localeID.span(), ULOC_KEYWORD_SEPARATOR);
+        if (keywordSepPos == notFound) {
+            m_minimal = languageTagForLocaleID(minBase.span().data());
+            if (m_minimal.isNull())
                 m_minimal = toString();
-                return m_minimal;
-            }
+            return m_minimal;
+        }
 
-            auto endOfLanguageScriptRegionVariant = WTF::find(m_localeID.span(), ULOC_KEYWORD_SEPARATOR);
-            if (endOfLanguageScriptRegionVariant != notFound)
-                minimal.appendRange(m_localeID.data() + endOfLanguageScriptRegionVariant, m_localeID.data() + m_localeID.length());
-            minimal.append('\0');
-            m_minimal = languageTagForLocaleID(minimal.span().data());
+        auto keywords = m_localeID.span().subspan(keywordSepPos);
+        Vector<char, 64> merged;
+        merged.append(minBase.span().first(minLen));
+        merged.append(keywords);
+        merged.append('\0');
+
+        m_minimal = languageTagForLocaleID(merged.span().data());
+        if (m_minimal.isNull()) {
+            auto cleanID = buildLocaleIDWithUnicodeKeywords(merged.span().data());
+            m_minimal = languageTagForLocaleID(cleanID.span().data());
+            if (m_minimal.isNull())
+                m_minimal = languageTagForLocaleID(minBase.span().data());
+            if (m_minimal.isNull())
+                m_minimal = baseName();
+            if (!m_nonUnicodeExtensions.isNull())
+                m_minimal = makeString(m_minimal, m_nonUnicodeExtensions);
         }
     }
     return m_minimal;
@@ -504,8 +601,19 @@ const String& IntlLocale::minimal()
 // https://tc39.es/ecma402/#sec-Intl.Locale.prototype.toString
 const String& IntlLocale::toString()
 {
-    if (m_fullString.isNull())
+    if (m_fullString.isNull()) {
         m_fullString = languageTagForLocaleID(m_localeID.data());
+        if (m_fullString.isNull()) {
+            // uloc_toLanguageTag failed — strip non-Unicode keywords and retry,
+            // then append stored non-Unicode BCP 47 extensions.
+            auto cleanID = buildLocaleIDWithUnicodeKeywords(m_localeID.data());
+            m_fullString = languageTagForLocaleID(cleanID.span().data());
+            if (m_fullString.isNull())
+                m_fullString = baseName();
+            if (!m_nonUnicodeExtensions.isNull())
+                m_fullString = makeString(m_fullString, m_nonUnicodeExtensions);
+        }
+    }
     return m_fullString;
 }
 

--- a/Source/JavaScriptCore/runtime/IntlLocale.h
+++ b/Source/JavaScriptCore/runtime/IntlLocale.h
@@ -97,6 +97,7 @@ private:
     String m_script;
     String m_region;
     String m_variants;
+    String m_nonUnicodeExtensions;
     std::optional<String> m_calendar;
     std::optional<String> m_caseFirst;
     std::optional<String> m_collation;

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -863,26 +863,87 @@ String defaultLocale(JSGlobalObject* globalObject)
     return "en"_s;
 }
 
-String removeUnicodeLocaleExtension(const String& locale)
+String removeUnicodeLocaleExtension(StringView locale)
 {
-    Vector<String> parts = locale.split('-');
     StringBuilder builder;
-    size_t partsSize = parts.size();
     bool atPrivate = false;
-    if (partsSize > 0)
-        builder.append(parts[0]);
-    for (size_t p = 1; p < partsSize; ++p) {
-        if (parts[p] == "x"_s)
+    auto subtags = locale.split('-');
+    auto cursor = subtags.begin();
+    auto end = subtags.end();
+
+    if (cursor == end)
+        return String();
+    builder.append(*cursor);
+    ++cursor;
+
+    while (cursor != end) {
+        auto part = *cursor;
+        if (part.length() == 1 && part[0] == 'x')
             atPrivate = true;
-        if (!atPrivate && parts[p] == "u"_s && p + 1 < partsSize) {
+        if (!atPrivate && part.length() == 1 && part[0] == 'u') {
             // Skip the u- and anything that follows until another singleton.
-            // While the next part is part of the unicode extension, skip it.
-            while (p + 1 < partsSize && parts[p + 1].length() > 1)
-                ++p;
-        } else {
-            builder.append('-', parts[p]);
+            ++cursor;
+            while (cursor != end && (*cursor).length() > 1)
+                ++cursor;
+            continue;
+        }
+        builder.append('-', part);
+        ++cursor;
+    }
+    return builder.toString();
+}
+
+// Extracts non-Unicode BCP 47 extensions from a language tag. Returns a string
+// containing extensions with singletons other than 'u' (Unicode) and 't'
+// (Transform), which ICU handles as multi-character keywords that
+// uloc_toLanguageTag can convert. Non-Unicode extensions like -a- and -x-
+// become single-character ICU keywords that some ICU versions cannot convert
+// back to BCP 47, so they must be preserved separately.
+// e.g. "en-a-foo-u-ca-gregory-x-bar" -> "-a-foo-x-bar"
+//      "en-u-co-phonebk" -> String() (only Unicode extension)
+//      "en-x-private" -> "-x-private"
+String extractNonUnicodeBCP47Extensions(StringView locale)
+{
+    StringBuilder builder;
+    bool atPrivate = false;
+    auto subtags = locale.split('-');
+    auto cursor = subtags.begin();
+    auto end = subtags.end();
+
+    // Skip the language subtag.
+    if (cursor == end)
+        return String();
+    ++cursor;
+
+    while (cursor != end) {
+        auto part = *cursor;
+        if (part.length() != 1) {
+            ++cursor;
+            continue;
+        }
+
+        auto singleton = part[0];
+        if (singleton == 'x')
+            atPrivate = true;
+
+        // Skip Unicode (u) and Transform (t) extensions — handled by ICU keywords.
+        if (!atPrivate && (singleton == 'u' || singleton == 't')) {
+            ++cursor;
+            while (cursor != end && (*cursor).length() > 1)
+                ++cursor;
+            continue;
+        }
+
+        // Collect this extension (or private use) and its subtags.
+        builder.append('-', part);
+        ++cursor;
+        while (cursor != end && (atPrivate || (*cursor).length() > 1)) {
+            builder.append('-', *cursor);
+            ++cursor;
         }
     }
+    if (builder.isEmpty())
+        return String();
     return builder.toString();
 }
 

--- a/Source/JavaScriptCore/runtime/IntlObject.h
+++ b/Source/JavaScriptCore/runtime/IntlObject.h
@@ -140,7 +140,8 @@ struct ResolvedLocale {
 
 ResolvedLocale resolveLocale(JSGlobalObject*, const LocaleSet& availableLocales, const Vector<String>& requestedLocales, LocaleMatcher, const ResolveLocaleOptions&, std::initializer_list<RelevantExtensionKey> relevantExtensionKeys, Vector<String> (*localeData)(const String&, RelevantExtensionKey));
 JSValue supportedLocales(JSGlobalObject*, const LocaleSet& availableLocales, const Vector<String>& requestedLocales, JSValue options);
-String removeUnicodeLocaleExtension(const String& locale);
+String removeUnicodeLocaleExtension(StringView locale);
+String extractNonUnicodeBCP47Extensions(StringView locale);
 String bestAvailableLocale(const LocaleSet& availableLocales, const String& requestedLocale);
 template<typename Predicate> String bestAvailableLocale(const String& requestedLocale, Predicate);
 Vector<String> numberingSystemsForLocale(const String& locale);


### PR DESCRIPTION
#### 65cc85bbf51038440464ee51b3476412c2466719
<pre>
[JSC] Tolerant againt non-Unicode BCP 47 extensions + maximize / minimize
<a href="https://bugs.webkit.org/show_bug.cgi?id=309221">https://bugs.webkit.org/show_bug.cgi?id=309221</a>
<a href="https://rdar.apple.com/problem/171786018">rdar://problem/171786018</a>

Reviewed by Yijia Huang.

On some ICU versions, uloc_toLanguageTag() fails when the ICU locale ID contains
single-character keywords from non-Unicode BCP 47 extensions like -a- or -x-.
This causes new Intl.Locale(&quot;en-a-not-assigned&quot;).maximize() to throw
RangeError: invalid language tag.

Let&apos;s always maximize/minimize only the base name (without keywords/extensions),
then merge extensions back. When uloc_toLanguageTag fails on the merged result,
strip non-Unicode (single-char) keywords, convert preserving Unicode extensions
(-u-), and append stored non-Unicode BCP 47 extensions separately.

We also make removeUnicodeLocaleExtension more efficient by avoiding
Vector&lt;String&gt; allocation.

* Source/JavaScriptCore/runtime/IntlLocale.cpp:
(JSC::buildLocaleIDWithUnicodeKeywords):
(JSC::IntlLocale::initializeLocale):
(JSC::IntlLocale::maximal):
(JSC::IntlLocale::minimal):
(JSC::IntlLocale::toString):
* Source/JavaScriptCore/runtime/IntlLocale.h:
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::removeUnicodeLocaleExtension):
(JSC::extractNonUnicodeBCP47Extensions):
* Source/JavaScriptCore/runtime/IntlObject.h:

Canonical link: <a href="https://commits.webkit.org/308753@main">https://commits.webkit.org/308753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f50c69e4faa21aab1eb08ba458b4c066870c4e0c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156929 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78f1248f-9b06-4d98-973b-b209ac4b806c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114291 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/377c4a7f-8517-4bd4-b38f-08777d0e9782) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133115 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95062 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/183dce5f-a2be-4972-952b-d11c779eb3f0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15648 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13456 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4366 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140213 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159262 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9033 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2397 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12537 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122324 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122544 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132843 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76890 "Hash f50c69e4 for PR 59957 does not build (failure)") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22866 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17956 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9582 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179673 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20347 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84132 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46001 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20078 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20224 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20133 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->