### PR TITLE
Adopt NODELETE in more places in Source/WebKitLegacy

### DIFF
--- a/Source/WebKitLegacy/Storage/StorageNamespaceImpl.cpp
+++ b/Source/WebKitLegacy/Storage/StorageNamespaceImpl.cpp
@@ -40,7 +40,7 @@ using namespace WebCore;
 
 namespace WebKit {
 
-static HashMap<String, WeakRef<StorageNamespaceImpl>>& localStorageNamespaceMap()
+static HashMap<String, WeakRef<StorageNamespaceImpl>>& NODELETE localStorageNamespaceMap()
 {
     static NeverDestroyed<HashMap<String, WeakRef<StorageNamespaceImpl>>> localStorageNamespaceMap;
 

--- a/Source/WebKitLegacy/Storage/StorageThread.cpp
+++ b/Source/WebKitLegacy/Storage/StorageThread.cpp
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-static HashSet<CheckedRef<StorageThread>>& activeStorageThreads()
+static HashSet<CheckedRef<StorageThread>>& NODELETE activeStorageThreads()
 {
     ASSERT(isMainThread());
     static NeverDestroyed<HashSet<CheckedRef<StorageThread>>> threads;

--- a/Source/WebKitLegacy/Storage/StorageTracker.h
+++ b/Source/WebKitLegacy/Storage/StorageTracker.h
@@ -47,7 +47,7 @@ class StorageTracker {
     WTF_MAKE_NONCOPYABLE(StorageTracker);
     WTF_MAKE_TZONE_ALLOCATED(StorageTracker);
 public:
-    static void initializeTracker(const String& storagePath, WebCore::StorageTrackerClient*);
+    static void NODELETE initializeTracker(const String& storagePath, WebCore::StorageTrackerClient*);
     static StorageTracker& tracker();
 
     void setOriginDetails(const String& originIdentifier, const String& databaseFile);
@@ -87,7 +87,7 @@ private:
 
     void originFilePaths(Vector<String>& paths);
     
-    void setIsActive(bool);
+    void NODELETE setIsActive(bool);
 
     // Sync to disk on background thread.
     void syncDeleteAllOrigins();

--- a/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp
+++ b/Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp
@@ -34,7 +34,7 @@ using namespace WebCore;
 
 namespace WebKit {
 
-static HashSet<WeakRef<WebStorageNamespaceProvider>>& storageNamespaceProviders()
+static HashSet<WeakRef<WebStorageNamespaceProvider>>& NODELETE storageNamespaceProviders()
 {
     static NeverDestroyed<HashSet<WeakRef<WebStorageNamespaceProvider>>> storageNamespaceProviders;
 

--- a/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.h
+++ b/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.h
@@ -56,7 +56,7 @@ public:
     const String& nameOverride() const final { return m_nameOverride; }
     void setNameOverride(const String&);
 
-    void detachFromPage();
+    void NODELETE detachFromPage();
 
 private:
     LegacyWebPageDebuggable(LegacyWebPageInspectorController&, WebCore::Page&);

--- a/Source/WebKitLegacy/WebCoreSupport/NetworkStorageSessionMap.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/NetworkStorageSessionMap.cpp
@@ -40,7 +40,7 @@ static std::unique_ptr<WebCore::NetworkStorageSession>& defaultNetworkStorageSes
     return session;
 }
 
-static HashMap<PAL::SessionID, std::unique_ptr<WebCore::NetworkStorageSession>>& globalSessionMap()
+static HashMap<PAL::SessionID, std::unique_ptr<WebCore::NetworkStorageSession>>& NODELETE globalSessionMap()
 {
     static NeverDestroyed<HashMap<PAL::SessionID, std::unique_ptr<WebCore::NetworkStorageSession>>> map;
     return map;

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.cpp
@@ -64,7 +64,7 @@ void SocketStreamHandleImpl::platformSend(std::span<const uint8_t> data, Functio
     return completionHandler(true);
 }
 
-static std::span<const uint8_t> removeTerminationCharacters(std::span<const uint8_t> data)
+static std::span<const uint8_t> NODELETE removeTerminationCharacters(std::span<const uint8_t> data)
 {
 #ifndef NDEBUG
     ASSERT(data.size() > 2);

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp
@@ -71,7 +71,7 @@ static inline CFRunLoopRef callbacksRunLoop()
 #endif
 }
 
-static inline auto callbacksRunLoopMode()
+static inline auto NODELETE callbacksRunLoopMode()
 {
     return kCFRunLoopCommonModes;
 }

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h
@@ -115,14 +115,14 @@ private:
         void schedule(WebCore::ResourceLoader*, WebCore::ResourceLoadPriority = WebCore::ResourceLoadPriority::VeryLow);
         void addLoadInProgress(WebCore::ResourceLoader*);
         void remove(WebCore::ResourceLoader*);
-        bool hasRequests() const;
+        bool NODELETE hasRequests() const;
         bool limitRequests(WebCore::ResourceLoadPriority) const;
 
         typedef Deque<RefPtr<WebCore::ResourceLoader>> RequestQueue;
         RequestQueue& requestsPending(WebCore::ResourceLoadPriority priority) { return m_requestsPending[priorityToIndex(priority)]; }
 
     private:
-        static unsigned priorityToIndex(WebCore::ResourceLoadPriority);
+        static unsigned NODELETE priorityToIndex(WebCore::ResourceLoadPriority);
 
         std::array<RequestQueue, WebCore::resourceLoadPriorityCount> m_requestsPending;
         typedef HashSet<RefPtr<WebCore::ResourceLoader>> RequestMap;

--- a/Source/WebKitLegacy/WebCoreSupport/WebViewGroup.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebViewGroup.cpp
@@ -35,7 +35,7 @@
 using namespace WebCore;
 
 // Any named groups will live for the lifetime of the process, thanks to the reference held by the RefPtr.
-static HashMap<String, RefPtr<WebViewGroup>>& webViewGroups()
+static HashMap<String, RefPtr<WebViewGroup>>& NODELETE webViewGroups()
 {
     static NeverDestroyed<HashMap<String, RefPtr<WebViewGroup>>> webViewGroups;
 

--- a/Source/WebKitLegacy/mac/DOM/DOMInternal.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMInternal.mm
@@ -49,7 +49,7 @@
 static Lock wrapperCacheLock;
 static HashMap<DOMObjectInternal*, NSObject *>& wrapperCache() WTF_REQUIRES_LOCK(wrapperCacheLock)
 #else
-static HashMap<DOMObjectInternal*, NSObject *>& wrapperCache()
+static HashMap<DOMObjectInternal*, NSObject *>& NODELETE wrapperCache()
 #endif
 {
     static NeverDestroyed<HashMap<DOMObjectInternal*, NSObject *>> map;

--- a/Source/WebKitLegacy/mac/DOM/DOMUtility.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMUtility.mm
@@ -118,7 +118,7 @@ static void disconnectWindowWrapper(WebScriptObject *windowWrapper)
     [(DOMAbstractView *)windowWrapper _disconnectFrame];
 }
 
-void initializeDOMWrapperHooks()
+void NODELETE initializeDOMWrapperHooks()
 {
     WebCore::initializeDOMWrapperHooks(createDOMWrapper, disconnectWindowWrapper);
 }

--- a/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
+++ b/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
@@ -256,7 +256,7 @@ using namespace JSC;
 @end
 
 #if !PLATFORM(IOS_FAMILY)
-static NSEventPhase toNSEventPhase(PlatformWheelEventPhase platformPhase)
+static NSEventPhase NODELETE toNSEventPhase(PlatformWheelEventPhase platformPhase)
 {
     switch (platformPhase) {
     case PlatformWheelEventPhase::None:

--- a/Source/WebKitLegacy/mac/History/BackForwardList.h
+++ b/Source/WebKitLegacy/mac/History/BackForwardList.h
@@ -48,8 +48,8 @@ public:
 
     void addItem(Ref<WebCore::HistoryItem>&&) override;
     void setChildItem(WebCore::BackForwardFrameItemIdentifier, Ref<WebCore::HistoryItem>&&) final { }
-    void goBack();
-    void goForward();
+    void NODELETE goBack();
+    void NODELETE goForward();
     void goToItem(WebCore::HistoryItem&) override;
 
     RefPtr<WebCore::HistoryItem> backItem();
@@ -61,16 +61,16 @@ public:
     void backListWithLimit(int, Vector<Ref<WebCore::HistoryItem>>&);
     void forwardListWithLimit(int, Vector<Ref<WebCore::HistoryItem>>&);
 
-    int capacity();
+    int NODELETE capacity();
     void setCapacity(int);
-    bool enabled();
+    bool NODELETE enabled();
     void setEnabled(bool);
     unsigned backListCount() const override;
     unsigned forwardListCount() const override;
     bool containsItem(const WebCore::HistoryItem&) const final;
 
     void close() override;
-    bool closed();
+    bool NODELETE closed();
 
     void removeItem(WebCore::HistoryItem&);
     const Vector<Ref<WebCore::HistoryItem>>& entries() const { return m_entries; }

--- a/Source/WebKitLegacy/mac/History/BinaryPropertyList.cpp
+++ b/Source/WebKitLegacy/mac/History/BinaryPropertyList.cpp
@@ -62,8 +62,8 @@ public:
     bool isDeletedValue() const { return HashTraits<size_t>::isDeletedValue(m_size); }
 
     using value_type = const int; // For std::span.
-    const int* data() const { ASSERT(!isDeletedValue()); return m_integers; }
-    size_t size() const { ASSERT(!isDeletedValue()); return m_size; }
+    const int* NODELETE data() const { ASSERT(!isDeletedValue()); return m_integers; }
+    size_t NODELETE size() const { ASSERT(!isDeletedValue()); return m_size; }
 
 private:
     friend struct IntegerArrayHashTraits;
@@ -73,7 +73,7 @@ private:
     size_t m_size;
 };
 
-inline bool operator==(const IntegerArray& a, const IntegerArray& b)
+inline bool NODELETE operator==(const IntegerArray& a, const IntegerArray& b)
 {
     return a.m_integers == b.m_integers &&  a.m_size == b.m_size;
 }
@@ -118,10 +118,10 @@ public:
     ObjectReference stringObjectReference(const String&) const;
     ObjectReference integerArrayObjectReference(const int*, size_t) const;
 
-    ObjectReference objectCount() const { return m_currentObjectReference; }
+    ObjectReference NODELETE objectCount() const { return m_currentObjectReference; }
 
-    ObjectReference byteCount() const { return m_byteCount; }
-    ObjectReference objectReferenceCount() const { return m_objectReferenceCount; }
+    ObjectReference NODELETE byteCount() const { return m_byteCount; }
+    ObjectReference NODELETE objectReferenceCount() const { return m_objectReferenceCount; }
 
 private:
     virtual void writeBooleanTrue();
@@ -140,7 +140,7 @@ private:
     void writeStringObject(const String&);
     void writeStringObject(const char*);
 
-    static ObjectReference invalidObjectReference() { return std::numeric_limits<ObjectReference>::max(); }
+    static ObjectReference NODELETE invalidObjectReference() { return std::numeric_limits<ObjectReference>::max(); }
 
     typedef HashMap<IntegerArray, ObjectReference, IntegerArrayHash, IntegerArrayHashTraits> IntegerArrayMap;
 
@@ -179,7 +179,7 @@ void BinaryPropertyListPlan::writeBooleanTrue()
     ++m_byteCount;
 }
 
-static inline int integerByteCount(size_t integer)
+static inline int NODELETE integerByteCount(size_t integer)
 {
     if (integer <= 0xFF)
         return 2;
@@ -275,7 +275,7 @@ void BinaryPropertyListPlan::writeDictionaryEnd(size_t savedAggregateSize)
     m_currentAggregateSize = savedAggregateSize + 1;
 }
 
-static size_t markerPlusLengthByteCount(size_t length)
+static size_t NODELETE markerPlusLengthByteCount(size_t length)
 {
     if (length <= maxLengthInMarkerByte)
         return 1;
@@ -411,7 +411,7 @@ inline void BinaryPropertyListSerializer::appendByte(int byte)
     ASSERT(m_currentByteIndex <= m_currentAggregateBufferByteIndex);
 }
 
-static int bytesNeeded(size_t count)
+static int NODELETE bytesNeeded(size_t count)
 {
     ASSERT(count);
     int bytesNeeded = 1;
@@ -420,7 +420,7 @@ static int bytesNeeded(size_t count)
     return bytesNeeded;
 }
 
-static inline void storeLength(std::span<UInt8> destination, size_t length)
+static inline void NODELETE storeLength(std::span<UInt8> destination, size_t length)
 {
 #ifdef __LP64__
     destination[0] = length >> 56;

--- a/Source/WebKitLegacy/mac/History/WebBackForwardList.mm
+++ b/Source/WebKitLegacy/mac/History/WebBackForwardList.mm
@@ -57,7 +57,7 @@ using BackForwardListMap = HashMap<WeakRef<BackForwardList>, WebBackForwardList*
 
 // FIXME: Instead of this we could just create a class derived from BackForwardList
 // with a pointer to a WebBackForwardList in it.
-static BackForwardListMap& backForwardLists()
+static BackForwardListMap& NODELETE backForwardLists()
 {
     static NeverDestroyed<BackForwardListMap> staticBackForwardLists;
     return staticBackForwardLists;

--- a/Source/WebKitLegacy/mac/History/WebHistory.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistory.mm
@@ -55,7 +55,7 @@ NSString *WebHistoryItemsDiscardedWhileLoadingNotification = @"WebHistoryItemsDi
 NSString *WebHistorySavedNotification = @"WebHistorySavedNotification";
 NSString *WebHistoryItemsKey = @"WebHistoryItems";
 
-static RetainPtr<WebHistory>& sharedHistory()
+static RetainPtr<WebHistory>& NODELETE sharedHistory()
 {
     static NeverDestroyed<RetainPtr<WebHistory>> _sharedHistory;
     return _sharedHistory;

--- a/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
+++ b/Source/WebKitLegacy/mac/History/WebHistoryItem.mm
@@ -106,7 +106,7 @@ static inline WebCoreHistoryItem* core(WebHistoryItemPrivate* itemPrivate)
     return itemPrivate->_historyItem.get();
 }
 
-static HistoryItemMap& historyItemWrappers()
+static HistoryItemMap& NODELETE historyItemWrappers()
 {
     static NeverDestroyed<HistoryItemMap> historyItemWrappers;
     return historyItemWrappers;

--- a/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
@@ -255,7 +255,7 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILite
     return externalRepresentation(_private->coreFrame, { RenderAsTextFlag::PrintingMode }).createNSString().autorelease();
 }
 
-static OptionSet<RenderAsTextFlag> toRenderAsTextFlags(WebRenderTreeAsTextOptions options)
+static OptionSet<RenderAsTextFlag> NODELETE toRenderAsTextFlags(WebRenderTreeAsTextOptions options)
 {
     OptionSet<RenderAsTextFlag> flags;
 

--- a/Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm
@@ -51,7 +51,7 @@
 
 using namespace WebCore;
 
-static RetainPtr<CFMutableDictionaryRef>& lookupTable()
+static RetainPtr<CFMutableDictionaryRef>& NODELETE lookupTable()
 {
     static NeverDestroyed<RetainPtr<CFMutableDictionaryRef>> lookupTable;
     return lookupTable;

--- a/Source/WebKitLegacy/mac/Misc/WebKitVersionChecks.h
+++ b/Source/WebKitLegacy/mac/Misc/WebKitVersionChecks.h
@@ -71,7 +71,7 @@ extern "C" {
 #endif
 
 BOOL WebKitLinkedOnOrAfter(int version);
-void setWebKitLinkTimeVersion(int);
+void NODELETE setWebKitLinkTimeVersion(int);
 
 #ifdef __cplusplus
 }

--- a/Source/WebKitLegacy/mac/Plugins/WebPluginController.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebPluginController.mm
@@ -98,7 +98,7 @@ static void installFlip4MacPlugInWorkaroundIfNecessary();
 #endif
 
 
-static RetainPtr<NSMutableSet>& pluginViews()
+static RetainPtr<NSMutableSet>& NODELETE pluginViews()
 {
     static NeverDestroyed<RetainPtr<NSMutableSet>> pluginViews;
     return pluginViews;

--- a/Source/WebKitLegacy/mac/Plugins/WebPluginDatabase.mm
+++ b/Source/WebKitLegacy/mac/Plugins/WebPluginDatabase.mm
@@ -59,7 +59,7 @@ static void checkCandidate(WebBasePluginPackage **currentPlugin, WebBasePluginPa
 
 @implementation WebPluginDatabase
 
-static RetainPtr<WebPluginDatabase>& sharedDatabase()
+static RetainPtr<WebPluginDatabase>& NODELETE sharedDatabase()
 {
     static NeverDestroyed<RetainPtr<WebPluginDatabase>> sharedDatabase;
     return sharedDatabase;
@@ -181,7 +181,7 @@ struct PluginPackageCandidates {
     return [plugins allValues];
 }
 
-static RetainPtr<NSArray>& additionalWebPlugInPaths()
+static RetainPtr<NSArray>& NODELETE additionalWebPlugInPaths()
 {
     static NeverDestroyed<RetainPtr<NSArray>> _additionalWebPlugInPaths;
     return _additionalWebPlugInPaths;

--- a/Source/WebKitLegacy/mac/Storage/WebStorageTrackerClient.h
+++ b/Source/WebKitLegacy/mac/Storage/WebStorageTrackerClient.h
@@ -28,7 +28,7 @@
 
 class WebStorageTrackerClient : public WebCore::StorageTrackerClient {
 public:
-    static WebStorageTrackerClient* sharedWebStorageTrackerClient();
+    static WebStorageTrackerClient* NODELETE sharedWebStorageTrackerClient();
     
     virtual ~WebStorageTrackerClient();
     void dispatchDidModifyOrigin(const String& originIdentifier) override;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebAlternativeTextClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebAlternativeTextClient.mm
@@ -60,7 +60,7 @@ String WebAlternativeTextClient::dismissAlternativeSoon(ReasonForDismissingAlter
     return m_correctionPanel.dismiss(reason);
 }
 
-static inline NSCorrectionResponse toCorrectionResponse(AutocorrectionResponse response)
+static inline NSCorrectionResponse NODELETE toCorrectionResponse(AutocorrectionResponse response)
 {
     switch (response) {
     case WebCore::AutocorrectionResponse::Reverted:

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm
@@ -78,7 +78,7 @@ WebDragClient::WebDragClient(WebView* webView)
 
 #if PLATFORM(MAC)
 
-static OptionSet<WebCore::DragSourceAction> coreDragSourceActionMask(WebDragSourceAction action)
+static OptionSet<WebCore::DragSourceAction> NODELETE coreDragSourceActionMask(WebDragSourceAction action)
 {
     OptionSet<WebCore::DragSourceAction> result;
 
@@ -94,7 +94,7 @@ static OptionSet<WebCore::DragSourceAction> coreDragSourceActionMask(WebDragSour
     return result;
 }
 
-static WebDragDestinationAction kit(WebCore::DragDestinationAction action)
+static WebDragDestinationAction NODELETE kit(WebCore::DragDestinationAction action)
 {
     switch (action) {
     case WebCore::DragDestinationAction::DHTML:

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h
@@ -219,7 +219,7 @@ private:
     EditorStateIsContentEditable m_lastEditorStateWasContentEditable { EditorStateIsContentEditable::Unset };
 };
 
-inline NSSelectionAffinity kit(WebCore::Affinity affinity)
+inline NSSelectionAffinity NODELETE kit(WebCore::Affinity affinity)
 {
     switch (affinity) {
     case WebCore::Affinity::Upstream:

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1625,7 +1625,7 @@ WebCore::ObjectContentType WebFrameLoaderClient::objectContentType(const URL& ur
     return WebCore::ObjectContentType::None;
 }
 
-static AtomString parameterValue(const Vector<AtomString>& paramNames, const Vector<AtomString>& paramValues, ASCIILiteral name)
+static AtomString NODELETE parameterValue(const Vector<AtomString>& paramNames, const Vector<AtomString>& paramValues, ASCIILiteral name)
 {
     size_t size = paramNames.size();
     ASSERT(size == paramValues.size());

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.h
@@ -31,7 +31,7 @@
 class WebMediaKeySystemClient final : public WebCore::MediaKeySystemClient {
     WTF_MAKE_TZONE_ALLOCATED(WebMediaKeySystemClient);
 public:
-    static WebMediaKeySystemClient& singleton();
+    static WebMediaKeySystemClient& NODELETE singleton();
 
     // Do nothing since this is a singleton object.
     void ref() const final { }

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm
@@ -39,7 +39,7 @@ using namespace WebCore;
 
 static bool s_shouldTrackVisitedLinks;
 
-static HashSet<WeakRef<WebVisitedLinkStore>>& visitedLinkStores()
+static HashSet<WeakRef<WebVisitedLinkStore>>& NODELETE visitedLinkStores()
 {
     static NeverDestroyed<HashSet<WeakRef<WebVisitedLinkStore>>> visitedLinkStores;
 

--- a/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDataSource.mm
@@ -114,7 +114,7 @@ public:
 #endif
 };
 
-static inline WebDataSourcePrivate* toPrivate(void* privateAttribute)
+static inline WebDataSourcePrivate* NODELETE toPrivate(void* privateAttribute)
 {
     return reinterpret_cast<WebDataSourcePrivate*>(privateAttribute);
 }

--- a/Source/WebKitLegacy/mac/WebView/WebDeviceOrientation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDeviceOrientation.mm
@@ -60,7 +60,7 @@ DeviceOrientationData* core(WebDeviceOrientation* orientation)
     return orientation ? orientation->m_internal->m_orientation.get() : 0;
 }
 
-static std::optional<double> convert(bool canProvide, double value)
+static std::optional<double> NODELETE convert(bool canProvide, double value)
 {
     if (!canProvide)
         return std::nullopt;

--- a/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.h
+++ b/Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.h
@@ -51,8 +51,8 @@ public:
     }
 
     void setDataSource(WebDataSource *, WebView*);
-    void detachDataSource();
-    WebDataSource *dataSource() const;
+    void NODELETE detachDataSource();
+    WebDataSource *NODELETE dataSource() const;
 
     void increaseLoadCount(WebCore::ResourceLoaderIdentifier);
     void decreaseLoadCount(WebCore::ResourceLoaderIdentifier);

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -214,7 +214,7 @@ NSString *NSAccessibilityEnhancedUserInterfaceAttribute = @"AXEnhancedUserInterf
 
 @end
 
-WebCore::EditableLinkBehavior core(WebKitEditableLinkBehavior editableLinkBehavior)
+WebCore::EditableLinkBehavior NODELETE core(WebKitEditableLinkBehavior editableLinkBehavior)
 {
     using namespace WebCore;
     switch (editableLinkBehavior) {
@@ -233,7 +233,7 @@ WebCore::EditableLinkBehavior core(WebKitEditableLinkBehavior editableLinkBehavi
     return EditableLinkBehavior::Default;
 }
 
-WebCore::TextDirectionSubmenuInclusionBehavior core(WebTextDirectionSubmenuInclusionBehavior behavior)
+WebCore::TextDirectionSubmenuInclusionBehavior NODELETE core(WebTextDirectionSubmenuInclusionBehavior behavior)
 {
     using namespace WebCore;
     switch (behavior) {
@@ -1083,7 +1083,7 @@ static NSURL *createUniqueWebDataURL();
     return NO;
 }
 
-static WebFrameLoadType toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
+static WebFrameLoadType NODELETE toWebFrameLoadType(WebCore::FrameLoadType frameLoadType)
 {
     using namespace WebCore;
     switch (frameLoadType) {

--- a/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm
@@ -466,7 +466,7 @@ static RetainPtr<NSWindow> createBackgroundFullscreenWindow(NSRect frame)
     return window;
 }
 
-static NSRect windowFrameFromApparentFrames(NSRect screenFrame, NSRect initialFrame, NSRect finalFrame)
+static NSRect NODELETE windowFrameFromApparentFrames(NSRect screenFrame, NSRect initialFrame, NSRect finalFrame)
 {
     NSRect initialWindowFrame;
     if (!NSWidth(initialFrame) || !NSWidth(finalFrame) || !NSHeight(initialFrame) || !NSHeight(finalFrame))

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -245,7 +245,7 @@ const auto WebEventMouseDown = NSEventTypeLeftMouseDown;
 - (void)forwardContextMenuAction:(id)sender;
 @end
 
-static std::optional<WebCore::ContextMenuAction> toAction(NSInteger tag)
+static std::optional<WebCore::ContextMenuAction> NODELETE toAction(NSInteger tag)
 {
     using namespace WebCore;
     if (tag >= ContextMenuItemBaseCustomTag && tag <= ContextMenuItemLastCustomTag) {
@@ -430,7 +430,7 @@ static std::optional<WebCore::ContextMenuAction> toAction(NSInteger tag)
     return std::nullopt;
 }
 
-static std::optional<NSInteger> toTag(WebCore::ContextMenuAction action)
+static std::optional<NSInteger> NODELETE toTag(WebCore::ContextMenuAction action)
 {
     using namespace WebCore;
     switch (action) {
@@ -721,7 +721,7 @@ static BOOL forceNSViewHitTest;
 // if YES, do the "top WebHTMLView" hit test (which we'd like to do all the time but can't because of Java requirements [see bug 4349721])
 static BOOL forceWebHTMLViewHitTest;
 
-static RetainPtr<WebHTMLView>& lastHitView()
+static RetainPtr<WebHTMLView>& NODELETE lastHitView()
 {
     static NeverDestroyed<RetainPtr<WebHTMLView>> lastHitView;
     return lastHitView;
@@ -1043,7 +1043,7 @@ struct WebHTMLViewInterpretKeyEventsParameters {
 
 #if PLATFORM(MAC)
 
-static NSControlStateValue kit(TriState state)
+static NSControlStateValue NODELETE kit(TriState state)
 {
     switch (state) {
     case TriState::False:
@@ -4223,7 +4223,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if ENABLE(DRAG_SUPPORT) && PLATFORM(MAC)
 
-static NSDragOperation kit(OptionSet<WebCore::DragOperation> operationMask)
+static NSDragOperation NODELETE kit(OptionSet<WebCore::DragOperation> operationMask)
 {
     NSDragOperation result = NSDragOperationNone;
     if (operationMask.contains(WebCore::DragOperation::Copy))

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -75,13 +75,13 @@ NSString *WebPreferencesCacheModelChangedInternalNotification = @"WebPreferences
 
 enum { WebPreferencesVersion = 1 };
 
-static RetainPtr<WebPreferences>& standardPreferences()
+static RetainPtr<WebPreferences>& NODELETE standardPreferences()
 {
     static NeverDestroyed<RetainPtr<WebPreferences>> standardPreferences;
     return standardPreferences;
 }
 
-static RetainPtr<NSMutableDictionary>& webPreferencesInstances()
+static RetainPtr<NSMutableDictionary>& NODELETE webPreferencesInstances()
 {
     static NeverDestroyed<RetainPtr<NSMutableDictionary>> webPreferencesInstances;
     return webPreferencesInstances;
@@ -1618,7 +1618,7 @@ public:
         @{ WebKitDefaultTextEncodingNamePreferenceKey: PAL::defaultTextEncodingNameForSystemLanguage().createNSString().get() }];
 }
 
-static RetainPtr<NSString>& classIBCreatorID()
+static RetainPtr<NSString>& NODELETE classIBCreatorID()
 {
     static NeverDestroyed<RetainPtr<NSString>> classIBCreatorID;
     return classIBCreatorID;

--- a/Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm
@@ -41,7 +41,7 @@
 @end
 
 using WorldMap = HashMap<SingleThreadWeakRef<WebCore::DOMWrapperWorld>, WebScriptWorld*>;
-static WorldMap& allWorlds()
+static WorldMap& NODELETE allWorlds()
 {
     static WorldMap& map = *new WorldMap;
     return map;

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -613,7 +613,7 @@ static const char webViewIsOpen[] = "At least one WebView is still open.";
 @end
 
 #if ENABLE(DRAG_SUPPORT)
-static OptionSet<WebCore::DragDestinationAction> coreDragDestinationActionMask(WebDragDestinationAction actionMask)
+static OptionSet<WebCore::DragDestinationAction> NODELETE coreDragDestinationActionMask(WebDragDestinationAction actionMask)
 {
     OptionSet<WebCore::DragDestinationAction> result;
     if (actionMask & WebDragDestinationActionDHTML)
@@ -634,7 +634,7 @@ typedef NS_OPTIONS(NSUInteger, _UIDragOperation) {
 };
 #endif
 
-OptionSet<WebCore::DragOperation> coreDragOperationMask(CocoaDragOperation operation)
+OptionSet<WebCore::DragOperation> NODELETE coreDragOperationMask(CocoaDragOperation operation)
 {
     OptionSet<WebCore::DragOperation> result;
 
@@ -662,7 +662,7 @@ OptionSet<WebCore::DragOperation> coreDragOperationMask(CocoaDragOperation opera
 }
 
 #if USE(APPKIT)
-static NSDragOperation kit(std::optional<WebCore::DragOperation> dragOperation)
+static NSDragOperation NODELETE kit(std::optional<WebCore::DragOperation> dragOperation)
 {
     if (!dragOperation)
         return NSDragOperationNone;
@@ -711,7 +711,7 @@ static _UIDragOperation kit(std::optional<WebCore::DragOperation> dragOperation)
 }
 #endif // USE(APPKIT)
 
-WebDragSourceAction kit(std::optional<WebCore::DragSourceAction> action)
+WebDragSourceAction NODELETE kit(std::optional<WebCore::DragSourceAction> action)
 {
     if (!action)
         return WebDragSourceActionNone;
@@ -742,7 +742,7 @@ WebDragSourceAction kit(std::optional<WebCore::DragSourceAction> action)
 }
 #endif // ENABLE(DRAG_SUPPORT)
 
-WebCore::FindOptions coreOptions(WebFindOptions options)
+WebCore::FindOptions NODELETE coreOptions(WebFindOptions options)
 {
     WebCore::FindOptions findOptions;
     if (options & WebFindOptionsCaseInsensitive)
@@ -760,7 +760,7 @@ WebCore::FindOptions coreOptions(WebFindOptions options)
     return findOptions;
 }
 
-OptionSet<WebCore::LayoutMilestone> coreLayoutMilestones(WebLayoutMilestones milestones)
+OptionSet<WebCore::LayoutMilestone> NODELETE coreLayoutMilestones(WebLayoutMilestones milestones)
 {
     OptionSet<WebCore::LayoutMilestone> layoutMilestone;
     if (milestones & WebDidFirstLayout)
@@ -772,14 +772,14 @@ OptionSet<WebCore::LayoutMilestone> coreLayoutMilestones(WebLayoutMilestones mil
     return layoutMilestone;
 }
 
-WebLayoutMilestones kitLayoutMilestones(OptionSet<WebCore::LayoutMilestone> milestones)
+WebLayoutMilestones NODELETE kitLayoutMilestones(OptionSet<WebCore::LayoutMilestone> milestones)
 {
     return (milestones & WebCore::LayoutMilestone::DidFirstLayout ? WebDidFirstLayout : 0)
         | (milestones & WebCore::LayoutMilestone::DidFirstVisuallyNonEmptyLayout ? WebDidFirstVisuallyNonEmptyLayout : 0)
         | (milestones & WebCore::LayoutMilestone::DidHitRelevantRepaintedObjectsAreaThreshold ? WebDidHitRelevantRepaintedObjectsAreaThreshold : 0);
 }
 
-static WebPageVisibilityState kit(WebCore::VisibilityState visibilityState)
+static WebPageVisibilityState NODELETE kit(WebCore::VisibilityState visibilityState)
 {
     switch (visibilityState) {
     case WebCore::VisibilityState::Visible:
@@ -792,7 +792,7 @@ static WebPageVisibilityState kit(WebCore::VisibilityState visibilityState)
     return WebPageVisibilityStateVisible;
 }
 
-static WebCore::StorageBlockingPolicy core(WebStorageBlockingPolicy storageBlockingPolicy)
+static WebCore::StorageBlockingPolicy NODELETE core(WebStorageBlockingPolicy storageBlockingPolicy)
 {
     switch (storageBlockingPolicy) {
     case WebAllowAllStorage:
@@ -935,7 +935,7 @@ enum { WebViewVersion = 4 };
 
 #define timedLayoutSize 4096
 
-static RetainPtr<NSMutableSet>& schemesWithRepresentationsSet()
+static RetainPtr<NSMutableSet>& NODELETE schemesWithRepresentationsSet()
 {
     static NeverDestroyed<RetainPtr<NSMutableSet>> schemesWithRepresentationsSet;
     return schemesWithRepresentationsSet;
@@ -1275,7 +1275,7 @@ static CFSetCallBacks NonRetainingSetCallbacks = {
     CFHash
 };
 
-static RetainPtr<CFMutableSetRef>& allWebViewsSet()
+static RetainPtr<CFMutableSetRef>& NODELETE allWebViewsSet()
 {
     static NeverDestroyed<RetainPtr<CFMutableSetRef>> allWebViewsSet;
     return allWebViewsSet;
@@ -6811,7 +6811,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return nil;
 }
 
-constexpr WebCore::TextCheckingType coreTextCheckingType(NSTextCheckingType type)
+constexpr WebCore::TextCheckingType NODELETE coreTextCheckingType(NSTextCheckingType type)
 {
     switch (type) {
     case NSTextCheckingTypeCorrection:
@@ -9337,7 +9337,7 @@ FORWARD(toggleUnderline)
     return self._isRichlyEditable ? _private->_richTextTouchBar.get() : _private->_plainTextTouchBar.get();
 }
 
-static NSTextAlignment nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle* style)
+static NSTextAlignment NODELETE nsTextAlignmentFromRenderStyle(const WebCore::RenderStyle* style)
 {
     NSTextAlignment textAlignment;
     switch (style->textAlign()) {

--- a/Source/WebKitLegacy/mac/WebView/WebWindowAnimation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebWindowAnimation.mm
@@ -41,7 +41,7 @@ static NSTimeInterval WebWindowAnimationDurationFromDuration(NSTimeInterval dura
     return ([[NSApp currentEvent] modifierFlags] & NSEventModifierFlagShift) ? duration * slowMotionFactor : duration;
 }
 
-static NSRect scaledRect(NSRect _initialFrame, NSRect _finalFrame, CGFloat factor)
+static NSRect NODELETE scaledRect(NSRect _initialFrame, NSRect _finalFrame, CGFloat factor)
 {
     NSRect currentRect = _initialFrame;
     currentRect.origin.x += (NSMinX(_finalFrame) - NSMinX(_initialFrame)) * factor;
@@ -51,7 +51,7 @@ static NSRect scaledRect(NSRect _initialFrame, NSRect _finalFrame, CGFloat facto
     return currentRect;
 }
 
-static CGFloat squaredDistance(NSPoint point1, NSPoint point2)
+static CGFloat NODELETE squaredDistance(NSPoint point1, NSPoint point2)
 {
     CGFloat deltaX = point1.x - point2.x;
     CGFloat deltaY = point1.y - point2.y;


### PR DESCRIPTION
#### a1b9c3a065c1ba655f99f24b65392b9abd1d329a
<pre>
Adopt NODELETE in more places in Source/WebKitLegacy
<a href="https://bugs.webkit.org/show_bug.cgi?id=309235">https://bugs.webkit.org/show_bug.cgi?id=309235</a>

Reviewed by Ryosuke Niwa.

* Source/WebKitLegacy/Storage/StorageNamespaceImpl.cpp:
(WebKit::localStorageNamespaceMap):
* Source/WebKitLegacy/Storage/StorageThread.cpp:
(WebCore::activeStorageThreads):
* Source/WebKitLegacy/Storage/StorageTracker.h:
* Source/WebKitLegacy/Storage/WebStorageNamespaceProvider.cpp:
(WebKit::storageNamespaceProviders):
* Source/WebKitLegacy/WebCoreSupport/LegacyWebPageDebuggable.h:
* Source/WebKitLegacy/WebCoreSupport/NetworkStorageSessionMap.cpp:
(globalSessionMap):
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImpl.cpp:
(WebCore::removeTerminationCharacters):
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandleImplCFNet.cpp:
(WebCore::callbacksRunLoopMode):
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.h:
* Source/WebKitLegacy/WebCoreSupport/WebViewGroup.cpp:
(webViewGroups):
* Source/WebKitLegacy/mac/DOM/DOMInternal.mm:
* Source/WebKitLegacy/mac/DOM/DOMUtility.mm:
(initializeDOMWrapperHooks):
* Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm:
(toNSEventPhase):
* Source/WebKitLegacy/mac/History/BackForwardList.h:
* Source/WebKitLegacy/mac/History/BinaryPropertyList.cpp:
(IntegerArray::data const):
(IntegerArray::size const):
(operator==):
(add):
(IntegerArrayHash::hash):
(BinaryPropertyListPlan::objectCount const):
(BinaryPropertyListPlan::byteCount const):
(BinaryPropertyListPlan::objectReferenceCount const):
(BinaryPropertyListPlan::invalidObjectReference):
(integerByteCount):
(markerPlusLengthByteCount):
(bytesNeeded):
(storeLength):
* Source/WebKitLegacy/mac/History/WebBackForwardList.mm:
(backForwardLists):
* Source/WebKitLegacy/mac/History/WebHistory.mm:
(sharedHistory):
* Source/WebKitLegacy/mac/History/WebHistoryItem.mm:
(historyItemWrappers):
* Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm:
(toRenderAsTextFlags):
* Source/WebKitLegacy/mac/Misc/WebElementDictionary.mm:
(lookupTable):
* Source/WebKitLegacy/mac/Misc/WebKitVersionChecks.h:
* Source/WebKitLegacy/mac/Plugins/WebBasePluginPackage.mm:
(swapIntsInHeader):
* Source/WebKitLegacy/mac/Plugins/WebPluginController.mm:
(pluginViews):
* Source/WebKitLegacy/mac/Plugins/WebPluginDatabase.mm:
(sharedDatabase):
(additionalWebPlugInPaths):
* Source/WebKitLegacy/mac/Storage/WebDatabaseManagerClient.h:
* Source/WebKitLegacy/mac/Storage/WebStorageTrackerClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebAlternativeTextClient.mm:
(toCorrectionResponse):
* Source/WebKitLegacy/mac/WebCoreSupport/WebDragClient.mm:
(coreDragSourceActionMask):
(kit):
* Source/WebKitLegacy/mac/WebCoreSupport/WebEditorClient.h:
(kit):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(parameterValue):
* Source/WebKitLegacy/mac/WebCoreSupport/WebMediaKeySystemClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebVisitedLinkStore.mm:
(visitedLinkStores):
* Source/WebKitLegacy/mac/WebView/WebDataSource.mm:
(toPrivate):
* Source/WebKitLegacy/mac/WebView/WebDeviceOrientation.mm:
(convert):
* Source/WebKitLegacy/mac/WebView/WebDocumentLoaderMac.h:
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(core):
(toWebFrameLoadType):
* Source/WebKitLegacy/mac/WebView/WebFullScreenController.mm:
(windowFrameFromApparentFrames):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(toAction):
(toTag):
(lastHitView):
(kit):
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
(standardPreferences):
(webPreferencesInstances):
(classIBCreatorID):
* Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm:
(allWorlds):
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(coreDragDestinationActionMask):
(coreDragOperationMask):
(kit):
(coreOptions):
(coreLayoutMilestones):
(kitLayoutMilestones):
(core):
(schemesWithRepresentationsSet):
(coreTextCheckingType):
(nsTextAlignmentFromRenderStyle):
* Source/WebKitLegacy/mac/WebView/WebWindowAnimation.mm:
(scaledRect):
(squaredDistance):

Canonical link: <a href="https://commits.webkit.org/308766@main">https://commits.webkit.org/308766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efa1aec095adeda6090be69cebed40bb53794615

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157071 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c5d32ba0-3e43-4d7c-a6ec-88d74139dc49) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/21530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114397 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151347 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/21530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95167 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12163dfc-e110-406c-a1e3-150bbe89e67f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/21530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13556 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4507 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/21530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159404 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2538 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12649 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122430 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122651 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33353 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/132946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9693 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20488 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84273 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20220 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20365 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->