### PR TITLE
[JSC] Bytecode profiler should include JIT comments

### DIFF
--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -210,7 +210,7 @@ public:
     // These methods are used to obtain handles to allow the code to be relinked / repatched later.
     
     template<PtrTag tag>
-    CodeLocationLabel<tag> entrypoint()
+    CodeLocationLabel<tag> entrypoint() const
     {
         return CodeLocationLabel<tag>(tagCodePtr<tag>(code()));
     }
@@ -354,7 +354,7 @@ private:
     }
 
     // Keep this private! - the underlying code should only be obtained externally via finalizeCode().
-    void* code()
+    void* code() const
     {
         return m_code.dataLocation();
     }

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -4281,7 +4281,9 @@ void SpeculativeJIT::compile(Node* node)
         break;
 
     case CountExecution:
+        JIT_COMMENT(*this, "Execution trace start");
         add64(TrustedImm32(1), AbsoluteAddress(node->executionCounter()->address()));
+        JIT_COMMENT(*this, "First non-trace instruction");
         break;
 
     case SuperSamplerBegin:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -5833,9 +5833,12 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
         
-    case CountExecution:
+    case CountExecution: {
+        JIT_COMMENT(*this, "Execution trace start");
         add64(TrustedImm32(1), AbsoluteAddress(node->executionCounter()->address()));
+        JIT_COMMENT(*this, "First non-trace instruction");
         break;
+    }
 
     case SuperSamplerBegin:
         add32(TrustedImm32(1), AbsoluteAddress(std::bit_cast<void*>(&g_superSamplerCount)));

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -16903,6 +16903,7 @@ IGNORE_CLANG_WARNINGS_END
 
     void compileCountExecution()
     {
+        // FIXME: Should this be a patchpoint with a JIT_COMMENT like we do for the other tiers? It seems a lot less valuable to bytecode profile at FTL anyway because of all the code motion that's possible.
         TypedPointer counter = m_out.absolute(m_node->executionCounter()->address());
         m_out.store64(m_out.add(m_out.load64(counter), m_out.constInt64(1)), counter);
     }

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -220,10 +220,12 @@ void JIT::privateCompileMainPass()
 #endif
 
         if (m_compilation) [[unlikely]] {
+            JIT_COMMENT(*this, "Execution trace start");
             add64(
                 TrustedImm32(1),
                 AbsoluteAddress(m_compilation->executionCounterFor(Profiler::OriginStack(Profiler::Origin(
                     m_compilation->bytecodes(), m_bytecodeIndex)))->address()));
+            JIT_COMMENT(*this, "First non-trace instruction");
         }
         
         if (Options::eagerlyUpdateTopCallFrame())

--- a/Source/JavaScriptCore/jit/JITDisassembler.cpp
+++ b/Source/JavaScriptCore/jit/JITDisassembler.cpp
@@ -52,10 +52,15 @@ JITDisassembler::JITDisassembler(CodeBlock *codeBlock)
 
 JITDisassembler::~JITDisassembler() = default;
 
-void JITDisassembler::dump(PrintStream& out, LinkBuffer& linkBuffer)
+void JITDisassembler::setLinkedStartAndEnd(const LinkBuffer& linkBuffer)
 {
     m_codeStart = linkBuffer.entrypoint<DisassemblyPtrTag>().untaggedPtr();
     m_codeEnd = std::bit_cast<uint8_t*>(m_codeStart) + linkBuffer.size();
+}
+
+void JITDisassembler::dump(PrintStream& out, LinkBuffer& linkBuffer)
+{
+    setLinkedStartAndEnd(linkBuffer);
 
     dumpHeader(out, linkBuffer);
     dumpDisassembly(out, linkBuffer, m_startOfCode, m_labelForBytecodeIndexInMainPath[0].first);
@@ -75,6 +80,8 @@ void JITDisassembler::dump(LinkBuffer& linkBuffer)
 
 void JITDisassembler::reportToProfiler(Profiler::Compilation* compilation, LinkBuffer& linkBuffer)
 {
+    setLinkedStartAndEnd(linkBuffer);
+
     StringPrintStream out;
     
     dumpHeader(out, linkBuffer);

--- a/Source/JavaScriptCore/jit/JITDisassembler.h
+++ b/Source/JavaScriptCore/jit/JITDisassembler.h
@@ -67,6 +67,7 @@ public:
     void reportToProfiler(Profiler::Compilation*, LinkBuffer&);
 
 private:
+    void setLinkedStartAndEnd(const LinkBuffer&);
     void dumpHeader(PrintStream&, LinkBuffer&);
     MacroAssembler::Label firstSlowLabel();
     

--- a/Source/JavaScriptCore/lol/LOLJIT.cpp
+++ b/Source/JavaScriptCore/lol/LOLJIT.cpp
@@ -299,10 +299,12 @@ void LOLJIT::privateCompileMainPass()
         }
 
         if (m_compilation) [[unlikely]] {
+            JIT_COMMENT(*this, "Execution trace start");
             add64(
                 TrustedImm32(1),
                 AbsoluteAddress(Ref(*m_compilation)->executionCounterFor(Profiler::OriginStack(Profiler::Origin(
                     m_compilation->bytecodes(), m_bytecodeIndex)))->address()));
+            JIT_COMMENT(*this, "First non-trace instruction");
         }
 
         if (Options::eagerlyUpdateTopCallFrame())

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -869,7 +869,8 @@ void Options::notifyOptionsChanged()
             || Options::dumpRegExpDisassembly()
             || Options::dumpWasmDisassembly()
             || Options::dumpBBQDisassembly()
-            || Options::dumpOMGDisassembly())
+            || Options::dumpOMGDisassembly()
+            || Options::useProfiler()) // For JIT comments in the profile.
             Options::needDisassemblySupport() = true;
 
         if (OptionsHelper::wasOverridden(jitPolicyScaleID))


### PR DESCRIPTION
#### ebc19a3dc75e891b5916de93914ec5771ab91fbc
<pre>
[JSC] Bytecode profiler should include JIT comments
<a href="https://bugs.webkit.org/show_bug.cgi?id=309270">https://bugs.webkit.org/show_bug.cgi?id=309270</a>
<a href="https://rdar.apple.com/171815352">rdar://171815352</a>

Reviewed by Yijia Huang and Dan Hecht.

Right now we just get the raw disassembly but it&apos;s nicer to see the JIT
comments so the assembly is easier to read. I also annotated the
profiling emitted assembly so it&apos;s easier to decern and ignore when
reading.

Additionally, add m_codeStart/End to reportToProfiler so that Baseline
logs immediates to the profile as well.

After this change, profile disassembly looks like:

```
      0                       0/0/0/0                      [  30] construct          dst:loc6, callee:loc6, argc:2, argv:16, valueProfile:2
      0                       0/0/0/0                                 &lt;496&gt; 0x118658630:    mov x17, #0x4120; Execution trace start
      0                       0/0/0/0                                 &lt;500&gt; 0x118658634:    movk        x17, #0x209, lsl #0x10
      0                       0/0/0/0                                 &lt;504&gt; 0x118658638:    movk        x17, #0x1, lsl #0x20 -&gt; 0x102094120
      0                       0/0/0/0                                 &lt;508&gt; 0x11865863c:    ldr x16, [x17, xzr]
      0                       0/0/0/0                                 &lt;512&gt; 0x118658640:    add x16, x16, #0x1
      0                       0/0/0/0                                 &lt;516&gt; 0x118658644:    stur        x16, [x17]
      0                       0/0/0/0                                 &lt;520&gt; 0x118658648:    sub sp, fp, #0x70; First non-trace instruction
      0                       0/0/0/0                                 &lt;524&gt; 0x11865864c:    orr w16, wzr, #0x2
      0                       0/0/0/0                                 &lt;528&gt; 0x118658650:    stur        w16, [sp, #0x10]
      0                       0/0/0/0                                 &lt;532&gt; 0x118658654:    orr w16, wzr, #0x1e
      0                       0/0/0/0                                 &lt;536&gt; 0x118658658:    stur        w16, [fp, #0x24]
      0                       0/0/0/0                                 &lt;540&gt; 0x11865865c:    ldur        x0, [fp, #-0x38]
      0                       0/0/0/0                                 &lt;544&gt; 0x118658660:    stur        x0, [sp, #0x8]
      0                       0/0/0/0                                 &lt;548&gt; 0x118658664:    add x2, x25, #0x68
      0                       0/0/0/0                                 &lt;552&gt; 0x118658668:    ldur        x5, [x2, #0x20]
      0                       0/0/0/0                                 &lt;556&gt; 0x11865866c:    ldur        x16, [x2, #0x28]
      0                       0/0/0/0                                 &lt;560&gt; 0x118658670:    cmp x16, x0
      0                       0/0/0/0                                 &lt;564&gt; 0x118658674:    b.eq        0x11865868c -&gt; &lt;588&gt;
      0                       0/0/0/0                                 &lt;568&gt; 0x118658678:    tbnz        w16, #0, 0x11865868c -&gt; &lt;588&gt;
      0                       0/0/0/0                                 &lt;572&gt; 0x11865867c:    mov x5, #0x100
      0                       0/0/0/0                                 &lt;576&gt; 0x118658680:    movk        x5, #0x1866, lsl #0x10
      0                       0/0/0/0                                 &lt;580&gt; 0x118658684:    movk        x5, #0x1, lsl #0x20
      0                       0/0/0/0                                 &lt;584&gt; 0x118658688:    movk        x5, #0xd86e, lsl #0x30 -&gt; 0xd86e000118660100 JIT PC
      0                       0/0/0/0                                 &lt;588&gt; 0x11865868c:    ldur        x16, [x2, #0x18]
      0                       0/0/0/0                                 &lt;592&gt; 0x118658690:    stur        x16, [sp]
      0                       0/0/0/0                                 &lt;596&gt; 0x118658694:    mov lr, #0x593 -&gt; 0x593 JSEntryPtrTag ?
      0                       0/0/0/0                                 &lt;600&gt; 0x118658698:    blrab       x5, lr
      0                       0/0/0/0                                 &lt;604&gt; 0x11865869c:    sub sp, fp, #0x80
      0                       0/0/0/0                                 &lt;608&gt; 0x1186586a0:    stur        x0, [x25, #-0x30]
      0                       0/0/0/0                                 &lt;612&gt; 0x1186586a4:    stur        x0, [fp, #-0x38]
```

No new tests, no user observable change.

Canonical link: <a href="https://commits.webkit.org/308738@main">https://commits.webkit.org/308738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/193821dddeb6ea047b73c89d4ba2aa007e2e94aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14611 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157014 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/345d7818-de56-4a1d-b11b-b4ff8cff6d28) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20921 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114368 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/82064ad4-3eb2-460c-bcf3-dd9017d3b979) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133187 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95138 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d26693fc-701b-478f-9e77-930ed20f1712) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15711 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13523 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4450 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140297 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125323 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159347 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9117 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2481 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12611 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122403 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20814 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17494 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122629 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20823 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132910 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76975 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22861 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/18024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9655 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179757 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20431 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84216 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46014 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20163 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20308 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20217 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->