### PR TITLE
Enhanced Security sites should age off after a reasonable time

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5329,7 +5329,7 @@ void WebPageProxy::receivedNavigationActionPolicyDecision(WebProcessProxy& proce
     if (preferences->enhancedSecurityForceDisabled())
         enhancedSecurity = EnhancedSecurity::Disabled;
 
-    if (preferences->enhancedSecurityHeuristicsEnabled())
+    if (preferences->enhancedSecurityHeuristicsEnabled() && enhancedSecurity != EnhancedSecurity::EnabledPolicy)
         protect(this->websiteDataStore())->trackEnhancedSecurityForDomain(RegistrableDomain { navigation.currentRequest().url() }, enhancedSecurity);
 
     Site site { navigation.currentRequest().url() };

--- a/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
@@ -33,6 +33,7 @@
 #include <wtf/MainThread.h>
 #include <wtf/Seconds.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/WallTime.h>
 #include <wtf/text/MakeString.h>
 
 #define ENHANCEDSECURITY_RELEASE_LOG(fmt, ...) RELEASE_LOG(EnhancedSecurity, "EnhancedSecuritySitesPersistence::" fmt, ##__VA_ARGS__)
@@ -43,8 +44,11 @@ static constexpr auto sitesTableName = "sites"_s;
 static constexpr auto siteIndexName = "idx_sites_site"_s;
 static constexpr auto enhancedSecurityStateIndexName = "idx_sites_enhanced_security_state"_s;
 
-static constexpr auto createSitesTableSQL = "CREATE TABLE sites (site TEXT PRIMARY KEY NOT NULL, enhanced_security_state INT NOT NULL)"_s;
+static constexpr auto createSitesTableSQL = "CREATE TABLE sites (site TEXT PRIMARY KEY NOT NULL, enhanced_security_state INT NOT NULL, last_modified REAL NOT NULL)"_s;
 static constexpr auto createEnhancedSecurityStateIndexSQL = "CREATE INDEX idx_sites_enhanced_security_state ON sites(enhanced_security_state)"_s;
+
+static constexpr Seconds enhancedSecuritySiteExpiryAge { 90 * 24 * 3600.0 };
+static constexpr auto deleteExpiredDisabledSitesSQL = "DELETE FROM sites WHERE enhanced_security_state = 0 AND last_modified < ?"_s;
 
 static constexpr auto selectAllSitesSQL = "SELECT site FROM sites"_s;
 
@@ -54,7 +58,7 @@ static constexpr auto selectEnhancedSecurityOnlySitesSQL = "SELECT site FROM sit
 static constexpr auto selectSpecificSiteSQL = "SELECT enhanced_security_state FROM sites WHERE site = ?"_s;
 static constexpr auto deleteAllSitesSQL = "DELETE FROM sites"_s;
 static constexpr auto deleteSiteSQL = "DELETE FROM sites WHERE site = ?"_s;
-static constexpr auto insertSiteSQL = "INSERT OR REPLACE INTO sites (site, enhanced_security_state) VALUES (?, ?)"_s;
+static constexpr auto insertSiteSQL = "INSERT OR REPLACE INTO sites (site, enhanced_security_state, last_modified) VALUES (?, ?, ?)"_s;
 
 EnhancedSecuritySitesPersistence::EnhancedSecuritySitesPersistence(const String& databaseDirectoryPath)
 {
@@ -135,6 +139,25 @@ bool EnhancedSecuritySitesPersistence::openDatabase(const String& directoryPath)
             return reportErrorAndCloseDatabase("create `enhanced_security_state` index on `sites` table"_s);
 
         ENHANCEDSECURITY_RELEASE_LOG("%s: Index %" PUBLIC_LOG_STRING " created", __FUNCTION__, enhancedSecurityStateIndexName.characters());
+    }
+
+    {
+        auto columnCheckStatement = checkedDB->prepareStatement("SELECT COUNT(*) FROM pragma_table_info('sites') WHERE name = 'last_modified'"_s);
+        bool hasLastModifiedColumn = columnCheckStatement && columnCheckStatement->step() == SQLITE_ROW && columnCheckStatement->columnInt(0) > 0;
+        if (!hasLastModifiedColumn) {
+            if (!checkedDB->executeCommand("ALTER TABLE sites ADD COLUMN last_modified REAL NOT NULL DEFAULT 0"_s))
+                return reportErrorAndCloseDatabase("add last_modified column"_s);
+            ENHANCEDSECURITY_RELEASE_LOG("%s: Added last_modified column to sites table", __FUNCTION__);
+        }
+    }
+
+    {
+        auto cutoff = (WallTime::now() - enhancedSecuritySiteExpiryAge).secondsSinceEpoch().value();
+        auto expiryStatement = checkedDB->prepareStatement(deleteExpiredDisabledSitesSQL);
+        if (!expiryStatement || expiryStatement->bindDouble(1, cutoff) != SQLITE_OK || !expiryStatement->executeCommand())
+            ENHANCEDSECURITY_RELEASE_LOG("%s: Failed to delete stale disabled sites", __FUNCTION__);
+        else
+            ENHANCEDSECURITY_RELEASE_LOG("%s: Deleted stale disabled sites older than %g days", __FUNCTION__, enhancedSecuritySiteExpiryAge.value() / (24 * 3600));
     }
 
     m_insertSiteSQLStatement = checkedDB->prepareStatement(insertSiteSQL);
@@ -266,10 +289,14 @@ void EnhancedSecuritySitesPersistence::trackEnhancedSecurityForDomain(WebCore::R
 
     CheckedPtr insertSiteStatement = cachedStatement(StatementType::InsertSite).get();
 
+    auto nowSeconds = WallTime::now().secondsSinceEpoch().value();
+    constexpr double secondsPerDay = 86400;
+    auto now = std::floor(nowSeconds / secondsPerDay) * secondsPerDay;
     auto enhancedSecurityReason = std::to_underlying(reason);
     if (!insertSiteStatement
         || insertSiteStatement->bindText(1, site.string()) != SQLITE_OK
         || insertSiteStatement->bindInt(2, enhancedSecurityReason) != SQLITE_OK
+        || insertSiteStatement->bindDouble(3, now) != SQLITE_OK
         || !insertSiteStatement->executeCommand())
         reportSQLError(__FUNCTION__, "Failed to insert or replace site"_s);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm
@@ -45,6 +45,7 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/WKWebpagePreferencesPrivate.h>
+#import <WebKit/WKWebsiteDataRecordPrivate.h>
 #import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <WebKit/WebKit.h>
 #import <WebKit/_WKFeature.h>
@@ -54,6 +55,7 @@
 #import <wtf/Assertions.h>
 #import <wtf/Function.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/WallTime.h>
 #import <wtf/text/MakeString.h>
 
 using namespace TestWebKitAPI;
@@ -1246,33 +1248,33 @@ static RetainPtr<NSString> emptyEnhancedSecuritySitesPath()
 static void createEnhancedSecuritySitesTable(WebCore::SQLiteDatabase& database)
 {
     constexpr auto createEnhancedSecuritySitesTable = "CREATE TABLE sites ("
-        "site TEXT PRIMARY KEY, enhanced_security_state INT NOT NULL)"_s;
+        "site TEXT PRIMARY KEY, enhanced_security_state INT NOT NULL, last_modified REAL NOT NULL DEFAULT 0)"_s;
 
     EXPECT_TRUE(database.executeCommand(createEnhancedSecuritySitesTable));
 }
 
-static void addEnhancedSecuritySite(WebCore::SQLiteDatabase& database, String site, SeenOutsideEnhancedSecurity seenOutsideEnhancedSecurity)
+static void addEnhancedSecuritySite(WebCore::SQLiteDatabase& database, String site, SeenOutsideEnhancedSecurity seenOutsideEnhancedSecurity, double lastModified = 0.0)
 {
-    constexpr auto query = "INSERT INTO sites (site, enhanced_security_state) VALUES (?, ?)"_s;
+    constexpr auto query = "INSERT INTO sites (site, enhanced_security_state, last_modified) VALUES (?, ?, ?)"_s;
     auto statement = database.prepareStatement(query);
-    EXPECT_TRUE(!!statement);
+    ASSERT_TRUE(!!statement);
 
     EXPECT_EQ(statement->bindText(1, site), SQLITE_OK);
     EXPECT_EQ(statement->bindInt(2, seenOutsideEnhancedSecurity == SeenOutsideEnhancedSecurity::Seen ? 0 : 1), SQLITE_OK);
+    EXPECT_EQ(statement->bindDouble(3, lastModified), SQLITE_OK);
     EXPECT_EQ(statement->step(), SQLITE_DONE);
     EXPECT_EQ(statement->reset(), SQLITE_OK);
 }
 
-static void setUpEnhancedSecuritySeenValues(std::initializer_list<std::pair<String, SeenOutsideEnhancedSecurity>> priorValues)
+static void setUpEnhancedSecuritySeenValues(std::initializer_list<std::tuple<String, SeenOutsideEnhancedSecurity, double>> priorValues)
 {
     auto database = makeUniqueRef<WebCore::SQLiteDatabase>();
     EXPECT_TRUE(database->open(emptyEnhancedSecuritySitesPath().get()));
 
     createEnhancedSecuritySitesTable(database.get());
 
-    RetainPtr<NSMutableDictionary> itemsDictionary = adoptNS([[NSMutableDictionary alloc] initWithCapacity:priorValues.size()]);
-    for (auto& pair : priorValues)
-        addEnhancedSecuritySite(database.get(), pair.first, pair.second);
+    for (auto& [site, state, lastModified] : priorValues)
+        addEnhancedSecuritySite(database.get(), site, state, lastModified);
 
     database->close();
 }
@@ -1290,7 +1292,7 @@ static void cleanUpEnhancedSecuritySites()
 static void runHttpThenNavigateToHttpsSiteWithCookiesViaAndExpectations(bool useSiteIsolation, SeenOutsideEnhancedSecurity seenOutsideEnhancedSecurity, ExpectedEnhancedSecurity finalExpectedEnhancedSecurity)
 {
     setUpEnhancedSecuritySeenValues({
-        { "different.internal"_s, seenOutsideEnhancedSecurity }
+        { "different.internal"_s, seenOutsideEnhancedSecurity, WallTime::now().secondsSinceEpoch().value() }
     });
 
     HTTPServer plaintextServer({
@@ -1468,6 +1470,127 @@ static void runForceDisabledOverridesHeuristics(bool useSiteIsolation)
     });
 }
 TEST_WITH_AND_WITHOUT_SITE_ISOLATION(ForceDisabledOverridesHeuristics)
+
+// MARK: - Stale Row Expiry Tests
+
+static void waitForEnhancedSecurityDatabaseOpen(WKWebView *webView)
+{
+    // Fetching EnhancedSecurityRecord data dispatches to the same serial work queue
+    // that openDatabase runs on, so completing this fetch guarantees openDatabase is done.
+    __block bool done = false;
+    NSSet *dataTypes = [NSSet setWithObject:_WKWebsiteDataTypeEnhancedSecurityRecord];
+    [[webView configuration].websiteDataStore fetchDataRecordsOfTypes:dataTypes completionHandler:^(NSArray<WKWebsiteDataRecord *> *) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
+static int countSitesInDatabase(WebCore::SQLiteDatabase& database, const String& site)
+{
+    constexpr auto query = "SELECT COUNT(*) FROM sites WHERE site = ?"_s;
+    auto statement = database.prepareStatement(query);
+    if (!statement || statement->bindText(1, site) != SQLITE_OK || statement->step() != SQLITE_ROW)
+        return -1;
+    return statement->columnInt(0);
+}
+
+TEST(EnhancedSecurityPolicies, StaleDisabledSiteIsRemovedOnDatabaseOpen)
+{
+    setUpEnhancedSecuritySeenValues({
+        std::tuple { "stale.internal"_s, SeenOutsideEnhancedSecurity::Seen, 0.0 }
+    });
+
+    auto webView = enhancedSecurityTestConfiguration(nullptr, nullptr, /* useSiteIsolation */ false, /* useNonPersistentStore */ false);
+    waitForEnhancedSecurityDatabaseOpen(webView.get());
+
+    auto verifyDB = makeUniqueRef<WebCore::SQLiteDatabase>();
+    EXPECT_TRUE(verifyDB->open(enhancedSecuritySitesPath().path));
+    EXPECT_EQ(countSitesInDatabase(verifyDB.get(), "stale.internal"_s), 0);
+    verifyDB->close();
+
+    cleanUpEnhancedSecuritySites();
+}
+
+TEST(EnhancedSecurityPolicies, RecentDisabledSiteIsKeptOnDatabaseOpen)
+{
+    setUpEnhancedSecuritySeenValues({
+        std::tuple { "recent.internal"_s, SeenOutsideEnhancedSecurity::Seen, WallTime::now().secondsSinceEpoch().value() }
+    });
+
+    auto webView = enhancedSecurityTestConfiguration(nullptr, nullptr, /* useSiteIsolation */ false, /* useNonPersistentStore */ false);
+    waitForEnhancedSecurityDatabaseOpen(webView.get());
+
+    auto verifyDB = makeUniqueRef<WebCore::SQLiteDatabase>();
+    EXPECT_TRUE(verifyDB->open(enhancedSecuritySitesPath().path));
+    EXPECT_EQ(countSitesInDatabase(verifyDB.get(), "recent.internal"_s), 1);
+    verifyDB->close();
+
+    cleanUpEnhancedSecuritySites();
+}
+
+TEST(EnhancedSecurityPolicies, StaleEnabledSiteIsKeptOnDatabaseOpen)
+{
+    setUpEnhancedSecuritySeenValues({
+        std::tuple { "stale-enabled.internal"_s, SeenOutsideEnhancedSecurity::NotSeen, 0.0 }
+    });
+
+    auto webView = enhancedSecurityTestConfiguration(nullptr, nullptr, /* useSiteIsolation */ false, /* useNonPersistentStore */ false);
+    waitForEnhancedSecurityDatabaseOpen(webView.get());
+
+    auto verifyDB = makeUniqueRef<WebCore::SQLiteDatabase>();
+    EXPECT_TRUE(verifyDB->open(enhancedSecuritySitesPath().path));
+    EXPECT_EQ(countSitesInDatabase(verifyDB.get(), "stale-enabled.internal"_s), 1);
+    verifyDB->close();
+
+    cleanUpEnhancedSecuritySites();
+}
+
+TEST(EnhancedSecurityPolicies, MigrationAddsLastModifiedColumnToExistingDatabase)
+{
+    auto dbPath = emptyEnhancedSecuritySitesPath();
+
+    {
+        auto database = makeUniqueRef<WebCore::SQLiteDatabase>();
+        EXPECT_TRUE(database->open(dbPath.get()));
+        EXPECT_TRUE(database->executeCommand("CREATE TABLE sites (site TEXT PRIMARY KEY, enhanced_security_state INT NOT NULL)"_s));
+        EXPECT_TRUE(database->executeCommand("CREATE INDEX idx_sites_enhanced_security_state ON sites(enhanced_security_state)"_s));
+
+        {
+            auto insertStmt = database->prepareStatement("INSERT INTO sites (site, enhanced_security_state) VALUES (?, ?)"_s);
+            ASSERT_TRUE(!!insertStmt);
+            EXPECT_EQ(insertStmt->bindText(1, "disabled-old.internal"_s), SQLITE_OK);
+            EXPECT_EQ(insertStmt->bindInt(2, 0), SQLITE_OK);
+            EXPECT_EQ(insertStmt->step(), SQLITE_DONE);
+            EXPECT_EQ(insertStmt->reset(), SQLITE_OK);
+
+            EXPECT_EQ(insertStmt->bindText(1, "enabled-old.internal"_s), SQLITE_OK);
+            EXPECT_EQ(insertStmt->bindInt(2, 1), SQLITE_OK);
+            EXPECT_EQ(insertStmt->step(), SQLITE_DONE);
+        }
+
+        database->close();
+    }
+
+    auto webView = enhancedSecurityTestConfiguration(nullptr, nullptr, /* useSiteIsolation */ false, /* useNonPersistentStore */ false);
+    waitForEnhancedSecurityDatabaseOpen(webView.get());
+
+    auto verifyDB = makeUniqueRef<WebCore::SQLiteDatabase>();
+    EXPECT_TRUE(verifyDB->open(dbPath.get()));
+
+    {
+        auto columnCheckStmt = verifyDB->prepareStatement("SELECT COUNT(*) FROM pragma_table_info('sites') WHERE name = 'last_modified'"_s);
+        EXPECT_TRUE(!!columnCheckStmt);
+        EXPECT_EQ(columnCheckStmt->step(), SQLITE_ROW);
+        EXPECT_GT(columnCheckStmt->columnInt(0), 0);
+    }
+
+    EXPECT_EQ(countSitesInDatabase(verifyDB.get(), "disabled-old.internal"_s), 0);
+    EXPECT_EQ(countSitesInDatabase(verifyDB.get(), "enabled-old.internal"_s), 1);
+
+    verifyDB->close();
+
+    cleanUpEnhancedSecuritySites();
+}
 
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/EnhancedSecurityPoliciesAdditions.mm>)
 #import <WebKitAdditions/EnhancedSecurityPoliciesAdditions.mm>


### PR DESCRIPTION
#### b3b6a65b02a9b7c41813846146975da29825d546
<pre>
Enhanced Security sites should age off after a reasonable time
<a href="https://bugs.webkit.org/show_bug.cgi?id=309250">https://bugs.webkit.org/show_bug.cgi?id=309250</a>
<a href="https://rdar.apple.com/171801546">rdar://171801546</a>

Reviewed by Matthew Finkel.

We should remove sites from the Enhanced Security sites DB after a
reasonable time period. This ages these entries off and periodically
clears them as needed.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationActionPolicyDecision):
* Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp:
(WebKit::EnhancedSecuritySitesPersistence::openDatabase):
(WebKit::EnhancedSecuritySitesPersistence::trackEnhancedSecurityForDomain):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurityPolicies.mm:
(createEnhancedSecuritySitesTable):
(addEnhancedSecuritySite):
(setUpEnhancedSecuritySeenValues):
(runHttpThenNavigateToHttpsSiteWithCookiesViaAndExpectations):
(waitForEnhancedSecurityDatabaseOpen):
(countSitesInDatabase):
(TEST(EnhancedSecurityPolicies, StaleDisabledSiteIsRemovedOnDatabaseOpen)):
(TEST(EnhancedSecurityPolicies, RecentDisabledSiteIsKeptOnDatabaseOpen)):
(TEST(EnhancedSecurityPolicies, StaleEnabledSiteIsKeptOnDatabaseOpen)):
(TEST(EnhancedSecurityPolicies, MigrationAddsLastModifiedColumnToExistingDatabase)):

Canonical link: <a href="https://commits.webkit.org/310445@main">https://commits.webkit.org/310445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68495dc4f52292a3df2ffbce2f8c077f4337df1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162610 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107322 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/24f1d18f-fd5e-4b24-beae-2f1b70c26b45) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155732 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27172 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26965 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118961 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84110 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1790f148-f34a-47ae-ba43-e5437eeccdb4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138154 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99671 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/15b37b42-9df1-450d-96c9-e1e3366c9996) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20308 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18270 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10442 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129956 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165082 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8214 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127047 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127214 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34514 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26442 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137808 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/83120 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22114 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14592 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26059 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90347 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25750 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25910 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25810 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->