### PR TITLE
[css-cascade] Implement revert-rule CSS keyword

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL revert-rule in keyframes, reverted-to value changing (standard property) assert_true: expected true got false
-FAIL revert-rule in keyframes, reverted-to value changing (custom property) assert_true: expected true got false
+FAIL revert-rule in keyframes, reverted-to value changing (standard property) assert_equals: expected "160px" but got "150px"
+FAIL revert-rule in keyframes, reverted-to value changing (custom property) assert_equals: expected "160px" but got "150px"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL revert-rule in keyframes (width) assert_true: expected true got false
-FAIL revert-rule in keyframes (--x) assert_true: expected true got false
+PASS revert-rule in keyframes (width)
+PASS revert-rule in keyframes (--x)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-basic-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL The revert-rule keyword rolls back to the previous rule assert_true: expected true got false
-FAIL Cascade order determines the previous rule, not order of appearance assert_true: expected true got false
-FAIL Reverting from style attribute reverts to regular rules assert_true: expected true got false
-FAIL A chain of revert-rule works assert_true: expected true got false
+PASS The revert-rule keyword rolls back to the previous rule
+PASS Cascade order determines the previous rule, not order of appearance
+PASS Reverting from style attribute reverts to regular rules
+PASS A chain of revert-rule works
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-custom-property-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-custom-property-expected.txt
@@ -1,0 +1,3 @@
+
+PASS revert-rule in a custom property
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-custom-property.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-custom-property.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<title>The revert-rule keyword: custom properties</title>
+<link rel="help" href="https://drafts.csswg.org/css-cascade-5/#revert-rule-keyword">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+#test1 {
+  --a: red;
+  --b: green;
+}
+#test1 {
+  --a: green;
+  --b: revert-rule;
+}
+#test1 {
+  --a: revert-rule;
+  --b: revert-rule;
+}
+</style>
+<div id=test1></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color:revert-rule'));
+    assert_equals(getComputedStyle(test1).getPropertyValue("--a"), 'green')
+    assert_equals(getComputedStyle(test1).getPropertyValue("--b"), 'green')
+
+  }, 'revert-rule in a custom property');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-important-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-important-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL revert-rule in !important declaration reverts to later normal rule if the !important rule comes first assert_true: expected true got false
+PASS revert-rule in !important declaration reverts to later normal rule if the !important rule comes first
 PASS revert-rule in !important declaration reverts across layers
 PASS revert-rule in !important declaration reverts to earlier normal rule if the !important rule comes later
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-layer-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL The revert-rule keyword can cross layers assert_true: expected true got false
-FAIL The revert-rule does not unconditionally cross layers assert_true: expected true got false
+PASS The revert-rule keyword can cross layers
+PASS The revert-rule does not unconditionally cross layers
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-revert-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-revert-layer-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Combination of revert-rule and revert-layer
+PASS Combination of revert-layer and revert-rule
+PASS Combination revert-rule/revert-rule/revert-layer
+PASS Combination revert-layer/revert-rule/revert-layer
+PASS Combination revert-rule/revert-layer/revert-rule
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-revert-layer.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-revert-layer.html
@@ -1,0 +1,175 @@
+<!DOCTYPE html>
+<title>The revert-rule keyword: interaction with revert-layer</title>
+<link rel="help" href="https://drafts.csswg.org/css-cascade-5/#revert-rule-keyword">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  @layer {
+    #test1 {
+      color: green;
+    }
+  }
+  @layer {
+    #test1 {
+      color: red;
+    }
+    #test1 {
+      color: revert-layer;
+    }
+  }
+  @layer {
+    #test1 {
+      color: revert-rule;
+      background-color: green;
+    }
+  }
+</style>
+<div id=test1></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color:revert-rule'));
+    assert_equals(getComputedStyle(test1).color, 'rgb(0, 128, 0)')
+    assert_equals(getComputedStyle(test1).backgroundColor, 'rgb(0, 128, 0)')
+  }, 'Combination of revert-rule and revert-layer');
+</script>
+
+<style>
+  @layer {
+    #test2 {
+      color: green;
+    }
+  }
+  @layer {
+    #test2 {
+      color: revert-rule;
+      background-color: green;
+    }
+  }
+  @layer {
+    #test2 {
+      color: red;
+    }
+    #test2 {
+      color: revert-layer;
+      background-color: revert-rule;
+    }
+  }
+</style>
+<div id=test2></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color:revert-rule'));
+    assert_equals(getComputedStyle(test2).color, 'rgb(0, 128, 0)')
+    assert_equals(getComputedStyle(test2).backgroundColor, 'rgb(0, 128, 0)')
+  }, 'Combination of revert-layer and revert-rule');
+</script>
+
+<style>
+  @layer {
+    #test3 {
+      color: green;
+    }
+  }
+  @layer {
+    #test3 {
+      color: red;
+    }
+    #test3 {
+      color: revert-layer;
+    }
+  }
+  @layer {
+    #test3 {
+      color: revert-rule;
+      background-color: green;
+    }
+  }
+  @layer {
+    #test3 {
+      color: revert-rule;
+      background-color: revert-rule;
+    }
+  }
+</style>
+<div id=test3></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color:revert-rule'));
+    assert_equals(getComputedStyle(test3).color, 'rgb(0, 128, 0)')
+    assert_equals(getComputedStyle(test3).backgroundColor, 'rgb(0, 128, 0)')
+  }, 'Combination revert-rule/revert-rule/revert-layer');
+</script>
+
+<style>
+  @layer {
+    #test4 {
+      color: green;
+    }
+  }
+  @layer {
+    #test4 {
+      color: red;
+    }
+    #test4 {
+      color: revert-layer;
+    }
+  }
+  @layer {
+    #test4 {
+      color: revert-rule;
+      background-color: green;
+    }
+  }
+  @layer {
+    #test4 {
+        color: red;
+        color: revert-layer;
+        background-color: revert-rule;
+    }
+  }
+</style>
+<div id=test4></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color:revert-rule'));
+    assert_equals(getComputedStyle(test4).color, 'rgb(0, 128, 0)')
+    assert_equals(getComputedStyle(test4).backgroundColor, 'rgb(0, 128, 0)')
+  }, 'Combination revert-layer/revert-rule/revert-layer');
+</script>
+
+<style>
+  @layer {
+    #test5 {
+      color: green;
+    }
+  }
+  @layer {
+    #test5 {
+      color: revert-rule;
+      background-color: green;
+    }
+  }
+  @layer {
+    #test5 {
+      color: red;
+    }
+    #test5 {
+      color: revert-layer;
+    }
+  }
+  @layer {
+    #test5 {
+      color: revert-rule;
+      background-color: revert-rule;
+    }
+  }
+</style>
+<div id=test5></div>
+<script>
+  test(() => {
+    assert_true(CSS.supports('color:revert-rule'));
+    assert_equals(getComputedStyle(test5).color, 'rgb(0, 128, 0)')
+    assert_equals(getComputedStyle(test5).backgroundColor, 'rgb(0, 128, 0)')
+  }, 'Combination revert-rule/revert-layer/revert-rule');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-property-style-queries-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-property-style-queries-expected.txt
@@ -55,6 +55,7 @@ PASS Query custom property including unknown var() reference with matching fallb
 PASS Query custom property matching guaranteed-invalid values
 PASS Style query with revert keyword is false
 PASS Style query with revert-layer keyword is false
+PASS Style query with revert-rule keyword is false
 PASS Style query 'initial' matching
 PASS Style query matching negated value-less query against initial value
 PASS Style query 'initial' not matching

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-env/env-revert-rule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-env/env-revert-rule-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL The revert-rule works in an env() fallback assert_true: expected true got false
+PASS The revert-rule works in an env() fallback
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-revert-rule.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-revert-rule.tentative-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL The revert-rule keyword can revert to a nested rule assert_true: expected true got false
-FAIL The revert-rule keyword can revert to a CSSNestedDeclarationsRule assert_true: expected true got false
-FAIL The revert-rule keyword can revert from a CSSNestedDeclarationsRule assert_true: expected true got false
-FAIL The revert-rule keyword can revert to scoped declarations assert_true: expected true got false
+PASS The revert-rule keyword can revert to a nested rule
+PASS The revert-rule keyword can revert to a CSSNestedDeclarationsRule
+PASS The revert-rule keyword can revert from a CSSNestedDeclarationsRule
+PASS The revert-rule keyword can revert to scoped declarations
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-function-revert-rule-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-function-revert-rule-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL The revert-rule works as a branch in if() assert_true: expected true got false
-FAIL The revert-rule works as a branch in if(), earlier return assert_true: expected true got false
+FAIL The revert-rule works as a branch in if() assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+FAIL The revert-rule works as a branch in if(), earlier return assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-rule-in-fallback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-rule-in-fallback-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL var(--unknown, revert-rule) in custom property assert_equals: expected "PASS" but got "revert-rule"
-FAIL var(--unknown, revert-rule) in shorthand assert_true: expected true got false
-FAIL var(--unknown, revert-rule) in shorthand observed via longhand assert_true: expected true got false
-FAIL var(--unknown, revert-rule) in longhand assert_true: expected true got false
+PASS var(--unknown, revert-rule) in custom property
+PASS var(--unknown, revert-rule) in shorthand
+PASS var(--unknown, revert-rule) in shorthand observed via longhand
+PASS var(--unknown, revert-rule) in longhand
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-rule-to-var-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-rule-to-var-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Using revert-rule to revert to a value containing var() assert_true: expected true got false
+PASS Using revert-rule to revert to a value containing var()
 

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -6,6 +6,7 @@ initial
 unset
 revert
 revert-layer
+revert-rule
 
 //
 // CSS_PROP_OUTLINE_STYLE

--- a/Source/WebCore/css/CSSWideKeyword.h
+++ b/Source/WebCore/css/CSSWideKeyword.h
@@ -38,7 +38,8 @@ enum class CSSWideKeyword : uint8_t {
     Inherit,
     Unset,
     Revert,
-    RevertLayer
+    RevertLayer,
+    RevertRule
 };
 
 inline bool isCSSWideKeyword(CSSValueID valueID)
@@ -49,6 +50,7 @@ inline bool isCSSWideKeyword(CSSValueID valueID)
     case CSSValueUnset:
     case CSSValueRevert:
     case CSSValueRevertLayer:
+    case CSSValueRevertRule:
         return true;
     default:
         return false;
@@ -68,6 +70,8 @@ inline std::optional<CSSWideKeyword> parseCSSWideKeyword(CSSValueID valueID)
         return CSSWideKeyword::Revert;
     case CSSValueRevertLayer:
         return CSSWideKeyword::RevertLayer;
+    case CSSValueRevertRule:
+        return CSSWideKeyword::RevertRule;
     default:
         return { };
     }
@@ -86,6 +90,8 @@ inline CSSValueID toValueID(CSSWideKeyword keyword)
         return CSSValueRevert;
     case CSSWideKeyword::RevertLayer:
         return CSSValueRevertLayer;
+    case CSSWideKeyword::RevertRule:
+        return CSSValueRevertRule;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -738,7 +738,8 @@ static bool isUniversalKeyword(StringView string)
         || equalLettersIgnoringASCIICase(string, "inherit"_s)
         || equalLettersIgnoringASCIICase(string, "unset"_s)
         || equalLettersIgnoringASCIICase(string, "revert"_s)
-        || equalLettersIgnoringASCIICase(string, "revert-layer"_s);
+        || equalLettersIgnoringASCIICase(string, "revert-layer"_s)
+        || equalLettersIgnoringASCIICase(string, "revert-rule"_s);
 }
 
 static RefPtr<CSSValue> parseKeywordValue(CSSPropertyID property, StringView string, CSS::PropertyParserState& state)

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -69,6 +69,20 @@ PropertyCascade::PropertyCascade(const PropertyCascade& parent, Origin maximumOr
     buildCascade();
 }
 
+// Constructs a cascade where all properties in the parent cascade have been reverted.
+PropertyCascade::PropertyCascade(const PropertyCascade& parent, RevertRuleTag)
+    : m_matchResult(parent.m_matchResult)
+    , m_includedProperties(normalProperties())
+    , m_maximumOrigin(parent.m_maximumOrigin)
+    , m_rollbackScope(parent.m_rollbackScope)
+    , m_maximumCascadeLayerPriorityForRollback(parent.m_maximumCascadeLayerPriorityForRollback)
+    , m_ruleRollbackDepth(parent.m_ruleRollbackDepth + 1) // Increment rollback depth.
+    , m_animationLayer(parent.m_animationLayer)
+    , m_positionTryFallbackProperties(parent.m_positionTryFallbackProperties)
+{
+    buildCascade();
+}
+
 PropertyCascade::~PropertyCascade() = default;
 
 PropertyCascade::AnimationLayer::AnimationLayer(const HashSet<AnimatableCSSProperty>& properties)
@@ -104,6 +118,8 @@ void PropertyCascade::buildCascade()
     }
 
     sortLogicalGroupPropertyIDs();
+
+    m_delayedRollbackProperties.clear();
 }
 
 void PropertyCascade::setPropertyInternal(Property& property, CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, Origin origin)
@@ -132,8 +148,10 @@ void PropertyCascade::setPropertyInternal(Property& property, CSSPropertyID id, 
 
 void PropertyCascade::set(CSSPropertyID id, CSSValue& cssValue, const MatchedProperties& matchedProperties, Origin origin)
 {
-    ASSERT(!CSSProperty::isInLogicalPropertyGroup(id));
-    ASSERT(id < firstLogicalGroupProperty);
+    if (id >= firstLogicalGroupProperty) {
+        setLogicalGroupProperty(id, cssValue, matchedProperties, origin);
+        return;
+    }
 
     ASSERT(id < m_propertyIsPresent.size());
     if (id == CSSPropertyCustom) {
@@ -169,6 +187,29 @@ void PropertyCascade::setLogicalGroupProperty(CSSPropertyID id, CSSValue& cssVal
     }
     setLogicalGroupPropertyIndex(id, ++m_lastIndexForLogicalGroup);
     setPropertyInternal(property, id, cssValue, matchedProperties, origin);
+}
+
+void PropertyCascade::setDelayingForRuleRollback(CSSPropertyID propertyID, CSSValue& cssValue, const MatchedProperties& matchedProperties, Origin origin)
+{
+    ASSERT(m_ruleRollbackDepth);
+
+    auto key = [&] -> std::pair<unsigned, AtomString>  {
+        if (propertyID == CSSPropertyCustom)
+            return { propertyID, downcast<CSSCustomPropertyValue>(cssValue).name() };
+        return { propertyID, emptyAtom() };
+    }();
+    auto& delayedValues = m_delayedRollbackProperties.ensure(key, [&] {
+        return Deque<DelayedRollbackProperty>();
+    }).iterator->value;
+
+    delayedValues.prepend(DelayedRollbackProperty { cssValue, matchedProperties, origin });
+
+    // Ignore the last m_ruleRollbackDepth values for each property.
+    if (delayedValues.size() <= m_ruleRollbackDepth)
+        return;
+
+    auto last = delayedValues.takeLast();
+    set(propertyID, last.value, last.properties, last.origin);
 }
 
 bool PropertyCascade::hasProperty(CSSPropertyID propertyID, const CSSValue& value)
@@ -287,10 +328,12 @@ bool PropertyCascade::addMatch(const MatchedProperties& matchedProperties, Origi
         if (!shouldIncludeProperty)
             continue;
 
-        if (propertyID < firstLogicalGroupProperty)
-            set(propertyID, *current.value(), matchedProperties, origin);
-        else
-            setLogicalGroupProperty(propertyID, *current.value(), matchedProperties, origin);
+        if (m_ruleRollbackDepth) {
+            setDelayingForRuleRollback(propertyID, *current.value(), matchedProperties, origin);
+            continue;
+        }
+
+        set(propertyID, *current.value(), matchedProperties, origin);
     }
 
     return hasImportantProperties;

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -73,6 +73,8 @@ public:
 
     PropertyCascade(const MatchResult&, IncludedProperties&&, const HashSet<AnimatableCSSProperty>* = nullptr, const StyleProperties* positionTryFallbackProperties = nullptr);
     PropertyCascade(const PropertyCascade&, Origin, std::optional<ScopeOrdinal> rollbackScope = { }, std::optional<CascadeLayerPriority> maximumCascadeLayerPriorityForRollback = { });
+    enum RevertRuleTag { RevertRule };
+    PropertyCascade(const PropertyCascade&, RevertRuleTag);
 
     ~PropertyCascade();
 
@@ -119,6 +121,7 @@ private:
     void set(CSSPropertyID, CSSValue&, const MatchedProperties&, Origin);
     void setLogicalGroupProperty(CSSPropertyID, CSSValue&, const MatchedProperties&, Origin);
     static void NODELETE setPropertyInternal(Property&, CSSPropertyID, CSSValue&, const MatchedProperties&, Origin);
+    void setDelayingForRuleRollback(CSSPropertyID, CSSValue&, const MatchedProperties&, Origin);
 
     bool NODELETE hasProperty(CSSPropertyID, const CSSValue&);
     bool NODELETE mayOverrideExistingProperty(CSSPropertyID, const CSSValue&);
@@ -132,6 +135,7 @@ private:
     const Origin m_maximumOrigin;
     const std::optional<ScopeOrdinal> m_rollbackScope;
     const std::optional<CascadeLayerPriority> m_maximumCascadeLayerPriorityForRollback;
+    const unsigned m_ruleRollbackDepth { 0 };
 
     struct AnimationLayer {
         AnimationLayer(const HashSet<AnimatableCSSProperty>&);
@@ -144,6 +148,13 @@ private:
     };
     std::optional<AnimationLayer> m_animationLayer;
     std::optional<MatchedProperties> m_positionTryFallbackProperties;
+
+    struct DelayedRollbackProperty {
+        CSSValue& value;
+        const MatchedProperties& properties;
+        Origin origin;
+    };
+    HashMap<std::pair<unsigned, AtomString>, Deque<DelayedRollbackProperty>> m_delayedRollbackProperties;
 
     // The CSSPropertyID enum is sorted like this:
     // 1. CSSPropertyInvalid and CSSPropertyCustom.

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -369,19 +369,27 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
     bool isUnset = valueID == CSSValueUnset;
     bool isRevert = valueID == CSSValueRevert;
     bool isRevertLayer = valueID == CSSValueRevertLayer;
-    bool isRevertOrRevertLayer = isRevert || isRevertLayer;
+    bool isRevertRule = valueID == CSSValueRevertRule;
+    bool isAnyRevert = isRevert || isRevertLayer || isRevertRule;
 
-    if (isRevertOrRevertLayer) {
-        // In @keyframes, 'revert-layer' rolls back the cascaded value to the author level.
+    if (isAnyRevert) {
+        // In @keyframes, 'revert-layer' and 'revert-rule' roll back the cascaded value to the author level.
         // We can just not apply the property in order to keep the value from the base style.
-        if (isRevertLayer && m_state->m_isBuildingKeyframeStyle)
+        if ((isRevertLayer || isRevertRule) && m_state->m_isBuildingKeyframeStyle)
             return;
 
-        auto* rollbackCascade = isRevert ? ensureRollbackCascadeForRevert() : ensureRollbackCascadeForRevertLayer();
+        auto* rollbackCascade = [&] -> const PropertyCascade* {
+            if (isRevert)
+                return ensureRollbackCascadeForRevert();
+            if (isRevertLayer)
+                return ensureRollbackCascadeForRevertLayer();
+            return ensureRollbackCascadeForRevertRule();
+        }();
 
         if (rollbackCascade) {
             // With the rollback cascade built, we need to obtain the property and apply it. If the property is
             // not present, then we behave like "unset." Otherwise we apply the property instead of our own.
+            SetForScope rollbackScope(m_state->m_currentRollbackCascade, rollbackCascade);
             if (applyRollbackCascadeProperty(*rollbackCascade, id, linkMatchMask))
                 return;
         }
@@ -397,7 +405,7 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
         return isInheritedProperty() ? ApplyValueType::Inherit : ApplyValueType::Initial;
     };
 
-    if (isUnset || isRevertOrRevertLayer)
+    if (isUnset || isAnyRevert)
         valueType = unsetValueType();
 
     if (!m_state->applyPropertyToRegularStyle() && !isValidVisitedLinkProperty(id)) {
@@ -426,10 +434,10 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
 
     BuilderGenerated::applyProperty(id, m_state, valueToApply.get(), valueType);
 
-    if (!isRevertOrRevertLayer)
+    if (!isAnyRevert)
         m_state->disableNativeAppearanceIfNeeded(id, cascadeOrigin);
 
-    if (!isUnset && !isRevertOrRevertLayer && m_state->isCurrentPropertyInvalidAtComputedValueTime()) {
+    if (!isUnset && !isAnyRevert && m_state->isCurrentPropertyInvalidAtComputedValueTime()) {
         // https://drafts.csswg.org/css-variables-2/#invalid-variables
         // A declaration can be invalid at computed-value time if...
         // When this happens, the computed value is one of the following...
@@ -476,6 +484,7 @@ void Builder::applyCustomProperty(const AtomString& name, Variant<Ref<const Styl
             ApplyValueType valueType = ApplyValueType::Value;
             bool isRevert = false;
             bool isRevertLayer = false;
+            bool isRevertRule = false;
 
             auto isInheritedProperty = [&] {
                 return registeredCustomProperty ? registeredCustomProperty->inherits : true;
@@ -505,19 +514,31 @@ void Builder::applyCustomProperty(const AtomString& name, Variant<Ref<const Styl
                 isRevertLayer = true;
                 valueType = unsetValueType();
                 break;
+            case CSSWideKeyword::RevertRule:
+                isRevertRule = true;
+                valueType = unsetValueType();
+                break;
             }
 
-            if (isRevert || isRevertLayer) {
-                // In @keyframes, 'revert-layer' rolls back the cascaded value to the author level.
+            bool isAnyRevert = isRevert || isRevertLayer || isRevertRule;
+            if (isAnyRevert) {
+                // In @keyframes, 'revert-layer' and 'revert-rule' roll back the cascaded value to the author level.
                 // We can just not apply the property in order to keep the value from the base style.
-                if (isRevertLayer && m_state->m_isBuildingKeyframeStyle)
+                if ((isRevertLayer || isRevertRule) && m_state->m_isBuildingKeyframeStyle)
                     return;
 
-                auto* rollbackCascade = isRevert ? ensureRollbackCascadeForRevert() : ensureRollbackCascadeForRevertLayer();
+                auto* rollbackCascade = [&] -> const PropertyCascade* {
+                    if (isRevert)
+                        return ensureRollbackCascadeForRevert();
+                    if (isRevertLayer)
+                        return ensureRollbackCascadeForRevertLayer();
+                    return ensureRollbackCascadeForRevertRule();
+                }();
 
                 if (rollbackCascade) {
                     // With the rollback cascade built, we need to obtain the property and apply it. If the property is
                     // not present, then we behave like "unset." Otherwise we apply the property instead of our own.
+                    SetForScope rollbackScope(m_state->m_currentRollbackCascade, rollbackCascade);
                     if (applyRollbackCascadeCustomProperty(*rollbackCascade, name))
                         return;
                 }
@@ -636,7 +657,8 @@ RefPtr<const CustomProperty> Builder::resolveCustomPropertyForContainerQueries(c
                 return isInherited ? inherit() : initial();
             case CSSWideKeyword::Revert:
             case CSSWideKeyword::RevertLayer:
-                // https://drafts.csswg.org/css-contain-3/#style-container
+            case CSSWideKeyword::RevertRule:
+                // https://drafts.csswg.org/css-conditional-5/#style-container
                 // "Cascade-dependent keywords, such as revert and revert-layer, are invalid as values in a style feature,
                 // and cause the container style query to be false."
                 return nullptr;
@@ -761,7 +783,8 @@ const PropertyCascade* Builder::ensureRollbackCascadeForRevert()
         return nullptr;
     }
 
-    auto key = makeRollbackCascadeKey(rollbackOrigin);
+    auto& parentCascade = parentCascadeForRollback();
+    auto key = makeRollbackCascadeKey(parentCascade, rollbackOrigin);
     return m_rollbackCascades.ensure(key, [&] {
         return makeUnique<const PropertyCascade>(m_cascade, rollbackOrigin);
     }).iterator->value.get();
@@ -780,16 +803,37 @@ const PropertyCascade* Builder::ensureRollbackCascadeForRevertLayer()
     if (property.fromStyleAttribute == FromStyleAttribute::No)
         --rollbackLayerPriority;
 
-    auto key = makeRollbackCascadeKey(property.origin, property.styleScopeOrdinal, rollbackLayerPriority);
+    auto& parentCascade = parentCascadeForRollback();
+    auto key = makeRollbackCascadeKey(parentCascade, property.origin, property.styleScopeOrdinal, rollbackLayerPriority);
+
     return m_rollbackCascades.ensure(key, [&] {
-        return makeUnique<const PropertyCascade>(m_cascade, property.origin, property.styleScopeOrdinal, rollbackLayerPriority);
+        return makeUnique<const PropertyCascade>(parentCascade, property.origin, property.styleScopeOrdinal, rollbackLayerPriority);
     }).iterator->value.get();
 }
 
-auto Builder::makeRollbackCascadeKey(PropertyCascade::Origin cascadeOrigin, ScopeOrdinal scopeOrdinal, CascadeLayerPriority cascadeLayerPriority) -> RollbackCascadeKey
+const PropertyCascade* Builder::ensureRollbackCascadeForRevertRule()
 {
-    static constexpr auto isNonEmptyValue = true;
-    return { static_cast<unsigned>(cascadeOrigin), static_cast<unsigned>(scopeOrdinal), static_cast<unsigned>(cascadeLayerPriority), isNonEmptyValue };
+    auto& parentCascade = parentCascadeForRollback();
+    auto key = makeRollbackCascadeKeyForRevertRule(parentCascade);
+
+    return m_rollbackCascades.ensure(key, [&] {
+        return makeUnique<const PropertyCascade>(parentCascade, PropertyCascade::RevertRule);
+    }).iterator->value.get();
+}
+
+const PropertyCascade& Builder::parentCascadeForRollback()
+{
+    return m_state->m_currentRollbackCascade ? *m_state->m_currentRollbackCascade : m_cascade;
+}
+
+auto Builder::makeRollbackCascadeKey(const PropertyCascade& parentCascade, PropertyCascade::Origin cascadeOrigin, ScopeOrdinal scopeOrdinal, CascadeLayerPriority cascadeLayerPriority) -> RollbackCascadeKey
+{
+    return { &parentCascade, static_cast<unsigned>(cascadeOrigin), static_cast<unsigned>(scopeOrdinal), static_cast<unsigned>(cascadeLayerPriority), false };
+}
+
+auto Builder::makeRollbackCascadeKeyForRevertRule(const PropertyCascade& parentCascade) -> RollbackCascadeKey
+{
+    return { &parentCascade, 0, 0, 0, true };
 }
 
 }

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -83,9 +83,12 @@ private:
 
     const PropertyCascade* ensureRollbackCascadeForRevert();
     const PropertyCascade* ensureRollbackCascadeForRevertLayer();
+    const PropertyCascade* ensureRollbackCascadeForRevertRule();
+    const PropertyCascade& parentCascadeForRollback();
 
-    using RollbackCascadeKey = std::tuple<unsigned, unsigned, unsigned, bool>;
-    RollbackCascadeKey makeRollbackCascadeKey(PropertyCascade::Origin, ScopeOrdinal = ScopeOrdinal::Element, CascadeLayerPriority = 0);
+    using RollbackCascadeKey = std::tuple<const PropertyCascade*, unsigned, unsigned, unsigned, bool>;
+    RollbackCascadeKey makeRollbackCascadeKey(const PropertyCascade& parentCascade, PropertyCascade::Origin, ScopeOrdinal = ScopeOrdinal::Element, CascadeLayerPriority = 0);
+    RollbackCascadeKey makeRollbackCascadeKeyForRevertRule(const PropertyCascade& parentCascade);
 
     const PropertyCascade m_cascade;
     // Rollback cascades are build on demand to resolve 'revert' and 'revert-layer' keywords.

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -255,6 +255,7 @@ private:
 
     const PropertyCascade::Property* m_currentProperty { nullptr };
     SelectorChecker::LinkMatchMask m_linkMatch { };
+    const PropertyCascade* m_currentRollbackCascade { nullptr };
 
     bool m_fontDirty { false };
     Vector<AtomString> m_registeredContentAttributes;


### PR DESCRIPTION
#### cdf824701b8c4d6c2047d7318deb2a9da0e0fbd2
<pre>
[css-cascade] Implement revert-rule CSS keyword
<a href="https://bugs.webkit.org/show_bug.cgi?id=308604">https://bugs.webkit.org/show_bug.cgi?id=308604</a>
<a href="https://rdar.apple.com/171132753">rdar://171132753</a>

Reviewed by Sam Weinig.

<a href="https://drafts.csswg.org/css-cascade-5/#revert-rule-keyword">https://drafts.csswg.org/css-cascade-5/#revert-rule-keyword</a>

The revert-rule CSS-wide keyword rolls back the cascade similar to revert and revert-layer,
except it works by style rule rather than cascade origin or cascade layer.

Tests: imported/w3c/web-platform-tests/css/css-cascade/revert-rule-custom-property.html
       imported/w3c/web-platform-tests/css/css-cascade/revert-rule-revert-layer.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-custom-property-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-custom-property.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-important-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-layer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-revert-layer-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-revert-layer.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-property-style-queries-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-env/env-revert-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-revert-rule.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-function-revert-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-rule-in-fallback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-rule-to-var-expected.txt:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/CSSWideKeyword.h:
(WebCore::isCSSWideKeyword):
(WebCore::parseCSSWideKeyword):
(WebCore::toValueID):
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::isUniversalKeyword):
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::PropertyCascade):

Add a constructor for revert-rule cascade.
This rolls backs every property by one or more rules.

(WebCore::Style::PropertyCascade::buildCascade):
(WebCore::Style::PropertyCascade::set):
(WebCore::Style::PropertyCascade::setDelayingForRuleRollback):

Instead of setting the value add it to a per-property vector.
Only set the values after this vector reaches the desired rollback depth.

(WebCore::Style::PropertyCascade::addMatch):
* Source/WebCore/style/PropertyCascade.h:
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):
(WebCore::Style::Builder::applyCustomProperty):
(WebCore::Style::Builder::resolveCustomPropertyForContainerQueries):
(WebCore::Style::Builder::ensureRollbackCascadeForRevert):
(WebCore::Style::Builder::ensureRollbackCascadeForRevertLayer):
(WebCore::Style::Builder::ensureRollbackCascadeForRevertRule):
(WebCore::Style::Builder::parentCascadeForRollback):

(WebCore::Style::Builder::makeRollbackCascadeKey):

Include the parent cascade to the rollback key.

(WebCore::Style::Builder::makeRollbackCascadeKeyForRevertRule):

Construct the revert-rule rollback cascade.

* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleBuilderState.h:

Test: imported/w3c/web-platform-tests/css/css-cascade/revert-rule-revert-layer.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-important-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-layer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-revert-layer-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/revert-rule-revert-layer.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-property-style-queries-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-env/env-revert-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/nesting-revert-rule.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/if-function-revert-rule-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-rule-in-fallback-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-variables/revert-rule-to-var-expected.txt:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/CSSWideKeyword.h:
(WebCore::isCSSWideKeyword):
(WebCore::parseCSSWideKeyword):
(WebCore::toValueID):
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::isUniversalKeyword):
* Source/WebCore/style/PropertyCascade.cpp:
(WebCore::Style::PropertyCascade::PropertyCascade):

Add a constructor for revert-rule cascade.
This simply rolls back every property as if they had `revert-rule` value, without considering the actual value.

(WebCore::Style::PropertyCascade::propertyIfExist const):

Add a helper.

(WebCore::Style::PropertyCascade::addMatch):

Skip property values equal to the cascade we are rolling back from, effectively falling back to whatever value
there would have if that rule did not exist.

* Source/WebCore/style/PropertyCascade.h:

* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):
(WebCore::Style::Builder::applyCustomProperty):

Track the current rollback cascade.
Handle t

(WebCore::Style::Builder::resolveCustomPropertyForContainerQueries):
(WebCore::Style::Builder::ensureRollbackCascadeForRevert):
(WebCore::Style::Builder::ensureRollbackCascadeForRevertLayer):
(WebCore::Style::Builder::ensureRollbackCascadeForRevertRule):

Add revert rule rollback cascade.

(WebCore::Style::Builder::parentCascadeForRollback):
(WebCore::Style::Builder::makeRollbackCascadeKey):

Include the parent cascade to the rollback key.

(WebCore::Style::Builder::makeRollbackCascadeKeyForRevertRule):
* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleBuilderState.h:

Canonical link: <a href="https://commits.webkit.org/308733@main">https://commits.webkit.org/308733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec60433d12cff2f38efc06daa54dbee45183e587

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157005 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64175cb9-8323-4642-8e4e-0d6e3a574acb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150195 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114354 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fbb381a9-916f-4ca8-8858-02ffa827a2d8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151282 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/16595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133181 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95124 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5645b49f-df6f-4dd5-a55e-ad3bfb6f012f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13513 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4442 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159338 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2473 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12604 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Passed layout tests; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122387 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17484 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122606 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/33336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20815 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132903 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76967 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/18020 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9649 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20423 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84208 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20155 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20300 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->