### PR TITLE
[Skia] Conversion between TransformationMatrix and SkM44 is wrong

### DIFF
--- a/Source/WebCore/platform/graphics/skia/TransformationMatrixSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/TransformationMatrixSkia.cpp
@@ -35,32 +35,21 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 namespace WebCore {
 
 TransformationMatrix::TransformationMatrix(const SkM44& t)
-    : TransformationMatrix(SkScalarToDouble(t.rc(0, 0)), SkScalarToDouble(t.rc(0, 1)), SkScalarToDouble(t.rc(0, 2)), SkScalarToDouble(t.rc(0, 3)),
-        SkScalarToDouble(t.rc(1, 0)), SkScalarToDouble(t.rc(1, 1)), SkScalarToDouble(t.rc(1, 2)), SkScalarToDouble(t.rc(1, 3)),
-        SkScalarToDouble(t.rc(2, 0)), SkScalarToDouble(t.rc(2, 1)), SkScalarToDouble(t.rc(2, 2)), SkScalarToDouble(t.rc(2, 3)),
-        SkScalarToDouble(t.rc(3, 0)), SkScalarToDouble(t.rc(3, 1)), SkScalarToDouble(t.rc(3, 2)), SkScalarToDouble(t.rc(3, 3)))
+    : TransformationMatrix(
+        SkScalarToDouble(t.rc(0, 0)), SkScalarToDouble(t.rc(1, 0)), SkScalarToDouble(t.rc(2, 0)), SkScalarToDouble(t.rc(3, 0)),
+        SkScalarToDouble(t.rc(0, 1)), SkScalarToDouble(t.rc(1, 1)), SkScalarToDouble(t.rc(2, 1)), SkScalarToDouble(t.rc(3, 1)),
+        SkScalarToDouble(t.rc(0, 2)), SkScalarToDouble(t.rc(1, 2)), SkScalarToDouble(t.rc(2, 2)), SkScalarToDouble(t.rc(3, 2)),
+        SkScalarToDouble(t.rc(0, 3)), SkScalarToDouble(t.rc(1, 3)), SkScalarToDouble(t.rc(2, 3)), SkScalarToDouble(t.rc(3, 3)))
 {
 }
 
 TransformationMatrix::operator SkM44() const
 {
     return SkM44 {
-        SkDoubleToScalar(m11()),
-        SkDoubleToScalar(m12()),
-        SkDoubleToScalar(m13()),
-        SkDoubleToScalar(m14()),
-        SkDoubleToScalar(m21()),
-        SkDoubleToScalar(m22()),
-        SkDoubleToScalar(m23()),
-        SkDoubleToScalar(m24()),
-        SkDoubleToScalar(m31()),
-        SkDoubleToScalar(m32()),
-        SkDoubleToScalar(m33()),
-        SkDoubleToScalar(m34()),
-        SkDoubleToScalar(m41()),
-        SkDoubleToScalar(m42()),
-        SkDoubleToScalar(m43()),
-        SkDoubleToScalar(m44())
+        SkDoubleToScalar(m11()), SkDoubleToScalar(m21()), SkDoubleToScalar(m31()), SkDoubleToScalar(m41()),
+        SkDoubleToScalar(m12()), SkDoubleToScalar(m22()), SkDoubleToScalar(m32()), SkDoubleToScalar(m42()),
+        SkDoubleToScalar(m13()), SkDoubleToScalar(m23()), SkDoubleToScalar(m33()), SkDoubleToScalar(m43()),
+        SkDoubleToScalar(m14()), SkDoubleToScalar(m24()), SkDoubleToScalar(m34()), SkDoubleToScalar(m44())
     };
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/TransformationMatrix.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/TransformationMatrix.cpp
@@ -42,6 +42,12 @@
 #include <QuartzCore/QuartzCore.h>
 #endif
 
+#if USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkM44.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#endif
+
 namespace TestWebKitAPI {
 
 static void testIdentity(const WebCore::TransformationMatrix& transform)
@@ -1170,7 +1176,7 @@ TEST(TransformationMatrix, Equality)
     ASSERT_TRUE(test3 != test4);
 }
 
-#if USE(CA)
+#if USE(CA) || USE(SKIA)
 static void testTranslationMatrix(const WebCore::TransformationMatrix& matrix)
 {
     EXPECT_DOUBLE_EQ(1.0, matrix.m11());
@@ -1222,6 +1228,31 @@ TEST(TransformationMatrix, Casting)
     EXPECT_DOUBLE_EQ(3.0, caFromWK.m42);
     EXPECT_DOUBLE_EQ(2.0, caFromWK.m43);
     EXPECT_DOUBLE_EQ(1.0, caFromWK.m44);
+#elif USE(SKIA)
+    SkM44 m44 = SkM44::Translate(10.0f, 15.0f, 30.0f);
+    WebCore::TransformationMatrix fromSkiaM44(m44);
+    testTranslationMatrix(fromSkiaM44);
+
+    SkM44 m44FromWK = test;
+    EXPECT_DOUBLE_EQ(m44FromWK.rc(0, 0), 16.0);
+    EXPECT_DOUBLE_EQ(m44FromWK.rc(1, 0), 15.0);
+    EXPECT_DOUBLE_EQ(m44FromWK.rc(2, 0), 14.0);
+    EXPECT_DOUBLE_EQ(m44FromWK.rc(3, 0), 13.0);
+    EXPECT_DOUBLE_EQ(m44FromWK.rc(0, 1), 12.0);
+    EXPECT_DOUBLE_EQ(m44FromWK.rc(1, 1), 11.0);
+    EXPECT_DOUBLE_EQ(m44FromWK.rc(2, 1), 10.0);
+    EXPECT_DOUBLE_EQ(m44FromWK.rc(3, 1), 9.0);
+    EXPECT_DOUBLE_EQ(m44FromWK.rc(0, 2), 8.0);
+    EXPECT_DOUBLE_EQ(m44FromWK.rc(1, 2), 7.0);
+    EXPECT_DOUBLE_EQ(m44FromWK.rc(2, 2), 6.0);
+    EXPECT_DOUBLE_EQ(m44FromWK.rc(3, 2), 5.0);
+    EXPECT_DOUBLE_EQ(m44FromWK.rc(0, 3), 4.0);
+    EXPECT_DOUBLE_EQ(m44FromWK.rc(1, 3), 3.0);
+    EXPECT_DOUBLE_EQ(m44FromWK.rc(2, 3), 2.0);
+    EXPECT_DOUBLE_EQ(m44FromWK.rc(3, 3), 1.0);
+
+    WebCore::TransformationMatrix fromMM4 = m44FromWK;
+    EXPECT_TRUE(fromMM4 == test);
 #else
     UNUSED_VARIABLE(test);
 #endif
@@ -1239,6 +1270,18 @@ TEST(TransformationMatrix, Casting)
     EXPECT_DOUBLE_EQ(11.0, cgFromWK.d);
     EXPECT_DOUBLE_EQ(4.0, cgFromWK.tx);
     EXPECT_DOUBLE_EQ(3.0, cgFromWK.ty);
+#elif USE(SKIA)
+    SkMatrix skMatrix = SkMatrix::MakeAll(6.0, 4.0, 2.0, 5.0, 3.0, 1.0, 0, 0, SK_Scalar1);
+    WebCore::TransformationMatrix fromSkMatrix = WebCore::AffineTransform(skMatrix);
+    testAffineLikeConstruction(fromSkMatrix);
+
+    SkMatrix skMatrixFromWK = test.toAffineTransform();
+    EXPECT_DOUBLE_EQ(16.0, skMatrixFromWK.get(SkMatrix::kMScaleX));
+    EXPECT_DOUBLE_EQ(15.0, skMatrixFromWK.get(SkMatrix::kMSkewY));
+    EXPECT_DOUBLE_EQ(12.0, skMatrixFromWK.get(SkMatrix::kMSkewX));
+    EXPECT_DOUBLE_EQ(11.0, skMatrixFromWK.get(SkMatrix::kMScaleY));
+    EXPECT_DOUBLE_EQ(4.0, skMatrixFromWK.get(SkMatrix::kMTransX));
+    EXPECT_DOUBLE_EQ(3.0, skMatrixFromWK.get(SkMatrix::kMTransY));
 #endif
 
 #if PLATFORM(WIN) || (PLATFORM(GTK) && OS(WINDOWS))


### PR DESCRIPTION
#### 0db582da747bfc2ec2a37dad193c233cc1d5ee68
<pre>
[Skia] Conversion between TransformationMatrix and SkM44 is wrong
<a href="https://bugs.webkit.org/show_bug.cgi?id=309246">https://bugs.webkit.org/show_bug.cgi?id=309246</a>

Reviewed by Nikolas Zimmermann.

SkM44 stores the matrix in column order like TransformationMatrix, but the api expects values in row order.

Test: Tools/TestWebKitAPI/Tests/WebCore/TransformationMatrix.cpp

* Source/WebCore/platform/graphics/skia/TransformationMatrixSkia.cpp:
(WebCore::TransformationMatrix::TransformationMatrix):
(WebCore::TransformationMatrix::operator SkM44 const):
* Tools/TestWebKitAPI/Tests/WebCore/TransformationMatrix.cpp:
(TestWebKitAPI::TEST(TransformationMatrix, Casting)):

Canonical link: <a href="https://commits.webkit.org/308691@main">https://commits.webkit.org/308691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0c620cf53592b76d6fcbcac18ff2bdbe798fbbd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148276 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156959 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114320 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16551 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133132 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95090 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4396 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159292 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/2427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122351 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20760 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17443 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122572 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132860 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22848 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9599 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20377 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20109 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->