### PR TITLE
[GTK][WPE] Add single-entry GPU atlas cache to SkiaPaintingEngine

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -1249,12 +1249,14 @@ SkiaRecordingData GraphicsContextSkia::endRecording()
     m_contextMode = ContextMode::PaintingMode;
 
     Vector<Ref<SkiaImageAtlasLayout>> atlasLayouts;
+    unsigned imageSetFingerprint = 0;
     if (m_atlasLayoutBuilder) {
         atlasLayouts = m_atlasLayoutBuilder->finalize();
+        imageSetFingerprint = m_atlasLayoutBuilder->imageSetFingerprint();
         m_atlasLayoutBuilder = nullptr;
     }
 
-    return { WTF::move(m_imageToFenceMap), WTF::move(atlasLayouts) };
+    return { WTF::move(m_imageToFenceMap), WTF::move(atlasLayouts), imageSetFingerprint };
 }
 
 void GraphicsContextSkia::enableStateReplayTracking()

--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
@@ -115,7 +115,7 @@ bool SkiaGPUAtlas::uploadImages()
             if (!writeScope)
                 return false;
 
-            for (const auto& entry : m_layout.entries()) {
+            for (const auto& entry : m_layout->entries()) {
                 if (auto pixels = pixelDataInSRGB(entry.rasterImage))
                     gpuBuffer->updateContents(*writeScope, pixels->first, entry.atlasRect, pixels->second);
             }
@@ -126,7 +126,7 @@ bool SkiaGPUAtlas::uploadImages()
 #endif
 
     // GL fallback: use BitmapTexture::updateContents() per entry.
-    for (const auto& entry : m_layout.entries()) {
+    for (const auto& entry : m_layout->entries()) {
         if (auto pixels = pixelDataInSRGB(entry.rasterImage))
             m_atlasTexture->updateContents(pixels->first, entry.atlasRect, IntPoint::zero(), pixels->second, PixelFormat::BGRA8);
     }

--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h
@@ -71,7 +71,7 @@ private:
     Ref<BitmapTexture> m_atlasTexture;
     GrBackendTexture m_backendTexture;
     ImageToRectMap m_imageToRect;
-    const SkiaImageAtlasLayout& m_layout;
+    Ref<const SkiaImageAtlasLayout> m_layout;
     IntSize m_size;
 };
 

--- a/Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayout.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayout.h
@@ -29,13 +29,11 @@
 
 #include "IntRect.h"
 #include "IntSize.h"
-#include <optional>
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkImage.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
-#include <wtf/HashMap.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Vector.h>
 

--- a/Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayoutBuilder.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayoutBuilder.cpp
@@ -58,6 +58,7 @@ void SkiaImageAtlasLayoutBuilder::collectRasterImage(const sk_sp<SkImage>& image
     if (!m_collectedSet.add(image.get()).isNewEntry)
         return;
 
+    add(m_hasher, image.get());
     m_collectedImages.append({ image, IntSize(width, height) });
 }
 

--- a/Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayoutBuilder.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayoutBuilder.h
@@ -36,6 +36,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 #include <wtf/HashSet.h>
+#include <wtf/Hasher.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Vector.h>
 
@@ -66,6 +67,9 @@ public:
     // Number of collected images.
     size_t imageCount() const { return m_collectedImages.size(); }
 
+    // Fingerprint of all collected images, computed incrementally.
+    unsigned imageSetFingerprint() const { return m_hasher.hash(); }
+
     // Finalize: compute atlas packing, may create multiple atlases.
     // Returns vector of atlas layouts (empty if not enough images for atlasing).
     Vector<Ref<SkiaImageAtlasLayout>> finalize();
@@ -90,6 +94,7 @@ private:
 
     Vector<CollectedImage> m_collectedImages;
     HashSet<const SkImage*> m_collectedSet;
+    Hasher m_hasher;
     bool m_finalized { false };
 };
 

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -165,6 +165,16 @@ RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout&
     return atlas;
 }
 
+bool SkiaPaintingEngine::tryReuseCachedAtlases(SkiaRecordingResult& result, unsigned fingerprint)
+{
+    if (m_cachedGPUAtlases.isEmpty() || fingerprint != m_cachedImageFingerprint)
+        return false;
+
+    // Cache hit — reuse GPU atlases.
+    result.setGPUAtlases(copyToVectorOf<Ref<SkiaGPUAtlas>>(m_cachedGPUAtlases));
+    return true;
+}
+
 Ref<CoordinatedTileBuffer> SkiaPaintingEngine::paint(const GraphicsLayerCoordinated& layer, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale)
 {
     // ### Synchronous rendering on main thread ###
@@ -217,36 +227,53 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
     auto result = SkiaRecordingResult::create(WTF::move(picture), WTF::move(recordingData), recordRect, renderingMode, contentsOpaque, contentsScale);
 
     // Prepare GPU atlases on main thread before dispatching to workers.
-    // Textures are acquired from BitmapTexturePool which handles recycling.
     if (result->hasAtlasLayouts()) {
-        PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent();
+        auto fingerprint = result->imageSetFingerprint();
 
-        auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
-        RELEASE_ASSERT(grContext);
+        // Fast path: reuse cached atlases if the image set is unchanged.
+        if (!tryReuseCachedAtlases(result.get(), fingerprint)) {
+            PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent();
 
-        Vector<Ref<SkiaGPUAtlas>> gpuAtlases;
-        auto uploadCondition = AtlasUploadCondition::create();
-        gpuAtlases.reserveInitialCapacity(result->atlasLayouts().size());
+            auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+            RELEASE_ASSERT(grContext);
 
-        for (const auto& layout : result->atlasLayouts()) {
-            if (auto atlas = createAtlas(layout.get(), uploadCondition.get()))
-                gpuAtlases.append(atlas.releaseNonNull());
+            Vector<Ref<SkiaGPUAtlas>> gpuAtlases;
+            auto uploadCondition = AtlasUploadCondition::create();
+            gpuAtlases.reserveInitialCapacity(result->atlasLayouts().size());
+
+            for (const auto& layout : result->atlasLayouts()) {
+                if (auto atlas = createAtlas(layout.get(), uploadCondition.get()))
+                    gpuAtlases.append(atlas.releaseNonNull());
+            }
+
+            if (!gpuAtlases.isEmpty()) {
+                // Only populate atlas cache when we see the same fingerprint twice in a row.
+                // This avoids holding the BitmapTextures by an extra frame, if not needed.
+                if (fingerprint == m_cachedImageFingerprint) {
+                    m_cachedGPUAtlases = WTF::move(gpuAtlases);
+                    result->setGPUAtlases(copyToVectorOf<Ref<SkiaGPUAtlas>>(m_cachedGPUAtlases), WTF::move(uploadCondition));
+                } else {
+                    m_cachedImageFingerprint = fingerprint;
+                    m_cachedGPUAtlases.clear();
+                    result->setGPUAtlases(WTF::move(gpuAtlases), WTF::move(uploadCondition));
+                }
+
+                // Flush and fence for the GL upload path, where
+                // BitmapTexture::updateContents() issues GL upload commands.
+                // On the DMA-buf path, uploading is CPU-side (memory-mapped),
+                // so this is a no-op flush but harmless.
+                auto& glDisplay = PlatformDisplay::sharedDisplay().glDisplay();
+                if (GLFence::isSupported(glDisplay)) {
+                    grContext->flushAndSubmit(GrSyncCpu::kNo);
+                    result->setUploadFence(GLFence::create(glDisplay));
+                } else
+                    grContext->flushAndSubmit(GrSyncCpu::kYes);
+            }
         }
-
-        if (!gpuAtlases.isEmpty()) {
-            result->setGPUAtlases(WTF::move(gpuAtlases), WTF::move(uploadCondition));
-
-            // Flush and fence for the GL upload path, where
-            // BitmapTexture::updateContents() issues GL upload commands.
-            // On the DMA-buf path, uploading is CPU-side (memory-mapped),
-            // so this is a no-op flush but harmless.
-            auto& glDisplay = PlatformDisplay::sharedDisplay().glDisplay();
-            if (GLFence::isSupported(glDisplay)) {
-                grContext->flushAndSubmit(GrSyncCpu::kNo);
-                result->setUploadFence(GLFence::create(glDisplay));
-            } else
-                grContext->flushAndSubmit(GrSyncCpu::kYes);
-        }
+    } else {
+        // No atlas layouts — clear cache to release GPU memory.
+        m_cachedImageFingerprint = 0;
+        m_cachedGPUAtlases.clear();
     }
 
     return result;

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -70,9 +70,12 @@ private:
     Ref<CoordinatedTileBuffer> createBuffer(RenderingMode, const IntSize&, bool contentsOpaque) const;
     void paintIntoGraphicsContext(const GraphicsLayer&, GraphicsContext&, const IntRect&, bool contentsOpaque, float contentsScale) const;
     RefPtr<SkiaGPUAtlas> createAtlas(const SkiaImageAtlasLayout&, AtlasUploadCondition&);
+    bool tryReuseCachedAtlases(SkiaRecordingResult&, unsigned fingerprint);
 
     RefPtr<WorkerPool> m_paintingWorkerPool;
     RefPtr<WorkQueue> m_uploadWorkQueue;
+    unsigned m_cachedImageFingerprint { 0 };
+    Vector<Ref<SkiaGPUAtlas>> m_cachedGPUAtlases;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp
@@ -34,6 +34,7 @@ SkiaRecordingResult::SkiaRecordingResult(sk_sp<SkPicture>&& picture, SkiaRecordi
     : m_picture(WTF::move(picture))
     , m_imageToFenceMap(WTF::move(recordingData.imageToFenceMap))
     , m_atlasLayouts(WTF::move(recordingData.atlasLayouts))
+    , m_imageSetFingerprint(recordingData.imageSetFingerprint)
     , m_recordRect(recordRect)
     , m_renderingMode(renderingMode)
     , m_contentsOpaque(contentsOpaque)

--- a/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h
@@ -83,6 +83,7 @@ private:
 struct SkiaRecordingData {
     SkiaImageToFenceMap imageToFenceMap;
     Vector<Ref<SkiaImageAtlasLayout>> atlasLayouts;
+    unsigned imageSetFingerprint { 0 };
 };
 
 class SkiaRecordingResult final : public ThreadSafeRefCounted<SkiaRecordingResult, WTF::DestructionThread::Main> {
@@ -102,9 +103,10 @@ public:
     // Atlas layouts for batched raster image uploads.
     bool hasAtlasLayouts() const { return !m_atlasLayouts.isEmpty(); }
     const Vector<Ref<SkiaImageAtlasLayout>>& atlasLayouts() const { return m_atlasLayouts; }
+    unsigned imageSetFingerprint() const { return m_imageSetFingerprint; }
 
     // GPU atlases prepared on main thread for worker threads to rewrap.
-    void setGPUAtlases(Vector<Ref<SkiaGPUAtlas>>&& atlases, Ref<AtlasUploadCondition>&& condition)
+    void setGPUAtlases(Vector<Ref<SkiaGPUAtlas>>&& atlases, RefPtr<AtlasUploadCondition>&& condition = nullptr)
     {
         m_gpuAtlases = WTF::move(atlases);
         m_uploadCondition = WTF::move(condition);
@@ -132,9 +134,10 @@ private:
     SkiaImageToFenceMap m_imageToFenceMap WTF_GUARDED_BY_LOCK(m_imageToFenceMapLock);
     Lock m_imageToFenceMapLock;
     Vector<Ref<SkiaImageAtlasLayout>> m_atlasLayouts;
+    unsigned m_imageSetFingerprint { 0 };
     Vector<Ref<SkiaGPUAtlas>> m_gpuAtlases;
     std::unique_ptr<GLFence> m_uploadFence; // Fence for async GPU upload
-    RefPtr<AtlasUploadCondition> m_uploadCondition; // Non-null when m_gpuAtlases is non-empty.
+    RefPtr<AtlasUploadCondition> m_uploadCondition;
     IntRect m_recordRect;
     RenderingMode m_renderingMode { RenderingMode::Unaccelerated };
     bool m_contentsOpaque : 1 { true };


### PR DESCRIPTION
#### 46f3b534eca4e044d22613ced4ef05f0c4c45f0c
<pre>
[GTK][WPE] Add single-entry GPU atlas cache to SkiaPaintingEngine
<a href="https://bugs.webkit.org/show_bug.cgi?id=309005">https://bugs.webkit.org/show_bug.cgi?id=309005</a>

Reviewed by Carlos Garcia Campos.

Relanding 308627@main after addressing the performance regression.

When the image set is unchanged between frames, reuse the GPU atlas from
the previous frame instead of allocating new textures, uploading pixels
and re-creating the atlas.

A WTF::Hasher-based fingerprint of the raster image pointer set is
computed incrementally in SkiaImageAtlasLayoutBuilder::collectRasterImage()
as images are collected during recording. The fingerprint is compared at
cache-lookup time for O(1) validation. Atlas refs are only stored in the
cache after seeing the same fingerprint twice in a row, so workloads
where the image set changes every frame (e.g. MotionMark/Images) never
cache any GPU atlases.

The SkiaGPUAtlas layout member is changed from a bare reference to
Ref&lt;const SkiaImageAtlasLayout&gt; so cached atlases can safely outlive
the SkiaRecordingResult that created them.

Covered by existing tests.

* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::endRecording):
* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp:
(WebCore::SkiaGPUAtlas::uploadImages):
* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h:
* Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayout.h:
* Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayoutBuilder.cpp:
(WebCore::SkiaImageAtlasLayoutBuilder::collectRasterImage):
* Source/WebCore/platform/graphics/skia/SkiaImageAtlasLayoutBuilder.h:
(WebCore::SkiaImageAtlasLayoutBuilder::imageSetFingerprint const):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::tryReuseCachedAtlases):
(WebCore::SkiaPaintingEngine::record):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:
* Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp:
(WebCore::SkiaRecordingResult::SkiaRecordingResult):
* Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h:

Canonical link: <a href="https://commits.webkit.org/308693@main">https://commits.webkit.org/308693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35fc96650ea222e2cf3b57ca0fc92c0d6cd22d3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148274 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156957 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150147 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20865 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114316 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95086 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4394 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125272 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159290 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2425 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12562 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122359 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20758 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122569 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/33321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132868 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22850 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17974 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9607 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20375 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20107 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20252 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->