### PR TITLE
Binary key over-read in IndexedDB deserialization

### DIFF
--- a/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBSerialization.cpp
@@ -351,7 +351,7 @@ RefPtr<SharedBuffer> serializeIDBKeyData(const IDBKeyData& key)
             return false;
 
         size_t size = static_cast<size_t>(size64);
-        Vector<uint8_t> dataVector(data);
+        Vector<uint8_t> dataVector(data.first(size));
         skip(data, size);
 
         result.setBinaryValue(ThreadSafeDataBuffer::create(WTF::move(dataVector)));

--- a/Tools/TestWebKitAPI/Tests/WebCore/IDBSerializationTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/IDBSerializationTest.cpp
@@ -27,6 +27,7 @@
 
 #include <WebCore/IDBKeyData.h>
 #include <WebCore/IDBSerialization.h>
+#include <array>
 
 using namespace WebCore;
 
@@ -38,31 +39,67 @@ TEST(IDBSerialization, KeyDeserializationStringOverflow)
     // length 0x80000000 (little-endian), then 4 bytes of char data.
     // The uint32_t length * 2 overflows to 0, bypassing the bounds check
     // without the fix.
-    const uint8_t corruptData[] = {
+    constexpr auto corruptData = std::to_array<uint8_t>({
         0x00, // version
         0x60, // SIDBKeyType::String
         0x00, 0x00, 0x00, 0x80, // length = 0x80000000 (little-endian)
         0x41, 0x00, 0x41, 0x00 // 2 UTF-16 chars 'A', 'A'
-    };
+    });
 
     IDBKeyData result;
-    bool success = deserializeIDBKeyData(std::span { corruptData, sizeof(corruptData) }, result);
+    bool success = deserializeIDBKeyData(std::span { corruptData }, result);
     EXPECT_FALSE(success);
 }
 
 TEST(IDBSerialization, KeyDeserializationStringValid)
 {
     // A valid string key: version byte, String type, length 2, then 2 UTF-16 chars.
-    const uint8_t validData[] = {
+    constexpr auto validData = std::to_array<uint8_t>({
         0x00, // version
         0x60, // SIDBKeyType::String
         0x02, 0x00, 0x00, 0x00, // length = 2 (little-endian)
         0x41, 0x00, 0x42, 0x00 // 'A', 'B'
-    };
+    });
 
     IDBKeyData result;
-    bool success = deserializeIDBKeyData(std::span { validData, sizeof(validData) }, result);
+    bool success = deserializeIDBKeyData(std::span { validData }, result);
     EXPECT_TRUE(success);
+}
+
+TEST(IDBSerialization, KeyDeserializationBinaryArraySlicing)
+{
+    // An array key with two binary sub-keys: [binary(0xAA, 0xBB), binary(0xCC)].
+    // Without the fix, the first binary sub-key's value would include the
+    // trailing serialized bytes of the second sub-key.
+    constexpr auto arrayData = std::to_array<uint8_t>({
+        0x00, // version
+        0xA0, // SIDBKeyType::Array
+        0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // array length = 2 (uint64_t LE)
+        0x80, // SIDBKeyType::Binary (first element)
+        0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // binary size = 2 (uint64_t LE)
+        0xAA, 0xBB, // binary data
+        0x80, // SIDBKeyType::Binary (second element)
+        0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // binary size = 1 (uint64_t LE)
+        0xCC // binary data
+    });
+
+    IDBKeyData result;
+    bool success = deserializeIDBKeyData(std::span { arrayData }, result);
+    EXPECT_TRUE(success);
+
+    auto& array = result.array();
+    ASSERT_EQ(array.size(), 2u);
+
+    auto* firstData = array[0].binary().data();
+    ASSERT_TRUE(firstData);
+    EXPECT_EQ(firstData->size(), 2u);
+    EXPECT_EQ((*firstData)[0], 0xAA);
+    EXPECT_EQ((*firstData)[1], 0xBB);
+
+    auto* secondData = array[1].binary().data();
+    ASSERT_TRUE(secondData);
+    EXPECT_EQ(secondData->size(), 1u);
+    EXPECT_EQ((*secondData)[0], 0xCC);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### a7aa0f525259a43d13e12bf89bbd4b3cade3300f
<pre>
Binary key over-read in IndexedDB deserialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=308712">https://bugs.webkit.org/show_bug.cgi?id=308712</a>
<a href="https://rdar.apple.com/171246072">rdar://171246072</a>

Reviewed by Chris Dumez.

This addresses a subtle regression from 276459@main. Also correct the
tests added in 308649@main to use std::array.

Test: Tools/TestWebKitAPI/Tests/WebCore/IDBSerializationTest.cpp
Canonical link: <a href="https://commits.webkit.org/308694@main">https://commits.webkit.org/308694@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f8d563119b3e01af6c52ac39674a6870d999c03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14546 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156948 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ffa6842d-1d13-411a-95ed-ac1dfc2ce407) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114310 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d5f9576-322e-4489-b205-08b63d73a61e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16543 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95080 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a18fb543-82d1-4688-a6f7-6d0d5c4a9510) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15661 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13469 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4385 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125267 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159281 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2416 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12552 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122343 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20749 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17434 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122563 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20758 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132858 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76909 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22851 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17982 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9597 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20366 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84151 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20098 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20243 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20152 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->