### PR TITLE
Adopt NODELETE in more places in Source/WebKit

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -191,7 +191,7 @@ public:
     void stopMonitoringCaptureDeviceRotation(WebCore::PageIdentifier, const String&);
     void updateCaptureAccess(bool allowAudioCapture, bool allowVideoCapture, bool allowDisplayCapture);
     void updateCaptureOrigin(const WebCore::SecurityOriginData&);
-    bool setCaptureAttributionString();
+    bool NODELETE setCaptureAttributionString();
     bool allowsAudioCapture() const { return m_allowsAudioCapture; }
     bool allowsVideoCapture() const { return m_allowsVideoCapture; }
     bool allowsDisplayCapture() const { return m_allowsDisplayCapture; }
@@ -247,7 +247,7 @@ public:
     using RemoteRenderingBackendMap = HashMap<RemoteRenderingBackendIdentifier, IPC::ScopedActiveMessageReceiveQueue<RemoteRenderingBackend>>;
     const RemoteRenderingBackendMap& remoteRenderingBackendMap() const LIFETIME_BOUND { return m_remoteRenderingBackendMap; }
 
-    RemoteRenderingBackend* remoteRenderingBackend(RemoteRenderingBackendIdentifier);
+    RemoteRenderingBackend* NODELETE remoteRenderingBackend(RemoteRenderingBackendIdentifier);
 
 #if HAVE(AUDIT_TOKEN)
     const HashMap<WebCore::PageIdentifier, CoreIPCAuditToken>& presentingApplicationAuditTokens() const LIFETIME_BOUND { return m_presentingApplicationAuditTokens; }

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -229,7 +229,7 @@ private:
     void cancelGetDisplayMediaPrompt();
 #endif
 #if PLATFORM(MAC)
-    void setScreenProperties(const WebCore::ScreenProperties&);
+    void NODELETE setScreenProperties(const WebCore::ScreenProperties&);
     void updateProcessName();
 #endif
 #if PLATFORM(COCOA)

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h
@@ -67,7 +67,7 @@ public:
     void NODELETE updateTexture(const WebModel::UpdateTextureDescriptor&);
     void NODELETE updateMaterial(const WebModel::UpdateMaterialDescriptor&);
     void NODELETE setTransform(const simd_float4x4&);
-    void setCameraDistance(float);
+    void NODELETE setCameraDistance(float);
     void NODELETE setBackgroundColor(const simd_float3&);
     void NODELETE setEnvironmentMap(const WebModel::ImageAsset&);
     void NODELETE play(bool);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h
@@ -157,7 +157,7 @@ public:
     void applyFillPattern();
 #endif
     void applyDeviceScaleFactor(float);
-    std::optional<WebKit::SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
+    std::optional<WebKit::SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess() const;
 
     void beginPage(const WebCore::FloatRect&);
     void endPage();

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -273,7 +273,7 @@ static RefPtr<ImageBuffer> allocateImageBufferInternal(const FloatSize& logicalS
     return imageBuffer;
 }
 
-static void adjustImageBufferRenderingMode(const RemoteSharedResourceCache& sharedResourceCache, RenderingPurpose purpose, RenderingMode& renderingMode)
+static void NODELETE adjustImageBufferRenderingMode(const RemoteSharedResourceCache& sharedResourceCache, RenderingPurpose purpose, RenderingMode& renderingMode)
 {
     if (renderingMode == RenderingMode::Accelerated && sharedResourceCache.reachedAcceleratedImageBufferLimit(purpose))
         renderingMode = RenderingMode::Unaccelerated;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h
@@ -68,7 +68,7 @@ public:
 
     void didReceiveMessageFromWebProcess(IPC::Connection& connection, IPC::Decoder& decoder) { didReceiveMessage(connection, decoder); }
 
-    bool allowsExitUnderMemoryPressure() const;
+    bool NODELETE allowsExitUnderMemoryPressure() const;
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
 private:

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -173,7 +173,7 @@ private:
     RefPtr<WebCore::AudioVideoRenderer> createRenderer();
     RefPtr<WebCore::AudioVideoRenderer> rendererFor(RemoteAudioVideoRendererIdentifier) const;
     RemoteAudioVideoRendererState stateFor(RemoteAudioVideoRendererIdentifier) const;
-    RendererContext& contextFor(RemoteAudioVideoRendererIdentifier);
+    RendererContext& NODELETE contextFor(RemoteAudioVideoRendererIdentifier);
     void rendereringModeChanged(RemoteAudioVideoRendererIdentifier);
     using LayerHostingContextCallback = CompletionHandler<void(WebCore::HostingContext)>;
     void requestHostingContext(RemoteAudioVideoRendererIdentifier, LayerHostingContextCallback&&);

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h
@@ -70,7 +70,7 @@ public:
 
     void addSession(RemoteLegacyCDMSessionIdentifier, Ref<RemoteLegacyCDMSessionProxy>&&);
     void removeSession(RemoteLegacyCDMSessionIdentifier, CompletionHandler<void()>&&);
-    RemoteLegacyCDMSessionProxy* getSession(const RemoteLegacyCDMSessionIdentifier&) const;
+    RemoteLegacyCDMSessionProxy* NODELETE getSession(const RemoteLegacyCDMSessionIdentifier&) const;
 
     RefPtr<GPUConnectionToWebProcess> gpuConnectionToWebProcess() { return m_gpuConnectionToWebProcess.get(); }
 

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h
@@ -56,7 +56,7 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    void invalidate();
+    void NODELETE invalidate();
 
     RemoteLegacyCDMFactoryProxy* factory() const { return m_factory.get(); }
     WebCore::LegacyCDMSession* session() const { return m_session.get(); }

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -66,7 +66,7 @@ public:
     void ref() const final { WebCore::SourceBufferPrivateClient::ref(); }
     void deref() const final { WebCore::SourceBufferPrivateClient::deref(); }
 
-    void setMediaPlayer(RemoteMediaPlayerProxy&);
+    void NODELETE setMediaPlayer(RemoteMediaPlayerProxy&);
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 

--- a/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h
@@ -123,7 +123,7 @@ private:
         bool useLowLatency { false };
         bool isInvalid { false };
     };
-    Encoder* findEncoder(VideoEncoderIdentifier) WTF_REQUIRES_CAPABILITY(workQueue());
+    Encoder* NODELETE findEncoder(VideoEncoderIdentifier) WTF_REQUIRES_CAPABILITY(workQueue());
 
     const Ref<IPC::Connection> m_connection;
     const Ref<WorkQueue> m_queue;

--- a/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.h
@@ -38,7 +38,7 @@ struct ITPThirdPartyDataForSpecificFirstParty {
     String toString() const;
 
     // FIXME: Since this ignores differences in decodedTimeLastUpdated it probably should be a named function, not operator==.
-    bool operator==(const ITPThirdPartyDataForSpecificFirstParty&) const;
+    bool NODELETE operator==(const ITPThirdPartyDataForSpecificFirstParty&) const;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -334,7 +334,7 @@ static String buildList(const ContainerType& values)
     return builder.toString();
 }
 
-static WeakHashSet<ResourceLoadStatisticsStore>& allStores()
+static WeakHashSet<ResourceLoadStatisticsStore>& NODELETE allStores()
 {
     ASSERT(!RunLoop::isMain());
 

--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h
@@ -333,7 +333,7 @@ private:
     const MemoryCompactLookupOnlyRobinHoodHashMap<String, TableAndIndexPair>& expectedTableAndIndexQueries() final;
     std::span<const ASCIILiteral> sortedTables() final;
     String ensureAndMakeDomainList(const HashSet<RegistrableDomain>&);
-    std::optional<WallTime> mostRecentUserInteractionTime(const DomainData&);
+    std::optional<WallTime> NODELETE mostRecentUserInteractionTime(const DomainData&);
     void grandfatherDataForDomains(const HashSet<RegistrableDomain>&);
     bool areAllUnpartitionedThirdPartyCookiesBlockedUnder(const TopFrameDomain&);
     bool hasStatisticsExpired(WallTime mostRecentUserInteractionTime, OperatingDatesWindow) const;

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h
@@ -218,7 +218,7 @@ public:
     void didCreateNetworkProcess();
 
     NetworkSession* NODELETE networkSession();
-    void invalidateAndCancel();
+    void NODELETE invalidateAndCancel();
 
     void resourceLoadStatisticsUpdated(Vector<WebCore::ResourceLoadStatistics>&&, CompletionHandler<void()>&&);
     void requestStorageAccessUnderOpener(DomainInNeedOfStorageAccess&&, WebCore::PageIdentifier openerID, OpenerDomain&&);

--- a/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
+++ b/Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h
@@ -96,7 +96,7 @@ private:
     void didFinishLoading(LegacyCustomProtocolID);
     void wasRedirectedToRequest(LegacyCustomProtocolID, const WebCore::ResourceRequest&, const WebCore::ResourceResponse& redirectResponse);
 
-    void registerProtocolClass();
+    void NODELETE registerProtocolClass();
 
     const CheckedRef<NetworkProcess> m_networkProcess;
 

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp
@@ -34,7 +34,7 @@
 
 namespace WebKit {
 
-constexpr uint64_t operator""_kbps(unsigned long long kilobytesPerSecond)
+constexpr uint64_t NODELETE operator""_kbps(unsigned long long kilobytesPerSecond)
 {
     return kilobytesPerSecond * 1024;
 }
@@ -56,7 +56,7 @@ static constexpr std::array throughputIntervals = {
     ThroughputInterval { 60_min, 128_kbps }
 };
 
-static Seconds timeUntilNextInterval(size_t currentInterval)
+static Seconds NODELETE timeUntilNextInterval(size_t currentInterval)
 {
     RELEASE_ASSERT(currentInterval + 1 < throughputIntervals.size());
     return throughputIntervals[currentInterval + 1].time - throughputIntervals[currentInterval].time;

--- a/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h
+++ b/Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h
@@ -52,7 +52,7 @@ public:
 private:
     WeakRef<Download> m_download;
 
-    double measuredThroughputRate() const;
+    double NODELETE measuredThroughputRate() const;
     uint32_t NODELETE testSpeedMultiplier() const;
     
     struct Timestamp {

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.h
@@ -124,7 +124,7 @@ public:
         ASSERT(!m_pendingDownloadID);
         m_pendingDownloadID = downloadID;
     }
-    void setPendingDownload(PendingDownload&);
+    void NODELETE setPendingDownload(PendingDownload&);
 
     virtual void setPendingDownloadLocation(const String& filename, SandboxExtension::Handle&&, bool /*allowOverwrite*/) { m_pendingDownloadLocation = filename; }
     const String& pendingDownloadLocation() const LIFETIME_BOUND { return m_pendingDownloadLocation; }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -203,7 +203,7 @@ public:
     void forEachNetworkSession(NOESCAPE const Function<void(NetworkSession&)>&);
 
     void forEachNetworkStorageSession(NOESCAPE const Function<void(WebCore::NetworkStorageSession&)>&);
-    WebCore::NetworkStorageSession* storageSession(PAL::SessionID) const;
+    WebCore::NetworkStorageSession* NODELETE storageSession(PAL::SessionID) const;
     std::unique_ptr<WebCore::NetworkStorageSession> newTestingSession(PAL::SessionID);
     void addStorageSession(PAL::SessionID, const WebsiteDataStoreParameters&);
 
@@ -395,7 +395,7 @@ public:
     const OptionSet<NetworkCache::CacheOption>& cacheOptions() const LIFETIME_BOUND { return m_cacheOptions; }
 
     NetworkConnectionToWebProcess* webProcessConnection(WebCore::ProcessIdentifier) const;
-    NetworkConnectionToWebProcess* webProcessConnection(const IPC::Connection&) const;
+    NetworkConnectionToWebProcess* NODELETE webProcessConnection(const IPC::Connection&) const;
     WebCore::MessagePortChannelRegistry& messagePortChannelRegistry() { return m_messagePortChannelRegistry; }
 
     void setServiceWorkerFetchTimeoutForTesting(Seconds, CompletionHandler<void()>&&);
@@ -478,7 +478,7 @@ public:
     void fetchSessionStorage(PAL::SessionID, WebPageProxyIdentifier, CompletionHandler<void(std::optional<HashMap<WebCore::ClientOrigin, HashMap<String, String>>>&&)>&&);
     void restoreSessionStorage(PAL::SessionID, WebPageProxyIdentifier, HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
 
-    WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlockingForPage(std::optional<WebPageProxyIdentifier>) const;
+    WebCore::ShouldRelaxThirdPartyCookieBlocking NODELETE shouldRelaxThirdPartyCookieBlockingForPage(std::optional<WebPageProxyIdentifier>) const;
 
     void setDefaultRequestTimeoutInterval(double);
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -52,7 +52,7 @@ namespace WebKit {
 struct NetworkResourceLoadParameters {
     void createSandboxExtensionHandlesIfNecessary();
 
-    RefPtr<WebCore::SecurityOrigin> parentOrigin() const;
+    RefPtr<WebCore::SecurityOrigin> NODELETE parentOrigin() const;
     NetworkLoadParameters networkLoadParameters() const;
 
     WebPageProxyIdentifier webPageProxyID;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -168,11 +168,11 @@ public:
     void startWithServiceWorker();
     void serviceWorkerDidNotHandle(ServiceWorkerFetchTask*);
     void setServiceWorkerRegistration(WebCore::SWServerRegistration& serviceWorkerRegistration) { m_serviceWorkerRegistration = serviceWorkerRegistration; }
-    void setWorkerStart(MonotonicTime);
+    void NODELETE setWorkerStart(MonotonicTime);
 
-    void setWorkerRouterEvaluationStart(MonotonicTime);
-    void setWorkerCacheLookupStart(MonotonicTime);
-    void setWorkerMatchedRouterSource(WebCore::RouterSourceEnum);
+    void NODELETE setWorkerRouterEvaluationStart(MonotonicTime);
+    void NODELETE setWorkerCacheLookupStart(MonotonicTime);
+    void NODELETE setWorkerMatchedRouterSource(WebCore::RouterSourceEnum);
     void NODELETE setWorkerFinalRouterSource(WebCore::RouterSourceEnum);
 
     std::optional<WebCore::ResourceError> doCrossOriginOpenerHandlingOfResponse(const WebCore::ResourceResponse&);

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -794,7 +794,7 @@ void NetworkSession::setEmulatedConditions(std::optional<int64_t>&& bytesPerSeco
 }
 #endif // ENABLE(INSPECTOR_NETWORK_THROTTLING)
 
-static double connectionTimesMovingAverage(const Deque<Seconds, 25>& connectionTimes)
+static double NODELETE connectionTimesMovingAverage(const Deque<Seconds, 25>& connectionTimes)
 {
     constexpr double alphaSmoothing { 0.75 };
     // EWMA:

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -221,7 +221,7 @@ public:
 
     void removeSoftUpdateLoader(ServiceWorkerSoftUpdateLoader* loader) { m_softUpdateLoaders.remove(loader); }
     void addNavigationPreloaderTask(ServiceWorkerFetchTask&);
-    ServiceWorkerFetchTask* navigationPreloaderTaskFromFetchIdentifier(WebCore::FetchIdentifier);
+    ServiceWorkerFetchTask* NODELETE navigationPreloaderTaskFromFetchIdentifier(WebCore::FetchIdentifier);
     void removeNavigationPreloaderTask(ServiceWorkerFetchTask&);
 
     WebCore::SWServer* swServer() { return m_swServer.get(); }
@@ -268,7 +268,7 @@ public:
     virtual void removeWebPageNetworkParameters(WebPageProxyIdentifier) { }
     virtual size_t countNonDefaultSessionSets() const { return 0; }
 
-    String attributedBundleIdentifierFromPageIdentifier(WebPageProxyIdentifier) const;
+    String NODELETE attributedBundleIdentifierFromPageIdentifier(WebPageProxyIdentifier) const;
 
 #if ENABLE(NETWORK_ISSUE_REPORTING)
     void reportNetworkIssue(WebPageProxyIdentifier, const URL&);

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
@@ -76,7 +76,7 @@ constexpr auto createPCMObservedDomain = "CREATE TABLE PCMObservedDomains ("
 constexpr auto insertObservedDomainQuery = "INSERT INTO PCMObservedDomains (registrableDomain) VALUES (?)"_s;
 constexpr auto clearAllPrivateClickMeasurementQuery = "DELETE FROM PCMObservedDomains WHERE domainID LIKE ?"_s;
 
-static WeakHashSet<Database>& allDatabases()
+static WeakHashSet<Database>& NODELETE allDatabases()
 {
     ASSERT(!RunLoop::isMain());
     static NeverDestroyed<WeakHashSet<Database>> set;

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm
@@ -35,7 +35,7 @@
 #import <wtf/NeverDestroyed.h>
 #import <wtf/cocoa/SpanCocoa.h>
 
-static RetainPtr<SecTrustRef>& allowedLocalTestServerTrust()
+static RetainPtr<SecTrustRef>& NODELETE allowedLocalTestServerTrust()
 {
     static NeverDestroyed<RetainPtr<SecTrustRef>> serverTrust;
     return serverTrust.get();

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -94,7 +94,7 @@ public:
 
     bool convertToDownload(DownloadManager&, DownloadID, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&);
 
-    MonotonicTime startTime() const;
+    MonotonicTime NODELETE startTime() const;
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h
@@ -60,7 +60,7 @@ public:
 
     ~WebSharedWorker();
 
-    static WebSharedWorker* fromIdentifier(WebCore::SharedWorkerIdentifier);
+    static WebSharedWorker* NODELETE fromIdentifier(WebCore::SharedWorkerIdentifier);
 
     const WebCore::SharedWorkerKey& key() const LIFETIME_BOUND { return m_key; }
     const WebCore::WorkerOptions& workerOptions() const LIFETIME_BOUND { return m_workerOptions; }

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h
@@ -66,7 +66,7 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     WebSharedWorkerServer* NODELETE server();
-    const WebSharedWorkerServer* server() const;
+    const WebSharedWorkerServer* NODELETE server() const;
 
     NetworkSession* session();
     WebCore::ProcessIdentifier webProcessIdentifier() const { return m_webProcessIdentifier; }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheData.h
@@ -75,7 +75,7 @@ public:
 #elif USE(CURL)
     Data(Variant<Vector<uint8_t>, FileSystem::MappedFileData>&&);
 #endif
-    bool isNull() const;
+    bool NODELETE isNull() const;
     bool isEmpty() const { return !size(); }
 
     std::span<const uint8_t> span() const LIFETIME_BOUND;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
@@ -141,7 +141,7 @@ public:
     bool deviceManagementRestrictionsEnabled() const { return m_deviceManagementRestrictionsEnabled; }
     bool allLoadsBlockedByDeviceManagementRestrictionsForTesting() const { return m_allLoadsBlockedByDeviceManagementRestrictionsForTesting; }
 
-    DMFWebsitePolicyMonitor *deviceManagementPolicyMonitor();
+    DMFWebsitePolicyMonitor *NODELETE deviceManagementPolicyMonitor();
 
     CFDictionaryRef proxyConfiguration() const { return m_proxyConfiguration.get(); }
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -151,7 +151,7 @@ static NSURLSessionAuthChallengeDisposition NODELETE toNSURLSessionAuthChallenge
     }
 }
 
-static WebCore::NetworkLoadPriority toNetworkLoadPriority(float priority)
+static WebCore::NetworkLoadPriority NODELETE toNetworkLoadPriority(float priority)
 {
     if (priority <= NSURLSessionTaskPriorityLow)
         return WebCore::NetworkLoadPriority::Low;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
@@ -43,7 +43,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-static inline bool computeIsAlwaysOnLoggingAllowed(NetworkSession& session)
+static inline bool NODELETE computeIsAlwaysOnLoggingAllowed(NetworkSession& session)
 {
     if (session.networkProcess().sessionIsControlledByAutomation(session.sessionID()))
         return true;

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h
@@ -42,7 +42,7 @@ public:
 
     void registerCache(WebCore::DOMCacheIdentifier, CacheStorageCache&);
     void unregisterCache(WebCore::DOMCacheIdentifier);
-    CacheStorageCache* cache(WebCore::DOMCacheIdentifier);
+    CacheStorageCache* NODELETE cache(WebCore::DOMCacheIdentifier);
 
 private:
     CacheStorageRegistry();

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.h
@@ -41,7 +41,7 @@ public:
 
     void registerHandle(WebCore::FileSystemHandleIdentifier, FileSystemStorageHandle&);
     void unregisterHandle(WebCore::FileSystemHandleIdentifier);
-    FileSystemStorageHandle* getHandle(WebCore::FileSystemHandleIdentifier);
+    FileSystemStorageHandle* NODELETE getHandle(WebCore::FileSystemHandleIdentifier);
 
 private:
     FileSystemStorageHandleRegistry();

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
@@ -46,8 +46,8 @@ public:
     bool NODELETE isActive() const;
     uint64_t allocatedUnusedCapacity() const;
     Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> createHandle(IPC::Connection::UniqueID, FileSystemStorageHandle::Type, String&& path, String&& name, bool createIfNecessary);
-    const String& getPath(WebCore::FileSystemHandleIdentifier);
-    FileSystemStorageHandle::Type getType(WebCore::FileSystemHandleIdentifier);
+    const String& NODELETE getPath(WebCore::FileSystemHandleIdentifier);
+    FileSystemStorageHandle::Type NODELETE getType(WebCore::FileSystemHandleIdentifier);
     void closeHandle(FileSystemStorageHandle&);
     void connectionClosed(IPC::Connection::UniqueID);
     Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> getDirectory(IPC::Connection::UniqueID);

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
@@ -53,10 +53,10 @@ public:
     void removeConnectionToClient(IPC::Connection::UniqueID);
     void registerConnection(WebCore::IDBServer::UniqueIDBDatabaseConnection&);
     void unregisterConnection(WebCore::IDBServer::UniqueIDBDatabaseConnection&);
-    WebCore::IDBServer::UniqueIDBDatabaseConnection* connection(WebCore::IDBDatabaseConnectionIdentifier);
+    WebCore::IDBServer::UniqueIDBDatabaseConnection* NODELETE connection(WebCore::IDBDatabaseConnectionIdentifier);
     void registerTransaction(WebCore::IDBServer::UniqueIDBDatabaseTransaction&);
     void unregisterTransaction(WebCore::IDBServer::UniqueIDBDatabaseTransaction&);
-    WebCore::IDBServer::UniqueIDBDatabaseTransaction* transaction(WebCore::IDBResourceIdentifier);
+    WebCore::IDBServer::UniqueIDBDatabaseTransaction* NODELETE transaction(WebCore::IDBResourceIdentifier);
 
 private:
     HashMap<WebCore::IDBConnectionIdentifier, std::unique_ptr<IDBStorageConnectionToClient>> m_connectionsToClient;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -162,9 +162,9 @@ private:
     NetworkStorageManager(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, std::optional<IPC::Connection::UniqueID>, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled);
     ~NetworkStorageManager();
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(IPC::Connection&) const;
-    bool isStorageTypeEnabled(IPC::Connection&, WebCore::StorageType) const;
-    bool isStorageAreaTypeEnabled(IPC::Connection&, StorageAreaBase::StorageType) const;
+    std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess(IPC::Connection&) const;
+    bool NODELETE isStorageTypeEnabled(IPC::Connection&, WebCore::StorageType) const;
+    bool NODELETE isStorageAreaTypeEnabled(IPC::Connection&, StorageAreaBase::StorageType) const;
     bool NODELETE useSQLiteMemoryBackingStore() const;
 
     void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
@@ -285,7 +285,7 @@ private:
     const SuspendableWorkQueue& workQueue() const WTF_RETURNS_CAPABILITY(m_queue.get()) { return m_queue; }
     SuspendableWorkQueue& workQueue() WTF_RETURNS_CAPABILITY(m_queue.get()) { return m_queue; }
     OriginQuotaManager::Parameters originQuotaManagerParameters(const WebCore::ClientOrigin&);
-    RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> idbTransaction(const WebCore::IDBRequestData&);
+    RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> NODELETE idbTransaction(const WebCore::IDBRequestData&);
     void setStorageSiteValidationEnabledInternal(bool);
     void addAllowedSitesForConnectionInternal(IPC::Connection::UniqueID, const Vector<WebCore::RegistrableDomain>&);
     bool isSiteAllowedForConnection(IPC::Connection::UniqueID, const WebCore::RegistrableDomain&) const;

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -74,15 +74,15 @@ public:
     void connectionClosed(IPC::Connection::UniqueID);
     String typeStoragePath(StorageType) const;
     FileSystemStorageManager& fileSystemStorageManager(FileSystemStorageHandleRegistry&, FileSystemStorageManager::QuotaCheckFunction&&);
-    FileSystemStorageManager* existingFileSystemStorageManager() { return m_fileSystemStorageManager.get(); }
+    FileSystemStorageManager* NODELETE existingFileSystemStorageManager() { return m_fileSystemStorageManager.get(); }
     LocalStorageManager& localStorageManager(StorageAreaRegistry&);
-    LocalStorageManager* existingLocalStorageManager() { return m_localStorageManager.get(); }
+    LocalStorageManager* NODELETE existingLocalStorageManager() { return m_localStorageManager.get(); }
     SessionStorageManager& sessionStorageManager(StorageAreaRegistry&);
-    SessionStorageManager* existingSessionStorageManager() { return m_sessionStorageManager.get(); }
+    SessionStorageManager* NODELETE existingSessionStorageManager() { return m_sessionStorageManager.get(); }
     IDBStorageManager& idbStorageManager(IDBStorageRegistry&, IDBStorageManager::QuotaCheckFunction&&, bool useSQLiteMemoryBackingStore);
-    IDBStorageManager* existingIDBStorageManager() { return m_idbStorageManager.get(); }
+    IDBStorageManager* NODELETE existingIDBStorageManager() { return m_idbStorageManager.get(); }
     CacheStorageManager& cacheStorageManager(CacheStorageRegistry&, const WebCore::ClientOrigin&, CacheStorageManager::QuotaCheckFunction&&, Ref<WorkQueue>&&);
-    CacheStorageManager* existingCacheStorageManager() { return m_cacheStorageManager.get(); }
+    CacheStorageManager* NODELETE existingCacheStorageManager() { return m_cacheStorageManager.get(); }
     BackgroundFetchStoreManager& backgroundFetchManager(Ref<WorkQueue>&&, BackgroundFetchStoreManager::QuotaCheckFunction&&);
     ServiceWorkerStorageManager& serviceWorkerStorageManager();
     uint64_t cacheStorageSize();

--- a/Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.h
@@ -41,7 +41,7 @@ public:
     StorageAreaRegistry();
     void registerStorageArea(StorageAreaIdentifier, StorageAreaBase&);
     void unregisterStorageArea(StorageAreaIdentifier);
-    StorageAreaBase* getStorageArea(StorageAreaIdentifier);
+    StorageAreaBase* NODELETE getStorageArea(StorageAreaIdentifier);
 
 private:
     HashMap<StorageAreaIdentifier, WeakPtr<StorageAreaBase>> m_storageAreas;

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm
@@ -65,7 +65,7 @@ public:
 
     class ConnectionStateTracker : public ThreadSafeRefCounted<ConnectionStateTracker> {
     public:
-        static Ref<ConnectionStateTracker> create() { return adoptRef(*new ConnectionStateTracker()); }
+        static Ref<ConnectionStateTracker> NODELETE create() { return adoptRef(*new ConnectionStateTracker()); }
         void NODELETE markAsStopped() { m_isStopped = true; }
         bool NODELETE isStopped() const { return m_isStopped; }
         bool NODELETE shouldLogMissingECN() const { return !m_didLogMissingECN; }

--- a/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h
+++ b/Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h
@@ -61,7 +61,7 @@ private:
     void detectError(WebCore::RTCDataChannelIdentifier, WebCore::RTCErrorDetailType, const String&);
     void bufferedAmountIsDecreasing(WebCore::RTCDataChannelIdentifier, uint64_t amount);
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(const IPC::Connection&);
+    std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess(const IPC::Connection&);
 
     const Ref<WorkQueue> m_queue;
     HashMap<WebCore::ProcessIdentifier, IPC::Connection::UniqueID> m_webProcessConnections;

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h
@@ -90,8 +90,8 @@ public:
     void terminate(WebCore::WebTransportSessionErrorCode, CString&&);
     void NODELETE datagramIncomingMaxAgeUpdated(std::optional<double>);
     void NODELETE datagramOutgoingMaxAgeUpdated(std::optional<double>);
-    void datagramIncomingHighWaterMarkUpdated(double);
-    void datagramOutgoingHighWaterMarkUpdated(double);
+    void NODELETE datagramIncomingHighWaterMarkUpdated(double);
+    void NODELETE datagramOutgoingHighWaterMarkUpdated(double);
 
     void receiveDatagram(std::span<const uint8_t>, bool, std::optional<WebCore::Exception>&&);
     void streamReceiveBytes(WebCore::WebTransportStreamIdentifier, std::span<const uint8_t>, bool, std::optional<WebCore::Exception>&&);

--- a/Source/WebKit/NetworkProcess/webtransport/NetworkTransportStream.h
+++ b/Source/WebKit/NetworkProcess/webtransport/NetworkTransportStream.h
@@ -71,8 +71,8 @@ public:
     void cancelReceive(std::optional<WebCore::WebTransportStreamErrorCode>);
     void cancelSend(std::optional<WebCore::WebTransportStreamErrorCode>);
     void cancel(std::optional<WebCore::WebTransportStreamErrorCode>);
-    WebCore::WebTransportSendStreamStats getSendStreamStats();
-    WebCore::WebTransportReceiveStreamStats getReceiveStreamStats();
+    WebCore::WebTransportSendStreamStats NODELETE getSendStreamStats();
+    WebCore::WebTransportReceiveStreamStats NODELETE getReceiveStreamStats();
 
 private:
 #if PLATFORM(COCOA)

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -556,7 +556,7 @@ public:
     static void NODELETE setShouldCrashOnMessageCheckFailure(bool);
 
 #if PLATFORM(COCOA)
-    static void setForceUseSharedMemoryForSendingForTesting(bool);
+    static void NODELETE setForceUseSharedMemoryForSendingForTesting(bool);
 #endif
 
 #if ENABLE(IPC_TESTING_API)
@@ -612,7 +612,7 @@ private:
     void processIncomingSyncReply(UniqueRef<Decoder>);
 
     bool canSendOutgoingMessages() const;
-    bool platformCanSendOutgoingMessages() const;
+    bool NODELETE platformCanSendOutgoingMessages() const;
     void sendOutgoingMessages();
     bool sendOutgoingMessage(UniqueRef<Encoder>&&);
     void connectionDidClose();
@@ -631,7 +631,7 @@ private:
     size_t incomingMessagesDispatchingBatchSize() const;
     CompletionHandler<void(Connection*, std::unique_ptr<Decoder>&&)> takeAsyncReplyHandlerWithDispatcherWithLockHeld(AsyncReplyID);
 
-    Timeout timeoutRespectingIgnoreTimeoutsForTesting(Timeout) const;
+    Timeout NODELETE timeoutRespectingIgnoreTimeoutsForTesting(Timeout) const;
 
     Error sendMessageImpl(UniqueRef<Encoder>&&, OptionSet<SendOption> sendOptions, std::optional<Thread::QOS> = std::nullopt);
 

--- a/Source/WebKit/Platform/IPC/Encoder.h
+++ b/Source/WebKit/Platform/IPC/Encoder.h
@@ -104,13 +104,13 @@ private:
     std::span<uint8_t> grow(size_t alignment, size_t);
 
     std::span<uint8_t> NODELETE capacityBuffer();
-    std::span<const uint8_t> capacityBuffer() const;
+    std::span<const uint8_t> NODELETE capacityBuffer() const;
 
     bool NODELETE hasAttachments() const;
 
     void encodeHeader();
     const OptionSet<MessageFlags>& NODELETE messageFlags() const;
-    OptionSet<MessageFlags>& messageFlags();
+    OptionSet<MessageFlags>& NODELETE messageFlags();
 
     void freeBufferIfNecessary();
 

--- a/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
+++ b/Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm
@@ -290,7 +290,7 @@ static descriptorType& popDescriptorAndAdvance(std::span<uint8_t>& data)
     return consumeAndReinterpretCastTo<descriptorType>(data);
 }
 
-static void setPortDescriptor(std::span<uint8_t>& messageSpan, mach_port_t sendRight)
+static void NODELETE setPortDescriptor(std::span<uint8_t>& messageSpan, mach_port_t sendRight)
 {
     auto& descriptor = popDescriptorAndAdvance<mach_msg_port_descriptor_t>(messageSpan);
     descriptor.name = sendRight;

--- a/Source/WebKit/Platform/Module.h
+++ b/Source/WebKit/Platform/Module.h
@@ -54,7 +54,7 @@ public:
     bool load();
     // Note: On Mac this leaks the CFBundle to avoid crashes when a bundle is unloaded and there are
     // live Objective-C objects whose methods come from that bundle.
-    void unload();
+    void NODELETE unload();
 
 #if USE(CF)
     String bundleIdentifier() const;

--- a/Source/WebKit/Platform/classifier/ResourceLoadStatisticsClassifier.cpp
+++ b/Source/WebKit/Platform/classifier/ResourceLoadStatisticsClassifier.cpp
@@ -32,7 +32,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-static double vectorLength(unsigned a, unsigned b, unsigned c)
+static double NODELETE vectorLength(unsigned a, unsigned b, unsigned c)
 {
     return std::hypot(a, b, c);
 }

--- a/Source/WebKit/Platform/classifier/ResourceLoadStatisticsClassifier.h
+++ b/Source/WebKit/Platform/classifier/ResourceLoadStatisticsClassifier.h
@@ -48,7 +48,7 @@ protected:
     {
         return classifyWithVectorThreshold(subresourceUnderTopFrameDomainsCount, subresourceUniqueRedirectsToCount, subframeUnderTopFrameOriginsCount);
     }
-    bool classifyWithVectorThreshold(unsigned, unsigned, unsigned);
+    bool NODELETE classifyWithVectorThreshold(unsigned, unsigned, unsigned);
 };
 
 }

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -191,7 +191,7 @@ private:
 
 class ResourceMonitorURLsController {
 public:
-    static ResourceMonitorURLsController& singleton();
+    static ResourceMonitorURLsController& NODELETE singleton();
 
     void prepare(CompletionHandler<void(WKContentRuleList *, bool)>&&);
     void getSource(CompletionHandler<void(String&&)>&&);

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -695,7 +695,7 @@ public:
     }
 
 private:
-    static MemoryCompactRobinHoodHashMap<String, TrackerDomainLookupInfo>& list()
+    static MemoryCompactRobinHoodHashMap<String, TrackerDomainLookupInfo>& NODELETE list()
     {
         static NeverDestroyed<MemoryCompactRobinHoodHashMap<String, TrackerDomainLookupInfo>> map;
         return map.get();

--- a/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
@@ -164,7 +164,7 @@ bool defaultRemoveBackgroundEnabled()
 
 #endif // ENABLE(IMAGE_ANALYSIS)
 
-bool defaultTopContentInsetBackgroundCanChangeAfterScrolling()
+SUPPRESS_NODELETE bool defaultTopContentInsetBackgroundCanChangeAfterScrolling()
 {
 #if PLATFORM(IOS_FAMILY)
     return PAL::currentUserInterfaceIdiomIsSmallScreen();

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -138,7 +138,7 @@ struct EditorState {
         bool canPaste { false };
     };
 
-    bool isEditableOrRanged() const;
+    bool NODELETE isEditableOrRanged() const;
     bool hasPostLayoutData() const { return !!postLayoutData; }
 
     // Visual data is only updated in sync with rendering updates.

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.h
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.h
@@ -42,7 +42,7 @@ namespace PCM {
 
 class DaemonConnectionSet {
 public:
-    static DaemonConnectionSet& singleton();
+    static DaemonConnectionSet& NODELETE singleton();
     
     void add(xpc_connection_t);
     void remove(xpc_connection_t);

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -64,7 +64,7 @@ static Vector<String>& NODELETE overrideLanguagesFromBootstrap()
     return languages;
 }
 
-static void stageOverrideLanguagesForMainThread(Vector<String>&& languages)
+static void NODELETE stageOverrideLanguagesForMainThread(Vector<String>&& languages)
 {
     RELEASE_ASSERT(overrideLanguagesFromBootstrap().isEmpty());
     overrideLanguagesFromBootstrap().swap(languages);

--- a/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
+++ b/Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h
@@ -80,7 +80,7 @@ bool matchesFrame(const WebExtensionFrameIdentifier&, const WebFrame&);
 
 WebExtensionFrameIdentifier NODELETE toWebExtensionFrameIdentifier(std::optional<WebCore::FrameIdentifier>);
 WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(const WebFrame&);
-WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(const FrameInfoData&);
+WebExtensionFrameIdentifier NODELETE toWebExtensionFrameIdentifier(const FrameInfoData&);
 
 #ifdef __OBJC__
 WebExtensionFrameIdentifier toWebExtensionFrameIdentifier(WKFrameInfo *);

--- a/Source/WebKit/Shared/JSHandleInfo.h
+++ b/Source/WebKit/Shared/JSHandleInfo.h
@@ -46,7 +46,7 @@ struct JSHandleInfo {
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(JSHandleInfo);
     JSHandleInfo(WebCore::JSHandleIdentifier, ContentWorldIdentifier, FrameInfoData&&, Markable<WebCore::FrameIdentifier>);
 
-    bool operator==(const JSHandleInfo&) const;
+    bool NODELETE operator==(const JSHandleInfo&) const;
 
     WebCore::JSHandleIdentifier identifier;
     ContentWorldIdentifier worldIdentifier;

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.cpp
@@ -52,7 +52,7 @@ namespace WebKit {
 
 class JavaScriptEvaluationResult::JSExtractor {
 public:
-    Map takeMap() { return WTF::move(m_map); }
+    Map NODELETE takeMap() { return WTF::move(m_map); }
     std::optional<JSObjectID> addObjectToMap(JSGlobalContextRef, JSValueRef, size_t nestingLevel);
     bool processContainersWithoutRecursion(JSGlobalContextRef);
 
@@ -87,7 +87,7 @@ private:
 
 class JavaScriptEvaluationResult::APIExtractor {
 public:
-    Map takeMap() { return WTF::move(m_map); }
+    Map NODELETE takeMap() { return WTF::move(m_map); }
     JSObjectID addObjectToMap(API::Object&);
 private:
     Value toValue(API::Object&);

--- a/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
+++ b/Source/WebKit/Shared/JavaScriptEvaluationResult.mm
@@ -35,7 +35,7 @@ namespace WebKit {
 
 class JavaScriptEvaluationResult::ObjCExtractor {
 public:
-    Map takeMap() { return WTF::move(m_map); }
+    Map NODELETE takeMap() { return WTF::move(m_map); }
     JSObjectID addObjectToMap(id);
 private:
     Value toValue(id);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h
@@ -154,7 +154,7 @@ public:
     HashSet<Ref<PlatformCALayerRemote>>& NODELETE changedLayers() LIFETIME_BOUND;
 
     const LayerPropertiesMap& NODELETE changedLayerProperties() const LIFETIME_BOUND;
-    LayerPropertiesMap& changedLayerProperties() LIFETIME_BOUND;
+    LayerPropertiesMap& NODELETE changedLayerProperties() LIFETIME_BOUND;
 
     void setRemoteContextHostedIdentifier(Markable<WebCore::LayerHostingContextIdentifier> identifier) { m_remoteContextHostedIdentifier = identifier; }
     Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostedIdentifier() const { return m_remoteContextHostedIdentifier; }

--- a/Source/WebKit/Shared/SandboxExtension.h
+++ b/Source/WebKit/Shared/SandboxExtension.h
@@ -63,7 +63,7 @@ public:
 
     [[nodiscard]] bool consume();
     bool invalidate();
-    [[nodiscard]] std::span<const uint8_t> getSerializedFormat();
+    [[nodiscard]] std::span<const uint8_t> NODELETE getSerializedFormat();
 
     SandboxExtensionImpl(SandboxExtensionImpl&& other)
         : m_token(std::exchange(other.m_token, CString()))

--- a/Source/WebKit/Shared/ScrollingAccelerationCurve.h
+++ b/Source/WebKit/Shared/ScrollingAccelerationCurve.h
@@ -71,7 +71,7 @@ private:
 
     void computeIntermediateValuesIfNeeded();
 
-    float evaluateQuartic(float) const;
+    float NODELETE evaluateQuartic(float) const;
 
     struct Parameters {
         float gainLinear { 0 };

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -82,7 +82,7 @@ public:
     const Vector<AtomString>& documentState() const LIFETIME_BOUND { return m_documentState; }
     enum class ShouldValidate : bool { No, Yes };
     void setDocumentState(const Vector<AtomString>&, ShouldValidate = ShouldValidate::No);
-    static bool validateDocumentState(const Vector<AtomString>&);
+    static bool NODELETE validateDocumentState(const Vector<AtomString>&);
     void replaceChildFrameState(Ref<FrameState>&&);
 
     String urlString;

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -41,7 +41,7 @@ public:
     static Ref<WebBackForwardListFrameItem> create(WebBackForwardListItem&, WebBackForwardListFrameItem* parentItem, Ref<FrameState>&&);
     ~WebBackForwardListFrameItem();
 
-    static WebBackForwardListFrameItem* itemForID(WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier);
+    static WebBackForwardListFrameItem* NODELETE itemForID(WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier);
 
     FrameState& frameState() const { return m_frameState; }
     void setFrameState(Ref<FrameState>&&);
@@ -61,14 +61,14 @@ public:
     WebBackForwardListFrameItem* NODELETE childItemForFrameID(WebCore::FrameIdentifier);
     WebBackForwardListFrameItem* NODELETE childItemAtIndex(uint64_t);
 
-    WebBackForwardListItem* backForwardListItem() const;
+    WebBackForwardListItem* NODELETE backForwardListItem() const;
 
     void setChild(Ref<FrameState>&&);
     void clearChildren() { m_children.clear(); }
 
-    void updateFrameID(WebCore::FrameIdentifier);
+    void NODELETE updateFrameID(WebCore::FrameIdentifier);
 
-    void setWasRestoredFromSession();
+    void NODELETE setWasRestoredFromSession();
 
     String loggingString();
 

--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -79,7 +79,7 @@ WebBackForwardListItem* WebBackForwardListItem::itemForID(BackForwardItemIdentif
     return allItems().get(identifier);
 }
 
-static const FrameState* childItemWithTarget(const FrameState& frameState, const String& target)
+static const FrameState* NODELETE childItemWithTarget(const FrameState& frameState, const String& target)
 {
     for (auto& child : frameState.children) {
         if (child->target == target)
@@ -101,7 +101,7 @@ bool WebBackForwardListItem::itemIsInSameDocument(const WebBackForwardListItem& 
     return mainFrameState->documentSequenceNumber == otherMainFrameState->documentSequenceNumber;
 }
 
-static bool hasSameFrames(const FrameState& a, const FrameState& b)
+static bool NODELETE hasSameFrames(const FrameState& a, const FrameState& b)
 {
     if (a.target != b.target)
         return false;

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -67,7 +67,7 @@ public:
     const String& NODELETE originalURL() const LIFETIME_BOUND;
     const String& NODELETE url() const LIFETIME_BOUND;
     const String& NODELETE title() const LIFETIME_BOUND;
-    bool wasCreatedByJSWithoutUserInteraction() const;
+    bool NODELETE wasCreatedByJSWithoutUserInteraction() const;
 
     const URL& resourceDirectoryURL() const LIFETIME_BOUND { return m_resourceDirectoryURL; }
     void setResourceDirectoryURL(URL&& url) { m_resourceDirectoryURL = WTF::move(url); }
@@ -90,7 +90,7 @@ public:
 
     std::optional<WebCore::FrameIdentifier> navigatedFrameID() const { return m_navigatedFrameID; }
 
-    WebBackForwardListFrameItem& navigatedFrameItem() const;
+    WebBackForwardListFrameItem& NODELETE navigatedFrameItem() const;
 
     // rdar://168057355
     WebBackForwardListFrameItem* WTF_NONNULL mainFrameItemPtrForSwift() const SWIFT_NAME(mainFrameItem()) { return &mainFrameItem(); }

--- a/Source/WebKit/Shared/WebEventConversion.h
+++ b/Source/WebKit/Shared/WebEventConversion.h
@@ -60,7 +60,7 @@ class WebGestureEvent;
 #endif
 
 WebCore::PlatformMouseEvent platform(const WebMouseEvent&);
-WebCore::PlatformWheelEvent platform(const WebWheelEvent&);
+WebCore::PlatformWheelEvent NODELETE platform(const WebWheelEvent&);
 WebCore::PlatformKeyboardEvent platform(const WebKeyboardEvent&);
 
 #if ENABLE(TOUCH_EVENTS)
@@ -74,17 +74,17 @@ WebCore::PlatformTouchPoint platform(const WebTouchPoint&);
 WebCore::PlatformGestureEvent platform(const WebGestureEvent&);
 #endif
 
-WebCore::MouseEventInputSource platform(WebMouseEventInputSource);
-WebMouseEventInputSource kit(WebCore::MouseEventInputSource);
+WebCore::MouseEventInputSource NODELETE platform(WebMouseEventInputSource);
+WebMouseEventInputSource NODELETE kit(WebCore::MouseEventInputSource);
 
 WebCore::MouseButton platform(WebMouseEventButton);
 WebMouseEventButton NODELETE kit(WebCore::MouseButton);
 
-WebCore::PlatformEvent::Type platform(WebEventType);
-WebEventType kit(WebCore::PlatformEvent::Type);
+WebCore::PlatformEvent::Type NODELETE platform(WebEventType);
+WebEventType NODELETE kit(WebCore::PlatformEvent::Type);
 
 OptionSet<WebCore::PlatformEvent::Modifier> platform(OptionSet<WebEventModifier>);
-OptionSet<WebKit::WebEventModifier> kit(OptionSet<WebCore::PlatformEvent::Modifier>);
+OptionSet<WebKit::WebEventModifier> NODELETE kit(OptionSet<WebCore::PlatformEvent::Modifier>);
 
 #if PLATFORM(GTK) || PLATFORM(WPE) || USE(LIBWPE)
 MonotonicTime monotonicTimeForEventTimeInMilliseconds(uint64_t);

--- a/Source/WebKit/Shared/WebEventModifier.cpp
+++ b/Source/WebKit/Shared/WebEventModifier.cpp
@@ -34,7 +34,7 @@
 
 namespace WebKit {
 
-OptionSet<WebEventModifier> modifiersFromPlatformEventModifiers(OptionSet<WebCore::PlatformEventModifier> modifiers)
+OptionSet<WebEventModifier> NODELETE modifiersFromPlatformEventModifiers(OptionSet<WebCore::PlatformEventModifier> modifiers)
 {
     OptionSet<WebEventModifier> result;
     if (modifiers.contains(WebCore::PlatformEventModifier::ShiftKey))

--- a/Source/WebKit/Shared/WebEventModifier.h
+++ b/Source/WebKit/Shared/WebEventModifier.h
@@ -42,7 +42,7 @@ enum class WebEventModifier : uint8_t {
     CapsLockKey = 1 << 4,
 };
 
-OptionSet<WebEventModifier> modifiersFromPlatformEventModifiers(OptionSet<WebCore::PlatformEventModifier>);
+OptionSet<WebEventModifier> NODELETE modifiersFromPlatformEventModifiers(OptionSet<WebCore::PlatformEventModifier>);
 OptionSet<WebEventModifier> modifiersForNavigationAction(const WebCore::NavigationAction&);
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebFindOptions.cpp
+++ b/Source/WebKit/Shared/WebFindOptions.cpp
@@ -28,7 +28,7 @@
 
 namespace WebKit {
 
-WebCore::FindOptions core(OptionSet<FindOptions> options)
+WebCore::FindOptions NODELETE core(OptionSet<FindOptions> options)
 {
     WebCore::FindOptions result;
     if (options.contains(FindOptions::CaseInsensitive))

--- a/Source/WebKit/Shared/WebFindOptions.h
+++ b/Source/WebKit/Shared/WebFindOptions.h
@@ -50,6 +50,6 @@ enum class FindDecorationStyle : uint8_t {
     Highlighted,
 };
 
-WebCore::FindOptions core(OptionSet<FindOptions>);
+WebCore::FindOptions NODELETE core(OptionSet<FindOptions>);
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebMouseEvent.cpp
+++ b/Source/WebKit/Shared/WebMouseEvent.cpp
@@ -75,7 +75,7 @@ bool WebMouseEvent::isMouseEventType(WebEventType type)
     return type == WebEventType::MouseDown || type == WebEventType::MouseUp || type == WebEventType::MouseMove || type == WebEventType::MouseForceUp || type == WebEventType::MouseForceDown || type == WebEventType::MouseForceChanged;
 }
 
-WebMouseEventButton mouseButton(const WebCore::NavigationAction& navigationAction)
+WebMouseEventButton NODELETE mouseButton(const WebCore::NavigationAction& navigationAction)
 {
     auto& mouseEventData = navigationAction.mouseEventData();
     if (mouseEventData && mouseEventData->buttonDown && mouseEventData->isTrusted)

--- a/Source/WebKit/Shared/WebMouseEvent.h
+++ b/Source/WebKit/Shared/WebMouseEvent.h
@@ -51,7 +51,7 @@ enum class WebMouseEventButton : int8_t {
     Forward,
     None = -2,
 };
-WebMouseEventButton mouseButton(const WebCore::NavigationAction&);
+WebMouseEventButton NODELETE mouseButton(const WebCore::NavigationAction&);
 
 enum class WebMouseEventSyntheticClickType : uint8_t {
     NoTap,

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -75,7 +75,7 @@ bool defaultShouldPrintBackgrounds()
 
 #if ENABLE(FULLSCREEN_API)
 
-bool defaultVideoFullscreenRequiresElementFullscreen()
+SUPPRESS_NODELETE bool defaultVideoFullscreenRequiresElementFullscreen()
 {
 #if USE(APPLE_INTERNAL_SDK)
     if (videoFullscreenRequiresElementFullscreenFromAdditions())
@@ -123,7 +123,7 @@ bool defaultCaptureAudioInGPUProcessEnabled()
 #endif
 }
 
-bool defaultManageCaptureStatusBarInGPUProcessEnabled()
+SUPPRESS_NODELETE bool defaultManageCaptureStatusBarInGPUProcessEnabled()
 {
 #if PLATFORM(IOS_FAMILY)
     // FIXME: Enable by default for all applications.
@@ -133,7 +133,7 @@ bool defaultManageCaptureStatusBarInGPUProcessEnabled()
 #endif
 }
 
-double defaultInactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes()
+SUPPRESS_NODELETE double defaultInactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes()
 {
     constexpr double inactiveMediaCaptureStreamRepromptIntervalForDesktop = 10;
 
@@ -252,7 +252,7 @@ bool defaultGamepadVibrationActuatorEnabled()
 #endif
 
 #if ENABLE(WEB_AUTHN)
-bool defaultDigitalCredentialsEnabled()
+SUPPRESS_NODELETE bool defaultDigitalCredentialsEnabled()
 {
 #if HAVE(DIGITAL_CREDENTIALS_UI)
     static bool enabled = [] {
@@ -270,7 +270,7 @@ bool defaultDigitalCredentialsEnabled()
 }
 #endif
 
-bool defaultShouldEnableScreenOrientationAPI()
+SUPPRESS_NODELETE bool defaultShouldEnableScreenOrientationAPI()
 {
 #if PLATFORM(MAC)
     return true;
@@ -343,7 +343,7 @@ bool defaultBuiltInNotificationsEnabled()
 #endif
 
 #if ENABLE(DEVICE_ORIENTATION)
-bool defaultDeviceOrientationPermissionAPIEnabled()
+SUPPRESS_NODELETE bool defaultDeviceOrientationPermissionAPIEnabled()
 {
 #if PLATFORM(IOS_FAMILY)
     return linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::SupportsDeviceOrientationAndMotionPermissionAPI);
@@ -434,7 +434,7 @@ bool defaultTrustedTypesEnabled()
 #endif
 }
 
-bool defaultGetBoundingClientRectZoomedEnabled()
+SUPPRESS_NODELETE bool defaultGetBoundingClientRectZoomedEnabled()
 {
 #if PLATFORM(IOS_FAMILY)
     return linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::GetBoundingClientRectZoomed);
@@ -443,7 +443,7 @@ bool defaultGetBoundingClientRectZoomedEnabled()
 #endif
 }
 
-bool defaultFacebookLiveRecordingQuirkEnabled()
+SUPPRESS_NODELETE bool defaultFacebookLiveRecordingQuirkEnabled()
 {
 #if PLATFORM(MAC)
     return true;

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -92,7 +92,7 @@ bool defaultTextAutosizingUsesIdempotentMode();
 #endif
 
 #if ENABLE(FULLSCREEN_API)
-bool defaultVideoFullscreenRequiresElementFullscreen();
+bool NODELETE defaultVideoFullscreenRequiresElementFullscreen();
 #endif
 
 #if PLATFORM(MAC)
@@ -106,8 +106,8 @@ bool defaultTextInputClientSelectionUpdatesEnabled();
 
 #if ENABLE(MEDIA_STREAM)
 bool NODELETE defaultCaptureAudioInGPUProcessEnabled();
-bool defaultManageCaptureStatusBarInGPUProcessEnabled();
-double defaultInactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes();
+bool NODELETE defaultManageCaptureStatusBarInGPUProcessEnabled();
+double NODELETE defaultInactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes();
 #endif
 
 #if ENABLE(MEDIA_SOURCE) && PLATFORM(IOS_FAMILY)
@@ -137,7 +137,7 @@ bool NODELETE defaultGamepadVibrationActuatorEnabled();
 #endif
 
 #if ENABLE(WEB_AUTHN)
-bool defaultDigitalCredentialsEnabled();
+bool NODELETE defaultDigitalCredentialsEnabled();
 #endif
 
 #if PLATFORM(IOS_FAMILY)
@@ -156,7 +156,7 @@ bool defaultShouldTakeNearSuspendedAssertion();
 bool defaultShowModalDialogEnabled();
 bool NODELETE defaultLinearMediaPlayerEnabled();
 
-bool defaultShouldEnableScreenOrientationAPI();
+bool NODELETE defaultShouldEnableScreenOrientationAPI();
 bool defaultPopoverAttributeEnabled();
 bool defaultUseGPUProcessForDOMRenderingEnabled();
 
@@ -170,7 +170,7 @@ bool NODELETE defaultBuiltInNotificationsEnabled();
 #endif
 
 #if ENABLE(DEVICE_ORIENTATION)
-bool defaultDeviceOrientationPermissionAPIEnabled();
+bool NODELETE defaultDeviceOrientationPermissionAPIEnabled();
 #endif
 
 #if ENABLE(REQUIRES_PAGE_VISIBILITY_FOR_NOW_PLAYING)
@@ -180,7 +180,7 @@ bool defaultRequiresPageVisibilityForVideoToBeNowPlaying();
 bool NODELETE defaultCookieStoreAPIEnabled();
 
 bool defaultContentInsetBackgroundFillEnabled();
-bool defaultTopContentInsetBackgroundCanChangeAfterScrolling();
+bool NODELETE defaultTopContentInsetBackgroundCanChangeAfterScrolling();
 
 #if ENABLE(SCREEN_TIME)
 bool defaultScreenTimeEnabled();
@@ -200,8 +200,8 @@ bool defaultMutationEventsEnabled();
 
 bool defaultTrustedTypesEnabled();
 
-bool defaultGetBoundingClientRectZoomedEnabled();
-bool defaultFacebookLiveRecordingQuirkEnabled();
+bool NODELETE defaultGetBoundingClientRectZoomedEnabled();
+bool NODELETE defaultFacebookLiveRecordingQuirkEnabled();
 bool defaultFontFaceSetConstructorEnabled();
 
 #if HAVE(MATERIAL_HOSTING)

--- a/Source/WebKit/Shared/WebWheelEventCoalescer.h
+++ b/Source/WebKit/Shared/WebWheelEventCoalescer.h
@@ -47,7 +47,7 @@ public:
 private:
     using CoalescedEventSequence = Vector<NativeWebWheelEvent>;
 
-    static bool canCoalesce(const WebWheelEvent&, const WebWheelEvent&);
+    static bool NODELETE canCoalesce(const WebWheelEvent&, const WebWheelEvent&);
     static WebWheelEvent coalesce(const WebWheelEvent&, const WebWheelEvent&);
 
     bool NODELETE shouldDispatchEventNow(const WebWheelEvent&) const;

--- a/Source/WebKit/Shared/WebsiteData/WebsiteData.h
+++ b/Source/WebKit/Shared/WebsiteData/WebsiteData.h
@@ -70,7 +70,7 @@ struct WebsiteData {
     HashSet<String> hostNamesWithHSTSCache;
     HashSet<WebCore::RegistrableDomain> registrableDomainsWithResourceLoadStatistics;
     static WebsiteDataProcessType NODELETE ownerProcess(WebsiteDataType);
-    static OptionSet<WebsiteDataType> filter(OptionSet<WebsiteDataType>, WebsiteDataProcessType);
+    static OptionSet<WebsiteDataType> NODELETE filter(OptionSet<WebsiteDataType>, WebsiteDataProcessType);
 };
 
 }

--- a/Source/WebKit/Shared/mac/ScrollingAccelerationCurveMac.mm
+++ b/Source/WebKit/Shared/mac/ScrollingAccelerationCurveMac.mm
@@ -37,7 +37,7 @@
 
 namespace WebKit {
 
-static float fromFixedPoint(float value)
+static float NODELETE fromFixedPoint(float value)
 {
     return value / 65536.0f;
 }

--- a/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h
@@ -67,7 +67,7 @@ public:
     bool NODELETE isInspectable() const;
     void NODELETE setInspectable(bool);
 
-    OptionSet<WebKit::ContentWorldOption> optionSet() const;
+    OptionSet<WebKit::ContentWorldOption> NODELETE optionSet() const;
 
 private:
     struct Data {

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -183,8 +183,8 @@ public:
     void setOriginatorAdvancedPrivacyProtections(OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections) { m_originatorAdvancedPrivacyProtections = advancedPrivacyProtections; }
     std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> originatorAdvancedPrivacyProtections() const { return m_originatorAdvancedPrivacyProtections; }
     void setSafeBrowsingCheckOngoing(size_t, bool);
-    bool safeBrowsingCheckOngoing(size_t);
-    bool safeBrowsingCheckOngoing();
+    bool NODELETE safeBrowsingCheckOngoing(size_t);
+    bool NODELETE safeBrowsingCheckOngoing();
     void setSafeBrowsingWarning(RefPtr<WebKit::BrowsingWarning>&&);
     RefPtr<WebKit::BrowsingWarning> NODELETE safeBrowsingWarning();
     void setSafeBrowsingCheckTimedOut() { m_safeBrowsingCheckTimedOut = true; }

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -158,7 +158,7 @@ public:
     void setWebExtensionController(RefPtr<WebKit::WebExtensionController>&&);
 
     WebKit::WebExtensionController* NODELETE weakWebExtensionController() const;
-    void setWeakWebExtensionController(WebKit::WebExtensionController*);
+    void NODELETE setWeakWebExtensionController(WebKit::WebExtensionController*);
 #endif
 
     WebKit::WebPageGroup* NODELETE pageGroup();
@@ -519,7 +519,7 @@ private:
         static WebKit::DragLiftDelay defaultDragLiftDelay();
 #endif
 #if PLATFORM(COCOA)
-        uintptr_t defaultMediaTypesRequiringUserActionForPlayback();
+        uintptr_t NODELETE defaultMediaTypesRequiringUserActionForPlayback();
 #endif
 
         LazyInitializedRef<WebKit::WebProcessPool, createWebProcessPool> processPool;

--- a/Source/WebKit/UIProcess/API/Cocoa/APIPageConfigurationCocoa.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/APIPageConfigurationCocoa.mm
@@ -48,7 +48,7 @@ WebKit::DragLiftDelay PageConfiguration::Data::defaultDragLiftDelay()
 }
 #endif
 
-uintptr_t PageConfiguration::Data::defaultMediaTypesRequiringUserActionForPlayback()
+SUPPRESS_NODELETE uintptr_t PageConfiguration::Data::defaultMediaTypesRequiringUserActionForPlayback()
 {
 #if PLATFORM(IOS_FAMILY)
 #if !PLATFORM(WATCHOS)

--- a/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm
@@ -143,13 +143,13 @@ constexpr NSUInteger maximumReadOnlyAccessPaths = 2;
     return s_cache.get().get();
 }
 
-static RetainPtr<WKWebViewConfiguration>& globalConfiguration()
+static RetainPtr<WKWebViewConfiguration>& NODELETE globalConfiguration()
 {
     static NeverDestroyed<RetainPtr<WKWebViewConfiguration>> configuration;
     return configuration;
 }
 
-static RetainPtr<NSString>& sourceApplicationBundleIdentifier()
+static RetainPtr<NSString>& NODELETE sourceApplicationBundleIdentifier()
 {
     static NeverDestroyed<RetainPtr<NSString>> identifier;
     return identifier;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -78,7 +78,7 @@
 @end
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-static RetainPtr<WKProcessPool>& sharedProcessPool()
+static RetainPtr<WKProcessPool>& NODELETE sharedProcessPool()
 {
     static NeverDestroyed<RetainPtr<WKProcessPool>> sharedProcessPool;
     return sharedProcessPool;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm
@@ -399,7 +399,7 @@ static inline WKWebExtensionContextPermissionStatus NODELETE toAPI(WebKit::WebEx
     }
 }
 
-static inline WebKit::WebExtensionContext::PermissionState toImpl(WKWebExtensionContextPermissionStatus status)
+static inline WebKit::WebExtensionContext::PermissionState NODELETE toImpl(WKWebExtensionContextPermissionStatus status)
 {
     switch (status) {
     case WKWebExtensionContextPermissionStatusDeniedExplicitly:
@@ -797,7 +797,7 @@ static inline WebKit::WebExtensionContext::TabSet toImpl(NSArray<id<WKWebExtensi
     extensionContext->didReplaceTab(toImpl(oldTab, extensionContext.get()), toImpl(newTab, extensionContext.get()));
 }
 
-static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> toImpl(WKWebExtensionTabChangedProperties properties)
+static inline OptionSet<WebKit::WebExtensionTab::ChangedProperties> NODELETE toImpl(WKWebExtensionTabChangedProperties properties)
 {
     if (properties == WKWebExtensionTabChangedPropertiesNone)
         return { };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm
@@ -222,7 +222,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionMatchPattern, WebExtensionMa
     return [self matchesURL:urlToMatch options:0];
 }
 
-static OptionSet<WebKit::WebExtensionMatchPattern::Options> toImpl(WKWebExtensionMatchPatternOptions options)
+static OptionSet<WebKit::WebExtensionMatchPattern::Options> NODELETE toImpl(WKWebExtensionMatchPatternOptions options)
 {
     OptionSet<WebKit::WebExtensionMatchPattern::Options> result;
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -380,7 +380,7 @@ static bool shouldAllowPictureInPictureMediaPlayback()
 
 #endif // PLATFORM(IOS_FAMILY)
 
-static bool shouldRequireUserGestureToLoadVideo()
+SUPPRESS_NODELETE static bool NODELETE shouldRequireUserGestureToLoadVideo()
 {
 #if PLATFORM(IOS_FAMILY)
     static bool shouldRequireUserGestureToLoadVideo = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::RequiresUserGestureToLoadVideo);
@@ -5496,7 +5496,7 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
     return _page->shouldUseBackForwardCache();
 }
 
-static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingProgressEvents events)
+static inline OptionSet<WebCore::LayoutMilestone> NODELETE layoutMilestones(_WKRenderingProgressEvents events)
 {
     OptionSet<WebCore::LayoutMilestone> milestones;
 
@@ -5866,7 +5866,7 @@ static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingP
     downcast<WebKit::FindClient>(_page->findClient()).setDelegate(findDelegate);
 }
 
-static inline OptionSet<WebKit::FindOptions> toFindOptions(_WKFindOptions wkFindOptions)
+static inline OptionSet<WebKit::FindOptions> NODELETE toFindOptions(_WKFindOptions wkFindOptions)
 {
     OptionSet<WebKit::FindOptions> findOptions;
 
@@ -7319,7 +7319,7 @@ static HashMap<String, HashMap<WebCore::JSHandleIdentifier, String>> extractClie
     return result;
 }
 
-static OptionSet<WebCore::TextExtraction::EventListenerCategory> coreEventListenerCategories(_WKTextExtractionEventListenerCategory categories)
+static OptionSet<WebCore::TextExtraction::EventListenerCategory> NODELETE coreEventListenerCategories(_WKTextExtractionEventListenerCategory categories)
 {
     OptionSet<WebCore::TextExtraction::EventListenerCategory> coreCategories;
     if (categories & _WKTextExtractionEventListenerCategoryClick)
@@ -7337,7 +7337,7 @@ static OptionSet<WebCore::TextExtraction::EventListenerCategory> coreEventListen
 
 #if ENABLE(DATA_DETECTION)
 
-static OptionSet<WebCore::DataDetectorType> coreDataDetectorTypes(_WKTextExtractionDataDetectorTypes types)
+static OptionSet<WebCore::DataDetectorType> NODELETE coreDataDetectorTypes(_WKTextExtractionDataDetectorTypes types)
 {
     OptionSet<WebCore::DataDetectorType> coreTypes;
     if (types & _WKTextExtractionDataDetectorMoney)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -529,7 +529,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     protect(*_pageConfiguration)->setDefaultWebsitePolicies(defaultWebpagePreferences ? defaultWebpagePreferences->_websitePolicies.get() : nullptr);
 }
 
-static NSString *defaultApplicationNameForUserAgent()
+SUPPRESS_NODELETE static NSString *NODELETE defaultApplicationNameForUserAgent()
 {
 #if PLATFORM(IOS_FAMILY)
     return @"Mobile/15E148";

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -139,7 +139,7 @@ public:
     public:
         static Ref<Debuggable> create(WebAutomationSession&);
 
-        void sessionDestroyed();
+        void NODELETE sessionDestroyed();
 
     // Inspector::RemoteAutomationTarget API
     String name() const;
@@ -379,8 +379,8 @@ private:
     // The type parameter of the NSArray argument is platform-dependent.
     void sendSynthesizedEventsToPage(WebPageProxy&, NSArray *eventsToSend);
 
-    std::optional<unichar> charCodeForVirtualKey(Inspector::Protocol::Automation::VirtualKey) const;
-    std::optional<unichar> charCodeIgnoringModifiersForVirtualKey(Inspector::Protocol::Automation::VirtualKey) const;
+    std::optional<unichar> NODELETE charCodeForVirtualKey(Inspector::Protocol::Automation::VirtualKey) const;
+    std::optional<unichar> NODELETE charCodeIgnoringModifiersForVirtualKey(Inspector::Protocol::Automation::VirtualKey) const;
 #endif
 
     WeakPtr<WebProcessPool> m_processPool;

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -82,7 +82,7 @@ public:
     void transitionPageToRemotePage(WebPageProxy&, const WebCore::Site& openerSite);
     void transitionProvisionalPageToRemotePage(ProvisionalPageProxy&, const WebCore::Site& provisionalNavigationFailureSite);
 
-    bool hasRemotePages(const WebPageProxy&);
+    bool NODELETE hasRemotePages(const WebPageProxy&);
 
 private:
     BrowsingContextGroup();

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.h
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.h
@@ -66,7 +66,7 @@ public:
     void ref() const final;
     void deref() const final;
 
-    static NavigationState* fromWebPage(WebPageProxy&);
+    static NavigationState* NODELETE fromWebPage(WebPageProxy&);
 
     UniqueRef<API::NavigationClient> createNavigationClient();
     UniqueRef<API::HistoryClient> createHistoryClient();

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -108,7 +108,7 @@
 namespace WebKit {
 using namespace WebCore;
 
-static WeakHashMap<WebPageProxy, WeakPtr<NavigationState>>& navigationStates()
+static WeakHashMap<WebPageProxy, WeakPtr<NavigationState>>& NODELETE navigationStates()
 {
     static NeverDestroyed<WeakHashMap<WebPageProxy, WeakPtr<NavigationState>>> navigationStates;
 

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -349,7 +349,7 @@ private:
     void setVolume(PlaybackSessionContextIdentifier, double);
     void setPlayingOnSecondScreen(PlaybackSessionContextIdentifier, bool);
     void sendRemoteCommand(PlaybackSessionContextIdentifier, WebCore::PlatformMediaSession::RemoteControlCommandType, const WebCore::PlatformMediaSession::RemoteCommandArgument&);
-    void setVideoReceiverEndpoint(PlaybackSessionContextIdentifier, const WebCore::VideoReceiverEndpoint&, WebCore::VideoReceiverEndpointIdentifier);
+    void NODELETE setVideoReceiverEndpoint(PlaybackSessionContextIdentifier, const WebCore::VideoReceiverEndpoint&, WebCore::VideoReceiverEndpointIdentifier);
     void NODELETE swapVideoReceiverEndpoints(PlaybackSessionContextIdentifier, PlaybackSessionContextIdentifier);
 #if HAVE(SPATIAL_TRACKING_LABEL)
     void setSpatialTrackingLabel(PlaybackSessionContextIdentifier, const String&);
@@ -369,7 +369,7 @@ private:
     const Logger& logger() const { return m_logger; }
     uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "PlaybackSessionManagerProxy"_s; }
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
 #endif
 
     WeakPtr<WebPageProxy> m_page;

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -169,7 +169,7 @@ public:
     void invalidate();
 
     void requestHideAndExitFullscreen();
-    bool hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const;
+    bool NODELETE hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenMode) const;
     bool mayAutomaticallyShowVideoPictureInPicture() const;
     void applicationDidBecomeActive();
     bool isVisible() const;
@@ -217,10 +217,10 @@ private:
     typedef std::pair<Ref<VideoPresentationModelContext>, Ref<WebCore::PlatformVideoPresentationInterface>> ModelInterfacePair;
     ModelInterfacePair createModelAndInterface(PlaybackSessionContextIdentifier);
     const ModelInterfacePair& ensureModelAndInterface(PlaybackSessionContextIdentifier);
-    const ModelInterfacePair* findModelAndInterface(PlaybackSessionContextIdentifier) const;
+    const ModelInterfacePair* NODELETE findModelAndInterface(PlaybackSessionContextIdentifier) const;
     Ref<VideoPresentationModelContext> ensureModel(PlaybackSessionContextIdentifier);
     Ref<WebCore::PlatformVideoPresentationInterface> ensureInterface(PlaybackSessionContextIdentifier);
-    RefPtr<WebCore::PlatformVideoPresentationInterface> findInterface(PlaybackSessionContextIdentifier) const;
+    RefPtr<WebCore::PlatformVideoPresentationInterface> NODELETE findInterface(PlaybackSessionContextIdentifier) const;
     void ensureClientForContext(PlaybackSessionContextIdentifier);
     void addClientForContext(PlaybackSessionContextIdentifier);
     void removeClientForContext(PlaybackSessionContextIdentifier);
@@ -295,9 +295,9 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& NODELETE logger() const;
-    uint64_t logIdentifier() const;
+    uint64_t NODELETE logIdentifier() const;
     ASCIILiteral logClassName() const;
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
 #endif
 
     bool m_mockVideoPresentationModeEnabled { false };

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -178,7 +178,7 @@ void WebPageProxy::didGeneratePageLoadTiming(const WebPageLoadTiming& timing)
         state->didGeneratePageLoadTiming(timing);
 }
 
-static bool exceedsRenderTreeSizeSizeThreshold(uint64_t thresholdSize, uint64_t committedSize)
+static bool NODELETE exceedsRenderTreeSizeSizeThreshold(uint64_t thresholdSize, uint64_t committedSize)
 {
     const double thesholdSizeFraction = 0.5; // Empirically-derived.
     return committedSize > thresholdSize * thesholdSizeFraction;

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -1131,7 +1131,7 @@ int webProcessThroughputQOS()
     return qos;
 }
 
-static WeakHashSet<LockdownModeObserver>& lockdownModeObservers()
+static WeakHashSet<LockdownModeObserver>& NODELETE lockdownModeObservers()
 {
     RELEASE_ASSERT(isMainRunLoop());
     static NeverDestroyed<WeakHashSet<LockdownModeObserver>> observers;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionAction.h
@@ -77,9 +77,9 @@ public:
     enum class Appearance : uint8_t { Default, Light, Dark, Both };
 #endif
 
-    bool operator==(const WebExtensionAction&) const;
+    bool NODELETE operator==(const WebExtensionAction&) const;
 
-    WebExtensionContext* extensionContext() const;
+    WebExtensionContext* NODELETE extensionContext() const;
     RefPtr<WebExtensionTab> tab() const { return m_tab.value_or(nullptr).get(); }
     RefPtr<WebExtensionWindow> window() const { return m_window.value_or(nullptr).get(); }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h
@@ -78,7 +78,7 @@ public:
 
     enum class SuppressEvents : bool { No, Yes };
 
-    bool operator==(const WebExtensionCommand&) const;
+    bool NODELETE operator==(const WebExtensionCommand&) const;
 
     WebExtensionCommandParameters parameters() const;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -173,7 +173,7 @@ public:
 
     static bool isURLForAnyExtension(const URL&);
 
-    static WebExtensionContext* get(WebExtensionContextIdentifier);
+    static WebExtensionContext* NODELETE get(WebExtensionContextIdentifier);
 
     explicit WebExtensionContext(Ref<WebExtension>&&);
 
@@ -552,7 +552,7 @@ public:
 #endif
 
     void userGesturePerformed(WebExtensionTab&);
-    bool hasActiveUserGesture(WebExtensionTab&) const;
+    bool NODELETE hasActiveUserGesture(WebExtensionTab&) const;
     void clearUserGesture(WebExtensionTab&);
 
     bool NODELETE inTestingMode() const;
@@ -691,7 +691,7 @@ private:
 
     bool isBackgroundPage(WebCore::FrameIdentifier) const;
     bool isBackgroundPage(WebPageProxyIdentifier) const;
-    bool backgroundContentIsLoaded() const;
+    bool NODELETE backgroundContentIsLoaded() const;
 
     void loadBackgroundWebViewDuringLoad();
     void loadBackgroundWebViewIfNeeded();
@@ -731,7 +731,7 @@ private:
     void unloadInspectorBackgroundPage(WebInspectorUIProxy&);
 
     RefPtr<API::InspectorExtension> inspectorExtension(WebPageProxyIdentifier) const;
-    RefPtr<WebInspectorUIProxy> inspector(const API::InspectorExtension&) const;
+    RefPtr<WebInspectorUIProxy> NODELETE inspector(const API::InspectorExtension&) const;
     HashSet<Ref<WebProcessProxy>> processes(const API::InspectorExtension&) const;
 #endif // ENABLE(INSPECTOR_EXTENSIONS)
 
@@ -1159,7 +1159,7 @@ private:
     Deque<TestMessage> m_testStartedQueue;
     Deque<TestMessage> m_testFinishedQueue;
 
-    bool hasTestEventListeners(WebExtensionEventListenerType);
+    bool NODELETE hasTestEventListeners(WebExtensionEventListenerType);
     void sendQueuedTestMessagesIfNeeded(WebExtensionEventListenerType);
 #if PLATFORM(COCOA)
     void addTestMessageToQueue(const String& message, id argument, WebExtensionEventListenerType);

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.h
@@ -88,7 +88,7 @@ class WebExtensionController : public API::ObjectImpl<API::Object::Type::WebExte
 
 public:
     static Ref<WebExtensionController> create(Ref<WebExtensionControllerConfiguration> configuration) { return adoptRef(*new WebExtensionController(configuration)); }
-    static RefPtr<WebExtensionController> get(WebExtensionControllerIdentifier);
+    static RefPtr<WebExtensionController> NODELETE get(WebExtensionControllerIdentifier);
 
     void ref() const final { API::ObjectImpl<API::Object::Type::WebExtensionController>::ref(); }
     void deref() const final { API::ObjectImpl<API::Object::Type::WebExtensionController>::deref(); }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h
@@ -73,7 +73,7 @@ public:
     WebsiteDataStore& defaultWebsiteDataStore() const;
     void setDefaultWebsiteDataStore(WebsiteDataStore* dataStore) { m_defaultWebsiteDataStore = dataStore; }
 
-    bool operator==(const WebExtensionControllerConfiguration&) const;
+    bool NODELETE operator==(const WebExtensionControllerConfiguration&) const;
 
 #ifdef __OBJC__
     WKWebExtensionControllerConfiguration *wrapper() const { return (WKWebExtensionControllerConfiguration *)API::ObjectImpl<API::Object::Type::WebExtensionControllerConfiguration>::wrapper(); }

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h
@@ -57,9 +57,9 @@ public:
     const String& displayName() const LIFETIME_BOUND { return m_displayName; }
     const String& uniqueIdentifier() const LIFETIME_BOUND { return m_uniqueIdentifier; }
 
-    OptionSet<Type> types() const;
+    OptionSet<Type> NODELETE types() const;
 
-    size_t totalSize() const;
+    size_t NODELETE totalSize() const;
     size_t sizeOfTypes(OptionSet<Type>) const;
 
     size_t sizeOfType(Type type) const { return m_typeSizes.get(type); }
@@ -74,7 +74,7 @@ public:
     WKWebExtensionDataRecord *wrapper() const { return (WKWebExtensionDataRecord *)API::ObjectImpl<API::Object::Type::WebExtensionDataRecord>::wrapper(); }
 #endif
 
-    bool operator==(const WebExtensionDataRecord&) const;
+    bool NODELETE operator==(const WebExtensionDataRecord&) const;
 
 private:
     String m_displayName;

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h
@@ -83,7 +83,7 @@ public:
     static Ref<WebExtensionMatchPattern> allURLsMatchPattern();
     static Ref<WebExtensionMatchPattern> allHostsAndSchemesMatchPattern();
 
-    static bool patternsMatchAllHosts(const MatchPatternSet&);
+    static bool NODELETE patternsMatchAllHosts(const MatchPatternSet&);
     static bool patternsMatchURL(const MatchPatternSet&, const URL&);
     static bool patternsMatchPattern(const MatchPatternSet&, const WebExtensionMatchPattern&);
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h
@@ -80,9 +80,9 @@ public:
 
     static NSArray *matchingPlatformMenuItems(const MenuItemVector&, const WebExtensionMenuItemContextParameters&, size_t limit = 0);
 
-    bool operator==(const WebExtensionMenuItem&) const;
+    bool NODELETE operator==(const WebExtensionMenuItem&) const;
 
-    WebExtensionMenuItemParameters minimalParameters() const;
+    WebExtensionMenuItemParameters NODELETE minimalParameters() const;
 
     WebExtensionContext* NODELETE extensionContext() const;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h
@@ -63,15 +63,15 @@ public:
 
     using Error = std::optional<std::pair<ErrorType, std::optional<String>>>;
 
-    bool operator==(const WebExtensionMessagePort&) const;
+    bool NODELETE operator==(const WebExtensionMessagePort&) const;
 
     const String& applicationIdentifier() const LIFETIME_BOUND { return m_applicationIdentifier; }
     WebExtensionPortChannelIdentifier channelIdentifier() const { return m_channelIdentifier; }
-    WebExtensionContext* extensionContext() const;
+    WebExtensionContext* NODELETE extensionContext() const;
 
     void disconnect(Error = std::nullopt);
     void reportDisconnection(Error);
-    bool isDisconnected() const;
+    bool NODELETE isDisconnected() const;
 
 #if PLATFORM(COCOA)
     void sendMessage(id message, CompletionHandler<void(Error)>&& = { });

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionTab.h
@@ -111,7 +111,7 @@ public:
     WebExtensionTabParameters parameters() const;
     WebExtensionTabParameters changedParameters(OptionSet<ChangedProperties> = { }) const;
 
-    WebExtensionContext* extensionContext() const;
+    WebExtensionContext* NODELETE extensionContext() const;
 
     bool operator==(const WebExtensionTab&) const;
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h
@@ -99,7 +99,7 @@ public:
     WebExtensionWindowParameters parameters(PopulateTabs = PopulateTabs::No) const;
     WebExtensionWindowParameters minimalParameters() const;
 
-    WebExtensionContext* extensionContext() const;
+    WebExtensionContext* NODELETE extensionContext() const;
 
     bool operator==(const WebExtensionWindow&) const;
 

--- a/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h
+++ b/Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h
@@ -57,7 +57,7 @@ public:
     Vector<GamepadData> gamepadStates() const;
 
 #if PLATFORM(COCOA)
-    static void setUsesGameControllerFramework();
+    static void NODELETE setUsesGameControllerFramework();
 #endif
 
     Vector<std::optional<GamepadData>> snapshotGamepads();

--- a/Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.h
+++ b/Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.h
@@ -45,7 +45,7 @@ public:
     void allow();
     void deny();
     
-    void invalidate();
+    void NODELETE invalidate();
 
     WebProcessProxy* NODELETE process() const;
 

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
@@ -166,7 +166,7 @@ private:
     void platformSave(Vector<WebCore::InspectorFrontendClient::SaveData>&&, bool forceSaveAs);
     void platformLoad(const String& path, CompletionHandler<void(const String&)>&&);
     void platformPickColorFromScreen(CompletionHandler<void(const std::optional<WebCore::Color>&)>&&);
-    void platformSetSheetRect(const WebCore::FloatRect&);
+    void NODELETE platformSetSheetRect(const WebCore::FloatRect&);
     void platformSetForcedAppearance(WebCore::InspectorFrontendClient::Appearance);
     void platformStartWindowDrag();
     void platformOpenURLExternally(const String& url);

--- a/Source/WebKit/UIProcess/Inspector/WasmDebuggerDebuggable.h
+++ b/Source/WebKit/UIProcess/Inspector/WasmDebuggerDebuggable.h
@@ -61,7 +61,7 @@ public:
 
     std::optional<ProcessID> webContentProcessPID() const override;
 
-    void detachFromProcess();
+    void NODELETE detachFromProcess();
 
     // Response forwarding for WebAssembly debugging
     void sendResponseToFrontend(const String& response);

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -249,7 +249,7 @@ private:
     void platformBringInspectedPageToFront();
     void platformHide();
     bool platformIsFront();
-    void platformAttachAvailabilityChanged(bool);
+    void NODELETE platformAttachAvailabilityChanged(bool);
     void platformSetForcedAppearance(WebCore::InspectorFrontendClient::Appearance);
     void platformOpenURLExternally(const String&);
     void platformInspectedURLChanged(const String&);
@@ -258,7 +258,7 @@ private:
     void platformDetach();
     void platformSetAttachedWindowHeight(unsigned);
     void platformSetAttachedWindowWidth(unsigned);
-    void platformSetSheetRect(const WebCore::FloatRect&);
+    void NODELETE platformSetSheetRect(const WebCore::FloatRect&);
     void platformStartWindowDrag();
     void platformRevealFileExternally(const String&);
     void platformSave(Vector<WebCore::InspectorFrontendClient::SaveData>&&, bool forceSaveAs);
@@ -291,7 +291,7 @@ private:
     void setInspectorPageDeveloperExtrasEnabled(bool);
     void setPageAndTextZoomFactors(double pageZoomFactor, double textZoomFactor);
     void elementSelectionChanged(bool);
-    void timelineRecordingChanged(bool);
+    void NODELETE timelineRecordingChanged(bool);
 
     void setDeveloperPreferenceOverride(WebCore::InspectorBackendClient::DeveloperPreference, std::optional<bool>);
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUtilities.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUtilities.cpp
@@ -45,13 +45,13 @@ namespace WebKit {
 
 using PageLevelMap = WeakHashMap<WebPageProxy, unsigned>;
 
-static PageLevelMap& pageLevelMap()
+static PageLevelMap& NODELETE pageLevelMap()
 {
     static NeverDestroyed<PageLevelMap> map;
     return map;
 }
 
-unsigned inspectorLevelForPage(WebPageProxy* page)
+unsigned NODELETE inspectorLevelForPage(WebPageProxy* page)
 {
     if (page) {
         auto findResult = pageLevelMap().find(*page);
@@ -80,7 +80,7 @@ void untrackInspectorPage(WebPageProxy& inspectorPage)
 static WebProcessPool* s_mainInspectorProcessPool;
 static WebProcessPool* s_nestedInspectorProcessPool;
 
-static WeakHashSet<WebProcessPool>& allInspectorProcessPools()
+static WeakHashSet<WebProcessPool>& NODELETE allInspectorProcessPools()
 {
     static NeverDestroyed<WeakHashSet<WebProcessPool>> allInspectorProcessPools;
     return allInspectorProcessPools.get();
@@ -104,12 +104,12 @@ void prepareProcessPoolForInspector(WebProcessPool& processPool)
     allInspectorProcessPools().add(processPool);
 }
 
-bool isInspectorProcessPool(WebProcessPool& processPool)
+bool NODELETE isInspectorProcessPool(WebProcessPool& processPool)
 {
     return allInspectorProcessPools().contains(processPool);
 }
 
-bool isInspectorPage(WebPageProxy& webPage)
+bool NODELETE isInspectorPage(WebPageProxy& webPage)
 {
     return pageLevelMap().contains(webPage);
 }

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUtilities.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUtilities.h
@@ -34,15 +34,15 @@ class WebProcessPool;
 
 // The inspector page groups are used to give different preferences to each
 // inspector level by setting a per-level page group identifier.
-unsigned inspectorLevelForPage(WebPageProxy*);
+unsigned NODELETE inspectorLevelForPage(WebPageProxy*);
 String defaultInspectorPageGroupIdentifierForPage(WebPageProxy*);
 void trackInspectorPage(WebPageProxy& inspectorPage, WebPageProxy* inspectedPage);
 void untrackInspectorPage(WebPageProxy& inspectorPage);
 
 void prepareProcessPoolForInspector(WebProcessPool&);
 WebProcessPool& defaultInspectorProcessPool(unsigned inspectionLevel);
-bool isInspectorProcessPool(WebProcessPool&);
-bool isInspectorPage(WebPageProxy&);
+bool NODELETE isInspectorProcessPool(WebProcessPool&);
+bool NODELETE isInspectorPage(WebPageProxy&);
 
 #if PLATFORM(COCOA)
 CFStringRef bundleIdentifierForSandboxBrokerSingleton();

--- a/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h
@@ -57,7 +57,7 @@ public:
     const String& nameOverride() const LIFETIME_BOUND final { return m_nameOverride; }
     void setNameOverride(const String&);
 
-    void detachFromPage();
+    void NODELETE detachFromPage();
 
 private:
     explicit WebPageDebuggable(WebPageProxy&);

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestProxy.h
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestProxy.h
@@ -51,7 +51,7 @@ public:
     void allow();
     void deny();
 
-    void invalidate();
+    void NODELETE invalidate();
 
     WebCore::MediaKeySystemRequestIdentifier mediaKeySystemID() const { return m_mediaKeySystemID; }
     WebCore::FrameIdentifier mainFrameID() const { return m_mainFrameID; }

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -127,7 +127,7 @@ using namespace WebCore;
 
 static constexpr Seconds networkProcessResponsivenessTimeout = 6_s;
 
-static WeakHashSet<NetworkProcessProxy>& networkProcessesSet()
+static WeakHashSet<NetworkProcessProxy>& NODELETE networkProcessesSet()
 {
     ASSERT(RunLoop::isMain());
     static NeverDestroyed<WeakHashSet<NetworkProcessProxy>> set;

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -425,7 +425,7 @@ private:
     void requestStorageSpace(PAL::SessionID, const WebCore::ClientOrigin&, uint64_t quota, uint64_t currentSize, uint64_t spaceRequired, CompletionHandler<void(std::optional<uint64_t> quota)>&&);
     void increaseQuota(PAL::SessionID, const WebCore::ClientOrigin&, QuotaIncreaseRequestIdentifier, uint64_t currentQuota, uint64_t currentUsage, uint64_t spaceRequested);
 
-    WebsiteDataStore* websiteDataStoreFromSessionID(PAL::SessionID);
+    WebsiteDataStore* NODELETE websiteDataStoreFromSessionID(PAL::SessionID);
 
     // ProcessLauncher::Client
     void didFinishLaunching(ProcessLauncher*, IPC::Connection::Identifier&&) override;

--- a/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h
@@ -60,7 +60,7 @@ public:
 private:
     explicit ServiceWorkerNotificationHandler() = default;
 
-    WebsiteDataStore* dataStoreForNotificationID(const WTF::UUID&);
+    WebsiteDataStore* NODELETE dataStoreForNotificationID(const WTF::UUID&);
 
     HashMap<WTF::UUID, PAL::SessionID> m_notificationToSessionMap;
 };

--- a/Source/WebKit/UIProcess/PageLoadState.h
+++ b/Source/WebKit/UIProcess/PageLoadState.h
@@ -196,7 +196,7 @@ public:
     void NODELETE setCanGoForward(const Transaction::Token&, bool);
 
     void NODELETE didStartProgress(const Transaction::Token&);
-    void didChangeProgress(const Transaction::Token&, double);
+    void NODELETE didChangeProgress(const Transaction::Token&, double);
     void NODELETE didFinishProgress(const Transaction::Token&);
     void NODELETE setNetworkRequestsInProgress(const Transaction::Token&, bool);
     void NODELETE setHTTPFallbackInProgress(const Transaction::Token&, bool);
@@ -206,7 +206,7 @@ public:
 
     bool committedHasInsecureContent() const { return m_committedState.hasInsecureContent; }
 
-    void setHadSafeBrowsingWarning(const Transaction::Token&);
+    void NODELETE setHadSafeBrowsingWarning(const Transaction::Token&);
     bool committedHadSafeBrowsingWarning() const { return m_committedState.hadSafeBrowsingWarning; }
 
     // FIXME: We piggy-back off PageLoadState::Observer so that both WKWebView and WKObservablePageState
@@ -257,7 +257,7 @@ private:
     static bool NODELETE isLoading(const Data&);
     static String NODELETE activeURL(const Data&);
     static bool hasOnlySecureContent(const Data&);
-    static double estimatedProgress(const Data&);
+    static double NODELETE estimatedProgress(const Data&);
 
     WebPageProxy& page() const { return m_webPageProxy.get(); }
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.h
@@ -202,7 +202,7 @@ private:
 #endif
 
     void initializeWebPage(RefPtr<API::WebsitePolicies>&&);
-    bool validateInput(WebCore::FrameIdentifier, const std::optional<WebCore::NavigationIdentifier>& = std::nullopt);
+    bool NODELETE validateInput(WebCore::FrameIdentifier, const std::optional<WebCore::NavigationIdentifier>& = std::nullopt);
 
     WeakPtr<WebPageProxy> m_page;
     WebCore::PageIdentifier m_webPageID;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -124,8 +124,8 @@ public:
     void acceleratedAnimationDidStart(WebCore::PlatformLayerIdentifier, const String& key, MonotonicTime startTime);
     void acceleratedAnimationDidEnd(WebCore::PlatformLayerIdentifier, const String& key);
 
-    TransactionID nextMainFrameLayerTreeTransactionID() const;
-    TransactionID lastCommittedMainFrameLayerTreeTransactionID() const;
+    TransactionID NODELETE nextMainFrameLayerTreeTransactionID() const;
+    TransactionID NODELETE lastCommittedMainFrameLayerTreeTransactionID() const;
 
     virtual void didRefreshDisplay();
     virtual void setDisplayLinkWantsFullSpeedUpdates(bool) { }
@@ -165,7 +165,7 @@ protected:
     bool shouldCoalesceVisualEditorStateUpdates() const override { return true; }
 
     ProcessState& processStateForConnection(IPC::Connection&);
-    const ProcessState& processStateForIdentifier(WebCore::ProcessIdentifier) const;
+    const ProcessState& NODELETE processStateForIdentifier(WebCore::ProcessIdentifier) const;
     IPC::Connection* connectionForIdentifier(WebCore::ProcessIdentifier);
     void forEachProcessState(NOESCAPE Function<void(ProcessState&, WebProcessProxy&)>&&);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -90,7 +90,7 @@ public:
     RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const;
 #endif
 
-    void detachFromDrawingArea();
+    void NODELETE detachFromDrawingArea();
     void clearLayers();
 
     // Detach the root layer; it will be reattached upon the next incoming commit.

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteMonotonicTimelineRegistry.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteMonotonicTimelineRegistry.h
@@ -40,7 +40,7 @@ public:
 
     bool isEmpty() const { return m_timelines.isEmpty(); }
     void update(WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&, MonotonicTime);
-    RemoteMonotonicTimeline* get(const TimelineID&) const;
+    RemoteMonotonicTimeline* NODELETE get(const TimelineID&) const;
     void advanceCurrentTime(MonotonicTime);
 
 private:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h
@@ -42,7 +42,7 @@ public:
 
     bool isEmpty() const { return m_timelines.isEmpty(); }
     void update(const RemoteScrollingTree&, WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&);
-    RemoteProgressBasedTimeline* get(const TimelineID&) const;
+    RemoteProgressBasedTimeline* NODELETE get(const TimelineID&) const;
     void updateTimelinesForNode(const WebCore::ScrollingTreeScrollingNode&);
     HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID) const;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -113,7 +113,7 @@ public:
 
     std::optional<WebCore::ScrollingNodeID> NODELETE rootScrollingNodeID() const;
 
-    const RemoteLayerTreeHost* layerTreeHost() const;
+    const RemoteLayerTreeHost* NODELETE layerTreeHost() const;
     WebPageProxy& NODELETE webPageProxy() const;
 
     virtual void stickyScrollingTreeNodeBeganSticking(WebCore::ScrollingNodeID);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -110,7 +110,7 @@ public:
 
 #if ENABLE(THREADED_ANIMATIONS)
     void updateTimelinesRegistration(WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&);
-    RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const;
+    RefPtr<const RemoteAnimationTimeline> NODELETE timeline(const TimelineID&) const;
     HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID) const;
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -135,7 +135,7 @@ private:
 
     DisplayLink* displayLink() const;
     DisplayLink* existingDisplayLink() const;
-    RemoteLayerTreeDrawingAreaProxyMac& drawingAreaMac() const;
+    RemoteLayerTreeDrawingAreaProxyMac& NODELETE drawingAreaMac() const;
 
     void startDisplayLinkObserver();
     void stopDisplayLinkObserver();

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -53,7 +53,7 @@ using namespace WebCore;
 
 static const Seconds suspensionTimeout { 10_s };
 
-static WeakHashSet<SuspendedPageProxy>& allSuspendedPages()
+static WeakHashSet<SuspendedPageProxy>& NODELETE allSuspendedPages()
 {
     static NeverDestroyed<WeakHashSet<SuspendedPageProxy>> map;
     return map;

--- a/Source/WebKit/UIProcess/TextChecker.h
+++ b/Source/WebKit/UIProcess/TextChecker.h
@@ -45,7 +45,7 @@ public:
     static void setGrammarCheckingEnabled(bool);
     
     static void setTestingMode(bool);
-    static bool isTestingMode();
+    static bool NODELETE isTestingMode();
 
 #if PLATFORM(COCOA)
     static void setAutomaticSpellingCorrectionEnabled(bool);
@@ -81,8 +81,8 @@ public:
 #if USE(UNIFIED_TEXT_CHECKING)
     static Vector<WebCore::TextCheckingResult> checkTextOfParagraph(SpellDocumentTag, StringView, int32_t insertionPoint, OptionSet<WebCore::TextCheckingType>, bool initialCapitalizationEnabled);
 #endif
-    static void checkSpellingOfString(SpellDocumentTag, StringView text, int32_t& misspellingLocation, int32_t& misspellingLength);
-    static void checkGrammarOfString(SpellDocumentTag, StringView text, Vector<WebCore::GrammarDetail>&, int32_t& badGrammarLocation, int32_t& badGrammarLength);
+    static void NODELETE checkSpellingOfString(SpellDocumentTag, StringView text, int32_t& misspellingLocation, int32_t& misspellingLength);
+    static void NODELETE checkGrammarOfString(SpellDocumentTag, StringView text, Vector<WebCore::GrammarDetail>&, int32_t& badGrammarLocation, int32_t& badGrammarLength);
     static bool spellingUIIsShowing();
     static void toggleSpellingUIIsShowing();
     static void updateSpellingUIWithMisspelledWord(SpellDocumentTag, const String& misspelledWord);
@@ -90,7 +90,7 @@ public:
     static void getGuessesForWord(SpellDocumentTag, const String& word, const String& context, int32_t insertionPoint, Vector<String>& guesses, bool initialCapitalizationEnabled);
     static void learnWord(SpellDocumentTag, const String& word);
     static void ignoreWord(SpellDocumentTag, const String& word);
-    static void requestCheckingOfString(Ref<TextCheckerCompletion>&&, int32_t insertionPoint);
+    static void NODELETE requestCheckingOfString(Ref<TextCheckerCompletion>&&, int32_t insertionPoint);
     static void requestExtendedCheckingOfString(Ref<TextCheckerCompletion>&&, int32_t insertionPoint);
 };
 

--- a/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
+++ b/Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h
@@ -82,7 +82,7 @@ public:
     WebUserContentControllerProxy();
     ~WebUserContentControllerProxy();
 
-    static WebUserContentControllerProxy* get(UserContentControllerIdentifier);
+    static WebUserContentControllerProxy* NODELETE get(UserContentControllerIdentifier);
 
     UserContentControllerParameters parametersForProcess(WebProcessProxy&) const;
 

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -73,7 +73,7 @@ static const MediaProducerMediaStateFlags activeCaptureMask { MediaProducerMedia
 #endif
 
 #if ENABLE(MEDIA_STREAM)
-static WeakHashSet<UserMediaPermissionRequestManagerProxy>& proxies()
+static WeakHashSet<UserMediaPermissionRequestManagerProxy>& NODELETE proxies()
 {
     static NeverDestroyed<WeakHashSet<UserMediaPermissionRequestManagerProxy>> set;
     return set;

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h
@@ -172,9 +172,9 @@ private:
 
     RequestAction getRequestAction(const UserMediaPermissionRequestProxy&);
 
-    bool wasGrantedVideoOrAudioAccess(WebCore::FrameIdentifier);
-    bool wasGrantedAudioAccess(WebCore::FrameIdentifier);
-    bool wasGrantedVideoAccess(WebCore::FrameIdentifier);
+    bool NODELETE wasGrantedVideoOrAudioAccess(WebCore::FrameIdentifier);
+    bool NODELETE wasGrantedAudioAccess(WebCore::FrameIdentifier);
+    bool NODELETE wasGrantedVideoAccess(WebCore::FrameIdentifier);
 
     void computeFilteredDeviceList(WebCore::FrameIdentifier, WebCore::PermissionState, WebCore::PermissionState, CompletionHandler<void(Vector<WebCore::CaptureDeviceWithCapabilities>&&)>&&);
     void platformGetMediaStreamDevices(bool revealIdsAndLabels, CompletionHandler<void(Vector<WebCore::CaptureDeviceWithCapabilities>&&)>&&);

--- a/Source/WebKit/UIProcess/UserMediaProcessManager.h
+++ b/Source/WebKit/UIProcess/UserMediaProcessManager.h
@@ -34,7 +34,7 @@ class WebProcessProxy;
 
 class UserMediaProcessManager : public WebCore::RealtimeMediaSourceCenterObserver {
 public:
-    static UserMediaProcessManager& singleton();
+    static UserMediaProcessManager& NODELETE singleton();
 
     UserMediaProcessManager();
 

--- a/Source/WebKit/UIProcess/ViewGestureController.cpp
+++ b/Source/WebKit/UIProcess/ViewGestureController.cpp
@@ -468,7 +468,7 @@ void ViewGestureController::SnapshotRemovalTracker::startWatchdog(Seconds durati
 }
 
 #if !PLATFORM(IOS_FAMILY)
-static bool deltaShouldCancelSwipe(FloatSize delta)
+static bool NODELETE deltaShouldCancelSwipe(FloatSize delta)
 {
     return std::abs(delta.height()) >= std::abs(delta.width()) * minimumScrollEventRatioForSwipe;
 }

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -184,7 +184,7 @@ public:
     void endMagnification();
 #endif
 
-    void setAlternateBackForwardListSourcePage(WebPageProxy*);
+    void NODELETE setAlternateBackForwardListSourcePage(WebPageProxy*);
 
     bool canSwipeInDirection(SwipeDirection, DeferToConflictingGestures) const;
 
@@ -230,7 +230,7 @@ private:
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
-    static ViewGestureController* controllerForGesture(WebPageProxyIdentifier, GestureID);
+    static ViewGestureController* NODELETE controllerForGesture(WebPageProxyIdentifier, GestureID);
 
     static GestureID NODELETE takeNextGestureID();
     void willBeginGesture(ViewGestureType);
@@ -241,7 +241,7 @@ private:
 
 #if PLATFORM(COCOA)
 #if ENABLE(BACK_FORWARD_LIST_SWIFT)
-    std::optional<WebBackForwardList> backForwardListForNavigation() const;
+    std::optional<WebBackForwardList> NODELETE backForwardListForNavigation() const;
 #else
     WebBackForwardList* backForwardListForNavigation() const;
 #endif
@@ -313,7 +313,7 @@ private:
 
     void endMagnificationGesture();
 
-    WebCore::FloatPoint scaledMagnificationOrigin(WebCore::FloatPoint origin, double scale);
+    WebCore::FloatPoint NODELETE scaledMagnificationOrigin(WebCore::FloatPoint origin, double scale);
 
     void startSwipeGesture(PlatformScrollEvent, SwipeDirection);
     void trackSwipeGesture(PlatformScrollEvent, SwipeDirection, RefPtr<WebBackForwardListItem>);
@@ -343,7 +343,7 @@ private:
         bool handleEvent(PlatformScrollEvent);
         void eventWasNotHandledByWebCore(PlatformScrollEvent);
 
-        void reset(ASCIILiteral resetReasonForLogging);
+        void NODELETE reset(ASCIILiteral resetReasonForLogging);
 
         bool shouldIgnorePinnedState() { return m_shouldIgnorePinnedState; }
         void setShouldIgnorePinnedState(bool ignore) { m_shouldIgnorePinnedState = ignore; }

--- a/Source/WebKit/UIProcess/ViewSnapshotStore.h
+++ b/Source/WebKit/UIProcess/ViewSnapshotStore.h
@@ -79,7 +79,7 @@ public:
     ~ViewSnapshot();
 
     void clearImage();
-    bool hasImage() const;
+    bool NODELETE hasImage() const;
 
 #if HAVE(IOSURFACE)
     id asLayerContents();
@@ -175,7 +175,7 @@ public:
     ViewSnapshotStore();
     ~ViewSnapshotStore();
 
-    static ViewSnapshotStore& singleton();
+    static ViewSnapshotStore& NODELETE singleton();
 
     void recordSnapshot(WebPageProxy&, WebBackForwardListItem&);
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -85,7 +85,7 @@ static void updateQueryIfNecessary(NSMutableDictionary *dictionary)
     [dictionary setObject:@YES forKey:(__bridge id)kSecAttrSynchronizable];
 }
 
-static inline RefPtr<ArrayBuffer> alternateBlobIfNecessary(const WebKit::WebAuthenticationRequestData& requestData)
+static inline RefPtr<ArrayBuffer> NODELETE alternateBlobIfNecessary(const WebKit::WebAuthenticationRequestData& requestData)
 {
 #if HAVE(WEB_AUTHN_PRF_API)
     return nullptr;

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h
@@ -93,7 +93,7 @@ public:
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
 
 #if HAVE(WEB_AUTHN_AS_MODERN)
-    static WeakPtr<WebAuthenticatorCoordinatorProxy>& activeConditionalMediationProxy();
+    static WeakPtr<WebAuthenticatorCoordinatorProxy>& NODELETE activeConditionalMediationProxy();
     void pauseConditionalAssertion(CompletionHandler<void()>&&);
     void unpauseConditionalAssertion();
     void makeActiveConditionalAssertion();

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -139,9 +139,9 @@ public:
     void ref() const final { API::ObjectImpl<API::Object::Type::Frame>::ref(); }
     void deref() const final { API::ObjectImpl<API::Object::Type::Frame>::deref(); }
 
-    static WebFrameProxy* webFrame(std::optional<WebCore::FrameIdentifier>);
+    static WebFrameProxy* NODELETE webFrame(std::optional<WebCore::FrameIdentifier>);
 
-    static bool canCreateFrame(WebCore::FrameIdentifier);
+    static bool NODELETE canCreateFrame(WebCore::FrameIdentifier);
 
     virtual ~WebFrameProxy();
 
@@ -308,11 +308,11 @@ public:
     void getSelectorPathsForNode(JSHandleInfo&&, CompletionHandler<void(Vector<HashSet<String>>&&)>&&);
     void getNodeForSelectorPaths(Vector<HashSet<String>>&&, CompletionHandler<void(std::optional<JSHandleInfo>&&)>&&);
 
-    ProvisionalFrameCreationParameters provisionalFrameCreationParameters(std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::LayerHostingContextIdentifier>, CommitTiming);
+    ProvisionalFrameCreationParameters NODELETE provisionalFrameCreationParameters(std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::LayerHostingContextIdentifier>, CommitTiming);
 private:
     WebFrameProxy(WebPageProxy&, FrameProcess&, WebCore::FrameIdentifier, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode, WebFrameProxy*, WebFrameProxy*, IsMainFrame, std::optional<URL>&&);
 
-    std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
+    std::optional<SharedPreferencesForWebProcess> NODELETE sharedPreferencesForWebProcess() const;
 
     std::optional<WebCore::PageIdentifier> NODELETE pageIdentifier() const;
     Ref<WebCore::SecurityOrigin> securityOrigin() const;
@@ -321,8 +321,8 @@ private:
     RefPtr<WebFrameProxy> deepLastChild();
     WebFrameProxy* NODELETE firstChild() const;
     WebFrameProxy* NODELETE lastChild() const;
-    WebFrameProxy* nextSibling() const;
-    WebFrameProxy* previousSibling() const;
+    WebFrameProxy* NODELETE nextSibling() const;
+    WebFrameProxy* NODELETE previousSibling() const;
 
     WeakPtr<WebPageProxy> m_page;
     Ref<FrameProcess> m_frameProcess;

--- a/Source/WebKit/UIProcess/WebGeolocationManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebGeolocationManagerProxy.h
@@ -112,8 +112,8 @@ private:
 #endif
     };
 
-    bool isUpdating(const PerDomainData&) const;
-    bool isHighAccuracyEnabled(const PerDomainData&) const;
+    bool NODELETE isUpdating(const PerDomainData&) const;
+    bool NODELETE isHighAccuracyEnabled(const PerDomainData&) const;
     void providerStartUpdating(PerDomainData&, const WebCore::RegistrableDomain&);
     void providerStopUpdating(PerDomainData&);
     void providerSetEnabledHighAccuracy(PerDomainData&, bool enabled);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6525,7 +6525,7 @@ void WebPageProxy::setGapBetweenPages(double gap)
     send(Messages::WebPage::SetGapBetweenPages(gap));
 }
 
-static bool scaleFactorIsValid(double scaleFactor)
+static bool NODELETE scaleFactorIsValid(double scaleFactor)
 {
     return scaleFactor > 0 && scaleFactor <= 100;
 }
@@ -13532,7 +13532,7 @@ void WebPageProxy::beginMonitoringCaptureDevices()
     UserMediaProcessManager::singleton().beginMonitoringCaptureDevices();
 }
 
-static WebCore::MediaStreamRequest toUserMediaRequest(WebCore::MediaProducerMediaCaptureKind kind, WebCore::PageIdentifier pageIdentifier)
+static WebCore::MediaStreamRequest NODELETE toUserMediaRequest(WebCore::MediaProducerMediaCaptureKind kind, WebCore::PageIdentifier pageIdentifier)
 {
     switch (kind) {
     case WebCore::MediaProducerMediaCaptureKind::Microphone:

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -753,7 +753,7 @@ public:
     using Identifier = WebPageProxyIdentifier;
 
     Identifier identifier() const { return m_identifier; }
-    static WebPageProxy* fromIdentifier(std::optional<Identifier>);
+    static WebPageProxy* NODELETE fromIdentifier(std::optional<Identifier>);
     WebCore::PageIdentifier webPageIDInMainFrameProcess() const { return m_webPageID; }
     WebCore::PageIdentifier identifierInSiteIsolatedProcess() const { return webPageIDInMainFrameProcess(); }
     WebCore::PageIdentifier webPageIDInProcess(const WebProcessProxy&) const;
@@ -1048,7 +1048,7 @@ public:
 
 #if PLATFORM(MAC)
     void setObscuredContentInsetsAsync(const WebCore::FloatBoxExtent&);
-    WebCore::FloatBoxExtent pendingOrActualObscuredContentInsets() const;
+    WebCore::FloatBoxExtent NODELETE pendingOrActualObscuredContentInsets() const;
 
     void scheduleSetObscuredContentInsetsDispatch();
     void dispatchSetObscuredContentInsets();
@@ -1087,7 +1087,7 @@ public:
     WebCore::Color NODELETE sampledPageTopColor() const;
 
     WebCore::Color underPageBackgroundColor() const;
-    WebCore::Color underPageBackgroundColorIgnoringPlatformColor() const;
+    WebCore::Color NODELETE underPageBackgroundColorIgnoringPlatformColor() const;
     WebCore::Color NODELETE underPageBackgroundColorOverride() const;
     void setUnderPageBackgroundColorOverride(WebCore::Color&&);
 
@@ -1514,7 +1514,7 @@ public:
     const String& toolTip() const LIFETIME_BOUND { return m_toolTip; }
 
     const String& userAgent() const LIFETIME_BOUND { return m_userAgent; }
-    String userAgentForURL(const URL&);
+    String NODELETE userAgentForURL(const URL&);
     void setApplicationNameForUserAgent(const String&);
     const String& applicationNameForUserAgent() const LIFETIME_BOUND { return m_applicationNameForUserAgent; }
     void setApplicationNameForDesktopUserAgent(const String& applicationName) { m_applicationNameForDesktopUserAgent = applicationName; }
@@ -1618,7 +1618,7 @@ public:
     WebCore::RectEdges<bool> NODELETE pinnedState() const;
     WebCore::RectEdges<bool> pinnedStateIncludingAncestorsAtPoint(WebCore::FloatPoint);
 
-    WebCore::RectEdges<bool> rubberBandableEdgesRespectingHistorySwipe() const;
+    WebCore::RectEdges<bool> NODELETE rubberBandableEdgesRespectingHistorySwipe() const;
     WebCore::RectEdges<bool> NODELETE rubberBandableEdges() const;
     void NODELETE setRubberBandableEdges(WebCore::RectEdges<bool>);
     void NODELETE setRubberBandsAtLeft(bool);
@@ -1957,7 +1957,7 @@ public:
 #endif
 
     const PageLoadState& NODELETE pageLoadState() const LIFETIME_BOUND;
-    PageLoadState& pageLoadState() LIFETIME_BOUND;
+    PageLoadState& NODELETE pageLoadState() LIFETIME_BOUND;
 
 #if PLATFORM(COCOA)
     void handleAlternativeTextUIResult(const String& result);
@@ -2050,7 +2050,7 @@ public:
     void setAutoSizingShouldExpandToViewHeight(bool);
 
     void setViewportSizeForCSSViewportUnits(const WebCore::FloatSize&);
-    WebCore::FloatSize viewportSizeForCSSViewportUnits() const;
+    WebCore::FloatSize NODELETE viewportSizeForCSSViewportUnits() const;
 
     void didReceiveAuthenticationChallengeProxy(Ref<AuthenticationChallengeProxy>&&, NegotiatedLegacyTLS);
     void negotiatedLegacyTLS();
@@ -2602,7 +2602,7 @@ public:
 
 #if ENABLE(WRITING_TOOLS)
 #if PLATFORM(MAC)
-    bool shouldEnableWritingToolsRequestedTool(WebCore::WritingTools::RequestedTool) const;
+    bool NODELETE shouldEnableWritingToolsRequestedTool(WebCore::WritingTools::RequestedTool) const;
 #endif
 #if ENABLE(CONTEXT_MENUS)
     bool canHandleContextMenuWritingTools() const;
@@ -2765,7 +2765,7 @@ public:
 #if ENABLE(WRITING_TOOLS)
     void setWritingToolsActive(bool);
 
-    WebCore::WritingTools::Behavior writingToolsBehavior() const;
+    WebCore::WritingTools::Behavior NODELETE writingToolsBehavior() const;
 
     void willBeginWritingToolsSession(const std::optional<WebCore::WritingTools::Session>&, CompletionHandler<void(const Vector<WebCore::WritingTools::Context>&)>&&);
 
@@ -3050,7 +3050,7 @@ private:
     void didReceiveTitleForFrame(IPC::Connection&, WebCore::FrameIdentifier, String&&, const UserData&);
     void NODELETE didFirstLayoutForFrame(WebCore::FrameIdentifier, const UserData&);
     void didFirstVisuallyNonEmptyLayoutForFrame(IPC::Connection&, WebCore::FrameIdentifier, const UserData&, WallTime);
-    void mainFramePluginHandlesPageScaleGestureDidChange(bool, double minScale, double maxScale);
+    void NODELETE mainFramePluginHandlesPageScaleGestureDidChange(bool, double minScale, double maxScale);
     void didStartProgress();
     void didChangeProgress(double);
     void didFinishProgress();
@@ -3360,7 +3360,7 @@ private:
 
     void setEditableElementIsFocused(bool);
 
-    void handleAcceptsFirstMouse(bool);
+    void NODELETE handleAcceptsFirstMouse(bool);
 #endif // PLATFORM(MAC)
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/WebPasteboardProxy.h
+++ b/Source/WebKit/UIProcess/WebPasteboardProxy.h
@@ -63,7 +63,7 @@ class WebPasteboardProxy : public IPC::MessageReceiver {
     WTF_MAKE_NONCOPYABLE(WebPasteboardProxy);
     friend NeverDestroyed<WebPasteboardProxy>;
 public:
-    static WebPasteboardProxy& singleton();
+    static WebPasteboardProxy& NODELETE singleton();
 
     void addWebProcessProxy(WebProcessProxy&);
     void removeWebProcessProxy(WebProcessProxy&);

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -421,7 +421,7 @@ public:
     static void establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWorkerType, WebCore::Site&&, std::optional<WebCore::ProcessIdentifier> requestingProcessIdentifier, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, PAL::SessionID, CompletionHandler<void(WebCore::ProcessIdentifier)>&&);
 
 #if PLATFORM(COCOA)
-    bool processSuppressionEnabled() const;
+    bool NODELETE processSuppressionEnabled() const;
 #endif
 
     void windowServerConnectionStateChanged();
@@ -476,7 +476,7 @@ public:
 
 #if PLATFORM(COCOA)
     bool cookieStoragePartitioningEnabled() const { return m_cookieStoragePartitioningEnabled; }
-    void setCookieStoragePartitioningEnabled(bool);
+    void NODELETE setCookieStoragePartitioningEnabled(bool);
 
     void clearPermanentCredentialsForProtectionSpace(WebCore::ProtectionSpace&&);
 
@@ -771,7 +771,7 @@ private:
 
     void platformLoadResourceMonitorRuleList(CompletionHandler<void(RefPtr<WebCompiledContentRuleList>)>&&);
     void platformCompileResourceMonitorRuleList(const String& rulesText, CompletionHandler<void(RefPtr<WebCompiledContentRuleList>)>&&);
-    String platformResourceMonitorRuleListSourceForTesting();
+    String NODELETE platformResourceMonitorRuleListSourceForTesting();
 #endif
 
     const Ref<API::ProcessPoolConfiguration> m_configuration;
@@ -785,7 +785,7 @@ private:
 
     HashMap<PAL::SessionID, WeakPtr<WebProcessProxy>> m_dummyProcessProxies; // Lightweight WebProcessProxy objects without backing process.
 
-    static WeakHashSet<WebProcessProxy>& remoteWorkerProcesses();
+    static WeakHashSet<WebProcessProxy>& NODELETE remoteWorkerProcesses();
 
     std::optional<WebPreferencesStore> m_remoteWorkerPreferences;
     RefPtr<WebUserContentControllerProxy> m_userContentControllerForRemoteWorkers;

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -167,7 +167,7 @@ using namespace WebCore;
 
 static unsigned s_maxProcessCount { 400 };
 
-static WeakListHashSet<WebProcessProxy>& liveProcessesLRU()
+static WeakListHashSet<WebProcessProxy>& NODELETE liveProcessesLRU()
 {
     ASSERT(RunLoop::isMain());
     static NeverDestroyed<WeakListHashSet<WebProcessProxy>> processes;

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -259,8 +259,8 @@ public:
 
     static RefPtr<WebProcessProxy> processForIdentifier(WebCore::ProcessIdentifier);
     static Ref<WebProcessProxy> fromConnection(const IPC::Connection&);
-    static WebPageProxy* webPage(WebPageProxyIdentifier);
-    static WebPageProxy* webPage(WebCore::PageIdentifier);
+    static WebPageProxy* NODELETE webPage(WebPageProxyIdentifier);
+    static WebPageProxy* NODELETE webPage(WebCore::PageIdentifier);
     static WebPageProxy* audioCapturingWebPage();
 #if ENABLE(WEBXR)
     static WebPageProxy* webPageWithActiveXRSession();
@@ -470,8 +470,8 @@ public:
     void unregisterRemoteWorkerClientProcess(RemoteWorkerType, WebProcessProxy&);
     void updateRemoteWorkerProcessAssertion(RemoteWorkerType);
     bool hasServiceWorkerPageProxy(WebPageProxyIdentifier pageProxyID) { return m_serviceWorkerInformation && m_serviceWorkerInformation->remoteWorkerPageProxyID == pageProxyID; }
-    bool hasServiceWorkerForegroundActivityForTesting() const;
-    bool hasServiceWorkerBackgroundActivityForTesting() const;
+    bool NODELETE hasServiceWorkerForegroundActivityForTesting() const;
+    bool NODELETE hasServiceWorkerBackgroundActivityForTesting() const;
     void startServiceWorkerBackgroundProcessing();
     void endServiceWorkerBackgroundProcessing();
     void setThrottleStateForTesting(ProcessThrottleState);
@@ -666,7 +666,7 @@ private:
     static void registerNotifyObservers();
 #endif
 
-    ProcessTerminationReason terminationReason() const;
+    ProcessTerminationReason NODELETE terminationReason() const;
 
     // IPC message handlers.
     void didDestroyUserGestureToken(WebCore::PageIdentifier, WebCore::UserGestureTokenIdentifier);
@@ -731,7 +731,7 @@ private:
 #endif
 
 #if PLATFORM(COCOA)
-    bool messageSourceIsValidWebContentProcess();
+    bool NODELETE messageSourceIsValidWebContentProcess();
 #endif
 
     bool shouldTakeNearSuspendedAssertion() const;

--- a/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp
@@ -90,7 +90,7 @@ void WebScreenOrientationManagerProxy::setCurrentOrientation(WebCore::ScreenOrie
         m_currentLockRequest(std::nullopt);
 }
 
-static WebCore::ScreenOrientationType resolveScreenOrientationLockType(WebCore::ScreenOrientationType currentOrientation, WebCore::ScreenOrientationLockType lockType)
+SUPPRESS_NODELETE static WebCore::ScreenOrientationType NODELETE resolveScreenOrientationLockType(WebCore::ScreenOrientationType currentOrientation, WebCore::ScreenOrientationLockType lockType)
 {
     switch (lockType) {
     case WebCore::ScreenOrientationLockType::Any:

--- a/Source/WebKit/UIProcess/WebURLSchemeHandler.h
+++ b/Source/WebKit/UIProcess/WebURLSchemeHandler.h
@@ -68,7 +68,7 @@ private:
     virtual void platformTaskCompleted(WebURLSchemeTask&) { };
 
     void removeTaskFromPageMap(WebPageProxyIdentifier, WebCore::ResourceLoaderIdentifier);
-    WebProcessProxy* processForTaskIdentifier(WebPageProxy&, WebCore::ResourceLoaderIdentifier) const;
+    WebProcessProxy* NODELETE processForTaskIdentifier(WebPageProxy&, WebCore::ResourceLoaderIdentifier) const;
 
     HashMap<std::pair<WebCore::ResourceLoaderIdentifier, WebPageProxyIdentifier>, Ref<WebURLSchemeTask>> m_tasks;
     HashMap<WebPageProxyIdentifier, HashSet<WebCore::ResourceLoaderIdentifier>> m_tasksByPageIdentifier;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataRecord.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataRecord.cpp
@@ -106,7 +106,7 @@ void WebsiteDataRecord::addResourceLoadStatisticsRegistrableDomain(const WebCore
     resourceLoadStatisticsRegistrableDomains.add(domain);
 }
 
-static inline bool hostIsInDomain(StringView host, StringView domain)
+static inline bool NODELETE hostIsInDomain(StringView host, StringView domain)
 {
     if (!host.endsWithIgnoringASCIICase(domain))
         return false;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -578,7 +578,7 @@ HashSet<WebCore::RegistrableDomain> WebsiteDataStore::platformAdditionalDomainsW
 }
 #endif
 
-static WebsiteDataStore::ProcessAccessType computeNetworkProcessAccessTypeForDataFetch(OptionSet<WebsiteDataType> dataTypes, bool isNonPersistentStore)
+static WebsiteDataStore::ProcessAccessType NODELETE computeNetworkProcessAccessTypeForDataFetch(OptionSet<WebsiteDataType> dataTypes, bool isNonPersistentStore)
 {
     for (auto dataType : dataTypes) {
         if (WebsiteData::ownerProcess(dataType) == WebsiteDataProcessType::Network)
@@ -847,7 +847,7 @@ void WebsiteDataStore::fetchDataForRegistrableDomains(OptionSet<WebsiteDataType>
     });
 }
 
-static WebsiteDataStore::ProcessAccessType computeNetworkProcessAccessTypeForDataRemoval(OptionSet<WebsiteDataType> dataTypes, bool isNonPersistentStore)
+static WebsiteDataStore::ProcessAccessType NODELETE computeNetworkProcessAccessTypeForDataRemoval(OptionSet<WebsiteDataType> dataTypes, bool isNonPersistentStore)
 {
     auto processAccessType = WebsiteDataStore::ProcessAccessType::None;
     for (auto dataType : dataTypes) {

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -131,7 +131,7 @@ public:
     static WebsiteDataStore& defaultDataStore();
     static bool NODELETE defaultDataStoreExists();
     static void deleteDefaultDataStoreForTesting();
-    static RefPtr<WebsiteDataStore> existingDataStoreForIdentifier(const WTF::UUID&);
+    static RefPtr<WebsiteDataStore> NODELETE existingDataStoreForIdentifier(const WTF::UUID&);
     
     static Ref<WebsiteDataStore> createNonPersistent();
     static Ref<WebsiteDataStore> create(Ref<WebsiteDataStoreConfiguration>&&, PAL::SessionID);
@@ -297,7 +297,7 @@ public:
     void removeScreenTimeDataWithInterval(WallTime);
 #endif
 
-    static void setCachedProcessSuspensionDelayForTesting(Seconds);
+    static void NODELETE setCachedProcessSuspensionDelayForTesting(Seconds);
 
 #if !PLATFORM(COCOA)
     void allowSpecificHTTPSCertificateForHost(const WebCore::CertificateInfo&, const String& host);
@@ -416,7 +416,7 @@ public:
     }
     static std::optional<double> defaultOriginQuotaRatio();
     static std::optional<double> defaultTotalQuotaRatio();
-    static UnifiedOriginStorageLevel defaultUnifiedOriginStorageLevel();
+    static UnifiedOriginStorageLevel NODELETE defaultUnifiedOriginStorageLevel();
 
 #if USE(GLIB)
     static const String& defaultBaseCacheDirectory();
@@ -539,7 +539,7 @@ private:
     void fetchDataAndApply(OptionSet<WebsiteDataType>, OptionSet<WebsiteDataFetchOption>, Ref<WorkQueue>&&, Function<void(Vector<WebsiteDataRecord>)>&& apply);
 
     void platformInitialize();
-    void platformDestroy();
+    void NODELETE platformDestroy();
     void platformSetNetworkParameters(WebsiteDataStoreParameters&);
     void removeRecentSearches(WallTime, CompletionHandler<void()>&&);
 
@@ -573,7 +573,7 @@ private:
 #endif
 
 #if ENABLE(MANAGED_DOMAINS)
-    static const HashSet<WebCore::RegistrableDomain>* managedDomainsIfInitialized();
+    static const HashSet<WebCore::RegistrableDomain>* NODELETE managedDomainsIfInitialized();
     static void forwardManagedDomainsToITPIfInitialized(CompletionHandler<void()>&&);
     void setManagedDomainsForITP(const HashSet<WebCore::RegistrableDomain>&, CompletionHandler<void()>&&);
 #endif

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -213,7 +213,7 @@ public:
     bool allLoadsBlockedByDeviceManagementRestrictionsForTesting() const { return m_allLoadsBlockedByDeviceManagementRestrictionsForTesting; }
     void setAllLoadsBlockedByDeviceManagementRestrictionsForTesting(bool blocked) { m_allLoadsBlockedByDeviceManagementRestrictionsForTesting = blocked; }
 
-    WebPushD::WebPushDaemonConnectionConfiguration webPushDaemonConnectionConfiguration() const;
+    WebPushD::WebPushDaemonConnectionConfiguration NODELETE webPushDaemonConnectionConfiguration() const;
 
     const String& dataConnectionServiceType() const LIFETIME_BOUND { return m_dataConnectionServiceType; }
     void setDataConnectionServiceType(String&& type) { m_dataConnectionServiceType = WTF::move(type); }

--- a/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.h
+++ b/Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.h
@@ -41,7 +41,7 @@ namespace WebKit {
 
 class DisplayCaptureSessionManager {
 public:
-    static DisplayCaptureSessionManager& singleton();
+    static DisplayCaptureSessionManager& NODELETE singleton();
     static bool isAvailable();
 
     DisplayCaptureSessionManager();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -263,10 +263,10 @@ public:
     void NODELETE scrollingCoordinatorWasCreated();
 
     void setDrawsBackground(bool);
-    bool drawsBackground() const;
+    bool NODELETE drawsBackground() const;
     void setBackgroundColor(NSColor *);
     NSColor *backgroundColor() const;
-    bool isOpaque() const;
+    bool NODELETE isOpaque() const;
 
     void setShouldSuppressFirstResponderChanges(bool);
     bool acceptsFirstMouse(NSEvent *);
@@ -384,14 +384,14 @@ public:
     RetainPtr<NSColor> underlayColor() const;
     RetainPtr<NSColor> pageExtendedBackgroundColor() const;
     
-    _WKRectEdge pinnedState();
-    _WKRectEdge rubberBandingEnabled();
-    void setRubberBandingEnabled(_WKRectEdge);
+    _WKRectEdge NODELETE pinnedState();
+    _WKRectEdge NODELETE rubberBandingEnabled();
+    void NODELETE setRubberBandingEnabled(_WKRectEdge);
 
-    bool alwaysBounceVertical();
-    void setAlwaysBounceVertical(bool);
-    bool alwaysBounceHorizontal();
-    void setAlwaysBounceHorizontal(bool);
+    bool NODELETE alwaysBounceVertical();
+    void NODELETE setAlwaysBounceVertical(bool);
+    bool NODELETE alwaysBounceHorizontal();
+    void NODELETE setAlwaysBounceHorizontal(bool);
 
     void setOverlayScrollbarStyle(std::optional<WebCore::ScrollbarOverlayStyle> scrollbarStyle);
     std::optional<WebCore::ScrollbarOverlayStyle> NODELETE overlayScrollbarStyle() const;
@@ -690,7 +690,7 @@ public:
     NSRect unionRectInVisibleSelectedRangeInScreen() const;
     NSRect documentVisibleRectInScreen() const;
 
-    bool isContentRichlyEditable() const;
+    bool NODELETE isContentRichlyEditable() const;
 
 #if ENABLE(MULTI_REPRESENTATION_HEIC)
     void insertMultiRepresentationHEIC(NSData *, NSString *);
@@ -745,7 +745,7 @@ public:
     NSTouchBar *makeTouchBar();
     void updateTouchBar();
     NSTouchBar *currentTouchBar() const LIFETIME_BOUND { return m_currentTouchBar.get(); }
-    NSCandidateListTouchBarItem *candidateListTouchBarItem() const;
+    NSCandidateListTouchBarItem *NODELETE candidateListTouchBarItem() const;
 #if ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
     WebCore::PlatformPlaybackSessionInterface* playbackSessionInterface() const;
     bool isPictureInPictureActive();
@@ -759,7 +759,7 @@ public:
 #endif
     void nowPlayingMediaTitleAndArtist(void(^completionHandler)(NSString *, NSString *));
 
-    NSTouchBar *textTouchBar() const;
+    NSTouchBar *NODELETE textTouchBar() const;
     void dismissTextTouchBarPopoverItemWithIdentifier(NSString *);
 
     bool clientWantsMediaPlaybackControlsView() const { return m_clientWantsMediaPlaybackControlsView; }
@@ -875,7 +875,7 @@ private:
     void updateMediaTouchBar();
 
     bool useMediaPlaybackControlsView() const;
-    bool isRichlyEditableForTouchBar() const;
+    bool NODELETE isRichlyEditableForTouchBar() const;
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
     void installImageAnalysisOverlayView(RetainPtr<VKCImageAnalysis>&&);
@@ -973,7 +973,7 @@ private:
     int32_t processImageAnalyzerRequest(CocoaImageAnalyzerRequest *, CompletionHandler<void(RetainPtr<CocoaImageAnalysis>&&, NSError *)>&&);
 #endif
 
-    std::optional<EditorState::PostLayoutData> postLayoutDataForContentEditable();
+    std::optional<EditorState::PostLayoutData> NODELETE postLayoutDataForContentEditable();
 
     WeakObjCPtr<WKWebView> m_view;
     const UniqueRef<PageClient> m_pageClient;

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h
@@ -64,7 +64,7 @@ public:
     NSString *name();
     NSDictionary *sender();
 
-    JSValue *error();
+    JSValue *NODELETE error();
     void setError(JSValue *);
 
     WebExtensionAPIEvent& onMessage();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
@@ -67,7 +67,7 @@ public:
     bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*);
 
     NSURL *getURL(const String& resourcePath, NSString **outExceptionString);
-    NSDictionary *getManifest();
+    NSDictionary *NODELETE getManifest();
     String getVersion();
     void getPlatformInfo(Ref<WebExtensionCallbackHandler>&&);
     void getBackgroundPage(Ref<WebExtensionCallbackHandler>&&);
@@ -79,9 +79,9 @@ public:
     void openOptionsPage(Ref<WebExtensionCallbackHandler>&&);
     void reload();
 
-    String runtimeIdentifier();
+    String NODELETE runtimeIdentifier();
 
-    JSValue *lastError();
+    JSValue *NODELETE lastError();
 
     void sendMessage(WebPageProxyIdentifier, WebFrame&, const String& extensionID, const String& messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     RefPtr<WebExtensionAPIPort> connect(WebPageProxyIdentifier, WebFrame&, JSContextRef, const String& extensionID, NSDictionary *options, NSString **outExceptionString);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h
@@ -50,16 +50,16 @@ public:
     void remove(WebPageProxyIdentifier, id keys, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
     void clear(WebPageProxyIdentifier, Ref<WebExtensionCallbackHandler>&&);
 
-    double quotaBytes();
+    double NODELETE quotaBytes();
 
     // Exposed only by storage.session.
     void setAccessLevel(WebPageProxyIdentifier, NSDictionary *, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);
 
     // Exposed only by storage.sync.
-    double quotaBytesPerItem();
-    double maxItems();
-    double maxWriteOperationsPerHour();
-    double maxWriteOperationsPerMinute();
+    double NODELETE quotaBytesPerItem();
+    double NODELETE maxItems();
+    double NODELETE maxWriteOperationsPerHour();
+    double NODELETE maxWriteOperationsPerMinute();
 
     WebExtensionAPIEvent& onChanged();
 

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm
@@ -47,7 +47,7 @@ static NSString *typesKey = @"types";
 
 static NSString *windowIdKey = @"windowId";
 
-_WKWebExtensionWebRequestResourceType toWebExtensionWebRequestResourceType(const ResourceLoadInfo& resourceLoadInfo)
+_WKWebExtensionWebRequestResourceType NODELETE toWebExtensionWebRequestResourceType(const ResourceLoadInfo& resourceLoadInfo)
 {
     switch (resourceLoadInfo.type) {
     case ResourceLoadInfo::Type::Document:

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h
@@ -60,7 +60,7 @@ class WebExtensionContextProxy final : public RefCounted<WebExtensionContextProx
     WTF_MAKE_NONCOPYABLE(WebExtensionContextProxy);
 
 public:
-    static RefPtr<WebExtensionContextProxy> get(WebExtensionContextIdentifier);
+    static RefPtr<WebExtensionContextProxy> NODELETE get(WebExtensionContextIdentifier);
     static Ref<WebExtensionContextProxy> getOrCreate(const WebExtensionContextParameters&, WebExtensionControllerProxy&, WebPage* = nullptr);
 
     ~WebExtensionContextProxy();
@@ -110,7 +110,7 @@ public:
     std::optional<WebExtensionTabIdentifier> NODELETE tabIdentifier(WebPage&) const;
 
     RefPtr<WebPage> NODELETE backgroundPage() const;
-    void setBackgroundPage(WebPage&);
+    void NODELETE setBackgroundPage(WebPage&);
 
     bool isUnsupportedAPI(const String& propertyPath, const ASCIILiteral& propertyName) const;
 

--- a/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
+++ b/Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h
@@ -48,7 +48,7 @@ class WebExtensionControllerProxy final : public RefCounted<WebExtensionControll
     WTF_MAKE_NONCOPYABLE(WebExtensionControllerProxy);
 
 public:
-    static RefPtr<WebExtensionControllerProxy> get(WebExtensionControllerIdentifier);
+    static RefPtr<WebExtensionControllerProxy> NODELETE get(WebExtensionControllerIdentifier);
     static Ref<WebExtensionControllerProxy> getOrCreate(const WebExtensionControllerParameters&, WebPage* = nullptr);
 
     ~WebExtensionControllerProxy();
@@ -75,7 +75,7 @@ public:
     // FIXME: Include the error here.
     void didFailLoadForFrame(WebPage&, WebFrame&, const URL&);
 
-    RefPtr<WebExtensionContextProxy> extensionContext(const String& uniqueIdentifier) const;
+    RefPtr<WebExtensionContextProxy> NODELETE extensionContext(const String& uniqueIdentifier) const;
     RefPtr<WebExtensionContextProxy> extensionContext(const URL&) const;
     RefPtr<WebExtensionContextProxy> extensionContext(WebFrame&, WebCore::DOMWrapperWorld&) const;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp
@@ -42,7 +42,7 @@ class RemoteImageBufferSetProxyFlushFence : public ThreadSafeRefCounted<RemoteIm
     WTF_MAKE_NONCOPYABLE(RemoteImageBufferSetProxyFlushFence);
     WTF_MAKE_TZONE_ALLOCATED_INLINE(RemoteImageBufferSetProxyFlushFence);
 public:
-    static Ref<RemoteImageBufferSetProxyFlushFence> create(RenderingUpdateID renderingUpdateID, Seconds timeoutDuration)
+    static Ref<RemoteImageBufferSetProxyFlushFence> NODELETE create(RenderingUpdateID renderingUpdateID, Seconds timeoutDuration)
     {
         return adoptRef(*new RemoteImageBufferSetProxyFlushFence { renderingUpdateID, timeoutDuration });
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
@@ -95,7 +95,7 @@ public:
 
     OptionSet<BufferInSetType> requestedVolatility() { return m_requestedVolatility; }
     OptionSet<BufferInSetType> confirmedVolatility() { return m_confirmedVolatility; }
-    void clearVolatility();
+    void NODELETE clearVolatility();
     void NODELETE addRequestedVolatility(OptionSet<BufferInSetType> request);
     void NODELETE setConfirmedVolatility(OptionSet<BufferInSetType> types);
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -77,7 +77,7 @@ public:
 
     void paintToCanvas(WebCore::NativeImage&, const WebCore::IntSize&, WebCore::GraphicsContext&) final;
     WebGPUIdentifier backing() const { return m_backing; }
-    RefPtr<WebKit::Mesh> createModelBacking(unsigned width, unsigned height, const WebModel::ImageAsset& diffuseTexture, const WebModel::ImageAsset& specularTexture, CompletionHandler<void(Vector<MachSendRight>&&)>&&);
+    RefPtr<WebKit::Mesh> NODELETE createModelBacking(unsigned width, unsigned height, const WebModel::ImageAsset& diffuseTexture, const WebModel::ImageAsset& specularTexture, CompletionHandler<void(Vector<MachSendRight>&&)>&&);
 
 private:
     friend class WebGPU::DowncastConvertToBackingContext;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h
@@ -74,7 +74,7 @@ public:
     void addSession(RemoteLegacyCDMSessionIdentifier, RemoteLegacyCDMSession&);
     void removeSession(RemoteLegacyCDMSessionIdentifier);
 
-    RemoteLegacyCDM* findCDM(WebCore::CDMPrivateInterface*) const;
+    RemoteLegacyCDM* NODELETE findCDM(WebCore::CDMPrivateInterface*) const;
 
     void NODELETE ref() const;
     void deref() const;

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -216,7 +216,7 @@ private:
 
     IPC::Connection* NODELETE encoderConnection(Encoder&) WTF_REQUIRES_LOCK(m_encodersConnectionLock);
     void setEncoderConnection(Encoder&, RefPtr<IPC::Connection>&&) WTF_REQUIRES_LOCK(m_encodersConnectionLock);
-    IPC::Connection* decoderConnection(Decoder&) WTF_REQUIRES_LOCK(m_connectionLock);
+    IPC::Connection* NODELETE decoderConnection(Decoder&) WTF_REQUIRES_LOCK(m_connectionLock);
     void setDecoderConnection(Decoder&, RefPtr<IPC::Connection>&&) WTF_REQUIRES_LOCK(m_connectionLock);
 
     template<typename Buffer> bool copySharedVideoFrame(LibWebRTCCodecs::Encoder&, IPC::Connection&, Buffer&&);

--- a/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h
+++ b/Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h
@@ -44,7 +44,7 @@ class GamepadData;
 
 class WebGamepadProvider final : public WebCore::GamepadProvider {
 public:
-    static WebGamepadProvider& singleton();
+    static WebGamepadProvider& NODELETE singleton();
 
     void gamepadConnected(const GamepadData&, WebCore::EventMakesGamepadsVisible);
     void gamepadDisconnected(unsigned index);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -584,7 +584,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
     return _editingDelegate.getAutoreleased();
 }
 
-static inline WKEditorInsertAction toWK(WebCore::EditorInsertAction action)
+static inline WKEditorInsertAction NODELETE toWK(WebCore::EditorInsertAction action)
 {
     switch (action) {
     case WebCore::EditorInsertAction::Typed:

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -69,7 +69,7 @@ using namespace HTMLNames;
 
 using DOMNodeHandleCache = WeakHashMap<Node, WeakRef<InjectedBundleNodeHandle>, WeakPtrImplWithEventTargetData>;
 
-static DOMNodeHandleCache& domNodeHandleCache()
+static DOMNodeHandleCache& NODELETE domNodeHandleCache()
 {
     static NeverDestroyed<DOMNodeHandleCache> cache;
     return cache;

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h
@@ -84,7 +84,7 @@ public:
     bool htmlTextAreaElementLastChangeWasUserEdit();
     bool isTextField() const;
     bool NODELETE isSelectElement() const;
-    bool isSelectableTextNode() const;
+    bool NODELETE isSelectableTextNode() const;
     
     RefPtr<InjectedBundleNodeHandle> htmlTableCellElementCellAbove();
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h
@@ -49,13 +49,13 @@ public:
     static Ref<InjectedBundleScriptWorld> create(ContentWorldIdentifier, const String& name, Type = Type::Internal);
     static Ref<InjectedBundleScriptWorld> getOrCreate(WebCore::DOMWrapperWorld&);
     static RefPtr<InjectedBundleScriptWorld> get(const WebCore::DOMWrapperWorld&);
-    static InjectedBundleScriptWorld* find(const String&);
+    static InjectedBundleScriptWorld* NODELETE find(const String&);
     static InjectedBundleScriptWorld& normalWorldSingleton();
 
     virtual ~InjectedBundleScriptWorld();
 
     const WebCore::DOMWrapperWorld& NODELETE coreWorld() const;
-    WebCore::DOMWrapperWorld& coreWorld();
+    WebCore::DOMWrapperWorld& NODELETE coreWorld();
 
     void clearWrappers();
     void NODELETE setAllowAutofill();

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.h
@@ -189,7 +189,7 @@ public:
 private:
     explicit WebInspectorUI(WebPage&);
 
-    void didEstablishConnection();
+    void NODELETE didEstablishConnection();
 
     template<typename T>
     IPC::Error sendToParentProcess(T&& message)

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -167,7 +167,7 @@ void WebLoaderStrategy::schedulePluginStreamLoad(LocalFrame& frame, NetscapePlug
     });
 }
 
-static Seconds maximumBufferingTime(CachedResource* resource)
+static Seconds NODELETE maximumBufferingTime(CachedResource* resource)
 {
     if (!resource)
         return 0_s;

--- a/Source/WebKit/WebProcess/Network/WebMockContentFilterManager.h
+++ b/Source/WebKit/WebProcess/Network/WebMockContentFilterManager.h
@@ -31,7 +31,7 @@ namespace WebKit {
 
 class WebMockContentFilterManager : public WebCore::MockContentFilterSettingsClient {
 public:
-    static WebMockContentFilterManager& singleton();
+    static WebMockContentFilterManager& NODELETE singleton();
 
     void startObservingSettings();
     

--- a/Source/WebKit/WebProcess/Network/WebResourceInterceptController.h
+++ b/Source/WebKit/WebProcess/Network/WebResourceInterceptController.h
@@ -34,7 +34,7 @@ namespace WebKit {
 
 class WebResourceInterceptController {
 public:
-    bool isIntercepting(WebCore::ResourceLoaderIdentifier) const;
+    bool NODELETE isIntercepting(WebCore::ResourceLoaderIdentifier) const;
 
     // Start intercepting a response.
     void beginInterceptingResponse(WebCore::ResourceLoaderIdentifier);

--- a/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h
@@ -46,7 +46,7 @@ class LibWebRTCSocketFactory;
 class WebRTCResolver : public RefCounted<WebRTCResolver> {
     WTF_MAKE_TZONE_ALLOCATED(WebRTCResolver);
 public:
-    static Ref<WebRTCResolver> create(LibWebRTCSocketFactory&, LibWebRTCResolverIdentifier);
+    static Ref<WebRTCResolver> NODELETE create(LibWebRTCSocketFactory&, LibWebRTCResolverIdentifier);
     ~WebRTCResolver();
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h
@@ -100,11 +100,11 @@ private:
 
     void unconditionalCompleteOutstandingRangeRequests();
 
-    ByteRangeRequest* byteRangeRequestForStreamLoader(WebCore::NetscapePlugInStreamLoader&);
+    ByteRangeRequest* NODELETE byteRangeRequestForStreamLoader(WebCore::NetscapePlugInStreamLoader&);
     void forgetStreamLoader(WebCore::NetscapePlugInStreamLoader&);
     void cancelAndForgetStreamLoader(WebCore::NetscapePlugInStreamLoader&);
 
-    std::optional<ByteRangeRequestIdentifier> identifierForLoader(WebCore::NetscapePlugInStreamLoader&);
+    std::optional<ByteRangeRequestIdentifier> NODELETE identifierForLoader(WebCore::NetscapePlugInStreamLoader&);
     void removeOutstandingByteRangeRequest(ByteRangeRequestIdentifier);
 
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -67,7 +67,7 @@ public:
     }
 
     NetscapePlugInStreamLoader* NODELETE streamLoader() { return m_streamLoader; }
-    void setStreamLoader(NetscapePlugInStreamLoader& loader) { m_streamLoader = loader; }
+    void NODELETE setStreamLoader(NetscapePlugInStreamLoader& loader) { m_streamLoader = loader; }
     void clearStreamLoader();
     void addData(std::span<const uint8_t> data) { m_accumulatedData.append(data); }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -466,10 +466,10 @@ protected:
 
     String annotationStyle() const;
 
-    static NSString *htmlPasteboardType();
-    static NSString *rtfPasteboardType();
-    static NSString *stringPasteboardType();
-    static NSString *urlPasteboardType();
+    static NSString *NODELETE htmlPasteboardType();
+    static NSString *NODELETE rtfPasteboardType();
+    static NSString *NODELETE stringPasteboardType();
+    static NSString *NODELETE urlPasteboardType();
 
 #if PLATFORM(MAC)
     void writeStringToFindPasteboard(const String&) const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -1150,7 +1150,7 @@ std::optional<PageIdentifier> PDFPluginBase::pageIdentifier() const
     return frame && frame->coreLocalFrame() ? frame->coreLocalFrame()->pageID() : std::nullopt;
 }
 
-NSString *PDFPluginBase::stringPasteboardType()
+SUPPRESS_NODELETE NSString *PDFPluginBase::stringPasteboardType()
 {
 #if PLATFORM(IOS_FAMILY)
     return UTTypeUTF8PlainText.identifier;
@@ -1159,7 +1159,7 @@ NSString *PDFPluginBase::stringPasteboardType()
 #endif
 }
 
-NSString *PDFPluginBase::urlPasteboardType()
+SUPPRESS_NODELETE NSString *PDFPluginBase::urlPasteboardType()
 {
 #if PLATFORM(IOS_FAMILY)
     return UTTypeURL.identifier;
@@ -1168,7 +1168,7 @@ NSString *PDFPluginBase::urlPasteboardType()
 #endif
 }
 
-NSString *PDFPluginBase::htmlPasteboardType()
+SUPPRESS_NODELETE NSString *PDFPluginBase::htmlPasteboardType()
 {
 #if PLATFORM(IOS_FAMILY)
     return UTTypeHTML.identifier;
@@ -1177,7 +1177,7 @@ NSString *PDFPluginBase::htmlPasteboardType()
 #endif
 }
 
-NSString *PDFPluginBase::rtfPasteboardType()
+SUPPRESS_NODELETE NSString *PDFPluginBase::rtfPasteboardType()
 {
 #if PLATFORM(IOS_FAMILY)
     return UTTypeRTF.identifier;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h
@@ -259,8 +259,8 @@ private:
     void ensurePreviewsForCurrentPageCoverage();
 
     static WebCore::FloatRect convertTileRectToPaintingCoords(const WebCore::FloatRect&, float pageScaleFactor);
-    static WebCore::AffineTransform tileToPaintingTransform(float tilingScaleFactor);
-    static WebCore::AffineTransform paintingToTileTransform(float tilingScaleFactor);
+    static WebCore::AffineTransform NODELETE tileToPaintingTransform(float tilingScaleFactor);
+    static WebCore::AffineTransform NODELETE paintingToTileTransform(float tilingScaleFactor);
 #if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
     WebCore::DynamicContentScalingResourceCache ensureDynamicContentScalingResourceCache();
 #endif

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
@@ -88,7 +88,7 @@ private:
     std::optional<PDFLayoutRow> visibleRow() const override;
     std::optional<PDFLayoutRow> rowForLayer(const WebCore::GraphicsLayer&) const override;
 
-    WebCore::FloatSize contentsOffsetForPage(PDFDocumentLayout::PageIndex) const;
+    WebCore::FloatSize NODELETE contentsOffsetForPage(PDFDocumentLayout::PageIndex) const;
 
     bool handleKeyboardEvent(const WebKeyboardEvent&) override;
 
@@ -189,7 +189,7 @@ private:
     std::array<std::array<float, 2>, 2> layerOpacitiesForStretchOffset(TransitionDirection, WebCore::FloatSize layerOffset, WebCore::FloatSize rowSize) const;
     WebCore::FloatSize layerOffsetForStretch(TransitionDirection, WebCore::FloatSize stretchDistance, WebCore::FloatSize rowSize) const;
     static float NODELETE relevantAxisForDirection(TransitionDirection, WebCore::FloatSize);
-    static void setRelevantAxisForDirection(TransitionDirection, WebCore::FloatSize&, float value);
+    static void NODELETE setRelevantAxisForDirection(TransitionDirection, WebCore::FloatSize&, float value);
 
     struct RowData {
         PDFLayoutRow pages;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -83,7 +83,7 @@ public:
     std::pair<PageIndex, WebCore::FloatPoint> pageIndexAndPagePointForDocumentYOffset(float) const;
 
     // This is not scaled by scale().
-    WebCore::FloatRect layoutBoundsForPageAtIndex(PageIndex) const;
+    WebCore::FloatRect NODELETE layoutBoundsForPageAtIndex(PageIndex) const;
     // Bounds of the pages in the row, including document margins. Not scaled.
     WebCore::FloatRect layoutBoundsForRow(PDFLayoutRow) const;
 
@@ -106,7 +106,7 @@ public:
 
     OptionSet<LayoutUpdateChange> updateLayout(WebCore::IntSize pluginSize, ShouldUpdateAutoSizeScale);
     WebCore::FloatSize NODELETE contentsSize() const;
-    WebCore::FloatSize scaledContentsSize() const;
+    WebCore::FloatSize NODELETE scaledContentsSize() const;
 
     void setDisplayMode(PDFDisplayMode displayMode) { m_displayMode = displayMode; }
     PDFDisplayMode displayMode() const { return m_displayMode; }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h
@@ -140,7 +140,7 @@ protected:
     RefPtr<AsyncPDFRenderer> NODELETE asyncRendererIfExists() const;
     void clearAsyncRenderer();
 
-    bool shouldUseInProcessBackingStore() const;
+    bool NODELETE shouldUseInProcessBackingStore() const;
 
     WebCore::Path shadowPathForLayer(const WebCore::GraphicsLayer&) const;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
@@ -96,7 +96,7 @@ private:
 
     void updatePageBackgroundLayers();
     std::optional<PDFDocumentLayout::PageIndex> NODELETE pageIndexForPageBackgroundLayer(const WebCore::GraphicsLayer&) const;
-    WebCore::GraphicsLayer* backgroundLayerForPage(PDFDocumentLayout::PageIndex) const;
+    WebCore::GraphicsLayer* NODELETE backgroundLayerForPage(PDFDocumentLayout::PageIndex) const;
 
     void didGeneratePreviewForPage(PDFDocumentLayout::PageIndex) override;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -233,7 +233,7 @@ public:
 
     bool shouldSizeToFitContent() const final;
 
-    static WebCore::ViewportConfiguration::Parameters viewportParameters();
+    static WebCore::ViewportConfiguration::Parameters NODELETE viewportParameters();
 
     bool hasSelection() const;
 
@@ -291,8 +291,8 @@ private:
     // Scale normalization is used to map the internal "scale factor" to the exposed scaleFactor()/setPageScaleFactor()
     // so that scale factor 1 shows at "Actual Size".
     void computeNormalizationFactor();
-    double fromNormalizedScaleFactor(double) const;
-    double toNormalizedScaleFactor(double) const;
+    double NODELETE fromNormalizedScaleFactor(double) const;
+    double NODELETE toNormalizedScaleFactor(double) const;
 
     void didBeginMagnificationGesture() override;
     void didEndMagnificationGesture() override;

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -118,7 +118,7 @@ public:
 
     void obscuredContentInsetsDidChange();
 
-    void webPageDestroyed();
+    void NODELETE webPageDestroyed();
 
     bool handleEditingCommand(const String& commandName, const String& argument);
     bool isEditingCommandEnabled(const String& commandName);

--- a/Source/WebKit/WebProcess/Storage/WebServiceWorkerProvider.h
+++ b/Source/WebKit/WebProcess/Storage/WebServiceWorkerProvider.h
@@ -41,7 +41,7 @@ namespace WebKit {
 
 class WebServiceWorkerProvider final : public WebCore::ServiceWorkerProvider {
 public:
-    static WebServiceWorkerProvider& singleton();
+    static WebServiceWorkerProvider& NODELETE singleton();
 
     void didReceiveServiceWorkerClientRegistrationMatch(IPC::Connection&, IPC::Decoder&);
     void updateThrottleState(bool isThrottleable);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -575,7 +575,7 @@ void WebChromeClient::rootFrameRemoved(const WebCore::LocalFrame& frame)
         drawingArea->removeRootFrame(frame.frameID());
 }
 
-static bool shouldSuppressJavaScriptDialogs(LocalFrame& frame)
+static bool NODELETE shouldSuppressJavaScriptDialogs(LocalFrame& frame)
 {
     if (frame.opener() && frame.loader().stateMachine().isDisplayingInitialEmptyDocument() && frame.loader().provisionalDocumentLoader())
         return true;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.h
@@ -54,7 +54,7 @@ public:
 
     void didChooseColor(const WebCore::Color&);
     void didEndChooser();
-    void disconnectFromPage();
+    void NODELETE disconnectFromPage();
 
     void reattachColorChooser(const WebCore::Color&) override;
     void setSelectedColor(const WebCore::Color&) override;

--- a/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
+++ b/Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp
@@ -544,7 +544,7 @@ void MomentumEventDispatcher::equalizeTailGaps()
     table.shrink(finalTableSize);
 }
 
-static float interpolate(float a, float b, float t)
+static float NODELETE interpolate(float a, float b, float t)
 {
     return a + t * (b - a);
 }
@@ -581,7 +581,7 @@ static float momentumDecayRate(WebCore::FloatSize delta, Seconds frameInterval)
     return std::pow(alpha, (frameInterval.seconds() / 0.008f));
 }
 
-static constexpr float fromFixedPoint(float value)
+static constexpr float NODELETE fromFixedPoint(float value)
 {
     return value / 65536.0f;
 }

--- a/Source/WebKit/WebProcess/WebPage/PageBanner.h
+++ b/Source/WebKit/WebProcess/WebPage/PageBanner.h
@@ -58,7 +58,7 @@ public:
 
 #if PLATFORM(MAC)
     static Ref<PageBanner> create(CALayer *, int height, std::unique_ptr<Client>&&);
-    CALayer *layer();
+    CALayer *NODELETE layer();
 #endif
 
     virtual ~PageBanner();

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -263,7 +263,7 @@ public:
 
     unsigned backingStoreBytesPerPixel() const override;
 
-    void setClonedLayer(const PlatformCALayer*);
+    void NODELETE setClonedLayer(const PlatformCALayer*);
 
     LayerProperties& properties() LIFETIME_BOUND { return m_properties; }
     const LayerProperties& properties() const LIFETIME_BOUND { return m_properties; }

--- a/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
+++ b/Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h
@@ -41,7 +41,7 @@ public:
 
     static void removeItem(WebCore::BackForwardFrameItemIdentifier);
 
-    void clearCachedListCounts();
+    void NODELETE clearCachedListCounts();
 
 private:
     WebBackForwardListProxy(WebPage&);

--- a/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieCache.h
@@ -71,7 +71,7 @@ public:
     void clear();
     void clearForHost(const String&);
 
-    void setOptInCookiePartitioningEnabled(bool);
+    void NODELETE setOptInCookiePartitioningEnabled(bool);
 
 private:
     WebCookieCache() = default;

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1403,7 +1403,7 @@ std::optional<OptionSet<WebCore::AdvancedPrivacyProtections>> WebFrame::originat
 }
 
 #if ENABLE(CONTEXT_MENU_EVENT)
-static bool isContextClick(const PlatformMouseEvent& event)
+static bool NODELETE isContextClick(const PlatformMouseEvent& event)
 {
 #if USE(APPKIT)
     return WebEventFactory::shouldBeHandledAsContextClick(event);
@@ -1633,7 +1633,7 @@ void WebFrame::findFocusableElementContinuingFromFrame(WebCore::FocusDirection d
     }
 }
 
-static RefPtr<Node> nodeFromJSHandleIdentifier(JSHandleIdentifier identifier)
+static RefPtr<Node> NODELETE nodeFromJSHandleIdentifier(JSHandleIdentifier identifier)
 {
     auto* object = WebKitJSHandle::objectForIdentifier(identifier);
     if (!object)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -130,7 +130,7 @@ public:
     WebPage* page() const;
 
     static WebFrame* webFrame(std::optional<WebCore::FrameIdentifier>);
-    static WebFrame* fromCoreFrame(const WebCore::Frame&);
+    static WebFrame* NODELETE fromCoreFrame(const WebCore::Frame&);
     WebCore::LocalFrame* NODELETE coreLocalFrame() const;
     WebCore::RemoteFrame* NODELETE coreRemoteFrame() const;
     WebCore::Frame* NODELETE coreFrame() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1834,7 +1834,7 @@ void WebPage::updateEditorStateAfterLayoutIfEditabilityChanged()
         scheduleFullEditorStateUpdate();
 }
 
-static OptionSet<RenderAsTextFlag> toRenderAsTextFlags(unsigned options)
+static OptionSet<RenderAsTextFlag> NODELETE toRenderAsTextFlags(unsigned options)
 {
     OptionSet<RenderAsTextFlag> flags;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -760,16 +760,16 @@ public:
     void didNavigateWithinPageForFrame(WebFrame&);
     void show();
     String userAgent(const URL&) const;
-    String platformUserAgent(const URL&) const;
+    String NODELETE platformUserAgent(const URL&) const;
     bool hasCustomUserAgent() const { return m_hasCustomUserAgent; }
     WebCore::KeyboardUIMode keyboardUIMode();
 
     void setMainFrameDocumentVisualUpdatesAllowed(bool);
 
     bool hasAccessoryMousePointingDevice() const;
-    bool hoverSupportedByPrimaryPointingDevice() const;
+    bool NODELETE hoverSupportedByPrimaryPointingDevice() const;
     bool hoverSupportedByAnyAvailablePointingDevice() const;
-    std::optional<WebCore::PointerCharacteristics> pointerCharacteristicsOfPrimaryPointingDevice() const;
+    std::optional<WebCore::PointerCharacteristics> NODELETE pointerCharacteristicsOfPrimaryPointingDevice() const;
     OptionSet<WebCore::PointerCharacteristics> pointerCharacteristicsOfAllAvailablePointingDevices() const;
 
     void animationDidFinishForElement(const WebCore::Element&);
@@ -791,15 +791,15 @@ public:
     inline void setHiddenPageDOMTimerThrottlingIncreaseLimit(Seconds);
 
     WebColorChooser* NODELETE activeColorChooser() const;
-    void setActiveColorChooser(WebColorChooser*);
+    void NODELETE setActiveColorChooser(WebColorChooser*);
     void didChooseColor(const WebCore::Color&);
     void didEndColorPicker();
 
-    void setActiveDataListSuggestionPicker(WebDataListSuggestionPicker&);
+    void NODELETE setActiveDataListSuggestionPicker(WebDataListSuggestionPicker&);
     void didSelectDataListOption(const String&);
     void didCloseSuggestions();
 
-    void setActiveDateTimeChooser(WebDateTimeChooser&);
+    void NODELETE setActiveDateTimeChooser(WebDateTimeChooser&);
     void didChooseDate(const String&);
     void didEndDateTimePicker();
 
@@ -1312,7 +1312,7 @@ public:
     void platformInitializeAccessibility(ShouldInitializeNSAccessibility);
     void registerUIProcessAccessibilityTokens(WebCore::AccessibilityRemoteToken elementToken, WebCore::AccessibilityRemoteToken windowToken);
     void registerRemoteFrameAccessibilityTokens(pid_t, WebCore::AccessibilityRemoteToken, WebCore::FrameIdentifier);
-    WKAccessibilityWebPageObject* accessibilityRemoteObject();
+    WKAccessibilityWebPageObject* NODELETE accessibilityRemoteObject();
     WebCore::IntPoint accessibilityRemoteFrameOffset();
     void createMockAccessibilityElement(pid_t);
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
@@ -1636,7 +1636,7 @@ public:
 
     Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::LocalFrame&, WebCore::ResourceRequest&&, WebCore::SubstituteData&&, WebCore::ResourceRequest&&);
     Ref<WebCore::DocumentLoader> createDocumentLoader(WebCore::LocalFrame&, WebCore::ResourceRequest&&, WebCore::SubstituteData&&);
-    void updateCachedDocumentLoader(WebCore::DocumentLoader&, WebCore::LocalFrame&);
+    void NODELETE updateCachedDocumentLoader(WebCore::DocumentLoader&, WebCore::LocalFrame&);
 
     void getBytecodeProfile(CompletionHandler<void(const String&)>&&);
     void getSamplingProfilerOutput(CompletionHandler<void(const String&)>&&);
@@ -1841,7 +1841,7 @@ public:
     void completeTextManipulation(const Vector<WebCore::TextManipulationItem>&, CompletionHandler<void(const WebCore::TextManipulationControllerManipulationResult&)>&&);
 
 #if ENABLE(APPLE_PAY)
-    WebPaymentCoordinator* paymentCoordinator();
+    WebPaymentCoordinator* NODELETE paymentCoordinator();
 #endif
 
 #if ENABLE(PLATFORM_DRIVEN_TEXT_CHECKING)
@@ -1849,8 +1849,8 @@ public:
 #endif
 
 #if PLATFORM(COCOA)
-    void setRemoteObjectRegistry(WebRemoteObjectRegistry*);
-    WebRemoteObjectRegistry* remoteObjectRegistry();
+    void NODELETE setRemoteObjectRegistry(WebRemoteObjectRegistry*);
+    WebRemoteObjectRegistry* NODELETE remoteObjectRegistry();
 #endif
 
     WebPageProxyIdentifier webPageProxyIdentifier() const { return m_webPageProxyIdentifier; }
@@ -2669,7 +2669,7 @@ private:
     void revokeSandboxExtensions(Vector<Ref<SandboxExtension>>& sandboxExtensions);
 
     bool NODELETE hasPendingEditorStateUpdate() const;
-    bool shouldAvoidComputingPostLayoutDataForEditorState() const;
+    bool NODELETE shouldAvoidComputingPostLayoutDataForEditorState() const;
 
     void useRedirectionForCurrentNavigation(WebCore::ResourceResponse&&);
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -246,7 +246,7 @@ public:
     void createWebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
     Awaitable<unsigned> countWebPagesForTesting();
     void removeWebPage(WebCore::PageIdentifier);
-    WebPage* focusedWebPage() const;
+    WebPage* NODELETE focusedWebPage() const;
     bool hasEverHadAnyWebPages() const { return m_hasEverHadAnyWebPages; }
     bool isBroadcastChannelEnabled() const { return m_isBroadcastChannelEnabled; }
 
@@ -272,7 +272,7 @@ public:
 
     void updateStorageAccessUserAgentStringQuirks(HashMap<WebCore::RegistrableDomain, String>&&);
 
-    WebFrame* webFrame(std::optional<WebCore::FrameIdentifier>) const;
+    WebFrame* NODELETE webFrame(std::optional<WebCore::FrameIdentifier>) const;
     void addWebFrame(WebCore::FrameIdentifier, WebFrame*);
     void removeWebFrame(WebCore::FrameIdentifier, WebPage*);
 
@@ -313,7 +313,7 @@ public:
     GPUProcessConnection& ensureGPUProcessConnection();
     GPUProcessConnection* existingGPUProcessConnection() { return m_gpuProcessConnection.get(); }
     // Returns timeout duration for GPU process connections. Thread-safe.
-    Seconds gpuProcessTimeoutDuration() const;
+    Seconds NODELETE gpuProcessTimeoutDuration() const;
     void gpuProcessConnectionClosed();
     void gpuProcessConnectionDidBecomeUnresponsive();
 
@@ -355,7 +355,7 @@ public:
 
     void registerStorageAreaMap(StorageAreaMap&);
     void unregisterStorageAreaMap(StorageAreaMap&);
-    WeakPtr<StorageAreaMap> storageAreaMap(StorageAreaMapIdentifier) const;
+    WeakPtr<StorageAreaMap> NODELETE storageAreaMap(StorageAreaMapIdentifier) const;
 
 #if PLATFORM(COCOA)
     RetainPtr<CFDataRef> sourceApplicationAuditData() const;
@@ -462,7 +462,7 @@ public:
     void disableURLSchemeCheckInDataDetectors() const;
 
 #if PLATFORM(MAC)
-    void updatePageScreenProperties();
+    void NODELETE updatePageScreenProperties();
 #endif
 
     void NODELETE setChildProcessDebuggabilityEnabled(bool);
@@ -612,9 +612,9 @@ private:
     void setOptInCookiePartitioningEnabled(bool);
 #endif
 
-    void platformSetCacheModel(CacheModel);
+    void NODELETE platformSetCacheModel(CacheModel);
 
-    void setEnhancedAccessibility(bool);
+    void NODELETE setEnhancedAccessibility(bool);
     void bindAccessibilityFrameWithData(WebCore::FrameIdentifier, std::span<const uint8_t>);
 
     void startMemorySampler(SandboxExtension::Handle&&, const String&, const double);
@@ -652,13 +652,13 @@ private:
     void setInjectedBundleParameter(const String& key, std::span<const uint8_t>);
     void setInjectedBundleParameters(std::span<const uint8_t>);
 
-    bool areAllPagesSuspended() const;
+    bool NODELETE areAllPagesSuspended() const;
 
     void ensureAutomationSessionProxy(const String& sessionIdentifier);
     void destroyAutomationSessionProxy();
 
     void logDiagnosticMessageForNetworkProcessCrash();
-    bool hasVisibleWebPage() const;
+    bool NODELETE hasVisibleWebPage() const;
     void updateCPULimit();
     enum class CPUMonitorUpdateReason { LimitHasChanged, VisibilityHasChanged };
     void updateCPUMonitorState(CPUMonitorUpdateReason);
@@ -775,7 +775,7 @@ private:
     void initializeLogForwarding(const WebProcessCreationParameters&);
 #endif
 
-    bool isProcessBeingCachedForPerformance();
+    bool NODELETE isProcessBeingCachedForPerformance();
 
     HashMap<WebCore::PageIdentifier, Ref<WebPage>> m_pageMap;
     HashMap<PageGroupIdentifier, Ref<WebPageGroupProxy>> m_pageGroupMap;
@@ -916,7 +916,7 @@ private:
 
     HashMap<StorageAreaMapIdentifier, WeakPtr<StorageAreaMap>> m_storageAreaMaps;
 
-    void updateIsBroadcastChannelEnabled();
+    void NODELETE updateIsBroadcastChannelEnabled();
     
     // Prewarmed WebProcesses do not have an associated sessionID yet, which is why this is an optional.
     // By the time the WebProcess gets a WebPage, it is guaranteed to have a sessionID.

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
@@ -80,7 +80,7 @@ public:
 
     void connect();
     void disconnect();
-    void incrementUseCount();
+    void NODELETE incrementUseCount();
     void decrementUseCount();
 
 private:

--- a/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.h
+++ b/Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.h
@@ -33,7 +33,7 @@ namespace WebKit {
 
 class LaunchServicesDatabaseManager : public WebKit::XPCEndpointClient {
 public:
-    static LaunchServicesDatabaseManager& singleton();
+    static LaunchServicesDatabaseManager& NODELETE singleton();
 
     void waitForDatabaseUpdate();
 

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -141,8 +141,8 @@ public:
     void mediaEngineChanged(WebCore::HTMLMediaElement&);
     WebCore::HTMLMediaElementIdentifier contextIdForMediaElement(WebCore::HTMLMediaElement&);
 
-    WebCore::HTMLMediaElement* mediaElementWithContextId(WebCore::HTMLMediaElementIdentifier) const;
-    WebCore::HTMLMediaElement* currentPlaybackControlsElement() const;
+    WebCore::HTMLMediaElement* NODELETE mediaElementWithContextId(WebCore::HTMLMediaElementIdentifier) const;
+    WebCore::HTMLMediaElement* NODELETE currentPlaybackControlsElement() const;
 
 #if HAVE(PIP_SKIP_PREROLL)
     void actionHandlersChanged() final;

--- a/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
+++ b/Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h
@@ -100,7 +100,7 @@ private:
     class VideoFactory : public WebCore::VideoCaptureFactory {
     public:
         explicit VideoFactory(UserMediaCaptureManager& manager) : m_manager(manager) { }
-        void setShouldCaptureInGPUProcess(bool);
+        void NODELETE setShouldCaptureInGPUProcess(bool);
 
     private:
         WebCore::CaptureSourceOrError createVideoCaptureSource(const WebCore::CaptureDevice&, WebCore::MediaDeviceHashSalts&&, const WebCore::MediaConstraints*, std::optional<WebCore::PageIdentifier>) final;
@@ -112,7 +112,7 @@ private:
     class DisplayFactory : public WebCore::DisplayCaptureFactory {
     public:
         explicit DisplayFactory(UserMediaCaptureManager& manager) : m_manager(manager) { }
-        void setShouldCaptureInGPUProcess(bool);
+        void NODELETE setShouldCaptureInGPUProcess(bool);
 
     private:
         WebCore::CaptureSourceOrError createDisplayCaptureSource(const WebCore::CaptureDevice&, WebCore::MediaDeviceHashSalts&&, const WebCore::MediaConstraints*, std::optional<WebCore::PageIdentifier>) final;

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -118,7 +118,7 @@ static constexpr Seconds s_incomingPushTransactionTimeout { 10_s };
 
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)
 
-static bool platformShouldPlaySound(const WebCore::NotificationData& data)
+static bool NODELETE platformShouldPlaySound(const WebCore::NotificationData& data)
 {
 #if PLATFORM(IOS)
     return data.silent == std::nullopt || !(*data.silent);


### PR DESCRIPTION
#### 70460999cc3e14d83f88dfeee33a5b21cc355e13
<pre>
Adopt NODELETE in more places in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=309231">https://bugs.webkit.org/show_bug.cgi?id=309231</a>

Reviewed by Ryosuke Niwa.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContext.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::adjustImageBufferRenderingMode):
* Source/WebKit/GPUProcess/media/RemoteAudioDestinationManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMFactoryProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/GPUProcess/webrtc/LibWebRTCCodecsProxy.h:
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.h:
* Source/WebKit/NetworkProcess/Classifier/ITPThirdPartyDataForSpecificFirstParty.h:
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::allStores):
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.h:
* Source/WebKit/NetworkProcess/CustomProtocols/LegacyCustomProtocolManager.h:
* Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.cpp:
(WebKit::operator_kbps):
(WebKit::timeUntilNextInterval):
* Source/WebKit/NetworkProcess/Downloads/DownloadMonitor.h:
* Source/WebKit/NetworkProcess/NetworkDataTask.h:
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::connectionTimesMovingAverage):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp:
(WebKit::PCM::allDatabases):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/cocoa/PrivateClickMeasurementNetworkLoaderCocoa.mm:
(allowedLocalTestServerTrust):
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorker.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.h:
* Source/WebKit/NetworkProcess/cache/NetworkCacheData.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(toNetworkLoadPriority):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::computeIsAlwaysOnLoggingAllowed):
* Source/WebKit/NetworkProcess/storage/CacheStorageRegistry.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandleRegistry.h:
* Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h:
* Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::existingFileSystemStorageManager):
(WebKit::OriginStorageManager::StorageBucket::existingLocalStorageManager):
(WebKit::OriginStorageManager::StorageBucket::existingSessionStorageManager):
(WebKit::OriginStorageManager::StorageBucket::existingIDBStorageManager):
(WebKit::OriginStorageManager::StorageBucket::existingCacheStorageManager):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/NetworkProcess/storage/StorageAreaRegistry.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm:
(WebKit::NetworkRTCUDPSocketCocoaConnections::ConnectionStateTracker::create):
* Source/WebKit/NetworkProcess/webrtc/RTCDataChannelRemoteManagerProxy.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportSession.h:
* Source/WebKit/NetworkProcess/webtransport/NetworkTransportStream.h:
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/Encoder.h:
* Source/WebKit/Platform/IPC/cocoa/ConnectionCocoa.mm:
(IPC::setPortDescriptor):
* Source/WebKit/Platform/Module.h:
* Source/WebKit/Platform/classifier/ResourceLoadStatisticsClassifier.cpp:
(WebKit::vectorLength):
* Source/WebKit/Platform/classifier/ResourceLoadStatisticsClassifier.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::TrackerDomainLookupInfo::list):
* Source/WebKit/Shared/AuxiliaryProcess.h:
* Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm:
(WebKit::defaultTopContentInsetBackgroundCanChangeAfterScrolling):
* Source/WebKit/Shared/EditorState.h:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/Daemon/PCMDaemonConnectionSet.h:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::stageOverrideLanguagesForMainThread):
(WebKit::setUserDirSuffix):
* Source/WebKit/Shared/Extensions/WebExtensionFrameIdentifier.h:
* Source/WebKit/Shared/JSHandleInfo.h:
* Source/WebKit/Shared/JavaScriptEvaluationResult.cpp:
(WebKit::JavaScriptEvaluationResult::JSExtractor::takeMap):
(WebKit::JavaScriptEvaluationResult::APIExtractor::takeMap):
* Source/WebKit/Shared/JavaScriptEvaluationResult.mm:
(WebKit::JavaScriptEvaluationResult::ObjCExtractor::takeMap):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeTransaction.h:
* Source/WebKit/Shared/SandboxExtension.h:
* Source/WebKit/Shared/ScrollingAccelerationCurve.h:
* Source/WebKit/Shared/SessionState.h:
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::childItemWithTarget):
(WebKit::hasSameFrames):
* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/Shared/WebEventConversion.h:
* Source/WebKit/Shared/WebEventModifier.cpp:
(WebKit::modifiersFromPlatformEventModifiers):
* Source/WebKit/Shared/WebEventModifier.h:
* Source/WebKit/Shared/WebFindOptions.cpp:
(WebKit::core):
* Source/WebKit/Shared/WebFindOptions.h:
* Source/WebKit/Shared/WebMouseEvent.cpp:
(WebKit::mouseButton):
* Source/WebKit/Shared/WebMouseEvent.h:
* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultVideoFullscreenRequiresElementFullscreen):
(WebKit::defaultManageCaptureStatusBarInGPUProcessEnabled):
(WebKit::defaultInactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes):
(WebKit::defaultDigitalCredentialsEnabled):
(WebKit::defaultShouldEnableScreenOrientationAPI):
(WebKit::defaultDeviceOrientationPermissionAPIEnabled):
(WebKit::defaultGetBoundingClientRectZoomedEnabled):
(WebKit::defaultFacebookLiveRecordingQuirkEnabled):
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKit/Shared/WebWheelEventCoalescer.h:
* Source/WebKit/Shared/WebsiteData/WebsiteData.h:
* Source/WebKit/Shared/mac/ScrollingAccelerationCurveMac.mm:
(WebKit::fromFixedPoint):
* Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h:
* Source/WebKit/UIProcess/API/APINavigation.h:
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/NSAttributedString.mm:
(globalConfiguration):
(sourceApplicationBundleIdentifier):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(sharedProcessPool):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionContext.mm:
(toImpl):
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm:
(toImpl):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(shouldRequireUserGestureToLoadVideo):
(layoutMilestones):
(toFindOptions):
(coreEventListenerCategories):
(coreDataDetectorTypes):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(defaultApplicationNameForUserAgent):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::navigationStates):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::exceedsRenderTreeSizeSizeThreshold):
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::lockdownModeObservers):
* Source/WebKit/UIProcess/Extensions/WebExtensionAction.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionCommand.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionController.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionControllerConfiguration.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionDataRecord.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionMatchPattern.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionMenuItem.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionMessagePort.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionTab.h:
* Source/WebKit/UIProcess/Extensions/WebExtensionWindow.h:
* Source/WebKit/UIProcess/Gamepad/UIGamepadProvider.h:
* Source/WebKit/UIProcess/GeolocationPermissionRequestProxy.h:
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Inspector/WasmDebuggerDebuggable.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUtilities.cpp:
(WebKit::pageLevelMap):
(WebKit::inspectorLevelForPage):
(WebKit::allInspectorProcessPools):
(WebKit::isInspectorProcessPool):
(WebKit::isInspectorPage):
* Source/WebKit/UIProcess/Inspector/WebInspectorUtilities.h:
* Source/WebKit/UIProcess/Inspector/WebPageDebuggable.h:
* Source/WebKit/UIProcess/Launcher/ProcessLauncher.h:
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestProxy.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::networkProcessesSet):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h:
* Source/WebKit/UIProcess/PageLoadState.h:
* Source/WebKit/UIProcess/ProcessAssertion.h:
* Source/WebKit/UIProcess/ProvisionalPageProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteMonotonicTimelineRegistry.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteProgressBasedTimelineRegistry.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::allSuspendedPages):
* Source/WebKit/UIProcess/TextChecker.h:
* Source/WebKit/UIProcess/UserContent/WebUserContentControllerProxy.h:
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::proxies):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.h:
* Source/WebKit/UIProcess/UserMediaProcessManager.h:
* Source/WebKit/UIProcess/ViewGestureController.cpp:
(WebKit::deltaShouldCancelSwipe):
* Source/WebKit/UIProcess/ViewGestureController.h:
* Source/WebKit/UIProcess/ViewSnapshotStore.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/AuthenticatorPresenterCoordinator.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(alternateBlobIfNecessary):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticatorCoordinatorProxy.h:
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebGeolocationManagerProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::scaleFactorIsValid):
(WebKit::toUserMediaRequest):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPasteboardProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::liveProcessesLRU):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.cpp:
(WebKit::resolveScreenOrientationLockType):
* Source/WebKit/UIProcess/WebScreenOrientationManagerProxy.h:
* Source/WebKit/UIProcess/WebURLSchemeHandler.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataRecord.cpp:
(WebKit::hostIsInDomain):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::computeNetworkProcessAccessTypeForDataFetch):
(WebKit::computeNetworkProcessAccessTypeForDataRemoval):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
* Source/WebKit/UIProcess/ios/fullscreen/FullscreenTouchSecheuristicParameters.h:
* Source/WebKit/UIProcess/mac/DisplayCaptureSessionManager.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIPort.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h:
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIStorageArea.h:
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.h:
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm:
(toWebExtensionWebRequestResourceType):
* Source/WebKit/WebProcess/Extensions/WebExtensionContextProxy.h:
* Source/WebKit/WebProcess/Extensions/WebExtensionControllerProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.cpp:
(WebKit::RemoteImageBufferSetProxyFlushFence::create):
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDMFactory.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
* Source/WebKit/WebProcess/Gamepad/WebGamepadProvider.h:
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm:
(toWK):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
(WebKit::domNodeHandleCache):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.h:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleScriptWorld.h:
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.h:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.h:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::maximumBufferingTime):
* Source/WebKit/WebProcess/Network/WebMockContentFilterManager.h:
* Source/WebKit/WebProcess/Network/WebResourceInterceptController.h:
* Source/WebKit/WebProcess/Network/webrtc/WebRTCResolver.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::ByteRangeRequest::setStreamLoader):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/AsyncPDFRenderer.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/Storage/WebServiceWorkerProvider.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::shouldSuppressJavaScriptDialogs):
* Source/WebKit/WebProcess/WebCoreSupport/WebColorChooser.h:
* Source/WebKit/WebProcess/WebPage/FindController.h:
* Source/WebKit/WebProcess/WebPage/MomentumEventDispatcher.cpp:
(WebKit::interpolate):
(WebKit::fromFixedPoint):
* Source/WebKit/WebProcess/WebPage/PageBanner.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.h:
* Source/WebKit/WebProcess/WebPage/WebBackForwardListProxy.h:
* Source/WebKit/WebProcess/WebPage/WebCookieCache.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::isContextClick):
(WebKit::nodeFromJSHandleIdentifier):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::toRenderAsTextFlags):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h:
* Source/WebKit/WebProcess/cocoa/LaunchServicesDatabaseManager.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
* Source/WebKit/WebProcess/cocoa/UserMediaCaptureManager.h:
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.h:
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::hostAppHasEntitlement):
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::platformShouldPlaySound):
(WebPushD::connectionMatchesPendingPushMessage):

Canonical link: <a href="https://commits.webkit.org/309163@main">https://commits.webkit.org/309163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/143c6ad9c809a8d95a09992620fd2e896a2a68ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158279 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103008 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22221 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115379 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82033 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17523 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96120 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16620 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14518 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6123 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126228 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160755 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3753 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13705 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123412 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123621 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33599 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133956 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78318 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18801 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10707 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21704 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85525 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21435 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21587 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21492 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->