### PR TITLE
Replace a few `Node*` parameters that must never be null with `Node&` parameters.

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -66,7 +66,7 @@
 #include "CustomElementDefaultARIA.h"
 #include "DeprecatedGlobalSettings.h"
 #include "DocumentPage.h"
-#include "Editing.h"
+#include "EditingInlines.h"
 #include "Editor.h"
 #include "ElementAncestorIteratorInlines.h"
 #include "ElementChildIteratorInlines.h"

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -4159,7 +4159,7 @@ String AccessibilityNodeObject::stringValue() const
             }
         }
 
-        std::optional range = makeSimpleRange(positionBeforeNode(node.get()), positionAfterNode(endNode.get()));
+        std::optional range = makeSimpleRange(positionBeforeNode(*node), positionAfterNode(*endNode));
         builder.append(range ? plainText(*range, textIteratorBehaviorForTextRange()) : emptyString());
 
         return builder.toString();

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -867,7 +867,7 @@ std::optional<SimpleRange> AccessibilityObject::simpleRange() const
     // |this| is a stitching of multiple objects, so we need to include all of their contents in the range.
     CheckedPtr cache = axObjectCache();
     if (RefPtr endNode = cache ? lastNode(stitchGroup->members(), *cache) : nullptr) {
-        if (std::optional range = makeSimpleRange(positionBeforeNode(node.get()), positionAfterNode(endNode.get())))
+        if (std::optional range = makeSimpleRange(positionBeforeNode(*node), positionAfterNode(*endNode)))
             return range;
     }
     return AXObjectCache::rangeForNodeContents(*node);
@@ -1177,8 +1177,8 @@ static std::optional<TextOperationRange> textOperationRangeFromRange(const Simpl
     if (!rootEditableElement)
         return std::nullopt;
 
-    auto scopeStart = firstPositionInNode(rootEditableElement.get());
-    auto scopeEnd = lastPositionInNode(rootEditableElement.get());
+    auto scopeStart = firstPositionInNode(*rootEditableElement);
+    auto scopeEnd = lastPositionInNode(*rootEditableElement);
 
     std::optional<SimpleRange> scope = makeSimpleRange(scopeStart, scopeEnd);
     if (!scope)
@@ -1947,7 +1947,7 @@ static StringView lineStartListMarkerText(const RenderListItem* listItem, const 
         return { };
 
     // Only include the list marker if the range includes the line start (where the marker would be), and is in the same line as the marker.
-    if (!isStartOfLine(startVisiblePosition) || !inSameLine(startVisiblePosition, firstPositionInNode(listItem->element())))
+    if (!isStartOfLine(startVisiblePosition) || !inSameLine(startVisiblePosition, firstPositionInNode(*listItem->element())))
         return { };
     return *markerText;
 }

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -718,8 +718,12 @@ String AccessibilityRenderObject::textUnderElement(TextUnderElementMode mode) co
                 // We define the start and end positions for the range as the ones right before and after
                 // the first and the last nodes in the DOM tree that is wrapped inside the anonymous block.
                 auto& firstNodeInBlock = *firstChildRenderer->node();
+                auto& lastNodeInBlock = *lastChildRenderer->node();
                 nodeDocument = firstNodeInBlock.document();
-                textRange = makeSimpleRange(positionInParentBeforeNode(&firstNodeInBlock), positionInParentAfterNode(lastChildRenderer->node()));
+                textRange = makeSimpleRange(
+                    positionInParentBeforeNode(firstNodeInBlock),
+                    positionInParentAfterNode(lastNodeInBlock)
+                );
             }
         }
 #endif // USE(ATSPI)
@@ -908,7 +912,7 @@ LayoutRect AccessibilityRenderObject::boundingBoxRect() const
             CheckedPtr cache = axObjectCache();
             RefPtr endNode = cache ? lastNode(stitchGroup->members(), *cache) : nullptr;
             if (endNode) {
-                if (std::optional range = makeSimpleRange(positionBeforeNode(node.get()), positionAfterNode(endNode.get()))) {
+                if (std::optional range = makeSimpleRange(positionBeforeNode(*node), positionAfterNode(*endNode))) {
                     quads = RenderObject::absoluteTextQuads(*range);
 
                     for (AXID axID : stitchGroup->members()) {

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2398,7 +2398,7 @@ RefPtr<CaretPosition> Document::caretPositionFromPoint(double x, double y, Caret
         adjustPosition = true;
     }
     if (adjustPosition)
-        position = positionInParentBeforeNode(anchorNode.get());
+        position = positionInParentBeforeNode(*anchorNode);
 
     position = position.parentAnchoredEquivalent();
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -53,7 +53,7 @@
 #include "DocumentQuirks.h"
 #include "DocumentSharedObjectPool.h"
 #include "DocumentView.h"
-#include "Editing.h"
+#include "EditingInlines.h"
 #include "ElementAncestorIteratorInlines.h"
 #include "ElementAnimationRareData.h"
 #include "ElementChildIteratorInlines.h"

--- a/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveGenerator.cpp
@@ -67,7 +67,7 @@ static VisiblePosition beforeStartOfCurrentBlock(const VisiblePosition& visibleP
 {
     auto position = visiblePosition.deepEquivalent();
     Ref blockContainer = nearestBlockAncestor(*protect(position.containerNode()).get());
-    VisiblePosition firstPositionInBlock = firstPositionInNode(blockContainer.ptr());
+    VisiblePosition firstPositionInBlock = firstPositionInNode(blockContainer);
     if (firstPositionInBlock == visiblePosition)
         return visiblePosition.previous();
     return visiblePosition;
@@ -77,7 +77,7 @@ static VisiblePosition afterEndOfCurrentBlock(const VisiblePosition& visiblePosi
 {
     auto position = visiblePosition.deepEquivalent();
     Ref blockContainer = nearestBlockAncestor(*protect(position.containerNode()).get());
-    VisiblePosition lastPositionInBlock = lastPositionInNode(blockContainer.ptr());
+    VisiblePosition lastPositionInBlock = lastPositionInNode(blockContainer);
     if (lastPositionInBlock == visiblePosition)
         return visiblePosition.next();
     return visiblePosition;

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -255,7 +255,7 @@ Position Position::parentAnchoredEquivalent() const
     // FIXME: This should only be necessary for legacy positions, but is also needed for positions before and after Tables
     if (!m_offset && (m_anchorType != PositionIsAfterAnchor && m_anchorType != PositionIsAfterChildren)) {
         if (anchorNode->parentNode() && (editingIgnoresContent(*anchorNode) || isRenderedTable(anchorNode.get())))
-            return positionInParentBeforeNode(anchorNode.get());
+            return positionInParentBeforeNode(*anchorNode);
         return Position(anchorNode.get(), 0, PositionIsOffsetInAnchor);
     }
 
@@ -263,7 +263,7 @@ Position Position::parentAnchoredEquivalent() const
         && (m_anchorType == PositionIsAfterAnchor || m_anchorType == PositionIsAfterChildren || static_cast<unsigned>(m_offset) == anchorNode->countChildNodes())
         && (editingIgnoresContent(*anchorNode) || isRenderedTable(anchorNode.get()))
         && containerNode()) {
-        return positionInParentAfterNode(anchorNode.get());
+        return positionInParentAfterNode(*anchorNode);
     }
 
     return { containerNode(), static_cast<unsigned>(computeOffsetInContainerNode()), PositionIsOffsetInAnchor };
@@ -391,11 +391,11 @@ Position Position::previous(PositionMoveType moveType) const
         return *this;
 
     if (positionBeforeOrAfterNodeIsCandidate(*node))
-        return positionBeforeNode(node.get());
+        return positionBeforeNode(*node);
 
     RefPtr previousSibling = node->previousSibling();
     if (previousSibling && positionBeforeOrAfterNodeIsCandidate(*previousSibling))
-        return positionAfterNode(previousSibling.get());
+        return positionAfterNode(*previousSibling);
 
     return makeContainerOffsetPosition(WTF::move(parent), node->computeNodeIndex());
 }
@@ -440,11 +440,11 @@ Position Position::next(PositionMoveType moveType) const
         return *this;
 
     if (isRenderedTable(node.get()) || editingIgnoresContent(*node))
-        return positionAfterNode(node.get());
+        return positionAfterNode(*node);
 
     RefPtr nextSibling = node->nextSibling();
     if (nextSibling && positionBeforeOrAfterNodeIsCandidate(*nextSibling))
-        return positionBeforeNode(nextSibling.get());
+        return positionBeforeNode(*nextSibling);
 
     return makeContainerOffsetPosition(WTF::move(parent), node->computeNodeIndex() + 1);
 }
@@ -724,7 +724,7 @@ Position Position::upstream(EditingBoundaryCrossingRule rule) const
         // Return position after tables and nodes which have content that can be ignored.
         if (editingIgnoresContent(currentNode) || isRenderedTable(currentNode.ptr())) {
             if (currentPosition.atEndOfNode())
-                return positionAfterNode(currentNode.ptr());
+                return positionAfterNode(currentNode);
             continue;
         }
 
@@ -834,7 +834,7 @@ Position Position::downstream(EditingBoundaryCrossingRule rule) const
         // Return position before tables and nodes which have content that can be ignored.
         if (editingIgnoresContent(currentNode) || isRenderedTable(currentNode.ptr())) {
             if (currentPosition.atStartOfNode())
-                return positionBeforeNode(currentNode.ptr());
+                return positionBeforeNode(currentNode);
             continue;
         }
 
@@ -1574,24 +1574,24 @@ Node* commonInclusiveAncestor(const Position& a, const Position& b)
     return commonInclusiveAncestor<ComposedTree>(*nodeA, *nodeB);
 }
 
-Position positionInParentBeforeNode(Node* node)
+Position positionInParentBeforeNode(Node& node)
 {
-    RefPtr currentNode = node;
-    RefPtr ancestor = node->parentNode();
+    Ref currentNode = node;
+    RefPtr ancestor = node.parentNode();
     while (ancestor && editingIgnoresContent(*ancestor)) {
-        currentNode = ancestor;
+        currentNode = *ancestor;
         ancestor = ancestor->parentNode();
     }
     ASSERT(ancestor);
     return Position(ancestor, currentNode->computeNodeIndex(), Position::PositionIsOffsetInAnchor);
 }
 
-Position positionInParentAfterNode(Node* node)
+Position positionInParentAfterNode(Node& node)
 {
-    RefPtr currentNode = node;
-    RefPtr ancestor = node->parentNode();
+    Ref currentNode = node;
+    RefPtr ancestor = node.parentNode();
     while (ancestor && editingIgnoresContent(*ancestor)) {
-        currentNode = ancestor;
+        currentNode = *ancestor;
         ancestor = ancestor->parentNode();
     }
     ASSERT(ancestor);

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -229,16 +229,16 @@ WEBCORE_EXPORT Position makeDeprecatedLegacyPosition(const BoundaryPoint&);
 
 WEBCORE_EXPORT std::optional<BoundaryPoint> makeBoundaryPoint(const Position&);
 
-Position positionInParentBeforeNode(Node*);
-Position positionInParentAfterNode(Node*);
+Position positionInParentBeforeNode(Node&);
+Position positionInParentAfterNode(Node&);
 
 // positionBeforeNode and positionAfterNode return neighbor-anchored positions, construction is O(1)
-Position positionBeforeNode(Node* anchorNode);
-Position positionAfterNode(Node* anchorNode);
+Position positionBeforeNode(Node& anchorNode);
+Position positionAfterNode(Node& anchorNode);
 
 // firstPositionInNode and lastPositionInNode return parent-anchored positions, lastPositionInNode construction is O(n) due to countChildNodes()
-Position firstPositionInNode(Node* anchorNode);
-inline Position lastPositionInNode(Node* anchorNode);
+inline Position firstPositionInNode(Node& anchorNode); // Defined in PositionInlines.h
+inline Position lastPositionInNode(Node& anchorNode); // Defined in PositionInlines.h
 
 bool offsetIsBeforeLastNodeOffset(unsigned offset, Node* anchorNode);
 
@@ -292,27 +292,17 @@ inline bool operator==(const Position& a, const Position& b)
 }
 
 // positionBeforeNode and positionAfterNode return neighbor-anchored positions, construction is O(1)
-inline Position positionBeforeNode(Node* anchorNode)
+inline Position positionBeforeNode(Node& anchorNode)
 {
-    ASSERT(anchorNode);
-    return Position(anchorNode, Position::PositionIsBeforeAnchor);
+    return Position(&anchorNode, Position::PositionIsBeforeAnchor);
 }
 
-inline Position positionAfterNode(Node* anchorNode)
+inline Position positionAfterNode(Node& anchorNode)
 {
-    ASSERT(anchorNode);
-    return Position(anchorNode, Position::PositionIsAfterAnchor);
+    return Position(&anchorNode, Position::PositionIsAfterAnchor);
 }
 
-// firstPositionInNode and lastPositionInNode return parent-anchored positions, lastPositionInNode construction is O(n) due to countChildNodes()
-inline Position firstPositionInNode(Node* anchorNode)
-{
-    if (anchorNode->isCharacterDataNode())
-        return Position(anchorNode, 0, Position::PositionIsOffsetInAnchor);
-    return Position(anchorNode, Position::PositionIsBeforeChildren);
-}
-
-inline bool offsetIsBeforeLastNodeOffset(unsigned offset, Node* anchorNode);
+inline bool offsetIsBeforeLastNodeOffset(unsigned offset, Node anchorNode);
 
 } // namespace WebCore
 

--- a/Source/WebCore/dom/PositionInlines.h
+++ b/Source/WebCore/dom/PositionInlines.h
@@ -41,11 +41,19 @@ inline TreeScope* Position::treeScope() const
     return m_anchorNode ? &m_anchorNode->treeScope() : nullptr;
 }
 
-Position lastPositionInNode(Node* anchorNode)
+// firstPositionInNode and lastPositionInNode return parent-anchored positions, lastPositionInNode construction is O(n) due to countChildNodes()
+inline Position firstPositionInNode(Node& anchorNode)
 {
-    if (anchorNode->isCharacterDataNode())
-        return Position(anchorNode, anchorNode->length(), Position::PositionIsOffsetInAnchor);
-    return Position(anchorNode, Position::PositionIsAfterChildren);
+    if (anchorNode.isCharacterDataNode())
+        return Position(&anchorNode, 0, Position::PositionIsOffsetInAnchor);
+    return Position(&anchorNode, Position::PositionIsBeforeChildren);
+}
+
+inline Position lastPositionInNode(Node& anchorNode)
+{
+    if (anchorNode.isCharacterDataNode())
+        return Position(&anchorNode, anchorNode.length(), Position::PositionIsOffsetInAnchor);
+    return Position(&anchorNode, Position::PositionIsAfterChildren);
 }
 
 inline bool offsetIsBeforeLastNodeOffset(unsigned offset, Node* anchorNode)

--- a/Source/WebCore/dom/PositionIterator.cpp
+++ b/Source/WebCore/dom/PositionIterator.cpp
@@ -56,11 +56,11 @@ PositionIterator::operator Position() const
         ASSERT(m_nodeAfterPositionInAnchor->parentNode() == anchorNode.get());
         // FIXME: This check is inadaquete because any ancestor could be ignored by editing
         if (positionBeforeOrAfterNodeIsCandidate(*anchorNode))
-            return positionBeforeNode(anchorNode.get());
-        return positionInParentBeforeNode(m_nodeAfterPositionInAnchor.get());
+            return positionBeforeNode(*anchorNode);
+        return positionInParentBeforeNode(*m_nodeAfterPositionInAnchor);
     }
     if (positionBeforeOrAfterNodeIsCandidate(*anchorNode))
-        return atStartOfNode() ? positionBeforeNode(anchorNode.get()) : positionAfterNode(anchorNode.get());
+        return atStartOfNode() ? positionBeforeNode(*anchorNode) : positionAfterNode(*anchorNode);
     if (anchorNode->hasChildNodes())
         return lastPositionInOrAfterNode(anchorNode.get());
     return makeDeprecatedLegacyPosition(WTF::move(anchorNode), m_offsetInAnchor);

--- a/Source/WebCore/editing/ApplyBlockElementCommand.cpp
+++ b/Source/WebCore/editing/ApplyBlockElementCommand.cpp
@@ -104,7 +104,7 @@ void ApplyBlockElementCommand::doApply()
         // using an extra newline to represent a large margin.
         // FIXME: Add a new TextIteratorBehavior to suppress it.
         if (start.isNotNull() && end.isNull())
-            end = lastPositionInNode(endScope.get());
+            end = lastPositionInNode(*endScope);
         if (start.isNotNull() && end.isNotNull()) {
             VisibleSelection selection { start, end, endingSelection().directionality() };
             // Use canonicalized positions for start & end.
@@ -123,7 +123,7 @@ void ApplyBlockElementCommand::formatSelection(const VisiblePosition& startOfSel
         insertNodeAt(blockquote.copyRef(), start);
         auto placeholder = HTMLBRElement::create(document());
         appendNode(placeholder.copyRef(), WTF::move(blockquote));
-        setEndingSelection(VisibleSelection(positionBeforeNode(placeholder.ptr()), Affinity::Downstream, endingSelection().directionality()));
+        setEndingSelection(VisibleSelection(positionBeforeNode(placeholder), Affinity::Downstream, endingSelection().directionality()));
         return;
     }
 
@@ -225,7 +225,7 @@ void ApplyBlockElementCommand::rangeForParagraphSplittingTextNodesIfNeeded(const
             RefPtr startText = start.containerText();
             ASSERT(startText);
             splitTextNode(*startText, startOffset);
-            start = firstPositionInNode(startText.get());
+            start = firstPositionInNode(*startText);
             if (isStartAndEndOnSameNode) {
                 ASSERT(end.offsetInContainerNode() >= startOffset);
                 end = Position(startText.get(), end.offsetInContainerNode() - startOffset);
@@ -270,7 +270,7 @@ void ApplyBlockElementCommand::rangeForParagraphSplittingTextNodesIfNeeded(const
                 else
                     m_endOfLastParagraph = Position(endContainer.get(), m_endOfLastParagraph.offsetInContainerNode() - endOffset);
             }
-            end = lastPositionInNode(endContainer->previousSibling());
+            end = lastPositionInNode(*endContainer->previousSibling());
         }
     }
 }
@@ -287,7 +287,7 @@ VisiblePosition ApplyBlockElementCommand::endOfNextParagraphSplittingTextNodesIf
     style = nullptr;
 
     RefPtr text = position.containerText();
-    if (!preserveNewLine || !position.offsetInContainerNode() || !isNewLineAtPosition(firstPositionInNode(text.get())))
+    if (!preserveNewLine || !position.offsetInContainerNode() || !isNewLineAtPosition(firstPositionInNode(*text)))
         return endOfNextParagraph;
 
     // \n at the beginning of the text node immediately following the current paragraph is trimmed by moveParagraphWithClones.

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -627,11 +627,11 @@ void ApplyStyleCommand::applyInlineStyle(EditingStyle& style)
         // Avoid removing the dir attribute and the unicode-bidi and direction properties from the unsplit ancestors.
         Position embeddingRemoveStart = removeStart;
         if (startUnsplitAncestor && nodeFullySelected(*startUnsplitAncestor, removeStart, end))
-            embeddingRemoveStart = positionInParentAfterNode(startUnsplitAncestor.get());
+            embeddingRemoveStart = positionInParentAfterNode(*startUnsplitAncestor);
 
         Position embeddingRemoveEnd = end;
         if (endUnsplitAncestor && nodeFullySelected(*endUnsplitAncestor, removeStart, end))
-            embeddingRemoveEnd = positionInParentBeforeNode(endUnsplitAncestor.get()).downstream();
+            embeddingRemoveEnd = positionInParentBeforeNode(*endUnsplitAncestor).downstream();
 
         if (embeddingRemoveEnd != removeStart || embeddingRemoveEnd != end) {
             styleWithoutEmbedding = style.copy();
@@ -679,8 +679,8 @@ void ApplyStyleCommand::applyInlineStyle(EditingStyle& style)
         auto embeddingEndNode = highestEmbeddingAncestor(endNode.get(), enclosingBlock(endNode).get());
 
         if (embeddingStartNode || embeddingEndNode) {
-            Position embeddingApplyStart = embeddingStartNode ? positionInParentAfterNode(embeddingStartNode.get()) : start;
-            Position embeddingApplyEnd = embeddingEndNode ? positionInParentBeforeNode(embeddingEndNode.get()) : end;
+            Position embeddingApplyStart = embeddingStartNode ? positionInParentAfterNode(*embeddingStartNode) : start;
+            Position embeddingApplyEnd = embeddingEndNode ? positionInParentBeforeNode(*embeddingEndNode) : end;
             ASSERT(embeddingApplyStart.isNotNull() && embeddingApplyEnd.isNotNull());
 
             if (!embeddingStyle) {
@@ -865,7 +865,7 @@ bool ApplyStyleCommand::shouldApplyInlineStyleToRun(EditingStyle& style, Node* r
         // We don't consider m_isInlineElementToRemoveFunction here because we never apply style when m_isInlineElementToRemoveFunction is specified
         if (!style.styleIsPresentInComputedStyleOfNode(*node))
             return true;
-        if (m_styledInlineElement && !enclosingElementWithTag(positionBeforeNode(node.get()), m_styledInlineElement->tagQName()))
+        if (m_styledInlineElement && !enclosingElementWithTag(positionBeforeNode(*node), m_styledInlineElement->tagQName()))
             return true;
     }
     return false;
@@ -1197,7 +1197,7 @@ void ApplyStyleCommand::splitTextAtStart(const Position& start, const Position& 
 
     RefPtr text = start.containerText();
     splitTextNode(*text, start.offsetInContainerNode());
-    updateStartEnd(firstPositionInNode(text.get()), newEnd);
+    updateStartEnd(firstPositionInNode(*text), newEnd);
 }
 
 void ApplyStyleCommand::splitTextAtEnd(const Position& start, const Position& end)
@@ -1213,7 +1213,7 @@ void ApplyStyleCommand::splitTextAtEnd(const Position& start, const Position& en
         return;
 
     Position newStart = shouldUpdateStart ? Position(prevNode.copyRef(), start.offsetInContainerNode()) : start;
-    updateStartEnd(newStart, lastPositionInNode(prevNode.get()));
+    updateStartEnd(newStart, lastPositionInNode(*prevNode));
 }
 
 void ApplyStyleCommand::splitTextElementAtStart(const Position& start, const Position& end)
@@ -1227,7 +1227,7 @@ void ApplyStyleCommand::splitTextElementAtStart(const Position& start, const Pos
         newEnd = end;
 
     splitTextNodeContainingElement(*protect(start.containerText()), start.offsetInContainerNode());
-    updateStartEnd(positionBeforeNode(protect(start.containerNode()).get()), newEnd);
+    updateStartEnd(positionBeforeNode(protect(*start.containerNode())), newEnd);
 }
 
 void ApplyStyleCommand::splitTextElementAtEnd(const Position& start, const Position& end)
@@ -1245,7 +1245,7 @@ void ApplyStyleCommand::splitTextElementAtEnd(const Position& start, const Posit
         return;
 
     Position newStart = shouldUpdateStart ? Position(firstTextNode.copyRef(), start.offsetInContainerNode()) : start;
-    updateStartEnd(newStart, positionAfterNode(firstTextNode.get()));
+    updateStartEnd(newStart, positionAfterNode(*firstTextNode));
 }
 
 bool ApplyStyleCommand::shouldSplitTextElement(Element* element, EditingStyle& style)
@@ -1421,7 +1421,7 @@ Position ApplyStyleCommand::positionToComputeInlineStyleChange(Node& startNode, 
     // It's okay to obtain the style at the startNode because we've removed all relevant styles from the current run.
     if (!is<Element>(startNode)) {
         dummyElement = createStyleSpanElement(document());
-        insertNodeAt(*dummyElement, positionBeforeNode(&startNode));
+        insertNodeAt(*dummyElement, positionBeforeNode(startNode));
         return firstPositionInOrBeforeNode(dummyElement.get());
     }
 

--- a/Source/WebCore/editing/BreakBlockquoteCommand.cpp
+++ b/Source/WebCore/editing/BreakBlockquoteCommand.cpp
@@ -74,7 +74,7 @@ void BreakBlockquoteCommand::doApply()
     if (!topBlockquote || !topBlockquote->parentNode())
         return;
 
-    auto breakNode = [&]() -> Ref<HTMLElement> {
+    auto breakNode = [&] -> Ref<HTMLElement> {
         auto lineBreak = HTMLBRElement::create(document());
         RefPtr containerNode = pos.containerNode();
         if (!containerNode || !containerNode->renderStyle())
@@ -99,7 +99,7 @@ void BreakBlockquoteCommand::doApply()
     // Instead, insert the break before the blockquote, unless the position is as the end of the quoted content.
     if (isFirstVisiblePositionInNode(visiblePos, topBlockquote.get()) && !isLastVisPosInNode) {
         insertNodeBefore(breakNode.copyRef(), *topBlockquote);
-        setEndingSelection(VisibleSelection(positionBeforeNode(breakNode.ptr()), Affinity::Downstream, endingSelection().directionality()));
+        setEndingSelection(VisibleSelection(positionBeforeNode(breakNode), Affinity::Downstream, endingSelection().directionality()));
         rebalanceWhitespace();   
         return;
     }
@@ -109,7 +109,7 @@ void BreakBlockquoteCommand::doApply()
 
     // If we're inserting the break at the end of the quoted content, we don't need to break the quote.
     if (isLastVisPosInNode) {
-        setEndingSelection(VisibleSelection(positionBeforeNode(breakNode.ptr()), Affinity::Downstream, endingSelection().directionality()));
+        setEndingSelection(VisibleSelection(positionBeforeNode(breakNode), Affinity::Downstream, endingSelection().directionality()));
         rebalanceWhitespace();
         return;
     }
@@ -206,7 +206,7 @@ void BreakBlockquoteCommand::doApply()
     addBlockPlaceholderIfNeeded(clonedBlockquote.ptr());
 
     // Put the selection right before br or at the first position in div.
-    auto beforeBROrFirstPositionInDiv = isAtomicNode(breakNode.ptr()) ? positionBeforeNode(breakNode.ptr()) : firstPositionInNode(breakNode.ptr());
+    auto beforeBROrFirstPositionInDiv = isAtomicNode(breakNode.ptr()) ? positionBeforeNode(breakNode) : firstPositionInNode(breakNode);
     setEndingSelection(VisibleSelection(beforeBROrFirstPositionInDiv, Affinity::Downstream, endingSelection().directionality()));
     rebalanceWhitespace();
 }

--- a/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -837,21 +837,21 @@ Position CompositeEditCommand::positionOutsideTabSpan(const Position& position)
     case Position::PositionIsOffsetInAnchor:
         break;
     case Position::PositionIsBeforeAnchor:
-        return positionInParentBeforeNode(position.anchorNode());
+        return positionInParentBeforeNode(*position.anchorNode());
     case Position::PositionIsAfterAnchor:
-        return positionInParentAfterNode(position.anchorNode());
+        return positionInParentAfterNode(*position.anchorNode());
     }
 
     RefPtr tabSpan { parentTabSpanNode(position.containerNode()) };
 
     if (position.offsetInContainerNode() <= caretMinOffset(*position.containerNode()))
-        return positionInParentBeforeNode(tabSpan.get());
+        return positionInParentBeforeNode(*tabSpan);
 
     if (position.offsetInContainerNode() >= caretMaxOffset(*position.containerNode()))
-        return positionInParentAfterNode(tabSpan.get());
+        return positionInParentAfterNode(*tabSpan);
 
     splitTextNodeContainingElement(downcast<Text>(*position.containerNode()), position.offsetInContainerNode());
-    return positionInParentBeforeNode(tabSpan.get());
+    return positionInParentBeforeNode(*tabSpan);
 }
 
 void CompositeEditCommand::insertNodeAtTabSpanPosition(Ref<Node>&& node, const Position& pos)
@@ -1271,7 +1271,7 @@ RefPtr<Node> CompositeEditCommand::moveParagraphContentsToNewBlockIfNecessary(co
 
     bool endWasBr = visibleParagraphEnd.deepEquivalent().deprecatedNode()->hasTagName(brTag);
 
-    moveParagraphs(visibleParagraphStart, visibleParagraphEnd, VisiblePosition(firstPositionInNode(newBlock.ptr())));
+    moveParagraphs(visibleParagraphStart, visibleParagraphEnd, VisiblePosition(firstPositionInNode(newBlock)));
 
     if (newBlock->lastChild() && newBlock->lastChild()->hasTagName(brTag) && !endWasBr)
         removeNode(*newBlock->lastChild());
@@ -1636,24 +1636,28 @@ bool CompositeEditCommand::breakOutOfEmptyListItem(ReconstitutePlainTextListIfNe
     Ref document = this->document();
     style->mergeTypingStyle(document);
 
-    RefPtr<Element> newBlock;
-    if (RefPtr blockEnclosingList = listNode->parentNode()) {
-        if (RefPtr liElement = dynamicDowncast<HTMLLIElement>(*blockEnclosingList)) { // listNode is inside another list item
-            if (visiblePositionAfterNode(*blockEnclosingList) == visiblePositionAfterNode(*listNode)) {
-                // If listNode appears at the end of the outer list item, then move listNode outside of this list item
-                // e.g. <ul><li>hello <ul><li><br></li></ul> </li></ul> should become <ul><li>hello</li> <ul><li><br></li></ul> </ul> after this section
-                // If listNode does NOT appear at the end, then we should consider it as a regular paragraph.
-                // e.g. <ul><li> <ul><li><br></li></ul> hello</li></ul> should become <ul><li> <div><br></div> hello</li></ul> at the end
-                splitElement(*liElement, *listNode);
-                removeNodePreservingChildren(*protect(listNode->parentNode()));
-                newBlock = HTMLLIElement::create(document);
+    Ref newBlock = [&] -> Ref<Element> {
+        if (RefPtr blockEnclosingList = listNode->parentNode()) {
+            // Check if listNode is inside another list item.
+            if (RefPtr liElement = dynamicDowncast<HTMLLIElement>(*blockEnclosingList)) {
+                if (visiblePositionAfterNode(*blockEnclosingList) == visiblePositionAfterNode(*listNode)) {
+                    // If listNode appears at the end of the outer list item, then move listNode outside of this list item
+                    // e.g. <ul><li>hello <ul><li><br></li></ul> </li></ul> should become <ul><li>hello</li> <ul><li><br></li></ul> </ul> after this section
+                    // If listNode does NOT appear at the end, then we should consider it as a regular paragraph.
+                    // e.g. <ul><li> <ul><li><br></li></ul> hello</li></ul> should become <ul><li> <div><br></div> hello</li></ul> at the end
+                    splitElement(*liElement, *listNode);
+                    removeNodePreservingChildren(*protect(listNode->parentNode()));
+                    return HTMLLIElement::create(document);
+                }
+                // If listNode does NOT appear at the end of the outer list item, then behave as if in a regular paragraph.
+                return createDefaultParagraphElement(document);
             }
-            // If listNode does NOT appear at the end of the outer list item, then behave as if in a regular paragraph.
-        } else if (blockEnclosingList->hasTagName(olTag) || blockEnclosingList->hasTagName(ulTag))
-            newBlock = HTMLLIElement::create(document);
-    }
-    if (!newBlock)
-        newBlock = createDefaultParagraphElement(document);
+
+            if (blockEnclosingList->hasTagName(olTag) || blockEnclosingList->hasTagName(ulTag))
+                return HTMLLIElement::create(document);
+        }
+        return createDefaultParagraphElement(document);
+    }();
 
     RefPtr<Node> previousListNode = emptyListItem->isElementNode() ? ElementTraversal::previousSibling(*emptyListItem): emptyListItem->previousSibling();
     RefPtr<Node> nextListNode = emptyListItem->isElementNode() ? ElementTraversal::nextSibling(*emptyListItem): emptyListItem->nextSibling();
@@ -1665,17 +1669,17 @@ bool CompositeEditCommand::breakOutOfEmptyListItem(ReconstitutePlainTextListIfNe
         // If emptyListItem is followed by other list item or nested list, then insert newBlock before the list node.
         // Because we have splitted the element, emptyListItem is the first element in the list node.
         // i.e. insert newBlock before ul or ol whose first element is emptyListItem
-        insertNodeBefore(*newBlock, *listNode);
+        insertNodeBefore(newBlock, *listNode);
         removeNode(*emptyListItem);
     } else {
         // When emptyListItem does not follow any list item or nested list, insert newBlock after the enclosing list node.
         // Remove the enclosing node if emptyListItem is the only child; otherwise just remove emptyListItem.
-        insertNodeAfter(*newBlock, *listNode);
+        insertNodeAfter(newBlock, *listNode);
         removeNode((previousListNode && (isListItem(*previousListNode) || isListHTMLElement(previousListNode.get()))) ? *emptyListItem : *listNode);
     }
 
-    appendBlockPlaceholder(*newBlock);
-    setEndingSelection(VisibleSelection(firstPositionInNode(newBlock.get()), Affinity::Downstream, endingSelection().directionality()));
+    appendBlockPlaceholder(newBlock.copyRef());
+    setEndingSelection(VisibleSelection(firstPositionInNode(newBlock), Affinity::Downstream, endingSelection().directionality()));
 
     if (reconstitutePlainTextListIfNeeded == ReconstitutePlainTextListIfNeeded::Yes) {
         if (auto smartListMarker = downcast<Element>(*listNode).getAttribute(HTMLNames::webkitsmartlistmarkerAttr); !smartListMarker.isEmpty())
@@ -1714,7 +1718,7 @@ bool CompositeEditCommand::breakOutOfEmptyMailBlockquotedParagraph()
     // We want to replace this quoted paragraph with an unquoted one, so insert a br
     // to hold the caret before the highest blockquote.
     insertNodeBefore(br, *highestBlockquote);
-    VisiblePosition atBR = positionBeforeNode(br.ptr());
+    VisiblePosition atBR = positionBeforeNode(br);
     // If the br we inserted collapsed, for example foo<br><blockquote>...</blockquote>, insert
     // a second one.
     if (!isStartOfParagraph(atBR))
@@ -1761,8 +1765,8 @@ Position CompositeEditCommand::positionAvoidingSpecialElementBoundary(const Posi
 
     // Don't avoid block level anchors, because that would insert content into the wrong paragraph.
     if (enclosingAnchor && !isBlock(*enclosingAnchor)) {
-        VisiblePosition firstInAnchor(firstPositionInNode(enclosingAnchor.get()));
-        VisiblePosition lastInAnchor(lastPositionInNode(enclosingAnchor.get()));
+        VisiblePosition firstInAnchor(firstPositionInNode(*enclosingAnchor));
+        VisiblePosition lastInAnchor(lastPositionInNode(*enclosingAnchor));
         // If visually just after the anchor, insert *inside* the anchor unless it's the last
         // VisiblePosition in the document, to match NSTextView.
         if (visiblePos == lastInAnchor) {
@@ -1780,7 +1784,7 @@ Position CompositeEditCommand::positionAvoidingSpecialElementBoundary(const Posi
             if (lineBreakExistsAtVisiblePosition(visiblePos) && protect(downstream.deprecatedNode())->isDescendantOf(enclosingAnchor.get()))
                 return original;
             
-            result = positionInParentAfterNode(enclosingAnchor.get());
+            result = positionInParentAfterNode(*enclosingAnchor);
         }
         // If visually just before an anchor, insert *outside* the anchor unless it's the first
         // VisiblePosition in a paragraph, to match NSTextView.
@@ -1794,7 +1798,7 @@ Position CompositeEditCommand::positionAvoidingSpecialElementBoundary(const Posi
             if (!enclosingAnchor)
                 return original;
 
-            result = positionInParentBeforeNode(enclosingAnchor.get());
+            result = positionInParentBeforeNode(*enclosingAnchor);
         }
     }
         
@@ -1822,7 +1826,7 @@ RefPtr<Node> CompositeEditCommand::splitTreeToNode(Node& start, Node& end, bool 
         if (!parentElement || editingIgnoresContent(*parentNode))
             break;
         // Do not split a node when doing so introduces an empty node.
-        VisiblePosition positionInParent = firstPositionInNode(parentNode.get());
+        VisiblePosition positionInParent = firstPositionInNode(*parentNode);
         VisiblePosition positionInNode = firstPositionInOrBeforeNode(node.get());
         if (positionInParent != positionInNode)
             splitElement(*parentElement, *node);

--- a/Source/WebCore/editing/CreateLinkCommand.cpp
+++ b/Source/WebCore/editing/CreateLinkCommand.cpp
@@ -52,7 +52,12 @@ void CreateLinkCommand::doApply()
     else {
         insertNodeAt(anchorElement.copyRef(), endingSelection().start());
         appendNode(Text::create(document, String { m_url }), anchorElement.copyRef());
-        setEndingSelection(VisibleSelection(positionInParentBeforeNode(anchorElement.ptr()), positionInParentAfterNode(anchorElement.ptr()), Affinity::Downstream, endingSelection().directionality()));
+        setEndingSelection(VisibleSelection(
+            positionInParentBeforeNode(anchorElement),
+            positionInParentAfterNode(anchorElement),
+            Affinity::Downstream,
+            endingSelection().directionality()
+        ));
     }
 }
 

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -65,7 +65,7 @@ static bool isTableRow(const Node& node)
 static bool isTableCellEmpty(Node& cell)
 {
     ASSERT(isTableCell(cell));
-    return VisiblePosition(firstPositionInNode(&cell)) == VisiblePosition(lastPositionInNode(&cell));
+    return VisiblePosition(firstPositionInNode(cell)) == VisiblePosition(lastPositionInNode(cell));
 }
 
 static bool isTableRowEmpty(const Node& row)
@@ -141,7 +141,7 @@ static std::pair<Position, RefPtr<HTMLElement>> positionBeforeContainingSpecialE
     RefPtr element = firstInSpecialElement(position);
     if (!element)
         return { position, nullptr };
-    auto result = positionInParentBeforeNode(element.get());
+    auto result = positionInParentBeforeNode(*element);
     if (result.isNull() || result.containerNode()->rootEditableElement() != position.containerNode()->rootEditableElement())
         return { position, nullptr };
     return { result, WTF::move(element) };
@@ -152,7 +152,7 @@ static std::pair<Position, RefPtr<HTMLElement>> positionAfterContainingSpecialEl
     RefPtr element = lastInSpecialElement(position);
     if (!element)
         return { position, nullptr };
-    auto result = positionInParentAfterNode(element.get());
+    auto result = positionInParentAfterNode(*element);
     if (result.isNull() || result.deprecatedNode()->rootEditableElement() != position.containerNode()->rootEditableElement())
         return { position, nullptr };
     return { result, WTF::move(element) };
@@ -195,9 +195,9 @@ void DeleteSelectionCommand::initializeStartEnd(Position& start, Position& end)
     // For HRs, we'll get a position at (HR,1) when hitting delete from the beginning of the previous line, or (HR,0) when forward deleting,
     // but in these cases, we want to delete it, so manually expand the selection
     if (start.deprecatedNode()->hasTagName(hrTag))
-        start = positionBeforeNode(start.deprecatedNode());
+        start = positionBeforeNode(*start.deprecatedNode());
     else if (end.deprecatedNode()->hasTagName(hrTag))
-        end = positionAfterNode(end.deprecatedNode());
+        end = positionAfterNode(*end.deprecatedNode());
     
     // FIXME: This is only used so that moveParagraphs can avoid the bugs in special element expansion.
     if (!m_expandForSpecialElements)
@@ -216,11 +216,11 @@ void DeleteSelectionCommand::initializeStartEnd(Position& start, Position& end)
             break;
 
         // If we're going to expand to include the startSpecialContainer, it must be fully selected.
-        if (startSpecialContainer && !endSpecialContainer && positionInParentAfterNode(startSpecialContainer.get()) >= end)
+        if (startSpecialContainer && !endSpecialContainer && positionInParentAfterNode(*startSpecialContainer) >= end)
             break;
 
         // If we're going to expand to include the endSpecialContainer, it must be fully selected.
-        if (endSpecialContainer && !startSpecialContainer && start >= positionInParentBeforeNode(endSpecialContainer.get()))
+        if (endSpecialContainer && !startSpecialContainer && start >= positionInParentBeforeNode(*endSpecialContainer))
             break;
 
         if (startSpecialContainer && startSpecialContainer->isDescendantOf(endSpecialContainer.get())) {
@@ -464,7 +464,7 @@ bool DeleteSelectionCommand::handleSpecialCaseBRDelete()
     // FIXME: This code doesn't belong in here.
     // We detect the case where the start is an empty line consisting of BR not wrapped in a block element.
     if (upstreamStartIsBR && downstreamStartIsBR
-        && !(isStartOfBlock(positionBeforeNode(nodeAfterUpstreamStart.get())) && isEndOfBlock(positionAfterNode(nodeAfterDownstreamStart.get())))
+        && !(isStartOfBlock(positionBeforeNode(*nodeAfterUpstreamStart)) && isEndOfBlock(positionAfterNode(*nodeAfterDownstreamStart)))
         && (!nodeAfterUpstreamEnd || nodeAfterUpstreamEnd->hasTagName(brTag) || nodeAfterUpstreamEnd->previousSibling() != nodeAfterUpstreamStart)) {
         m_startsAtEmptyLine = true;
         m_endingPosition = m_downstreamEnd;
@@ -497,11 +497,11 @@ void DeleteSelectionCommand::insertBlockPlaceholderForTableCellIfNeeded(Element&
 void DeleteSelectionCommand::removeNodeUpdatingStates(Node& node, ShouldAssumeContentIsAlwaysEditable shouldAssumeContentIsAlwaysEditable)
 {
     if (&node == m_startBlock) {
-        auto prev = VisiblePosition(firstPositionInNode(protect(m_startBlock).get())).previous();
+        auto prev = VisiblePosition(firstPositionInNode(protect(*m_startBlock))).previous();
         if (!prev.isNull() && !isEndOfBlock(prev))
             m_needPlaceholder = true;
     } else if (&node == m_endBlock) {
-        auto next = VisiblePosition(lastPositionInNode(protect(m_endBlock).get())).next();
+        auto next = VisiblePosition(lastPositionInNode(protect(*m_endBlock))).next();
         if (!next.isNull() && !isStartOfBlock(next))
             m_needPlaceholder = true;
     }

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -274,8 +274,8 @@ Position firstEditablePositionAfterPositionInRoot(const Position& position, Cont
         return { };
 
     // position falls before highestRoot.
-    if (position < firstPositionInNode(highestRoot) && highestRoot->hasEditableStyle())
-        return firstPositionInNode(highestRoot);
+    if (auto result = firstPositionInNode(*highestRoot); position < result && highestRoot->hasEditableStyle())
+        return result;
 
     Position candidate = position;
 
@@ -284,11 +284,11 @@ Position firstEditablePositionAfterPositionInRoot(const Position& position, Cont
         if (!shadowAncestor)
             return { };
 
-        candidate = positionAfterNode(shadowAncestor.get());
+        candidate = positionAfterNode(*shadowAncestor);
     }
 
     while (candidate.deprecatedNode() && !isEditablePosition(candidate) && protect(candidate.deprecatedNode())->isDescendantOf(*highestRoot))
-        candidate = isAtomicNode(candidate.deprecatedNode()) ? positionInParentAfterNode(protect(candidate.deprecatedNode()).get()) : nextVisuallyDistinctCandidate(candidate);
+        candidate = isAtomicNode(candidate.deprecatedNode()) ? positionInParentAfterNode(protect(*candidate.deprecatedNode())) : nextVisuallyDistinctCandidate(candidate);
 
     if (candidate.deprecatedNode() && !protect(candidate.deprecatedNode())->isInclusiveDescendantOf(*highestRoot))
         return { };
@@ -302,8 +302,8 @@ Position lastEditablePositionBeforePositionInRoot(const Position& position, Cont
         return { };
 
     // When position falls after highestRoot, the result is easy to compute.
-    if (position > lastPositionInNode(highestRoot))
-        return lastPositionInNode(highestRoot);
+    if (auto result = lastPositionInNode(*highestRoot); position > result)
+        return result;
 
     Position candidate = position;
 
@@ -316,7 +316,7 @@ Position lastEditablePositionBeforePositionInRoot(const Position& position, Cont
     }
 
     while (candidate.deprecatedNode() && !isEditablePosition(candidate) && protect(candidate.deprecatedNode())->isDescendantOf(*highestRoot))
-        candidate = isAtomicNode(candidate.deprecatedNode()) ? positionInParentBeforeNode(protect(candidate.deprecatedNode()).get()) : previousVisuallyDistinctCandidate(candidate);
+        candidate = isAtomicNode(candidate.deprecatedNode()) ? positionInParentBeforeNode(protect(*candidate.deprecatedNode())) : previousVisuallyDistinctCandidate(candidate);
 
     if (candidate.deprecatedNode() && !protect(candidate.deprecatedNode())->isInclusiveDescendantOf(*highestRoot))
         return { };
@@ -456,7 +456,7 @@ VisiblePosition visiblePositionBeforeNode(Node& node)
         return VisiblePosition(firstPositionInOrBeforeNode(&node));
     ASSERT(node.parentNode());
     ASSERT(!node.parentNode()->isShadowRoot());
-    return positionInParentBeforeNode(&node);
+    return positionInParentBeforeNode(node);
 }
 
 // Returns the visible position at the ending of a node
@@ -466,7 +466,7 @@ VisiblePosition visiblePositionAfterNode(Node& node)
         return VisiblePosition(lastPositionInOrAfterNode(&node));
     ASSERT(node.parentNode());
     ASSERT(!node.parentNode()->isShadowRoot());
-    return positionInParentAfterNode(&node);
+    return positionInParentAfterNode(node);
 }
 
 VisiblePosition closestEditablePositionInElementForAbsolutePoint(const Element& element, const IntPoint& point)
@@ -677,7 +677,7 @@ bool canMergeLists(Element* firstList, Element* secondList)
         && first->hasEditableStyle() && second->hasEditableStyle() // both lists are editable
         && first->rootEditableElement() == second->rootEditableElement() // don't cross editing boundaries
         // Make sure there is no visible content between this li and the previous list.
-        && isVisiblyAdjacent(positionInParentAfterNode(first), positionInParentBeforeNode(second));
+        && isVisiblyAdjacent(positionInParentAfterNode(*first), positionInParentBeforeNode(*second));
 }
 
 static Node* previousNodeConsideringAtomicNodes(const Node* node)
@@ -850,25 +850,25 @@ void updatePositionForNodeRemoval(Position& position, Node& node)
     switch (position.anchorType()) {
     case Position::PositionIsBeforeChildren:
         if (node.isShadowIncludingInclusiveAncestorOf(position.containerNode()))
-            position = positionInParentBeforeNode(&node);
+            position = positionInParentBeforeNode(node);
         break;
     case Position::PositionIsAfterChildren:
         if (node.isShadowIncludingInclusiveAncestorOf(position.containerNode()))
-            position = positionInParentBeforeNode(&node);
+            position = positionInParentBeforeNode(node);
         break;
     case Position::PositionIsOffsetInAnchor:
         if (position.containerNode() == node.parentNode() && static_cast<unsigned>(position.offsetInContainerNode()) > node.computeNodeIndex())
             position.moveToOffset(position.offsetInContainerNode() - 1);
         else if (node.isShadowIncludingInclusiveAncestorOf(position.containerNode()))
-            position = positionInParentBeforeNode(&node);
+            position = positionInParentBeforeNode(node);
         break;
     case Position::PositionIsAfterAnchor:
         if (node.isShadowIncludingInclusiveAncestorOf(position.anchorNode()))
-            position = positionInParentAfterNode(&node);
+            position = positionInParentAfterNode(node);
         break;
     case Position::PositionIsBeforeAnchor:
         if (node.isShadowIncludingInclusiveAncestorOf(position.anchorNode()))
-            position = positionInParentBeforeNode(&node);
+            position = positionInParentBeforeNode(node);
         break;
     }
 }
@@ -1056,11 +1056,11 @@ bool isNodeVisiblyContainedWithin(Node& node, const SimpleRange& range)
     auto endPosition = makeDeprecatedLegacyPosition(range.end);
 
     bool startIsVisuallySame = visiblePositionBeforeNode(node) == startPosition;
-    if (startIsVisuallySame && positionInParentAfterNode(&node) < endPosition)
+    if (startIsVisuallySame && positionInParentAfterNode(node) < endPosition)
         return true;
 
     bool endIsVisuallySame = visiblePositionAfterNode(node) == endPosition;
-    if (endIsVisuallySame && startPosition < positionInParentBeforeNode(&node))
+    if (endIsVisuallySame && startPosition < positionInParentBeforeNode(node))
         return true;
 
     return startIsVisuallySame && endIsVisuallySame;

--- a/Source/WebCore/editing/Editing.h
+++ b/Source/WebCore/editing/Editing.h
@@ -140,8 +140,8 @@ enum class SkipDisplayContents : bool { No, Yes };
 Position nextVisuallyDistinctCandidate(const Position&, SkipDisplayContents = SkipDisplayContents::Yes);
 Position previousVisuallyDistinctCandidate(const Position&);
 
-Position firstPositionInOrBeforeNode(Node*);
-inline Position lastPositionInOrAfterNode(Node*);
+inline Position firstPositionInOrBeforeNode(Node*); // Defined in EditingInlines.h
+inline Position lastPositionInOrAfterNode(Node*); // Defined in EditingInlines.h
 
 Position firstEditablePositionAfterPositionInRoot(const Position&, ContainerNode* root);
 Position lastEditablePositionBeforePositionInRoot(const Position&, ContainerNode* root);
@@ -257,13 +257,6 @@ inline bool editingIgnoresContent(const Node& node)
 inline bool positionBeforeOrAfterNodeIsCandidate(Node& node)
 {
     return isRenderedTable(&node) || editingIgnoresContent(node);
-}
-
-inline Position firstPositionInOrBeforeNode(Node* node)
-{
-    if (!node)
-        return { };
-    return editingIgnoresContent(*node) ? positionBeforeNode(node) : firstPositionInNode(node);
 }
 
 }

--- a/Source/WebCore/editing/EditingInlines.h
+++ b/Source/WebCore/editing/EditingInlines.h
@@ -30,11 +30,18 @@
 
 namespace WebCore {
 
-Position lastPositionInOrAfterNode(Node* node)
+inline Position firstPositionInOrBeforeNode(Node* node)
 {
     if (!node)
         return { };
-    return editingIgnoresContent(*node) ? positionAfterNode(node) : lastPositionInNode(node);
+    return editingIgnoresContent(*node) ? positionBeforeNode(*node) : firstPositionInNode(*node);
 }
 
+inline Position lastPositionInOrAfterNode(Node* node)
+{
+    if (!node)
+        return { };
+    return editingIgnoresContent(*node) ? positionAfterNode(*node) : lastPositionInNode(*node);
 }
+
+} // namespace WebCore

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -40,7 +40,7 @@
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
 #include "ColorSerialization.h"
-#include "Editing.h"
+#include "EditingInlines.h"
 #include "Editor.h"
 #include "ElementInlines.h"
 #include "FilterOperations.h"

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -3885,7 +3885,7 @@ RefPtr<TextPlaceholderElement> Editor::insertTextPlaceholder(const IntSize& size
 
     document->selection().addCaretVisibilitySuppressionReason(CaretVisibilitySuppressionReason::TextPlaceholderIsShowing);
 
-    document->selection().setSelection(VisibleSelection { positionInParentBeforeNode(placeholder.ptr()) }, FrameSelection::defaultSetSelectionOptions(UserTriggered::Yes));
+    document->selection().setSelection(VisibleSelection { positionInParentBeforeNode(placeholder) }, FrameSelection::defaultSetSelectionOptions(UserTriggered::Yes));
 
 #if ENABLE(WRITING_TOOLS)
     // For Writing Tools, we need the snapshot of the last inserted placeholder.
@@ -3904,7 +3904,7 @@ void Editor::removeTextPlaceholder(TextPlaceholderElement& placeholder)
 
     // Save off state so that we can set the text insertion position to just before the placeholder element after removal.
     RefPtr savedRootEditableElement { placeholder.rootEditableElement() };
-    auto savedPositionBeforePlaceholder = positionInParentBeforeNode(&placeholder);
+    auto savedPositionBeforePlaceholder = positionInParentBeforeNode(placeholder);
 
     // FIXME: Save the current selection if it has changed since the placeholder was inserted
     // and restore it after text insertion.
@@ -4949,7 +4949,7 @@ std::optional<SimpleRange> Editor::adjustedSelectionRange()
     // FIXME: Why do we need to adjust the selection to include the anchor tag it's in? Whoever wrote this code originally forgot to leave us a comment explaining the rationale.
     auto range = selectedRange();
     if (range) {
-        if (RefPtr enclosingAnchor = enclosingElementWithTag(firstPositionInNode(commonInclusiveAncestor<ComposedTree>(*range)), HTMLNames::aTag)) {
+        if (RefPtr enclosingAnchor = enclosingElementWithTag(firstPositionInNode(*commonInclusiveAncestor<ComposedTree>(*range)), HTMLNames::aTag)) {
             if (firstPositionInOrBeforeNode(range->start.container.ptr()) >= makeDeprecatedLegacyPosition(range->start))
                 range->start = makeBoundaryPointBeforeNodeContents(*enclosingAnchor);
         }

--- a/Source/WebCore/editing/FormatBlockCommand.cpp
+++ b/Source/WebCore/editing/FormatBlockCommand.cpp
@@ -111,7 +111,7 @@ void FormatBlockCommand::formatRange(const Position& start, const Position& end,
     }
 
     RefPtr lastChild = blockNode->lastChild();
-    Position lastParagraphInBlockNode = lastChild ? positionAfterNode(lastChild.get()) : Position();
+    Position lastParagraphInBlockNode = lastChild ? positionAfterNode(*lastChild) : Position();
     bool wasEndOfParagraph = isEndOfParagraph(lastParagraphInBlockNode);
 
     moveParagraphWithClones(start, end, blockNode.get(), outerBlock.get());

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -944,7 +944,7 @@ void FrameSelection::adjustSelectionExtentIfNeeded(VisiblePosition& extent, bool
     }
 
     if (RefPtr rootUserSelectAll = Position::rootUserSelectAllForNode(extent.deepEquivalent().anchorNode()))
-        extent = isForward ? positionAfterNode(rootUserSelectAll.get()).downstream(CanCrossEditingBoundary) : positionBeforeNode(rootUserSelectAll.get()).upstream(CanCrossEditingBoundary);
+        extent = isForward ? positionAfterNode(*rootUserSelectAll).downstream(CanCrossEditingBoundary) : positionBeforeNode(*rootUserSelectAll).upstream(CanCrossEditingBoundary);
 }
 
 VisiblePosition FrameSelection::modifyExtendingRight(TextGranularity granularity, UserTriggered userTriggered)

--- a/Source/WebCore/editing/IndentOutdentCommand.cpp
+++ b/Source/WebCore/editing/IndentOutdentCommand.cpp
@@ -124,7 +124,7 @@ void IndentOutdentCommand::indentIntoBlockquote(const Position& start, const Pos
             removeNode(*targetBlockquote);
             return;
         }
-        startOfContents = positionInParentAfterNode(targetBlockquote.get());
+        startOfContents = positionInParentAfterNode(*targetBlockquote);
     }
     
     if (startOfContents.deepEquivalent().containerNode() && !startOfContents.deepEquivalent().containerNode()->isDescendantOf(outerBlock.get()) && startOfContents.deepEquivalent().containerNode()->parentNode() != outerBlock->parentNode())
@@ -153,11 +153,11 @@ void IndentOutdentCommand::outdentParagraph()
     }
     
     // The selection is inside a blockquote i.e. enclosingNode is a blockquote
-    VisiblePosition positionInEnclosingBlock = VisiblePosition(firstPositionInNode(enclosingNode.get()));
+    VisiblePosition positionInEnclosingBlock = VisiblePosition(firstPositionInNode(*enclosingNode));
     // If the blockquote is inline, the start of the enclosing block coincides with
     // positionInEnclosingBlock.
     VisiblePosition startOfEnclosingBlock = (enclosingNode->renderer() && enclosingNode->renderer()->isInline()) ? positionInEnclosingBlock : startOfBlock(positionInEnclosingBlock);
-    VisiblePosition lastPositionInEnclosingBlock = VisiblePosition(lastPositionInNode(enclosingNode.get()));
+    VisiblePosition lastPositionInEnclosingBlock = VisiblePosition(lastPositionInNode(*enclosingNode));
     VisiblePosition endOfEnclosingBlock = endOfBlock(lastPositionInEnclosingBlock);
     if (visibleStartOfParagraph == startOfEnclosingBlock &&
         visibleEndOfParagraph == endOfEnclosingBlock) {
@@ -209,7 +209,7 @@ void IndentOutdentCommand::outdentParagraph()
     auto visibleEndOfParagraphToMove = endOfParagraph(visibleEndOfParagraph);
     if (visibleStartOfParagraphToMove.isNull() || visibleEndOfParagraphToMove.isNull())
         return;
-    moveParagraph(visibleStartOfParagraphToMove, visibleEndOfParagraphToMove, positionBeforeNode(placeholder.ptr()), true);
+    moveParagraph(visibleStartOfParagraphToMove, visibleEndOfParagraphToMove, positionBeforeNode(placeholder), true);
 }
 
 // FIXME: We should merge this function with ApplyBlockElementCommand::formatSelection

--- a/Source/WebCore/editing/InsertLineBreakCommand.cpp
+++ b/Source/WebCore/editing/InsertLineBreakCommand.cpp
@@ -88,47 +88,47 @@ void InsertLineBreakCommand::doApply()
         return;
 
     Ref document = this->document();
-    RefPtr<Node> nodeToInsert;
-    if (shouldUseBreakElement(position))
-        nodeToInsert = HTMLBRElement::create(document);
-    else
-        nodeToInsert = document->createTextNode("\n"_s);
-    
+    Ref nodeToInsert = [&] -> Ref<Node> {
+        if (shouldUseBreakElement(position))
+            return HTMLBRElement::create(document);
+        return document->createTextNode("\n"_s);
+    }();
+
     // FIXME: Need to merge text nodes when inserting just after or before text.
     document->updateLayoutIgnorePendingStylesheets();
     if (isEndOfParagraph(caret) && !lineBreakExistsAtVisiblePosition(caret)) {
         bool needExtraLineBreak = !is<HTMLHRElement>(*position.deprecatedNode()) && !is<HTMLTableElement>(*position.deprecatedNode());
 
-        insertNodeAt(*nodeToInsert, position);
-        
+        insertNodeAt(nodeToInsert.copyRef(), position);
+
         if (needExtraLineBreak)
-            insertNodeBefore(nodeToInsert->cloneNode(false), *nodeToInsert);
+            insertNodeBefore(nodeToInsert->cloneNode(false), nodeToInsert);
         
-        VisiblePosition endingPosition(positionBeforeNode(nodeToInsert.get()));
+        VisiblePosition endingPosition(positionBeforeNode(nodeToInsert));
         setEndingSelection(VisibleSelection(endingPosition, endingSelection().directionality()));
     } else if (position.deprecatedEditingOffset() <= caretMinOffset(*position.deprecatedNode())) {
-        insertNodeAt(*nodeToInsert, position);
+        insertNodeAt(nodeToInsert.copyRef(), position);
         
         // Insert an extra br or '\n' if the just inserted one collapsed.
-        if (!isStartOfParagraph(positionBeforeNode(nodeToInsert.get())))
-            insertNodeBefore(nodeToInsert->cloneNode(false), *nodeToInsert);
+        if (!isStartOfParagraph(positionBeforeNode(nodeToInsert)))
+            insertNodeBefore(nodeToInsert->cloneNode(false), nodeToInsert);
         
-        setEndingSelection(VisibleSelection(positionInParentAfterNode(nodeToInsert.get()), Affinity::Downstream, endingSelection().directionality()));
+        setEndingSelection(VisibleSelection(positionInParentAfterNode(nodeToInsert), Affinity::Downstream, endingSelection().directionality()));
     // If we're inserting after all of the rendered text in a text node, or into a non-text node,
     // a simple insertion is sufficient.
     } else if (position.deprecatedEditingOffset() >= caretMaxOffset(*position.deprecatedNode()) || !is<Text>(*position.deprecatedNode())) {
-        insertNodeAt(*nodeToInsert, position);
-        setEndingSelection(VisibleSelection(positionInParentAfterNode(nodeToInsert.get()), Affinity::Downstream, endingSelection().directionality()));
+        insertNodeAt(nodeToInsert.copyRef(), position);
+        setEndingSelection(VisibleSelection(positionInParentAfterNode(nodeToInsert), Affinity::Downstream, endingSelection().directionality()));
     } else if (RefPtr textNode = dynamicDowncast<Text>(*position.deprecatedNode())) {
         // Split a text node
         splitTextNode(*textNode, position.deprecatedEditingOffset());
-        insertNodeBefore(*nodeToInsert, *textNode);
-        Position endingPosition = firstPositionInNode(textNode.get());
-        
+        insertNodeBefore(nodeToInsert.copyRef(), *textNode);
+        Position endingPosition = firstPositionInNode(*textNode);
+
         // Handle whitespace that occurs after the split
         document->updateLayoutIgnorePendingStylesheets();
         if (!endingPosition.isRenderedCharacter()) {
-            Position positionBeforeTextNode(positionInParentBeforeNode(textNode.get()));
+            Position positionBeforeTextNode(positionInParentBeforeNode(*textNode));
             // Clear out all whitespace and insert one non-breaking space
             deleteInsignificantTextDownstream(endingPosition);
             ASSERT(!textNode->renderer() || textNode->renderer()->style().collapseWhiteSpace());
@@ -138,7 +138,7 @@ void InsertLineBreakCommand::doApply()
             else {
                 auto nbspNode = document->createTextNode(String { nonBreakingSpaceString() });
                 insertNodeAt(nbspNode.copyRef(), positionBeforeTextNode);
-                endingPosition = firstPositionInNode(nbspNode.ptr());
+                endingPosition = firstPositionInNode(nbspNode);
             }
         }
         
@@ -154,7 +154,7 @@ void InsertLineBreakCommand::doApply()
         // leaves and then comes back, new input will have the right style.
         // FIXME: We shouldn't always apply the typing style to the line break here,
         // see <rdar://problem/5794462>.
-        applyStyle(typingStyle.get(), firstPositionInOrBeforeNode(nodeToInsert.get()), lastPositionInOrAfterNode(nodeToInsert.get()));
+        applyStyle(typingStyle.get(), firstPositionInOrBeforeNode(nodeToInsert.ptr()), lastPositionInOrAfterNode(nodeToInsert.ptr()));
         // Even though this applyStyle operates on a Range, it still sets an endingSelection().
         // It tries to set a VisibleSelection around the content it operated on. So, that VisibleSelection
         // will either (a) select the line break we inserted, or it will (b) be a caret just 

--- a/Source/WebCore/editing/InsertListCommand.cpp
+++ b/Source/WebCore/editing/InsertListCommand.cpp
@@ -272,10 +272,10 @@ void InsertListCommand::doApplyForSingleParagraph(bool forceCreateList, const HT
             if (!newList->hasEditableStyle())
                 return;
 
-            RefPtr firstChildInList = enclosingListChild(VisiblePosition(firstPositionInNode(listNode.get())).deepEquivalent().deprecatedNode(), listNode.get());
+            RefPtr firstChildInList = enclosingListChild(VisiblePosition(firstPositionInNode(*listNode)).deepEquivalent().deprecatedNode(), listNode.get());
             RefPtr outerBlock = firstChildInList && isBlockFlowElement(*firstChildInList) ? firstChildInList : listNode.get();
             
-            moveParagraphWithClones(firstPositionInNode(listNode.get()), lastPositionInNode(listNode.get()), newList.get(), outerBlock.get());
+            moveParagraphWithClones(firstPositionInNode(*listNode), lastPositionInNode(*listNode), newList.get(), outerBlock.get());
 
             // Manually remove listNode because moveParagraphWithClones sometimes leaves it behind in the document.
             // See the bug 33668 and editing/execCommand/insert-list-orphaned-item-with-nested-lists.html.
@@ -296,7 +296,7 @@ void InsertListCommand::doApplyForSingleParagraph(bool forceCreateList, const HT
                 setEndingSelection(VisibleSelection(makeContainerOffsetPosition(currentSelection.start),
                     makeContainerOffsetPosition(currentSelection.end)));
             } else
-                setEndingSelection(VisibleSelection(firstPositionInNode(newList.get())));
+                setEndingSelection(VisibleSelection(firstPositionInNode(*newList)));
 
             return;
         }
@@ -319,8 +319,8 @@ void InsertListCommand::unlistifyParagraph(const VisiblePosition& originalStart,
         return;
 
     if (listChildNode->hasTagName(liTag)) {
-        start = firstPositionInNode(listChildNode);
-        end = lastPositionInNode(listChildNode);
+        start = firstPositionInNode(*listChildNode);
+        end = lastPositionInNode(*listChildNode);
         nextListChild = listChildNode->nextSibling();
         previousListChild = listChildNode->previousSibling();
     } else {
@@ -338,13 +338,13 @@ void InsertListCommand::unlistifyParagraph(const VisiblePosition& originalStart,
 
     // When removing a list, we must always create a placeholder to act as a point of insertion
     // for the list content being removed.
-    auto placeholder = HTMLBRElement::create(document());
-    RefPtr<Element> nodeToInsert = placeholder.copyRef();
+    Ref placeholder = HTMLBRElement::create(document());
+    Ref<Element> nodeToInsert = placeholder.copyRef();
     // If the content of the list item will be moved into another list, put it in a list item
     // so that we don't create an orphaned list child.
     if (enclosingList(&listNode)) {
         nodeToInsert = HTMLLIElement::create(document());
-        appendNode(placeholder.copyRef(), *nodeToInsert);
+        appendNode(placeholder.copyRef(), nodeToInsert);
     }
 
     if (nextListChild && previousListChild) {
@@ -356,7 +356,7 @@ void InsertListCommand::unlistifyParagraph(const VisiblePosition& originalStart,
         // listChildNode below in moveParagraphs, previousListChild will be removed along with it if it is 
         // unrendered. But we ought to remove nextListChild too, if it is unrendered.
         splitElement(listNode, *splitTreeToNode(*nextListChild, listNode));
-        insertNodeBefore(nodeToInsert.releaseNonNull(), listNode);
+        insertNodeBefore(WTF::move(nodeToInsert), listNode);
     } else if (nextListChild || listChildNode->parentNode() != &listNode) {
         // Just because listChildNode has no previousListChild doesn't mean there isn't any content
         // in listNode that comes before listChildNode, as listChildNode could have ancestors
@@ -364,11 +364,11 @@ void InsertListCommand::unlistifyParagraph(const VisiblePosition& originalStart,
         // where we're about to move listChildNode to.
         if (RefPtr listChildNodeParentNode { listChildNode->parentNode() }; listChildNodeParentNode && listChildNodeParentNode != &listNode)
             splitElement(listNode, *splitTreeToNode(*listChildNode, listNode).get());
-        insertNodeBefore(nodeToInsert.releaseNonNull(), listNode);
+        insertNodeBefore(WTF::move(nodeToInsert), listNode);
     } else
-        insertNodeAfter(nodeToInsert.releaseNonNull(), listNode);
+        insertNodeAfter(WTF::move(nodeToInsert), listNode);
 
-    VisiblePosition insertionPoint = VisiblePosition(positionBeforeNode(placeholder.ptr()));
+    VisiblePosition insertionPoint = VisiblePosition(positionBeforeNode(placeholder));
     moveParagraphs(start, end, insertionPoint, true);
 }
 
@@ -414,7 +414,7 @@ RefPtr<HTMLElement> InsertListCommand::listifyParagraph(const VisiblePosition& o
     if (previousList)
         appendNode(WTF::move(listItemElement), *previousList);
     else if (nextList)
-        insertNodeAt(WTF::move(listItemElement), positionBeforeNode(nextList.get()));
+        insertNodeAt(WTF::move(listItemElement), positionBeforeNode(*nextList));
     else {
         // Create the list.
         listElement = createHTMLElement(document(), listTag);
@@ -427,7 +427,7 @@ RefPtr<HTMLElement> InsertListCommand::listifyParagraph(const VisiblePosition& o
                 // by a br or a '\n', will invalidate start and end. Insert
                 // a placeholder and then recompute start and end.
                 auto blockPlaceholder = insertBlockPlaceholder(start.deepEquivalent());
-                start = positionBeforeNode(blockPlaceholder.get());
+                start = positionBeforeNode(*blockPlaceholder);
                 end = start;
             }
         }
@@ -441,7 +441,7 @@ RefPtr<HTMLElement> InsertListCommand::listifyParagraph(const VisiblePosition& o
         // Also avoid the containing list item.
         RefPtr listChild = enclosingListChild(insertionPos.deprecatedNode());
         if (listChild && listChild->hasTagName(liTag))
-            insertionPos = positionInParentBeforeNode(listChild.get());
+            insertionPos = positionInParentBeforeNode(*listChild);
 
         if (!isEditablePosition(insertionPos))
             return nullptr;
@@ -460,7 +460,7 @@ RefPtr<HTMLElement> InsertListCommand::listifyParagraph(const VisiblePosition& o
     document().updateLayoutIgnorePendingStylesheets();
     start = startOfParagraph(startOfParagraph(start, CanSkipOverEditingBoundary));
     end = endOfParagraph(endOfParagraph(start, CanSkipOverEditingBoundary));
-    moveParagraph(start, end, positionBeforeNode(placeholder.ptr()), true);
+    moveParagraph(start, end, positionBeforeNode(placeholder), true);
 
     if (listElement)
         return mergeWithNeighboringLists(*listElement);

--- a/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
+++ b/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
@@ -293,14 +293,15 @@ void InsertParagraphSeparatorCommand::doApply()
         return;
 
     // Create block to be inserted.
-    RefPtr<Element> blockToInsert;
-    if (startBlock->isRootEditableElement()) {
-        blockToInsert = createDefaultParagraphElement(document);
-        nestNewBlock = true;
-    } else if (shouldUseDefaultParagraphElement(startBlock.get())) 
-        blockToInsert = createDefaultParagraphElement(document);
-    else
-        blockToInsert = startBlock->cloneElementWithoutChildren(document, nullptr);
+    Ref blockToInsert = [&] -> Ref<Element> {
+        if (startBlock->isRootEditableElement()) {
+            nestNewBlock = true;
+            return createDefaultParagraphElement(document);
+        }
+        if (shouldUseDefaultParagraphElement(startBlock.get()))
+            return createDefaultParagraphElement(document);
+        return startBlock->cloneElementWithoutChildren(document, nullptr);
+    }();
 
     //---------------------------------------------------------------------
     // Handle case when position is in the last visible position in its block,
@@ -315,7 +316,7 @@ void InsertParagraphSeparatorCommand::doApply()
                 if (!appendBlockPlaceholder(WTF::move(extraBlock)))
                     return;
             }
-            appendNode(*blockToInsert, *startBlock);
+            appendNode(blockToInsert, *startBlock);
         } else {
             // We can get here if we pasted a copied portion of a blockquote with a newline at the end and are trying to paste it
             // into an unquoted area. We then don't want the newline within the blockquote or else it will also be quoted.
@@ -329,19 +330,19 @@ void InsertParagraphSeparatorCommand::doApply()
             RefPtr siblingNode = startBlock.get();
             if (blockToInsert->hasTagName(divTag))
                 siblingNode = highestVisuallyEquivalentDivBelowRoot(startBlock.get());
-            insertNodeAfter(*blockToInsert, *siblingNode);
+            insertNodeAfter(blockToInsert, *siblingNode);
         }
 
         // Recreate the same structure in the new paragraph.
 
         Vector<Ref<Element>> ancestors;
         getAncestorsInsideBlock(positionOutsideTabSpan(insertionPosition).deprecatedNode(), startBlock.get(), ancestors);
-        Ref parent = cloneHierarchyUnderNewBlock(ancestors, *blockToInsert);
-        
+        Ref parent = cloneHierarchyUnderNewBlock(ancestors, WTF::move(blockToInsert));
+
         if (!appendBlockPlaceholder(parent.copyRef()))
             return;
 
-        setEndingSelection(VisibleSelection(VisiblePosition(firstPositionInNode(parent.ptr()), Affinity::Downstream), endingSelection().directionality()));
+        setEndingSelection(VisibleSelection(VisiblePosition(firstPositionInNode(parent), Affinity::Downstream), endingSelection().directionality()));
         return;
     }
     
@@ -369,14 +370,14 @@ void InsertParagraphSeparatorCommand::doApply()
         // find ending selection position easily before inserting the paragraph
         insertionPosition = insertionPosition.downstream();
         
-        insertNodeBefore(*blockToInsert, *refNode);
+        insertNodeBefore(blockToInsert, *refNode);
 
         // Recreate the same structure in the new paragraph.
 
         Vector<Ref<Element>> ancestors;
         getAncestorsInsideBlock(positionAvoidingSpecialElementBoundary(positionOutsideTabSpan(insertionPosition)).deprecatedNode(), startBlock.get(), ancestors);
 
-        auto parent = cloneHierarchyUnderNewBlock(ancestors, *blockToInsert);
+        auto parent = cloneHierarchyUnderNewBlock(ancestors, WTF::move(blockToInsert));
         if (!appendBlockPlaceholder(WTF::move(parent)))
             return;
         
@@ -397,7 +398,7 @@ void InsertParagraphSeparatorCommand::doApply()
         insertNodeAt(br.copyRef(), insertionPosition);
         if (!br->parentNode())
             return;
-        insertionPosition = positionInParentAfterNode(br.ptr());
+        insertionPosition = positionInParentAfterNode(br);
         // If the insertion point is a break element, there is nothing else
         // we need to do.
         if (CheckedPtr renderer = visiblePos.deepEquivalent().anchorNode()->renderer(); renderer && renderer->isBR()) {
@@ -442,7 +443,7 @@ void InsertParagraphSeparatorCommand::doApply()
         bool atEnd = static_cast<unsigned>(insertionPosition.offsetInContainerNode()) >= textNode->length();
         if (insertionPosition.deprecatedEditingOffset() > 0 && !atEnd) {
             splitTextNode(*textNode, insertionPosition.offsetInContainerNode());
-            positionAfterSplit = firstPositionInNode(textNode.get());
+            positionAfterSplit = firstPositionInNode(*textNode);
             if (!textNode->previousSibling())
                 return; // Bail out if mutation events detachd the split text node.
             insertionPosition.moveToPosition(textNode->previousSibling(), insertionPosition.offsetInContainerNode());
@@ -456,9 +457,9 @@ void InsertParagraphSeparatorCommand::doApply()
 
     // Put the added block in the tree.
     if (nestNewBlock)
-        appendNode(*blockToInsert, *startBlock);
+        appendNode(blockToInsert, *startBlock);
     else
-        insertNodeAfter(*blockToInsert, *startBlock);
+        insertNodeAfter(blockToInsert, *startBlock);
 
     document->updateLayoutIgnorePendingStylesheets();
 
@@ -466,10 +467,10 @@ void InsertParagraphSeparatorCommand::doApply()
     // created.  All of the nodes, starting at visiblePos, are about to be added to the new paragraph 
     // element.  If the first node to be inserted won't be one that will hold an empty line open, add a br.
     if (isEndOfParagraph(visiblePos) && !lineBreakExistsAtVisiblePosition(visiblePos))
-        appendNode(HTMLBRElement::create(document), *blockToInsert);
+        appendNode(HTMLBRElement::create(document), blockToInsert);
 
     // Move the start node and the siblings of the start node.
-    if (VisiblePosition(insertionPosition) != VisiblePosition(positionBeforeNode(blockToInsert.get()))) {
+    if (VisiblePosition(insertionPosition) != VisiblePosition(positionBeforeNode(blockToInsert))) {
         RefPtr<Node> n;
         if (insertionPosition.containerNode() == startBlock)
             n = insertionPosition.computeNodeAfterPosition();
@@ -481,14 +482,14 @@ void InsertParagraphSeparatorCommand::doApply()
                 splitTreeToNode(*splitTo, *startBlock);
 
                 for (n = startBlock->firstChild(); n; n = n->nextSibling()) {
-                    if (VisiblePosition(insertionPosition) <= VisiblePosition(positionBeforeNode(n.get())))
+                    if (VisiblePosition(insertionPosition) <= VisiblePosition(positionBeforeNode(*n)))
                         break;
                 }
             }
         }
 
-        moveRemainingSiblingsToNewParent(n.get(), blockToInsert.get(), *blockToInsert);
-    }            
+        moveRemainingSiblingsToNewParent(n.get(), blockToInsert.ptr(), blockToInsert);
+    }
 
     // Handle whitespace that occurs after the split
     if (positionAfterSplit.isNotNull()) {
@@ -502,7 +503,7 @@ void InsertParagraphSeparatorCommand::doApply()
         }
     }
 
-    setEndingSelection(VisibleSelection(VisiblePosition(firstPositionInNode(blockToInsert.get()), Affinity::Downstream), endingSelection().directionality()));
+    setEndingSelection(VisibleSelection(VisiblePosition(firstPositionInNode(blockToInsert), Affinity::Downstream), endingSelection().directionality()));
     applyStyleAfterInsertion(startBlock.get());
 }
 

--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -69,7 +69,7 @@ Position InsertTextCommand::positionInsideTextNode(const Position& p)
     if (parentTabSpanNode(pos.anchorNode())) {
         auto textNode = document().createEditingTextNode(String { emptyString() });
         insertNodeAtTabSpanPosition(textNode.copyRef(), pos);
-        return firstPositionInNode(textNode.ptr());
+        return firstPositionInNode(textNode);
     }
 
     // Prepare for text input by looking at the specified position.
@@ -77,7 +77,7 @@ Position InsertTextCommand::positionInsideTextNode(const Position& p)
     if (!pos.containerNode()->isTextNode()) {
         auto textNode = document().createEditingTextNode(String { emptyString() });
         insertNodeAt(textNode.copyRef(), pos);
-        return firstPositionInNode(textNode.ptr());
+        return firstPositionInNode(textNode);
     }
 
     return pos;
@@ -234,7 +234,7 @@ void InsertTextCommand::doApply()
     
     // It is possible for the node that contains startPosition to contain only unrendered whitespace,
     // and so deleteInsignificantText could remove it.  Save the position before the node in case that happens.
-    Position positionBeforeStartNode(positionInParentBeforeNode(startPosition.containerNode()));
+    Position positionBeforeStartNode(positionInParentBeforeNode(*startPosition.containerNode()));
 
     if (!document().editor().isInsertingTextForWritingSuggestion())
         deleteInsignificantText(startPosition, startPosition.downstream());
@@ -361,7 +361,7 @@ Position InsertTextCommand::insertTab(const Position& pos)
         insertNodeAt(spanNode.copyRef(), insertPos);
 
     // return the position following the new tab
-    return lastPositionInNode(spanNode.ptr());
+    return lastPositionInNode(spanNode);
 }
 
 }

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -162,7 +162,7 @@ static Position positionAvoidingPrecedingNodes(Position position)
             break;
 
         if (position.containerNode()->nonShadowBoundaryParentNode())
-            nextPosition = positionInParentAfterNode(protect(position.containerNode()).get());
+            nextPosition = positionInParentAfterNode(protect(*position.containerNode()));
 
         if (nextPosition == position)
             break;
@@ -707,7 +707,7 @@ void ReplaceSelectionCommand::removeRedundantStylesAndKeepStyleSpanInline(Insert
                     return false;
                 if (isMailPasteAsQuotationNode(*context))
                     return true;
-                return enclosingNodeOfType(firstPositionInNode(context.get()), isMailBlockquote, CanCrossEditingBoundary);
+                return enclosingNodeOfType(firstPositionInNode(*context), isMailBlockquote, CanCrossEditingBoundary);
             };
             if (hasBlockquoteNode())
                 newInlineStyle->removeStyleFromRulesAndContext(*element, document().documentElement());
@@ -727,8 +727,8 @@ void ReplaceSelectionCommand::removeRedundantStylesAndKeepStyleSpanInline(Insert
 
         // FIXME: Tolerate differences in id, class, and style attributes.
         if (element->parentNode() && isNonTableCellHTMLBlockElement(element.get()) && elementIfEquivalent(*element, *element->parentNode())
-            && VisiblePosition(firstPositionInNode(element->parentNode())) == VisiblePosition(firstPositionInNode(element.get()))
-            && VisiblePosition(lastPositionInNode(element->parentNode())) == VisiblePosition(lastPositionInNode(element.get()))) {
+            && VisiblePosition(firstPositionInNode(*element->parentNode())) == VisiblePosition(firstPositionInNode(*element))
+            && VisiblePosition(lastPositionInNode(*element->parentNode())) == VisiblePosition(lastPositionInNode(*element))) {
             insertedNodes.willRemoveNodePreservingChildren(element.get());
             removeNodePreservingChildren(*element);
             continue;
@@ -837,7 +837,7 @@ void ReplaceSelectionCommand::makeInsertedContentRoundTrippableWithHTMLTreeBuild
             continue;
 
         if (isProhibitedParagraphChild(element->tagQName())) {
-            if (RefPtr paragraphElement = enclosingElementWithTag(positionInParentBeforeNode(node.get()), pTag)) {
+            if (RefPtr paragraphElement = enclosingElementWithTag(positionInParentBeforeNode(*node), pTag)) {
                 RefPtr parent { paragraphElement->parentNode() };
                 if (parent && parent->hasEditableStyle()) {
                     moveNodeOutOfAncestor(*node, *paragraphElement, insertedNodes);
@@ -848,7 +848,7 @@ void ReplaceSelectionCommand::makeInsertedContentRoundTrippableWithHTMLTreeBuild
         }
 
         if (is<HTMLHeadingElement>(*node)) {
-            if (RefPtr headerElement = highestEnclosingNodeOfType(positionInParentBeforeNode(node.get()), [](auto& node) { return is<HTMLHeadingElement>(node); })) {
+            if (RefPtr headerElement = highestEnclosingNodeOfType(positionInParentBeforeNode(*node), [](auto& node) { return is<HTMLHeadingElement>(node); })) {
                 if (headerElement->parentNode() && headerElement->parentNode()->isContentRichlyEditable())
                     moveNodeOutOfAncestor(*node, *headerElement, insertedNodes);
                 else {
@@ -874,7 +874,7 @@ void ReplaceSelectionCommand::moveNodeOutOfAncestor(Node& node, Node& ancestor, 
         return;
 
     VisiblePosition positionAtEndOfNode = lastPositionInOrAfterNode(&node);
-    VisiblePosition lastPositionInParagraph = lastPositionInNode(&ancestor);
+    VisiblePosition lastPositionInParagraph = lastPositionInNode(ancestor);
     if (positionAtEndOfNode == lastPositionInParagraph) {
         removeNode(node);
         if (!ancestor.isConnected())
@@ -1012,13 +1012,13 @@ void ReplaceSelectionCommand::handleStyleSpans(InsertedNodes& insertedNodes)
     if (context && isMailPasteAsQuotationNode(*context))
         blockquoteNode = context;
     else
-        blockquoteNode = enclosingNodeOfType(firstPositionInNode(context.get()), isMailBlockquote, CanCrossEditingBoundary);
+        blockquoteNode = enclosingNodeOfType(firstPositionInNode(*context), isMailBlockquote, CanCrossEditingBoundary);
 
     if (blockquoteNode)
         context = document().documentElement();
 
     // This operation requires that only editing styles to be removed from sourceDocumentStyle.
-    style->prepareToApplyAt(firstPositionInNode(context.get()));
+    style->prepareToApplyAt(firstPositionInNode(*context));
 
     // Remove block properties in the span's style. This prevents properties that probably have no effect 
     // currently from affecting blocks later if the style is cloned for a new block element during a future 
@@ -1066,7 +1066,7 @@ void ReplaceSelectionCommand::mergeEndIfNeeded()
     if (endOfParagraph(startOfParagraphToMove) == destination) {
         auto placeholder = HTMLBRElement::create(document());
         insertNodeBefore(placeholder, *startOfParagraphToMove.deepEquivalent().deprecatedNode());
-        destination = VisiblePosition(positionBeforeNode(placeholder.ptr()));
+        destination = VisiblePosition(positionBeforeNode(placeholder));
     }
 
     moveParagraph(startOfParagraphToMove, endOfParagraph(startOfParagraphToMove), destination);
@@ -1242,7 +1242,7 @@ void ReplaceSelectionCommand::doApply()
         // This will leave a br between the split.
         if (RefPtr br = endingSelection().start().deprecatedNode()) {
             ASSERT(br->hasTagName(brTag));
-            insertionPos = positionInParentBeforeNode(br.get());
+            insertionPos = positionInParentBeforeNode(*br);
             removeNode(*br);
         }
     }
@@ -1260,8 +1260,8 @@ void ReplaceSelectionCommand::doApply()
     RefPtr endBR = insertionPos.downstream().deprecatedNode()->hasTagName(brTag) ? insertionPos.downstream().deprecatedNode() : nullptr;
     VisiblePosition originalVisPosBeforeEndBR;
     if (endBR)
-        originalVisPosBeforeEndBR = VisiblePosition(positionBeforeNode(endBR.get())).previous();
-    
+        originalVisPosBeforeEndBR = VisiblePosition(positionBeforeNode(*endBR)).previous();
+
     RefPtr<Node> insertionBlock = enclosingBlock(protect(insertionPos.deprecatedNode()));
     
     // Adjust insertionPos to prevent nesting.
@@ -1269,9 +1269,9 @@ void ReplaceSelectionCommand::doApply()
     if (m_preventNesting && insertionBlock && insertionBlock != currentRoot && !isTableCell(*insertionBlock) && !shouldHandleMailBlockquote) {
         VisiblePosition visibleInsertionPos(insertionPos);
         if (isEndOfBlock(visibleInsertionPos) && !(isStartOfBlock(visibleInsertionPos) && fragment.hasInterchangeNewlineAtEnd()))
-            insertionPos = positionInParentAfterNode(insertionBlock.get());
+            insertionPos = positionInParentAfterNode(*insertionBlock);
         else if (isStartOfBlock(visibleInsertionPos))
-            insertionPos = positionInParentBeforeNode(insertionBlock.get());
+            insertionPos = positionInParentBeforeNode(*insertionBlock);
     }
     
     // Paste at start or end of link goes outside of link.
@@ -1307,7 +1307,7 @@ void ReplaceSelectionCommand::doApply()
         if (RefPtr containerNode = insertionPos.containerNode()) {
             if (containerNode->isTextNode() && insertionPos.offsetInContainerNode() && !insertionPos.atLastEditingPositionForNode()) {
                 splitTextNode(*insertionPos.containerText(), insertionPos.offsetInContainerNode());
-                insertionPos = firstPositionInNode(insertionPos.containerNode());
+                insertionPos = firstPositionInNode(*insertionPos.containerNode());
             }
         }
 
@@ -1320,7 +1320,7 @@ void ReplaceSelectionCommand::doApply()
                 ASSERT(splitStart);
                 if (splitStart != nodeToSplitTo) {
                     nodeToSplitTo = splitTreeToNode(*splitStart, *parentNode).get();
-                    insertionPos = positionInParentBeforeNode(nodeToSplitTo.get());
+                    insertionPos = positionInParentBeforeNode(*nodeToSplitTo);
                 }
             }
         }
@@ -1495,7 +1495,7 @@ void ReplaceSelectionCommand::doApply()
                 if (enclosingNode && isListItem(*enclosingNode)) {
                     auto newListItem = HTMLLIElement::create(document());
                     insertNodeAfter(newListItem.copyRef(), *enclosingNode);
-                    setEndingSelection(VisiblePosition(firstPositionInNode(newListItem.ptr())));
+                    setEndingSelection(VisiblePosition(firstPositionInNode(newListItem)));
                 } else {
                     // Use a default paragraph element (a plain div) for the empty paragraph, using the last paragraph
                     // block's style seems to annoy users.
@@ -1556,8 +1556,8 @@ bool ReplaceSelectionCommand::shouldRemoveEndBR(Node* endBR, const VisiblePositi
     if (!endBR || !endBR->isConnected())
         return false;
 
-    VisiblePosition visiblePos(positionBeforeNode(endBR));
-    
+    VisiblePosition visiblePos(positionBeforeNode(*endBR));
+
     // Don't remove the br if nothing was inserted.
     if (visiblePos.previous() == originalVisPosBeforeEndBR)
         return false;
@@ -1689,7 +1689,7 @@ void ReplaceSelectionCommand::addSpacesForSmartReplace()
             // Don't updateNodesInserted. Doing so would set m_endOfInsertedContent to be the node containing the leading space,
             // but m_endOfInsertedContent is supposed to mark the end of pasted content.
             insertNodeBefore(node, *startNode);
-            m_startOfInsertedContent = firstPositionInNode(node.ptr());
+            m_startOfInsertedContent = firstPositionInNode(node);
         }
     }
 }
@@ -1870,7 +1870,8 @@ static bool fullySelectsEnclosingLink(const VisibleSelection& selection)
     if (!link)
         return false;
 
-    return positionBeforeNode(link.get()).downstream().equals(start) && positionAfterNode(link.get()).upstream().equals(end);
+    return positionBeforeNode(*link).downstream().equals(start)
+        && positionAfterNode(*link).upstream().equals(end);
 }
 
 // During simple pastes, where we're just pasting a text node into a run of text, we insert the text node
@@ -1903,7 +1904,7 @@ bool ReplaceSelectionCommand::performTrivialReplace(const ReplacementFragment& f
         return false;
 
     if (nodeAfterInsertionPos && nodeAfterInsertionPos->parentNode() && nodeAfterInsertionPos->hasTagName(brTag)
-        && shouldRemoveEndBR(nodeAfterInsertionPos.get(), positionBeforeNode(nodeAfterInsertionPos.get())))
+        && shouldRemoveEndBR(nodeAfterInsertionPos.get(), positionBeforeNode(*nodeAfterInsertionPos)))
         removeNodeAndPruneAncestors(*nodeAfterInsertionPos);
 
     VisibleSelection selectionAfterReplace(m_selectReplacement ? start : end, end);

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -1071,7 +1071,7 @@ bool TextIterator::shouldRepresentNodeOffsetZero()
     // The currPos.isNotNull() check is needed because positions in non-HTML content
     // (like SVG) do not have visible positions, and we don't want to emit for them either.
     VisiblePosition startPos = VisiblePosition(Position(protect(m_startContainer), m_startOffset, Position::PositionIsOffsetInAnchor));
-    VisiblePosition currPos = VisiblePosition(positionBeforeNode(currentNode.ptr()));
+    VisiblePosition currPos = VisiblePosition(positionBeforeNode(currentNode));
     return startPos.isNotNull() && currPos.isNotNull() && !inSameLine(startPos, currPos);
 }
 

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -147,7 +147,7 @@ void TextManipulationController::startObservingParagraphs(ManipulationItemCallba
     m_callback = WTF::move(callback);
     m_exclusionRules = WTF::move(exclusionRules);
 
-    observeParagraphs(firstPositionInNode(document.get()), lastPositionInNode(document.get()));
+    observeParagraphs(firstPositionInNode(*document), lastPositionInNode(*document));
     flushPendingItemsForCallback();
 }
 
@@ -477,7 +477,7 @@ void TextManipulationController::addItemIfPossible(Vector<ManipulationUnit>&& un
 
     ASSERT(end);
     auto startPosition = firstPositionInOrBeforeNode(units[index].node.ptr());
-    auto endPosition = positionAfterNode(units[end - 1].node.ptr());
+    auto endPosition = positionAfterNode(units[end - 1].node);
     Vector<TextManipulationToken> tokens;
     for (; index < end; ++index)
         tokens.appendVector(WTF::move(units[index].tokens));
@@ -505,7 +505,7 @@ void TextManipulationController::observeParagraphs(const Position& start, const 
         ASSERT(contentNode);
 
         if (RefPtr shadowRoot = contentNode->shadowRoot(); shadowRoot && shadowRoot->mode() != ShadowRootMode::UserAgent)
-            observeParagraphs(firstPositionInNode(shadowRoot.get()), lastPositionInNode(shadowRoot.get()));
+            observeParagraphs(firstPositionInNode(*shadowRoot), lastPositionInNode(*shadowRoot));
 
         while (!enclosingItemBoundaryElements.isEmpty() && !enclosingItemBoundaryElements.last()->contains(contentNode.get())) {
             addItemIfPossible(std::exchange(unitsInCurrentParagraph, { }));
@@ -642,10 +642,10 @@ void TextManipulationController::scheduleObservationUpdate()
         }
 
         Position start;
-        if (RefPtr element = dynamicDowncast<Element>(commonAncestor.get())) {
+        if (RefPtr element = dynamicDowncast<Element>(commonAncestor)) {
             // Ensure to include the element in the range.
             if (canPerformTextManipulationByReplacingEntireTextContent(*element))
-                start = positionBeforeNode(commonAncestor.get());
+                start = positionBeforeNode(*element);
         }
         if (start.isNull())
             start = firstPositionInOrBeforeNode(commonAncestor.get());

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -643,7 +643,7 @@ bool TypingCommand::makeEditableRootEmpty()
         removeNode(*child);
 
     addBlockPlaceholderIfNeeded(root.get());
-    setEndingSelection(VisibleSelection(firstPositionInNode(root.get()), Affinity::Downstream, endingSelection().directionality()));
+    setEndingSelection(VisibleSelection(firstPositionInNode(*root), Affinity::Downstream, endingSelection().directionality()));
 
     return true;
 }
@@ -702,7 +702,7 @@ void TypingCommand::deleteKeyPressed(TextGranularity granularity, bool shouldAdd
         }
 
         // If we have a caret selection at the beginning of a cell, we have nothing to do.
-        if (enclosingTableCell && visibleStart == firstPositionInNode(enclosingTableCell.get()))
+        if (enclosingTableCell && visibleStart == firstPositionInNode(*enclosingTableCell))
             return;
 
         // If the caret is at the start of a paragraph after a table, move content into the last table cell.
@@ -714,7 +714,7 @@ void TypingCommand::deleteKeyPressed(TextGranularity granularity, bool shouldAdd
             selection->modify(FrameSelection::Alteration::Extend, SelectionDirection::Backward, granularity);
         // If the caret is just after a table, select the table and don't delete anything.
         } else if (RefPtr table = isFirstPositionAfterTable(visibleStart)) {
-            setEndingSelection(VisibleSelection(positionBeforeNode(table.get()), endingSelection().start(), Affinity::Downstream, endingSelection().directionality()));
+            setEndingSelection(VisibleSelection(positionBeforeNode(*table), endingSelection().start(), Affinity::Downstream, endingSelection().directionality()));
             typingAddedToOpenCommand(Type::DeleteKey);
             return;
         }
@@ -802,14 +802,14 @@ void TypingCommand::forwardDeleteKeyPressed(TextGranularity granularity, bool sh
         Position downstreamEnd = endingSelection().end().downstream();
         VisiblePosition visibleEnd = endingSelection().visibleEnd();
         auto enclosingTableCell = enclosingNodeOfType(visibleEnd.deepEquivalent(), &isTableCell);
-        if (enclosingTableCell && visibleEnd == lastPositionInNode(enclosingTableCell.get()))
+        if (enclosingTableCell && visibleEnd == lastPositionInNode(*enclosingTableCell))
             return;
         if (visibleEnd == endOfParagraph(visibleEnd))
             downstreamEnd = visibleEnd.next(CannotCrossEditingBoundary).deepEquivalent().downstream();
         // When deleting tables: Select the table first, then perform the deletion
         if (downstreamEnd.containerNode() && downstreamEnd.containerNode()->renderer() && downstreamEnd.containerNode()->renderer()->isRenderTable()
             && downstreamEnd.computeOffsetInContainerNode() <= caretMinOffset(*downstreamEnd.containerNode())) {
-            setEndingSelection(VisibleSelection(endingSelection().end(), positionAfterNode(downstreamEnd.containerNode()), Affinity::Downstream, endingSelection().directionality()));
+            setEndingSelection(VisibleSelection(endingSelection().end(), positionAfterNode(*downstreamEnd.containerNode()), Affinity::Downstream, endingSelection().directionality()));
             typingAddedToOpenCommand(Type::ForwardDeleteKey);
             return;
         }

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -91,7 +91,10 @@ VisibleSelection::VisibleSelection(const SimpleRange& range, Affinity affinity, 
 VisibleSelection VisibleSelection::selectionFromContentsOfNode(Node* node)
 {
     ASSERT(!editingIgnoresContent(*node));
-    return VisibleSelection(VisiblePosition { firstPositionInNode(node) }, VisiblePosition { lastPositionInNode(node) });
+    return VisibleSelection(
+        VisiblePosition { firstPositionInNode(*node) },
+        VisiblePosition { lastPositionInNode(*node) }
+    );
 }
 
 const Position& VisibleSelection::uncanonicalizedStart() const
@@ -486,12 +489,12 @@ Position VisibleSelection::adjustPositionForEnd(const Position& currentPosition,
 
     if (RefPtr ancestor = treeScope->ancestorNodeInThisScope(currentPosition.containerNode())) {
         if (ancestor->contains(startContainerNode))
-            return positionAfterNode(ancestor.get());
-        return positionBeforeNode(ancestor.get());
+            return positionAfterNode(*ancestor);
+        return positionBeforeNode(*ancestor);
     }
 
     if (RefPtr lastChild = treeScope->rootNode().lastChild())
-        return positionAfterNode(lastChild.get());
+        return positionAfterNode(*lastChild);
 
     return Position();
 }
@@ -504,12 +507,12 @@ Position VisibleSelection::adjustPositionForStart(const Position& currentPositio
     
     if (RefPtr ancestor = treeScope->ancestorNodeInThisScope(currentPosition.containerNode())) {
         if (ancestor->contains(endContainerNode))
-            return positionBeforeNode(ancestor.get());
-        return positionAfterNode(ancestor.get());
+            return positionBeforeNode(*ancestor);
+        return positionAfterNode(*ancestor);
     }
 
     if (RefPtr firstChild = treeScope->rootNode().firstChild())
-        return positionBeforeNode(firstChild.get());
+        return positionBeforeNode(*firstChild);
 
     return Position();
 }
@@ -610,13 +613,13 @@ void VisibleSelection::adjustSelectionToAvoidCrossingEditingBoundaries()
             Position p = previousVisuallyDistinctCandidate(m_end);
             RefPtr shadowAncestor = endRoot ? endRoot->shadowHost() : nullptr;
             if (p.isNull() && shadowAncestor)
-                p = positionAfterNode(shadowAncestor.get());
+                p = positionAfterNode(*shadowAncestor);
             while (p.isNotNull() && !(lowestEditableAncestor(protect(p.containerNode()).get()) == baseEditableAncestor && !isEditablePosition(p))) {
                 RefPtr root = editableRootForPosition(p);
                 shadowAncestor = root ? root->shadowHost() : nullptr;
-                p = isAtomicNode(protect(p.containerNode()).get()) ? positionInParentBeforeNode(protect(p.containerNode()).get()) : previousVisuallyDistinctCandidate(p);
+                p = isAtomicNode(protect(p.containerNode())) ? positionInParentBeforeNode(protect(*p.containerNode())) : previousVisuallyDistinctCandidate(p);
                 if (p.isNull() && shadowAncestor)
-                    p = positionAfterNode(shadowAncestor.get());
+                    p = positionAfterNode(*shadowAncestor);
             }
             VisiblePosition previous(p);
 
@@ -634,13 +637,13 @@ void VisibleSelection::adjustSelectionToAvoidCrossingEditingBoundaries()
             Position p = nextVisuallyDistinctCandidate(m_start);
             RefPtr shadowAncestor = startRoot ? startRoot->shadowHost() : nullptr;
             if (p.isNull() && shadowAncestor)
-                p = positionBeforeNode(shadowAncestor.get());
+                p = positionBeforeNode(*shadowAncestor);
             while (p.isNotNull() && !(lowestEditableAncestor(protect(p.containerNode()).get()) == baseEditableAncestor && !isEditablePosition(p))) {
                 RefPtr root = editableRootForPosition(p);
                 shadowAncestor = root ? root->shadowHost() : nullptr;
-                p = isAtomicNode(protect(p.containerNode()).get()) ? positionInParentAfterNode(protect(p.containerNode()).get()) : nextVisuallyDistinctCandidate(p);
+                p = isAtomicNode(protect(p.containerNode())) ? positionInParentAfterNode(protect(*p.containerNode())) : nextVisuallyDistinctCandidate(p);
                 if (p.isNull() && shadowAncestor)
-                    p = positionBeforeNode(shadowAncestor.get());
+                    p = positionBeforeNode(*shadowAncestor);
             }
             VisiblePosition next(p);
             

--- a/Source/WebCore/editing/VisibleUnits.cpp
+++ b/Source/WebCore/editing/VisibleUnits.cpp
@@ -29,7 +29,7 @@
 
 #include "BoundaryPointInlines.h"
 #include "Document.h"
-#include "Editing.h"
+#include "EditingInlines.h"
 #include "HTMLBRElement.h"
 #include "HTMLElement.h"
 #include "HTMLNames.h"
@@ -96,7 +96,7 @@ static Position previousLineCandidatePosition(Node* node, const VisiblePosition&
         if (highestEditableRoot(firstPositionInOrBeforeNode(previousNode.get()), editableType) != highestRoot)
             break;
 
-        Position pos = previousNode->hasTagName(HTMLNames::brTag) ? positionBeforeNode(previousNode.get()) :
+        Position pos = previousNode->hasTagName(HTMLNames::brTag) ? positionBeforeNode(*previousNode) :
             makeDeprecatedLegacyPosition(previousNode.get(), caretMaxOffset(*previousNode));
         
         if (pos.isCandidate())
@@ -774,9 +774,9 @@ static VisiblePosition startPositionForLine(const VisiblePosition& c, LineEndpoi
             startBox.traverseLineRightwardOnLine();
     }
 
-    RefPtr startTextNode = dynamicDowncast<Text>(*startNode);
-    return startTextNode ? Position(startTextNode.releaseNonNull(), downcast<InlineIterator::TextBox>(*startBox).start())
-        : positionBeforeNode(startNode.get());
+    if (RefPtr startTextNode = dynamicDowncast<Text>(*startNode))
+        return Position(startTextNode.releaseNonNull(), downcast<InlineIterator::TextBox>(*startBox).start());
+    return positionBeforeNode(*startNode);
 }
 
 static VisiblePosition startOfLine(const VisiblePosition& c, LineEndpointComputationMode mode, bool* reachedBoundary)
@@ -790,7 +790,7 @@ static VisiblePosition startOfLine(const VisiblePosition& c, LineEndpointComputa
     if (mode == UseLogicalOrdering) {
         if (auto editableRoot = highestEditableRoot(c.deepEquivalent())) {
             if (!editableRoot->contains(visPos.deepEquivalent().containerNode())) {
-                VisiblePosition newPosition = firstPositionInNode(editableRoot.get());
+                VisiblePosition newPosition = firstPositionInNode(*editableRoot);
                 if (reachedBoundary)
                     *reachedBoundary = c == newPosition;
                 return newPosition;
@@ -849,7 +849,7 @@ static VisiblePosition endPositionForLine(const VisiblePosition& c, LineEndpoint
 
     Position pos;
     if (is<HTMLBRElement>(*endNode))
-        pos = positionBeforeNode(endNode.get());
+        pos = positionBeforeNode(*endNode);
     else if (RefPtr endTextNode = dynamicDowncast<Text>(*endNode); endTextNode && is<InlineIterator::TextBox>(*endBox)) {
         auto& endTextBox = downcast<InlineIterator::TextBox>(*endBox);
         int endOffset = endTextBox.start();
@@ -857,8 +857,8 @@ static VisiblePosition endPositionForLine(const VisiblePosition& c, LineEndpoint
             endOffset += endTextBox.length();
         pos = Position(endTextNode.releaseNonNull(), endOffset);
     } else
-        pos = positionAfterNode(endNode.get());
-    
+        pos = positionAfterNode(*endNode);
+
     return VisiblePosition(pos, Affinity::Upstream);
 }
 
@@ -886,7 +886,7 @@ static VisiblePosition endOfLine(const VisiblePosition& c, LineEndpointComputati
 
         if (RefPtr editableRoot = highestEditableRoot(c.deepEquivalent())) {
             if (!editableRoot->contains(visPos.deepEquivalent().containerNode())) {
-                VisiblePosition newPosition = lastPositionInNode(editableRoot.get());
+                VisiblePosition newPosition = lastPositionInNode(*editableRoot);
                 if (reachedBoundary)
                     *reachedBoundary = c == newPosition;
                 return newPosition;
@@ -1002,7 +1002,7 @@ VisiblePosition previousLinePosition(const VisiblePosition& visiblePosition, Lay
         CheckedRef renderer = box->renderer();
         RefPtr node = renderer->node();
         if (node && editingIgnoresContent(*node))
-            return positionInParentBeforeNode(node.get());
+            return positionInParentBeforeNode(*node);
         // FIXME: The HitTestSource state should be propagated down from calls into JavaScript bindings.
         // For the time being, just err on the side of passing in `Bindings`.
         CheckedPtr renderBox = dynamicDowncast<RenderBox>(renderer.get());
@@ -1016,7 +1016,7 @@ VisiblePosition previousLinePosition(const VisiblePosition& visiblePosition, Lay
     RefPtr rootElement = rootEditableOrDocumentElement(*node, editableType);
     if (!rootElement)
         return VisiblePosition();
-    return firstPositionInNode(rootElement.get());
+    return firstPositionInNode(*rootElement);
 }
 
 VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutUnit lineDirectionPoint, EditableType editableType)
@@ -1064,7 +1064,7 @@ VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutU
         CheckedRef renderer = box->renderer();
         RefPtr node = renderer->node();
         if (node && editingIgnoresContent(*node))
-            return positionInParentBeforeNode(node.get());
+            return positionInParentBeforeNode(*node);
         // FIXME: The HitTestSource state should be propagated down from calls into JavaScript bindings.
         // For the time being, just err on the side of passing in `Bindings`.
         CheckedPtr renderBox = dynamicDowncast<RenderBox>(renderer.get());
@@ -1078,7 +1078,7 @@ VisiblePosition nextLinePosition(const VisiblePosition& visiblePosition, LayoutU
     RefPtr rootElement = rootEditableOrDocumentElement(*node, editableType);
     if (!rootElement)
         return VisiblePosition();
-    return lastPositionInNode(rootElement.get());
+    return lastPositionInNode(*rootElement);
 }
 
 // ---------
@@ -1254,7 +1254,7 @@ VisiblePosition startOfParagraph(const VisiblePosition& c, EditingBoundaryCrossi
         return VisiblePosition();
 
     if (isRenderedAsNonInlineTableImageOrHR(startNode.get()))
-        return positionBeforeNode(startNode.get());
+        return positionBeforeNode(*startNode);
 
     RefPtr startBlock = enclosingBlock(startNode.get());
 
@@ -1284,7 +1284,7 @@ VisiblePosition endOfParagraph(const VisiblePosition& c, EditingBoundaryCrossing
     RefPtr startNode = p.deprecatedNode();
 
     if (isRenderedAsNonInlineTableImageOrHR(startNode.get()))
-        return positionAfterNode(startNode.get());
+        return positionAfterNode(*startNode);
 
     RefPtr stayInsideBlock = enclosingBlock(startNode.get());
 
@@ -1367,7 +1367,7 @@ VisiblePosition startOfBlock(const VisiblePosition& visiblePosition, EditingBoun
     RefPtr<Node> startBlock;
     if (!position.containerNode() || !(startBlock = enclosingBlock(protect(position.containerNode()), rule)))
         return VisiblePosition();
-    return firstPositionInNode(startBlock.get());
+    return firstPositionInNode(*startBlock);
 }
 
 VisiblePosition endOfBlock(const VisiblePosition& visiblePosition, EditingBoundaryCrossingRule rule)
@@ -1376,7 +1376,7 @@ VisiblePosition endOfBlock(const VisiblePosition& visiblePosition, EditingBounda
     RefPtr<Node> endBlock;
     if (!position.containerNode() || !(endBlock = enclosingBlock(protect(position.containerNode()), rule)))
         return VisiblePosition();
-    return lastPositionInNode(endBlock.get());
+    return lastPositionInNode(*endBlock);
 }
 
 bool inSameBlock(const VisiblePosition& a, const VisiblePosition& b)
@@ -1452,13 +1452,13 @@ bool isEndOfDocument(const VisiblePosition& p)
 VisiblePosition startOfEditableContent(const VisiblePosition& visiblePosition)
 {
     RefPtr highestRoot = highestEditableRoot(visiblePosition.deepEquivalent());
-    return highestRoot ? firstPositionInNode(highestRoot.get()) : VisiblePosition { };
+    return highestRoot ? firstPositionInNode(*highestRoot) : VisiblePosition { };
 }
 
 VisiblePosition endOfEditableContent(const VisiblePosition& visiblePosition)
 {
     RefPtr highestRoot = highestEditableRoot(visiblePosition.deepEquivalent());
-    return highestRoot ? lastPositionInNode(highestRoot.get()) : VisiblePosition { };
+    return highestRoot ? lastPositionInNode(*highestRoot) : VisiblePosition { };
 }
 
 bool isEndOfEditableOrNonEditableContent(const VisiblePosition& p)

--- a/Source/WebCore/editing/cocoa/DataDetection.mm
+++ b/Source/WebCore/editing/cocoa/DataDetection.mm
@@ -35,7 +35,7 @@
 #import "CommonAtomStrings.h"
 #import "DataDetectionResultsStorage.h"
 #import "DocumentView.h"
-#import "Editing.h"
+#import "EditingInlines.h"
 #import "ElementAncestorIteratorInlines.h"
 #import "ElementRareData.h"
 #import "ElementTraversal.h"

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -51,7 +51,7 @@
 #include "DocumentQuirks.h"
 #include "DocumentType.h"
 #include "DocumentView.h"
-#include "Editing.h"
+#include "EditingInlines.h"
 #include "Editor.h"
 #include "EditorClient.h"
 #include "ElementChildIteratorInlines.h"
@@ -624,7 +624,7 @@ void StyledMarkupAccumulator::appendText(StringBuilder& out, const Text& text)
         auto content = textContentRespectingRange(text);
         appendCharactersReplacingEntities(out, content, entityMaskForText(text));
     } else {
-        const bool useRenderedText = !enclosingElementWithTag(firstPositionInNode(const_cast<Text*>(&text)), selectTag);
+        const bool useRenderedText = !enclosingElementWithTag(firstPositionInNode(const_cast<Text&>(text)), selectTag);
         String content = useRenderedText ? renderedTextRespectingRange(text) : textContentRespectingRange(text);
         StringBuilder buffer;
         appendCharactersReplacingEntities(buffer, content, EntityMaskInPCDATA);
@@ -640,12 +640,12 @@ void StyledMarkupAccumulator::appendText(StringBuilder& out, const Text& text)
 String StyledMarkupAccumulator::renderedTextRespectingRange(const Text& text)
 {
     TextIteratorBehaviors behaviors;
-    Position start = &text == m_start.containerNode() ? m_start : firstPositionInNode(const_cast<Text*>(&text));
+    Position start = &text == m_start.containerNode() ? m_start : firstPositionInNode(const_cast<Text&>(text));
     Position end;
     if (&text == m_end.containerNode())
         end = m_end;
     else {
-        end = lastPositionInNode(const_cast<Text*>(&text));
+        end = lastPositionInNode(const_cast<Text&>(text));
         if (!m_end.isNull())
             behaviors.add(TextIteratorBehavior::BehavesAsIfNodesFollowing);
     }
@@ -1055,7 +1055,7 @@ static RefPtr<Node> highestAncestorToWrapMarkup(const Position& start, const Pos
 
     RefPtr checkAncestor = specialCommonAncestor ? specialCommonAncestor : RefPtr { &commonAncestor };
     if (checkAncestor->renderer() && checkAncestor->renderer()->containingBlock()) {
-        RefPtr newSpecialCommonAncestor = highestEnclosingNodeOfType(firstPositionInNode(checkAncestor.get()), &isElementPresentational, CanCrossEditingBoundary, protect(checkAncestor->renderer()->containingBlock()->element()).get());
+        RefPtr newSpecialCommonAncestor = highestEnclosingNodeOfType(firstPositionInNode(*checkAncestor), &isElementPresentational, CanCrossEditingBoundary, protect(checkAncestor->renderer()->containingBlock()->element()).get());
         if (newSpecialCommonAncestor)
             specialCommonAncestor = WTF::move(newSpecialCommonAncestor);
     }
@@ -1069,10 +1069,10 @@ static RefPtr<Node> highestAncestorToWrapMarkup(const Position& start, const Pos
     if (!specialCommonAncestor && tabSpanNode(&commonAncestor))
         specialCommonAncestor = commonAncestor;
 
-    if (RefPtr enclosingAnchor = enclosingElementWithTag(firstPositionInNode(specialCommonAncestor ? specialCommonAncestor.get() : &commonAncestor), aTag))
+    if (RefPtr enclosingAnchor = enclosingElementWithTag(firstPositionInNode(specialCommonAncestor ? *specialCommonAncestor : commonAncestor), aTag))
         specialCommonAncestor = WTF::move(enclosingAnchor);
 
-    if (RefPtr enclosingPicture = enclosingElementWithTag(firstPositionInNode(specialCommonAncestor ? specialCommonAncestor.get() : &commonAncestor), pictureTag))
+    if (RefPtr enclosingPicture = enclosingElementWithTag(firstPositionInNode(specialCommonAncestor ? *specialCommonAncestor : commonAncestor), pictureTag))
         specialCommonAncestor = WTF::move(enclosingPicture);
 
     return specialCommonAncestor;
@@ -1096,10 +1096,10 @@ static String serializePreservingVisualAppearanceInternal(const Position& start,
     VisiblePosition visibleStart { start };
     VisiblePosition visibleEnd { end };
 
-    RefPtr body = enclosingElementWithTag(firstPositionInNode(commonAncestor.get()), bodyTag);
+    RefPtr body = enclosingElementWithTag(firstPositionInNode(*commonAncestor), bodyTag);
     RefPtr<Element> fullySelectedRoot;
     // FIXME: Do this for all fully selected blocks, not just the body.
-    if (body && VisiblePosition(firstPositionInNode(body.get())) == visibleStart && VisiblePosition(lastPositionInNode(body.get())) == visibleEnd)
+    if (body && VisiblePosition(firstPositionInNode(*body)) == visibleStart && VisiblePosition(lastPositionInNode(*body)) == visibleEnd)
         fullySelectedRoot = body;
     bool needsPositionStyleConversion = body && fullySelectedRoot == body && document->settings().shouldConvertPositionStyleOnCopy();
 
@@ -1110,7 +1110,7 @@ static String serializePreservingVisualAppearanceInternal(const Position& start,
     Position adjustedStart = start;
 
     if (RefPtr pictureElement = enclosingElementWithTag(adjustedStart, pictureTag))
-        adjustedStart = firstPositionInNode(pictureElement.get());
+        adjustedStart = firstPositionInNode(*pictureElement);
 
     if (annotate == AnnotateForInterchange::Yes && needInterchangeNewlineAfter(visibleStart)) {
         if (visibleStart == visibleEnd.previous())
@@ -1220,7 +1220,7 @@ String sanitizedMarkupForFragmentInDocument(Ref<DocumentFragment>&& fragment, Do
     bodyElement->appendChild(fragment.get());
 
     // SerializeComposedTree::No because there can't be a shadow tree in the pasted fragment.
-    auto result = serializePreservingVisualAppearanceInternal(firstPositionInNode(bodyElement.get()), lastPositionInNode(bodyElement.get()), nullptr,
+    auto result = serializePreservingVisualAppearanceInternal(firstPositionInNode(*bodyElement), lastPositionInNode(*bodyElement), nullptr,
         ResolveURLs::YesExcludingURLsForPrivacy, SerializeComposedTree::No, IgnoreUserSelectNone::No, AnnotateForInterchange::Yes, ConvertBlocksToInlines::No, StandardFontFamilySerializationMode::Strip, msoListMode, PreserveBaseElement::No, PreserveDirectionForInlineText::No);
 
     if (msoListMode != MSOListMode::Preserve)

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -752,7 +752,7 @@ static Position positionForIndex(TextControlInnerTextElement* innerText, unsigne
     for (RefPtr<Node> node = innerText; node; node = NodeTraversal::next(*node, innerText)) {
         if (node->hasTagName(brTag)) {
             if (!remainingCharactersToMoveForward)
-                return positionBeforeNode(node.get());
+                return positionBeforeNode(*node);
             remainingCharactersToMoveForward--;
             lastBrOrText = node;
         } else if (auto* text = dynamicDowncast<Text>(*node)) {
@@ -771,7 +771,7 @@ unsigned HTMLTextFormControlElement::indexForPosition(const Position& passedPosi
     if (!innerText || !innerText->contains(passedPosition.anchorNode()) || passedPosition.isNull())
         return 0;
 
-    if (positionBeforeNode(innerText.get()) == passedPosition)
+    if (positionBeforeNode(*innerText) == passedPosition)
         return 0;
 
     unsigned index = 0;

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -52,7 +52,7 @@
 #include "DragEvent.h"
 #include "DragEventTargetData.h"
 #include "DragState.h"
-#include "Editing.h"
+#include "EditingInlines.h"
 #include "Editor.h"
 #include "EditorClient.h"
 #include "ElementInlines.h"
@@ -561,8 +561,8 @@ static VisibleSelection expandSelectionToRespectSelectOnMouseDown(Node& targetNo
         return selection;
 
     VisibleSelection newSelection(selection);
-    newSelection.setBase(positionBeforeNode(nodeToSelect.get()).upstream(CanCrossEditingBoundary));
-    newSelection.setExtent(positionAfterNode(nodeToSelect.get()).downstream(CanCrossEditingBoundary));
+    newSelection.setBase(positionBeforeNode(*nodeToSelect).upstream(CanCrossEditingBoundary));
+    newSelection.setExtent(positionAfterNode(*nodeToSelect).downstream(CanCrossEditingBoundary));
 
     return newSelection;
 }
@@ -1161,18 +1161,18 @@ void EventHandler::updateSelectionForMouseDrag(const HitTestResult& hitTestResul
 
     RefPtr rootUserSelectAllForMousePressNode = Position::rootUserSelectAllForNode(m_mousePressNode);
     if (rootUserSelectAllForMousePressNode && rootUserSelectAllForMousePressNode == Position::rootUserSelectAllForNode(target.get())) {
-        newSelection.setBase(positionBeforeNode(rootUserSelectAllForMousePressNode.get()).upstream(CanCrossEditingBoundary));
-        newSelection.setExtent(positionAfterNode(rootUserSelectAllForMousePressNode.get()).downstream(CanCrossEditingBoundary));
+        newSelection.setBase(positionBeforeNode(*rootUserSelectAllForMousePressNode).upstream(CanCrossEditingBoundary));
+        newSelection.setExtent(positionAfterNode(*rootUserSelectAllForMousePressNode).downstream(CanCrossEditingBoundary));
     } else {
         // Reset base for user select all when base is inside user-select-all area and extent < base.
         if (rootUserSelectAllForMousePressNode && target->renderer()->visiblePositionForPoint(hitTestResult.localPoint(), HitTestSource::User) < m_mousePressNode->renderer()->visiblePositionForPoint(m_dragStartPosition, HitTestSource::User))
-            newSelection.setBase(positionAfterNode(rootUserSelectAllForMousePressNode.get()).downstream(CanCrossEditingBoundary));
-        
+            newSelection.setBase(positionAfterNode(*rootUserSelectAllForMousePressNode).downstream(CanCrossEditingBoundary));
+
         RefPtr rootUserSelectAllForTarget = Position::rootUserSelectAllForNode(target.get());
         if (rootUserSelectAllForTarget && m_mousePressNode->renderer() && target->renderer()->visiblePositionForPoint(hitTestResult.localPoint(), HitTestSource::User) < m_mousePressNode->renderer()->visiblePositionForPoint(m_dragStartPosition, HitTestSource::User))
-            newSelection.setExtent(positionBeforeNode(rootUserSelectAllForTarget.get()).upstream(CanCrossEditingBoundary));
+            newSelection.setExtent(positionBeforeNode(*rootUserSelectAllForTarget).upstream(CanCrossEditingBoundary));
         else if (rootUserSelectAllForTarget && m_mousePressNode->renderer())
-            newSelection.setExtent(positionAfterNode(rootUserSelectAllForTarget.get()).downstream(CanCrossEditingBoundary));
+            newSelection.setExtent(positionAfterNode(*rootUserSelectAllForTarget).downstream(CanCrossEditingBoundary));
         else
             newSelection.setExtent(targetPosition);
     }
@@ -4381,14 +4381,14 @@ static void setInitialKeyboardSelection(LocalFrame& frame, SelectionDirection di
     case SelectionDirection::Backward:
     case SelectionDirection::Left:
         if (focusedElement)
-            visiblePosition = VisiblePosition(positionBeforeNode(focusedElement.get()));
+            visiblePosition = VisiblePosition(positionBeforeNode(*focusedElement));
         else
             visiblePosition = endOfDocument(document.get());
         break;
     case SelectionDirection::Forward:
     case SelectionDirection::Right:
         if (focusedElement)
-            visiblePosition = VisiblePosition(positionAfterNode(focusedElement.get()));
+            visiblePosition = VisiblePosition(positionAfterNode(*focusedElement));
         else
             visiblePosition = startOfDocument(document.get());
         break;

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -50,7 +50,7 @@
 #include "DocumentSyncClient.h"
 #include "DocumentType.h"
 #include "DocumentView.h"
-#include "Editing.h"
+#include "EditingInlines.h"
 #include "Editor.h"
 #include "EditorClient.h"
 #include "ElementInlines.h"

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -31,6 +31,7 @@
 #include "LegacyRenderSVGResource.h"
 #include "LocalFrame.h"
 #include "NodeInlines.h"
+#include "PositionInlines.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGText.h"
 #include "SVGElementTypeHelpers.h"
@@ -133,7 +134,7 @@ ExceptionOr<void> SVGTextContentElement::selectSubString(unsigned charnum, unsig
     CheckedRef selection = frame->selection();
 
     // Find selection start
-    VisiblePosition start(firstPositionInNode(const_cast<SVGTextContentElement*>(this)));
+    VisiblePosition start(firstPositionInNode(const_cast<SVGTextContentElement&>(*this)));
     for (unsigned i = 0; i < charnum; ++i)
         start = start.next();
 

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp
@@ -240,8 +240,9 @@ RefPtr<InjectedBundleRangeHandle> InjectedBundleNodeHandle::visibleRange()
 {
     if (!m_node)
         return nullptr;
-    VisiblePosition start = firstPositionInNode(m_node.get());
-    VisiblePosition end = lastPositionInNode(m_node.get());
+    Ref node = *m_node;
+    VisiblePosition start = firstPositionInNode(node);
+    VisiblePosition end = lastPositionInNode(node);
     return createHandle(makeSimpleRange(start, end));
 }
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -75,8 +75,8 @@
 #import <WebCore/DocumentQuirks.h>
 #import <WebCore/DocumentView.h>
 #import <WebCore/DragImage.h>
-#import <WebCore/Editing.h>
 #import <WebCore/EditingHTMLConverter.h>
+#import <WebCore/EditingInlines.h>
 #import <WebCore/Editor.h>
 #import <WebCore/ElementAncestorIteratorInlines.h>
 #import <WebCore/EventHandler.h>
@@ -474,7 +474,7 @@ void WebPage::addDictationAlternative(const String& text, DictationContext conte
         return;
     }
 
-    auto firstEditablePosition = firstPositionInNode(editableRoot.get());
+    auto firstEditablePosition = firstPositionInNode(*editableRoot);
     auto selectionEnd = selection.end();
     auto searchRange = makeSimpleRange(firstEditablePosition, selectionEnd);
     if (!searchRange) {

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -311,10 +311,13 @@ static void computeEditableRootHasContentAndPlainText(const VisibleSelection& se
     if (!root || editingIgnoresContent(*root))
         return;
 
-    auto startInEditableRoot = firstPositionInNode(root);
+    auto startInEditableRoot = firstPositionInNode(*root);
     data.hasContent = root->hasChildNodes() && !isEndOfEditableOrNonEditableContent(startInEditableRoot);
     if (data.hasContent) {
-        auto range = makeSimpleRange(VisiblePosition { startInEditableRoot }, VisiblePosition { lastPositionInNode(root) });
+        auto range = makeSimpleRange(
+            VisiblePosition { startInEditableRoot },
+            VisiblePosition { lastPositionInNode(*root) }
+        );
         data.hasPlainText = range && hasAnyPlainText(*range);
     }
 }
@@ -1279,14 +1282,14 @@ static std::optional<SimpleRange> expandForImageOverlay(const SimpleRange& range
 
     for (auto start = expandedStart; insideImageOverlay(start); start = start.previous()) {
         if (RefPtr container = start.deepEquivalent().containerNode(); is<Text>(container)) {
-            expandedStart = firstPositionInNode(container.get()).downstream();
+            expandedStart = firstPositionInNode(*container).downstream();
             break;
         }
     }
 
     for (auto end = expandedEnd; insideImageOverlay(end); end = end.next()) {
         if (RefPtr container = end.deepEquivalent().containerNode(); is<Text>(container)) {
-            expandedEnd = lastPositionInNode(container.get()).upstream();
+            expandedEnd = lastPositionInNode(*container).upstream();
             break;
         }
     }


### PR DESCRIPTION
#### b0dd983d54fd6ccc4f4c3218b8a7a7816d6d11a8
<pre>
Replace a few `Node*` parameters that must never be null with `Node&amp;` parameters.
<a href="https://bugs.webkit.org/show_bug.cgi?id=309271">https://bugs.webkit.org/show_bug.cgi?id=309271</a>

Reviewed by Ryosuke Niwa.

The functions `positionInParentBeforeNode`, `positionInParentAfterNode`, `positionBeforeNode`,
`positionAfterNode`, `firstPositionInNode`, and `lastPositionInNode` all previously took a
single `Node*` parameter, but required that the `Node*` never be null, unconditionally
dereferencing it without any null checks.

This changes them to take a `Node&amp;` instead, and updates the call sites to match. This makes
it easier to understand at the callers side and makes it necessary for them to understand
why dereferencing is safe.

In a few places where it was easily accomplished, RefPtrs were converted to Refs
allowing the removal of some explicit dereferencing at call sites.

Additionally, the definitions of the functions `firstPositionInOrBeforeNode` and
`firstPositionInNode` were moved to their corresponding `Inlines.h&quot; files so they
could be adjacent to their &quot;last&quot; counterparts.

* Source/WebCore/accessibility/AXObjectCache.cpp:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/dom/Element.cpp:
* Source/WebCore/dom/FragmentDirectiveGenerator.cpp:
* Source/WebCore/dom/Position.cpp:
* Source/WebCore/dom/Position.h:
* Source/WebCore/dom/PositionInlines.h:
* Source/WebCore/dom/PositionIterator.cpp:
* Source/WebCore/editing/ApplyBlockElementCommand.cpp:
* Source/WebCore/editing/ApplyStyleCommand.cpp:
* Source/WebCore/editing/BreakBlockquoteCommand.cpp:
* Source/WebCore/editing/CompositeEditCommand.cpp:
* Source/WebCore/editing/CreateLinkCommand.cpp:
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
* Source/WebCore/editing/Editing.cpp:
* Source/WebCore/editing/Editing.h:
* Source/WebCore/editing/EditingInlines.h:
* Source/WebCore/editing/EditingStyle.cpp:
* Source/WebCore/editing/Editor.cpp:
* Source/WebCore/editing/FormatBlockCommand.cpp:
* Source/WebCore/editing/FrameSelection.cpp:
* Source/WebCore/editing/IndentOutdentCommand.cpp:
* Source/WebCore/editing/InsertLineBreakCommand.cpp:
* Source/WebCore/editing/InsertListCommand.cpp:
* Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp:
* Source/WebCore/editing/InsertTextCommand.cpp:
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
* Source/WebCore/editing/TextIterator.cpp:
* Source/WebCore/editing/TextManipulationController.cpp:
* Source/WebCore/editing/TypingCommand.cpp:
* Source/WebCore/editing/VisibleSelection.cpp:
* Source/WebCore/editing/VisibleUnits.cpp:
* Source/WebCore/editing/cocoa/DataDetection.mm:
* Source/WebCore/editing/markup.cpp:
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
* Source/WebCore/page/EventHandler.cpp:
* Source/WebCore/page/LocalFrame.cpp:
* Source/WebCore/svg/SVGTextContentElement.cpp:
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleNodeHandle.cpp:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:

Canonical link: <a href="https://commits.webkit.org/308798@main">https://commits.webkit.org/308798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/846a81ca6e0d27ca8880dff9df0c38e081062aab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148439 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157123 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101869 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21030 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114431 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81516 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151399 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95201 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15766 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13593 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4559 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125377 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159456 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2590 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12688 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122475 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122697 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33375 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20932 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132983 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77084 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18074 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9732 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20540 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84325 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20272 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20417 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20326 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->