### PR TITLE
[WPE] Add WPEPlatform portable C++ flag-enum annotation for flags typedefs

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/WPEDefines.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDefines.h
@@ -34,6 +34,16 @@
 
 #define WPE_API __attribute__((visibility("default")))
 
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+#if __has_attribute(flag_enum)
+#define WPE_FLAG_ENUM __attribute__((flag_enum))
+#else
+#define WPE_FLAG_ENUM
+#endif
+
 /*
  * The G_DECLARE_DERIVABLE_TYPE macro creates an instance struct that
  * has ParentName as its only member; but to be able to use smart pointers

--- a/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEDisplay.h
@@ -50,7 +50,7 @@ G_BEGIN_DECLS
 #define WPE_TYPE_DISPLAY (wpe_display_get_type())
 WPE_DECLARE_DERIVABLE_TYPE (WPEDisplay, wpe_display, WPE, DISPLAY, GObject)
 
-typedef enum {
+typedef enum WPE_FLAG_ENUM {
     WPE_AVAILABLE_INPUT_DEVICE_NONE        = 0,
     WPE_AVAILABLE_INPUT_DEVICE_MOUSE       = (1 << 0),
     WPE_AVAILABLE_INPUT_DEVICE_KEYBOARD    = (1 << 1),

--- a/Source/WebKit/WPEPlatform/wpe/WPEEvent.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEEvent.h
@@ -114,7 +114,7 @@ typedef enum {
  *
  * Flags to indicate the state of modifier keys and pointer buttons.
  */
-typedef enum {
+typedef enum WPE_FLAG_ENUM {
     WPE_MODIFIER_KEYBOARD_CONTROL = 1 << 0,
     WPE_MODIFIER_KEYBOARD_SHIFT = 1 << 1,
     WPE_MODIFIER_KEYBOARD_ALT = 1 << 2,

--- a/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h
@@ -107,8 +107,7 @@ typedef enum
  * Some common sense is expected when using these flags - mixing
  * %WPE_INPUT_HINT_LOWERCASE with any of the uppercase hints makes no sense.
  */
-typedef enum
-{
+typedef enum WPE_FLAG_ENUM {
   WPE_INPUT_HINT_NONE                = 0,
   WPE_INPUT_HINT_SPELLCHECK          = 1 << 0,
   WPE_INPUT_HINT_NO_SPELLCHECK       = 1 << 1,

--- a/Source/WebKit/WPEPlatform/wpe/WPEToplevel.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEToplevel.h
@@ -72,7 +72,7 @@ struct _WPEToplevelClass
  *
  * The current state of a #WPEToplevel.
  */
-typedef enum {
+typedef enum WPE_FLAG_ENUM {
     WPE_TOPLEVEL_STATE_NONE       = 0,
     WPE_TOPLEVEL_STATE_FULLSCREEN = (1 << 0),
     WPE_TOPLEVEL_STATE_MAXIMIZED  = (1 << 1),


### PR DESCRIPTION
#### a592b57c07f9dc07ec54737465816a50d70ae534
<pre>
[WPE] Add WPEPlatform portable C++ flag-enum annotation for flags typedefs
<a href="https://bugs.webkit.org/show_bug.cgi?id=309247">https://bugs.webkit.org/show_bug.cgi?id=309247</a>

Reviewed by NOBODY (OOPS!).

This is causing problems with the Android port compilation because we are
using the C headers from C++ and they are not expected to be used as bitmasks
unless we explecitely define them like flag_enum.

Introduced WPE_FLAG_ENUM in WPEDefines.h and use it on WPE flags enums:
  - WPEAvailableInputDevices
  - WPEModifiers
  - WPEInputHints
  - WPEToplevelState

This keeps compiler-level flag_enum annotations in public headers without
using __attribute__((flag_enum)) directly in enum declarations, that
causes problems with the glib-mkenums tool.

* Source/WebKit/WPEPlatform/wpe/WPEDefines.h:
* Source/WebKit/WPEPlatform/wpe/WPEDisplay.h:
* Source/WebKit/WPEPlatform/wpe/WPEEvent.h:
* Source/WebKit/WPEPlatform/wpe/WPEInputMethodContext.h:
* Source/WebKit/WPEPlatform/wpe/WPEToplevel.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a592b57c07f9dc07ec54737465816a50d70ae534

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156972 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101717 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114329 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81468 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16560 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95099 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15676 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13486 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4409 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125284 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159305 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2440 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122363 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17454 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122582 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20782 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132875 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76933 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17985 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9614 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20390 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84175 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20122 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20267 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20176 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->