### PR TITLE
HTMLMediaElement::checkForAudioAndVideo should only call canProduceAudioChanged when audio/video state actually change

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -6605,9 +6605,12 @@ void HTMLMediaElement::pausePlayer()
 
 void HTMLMediaElement::checkForAudioAndVideo()
 {
+    bool hadAudio = m_hasEverHadAudio;
+    bool hadVideo = m_hasEverHadVideo;
     m_hasEverHadAudio |= hasAudio();
     m_hasEverHadVideo |= hasVideo();
-    canProduceAudioChanged();
+    if (m_hasEverHadAudio != hadAudio || m_hasEverHadVideo != hadVideo)
+        canProduceAudioChanged();
 }
 
 void HTMLMediaElement::setPlaying(bool playing)


### PR DESCRIPTION
#### 1f4b11120e635608e33d5579beca220f96f63168
<pre>
HTMLMediaElement::checkForAudioAndVideo should only call canProduceAudioChanged when audio/video state actually change
<a href="https://bugs.webkit.org/show_bug.cgi?id=309240">https://bugs.webkit.org/show_bug.cgi?id=309240</a>
<a href="https://rdar.apple.com/171790748">rdar://171790748</a>

Reviewed by NOBODY (OOPS!).

checkForAudioAndVideo() unconditionally called canProduceAudioChanged() on every
invocation, which does non-trivial work: ref-counting the media session, calling
into MediaElementSession::canProduceAudioChanged(), and calling updateSleepDisabling().
This function is called from five sites including hot paths like updatePlayState()
and mediaPlayerCharacteristicChanged().

Since m_hasEverHadAudio and m_hasEverHadVideo use |= (once true, they stay true),
canProduceAudioChanged() only needs to be called when either flag transitions from
false to true, at most twice in the lifetime of a media element. Every subsequent
call was pure overhead.

No new tests since no behavior change, this is just an optimization.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::checkForAudioAndVideo):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f4b11120e635608e33d5579beca220f96f63168

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14539 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156941 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101686 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0cb46072-d2b3-42f8-8737-899429d24ac5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150131 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114301 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81464 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/57a0cac1-6718-4636-bc53-1d02660a0fbb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16537 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95072 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f019439c-9fd5-4a02-b8b5-8330b1bea727) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15657 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13463 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4378 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125263 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11030 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159274 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2409 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12548 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122333 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17426 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122553 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20751 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132854 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76902 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17964 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9593 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20359 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84144 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20091 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20236 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20145 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->