### PR TITLE
Disable floating of flex/grid items without adjusting float computed style.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-with-float-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-with-float-dynamic-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL computed style for float assert_equals: expected "left" but got "none"
+PASS computed style for float
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-with-float-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-with-float-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL computed style for float assert_equals: expected "left" but got "none"
+PASS computed style for float
 

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -99,7 +99,7 @@ static bool isSpecialHTMLElement(const Node& node)
     if (renderer->style().display().isTableBox())
         return true;
 
-    if (renderer->style().floating() != Float::None)
+    if (!renderer->style().isFlexOrGridItem() && renderer->style().floating() != Float::None)
         return true;
 
     if (renderer->style().position() != PositionType::Static)

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -755,7 +755,7 @@ void ReplaceSelectionCommand::removeRedundantStylesAndKeepStyleSpanInline(Insert
             // Mutate using the CSSOM wrapper so we get the same event behavior as a script.
             if (isBlock(*element))
                 element->cssomStyle().setPropertyInternal(CSSPropertyDisplay, "inline"_s, IsImportant::No);
-            if (element->renderer() && element->renderer()->style().floating() != Float::None)
+            if (element->renderer() && !element->renderer()->style().isFlexOrGridItem() && element->renderer()->style().floating() != Float::None)
                 element->cssomStyle().setPropertyInternal(CSSPropertyFloat, noneAtom(), IsImportant::No);
         }
     }

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -346,7 +346,7 @@ static bool isEnclosingItemBoundaryElement(const Element& element)
             return true;
 
         auto floating = renderer->style().floating();
-        if (isListItem && (floating == Float::Left || floating == Float::Right))
+        if (isListItem && !renderer->style().isFlexOrGridItem() && (floating == Float::Left || floating == Float::Right))
             return true;
 
         for (RefPtr parent = element.parentElement(); parent; parent = parent->parentElement()) {

--- a/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp
@@ -103,7 +103,7 @@ bool InlineInvalidation::styleWillChange(const Box& layoutBox, const RenderStyle
         CheckedRef oldStyle = layoutBox.style();
 
         auto hasInlineItemTypeChanged = oldStyle->hasOutOfFlowPosition() != newStyle.hasOutOfFlowPosition()
-            || (oldStyle->floating() != Float::None) != (newStyle.floating() != Float::None)
+            || (!oldStyle->isFlexOrGridItem() && oldStyle->floating() != Float::None) != (!newStyle.isFlexOrGridItem() && newStyle.floating() != Float::None)
             || oldStyle->display() != newStyle.display();
         if (hasInlineItemTypeChanged)
             return true;

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -203,7 +203,7 @@ bool Box::isFloatingPositioned() const
     // FIXME: Rendering code caches values like this. (style="position: absolute; float: left")
     if (isOutOfFlowPositioned())
         return false;
-    return m_style.floating() != Float::None;
+    return !m_style.isFlexOrGridItem() && m_style.floating() != Float::None;
 }
 
 bool Box::hasFloatClear() const

--- a/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp
@@ -213,7 +213,7 @@ std::unique_ptr<Box> TreeBuilder::createLayoutBox(const ElementBox& parentContai
             // on the table box and not the table wrapper box.
             auto tableWrapperBoxStyle = RenderStyle::createAnonymousStyleWithDisplay(parentContainer.style(), renderer.style().display() == Style::DisplayType::BlockTable ? Style::DisplayType::BlockFlow : Style::DisplayType::InlineFlow);
             tableWrapperBoxStyle.setPosition(renderer.style().position());
-            tableWrapperBoxStyle.setFloating(renderer.style().floating());
+            tableWrapperBoxStyle.setFloating(!renderer.style().isFlexOrGridItem() ? renderer.style().floating() : Float::None);
 
             tableWrapperBoxStyle.setInsetBox(Style::InsetBox { renderer.style().insetBox() });
             tableWrapperBoxStyle.setMarginBox(Style::MarginBox { renderer.style().marginBox() });

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -297,7 +297,7 @@ void RenderBlock::styleWillChange(Style::Difference diff, const RenderStyle& new
     setBlockLevelReplacedOrAtomicInline(newStyle.display().isInlineType());
     if (oldStyle) {
         removeOutOfFlowBoxesIfNeededOnStyleChange(*this, *oldStyle, newStyle);
-        if (isLegend() && oldStyle->floating() == Float::None && newStyle.floating() != Float::None)
+        if (isLegend() && (oldStyle->isFlexOrGridItem() || oldStyle->floating() == Float::None) && (!newStyle.isFlexOrGridItem() && newStyle.floating() != Float::None))
             setIsExcludedFromNormalLayout(false);
     }
     RenderBox::styleWillChange(diff, newStyle);
@@ -1311,7 +1311,7 @@ bool RenderBlock::establishesIndependentFormattingContextIgnoringDisplayType(con
             && style.overflowX() != Overflow::Visible;
     };
 
-    return style.floating() != Float::None
+    return (!style.isFlexOrGridItem() && style.floating() != Float::None)
         || style.hasOutOfFlowPosition()
         || isBlockBoxWithPotentiallyScrollableOverflow()
         || style.usedContain().contains(Style::ContainValue::Layout)

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -506,7 +506,7 @@ void RenderBox::updateFromStyle()
     if (isDocElementRenderer || isViewObject)
         setHasVisibleBoxDecorations(true);
 
-    setFloating(!isOutOfFlowPositioned() && styleToUse.floating() != Float::None);
+    setFloating(!isOutOfFlowPositioned() && !styleToUse.isFlexOrGridItem() && styleToUse.floating() != Float::None);
 
     // We also handle <body> and <html>, whose overflow applies to the viewport.
     if (!(effectiveOverflowX() == Overflow::Visible && effectiveOverflowY() == Overflow::Visible) && !isDocElementRenderer && isRenderBlock()) {

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -990,7 +990,7 @@ void RenderElement::styleWillChange(Style::Difference diff, const RenderStyle& n
                 layer->invalidateEventRegion(RenderLayer::EventRegionInvalidationReason::Style);
         }
 
-        if (isFloating() && m_style.floating() != newStyle.floating()) {
+        if (isFloating() && (m_style.isFlexOrGridItem() != newStyle.isFlexOrGridItem() || m_style.floating() != newStyle.floating())) {
             // For changes in float styles, we need to conceivably remove ourselves
             // from the floating objects list.
             downcast<RenderBox>(*this).removeFloatingOrOutOfFlowChildFromBlockLists();

--- a/Source/WebCore/rendering/TextAutoSizing.cpp
+++ b/Source/WebCore/rendering/TextAutoSizing.cpp
@@ -128,6 +128,7 @@ unsigned TextAutoSizingHashTranslator::hash(const RenderStyle& style)
     hash ^= std::to_underlying(style.boxDirection());
     hash ^= std::to_underlying(style.rtlOrdering());
     hash ^= std::to_underlying(style.position());
+    hash ^= static_cast<unsigned>(style.isFlexOrGridItem());
     hash ^= std::to_underlying(style.floating());
     hash ^= std::to_underlying(style.textOverflow());
     return hash;
@@ -154,6 +155,7 @@ bool TextAutoSizingHashTranslator::equal(const RenderStyle& styleA, const Render
         && styleA.boxDirection() == styleB.boxDirection()
         && styleA.rtlOrdering() == styleB.rtlOrdering()
         && styleA.position() == styleB.position()
+        && styleA.isFlexOrGridItem() == styleB.isFlexOrGridItem()
         && styleA.floating() == styleB.floating()
         && styleA.textOverflow() == styleB.textOverflow();
 }

--- a/Source/WebCore/rendering/style/AutosizeStatus.cpp
+++ b/Source/WebCore/rendering/style/AutosizeStatus.cpp
@@ -64,7 +64,7 @@ auto AutosizeStatus::compute(const RenderStyle& style) -> AutosizeStatus
     if (style.overflowX() == Overflow::Hidden)
         result.add(Fields::OverflowXHidden);
 
-    if (style.floating() != Float::None)
+    if (!style.isFlexOrGridItem() && style.floating() != Float::None)
         result.add(Fields::Floating);
 
     return AutosizeStatus(result);

--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -122,6 +122,11 @@ inline bool RenderStyle::isLink() const
     return m_computedStyle.isLink();
 }
 
+inline bool RenderStyle::isFlexOrGridItem() const
+{
+    return m_computedStyle.isFlexOrGridItem();
+}
+
 inline bool RenderStyle::emptyState() const
 {
     return m_computedStyle.emptyState();

--- a/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
@@ -102,6 +102,11 @@ inline void RenderStyle::setIsLink(bool isLink)
     m_computedStyle.setIsLink(isLink);
 }
 
+inline void RenderStyle::setIsFlexOrGridItem(bool isFlexOrGridItem)
+{
+    m_computedStyle.setIsFlexOrGridItem(isFlexOrGridItem);
+}
+
 inline void RenderStyle::setEmptyState(bool emptyState)
 {
     m_computedStyle.setEmptyState(emptyState);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -103,6 +103,9 @@ public:
     inline bool isLink() const;
     inline void setIsLink(bool);
 
+    inline bool isFlexOrGridItem() const;
+    inline void setIsFlexOrGridItem(bool);
+
     inline bool emptyState() const;
     inline void setEmptyState(bool);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -657,9 +657,9 @@ void RenderTreeBuilder::normalizeTreeAfterStyleChange(RenderElement& renderer, R
     if (!renderer.parent())
         return;
 
-    bool wasFloating = oldStyle.floating() != Float::None;
+    bool wasFloating = !oldStyle.isFlexOrGridItem() && oldStyle.floating() != Float::None;
     bool wasOutOfFlowPositioned = oldStyle.hasOutOfFlowPosition();
-    bool isFloating = renderer.style().floating() != Float::None;
+    bool isFloating = !renderer.style().isFlexOrGridItem() && renderer.style().floating() != Float::None;
     bool isOutOfFlowPositioned = renderer.style().hasOutOfFlowPosition();
     bool startsAffectingParent = false;
     bool noLongerAffectsParent = false;
@@ -873,7 +873,7 @@ void RenderTreeBuilder::removeAnonymousWrappersForInlineChildrenIfNeeded(RenderE
     // if we find a continuation.
     std::optional<bool> shouldAllChildrenBeInline;
     for (auto* current = blockParent->firstChild(); current; current = current->nextSibling()) {
-        if (current->style().floating() != Float::None || current->style().hasOutOfFlowPosition())
+        if ((!current->style().isFlexOrGridItem() && current->style().floating() != Float::None) || current->style().hasOutOfFlowPosition())
             continue;
 
         if (!is<RenderBlock>(*current))

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -53,7 +53,7 @@ static std::optional<RenderStyle> styleForFirstLetter(const RenderElement& first
     auto firstLetterStyle = RenderStyle::clone(*style);
 
     // If we have an initial letter drop that is >= 1, then we need to force floating to be on.
-    if (firstLetterStyle.initialLetter().drop() >= 1 && firstLetterStyle.floating() == Float::None)
+    if (firstLetterStyle.initialLetter().drop() >= 1 && !firstLetterStyle.isFlexOrGridItem() && firstLetterStyle.floating() == Float::None)
         firstLetterStyle.setFloating(firstLetterStyle.writingMode().isBidiLTR() ? Float::Left : Float::Right);
 
     // We have to compute the correct font-size for the first-letter if it has an initial letter height set.
@@ -89,7 +89,7 @@ static std::optional<RenderStyle> styleForFirstLetter(const RenderElement& first
 
     firstLetterStyle.setPseudoElementIdentifier({ { PseudoElementType::FirstLetter } });
     // Force inline display (except for floating first-letters).
-    firstLetterStyle.setDisplay(firstLetterStyle.floating() != Float::None ? Style::DisplayType::BlockFlow : Style::DisplayType::InlineFlow);
+    firstLetterStyle.setDisplay(!firstLetterStyle.isFlexOrGridItem() && firstLetterStyle.floating() != Float::None ? Style::DisplayType::BlockFlow : Style::DisplayType::InlineFlow);
     // CSS2 says first-letter can't be positioned.
     firstLetterStyle.setPosition(PositionType::Static);
 

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -134,7 +134,7 @@ static void addIntrinsicMargins(RenderStyle& style)
 
 static bool shouldInheritTextDecorationsInEffect(const RenderStyle& style, const Element* element)
 {
-    if (style.floating() != Float::None || style.hasOutOfFlowPosition())
+    if ((!style.isFlexOrGridItem() && style.floating() != Float::None) || style.hasOutOfFlowPosition())
         return false;
 
     // Media elements have a special rendering where the media controls do not use a proper containing
@@ -422,7 +422,7 @@ void Adjuster::adjustFirstLetterStyle(RenderStyle& style)
         return;
 
     // Force inline display (except for floating first-letters).
-    style.setDisplayMaintainingOriginalDisplay(style.floating() != Float::None ? DisplayType::BlockFlow : DisplayType::InlineFlow);
+    style.setDisplayMaintainingOriginalDisplay(!style.isFlexOrGridItem() && style.floating() != Float::None ? DisplayType::BlockFlow : DisplayType::InlineFlow);
 }
 
 void Adjuster::adjustFirstLineStyle(RenderStyle& style)
@@ -471,7 +471,7 @@ void Adjuster::adjust(RenderStyle& style) const
             style.setPosition(PositionType::Absolute);
 
         // Absolute/fixed positioned elements, floating elements and the document element need block-like outside display.
-        if (style.hasOutOfFlowPosition() || style.floating() != Float::None || (m_element && m_document->documentElement() == m_element.get()))
+        if (style.hasOutOfFlowPosition() || (!style.isFlexOrGridItem() && style.floating() != Float::None) || (m_element && m_document->documentElement() == m_element.get()))
             style.setDisplayMaintainingOriginalDisplay(style.display().blockified());
 
         adjustFirstLetterStyle(style);
@@ -520,12 +520,12 @@ void Adjuster::adjust(RenderStyle& style) const
         }
 
         if (m_parentBoxStyle.display().isDeprecatedFlexibleBox())
-            style.setFloating(Float::None);
+            style.setIsFlexOrGridItem(true);
 
         // https://www.w3.org/TR/css-display/#transformations
         // "A parent with a grid or flex display value blockifies the box’s display type."
         if (m_parentBoxStyle.display().isFlexibleOrGridFormattingContextBox()) {
-            style.setFloating(Float::None);
+            style.setIsFlexOrGridItem(true);
             style.setDisplayMaintainingOriginalDisplay(style.display().blockified());
         }
 

--- a/Source/WebCore/style/StyleChange.cpp
+++ b/Source/WebCore/style/StyleChange.cpp
@@ -55,7 +55,8 @@ OptionSet<Change> determineChanges(const RenderStyle& s1, const RenderStyle& s2)
         if (s1.columnSpan() != ColumnSpan::All)
             return false;
         // Spanning in ignored for floating and out-of-flow boxes.
-        return (s1.floating() != Float::None) != (s2.floating() != Float::None)
+        return
+            (!s1.isFlexOrGridItem() && s1.floating() != Float::None) != (!s2.isFlexOrGridItem() && s2.floating() != Float::None)
             || s1.hasOutOfFlowPosition() != s2.hasOutOfFlowPosition();
     };
 

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -603,7 +603,7 @@ static bool isChildInBlockFormattingContext(const RenderStyle& style)
         return false;
     if (style.hasOutOfFlowPosition())
         return false;
-    if (style.floating() != Float::None)
+    if (!style.isFlexOrGridItem() && style.floating() != Float::None)
         return false;
     if (style.overflowX() != Overflow::Visible || style.overflowY() != Overflow::Visible)
         return false;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
@@ -85,6 +85,7 @@ inline ComputedStyleBase::ComputedStyleBase(CreateDefaultStyleTag)
     m_nonInheritedFlags.firstChildState = false;
     m_nonInheritedFlags.lastChildState = false;
     m_nonInheritedFlags.isLink = false;
+    m_nonInheritedFlags.isFlexOrGridItem = false;
     m_nonInheritedFlags.pseudoElementType = 0;
     m_nonInheritedFlags.pseudoBits = 0;
 
@@ -130,6 +131,7 @@ inline void ComputedStyleBase::NonInheritedFlags::copyNonInheritedFrom(const Non
     useTreeCountingFunctions = other.useTreeCountingFunctions;
     hasExplicitlyInheritedProperties = other.hasExplicitlyInheritedProperties;
     disallowsFastPathInheritance = other.disallowsFastPathInheritance;
+    isFlexOrGridItem = other.isFlexOrGridItem;
 }
 
 } // namespace Style

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -124,6 +124,11 @@ inline bool ComputedStyleBase::isLink() const
     return m_nonInheritedFlags.isLink;
 }
 
+inline bool ComputedStyleBase::isFlexOrGridItem() const
+{
+    return m_nonInheritedFlags.isFlexOrGridItem;
+}
+
 inline bool ComputedStyleBase::emptyState() const
 {
     return m_nonInheritedFlags.emptyState;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -83,6 +83,11 @@ inline void ComputedStyleBase::setIsLink(bool isLink)
     m_nonInheritedFlags.isLink = isLink;
 }
 
+inline void ComputedStyleBase::setIsFlexOrGridItem(bool isFlexOrGridItem)
+{
+    m_nonInheritedFlags.isFlexOrGridItem = isFlexOrGridItem;
+}
+
 inline void ComputedStyleBase::setEmptyState(bool emptyState)
 {
     m_nonInheritedFlags.emptyState = emptyState;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -433,6 +433,7 @@ void ComputedStyleBase::NonInheritedFlags::dumpDifferences(TextStream& ts, const
     LOG_IF_DIFFERENT(firstChildState);
     LOG_IF_DIFFERENT(lastChildState);
     LOG_IF_DIFFERENT(isLink);
+    LOG_IF_DIFFERENT(isFlexOrGridItem);
 
     LOG_IF_DIFFERENT_WITH_CAST(PseudoId, pseudoElementType);
     LOG_IF_DIFFERENT_WITH_CAST(unsigned, pseudoBits);

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -475,6 +475,9 @@ public:
     inline bool isLink() const;
     inline void setIsLink(bool);
 
+    inline bool isFlexOrGridItem() const;
+    inline void setIsFlexOrGridItem(bool);
+
     inline bool emptyState() const;
     inline void setEmptyState(bool);
 
@@ -764,6 +767,7 @@ public:
         PREFERRED_TYPE(bool) unsigned firstChildState : 1;
         PREFERRED_TYPE(bool) unsigned lastChildState : 1;
         PREFERRED_TYPE(bool) unsigned isLink : 1;
+        PREFERRED_TYPE(bool) unsigned isFlexOrGridItem : 1;
         PREFERRED_TYPE(PseudoElementType) unsigned pseudoElementType : PseudoElementTypeBits;
         unsigned pseudoBits : PublicPseudoIDBits;
         unsigned textDecorationLine : TextDecorationLineBits; // Text decorations defined *only* by this element. PREFERRED_TYPE elided to avoid header inclusion.


### PR DESCRIPTION
#### b0492d2ebaeb38aeb17d84e6e5c613a8c8b100ec
<pre>
Disable floating of flex/grid items without adjusting float computed style.
<a href="https://bugs.webkit.org/show_bug.cgi?id=172999">https://bugs.webkit.org/show_bug.cgi?id=172999</a>

Reviewed by NOBODY (OOPS!).

Introduce a NonInheritedFlag in the style to indicate whether an element is a
flex/grid item and set it to true instead of setting the computed float property
to Float::None. Make sure to check this flag when internally testing for the
float property. This is generally replacing calls to floating() with
!isFlexOrGridItem() ? floating() : Float::None but there are minor behavior
differences with some invalidation checks.

* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-with-float-dynamic-expected.txt: Update expectation to PASS.
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/display-with-float-expected.txt: Update expectation to PASS.
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::isSpecialHTMLElement): Basic inclusion of isFlexOrGridItem().
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplaceSelectionCommand::removeRedundantStylesAndKeepStyleSpanInline): Ditto.
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::isEnclosingItemBoundaryElement): Ditto.
* Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp:
(WebCore::Layout::InlineInvalidation::styleWillChange): Ditto.
* Source/WebCore/layout/layouttree/LayoutBox.cpp:
(WebCore::Layout::Box::isFloatingPositioned const): Ditto.
* Source/WebCore/layout/layouttree/LayoutTreeBuilder.cpp:
(WebCore::Layout::TreeBuilder::createLayoutBox): Ditto.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::styleWillChange): Ditto.
(WebCore::RenderBlock::establishesIndependentFormattingContextIgnoringDisplayType const): Ditto.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::updateFromStyle): Ditto.
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleWillChange): Stricter invalidation condition, based on isFlexOrGridItem().
* Source/WebCore/rendering/TextAutoSizing.cpp:
(WebCore::TextAutoSizingHashTranslator::hash): Make the HashTranslator include isFlexOrGridItem().
(WebCore::TextAutoSizingHashTranslator::equal): Ditto.
* Source/WebCore/rendering/style/AutosizeStatus.cpp:
(WebCore::AutosizeStatus::compute): Basic inclusion of isFlexOrGridItem().
* Source/WebCore/rendering/style/RenderStyle+GettersInlines.h:
(WebCore::RenderStyle::isFlexOrGridItem const): Expose getter.
* Source/WebCore/rendering/style/RenderStyle+SettersInlines.h:
(WebCore::RenderStyle::setIsFlexOrGridItem): Expose setter.
* Source/WebCore/rendering/style/RenderStyle.h: Define getter/setter.
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::normalizeTreeAfterStyleChange): Basic inclusion of isFlexOrGridItem().
(WebCore::RenderTreeBuilder::removeAnonymousWrappersForInlineChildrenIfNeeded): Ditto.
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
(WebCore::styleForFirstLetter): Basic inclusion of isFlexOrGridItem().
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::shouldInheritTextDecorationsInEffect): Basic inclusion of isFlexOrGridItem().
(WebCore::Style::Adjuster::adjustFirstLetterStyle): Ditto.
(WebCore::Style::Adjuster::adjust const): Ditto and set isFlexOrGridItem instead of overriding the float property.
* Source/WebCore/style/StyleChange.cpp:
(WebCore::Style::determineChanges): Basic inclusion of isFlexOrGridItem().
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::isChildInBlockFormattingContext): Ditto.
* Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h:
(WebCore::Style::ComputedStyleBase::ComputedStyleBase): Initialize non inherited flag.
(WebCore::Style::ComputedStyleBase::NonInheritedFlags::copyNonInheritedFrom): Copy non inherited flag.
* Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h:
(WebCore::Style::ComputedStyleBase::isFlexOrGridItem const): Expose getter.
* Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h:
(WebCore::Style::ComputedStyleBase::setIsFlexOrGridItem): Expose setter.
* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
(WebCore::Style::ComputedStyleBase::NonInheritedFlags::dumpDifferences const): logging for isFlexOrGridItem.
* Source/WebCore/style/computed/StyleComputedStyleBase.h: New flag and setter/getter.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0492d2ebaeb38aeb17d84e6e5c613a8c8b100ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156970 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101715 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114328 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81472 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16565 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133147 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95098 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15681 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13484 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4407 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125289 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159303 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2438 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12570 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122362 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20771 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122581 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20780 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132876 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76931 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17989 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9615 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20388 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84173 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20120 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20174 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->