### PR TITLE
Web Inspector: REGRESSION(307475@main): Storage tab, Network tab, Heap Snapshot content scroll uncontrollably

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DataGrid.css
+++ b/Source/WebInspectorUI/UserInterface/Views/DataGrid.css
@@ -55,6 +55,7 @@
     right: 0;
     overflow-x: hidden;
     overflow-y: scroll;
+    overflow-anchor: none;
 }
 
 .data-grid.inline .data-container {

--- a/Source/WebInspectorUI/UserInterface/Views/Table.css
+++ b/Source/WebInspectorUI/UserInterface/Views/Table.css
@@ -85,6 +85,7 @@
     right: 0;
     overflow-x: hidden;
     overflow-y: scroll;
+    overflow-anchor: none;
 }
 
 .table > .resizers {


### PR DESCRIPTION
#### 88e4b7b165201ae9a16a869676bd198ca646e4ff
<pre>
Web Inspector: REGRESSION(307475@main): Storage tab, Network tab, Heap Snapshot content scroll uncontrollably
<a href="https://bugs.webkit.org/show_bug.cgi?id=309248">https://bugs.webkit.org/show_bug.cgi?id=309248</a>
<a href="https://rdar.apple.com/171394072">rdar://171394072</a>

Reviewed by BJ Burg.

With scroll anchoring enabled, the &quot;before layout&quot; hook occurs after building the render tree but before layout.

In the case of `WI.Table` and `WI.DataGrid` which populate the rows and then trigger layout,
scroll anchoring latches onto a &lt;tbody&gt; with lots of 0x0 rows.

This patch disables scroll anchoring for these cases.

* Source/WebInspectorUI/UserInterface/Views/DataGrid.css:
(.data-grid .data-container):
* Source/WebInspectorUI/UserInterface/Views/Table.css:
(.table &gt; .data-container):

Canonical link: <a href="https://commits.webkit.org/308726@main">https://commits.webkit.org/308726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ebab47df82d6202532dda3e5c4860f471a713d1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20971 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156968 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/607cf287-6de3-41c8-a82f-6d503d47c0dc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114326 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e323fe7f-2784-49e9-8af5-6ffa7d6e2a0a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133141 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95096 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d166f905-b41f-4fc9-b313-669863b879af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15673 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13482 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4405 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125281 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11046 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159301 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2436 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122358 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20769 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17450 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122579 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33330 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20778 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132870 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76929 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17981 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9609 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20386 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84171 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20118 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20263 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20172 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->