### PR TITLE
[WebXR Layers] textureType belongs to XRLayerInit not to its subclasses

### DIFF
--- a/Source/WebCore/Modules/webxr/XRCylinderLayerInit.h
+++ b/Source/WebCore/Modules/webxr/XRCylinderLayerInit.h
@@ -35,7 +35,6 @@ namespace WebCore {
 
 // https://immersive-web.github.io/layers/#xrcylinderlayerinit
 struct XRCylinderLayerInit : public XRLayerInit {
-    XRTextureType textureType;
     RefPtr<WebXRRigidTransform> transform;
     float radius;
     float centralAngle;

--- a/Source/WebCore/Modules/webxr/XRCylinderLayerInit.idl
+++ b/Source/WebCore/Modules/webxr/XRCylinderLayerInit.idl
@@ -29,7 +29,6 @@
     EnabledBySetting=WebXRLayersAPIEnabled,
     LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XRCylinderLayerInit : XRLayerInit {
-    XRTextureType textureType = "texture";
     WebXRRigidTransform? transform;
     float radius = 2.0;
     float centralAngle = 0.78539;

--- a/Source/WebCore/Modules/webxr/XREquirectLayerInit.h
+++ b/Source/WebCore/Modules/webxr/XREquirectLayerInit.h
@@ -35,7 +35,6 @@ namespace WebCore {
 
 // https://immersive-web.github.io/layers/#xrequirectlayerinit
 struct XREquirectLayerInit : public XRLayerInit {
-    XRTextureType textureType;
     RefPtr<WebXRRigidTransform> transform;
     float radius;
     float centralHorizontalAngle;

--- a/Source/WebCore/Modules/webxr/XREquirectLayerInit.idl
+++ b/Source/WebCore/Modules/webxr/XREquirectLayerInit.idl
@@ -29,7 +29,6 @@
     EnabledBySetting=WebXRLayersAPIEnabled,
     LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XREquirectLayerInit : XRLayerInit {
-    XRTextureType textureType = "texture";
     WebXRRigidTransform? transform;
     float radius = 0;
     float centralHorizontalAngle = 6.28318;

--- a/Source/WebCore/Modules/webxr/XRLayerInit.h
+++ b/Source/WebCore/Modules/webxr/XRLayerInit.h
@@ -30,12 +30,14 @@
 #include "GraphicsTypesGL.h"
 #include "WebXRSpace.h"
 #include "XRLayerLayout.h"
+#include "XRTextureType.h"
 
 namespace WebCore {
 
 // https://immersive-web.github.io/layers/#xrlayerinittype
 struct XRLayerInit {
     RefPtr<WebXRSpace> space;
+    XRTextureType textureType;
     GCGLenum colorFormat;
     std::optional<GCGLenum> depthFormat;
     uint32_t mipLevels;

--- a/Source/WebCore/Modules/webxr/XRLayerInit.idl
+++ b/Source/WebCore/Modules/webxr/XRLayerInit.idl
@@ -32,6 +32,7 @@ typedef unsigned long GLenum;
     LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XRLayerInit {
     required WebXRSpace space;
+    XRTextureType textureType = "texture";
     GLenum colorFormat = 0x1908;
     GLenum? depthFormat;
     unsigned long mipLevels = 1;

--- a/Source/WebCore/Modules/webxr/XRQuadLayerInit.h
+++ b/Source/WebCore/Modules/webxr/XRQuadLayerInit.h
@@ -35,7 +35,6 @@ namespace WebCore {
 
 // https://immersive-web.github.io/layers/#xrquadlayerinit
 struct XRQuadLayerInit : XRLayerInit {
-    XRTextureType textureType;
     RefPtr<WebXRRigidTransform> transform;
     float width;
     float height;

--- a/Source/WebCore/Modules/webxr/XRQuadLayerInit.idl
+++ b/Source/WebCore/Modules/webxr/XRQuadLayerInit.idl
@@ -31,7 +31,6 @@
     JSGenerateToNativeObject,
     LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary XRQuadLayerInit : XRLayerInit {
-    XRTextureType textureType = "texture";
     WebXRRigidTransform? transform;
     float width = 1.0;
     float height = 1.0;


### PR DESCRIPTION
#### 0d308ed455bcdd377f22bd3dfff457cd09da2cd7
<pre>
[WebXR Layers] textureType belongs to XRLayerInit not to its subclasses
<a href="https://bugs.webkit.org/show_bug.cgi?id=309242">https://bugs.webkit.org/show_bug.cgi?id=309242</a>

Reviewed by Fujii Hironori.

Moving the textureType attribute that is common to all layers to
XRLayerInit. Previously it was specified for each layer type in their
respective Init structs

No new tests as this is just a refactoring.

* Source/WebCore/Modules/webxr/XRCylinderLayerInit.h:
* Source/WebCore/Modules/webxr/XRCylinderLayerInit.idl:
* Source/WebCore/Modules/webxr/XREquirectLayerInit.h:
* Source/WebCore/Modules/webxr/XREquirectLayerInit.idl:
* Source/WebCore/Modules/webxr/XRLayerInit.h:
* Source/WebCore/Modules/webxr/XRLayerInit.idl:
* Source/WebCore/Modules/webxr/XRQuadLayerInit.h:
* Source/WebCore/Modules/webxr/XRQuadLayerInit.idl:

Canonical link: <a href="https://commits.webkit.org/308722@main">https://commits.webkit.org/308722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/798d20acb24355290b20392923aa8198ba92fe00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156946 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21406 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114307 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151223 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133125 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95077 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15659 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13466 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4383 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125265 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159279 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2414 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122337 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20747 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122557 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33325 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20756 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132853 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76907 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17969 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9592 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20364 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84149 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20096 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20241 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20150 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->