### PR TITLE
[webkitpy][GLIB] Fix architecture field value for glib Port classes

### DIFF
--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -34,6 +34,7 @@ import re
 import uuid
 
 from webkitpy.common.memoized import memoized
+from webkitpy.layout_tests.models.test_configuration import TestConfiguration
 from webkitpy.port.base import Port
 from webkitpy.port.leakdetector_valgrind import LeakDetectorValgrind
 from webkitpy.port.linux_get_crash_log import GDBCrashLogGenerator
@@ -42,6 +43,8 @@ _log = logging.getLogger(__name__)
 
 
 class GLibPort(Port):
+
+    ARCHITECTURES = ['x86_64', 'arm64']
 
     def __init__(self, *args, **kwargs):
         super(GLibPort, self).__init__(*args, **kwargs)
@@ -68,6 +71,19 @@ class GLibPort(Port):
         if self.get_option('configuration') == 'Debug':
             multiplier *= 2
         return multiplier * default_timeout
+
+    def architecture(self):
+        result = self.get_option('architecture') or self.host.platform.architecture()
+        if result == 'aarch64':
+            return 'arm64'
+        return result
+
+    def _generate_all_test_configurations(self):
+        configurations = []
+        for build_type in self.ALL_BUILD_TYPES:
+            for architecture in self.ARCHITECTURES:
+                configurations.append(TestConfiguration(version=self.version_name(), architecture=architecture, build_type=build_type))
+        return configurations
 
     @classmethod
     def determine_full_port_name(cls, host, options, port_name):

--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -37,7 +37,6 @@ import webkitpy
 from webkitpy.common.system import path
 from webkitpy.common.memoized import memoized
 from webkitpy.common.system.executive import ScriptError
-from webkitpy.layout_tests.models.test_configuration import TestConfiguration
 from webkitpy.port.glib import GLibPort
 from webkitpy.port.xvfbdriver import XvfbDriver
 from webkitpy.port.westondriver import WestonDriver
@@ -96,12 +95,6 @@ class GtkPort(GLibPort):
                 _log.warning("Can't find Gallium llvmpipe driver. Try to run update-webkitgtk-libs")
 
         return environment
-
-    def _generate_all_test_configurations(self):
-        configurations = []
-        for build_type in self.ALL_BUILD_TYPES:
-            configurations.append(TestConfiguration(version=self.version_name(), architecture='x86', build_type=build_type))
-        return configurations
 
     def _path_to_driver(self):
         return self._built_executables_path(self.driver_name())

--- a/Tools/Scripts/webkitpy/port/gtk_unittest.py
+++ b/Tools/Scripts/webkitpy/port/gtk_unittest.py
@@ -84,6 +84,29 @@ class GtkPortTest(port_testcase.PortTestCase):
         self.assertEqual(self.make_port(options=MockOptions(configuration='Release', leaks=True, wrapper="valgrind")).default_timeout_ms(), 300000)
         self.assertEqual(self.make_port(options=MockOptions(configuration='Debug', leaks=True, wrapper="valgrind")).default_timeout_ms(), 600000)
 
+    def test_architecture_default(self):
+        port = self.make_port()
+        self.assertEqual(port.architecture(), port.host.platform.architecture())
+
+    def test_architecture_cli_override(self):
+        port = self.make_port(options=MockOptions(configuration='Release', architecture='custom_arch'))
+        self.assertEqual(port.architecture(), 'custom_arch')
+
+    def test_architecture_aarch64_normalization(self):
+        port = self.make_port()
+        port.host.platform._architecture = 'aarch64'
+        self.assertEqual(port.architecture(), 'arm64')
+
+    def test_architecture_cli_override_aarch64(self):
+        port = self.make_port(options=MockOptions(configuration='Release', architecture='aarch64'))
+        self.assertEqual(port.architecture(), 'arm64')
+
+    def test_all_test_configurations_architectures(self):
+        port = self.make_port()
+        configurations = port.all_test_configurations()
+        architectures = {config.architecture for config in configurations}
+        self.assertEqual(architectures, {'x86_64', 'arm64'})
+
     def test_get_crash_log(self):
         # This function tested in linux_get_crash_log_unittest.py
         pass

--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -33,7 +33,6 @@ import shlex
 
 from webkitpy.common.system import path
 from webkitpy.common.memoized import memoized
-from webkitpy.layout_tests.models.test_configuration import TestConfiguration
 from webkitpy.port.glib import GLibPort
 from webkitpy.port.headlessdriver import HeadlessDriver
 from webkitpy.port.westondriver import WestonDriver
@@ -88,12 +87,6 @@ class WPEPort(GLibPort):
 
     def check_sys_deps(self):
         return super(WPEPort, self).check_sys_deps() and self._driver_class().check_driver(self)
-
-    def _generate_all_test_configurations(self):
-        configurations = []
-        for build_type in self.ALL_BUILD_TYPES:
-            configurations.append(TestConfiguration(version=self.version_name(), architecture='x86', build_type=build_type))
-        return configurations
 
     def _path_to_driver(self):
         return self._built_executables_path(self.driver_name())

--- a/Tools/Scripts/webkitpy/port/wpe_unittest.py
+++ b/Tools/Scripts/webkitpy/port/wpe_unittest.py
@@ -79,6 +79,29 @@ class WPEPortTest(port_testcase.PortTestCase):
         self.assertEqual(self.make_port(options=MockOptions(configuration='Release', leaks=True, wrapper="valgrind")).default_timeout_ms(), 300000)
         self.assertEqual(self.make_port(options=MockOptions(configuration='Debug', leaks=True, wrapper="valgrind")).default_timeout_ms(), 600000)
 
+    def test_architecture_default(self):
+        port = self.make_port()
+        self.assertEqual(port.architecture(), port.host.platform.architecture())
+
+    def test_architecture_cli_override(self):
+        port = self.make_port(options=MockOptions(configuration='Release', architecture='custom_arch'))
+        self.assertEqual(port.architecture(), 'custom_arch')
+
+    def test_architecture_aarch64_normalization(self):
+        port = self.make_port()
+        port.host.platform._architecture = 'aarch64'
+        self.assertEqual(port.architecture(), 'arm64')
+
+    def test_architecture_cli_override_aarch64(self):
+        port = self.make_port(options=MockOptions(configuration='Release', architecture='aarch64'))
+        self.assertEqual(port.architecture(), 'arm64')
+
+    def test_all_test_configurations_architectures(self):
+        port = self.make_port()
+        configurations = port.all_test_configurations()
+        architectures = {config.architecture for config in configurations}
+        self.assertEqual(architectures, {'x86_64', 'arm64'})
+
     def test_get_crash_log(self):
         # This function tested in linux_get_crash_log_unittest.py
         pass


### PR DESCRIPTION
#### 1927f6c9ffc4112f9022bedc27d88abf79321d5d
<pre>
[webkitpy][GLIB] Fix architecture field value for glib Port classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=309249">https://bugs.webkit.org/show_bug.cgi?id=309249</a>

Reviewed by Carlos Alberto Lopez Perez.

Replace the currently hardcoded x86 architecture with runtime detection.

This fixes the results uploaded by the new ARM64 testers (307868@main).
Currently, they have the same x86 architecture as the x86_64, making it
hard to follow the history, especially when the outcome differ. For
example, while the x86_64 bot is in a good shape, queries to the
results database showed alternating green and red runs.

This commit also expands the list of test configurations for the glib
ports, covering both the default x86_64 and arm64 architectures, and
enabling architecture-specific expectations within the same expectation
file, for example:

[ arm64 ] some/test.html [ Crash ]

* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort):
(GLibPort.architecture):
(GLibPort._generate_all_test_configurations):
* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort.setup_environ_for_server):
(GtkPort._generate_all_test_configurations): Deleted.
* Tools/Scripts/webkitpy/port/gtk_unittest.py:
(GtkPortTest.test_architecture_default):
(GtkPortTest):
(GtkPortTest.test_architecture_cli_override):
(GtkPortTest.test_architecture_aarch64_normalization):
(GtkPortTest.test_architecture_cli_override_aarch64):
(GtkPortTest.test_all_test_configurations_architectures):
* Tools/Scripts/webkitpy/port/wpe.py:
(WPEPort.check_sys_deps):
(WPEPort._generate_all_test_configurations): Deleted.
* Tools/Scripts/webkitpy/port/wpe_unittest.py:
(WPEPortTest.test_architecture_default):
(WPEPortTest):
(WPEPortTest.test_architecture_cli_override):
(WPEPortTest.test_architecture_aarch64_normalization):
(WPEPortTest.test_architecture_cli_override_aarch64):
(WPEPortTest.test_all_test_configurations_architectures):

Canonical link: <a href="https://commits.webkit.org/308721@main">https://commits.webkit.org/308721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b15c51616301a92eb5ce6737640266c831342f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14571 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156973 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20881 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114331 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16564 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95101 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/147611 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15680 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13487 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4410 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125288 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159306 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12574 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122365 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122584 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33322 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132880 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76934 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17986 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9619 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20391 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20123 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20268 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20177 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->