### PR TITLE
RTCRtpTransceiver and friends should have a non-null backend

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpSender-getStats.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpSender-getStats.https-expected.txt
@@ -1,7 +1,7 @@
 
 PASS sender.getStats() via addTransceiver should return stats report containing outbound-rtp stats
 PASS sender.getStats() via addTrack should return stats report containing outbound-rtp stats
-FAIL sender.getStats() should work on a stopped transceiver but not have outbound-rtp stats assert_false: expected false got true
+PASS sender.getStats() should work on a stopped transceiver but not have outbound-rtp stats
 PASS sender.getStats() should work with a closed PeerConnection but not have outbound-rtp objects
 PASS sender.getStats() should return stats report containing ICE candidate stats
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -164,10 +164,8 @@ ExceptionOr<void> RTCPeerConnection::removeTrack(RTCRtpSender& sender)
         return Exception { ExceptionCode::InvalidAccessError, "RTCPeerConnection did not create the given sender"_s };
 
     bool shouldAbort = true;
-    RTCRtpTransceiver* senderTransceiver = nullptr;
     for (auto& transceiver : m_transceiverSet.list()) {
         if (&sender == &transceiver->sender()) {
-            senderTransceiver = transceiver.ptr();
             shouldAbort = sender.isStopped() || !sender.track();
             break;
         }
@@ -176,7 +174,6 @@ ExceptionOr<void> RTCPeerConnection::removeTrack(RTCRtpSender& sender)
         return { };
 
     sender.setTrackToNull();
-    senderTransceiver->disableSendingDirection();
     protect(*m_backend)->removeTrack(sender);
     return { };
 }
@@ -1194,13 +1191,11 @@ void RTCPeerConnection::updateDescriptions(PeerConnectionBackend::DescriptionSta
 void RTCPeerConnection::updateTransceiverTransports()
 {
     for (auto& transceiver : m_transceiverSet.list()) {
-        auto& sender = transceiver->sender();
-        if (RefPtr senderBackend = sender.backend())
-            sender.setTransport(getOrCreateDtlsTransport(senderBackend->dtlsTransportBackend()));
+        Ref sender = transceiver->sender();
+        sender->setTransport(getOrCreateDtlsTransport(sender->dtlsTransportBackend()));
 
-        auto& receiver = transceiver->receiver();
-        if (auto* receiverBackend = receiver.backend())
-            receiver.setTransport(getOrCreateDtlsTransport(receiverBackend->dtlsTransportBackend()));
+        Ref receiver = transceiver->receiver();
+        receiver->setTransport(getOrCreateDtlsTransport(receiver->dtlsTransportBackend()));
     }
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiver.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiver.cpp
@@ -51,7 +51,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RTCRtpReceiver);
 
-RTCRtpReceiver::RTCRtpReceiver(PeerConnectionBackend& connection, Ref<MediaStreamTrack>&& track, std::unique_ptr<RTCRtpReceiverBackend>&& backend)
+RTCRtpReceiver::RTCRtpReceiver(PeerConnectionBackend& connection, Ref<MediaStreamTrack>&& track, UniqueRef<RTCRtpReceiverBackend>&& backend)
     : m_track(WTF::move(track))
     , m_backend(WTF::move(backend))
     , m_connection(connection)
@@ -70,13 +70,14 @@ RTCRtpReceiver::~RTCRtpReceiver()
 
 void RTCRtpReceiver::stop()
 {
-    if (!m_backend)
+    if (m_isStopped)
         return;
+
+    m_isStopped = true;
 
     if (m_transform)
         m_transform->detachFromReceiver(*this);
 
-    m_backend = nullptr;
     m_track->stopTrack(MediaStreamTrack::StopMode::PostEvent);
 }
 
@@ -126,7 +127,7 @@ std::optional<RTCRtpTransform::Internal> RTCRtpReceiver::transform()
 
 ExceptionOr<RTCEncodedStreams> RTCRtpReceiver::createEncodedStreams(ScriptExecutionContext& context)
 {
-    if (!m_backend)
+    if (m_isStopped)
         return Exception { ExceptionCode::InvalidStateError };
 
     if (!m_encodedStreamProducer) {
@@ -139,6 +140,16 @@ ExceptionOr<RTCEncodedStreams> RTCRtpReceiver::createEncodedStreams(ScriptExecut
     }
 
     return m_encodedStreamProducer->streams();
+}
+
+std::unique_ptr<RTCDtlsTransportBackend> RTCRtpReceiver::dtlsTransportBackend()
+{
+    return m_backend->dtlsTransportBackend();
+}
+
+Ref<RTCRtpTransformBackend> RTCRtpReceiver::rtcRtpTransformBackend()
+{
+    return m_backend->rtcRtpTransformBackend();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediastream/RTCRtpReceiver.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpReceiver.h
@@ -43,7 +43,9 @@ namespace WebCore {
 
 class DeferredPromise;
 class PeerConnectionBackend;
+class RTCDtlsTransportBackend;
 class RTCEncodedStreamProducer;
+class RTCRtpTransformBackend;
 
 struct RTCEncodedStreams;
 struct RTCRtpCapabilities;
@@ -56,7 +58,7 @@ class RTCRtpReceiver final : public RefCounted<RTCRtpReceiver>
     {
     WTF_MAKE_TZONE_ALLOCATED(RTCRtpReceiver);
 public:
-    static Ref<RTCRtpReceiver> create(PeerConnectionBackend& connection, Ref<MediaStreamTrack>&& track, std::unique_ptr<RTCRtpReceiverBackend>&& backend)
+    static Ref<RTCRtpReceiver> create(PeerConnectionBackend& connection, Ref<MediaStreamTrack>&& track, UniqueRef<RTCRtpReceiverBackend>&& backend)
     {
         return adoptRef(*new RTCRtpReceiver(connection, WTF::move(track), WTF::move(backend)));
     }
@@ -66,17 +68,18 @@ public:
 
     void stop();
 
-    void setBackend(std::unique_ptr<RTCRtpReceiverBackend>&& backend) { m_backend = WTF::move(backend); }
-    RTCRtpParameters getParameters() { return m_backend ? m_backend->getParameters() : RTCRtpParameters(); }
-    Vector<RTCRtpContributingSource> getContributingSources() const { return m_backend ? m_backend->getContributingSources() : Vector<RTCRtpContributingSource> { }; }
-    Vector<RTCRtpSynchronizationSource> getSynchronizationSources() const { return m_backend ? m_backend->getSynchronizationSources() : Vector<RTCRtpSynchronizationSource> { }; }
+    RTCRtpParameters getParameters() { return m_backend->getParameters(); }
+    Vector<RTCRtpContributingSource> getContributingSources() const { return m_backend->getContributingSources(); }
+    Vector<RTCRtpSynchronizationSource> getSynchronizationSources() const { return m_backend->getSynchronizationSources(); }
 
     MediaStreamTrack& track() { return m_track.get(); }
 
     RTCDtlsTransport* transport() { return m_transport.get(); }
     void setTransport(RefPtr<RTCDtlsTransport>&& transport) { m_transport = WTF::move(transport); }
 
-    RTCRtpReceiverBackend* backend() { return m_backend.get(); }
+    RTCRtpReceiverBackend& backend() { return m_backend.get(); }
+    std::unique_ptr<RTCDtlsTransportBackend> dtlsTransportBackend();
+    Ref<RTCRtpTransformBackend> rtcRtpTransformBackend();
     void getStats(Ref<DeferredPromise>&&);
 
     std::optional<RTCRtpTransform::Internal> transform();
@@ -87,7 +90,7 @@ public:
     const Vector<WeakPtr<MediaStream>>& associatedStreams() const LIFETIME_BOUND { return m_associatedStreams; }
     void setAssociatedStreams(Vector<WeakPtr<MediaStream>>&& streams) { m_associatedStreams = WTF::move(streams); }
 private:
-    RTCRtpReceiver(PeerConnectionBackend&, Ref<MediaStreamTrack>&&, std::unique_ptr<RTCRtpReceiverBackend>&&);
+    RTCRtpReceiver(PeerConnectionBackend&, Ref<MediaStreamTrack>&&, UniqueRef<RTCRtpReceiverBackend>&&);
 
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return m_logger.get(); }
@@ -96,9 +99,10 @@ private:
     WTFLogChannel& NODELETE logChannel() const final;
 #endif
 
+    bool m_isStopped { false };
     const Ref<MediaStreamTrack> m_track;
     RefPtr<RTCDtlsTransport> m_transport;
-    std::unique_ptr<RTCRtpReceiverBackend> m_backend;
+    const UniqueRef<RTCRtpReceiverBackend> m_backend;
     WeakPtr<PeerConnectionBackend> m_connection;
     std::unique_ptr<RTCRtpTransform> m_transform;
     const RefPtr<RTCEncodedStreamProducer> m_encodedStreamProducer;

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
@@ -76,7 +76,6 @@ RTCRtpSender::RTCRtpSender(RTCPeerConnection& connection, String&& trackKind, Re
     , m_logIdentifier(connection.logIdentifier())
 #endif
 {
-    ASSERT(m_backend);
 }
 
 RTCRtpSender::~RTCRtpSender()
@@ -99,7 +98,7 @@ void RTCRtpSender::stop()
 
     m_trackId = { };
     m_track = nullptr;
-    m_backend = nullptr;
+    m_isStopped = true;
 }
 
 void RTCRtpSender::setTrack(Ref<MediaStreamTrack>&& track)
@@ -176,7 +175,7 @@ ExceptionOr<void> RTCRtpSender::setStreams(const FixedVector<std::reference_wrap
 
 ExceptionOr<void> RTCRtpSender::setMediaStreamIds(const FixedVector<String>& streamIds)
 {
-    if (!m_connection || m_connection->isClosed() || !m_backend)
+    if (!m_connection || m_connection->isClosed() || isStopped())
         return Exception { ExceptionCode::InvalidStateError, "connection is closed"_s };
     m_backend->setMediaStreamIds(streamIds);
     return { };
@@ -203,7 +202,7 @@ std::optional<RTCRtpCapabilities> RTCRtpSender::getCapabilities(ScriptExecutionC
 
 RTCDTMFSender* RTCRtpSender::dtmf()
 {
-    if (!m_dtmfSender && m_connection && m_connection->scriptExecutionContext() && m_backend && m_trackKind == "audio"_s)
+    if (!m_dtmfSender && m_connection && m_connection->scriptExecutionContext() && !isStopped() && m_trackKind == "audio"_s)
         m_dtmfSender = RTCDTMFSender::create(*protect(m_connection->scriptExecutionContext()), *this, m_backend->createDTMFBackend());
 
     return m_dtmfSender.get();
@@ -260,7 +259,7 @@ std::optional<RTCRtpTransform::Internal> RTCRtpSender::transform()
 
 ExceptionOr<RTCEncodedStreams> RTCRtpSender::createEncodedStreams(ScriptExecutionContext& context)
 {
-    if (!m_backend)
+    if (isStopped())
         return Exception { ExceptionCode::InvalidStateError };
 
     if (!m_encodedStreamProducer) {
@@ -273,6 +272,16 @@ ExceptionOr<RTCEncodedStreams> RTCRtpSender::createEncodedStreams(ScriptExecutio
     }
 
     return m_encodedStreamProducer->streams();
+}
+
+std::unique_ptr<RTCDtlsTransportBackend> RTCRtpSender::dtlsTransportBackend()
+{
+    return m_backend->dtlsTransportBackend();
+}
+
+Ref<RTCRtpTransformBackend> RTCRtpSender::rtcRtpTransformBackend()
+{
+    return m_backend->rtcRtpTransformBackend();
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.h
@@ -45,8 +45,10 @@ namespace WebCore {
 
 class MediaStream;
 class RTCDTMFSender;
+class RTCDtlsTransportBackend;
 class RTCEncodedStreamProducer;
 class RTCPeerConnection;
+class RTCRtpTransformBackend;
 
 struct RTCEncodedStreams;
 struct RTCRtpCapabilities;
@@ -77,7 +79,7 @@ public:
     ExceptionOr<void> setMediaStreamIds(const FixedVector<String>&);
     ExceptionOr<void> setStreams(const FixedVector<std::reference_wrapper<MediaStream>>&);
 
-    bool isStopped() const { return !m_backend; }
+    bool isStopped() const { return m_isStopped; }
     void stop();
     void setTrack(Ref<MediaStreamTrack>&&);
     void setTrackToNull();
@@ -87,7 +89,9 @@ public:
     RTCRtpSendParameters getParameters();
     void setParameters(const RTCRtpSendParameters&, DOMPromiseDeferred<void>&&);
 
-    RTCRtpSenderBackend* backend() { return m_backend.get(); }
+    RTCRtpSenderBackend& backend() { return m_backend.get(); }
+    std::unique_ptr<RTCDtlsTransportBackend> dtlsTransportBackend();
+    Ref<RTCRtpTransformBackend> rtcRtpTransformBackend();
 
     void getStats(Ref<DeferredPromise>&&);
 
@@ -111,11 +115,12 @@ private:
     WTFLogChannel& NODELETE logChannel() const final;
 #endif
 
+    bool m_isStopped { false };
     RefPtr<MediaStreamTrack> m_track;
     RefPtr<RTCDtlsTransport> m_transport;
     String m_trackId;
     String m_trackKind;
-    RefPtr<RTCRtpSenderBackend> m_backend;
+    const Ref<RTCRtpSenderBackend> m_backend;
     WeakPtr<RTCPeerConnection, WeakPtrImplWithEventTargetData> m_connection;
     RefPtr<RTCDTMFSender> m_dtmfSender;
     std::unique_ptr<RTCRtpTransform> m_transform;

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.cpp
@@ -45,9 +45,8 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RTCRtpTransceiver);
 
-RTCRtpTransceiver::RTCRtpTransceiver(Ref<RTCRtpSender>&& sender, Ref<RTCRtpReceiver>&& receiver, std::unique_ptr<RTCRtpTransceiverBackend>&& backend)
-    : m_direction(RTCRtpTransceiverDirection::Sendrecv)
-    , m_sender(WTF::move(sender))
+RTCRtpTransceiver::RTCRtpTransceiver(Ref<RTCRtpSender>&& sender, Ref<RTCRtpReceiver>&& receiver, UniqueRef<RTCRtpTransceiverBackend>&& backend)
+    : m_sender(WTF::move(sender))
     , m_receiver(WTF::move(receiver))
     , m_backend(WTF::move(backend))
 {
@@ -57,50 +56,22 @@ RTCRtpTransceiver::~RTCRtpTransceiver() = default;
 
 String RTCRtpTransceiver::mid() const
 {
-    return m_backend ? m_backend->mid() : String { };
-}
-
-bool RTCRtpTransceiver::hasSendingDirection() const
-{
-    return m_direction == RTCRtpTransceiverDirection::Sendrecv || m_direction == RTCRtpTransceiverDirection::Sendonly;
+    return m_backend->mid();
 }
 
 RTCRtpTransceiverDirection RTCRtpTransceiver::direction() const
 {
-    if (!m_backend)
-        return m_direction;
     return m_backend->direction();
 }
 
 std::optional<RTCRtpTransceiverDirection> RTCRtpTransceiver::currentDirection() const
 {
-    if (!m_backend)
-        return std::nullopt;
     return m_backend->currentDirection();
 }
 
 void RTCRtpTransceiver::setDirection(RTCRtpTransceiverDirection direction)
 {
-    m_direction = direction;
-    if (m_backend)
-        m_backend->setDirection(direction);
-}
-
-
-void RTCRtpTransceiver::enableSendingDirection()
-{
-    if (m_direction == RTCRtpTransceiverDirection::Recvonly)
-        m_direction = RTCRtpTransceiverDirection::Sendrecv;
-    else if (m_direction == RTCRtpTransceiverDirection::Inactive)
-        m_direction = RTCRtpTransceiverDirection::Sendonly;
-}
-
-void RTCRtpTransceiver::disableSendingDirection()
-{
-    if (m_direction == RTCRtpTransceiverDirection::Sendrecv)
-        m_direction = RTCRtpTransceiverDirection::Recvonly;
-    else if (m_direction == RTCRtpTransceiverDirection::Sendonly)
-        m_direction = RTCRtpTransceiverDirection::Inactive;
+    m_backend->setDirection(direction);
 }
 
 void RTCRtpTransceiver::setConnection(RTCPeerConnection& connection)
@@ -120,8 +91,7 @@ ExceptionOr<void> RTCRtpTransceiver::stop()
     m_stopped = true;
     m_receiver->stop();
     m_sender->stop();
-    if (m_backend)
-        m_backend->stop();
+    m_backend->stop();
 
     // No need to call negotiation needed, it will be done by the backend itself.
     return { };
@@ -129,18 +99,13 @@ ExceptionOr<void> RTCRtpTransceiver::stop()
 
 ExceptionOr<void> RTCRtpTransceiver::setCodecPreferences(const Vector<RTCRtpCodecCapability>& codecs)
 {
-    if (!m_backend)
-        return { };
-
     RELEASE_LOG_INFO(WebRTC, "RTCRtpTransceiver::setCodecPreferences");
     return m_backend->setCodecPreferences(codecs);
 }
 
 bool RTCRtpTransceiver::stopped() const
 {
-    if (m_backend)
-        return m_backend->stopped();
-    return m_stopped;
+    return m_backend->stopped();
 }
 
 void RtpTransceiverSet::append(Ref<RTCRtpTransceiver>&& transceiver)

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h
@@ -50,12 +50,8 @@ struct RTCRtpCodecCapability;
 class RTCRtpTransceiver final : public RefCounted<RTCRtpTransceiver>, public ScriptWrappable {
     WTF_MAKE_TZONE_ALLOCATED(RTCRtpTransceiver);
 public:
-    static Ref<RTCRtpTransceiver> create(Ref<RTCRtpSender>&& sender, Ref<RTCRtpReceiver>&& receiver, std::unique_ptr<RTCRtpTransceiverBackend>&& backend) { return adoptRef(*new RTCRtpTransceiver(WTF::move(sender), WTF::move(receiver), WTF::move(backend))); }
+    static Ref<RTCRtpTransceiver> create(Ref<RTCRtpSender>&& sender, Ref<RTCRtpReceiver>&& receiver, UniqueRef<RTCRtpTransceiverBackend>&& backend) { return adoptRef(*new RTCRtpTransceiver(WTF::move(sender), WTF::move(receiver), WTF::move(backend))); }
     ~RTCRtpTransceiver();
-
-    bool NODELETE hasSendingDirection() const;
-    void NODELETE enableSendingDirection();
-    void NODELETE disableSendingDirection();
 
     RTCRtpTransceiverDirection direction() const;
     std::optional<RTCRtpTransceiverDirection> currentDirection() const;
@@ -69,24 +65,21 @@ public:
     ExceptionOr<void> stop();
     ExceptionOr<void> setCodecPreferences(const Vector<RTCRtpCodecCapability>&);
 
-    RTCRtpTransceiverBackend* backend() { return m_backend.get(); }
+    RTCRtpTransceiverBackend& backend() { return m_backend.get(); }
     void setConnection(RTCPeerConnection&);
 
     std::optional<RTCRtpTransceiverDirection> firedDirection() const { return m_firedDirection; }
     void setFiredDirection(std::optional<RTCRtpTransceiverDirection> firedDirection) { m_firedDirection = firedDirection; }
 
 private:
-    RTCRtpTransceiver(Ref<RTCRtpSender>&&, Ref<RTCRtpReceiver>&&, std::unique_ptr<RTCRtpTransceiverBackend>&&);
+    RTCRtpTransceiver(Ref<RTCRtpSender>&&, Ref<RTCRtpReceiver>&&, UniqueRef<RTCRtpTransceiverBackend>&&);
 
-    RTCRtpTransceiverDirection m_direction;
+    bool m_stopped { false };
     std::optional<RTCRtpTransceiverDirection> m_firedDirection;
 
     const Ref<RTCRtpSender> m_sender;
     const Ref<RTCRtpReceiver> m_receiver;
-
-    bool m_stopped { false };
-
-    std::unique_ptr<RTCRtpTransceiverBackend> m_backend;
+    const UniqueRef<RTCRtpTransceiverBackend> m_backend;
     WeakPtr<RTCPeerConnection, WeakPtrImplWithEventTargetData> m_connection;
 };
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransform.cpp
@@ -71,8 +71,8 @@ void RTCRtpTransform::attachToReceiver(RTCRtpReceiver& receiver, RTCRtpTransform
 
     if (previousTransform)
         m_backend = previousTransform->takeBackend();
-    else if (auto* backend = receiver.backend())
-        m_backend = backend->rtcRtpTransformBackend();
+    else
+        m_backend = receiver.rtcRtpTransformBackend();
 
     if (!m_backend)
         return;
@@ -93,8 +93,8 @@ void RTCRtpTransform::attachToSender(RTCRtpSender& sender, RTCRtpTransform* prev
 
     if (previousTransform)
         m_backend = previousTransform->takeBackend();
-    else if (RefPtr backend = sender.backend())
-        m_backend = backend->rtcRtpTransformBackend();
+    else
+        m_backend = sender.rtcRtpTransformBackend();
 
     if (!m_backend)
         return;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1291,7 +1291,7 @@ std::optional<bool> GStreamerMediaEndpoint::isIceGatheringComplete(const String&
     return true;
 }
 
-ExceptionOr<RefPtr<GStreamerRtpSenderBackend>> GStreamerMediaEndpoint::addTrack(MediaStreamTrack& track, const FixedVector<String>& mediaStreamIds)
+ExceptionOr<Ref<GStreamerRtpSenderBackend>> GStreamerMediaEndpoint::addTrack(MediaStreamTrack& track, const FixedVector<String>& mediaStreamIds)
 {
     GStreamerRtpSenderBackend::Source source;
     auto mediaStreamId = mediaStreamIds.isEmpty() ? "-"_s : mediaStreamIds[0];
@@ -1565,7 +1565,7 @@ void GStreamerMediaEndpoint::connectIncomingTrack(WebRTCTrackData& data)
             return;
         }
         const auto& trackId = data.trackId;
-        transceiver = peerConnectionBackend->newRemoteTransceiver(makeUnique<GStreamerRtpTransceiverBackend>(WTF::move(rtcTransceiver)), data.type, trackId.isolatedCopy());
+        transceiver = peerConnectionBackend->newRemoteTransceiver(makeUniqueRef<GStreamerRtpTransceiverBackend>(WTF::move(rtcTransceiver)), data.type, trackId.isolatedCopy());
         GST_DEBUG_OBJECT(m_pipeline.get(), "New remote transceiver created for track");
     }
 
@@ -1940,7 +1940,7 @@ ExceptionOr<GStreamerMediaEndpoint::Backends> GStreamerMediaEndpoint::createTran
     }, [](std::nullptr_t&) {
     });
 
-    auto transceiver = makeUnique<GStreamerRtpTransceiverBackend>(WTF::move(rtcTransceiver));
+    auto transceiver = makeUniqueRef<GStreamerRtpTransceiverBackend>(WTF::move(rtcTransceiver));
 
     return GStreamerMediaEndpoint::Backends { transceiver->createSenderBackend(WeakPtr { m_peerConnectionBackend }, WTF::move(source), WTF::move(initData)), transceiver->createReceiverBackend(), WTF::move(transceiver) };
 }
@@ -2444,7 +2444,7 @@ void GStreamerMediaEndpoint::collectTransceivers()
             return false;
         }
 
-        existingTransceiver = peerConnectionBackend->newRemoteTransceiver(WTF::makeUnique<GStreamerRtpTransceiverBackend>(WTF::move(transceiver)), m_mediaForMid.get(String(mid.span())), trackIdFromSDPMedia(*media));
+        existingTransceiver = peerConnectionBackend->newRemoteTransceiver(WTF::makeUniqueRef<GStreamerRtpTransceiverBackend>(WTF::move(transceiver)), m_mediaForMid.get(String(mid.span())), trackIdFromSDPMedia(*media));
         return false;
     });
 }

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -88,15 +88,15 @@ public:
 
     void configureSource(RealtimeOutgoingMediaSourceGStreamer&, GUniquePtr<GstStructure>&&);
 
-    ExceptionOr<RefPtr<GStreamerRtpSenderBackend>> addTrack(MediaStreamTrack&, const FixedVector<String>&);
+    ExceptionOr<Ref<GStreamerRtpSenderBackend>> addTrack(MediaStreamTrack&, const FixedVector<String>&);
     void removeTrack(GStreamerRtpSenderBackend&);
 
     void recycleTransceiverForSenderTrack(GStreamerRtpTransceiverBackend*, MediaStreamTrack&, const FixedVector<String>&);
 
     struct Backends {
-        RefPtr<GStreamerRtpSenderBackend> senderBackend;
-        std::unique_ptr<GStreamerRtpReceiverBackend> receiverBackend;
-        std::unique_ptr<GStreamerRtpTransceiverBackend> transceiverBackend;
+        Ref<GStreamerRtpSenderBackend> senderBackend;
+        UniqueRef<GStreamerRtpReceiverBackend> receiverBackend;
+        UniqueRef<GStreamerRtpTransceiverBackend> transceiverBackend;
     };
     ExceptionOr<Backends> addTransceiver(const String& trackKind, const RTCRtpTransceiverInit&, PeerConnectionBackend::IgnoreNegotiationNeededFlag);
     ExceptionOr<Backends> addTransceiver(MediaStreamTrack&, const RTCRtpTransceiverInit&, PeerConnectionBackend::IgnoreNegotiationNeededFlag);

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -157,7 +157,7 @@ bool GStreamerPeerConnectionBackend::setConfiguration(MediaEndpointConfiguration
 GStreamerRtpSenderBackend& GStreamerPeerConnectionBackend::backendFromRTPSender(RTCRtpSender& sender)
 {
     ASSERT(!sender.isStopped());
-    return static_cast<GStreamerRtpSenderBackend&>(*sender.backend());
+    return static_cast<GStreamerRtpSenderBackend&>(sender.backend());
 }
 
 void GStreamerPeerConnectionBackend::dispatchSenderBitrateRequest(const GRefPtr<GstWebRTCDTLSTransport>& transport, uint32_t bitrate)
@@ -184,11 +184,6 @@ void GStreamerPeerConnectionBackend::getStats(Ref<DeferredPromise>&& promise)
 
 void GStreamerPeerConnectionBackend::getStats(RTCRtpSender& sender, Ref<DeferredPromise>&& promise)
 {
-    if (!sender.backend()) {
-        m_endpoint->getStats(nullptr, WTF::move(promise));
-        return;
-    }
-
     auto& backend = backendFromRTPSender(sender);
     GRefPtr<GstPad> pad;
     if (RealtimeOutgoingAudioSourceGStreamer* source = backend.audioSource())
@@ -250,7 +245,7 @@ void GStreamerPeerConnectionBackend::doAddIceCandidate(RTCIceCandidate& candidat
     m_endpoint->addIceCandidate(candidate, WTF::move(callback));
 }
 
-Ref<RTCRtpReceiver> GStreamerPeerConnectionBackend::createReceiver(std::unique_ptr<GStreamerRtpReceiverBackend>&& backend, const String& trackKind, const String& trackId)
+Ref<RTCRtpReceiver> GStreamerPeerConnectionBackend::createReceiver(UniqueRef<GStreamerRtpReceiverBackend>&& backend, const String& trackKind, const String& trackId)
 {
     auto& document = downcast<Document>(*protect(m_peerConnection)->scriptExecutionContext());
 
@@ -350,7 +345,7 @@ ExceptionOr<Ref<RTCRtpSender>> GStreamerPeerConnectionBackend::addTrack(MediaStr
         if (!transceiver)
             return Exception { ExceptionCode::TypeError, "Unable to add track"_s };
 
-        m_endpoint->recycleTransceiverForSenderTrack(reinterpret_cast<GStreamerRtpTransceiverBackend*>(transceiver->backend()), track, mediaStreamIds);
+        m_endpoint->recycleTransceiverForSenderTrack(reinterpret_cast<GStreamerRtpTransceiverBackend*>(&transceiver->backend()), track, mediaStreamIds);
 
         // 5. If transceiver.[[Direction]] is "recvonly", set transceiver.[[Direction]] to "sendrecv".
         // 6. If transceiver.[[Direction]] is "inactive", set transceiver.[[Direction]] to "sendonly".
@@ -374,12 +369,14 @@ ExceptionOr<Ref<RTCRtpSender>> GStreamerPeerConnectionBackend::addTrack(MediaStr
 
     auto senderBackend = addTrackResult.releaseReturnValue();
 
-    auto transceiverBackend = m_endpoint->transceiverBackendFromSender(*senderBackend);
+    auto transceiverBackend = m_endpoint->transceiverBackendFromSender(senderBackend.get());
+    if (!transceiverBackend)
+        return Exception { ExceptionCode::TypeError, "Internal error prevented to add track"_s };
 
-    auto newSender = RTCRtpSender::create(peerConnection, track, senderBackend.releaseNonNull());
+    auto newSender = RTCRtpSender::create(peerConnection.get(), track, WTF::move(senderBackend));
     newSender->setMediaStreamIds(mediaStreamIds);
     auto receiver = createReceiver(transceiverBackend->createReceiverBackend(), track.kind(), track.id());
-    auto transceiver = RTCRtpTransceiver::create(newSender.copyRef(), WTF::move(receiver), WTF::move(transceiverBackend));
+    auto transceiver = RTCRtpTransceiver::create(newSender.copyRef(), WTF::move(receiver), makeUniqueRefFromNonNullUniquePtr(WTF::move(transceiverBackend)));
     peerConnection->addInternalTransceiver(WTF::move(transceiver));
     return newSender;
 }
@@ -395,7 +392,7 @@ ExceptionOr<Ref<RTCRtpTransceiver>> GStreamerPeerConnectionBackend::addTransceiv
     GST_DEBUG_OBJECT(m_endpoint->pipeline(), "Creating new transceiver.");
     auto backends = result.releaseReturnValue();
     Ref peerConnection = m_peerConnection.get();
-    auto sender = RTCRtpSender::create(peerConnection, WTF::move(trackOrKind), backends.senderBackend.releaseNonNull());
+    auto sender = RTCRtpSender::create(peerConnection, WTF::move(trackOrKind), WTF::move(backends.senderBackend));
     auto receiver = createReceiver(WTF::move(backends.receiverBackend), sender->trackKind(), sender->trackId());
     auto transceiver = RTCRtpTransceiver::create(WTF::move(sender), WTF::move(receiver), WTF::move(backends.transceiverBackend));
     peerConnection->addInternalTransceiver(transceiver.copyRef());
@@ -419,7 +416,7 @@ GStreamerRtpSenderBackend::Source GStreamerPeerConnectionBackend::createSourceFo
 
 static inline GStreamerRtpTransceiverBackend& backendFromRTPTransceiver(RTCRtpTransceiver& transceiver)
 {
-    return static_cast<GStreamerRtpTransceiverBackend&>(*transceiver.backend());
+    return static_cast<GStreamerRtpTransceiverBackend&>(transceiver.backend());
 }
 
 RefPtr<RTCRtpTransceiver> GStreamerPeerConnectionBackend::existingTransceiver(WTF::Function<bool(GStreamerRtpTransceiverBackend&)>&& matchingFunction)
@@ -432,7 +429,7 @@ RefPtr<RTCRtpTransceiver> GStreamerPeerConnectionBackend::existingTransceiver(WT
     return nullptr;
 }
 
-Ref<RTCRtpTransceiver> GStreamerPeerConnectionBackend::newRemoteTransceiver(std::unique_ptr<GStreamerRtpTransceiverBackend>&& transceiverBackend, RealtimeMediaSource::Type type, String&& receiverTrackId)
+Ref<RTCRtpTransceiver> GStreamerPeerConnectionBackend::newRemoteTransceiver(UniqueRef<GStreamerRtpTransceiverBackend>&& transceiverBackend, RealtimeMediaSource::Type type, String&& receiverTrackId)
 {
     auto trackKind = type == RealtimeMediaSource::Type::Audio ? "audio"_s : "video"_s;
     Ref peerConnection = m_peerConnection.get();
@@ -493,8 +490,7 @@ void GStreamerPeerConnectionBackend::tearDown()
         auto& sender = transceiver->sender();
         sender.setTransport(nullptr);
 
-        if (auto senderBackend = sender.backend())
-            static_cast<GStreamerRtpSenderBackend*>(senderBackend)->tearDown();
+        static_cast<GStreamerRtpSenderBackend&>(sender.backend()).tearDown();
 
         auto& receiver = transceiver->receiver();
         receiver.setTransport(nullptr);
@@ -502,8 +498,7 @@ void GStreamerPeerConnectionBackend::tearDown()
         auto& incomingSource = static_cast<RealtimeIncomingSourceGStreamer&>(receiver.track().privateTrack().source());
         incomingSource.tearDown();
 
-        if (auto receiverBackend = receiver.backend())
-            static_cast<GStreamerRtpReceiverBackend*>(receiverBackend)->tearDown();
+        static_cast<GStreamerRtpReceiverBackend&>(receiver.backend()).tearDown();
 
         auto& backend = backendFromRTPTransceiver(transceiver);
         backend.tearDown();

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
@@ -99,7 +99,7 @@ private:
     GStreamerRtpSenderBackend::Source createSourceForTrack(MediaStreamTrack&);
 
     RefPtr<RTCRtpTransceiver> existingTransceiver(WTF::Function<bool(GStreamerRtpTransceiverBackend&)>&&);
-    Ref<RTCRtpTransceiver> newRemoteTransceiver(std::unique_ptr<GStreamerRtpTransceiverBackend>&&, RealtimeMediaSource::Type, String&&);
+    Ref<RTCRtpTransceiver> newRemoteTransceiver(UniqueRef<GStreamerRtpTransceiverBackend>&&, RealtimeMediaSource::Type, String&&);
 
     void collectTransceivers() final;
 
@@ -108,7 +108,7 @@ private:
     template<typename T>
     ExceptionOr<Ref<RTCRtpTransceiver>> addTransceiverFromTrackOrKind(T&& trackOrKind, const RTCRtpTransceiverInit&, IgnoreNegotiationNeededFlag);
 
-    Ref<RTCRtpReceiver> createReceiver(std::unique_ptr<GStreamerRtpReceiverBackend>&&, const String& trackKind, const String& trackId);
+    Ref<RTCRtpReceiver> createReceiver(UniqueRef<GStreamerRtpReceiverBackend>&&, const String& trackKind, const String& trackId);
 
     void suspend() final;
     void resume() final;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.cpp
@@ -62,9 +62,9 @@ GStreamerRtpTransceiverBackend::GStreamerRtpTransceiverBackend(GRefPtr<GstWebRTC
     g_object_set(m_rtcTransceiver.get(), "do-nack", TRUE, nullptr);
 }
 
-std::unique_ptr<GStreamerRtpReceiverBackend> GStreamerRtpTransceiverBackend::createReceiverBackend()
+UniqueRef<GStreamerRtpReceiverBackend> GStreamerRtpTransceiverBackend::createReceiverBackend()
 {
-    return WTF::makeUnique<GStreamerRtpReceiverBackend>(GRefPtr(m_rtcTransceiver));
+    return WTF::makeUniqueRef<GStreamerRtpReceiverBackend>(GRefPtr(m_rtcTransceiver));
 }
 
 Ref<GStreamerRtpSenderBackend> GStreamerRtpTransceiverBackend::createSenderBackend(WeakPtr<GStreamerPeerConnectionBackend>&& backend, GStreamerRtpSenderBackend::Source&& source, GUniquePtr<GstStructure>&& initData)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpTransceiverBackend.h
@@ -36,7 +36,7 @@ class GStreamerRtpTransceiverBackend final : public RTCRtpTransceiverBackend {
 public:
     GStreamerRtpTransceiverBackend(GRefPtr<GstWebRTCRTPTransceiver>&&);
 
-    std::unique_ptr<GStreamerRtpReceiverBackend> createReceiverBackend();
+    UniqueRef<GStreamerRtpReceiverBackend> createReceiverBackend();
     Ref<GStreamerRtpSenderBackend> createSenderBackend(WeakPtr<GStreamerPeerConnectionBackend>&&, GStreamerRtpSenderBackend::Source&&, GUniquePtr<GstStructure>&&);
 
     GstWebRTCRTPTransceiver* rtcTransceiver() { return m_rtcTransceiver.get(); }

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -384,7 +384,7 @@ void LibWebRTCMediaEndpoint::collectTransceivers()
             continue;
 
         Ref rtcReceiver = toRef(rtcTransceiver->receiver());
-        existingTransceiver = peerConnectionBackend->newRemoteTransceiver(makeUnique<LibWebRTCRtpTransceiverBackend>(toRef(WTF::move(rtcTransceiver))), rtcReceiver->media_type() == webrtc::MediaType::AUDIO ? RealtimeMediaSource::Type::Audio : RealtimeMediaSource::Type::Video);
+        existingTransceiver = peerConnectionBackend->newRemoteTransceiver(makeUniqueRef<LibWebRTCRtpTransceiverBackend>(toRef(WTF::move(rtcTransceiver))), rtcReceiver->media_type() == webrtc::MediaType::AUDIO ? RealtimeMediaSource::Type::Audio : RealtimeMediaSource::Type::Video);
     }
 }
 
@@ -405,7 +405,7 @@ ExceptionOr<LibWebRTCMediaEndpoint::Backends> LibWebRTCMediaEndpoint::createTran
     if (!result.ok())
         return toException(result.error());
 
-    auto transceiver = makeUnique<LibWebRTCRtpTransceiverBackend>(toRef(result.MoveValue()));
+    auto transceiver = makeUniqueRef<LibWebRTCRtpTransceiverBackend>(toRef(result.MoveValue()));
     return LibWebRTCMediaEndpoint::Backends { transceiver->createSenderBackend(*protect(m_peerConnectionBackend), WTF::move(source)), transceiver->createReceiverBackend(), WTF::move(transceiver) };
 }
 
@@ -466,6 +466,7 @@ std::unique_ptr<LibWebRTCRtpTransceiverBackend> LibWebRTCMediaEndpoint::transcei
         if (transceiver->sender().get() == backend.rtcSender())
             return makeUnique<LibWebRTCRtpTransceiverBackend>(toRef(webrtc::scoped_refptr { transceiver }));
     }
+    ASSERT_NOT_REACHED();
     return nullptr;
 }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -107,9 +107,9 @@ public:
     void removeTrack(LibWebRTCRtpSenderBackend&);
 
     struct Backends {
-        RefPtr<LibWebRTCRtpSenderBackend> senderBackend;
-        std::unique_ptr<LibWebRTCRtpReceiverBackend> receiverBackend;
-        std::unique_ptr<LibWebRTCRtpTransceiverBackend> transceiverBackend;
+        Ref<LibWebRTCRtpSenderBackend> senderBackend;
+        UniqueRef<LibWebRTCRtpReceiverBackend> receiverBackend;
+        UniqueRef<LibWebRTCRtpTransceiverBackend> transceiverBackend;
     };
     ExceptionOr<Backends> addTransceiver(const String& trackKind, const RTCRtpTransceiverInit&, PeerConnectionBackend::IgnoreNegotiationNeededFlag);
     ExceptionOr<Backends> addTransceiver(MediaStreamTrack&, const RTCRtpTransceiverInit&, PeerConnectionBackend::IgnoreNegotiationNeededFlag);

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -205,13 +205,12 @@ void LibWebRTCPeerConnectionBackend::getStats(Ref<DeferredPromise>&& promise)
 
 static inline LibWebRTCRtpSenderBackend& NODELETE backendFromRTPSender(RTCRtpSender& sender)
 {
-    ASSERT(!sender.isStopped());
-    return downcast<LibWebRTCRtpSenderBackend>(*sender.backend());
+    return downcast<LibWebRTCRtpSenderBackend>(sender.backend());
 }
 
 void LibWebRTCPeerConnectionBackend::getStats(RTCRtpSender& sender, Ref<DeferredPromise>&& promise)
 {
-    webrtc::RtpSenderInterface* rtcSender = sender.backend() ? backendFromRTPSender(sender).rtcSender() : nullptr;
+    RefPtr rtcSender = backendFromRTPSender(sender).rtcSender();
 
     if (!rtcSender) {
         m_endpoint->getStats(WTF::move(promise));
@@ -222,14 +221,13 @@ void LibWebRTCPeerConnectionBackend::getStats(RTCRtpSender& sender, Ref<Deferred
 
 void LibWebRTCPeerConnectionBackend::getStats(RTCRtpReceiver& receiver, Ref<DeferredPromise>&& promise)
 {
-    RefPtr<webrtc::RtpReceiverInterface> rtcReceiver;
-    if (auto* backend = receiver.backend())
-        rtcReceiver = downcast<LibWebRTCRtpReceiverBackend>(backend)->rtcReceiver();
+    RefPtr rtcReceiver = downcast<LibWebRTCRtpReceiverBackend>(receiver.backend()).rtcReceiver();
 
     if (!rtcReceiver) {
         m_endpoint->getStats(WTF::move(promise));
         return;
     }
+
     m_endpoint->getStats(*rtcReceiver, WTF::move(promise));
 }
 
@@ -284,7 +282,7 @@ void LibWebRTCPeerConnectionBackend::doAddIceCandidate(RTCIceCandidate& candidat
     m_endpoint->addIceCandidate(WTF::move(rtcCandidate), WTF::move(callback));
 }
 
-Ref<RTCRtpReceiver> LibWebRTCPeerConnectionBackend::createReceiver(std::unique_ptr<LibWebRTCRtpReceiverBackend>&& backend)
+Ref<RTCRtpReceiver> LibWebRTCPeerConnectionBackend::createReceiver(UniqueRef<LibWebRTCRtpReceiverBackend>&& backend)
 {
     Ref document = downcast<Document>(*protect(m_peerConnection)->scriptExecutionContext());
 
@@ -329,11 +327,13 @@ ExceptionOr<Ref<RTCRtpSender>> LibWebRTCPeerConnectionBackend::addTrack(MediaStr
     }
 
     auto transceiverBackend = m_endpoint->transceiverBackendFromSender(senderBackend);
+    if (!transceiverBackend)
+        return Exception { ExceptionCode::TypeError, "Internal error prevented to add track"_s };
 
     Ref sender = RTCRtpSender::create(peerConnection, track, WTF::move(senderBackend));
     sender->setMediaStreamIds(mediaStreamIds);
     Ref receiver = createReceiver(transceiverBackend->createReceiverBackend());
-    Ref transceiver = RTCRtpTransceiver::create(sender.copyRef(), WTF::move(receiver), WTF::move(transceiverBackend));
+    Ref transceiver = RTCRtpTransceiver::create(sender.copyRef(), WTF::move(receiver), makeUniqueRefFromNonNullUniquePtr(WTF::move(transceiverBackend)));
     peerConnection->addInternalTransceiver(WTF::move(transceiver));
     return sender;
 }
@@ -347,7 +347,7 @@ ExceptionOr<Ref<RTCRtpTransceiver>> LibWebRTCPeerConnectionBackend::addTransceiv
 
     auto backends = result.releaseReturnValue();
     Ref peerConnection = m_peerConnection;
-    Ref sender = RTCRtpSender::create(peerConnection, std::forward<T>(trackOrKind), backends.senderBackend.releaseNonNull());
+    Ref sender = RTCRtpSender::create(peerConnection, std::forward<T>(trackOrKind), WTF::move(backends.senderBackend));
     auto receiver = createReceiver(WTF::move(backends.receiverBackend));
     auto transceiver = RTCRtpTransceiver::create(WTF::move(sender), WTF::move(receiver), WTF::move(backends.transceiverBackend));
     peerConnection->addInternalTransceiver(transceiver.copyRef());
@@ -371,7 +371,7 @@ void LibWebRTCPeerConnectionBackend::setSenderSourceFromTrack(LibWebRTCRtpSender
 
 static inline LibWebRTCRtpTransceiverBackend& NODELETE backendFromRTPTransceiver(RTCRtpTransceiver& transceiver)
 {
-    return downcast<LibWebRTCRtpTransceiverBackend>(*transceiver.backend());
+    return downcast<LibWebRTCRtpTransceiverBackend>(transceiver.backend());
 }
 
 RefPtr<RTCRtpTransceiver> LibWebRTCPeerConnectionBackend::existingTransceiver(Function<bool(LibWebRTCRtpTransceiverBackend&)>&& matchingFunction)
@@ -384,7 +384,7 @@ RefPtr<RTCRtpTransceiver> LibWebRTCPeerConnectionBackend::existingTransceiver(Fu
     return nullptr;
 }
 
-Ref<RTCRtpTransceiver> LibWebRTCPeerConnectionBackend::newRemoteTransceiver(std::unique_ptr<LibWebRTCRtpTransceiverBackend>&& transceiverBackend, RealtimeMediaSource::Type type)
+Ref<RTCRtpTransceiver> LibWebRTCPeerConnectionBackend::newRemoteTransceiver(UniqueRef<LibWebRTCRtpTransceiverBackend>&& transceiverBackend, RealtimeMediaSource::Type type)
 {
     Ref peerConnection = m_peerConnection;
     Ref sender = RTCRtpSender::create(peerConnection, type == RealtimeMediaSource::Type::Audio ? "audio"_s : "video"_s, transceiverBackend->createSenderBackend(*this, nullptr));

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
@@ -91,7 +91,7 @@ private:
     void setSenderSourceFromTrack(LibWebRTCRtpSenderBackend&, MediaStreamTrack&);
 
     RefPtr<RTCRtpTransceiver> existingTransceiver(Function<bool(LibWebRTCRtpTransceiverBackend&)>&&);
-    Ref<RTCRtpTransceiver> newRemoteTransceiver(std::unique_ptr<LibWebRTCRtpTransceiverBackend>&&, RealtimeMediaSource::Type);
+    Ref<RTCRtpTransceiver> newRemoteTransceiver(UniqueRef<LibWebRTCRtpTransceiverBackend>&&, RealtimeMediaSource::Type);
 
     void collectTransceivers() final;
 
@@ -108,7 +108,7 @@ private:
     template<typename T>
     ExceptionOr<Ref<RTCRtpTransceiver>> addTransceiverFromTrackOrKind(T&& trackOrKind, const RTCRtpTransceiverInit&, IgnoreNegotiationNeededFlag = IgnoreNegotiationNeededFlag::No);
 
-    Ref<RTCRtpReceiver> createReceiver(std::unique_ptr<LibWebRTCRtpReceiverBackend>&&);
+    Ref<RTCRtpReceiver> createReceiver(UniqueRef<LibWebRTCRtpReceiverBackend>&&);
 
     void suspend() final;
     void resume() final;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.cpp
@@ -39,9 +39,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LibWebRTCRtpTransceiverBackend);
 
-std::unique_ptr<LibWebRTCRtpReceiverBackend> LibWebRTCRtpTransceiverBackend::createReceiverBackend()
+UniqueRef<LibWebRTCRtpReceiverBackend> LibWebRTCRtpTransceiverBackend::createReceiverBackend()
 {
-    return makeUnique<LibWebRTCRtpReceiverBackend>(toRef(m_rtcTransceiver->receiver()));
+    return makeUniqueRef<LibWebRTCRtpReceiverBackend>(toRef(m_rtcTransceiver->receiver()));
 }
 
 Ref<LibWebRTCRtpSenderBackend> LibWebRTCRtpTransceiverBackend::createSenderBackend(LibWebRTCPeerConnectionBackend& backend, LibWebRTCRtpSenderBackend::Source&& source)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.h
@@ -44,7 +44,7 @@ public:
     {
     }
 
-    std::unique_ptr<LibWebRTCRtpReceiverBackend> createReceiverBackend();
+    UniqueRef<LibWebRTCRtpReceiverBackend> createReceiverBackend();
     Ref<LibWebRTCRtpSenderBackend> createSenderBackend(LibWebRTCPeerConnectionBackend&, LibWebRTCRtpSenderBackend::Source&&);
 
     webrtc::RtpTransceiverInterface* rtcTransceiver() { return m_rtcTransceiver.ptr(); }


### PR DESCRIPTION
#### 376821219197a063e788da5bcae1060049295f60
<pre>
RTCRtpTransceiver and friends should have a non-null backend
<a href="https://rdar.apple.com/171806516">rdar://171806516</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309253">https://bugs.webkit.org/show_bug.cgi?id=309253</a>

Reviewed by Philippe Normand.

To simplify the handling of backends and wrappers, we no longer nullify transceiver/sender/receiver backends when stopping them.
Instead we use a boolean isStopped when needed.
This allows to mark the backend as const Ref/UniqueRef.
We can then remove some if checks.

We also remove some no longer needed members and methods in RTCRtpTransceiver as a drive-by fix.

getStats is now always passing the sender/receiver, even when they are stopped, which allows to fix one WPT test.

Canonical link: <a href="https://commits.webkit.org/308898@main">https://commits.webkit.org/308898@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/add86f29e511b67f8ede44322a84cbae910da97e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157187 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101933 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6e5e4e2-b3fc-4475-8416-c71c41f46429) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150376 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114478 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81540 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f701ccb-1522-4ec3-901a-32fa7cec8908) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151463 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95248 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e9f29a0-9e0f-44e3-a69e-7e3cb3d64e64) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15802 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13633 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4623 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159522 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2654 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12746 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122527 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20987 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17624 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122748 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33440 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20996 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133019 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77148 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18100 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9788 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20604 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84428 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20336 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20481 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20390 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->