### PR TITLE
Adopt NODELETE in more places in Source/JavaScriptCore

### DIFF
--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -24906,7 +24906,7 @@ IGNORE_CLANG_WARNINGS_END
         callPreflight(codeOriginDescriptionOfCallSite());
     }
 
-    CodeOrigin codeOriginDescriptionOfCallSite() const
+    CodeOrigin NODELETE codeOriginDescriptionOfCallSite() const
     {
         CodeOrigin codeOrigin = m_origin.semantic;
         switch (m_node->op()) {

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1058,7 +1058,7 @@ static URL currentWorkingDirectory()
 // FIXME: We may wish to support module specifiers beginning with a (back)slash on Windows. We could either:
 // - align with V8 and SM:  treat '/foo' as './foo'
 // - align with PowerShell: treat '/foo' as 'C:/foo'
-static bool isAbsolutePath(StringView path)
+static bool NODELETE isAbsolutePath(StringView path)
 {
 #if OS(WINDOWS)
     // Just look for local drives like C:\.

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -5526,7 +5526,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseArrowFunctio
     return context.createArrowFunctionExpr(location, info);
 }
 
-static const char* operatorString(bool prefix, unsigned tok)
+static const char* NODELETE operatorString(bool prefix, unsigned tok)
 {
     switch (tok) {
     case MINUSMINUS:

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -1866,7 +1866,7 @@ private:
     template <class TreeBuilder> ALWAYS_INLINE bool isSimpleAssignmentTarget(TreeBuilder&, TreeExpression, bool ignoreStrictCheck = false);
 
     ALWAYS_INLINE int NODELETE isBinaryOperator(JSTokenType);
-    bool allowAutomaticSemicolon();
+    bool NODELETE allowAutomaticSemicolon();
     
     bool autoSemiColon()
     {

--- a/Source/JavaScriptCore/runtime/JSDateMath.h
+++ b/Source/JavaScriptCore/runtime/JSDateMath.h
@@ -114,7 +114,7 @@ public:
 
     String defaultTimeZone();
     String timeZoneDisplayName(bool isDST);
-    Ref<DateInstanceData> cachedDateInstanceData(double millisecondsFromEpoch);
+    Ref<DateInstanceData> NODELETE cachedDateInstanceData(double millisecondsFromEpoch);
 
     void msToGregorianDateTime(double millisecondsFromEpoch, TimeType outputTimeType, GregorianDateTime&);
     double gregorianDateTimeToMS(const GregorianDateTime&, double milliseconds, TimeType);
@@ -158,7 +158,7 @@ private:
         LocalTimeOffset localTimeOffset(DateCache&, int64_t millisecondsFromEpoch, TimeType);
 
     private:
-        LocalTimeOffsetCache* leastRecentlyUsed(LocalTimeOffsetCache* exclude);
+        LocalTimeOffsetCache* NODELETE leastRecentlyUsed(LocalTimeOffsetCache* exclude);
         std::tuple<LocalTimeOffsetCache*, LocalTimeOffsetCache*> probe(int64_t millisecondsFromEpoch);
         void extendTheAfterCache(int64_t millisecondsFromEpoch, LocalTimeOffset);
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -165,7 +165,7 @@ public:
 
         void dump(PrintStream& out) const;
 
-        bool operator==(Location other) const;
+        bool NODELETE operator==(Location other) const;
 
         Kind NODELETE kind() const;
 
@@ -438,8 +438,8 @@ public:
         };
 
         static RegisterBinding none() { return RegisterBinding(); }
-        static RegisterBinding fromValue(Value value);
-        static RegisterBinding scratch();
+        static RegisterBinding NODELETE fromValue(Value);
+        static RegisterBinding NODELETE scratch();
 
         Value NODELETE toValue() const;
 
@@ -849,7 +849,7 @@ public:
 
         void linkIfBranch(MacroAssembler::AbstractMacroAssemblerType* masm);
 
-        void dump(PrintStream& out) const;
+        void NODELETE dump(PrintStream& out) const;
 
         LocalOrTempIndex NODELETE enclosedHeight() const;
 
@@ -1377,7 +1377,7 @@ public:
 
     TruncationKind NODELETE truncationKind(OpType truncationOp);
 
-    TruncationKind truncationKind(Ext1OpType truncationOp);
+    TruncationKind NODELETE truncationKind(Ext1OpType truncationOp);
 
     FloatingPointRange NODELETE lookupTruncationRange(TruncationKind truncationKind);
 
@@ -1394,7 +1394,7 @@ public:
 
     [[nodiscard]] PartialResult addI31GetU(TypedExpression value, ExpressionType& result);
 
-    const Ref<TypeDefinition> getTypeDefinition(uint32_t typeIndex);
+    const Ref<TypeDefinition> NODELETE getTypeDefinition(uint32_t typeIndex);
 
     // Given a type index, verify that it's an array type and return its expansion
     const ArrayType* getArrayTypeDefinition(uint32_t typeIndex);
@@ -1926,17 +1926,17 @@ public:
     // Control flow
     [[nodiscard]] ControlData addTopLevel(BlockSignature&&);
 
-    bool hasLoops() const;
+    bool NODELETE hasLoops() const;
 
     MacroAssembler::Label addLoopOSREntrypoint();
 
     [[nodiscard]] PartialResult addBlock(BlockSignature&&, Stack& enclosingStack, ControlType& result, Stack& newStack);
 
-    B3::Type toB3Type(Type type);
+    B3::Type NODELETE toB3Type(Type);
 
-    B3::Type toB3Type(TypeKind kind);
+    B3::Type toB3Type(TypeKind);
 
-    B3::ValueRep toB3Rep(Location location);
+    B3::ValueRep toB3Rep(Location);
 
     StackMap makeStackMap(const ControlData& data, Stack& enclosingStack);
 
@@ -2004,7 +2004,7 @@ public:
         BranchNotFolded
     };
 
-    [[nodiscard]] BranchFoldResult tryFoldFusedBranchCompare(OpType, ExpressionType);
+    [[nodiscard]] BranchFoldResult NODELETE tryFoldFusedBranchCompare(OpType, ExpressionType);
     [[nodiscard]] Jump emitFusedBranchCompareBranch(OpType, ExpressionType, Location);
     [[nodiscard]] BranchFoldResult tryFoldFusedBranchCompare(OpType, ExpressionType, ExpressionType);
     [[nodiscard]] Jump emitFusedBranchCompareBranch(OpType, ExpressionType, Location, ExpressionType, Location);
@@ -2032,9 +2032,9 @@ public:
     template<typename Args>
     void saveValuesAcrossCallAndPassArguments(const Args& arguments, const CallInformation& callInfo, const TypeDefinition& signature);
 
-    void slowPathSpillBindings(const RegisterBindings& bindings);
+    void slowPathSpillBindings(const RegisterBindings&);
     void slowPathRestoreBindings(const RegisterBindings&);
-    void restoreValuesAfterCall(const CallInformation& callInfo);
+    void NODELETE restoreValuesAfterCall(const CallInformation&);
 
     template<size_t N>
     void returnValuesFromCall(Vector<Value, N>& results, const FunctionSignature& functionType, const CallInformation& callInfo);
@@ -2067,7 +2067,7 @@ public:
 
     // SIMD
 
-    bool usesSIMD();
+    bool NODELETE usesSIMD();
 
     void notifyFunctionUsesSIMD();
 
@@ -2118,20 +2118,20 @@ public:
     PartialResult addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&);
 
     void dump(const ControlStack&, const Stack*);
-    void didFinishParsingLocals();
-    void didPopValueFromStack(ExpressionType, ASCIILiteral);
+    void NODELETE didFinishParsingLocals();
+    void NODELETE didPopValueFromStack(ExpressionType, ASCIILiteral);
 
     void finalize();
 
-    Vector<UnlinkedHandlerInfo>&& takeExceptionHandlers();
-    FixedBitVector&& takeDirectCallees();
-    Vector<CCallHelpers::Label>&& takeCatchEntrypoints();
+    Vector<UnlinkedHandlerInfo>&& NODELETE takeExceptionHandlers();
+    FixedBitVector&& NODELETE takeDirectCallees();
+    Vector<CCallHelpers::Label>&& NODELETE takeCatchEntrypoints();
     Box<PCToCodeOriginMapBuilder> takePCToCodeOriginMapBuilder();
 
     std::unique_ptr<BBQDisassembler> takeDisassembler();
 
 private:
-    static bool isScratch(Location loc);
+    static bool NODELETE isScratch(Location);
 
     void emitStoreConst(Value constant, Location dst);
     void emitStoreConst(StorageType, Value constant, BaseIndex dst);
@@ -2173,32 +2173,32 @@ private:
     template<size_t N, typename OverflowHandler>
     void emitShuffle(Vector<Value, N, OverflowHandler>& srcVector, Vector<Location, N, OverflowHandler>& dstVector);
 
-    ControlData& currentControlData();
+    ControlData& NODELETE currentControlData();
 
-    void setLRUKey(Location, LocalOrTempIndex key);
-    void increaseLRUKey(Location);
+    void NODELETE setLRUKey(Location, LocalOrTempIndex key);
+    void NODELETE increaseLRUKey(Location);
     uint32_t nextLRUKey() { return ++m_lastUseTimestamp; }
 
-    Location bind(Value value);
+    Location bind(Value);
 
-    Location allocate(Value value);
+    Location allocate(Value);
 
-    Location allocateWithHint(Value value, Location hint);
+    Location allocateWithHint(Value, Location hint);
 
-    Location locationOfWithoutBinding(Value value);
+    Location NODELETE locationOfWithoutBinding(Value);
 
-    Location locationOf(Value value);
+    Location locationOf(Value);
 
-    Location loadIfNecessary(Value value);
+    Location loadIfNecessary(Value);
 
     // This should generally be avoided if possible but sometimes you just *need* a value in a register.
     Location materializeToGPR(Value, std::optional<ScratchScope<1, 0>>&);
 
-    void consume(Value value);
+    void consume(Value);
 
-    Location bind(Value value, Location loc);
+    Location bind(Value, Location);
 
-    void unbind(Value value, Location loc);
+    void unbind(Value, Location);
 
     void unbindAllRegisters();
 
@@ -2211,7 +2211,7 @@ private:
     void clobber(FPRReg fpr) { m_fprAllocator.clobber(*this, fpr); }
     void clobber(JSC::Reg reg) { reg.isGPR() ? clobber(reg.gpr()) : clobber(reg.fpr()); }
 
-    Location canonicalSlot(Value value);
+    Location NODELETE canonicalSlot(Value);
 
     Location allocateStack(Value value);
 

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp
@@ -80,7 +80,7 @@ public:
     Workers() = default;
     ~Workers() = default;
 
-    static Workers& singleton()
+    static Workers& NODELETE singleton()
     {
         static Workers* workers = new Workers();
         return *workers;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h
@@ -86,7 +86,7 @@ public:
     inline void set(VM&, uint32_t index, v128_t value);
 
     void fill(VM&, uint32_t, uint64_t, uint32_t);
-    void fill(VM&, uint32_t, v128_t, uint32_t);
+    void NODELETE fill(VM&, uint32_t, v128_t, uint32_t);
     void copy(VM&, JSWebAssemblyArray&, uint32_t, uint32_t, uint32_t);
 
 #if ASSERT_ENABLED


### PR DESCRIPTION
#### b9a7c919ca1f4632a0d1fac45f536b36207483d8
<pre>
Adopt NODELETE in more places in Source/JavaScriptCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=309234">https://bugs.webkit.org/show_bug.cgi?id=309234</a>

Reviewed by Geoffrey Garen.

* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/jsc.cpp:
(isAbsolutePath):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::operatorString):
* Source/JavaScriptCore/parser/Parser.h:
* Source/JavaScriptCore/runtime/JSDateMath.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.cpp:
(ExecutionHandlerTestSupport::Workers::singleton):
* Source/JavaScriptCore/wasm/js/JSWebAssemblyArray.h:

Canonical link: <a href="https://commits.webkit.org/308751@main">https://commits.webkit.org/308751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86d6ecd65ca0f0aa4ba9115a7ba8546898a420e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156960 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114322 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f41dc47f-8836-47bb-b9f1-430912f30da8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16558 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133143 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95092 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/814159af-a97d-482b-9b95-7224365e3329) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15674 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13478 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4397 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140244 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125282 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159293 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9064 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2428 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122353 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20761 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17445 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122574 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33345 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20770 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132872 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76921 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17988 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9611 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179704 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20378 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84163 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46004 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20110 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20255 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20164 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->