### PR TITLE
Adopt NODELETE in more places in Source/WTF

### DIFF
--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -903,7 +903,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END \
 // The combination of line, file, and function should be a unique number per call to this crash. This tricks the compiler into not coalescing calls to WTFCrashWithInfo.
 // The easiest way to fill these values per translation unit is to pass __LINE__, __FILE__, and WTF_PRETTY_FUNCTION.
 WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void NODELETE WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5, uint64_t misc6);
-WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5);
+WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void NODELETE WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5);
 WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4);
 WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3);
 WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1, uint64_t misc2);

--- a/Source/WTF/wtf/AutomaticThread.h
+++ b/Source/WTF/wtf/AutomaticThread.h
@@ -72,7 +72,7 @@ class AutomaticThread;
 
 class AutomaticThreadCondition : public ThreadSafeRefCounted<AutomaticThreadCondition> {
 public:
-    static WTF_EXPORT_PRIVATE Ref<AutomaticThreadCondition> create();
+    static WTF_EXPORT_PRIVATE Ref<AutomaticThreadCondition> NODELETE create();
 
     WTF_EXPORT_PRIVATE ~AutomaticThreadCondition();
     

--- a/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
+++ b/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
@@ -147,7 +147,7 @@ void ARC4RandomNumberGenerator::randomValues(std::span<uint8_t> buffer)
     }
 }
 
-ARC4RandomNumberGenerator& sharedRandomNumberGenerator()
+ARC4RandomNumberGenerator& NODELETE sharedRandomNumberGenerator()
 {
     static NeverDestroyed<ARC4RandomNumberGenerator> randomNumberGenerator;
     return randomNumberGenerator;

--- a/Source/WTF/wtf/MediaTime.h
+++ b/Source/WTF/wtf/MediaTime.h
@@ -58,9 +58,9 @@ public:
     constexpr MediaTime(int64_t value, uint32_t scale, uint8_t flags = Valid);
     MediaTime(const MediaTime&) = default;
 
-    static MediaTime createWithFloat(float floatTime);
+    static MediaTime NODELETE createWithFloat(float floatTime);
     static MediaTime createWithFloat(float floatTime, uint32_t timeScale);
-    static MediaTime createWithDouble(double doubleTime);
+    static MediaTime NODELETE createWithDouble(double doubleTime);
     static MediaTime createWithDouble(double doubleTime, uint32_t timeScale);
     static MediaTime createWithSeconds(Seconds seconds) { return createWithDouble(seconds.value()); }
 
@@ -73,9 +73,9 @@ public:
     MediaTime& operator-=(const MediaTime& rhs) { return *this = *this - rhs; }
     MediaTime operator+(const MediaTime& rhs) const;
     MediaTime operator-(const MediaTime& rhs) const;
-    MediaTime operator-() const;
+    MediaTime NODELETE operator-() const;
     MediaTime operator*(int32_t) const;
-    bool operator!() const;
+    bool NODELETE operator!() const;
     explicit operator bool() const;
 
     WTF_EXPORT_PRIVATE friend std::partial_ordering operator<=>(const MediaTime&, const MediaTime&);

--- a/Source/WTF/wtf/MetaAllocator.h
+++ b/Source/WTF/wtf/MetaAllocator.h
@@ -101,7 +101,7 @@ public:
         Locker locker { m_lock };
         return currentStatistics(locker);
     }
-    WTF_EXPORT_PRIVATE Statistics currentStatistics(const Locker<Lock>&);
+    WTF_EXPORT_PRIVATE Statistics NODELETE currentStatistics(const Locker<Lock>&);
 
     // Add more free space to the allocator. Call this directly from
     // the constructor if you wish to operate the allocator within a
@@ -189,8 +189,8 @@ private:
     
     size_t NODELETE roundUp(size_t sizeInBytes);
     
-    FreeSpaceNode* allocFreeSpaceNode();
-    WTF_EXPORT_PRIVATE void freeFreeSpaceNode(CheckedPtr<FreeSpaceNode>&&);
+    FreeSpaceNode* NODELETE allocFreeSpaceNode();
+    WTF_EXPORT_PRIVATE void NODELETE freeFreeSpaceNode(CheckedPtr<FreeSpaceNode>&&);
     
     size_t m_allocationGranule;
     size_t m_pageSize;

--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -54,7 +54,7 @@ struct ObjectIdentifierMainThreadAccessTraits {
 
 template<>
 struct ObjectIdentifierMainThreadAccessTraits<uint64_t> {
-    WTF_EXPORT_PRIVATE static uint64_t generateIdentifierInternal();
+    WTF_EXPORT_PRIVATE static uint64_t NODELETE generateIdentifierInternal();
 };
 
 template<>

--- a/Source/WTF/wtf/ParallelHelperPool.h
+++ b/Source/WTF/wtf/ParallelHelperPool.h
@@ -209,7 +209,7 @@ private:
     friend class ParallelHelperPool;
 
     void finishWithLock() WTF_REQUIRES_LOCK(*m_pool->m_lock);
-    RefPtr<SharedTask<void ()>> claimTask() WTF_REQUIRES_LOCK(*m_pool->m_lock);
+    RefPtr<SharedTask<void()>> NODELETE claimTask() WTF_REQUIRES_LOCK(*m_pool->m_lock);
     void runTask(const RefPtr<SharedTask<void ()>>&);
 
     const RefPtr<ParallelHelperPool> m_pool;

--- a/Source/WTF/wtf/PreciseSum.h
+++ b/Source/WTF/wtf/PreciseSum.h
@@ -45,9 +45,9 @@ struct SmallAccumulator final {
     size_t sizeCount; // number of added values
     bool hasPosNumber; // check if added values have at least one positive number
 
-    int carryPropagate();
+    int NODELETE carryPropagate();
     COLD void addInfNan(int64_t ivalue);
-    inline void add1NoCarry(double value);
+    inline void NODELETE add1NoCarry(double value);
     ALWAYS_INLINE void incrementWhenValueAdded(double value);
 };
 
@@ -60,9 +60,9 @@ struct LargeAccumulator final {
 
     explicit LargeAccumulator();
 
-    void addLchunkToSmall(int_fast16_t ix);
+    void NODELETE addLchunkToSmall(int_fast16_t ix);
     COLD void largeAddValueInfNan(int_fast16_t ix, uint64_t uintv);
-    void transferToSmall();
+    void NODELETE transferToSmall();
 };
 
 class XsumInterface {

--- a/Source/WTF/wtf/ProcessPrivilege.cpp
+++ b/Source/WTF/wtf/ProcessPrivilege.cpp
@@ -39,7 +39,7 @@ OptionSet<ProcessPrivilege> allPrivileges()
     };
 }
 
-static OptionSet<ProcessPrivilege>& processPrivileges()
+static OptionSet<ProcessPrivilege>& NODELETE processPrivileges()
 {
     static OptionSet<ProcessPrivilege> privileges = { };
     return privileges;

--- a/Source/WTF/wtf/ProcessPrivilege.h
+++ b/Source/WTF/wtf/ProcessPrivilege.h
@@ -35,10 +35,10 @@ enum class ProcessPrivilege {
     CanCommunicateWithWindowServer = 1 << 2,
 };
 
-WTF_EXPORT_PRIVATE void setProcessPrivileges(OptionSet<ProcessPrivilege>);
-WTF_EXPORT_PRIVATE void addProcessPrivilege(ProcessPrivilege);
-WTF_EXPORT_PRIVATE void removeProcessPrivilege(ProcessPrivilege);
-WTF_EXPORT_PRIVATE bool hasProcessPrivilege(ProcessPrivilege);
+WTF_EXPORT_PRIVATE void NODELETE setProcessPrivileges(OptionSet<ProcessPrivilege>);
+WTF_EXPORT_PRIVATE void NODELETE addProcessPrivilege(ProcessPrivilege);
+WTF_EXPORT_PRIVATE void NODELETE removeProcessPrivilege(ProcessPrivilege);
+WTF_EXPORT_PRIVATE bool NODELETE hasProcessPrivilege(ProcessPrivilege);
 WTF_EXPORT_PRIVATE OptionSet<ProcessPrivilege> allPrivileges();
 
 } // namespace WTF

--- a/Source/WTF/wtf/Seconds.h
+++ b/Source/WTF/wtf/Seconds.h
@@ -110,12 +110,12 @@ public:
 
     explicit constexpr operator bool() const { return !!m_value; }
     
-    constexpr Seconds operator+(Seconds other) const
+    constexpr Seconds NODELETE operator+(Seconds other) const
     {
         return Seconds(value() + other.value());
     }
     
-    constexpr Seconds operator-(Seconds other) const
+    constexpr Seconds NODELETE operator-(Seconds other) const
     {
         return Seconds(value() - other.value());
     }

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -162,7 +162,7 @@ public:
     static Thread& currentSingleton();
 
     // Set of all WTF::Thread created threads.
-    WTF_EXPORT_PRIVATE static ThreadSafeWeakHashSet<Thread>& allThreads();
+    WTF_EXPORT_PRIVATE static ThreadSafeWeakHashSet<Thread>& NODELETE allThreads();
 
     WTF_EXPORT_PRIVATE unsigned numberOfThreadGroups();
 

--- a/Source/WTF/wtf/TimeWithDynamicClockType.h
+++ b/Source/WTF/wtf/TimeWithDynamicClockType.h
@@ -112,7 +112,7 @@ public:
         return withSameClockAndRawSeconds(m_value + other.value());
     }
     
-    TimeWithDynamicClockType operator-(Seconds other) const
+    TimeWithDynamicClockType NODELETE operator-(Seconds other) const
     {
         return withSameClockAndRawSeconds(m_value - other.value());
     }

--- a/Source/WTF/wtf/TimingScope.cpp
+++ b/Source/WTF/wtf/TimingScope.cpp
@@ -43,7 +43,7 @@ public:
         unsigned callCount { 0 };
         Seconds maxDuration;
         
-        Seconds meanDuration() const { return totalDuration / callCount; }
+        Seconds NODELETE meanDuration() const { return totalDuration / callCount; }
     };
 
     State() = default;

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -1323,7 +1323,7 @@ Vector<KeyValuePair<String, String>> differingQueryParameters(const URL& firstUR
     return differingQueryParameters;
 }
 
-static StringView substringIgnoringQueryAndFragments(const URL& url LIFETIME_BOUND)
+static StringView NODELETE substringIgnoringQueryAndFragments(const URL& url LIFETIME_BOUND)
 {
     if (!url.isValid())
         return StringView(url.string());

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -147,20 +147,20 @@ public:
     // Unlike user() and password(), encodedUser() and encodedPassword() don't decode escape sequences.
     // This is necessary for accurate round-tripping, because encoding doesn't encode '%' characters.
 
-    WTF_EXPORT_PRIVATE StringView protocol() const LIFETIME_BOUND;
-    WTF_EXPORT_PRIVATE StringView encodedUser() const LIFETIME_BOUND;
-    WTF_EXPORT_PRIVATE StringView encodedPassword() const LIFETIME_BOUND;
-    WTF_EXPORT_PRIVATE StringView host() const LIFETIME_BOUND;
+    WTF_EXPORT_PRIVATE StringView NODELETE protocol() const LIFETIME_BOUND;
+    WTF_EXPORT_PRIVATE StringView NODELETE encodedUser() const LIFETIME_BOUND;
+    WTF_EXPORT_PRIVATE StringView NODELETE encodedPassword() const LIFETIME_BOUND;
+    WTF_EXPORT_PRIVATE StringView NODELETE host() const LIFETIME_BOUND;
     WTF_EXPORT_PRIVATE std::optional<uint16_t> port() const;
-    WTF_EXPORT_PRIVATE StringView path() const LIFETIME_BOUND;
-    WTF_EXPORT_PRIVATE StringView lastPathComponent() const LIFETIME_BOUND;
-    WTF_EXPORT_PRIVATE StringView query() const LIFETIME_BOUND;
-    WTF_EXPORT_PRIVATE StringView fragmentIdentifier() const LIFETIME_BOUND;
+    WTF_EXPORT_PRIVATE StringView NODELETE path() const LIFETIME_BOUND;
+    WTF_EXPORT_PRIVATE StringView NODELETE lastPathComponent() const LIFETIME_BOUND;
+    WTF_EXPORT_PRIVATE StringView NODELETE query() const LIFETIME_BOUND;
+    WTF_EXPORT_PRIVATE StringView NODELETE fragmentIdentifier() const LIFETIME_BOUND;
 
-    WTF_EXPORT_PRIVATE StringView queryWithLeadingQuestionMark() const LIFETIME_BOUND;
-    WTF_EXPORT_PRIVATE StringView fragmentIdentifierWithLeadingNumberSign() const LIFETIME_BOUND;
-    WTF_EXPORT_PRIVATE StringView viewWithoutQueryOrFragmentIdentifier() const LIFETIME_BOUND;
-    WTF_EXPORT_PRIVATE StringView viewWithoutFragmentIdentifier() const LIFETIME_BOUND;
+    WTF_EXPORT_PRIVATE StringView NODELETE queryWithLeadingQuestionMark() const LIFETIME_BOUND;
+    WTF_EXPORT_PRIVATE StringView NODELETE fragmentIdentifierWithLeadingNumberSign() const LIFETIME_BOUND;
+    WTF_EXPORT_PRIVATE StringView NODELETE viewWithoutQueryOrFragmentIdentifier() const LIFETIME_BOUND;
+    WTF_EXPORT_PRIVATE StringView NODELETE viewWithoutFragmentIdentifier() const LIFETIME_BOUND;
     WTF_EXPORT_PRIVATE String stringWithoutFragmentIdentifier() const;
 
     WTF_EXPORT_PRIVATE String protocolHostAndPort() const;
@@ -193,7 +193,7 @@ public:
     WTF_EXPORT_PRIVATE bool isAboutBlank() const;
     WTF_EXPORT_PRIVATE bool isAboutSrcDoc() const;
 
-    WTF_EXPORT_PRIVATE bool isMatchingDomain(StringView) const;
+    WTF_EXPORT_PRIVATE bool NODELETE isMatchingDomain(StringView) const;
 
     WTF_EXPORT_PRIVATE bool setProtocol(StringView);
     WTF_EXPORT_PRIVATE bool setHost(StringView);
@@ -297,11 +297,11 @@ static_assert(sizeof(URL) == sizeof(String) + 8 * sizeof(unsigned), "URL should 
 bool operator==(const URL&, const URL&);
 bool operator==(const URL&, const String&);
 
-WTF_EXPORT_PRIVATE bool equalIgnoringFragmentIdentifier(const URL&, const URL&);
+WTF_EXPORT_PRIVATE bool NODELETE equalIgnoringFragmentIdentifier(const URL&, const URL&);
 WTF_EXPORT_PRIVATE bool protocolHostAndPortAreEqual(const URL&, const URL&);
 WTF_EXPORT_PRIVATE Vector<KeyValuePair<String, String>> differingQueryParameters(const URL&, const URL&);
 WTF_EXPORT_PRIVATE Vector<KeyValuePair<String, String>> queryParameters(const URL&);
-WTF_EXPORT_PRIVATE bool isEqualIgnoringQueryAndFragments(const URL&, const URL&);
+WTF_EXPORT_PRIVATE bool NODELETE isEqualIgnoringQueryAndFragments(const URL&, const URL&);
 
 // Returns the parameters that were removed (including duplicates), in the order that they appear in the URL.
 WTF_EXPORT_PRIVATE Vector<String> removeQueryParameters(URL&, const HashSet<String>&);

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -356,7 +356,7 @@ static bool isLookalikeCharacter(const std::optional<char32_t>& previousCodePoin
     }
 }
 
-static void addScriptToIDNAllowedScriptList(int32_t script)
+static void NODELETE addScriptToIDNAllowedScriptList(int32_t script)
 {
     if (script >= 0 && script < scriptCodeLimit) {
         size_t index = script / 32;
@@ -365,7 +365,7 @@ static void addScriptToIDNAllowedScriptList(int32_t script)
     }
 }
 
-static void addScriptToIDNAllowedScriptList(UScriptCode script)
+static void NODELETE addScriptToIDNAllowedScriptList(UScriptCode script)
 {
     addScriptToIDNAllowedScriptList(static_cast<int32_t>(script));
 }

--- a/Source/WTF/wtf/URLParser.h
+++ b/Source/WTF/wtf/URLParser.h
@@ -128,7 +128,7 @@ private:
     bool copyBaseWindowsDriveLetter(const URL&);
     StringView parsedDataView(size_t start, size_t length) LIFETIME_BOUND;
     char16_t parsedDataView(size_t position);
-    template<typename CharacterType> bool subdomainStartsWithXNDashDash(CodePointIterator<CharacterType>);
+    template<typename CharacterType> bool NODELETE subdomainStartsWithXNDashDash(CodePointIterator<CharacterType>);
     bool subdomainStartsWithXNDashDash(StringImpl&);
 
     bool NODELETE needsNonSpecialDotSlash() const;
@@ -149,7 +149,7 @@ private:
 
     enum class URLPart;
     template<typename CharacterType> void copyURLPartsUntil(const URL& base, URLPart, const CodePointIterator<CharacterType>&, const URLTextEncoding*&);
-    template<typename CharacterType> bool isForbiddenHostCodePoint(CharacterType);
+    template<typename CharacterType> bool NODELETE isForbiddenHostCodePoint(CharacterType);
     template<typename CharacterType> bool isForbiddenDomainCodePoint(CharacterType);
     static size_t NODELETE urlLengthUntilPart(const URL&, URLPart);
     void popPath();

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -145,7 +145,7 @@ WTF_EXPORT_PRIVATE const SDKAlignedBehaviors& sdkAlignedBehaviors();
 WTF_EXPORT_PRIVATE void NODELETE setSDKAlignedBehaviors(SDKAlignedBehaviors);
 
 WTF_EXPORT_PRIVATE void enableAllSDKAlignedBehaviors();
-WTF_EXPORT_PRIVATE void disableAllSDKAlignedBehaviors();
+WTF_EXPORT_PRIVATE void NODELETE disableAllSDKAlignedBehaviors();
 
 WTF_EXPORT_PRIVATE bool linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior);
 

--- a/Source/WTF/wtf/posix/CPUTimePOSIX.cpp
+++ b/Source/WTF/wtf/posix/CPUTimePOSIX.cpp
@@ -32,7 +32,7 @@
 
 namespace WTF {
 
-static Seconds timevalToSeconds(const struct timeval& value)
+static Seconds NODELETE timevalToSeconds(const struct timeval& value)
 {
     return Seconds(value.tv_sec) + Seconds::fromMicroseconds(value.tv_usec);
 }

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -266,7 +266,7 @@ struct Latin1BufferTranslator {
 template<typename CharType>
 struct BufferFromStaticDataTranslator {
     using Buffer = HashTranslatorCharBuffer<CharType>;
-    static unsigned hash(const Buffer& buf)
+    static unsigned NODELETE hash(const Buffer& buf)
     {
         return buf.hash;
     }

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -110,7 +110,7 @@ private:
     RefPtr<CStringBuffer> m_buffer;
 } SWIFT_ESCAPABLE;
 
-WTF_EXPORT_PRIVATE bool operator==(const CString&, const CString&);
+WTF_EXPORT_PRIVATE bool NODELETE operator==(const CString&, const CString&);
 WTF_EXPORT_PRIVATE bool operator<(const CString&, const CString&);
 
 WTF_EXPORT_PRIVATE CString convertToASCIILowercase(std::span<const char8_t>);
@@ -118,7 +118,7 @@ WTF_EXPORT_PRIVATE CString convertToASCIIUppercase(std::span<const char8_t>);
 
 struct CStringHash {
     static unsigned hash(const CString& string) { return string.hash(); }
-    WTF_EXPORT_PRIVATE static bool equal(const CString& a, const CString& b);
+    WTF_EXPORT_PRIVATE static bool NODELETE equal(const CString& a, const CString& b);
     static constexpr bool safeToCompareToEmptyOrDeleted = true;
 };
 

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -99,7 +99,7 @@ public:
     WTF_EXPORT_PRIVATE bool NODELETE shouldShrinkToFit() const;
     WTF_EXPORT_PRIVATE void shrinkToFit();
 
-    WTF_EXPORT_PRIVATE bool containsOnlyASCII() const;
+    WTF_EXPORT_PRIVATE bool NODELETE containsOnlyASCII() const;
 
 private:
     static unsigned expandedCapacity(unsigned capacity, unsigned requiredCapacity);

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -476,7 +476,7 @@ public:
     bool containsOnlyLatin1() const;
     template<bool isSpecialCharacter(char16_t)> bool containsOnly() const;
 
-    size_t find(Latin1Character, size_t start = 0);
+    size_t NODELETE find(Latin1Character, size_t start = 0);
     size_t find(char, size_t start = 0);
     size_t find(char16_t, size_t start = 0);
     template<typename CodeUnitMatchFunction>

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -231,7 +231,7 @@ private:
 
     WTF_EXPORT_PRIVATE bool NODELETE underlyingStringIsValidImpl() const;
     WTF_EXPORT_PRIVATE void NODELETE setUnderlyingStringImpl(const StringImpl*);
-    WTF_EXPORT_PRIVATE void setUnderlyingStringImpl(const StringView&);
+    WTF_EXPORT_PRIVATE void NODELETE setUnderlyingStringImpl(const StringView&);
 
 #if CHECK_STRINGVIEW_LIFETIME
     bool underlyingStringIsValid() const { return underlyingStringIsValidImpl(); }
@@ -868,18 +868,18 @@ public:
     using pointer = value_type*;
     using reference = value_type&;
 
-    StringView operator*() const;
+    StringView NODELETE operator*() const;
 
-    WTF_EXPORT_PRIVATE Iterator& operator++();
+    WTF_EXPORT_PRIVATE Iterator& NODELETE operator++();
 
-    bool operator==(const Iterator&) const;
+    bool NODELETE operator==(const Iterator&) const;
 
 private:
     enum PositionTag { AtEnd };
     Iterator(const SplitResult&);
     Iterator(const SplitResult&, PositionTag);
 
-    WTF_EXPORT_PRIVATE void findNextSubstring();
+    WTF_EXPORT_PRIVATE void NODELETE findNextSubstring();
 
     friend SplitResult;
 

--- a/Source/WTF/wtf/text/TextStream.cpp
+++ b/Source/WTF/wtf/text/TextStream.cpp
@@ -38,7 +38,7 @@ namespace WTF {
 
 static constexpr size_t printBufferSize = 100; // large enough for any integer or floating point value in string format, including trailing null character
 
-static inline bool hasFractions(double val)
+static inline bool NODELETE hasFractions(double val)
 {
     static constexpr double s_epsilon = 0.0001;
     int ival = static_cast<int>(val);

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -132,7 +132,7 @@ public:
     char16_t operator[](unsigned index) const { return characterAt(index); }
 
     WTF_EXPORT_PRIVATE static String NODELETE number(int);
-    WTF_EXPORT_PRIVATE static String number(unsigned);
+    WTF_EXPORT_PRIVATE static String NODELETE number(unsigned);
     WTF_EXPORT_PRIVATE static String number(long);
     WTF_EXPORT_PRIVATE static String number(unsigned long);
     WTF_EXPORT_PRIVATE static String number(long long);
@@ -169,7 +169,7 @@ public:
     WTF_EXPORT_PRIVATE Expected<Vector<char16_t>, UTF8ConversionError> charactersWithNullTermination() const;
     WTF_EXPORT_PRIVATE Expected<Vector<char16_t>, UTF8ConversionError> charactersWithoutNullTermination() const;
 
-    WTF_EXPORT_PRIVATE char32_t characterStartingAt(unsigned) const;
+    WTF_EXPORT_PRIVATE char32_t NODELETE characterStartingAt(unsigned) const;
 
     bool contains(char16_t character) const { return find(character) != notFound; }
     bool contains(ASCIILiteral literal) const { return find(literal) != notFound; }

--- a/Source/WTF/wtf/unicode/UTF8Conversion.h
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.h
@@ -47,11 +47,11 @@ template<typename CharacterType> struct ConversionResult {
 
 WTF_EXPORT_PRIVATE ConversionResult<char16_t> convert(std::span<const char8_t>, std::span<char16_t>);
 WTF_EXPORT_PRIVATE ConversionResult<char8_t> convert(std::span<const char16_t>, std::span<char8_t>);
-WTF_EXPORT_PRIVATE ConversionResult<char8_t> convert(std::span<const Latin1Character>, std::span<char8_t>);
+WTF_EXPORT_PRIVATE ConversionResult<char8_t> NODELETE convert(std::span<const Latin1Character>, std::span<char8_t>);
 
 // Invalid sequences are converted to the replacement character.
 WTF_EXPORT_PRIVATE ConversionResult<char16_t> convertReplacingInvalidSequences(std::span<const char8_t>, std::span<char16_t>);
-WTF_EXPORT_PRIVATE ConversionResult<char8_t> convertReplacingInvalidSequences(std::span<const char16_t>, std::span<char8_t>);
+WTF_EXPORT_PRIVATE ConversionResult<char8_t> NODELETE convertReplacingInvalidSequences(std::span<const char16_t>, std::span<char8_t>);
 
 WTF_EXPORT_PRIVATE bool equal(std::span<const char16_t>, std::span<const char8_t>);
 WTF_EXPORT_PRIVATE bool equal(std::span<const Latin1Character>, std::span<const char8_t>);


### PR DESCRIPTION
#### 5bc5695068ef3e152080206c78510abed97e3a39
<pre>
Adopt NODELETE in more places in Source/WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=309233">https://bugs.webkit.org/show_bug.cgi?id=309233</a>

Reviewed by Ryosuke Niwa.

* Source/WTF/wtf/Assertions.h:
* Source/WTF/wtf/AutomaticThread.h:
* Source/WTF/wtf/CryptographicallyRandomNumber.cpp:
* Source/WTF/wtf/MediaTime.h:
* Source/WTF/wtf/MetaAllocator.h:
* Source/WTF/wtf/ObjectIdentifier.h:
* Source/WTF/wtf/ParallelHelperPool.h:
* Source/WTF/wtf/PreciseSum.h:
* Source/WTF/wtf/ProcessPrivilege.cpp:
(WTF::processPrivileges):
* Source/WTF/wtf/ProcessPrivilege.h:
* Source/WTF/wtf/Seconds.h:
* Source/WTF/wtf/Threading.h:
* Source/WTF/wtf/TimeWithDynamicClockType.h:
* Source/WTF/wtf/TimingScope.cpp:
* Source/WTF/wtf/URL.cpp:
(WTF::substringIgnoringQueryAndFragments):
* Source/WTF/wtf/URL.h:
* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::addScriptToIDNAllowedScriptList):
* Source/WTF/wtf/URLParser.h:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/posix/CPUTimePOSIX.cpp:
(WTF::timevalToSeconds):
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::BufferFromStaticDataTranslator::hash):
* Source/WTF/wtf/text/CString.h:
* Source/WTF/wtf/text/StringBuilder.h:
* Source/WTF/wtf/text/StringImpl.h:
* Source/WTF/wtf/text/StringView.h:
* Source/WTF/wtf/text/TextStream.cpp:
(WTF::hasFractions):
* Source/WTF/wtf/text/WTFString.h:
* Source/WTF/wtf/unicode/UTF8Conversion.h:

Canonical link: <a href="https://commits.webkit.org/308768@main">https://commits.webkit.org/308768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac14517a2725badccd733b8b748b3af34d374642

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14668 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157070 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114399 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151346 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/16626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133225 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95169 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13563 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4506 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140353 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159403 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9173 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2537 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12651 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122444 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122665 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33354 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132948 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77031 "Built successfully") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9695 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179813 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20487 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84272 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20219 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20364 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->