### PR TITLE
[GTK] Implement playEffect by supporting gamepad rumble

### DIFF
--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp
@@ -136,6 +136,8 @@ static void onButtonReleaseEvent(ManetteDevice* device, ManetteEvent* event, Man
 ManetteGamepad::ManetteGamepad(ManetteDevice* device, unsigned index)
     : PlatformGamepad(index)
     , m_device(device)
+    , m_effectDelayTimer(RunLoop::currentSingleton(), "ManetteGamepad::EffectDelayTimer"_s, this, &ManetteGamepad::effectDelayTimerFired)
+    , m_effectDurationTimer(RunLoop::currentSingleton(), "ManetteGamepad::EffectDurationTimer"_s, this, &ManetteGamepad::effectDurationTimerFired)
 {
     ASSERT(index < 4);
 
@@ -151,6 +153,9 @@ ManetteGamepad::ManetteGamepad(ManetteDevice* device, unsigned index)
     m_buttonValues.resize(static_cast<size_t>(standardGamepadButtonCount));
     for (auto& value : m_buttonValues)
         value.setValue(0.0);
+
+    if (manette_device_has_rumble(m_device.get()))
+        m_supportedEffectTypes.add(GamepadHapticEffectType::DualRumble);
 
     g_signal_connect(device, "button-press-event", G_CALLBACK(onButtonPressEvent), this);
     g_signal_connect(device, "button-release-event", G_CALLBACK(onButtonReleaseEvent), this);
@@ -176,6 +181,61 @@ void ManetteGamepad::absoluteAxisChanged(ManetteDevice*, StandardGamepadAxis axi
     m_axisValues[static_cast<int>(axis)].setValue(value);
 
     ManetteGamepadProvider::singleton().gamepadHadInput(*this, ManetteGamepadProvider::ShouldMakeGamepadsVisible::Yes);
+}
+
+void ManetteGamepad::playEffect(GamepadHapticEffectType type, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
+{
+    if (!m_supportedEffectTypes.contains(type))
+        return completionHandler(false);
+
+    if (m_effectCompletionHandler)
+        stopEffects({ });
+
+    m_effectCompletionHandler = WTF::move(completionHandler);
+    if (parameters.startDelay) {
+        m_pendingEffectParameters = parameters;
+        m_effectDelayTimer.startOneShot(Seconds::fromMilliseconds(parameters.startDelay));
+        return;
+    }
+
+    startRumble(parameters);
+}
+
+void ManetteGamepad::stopEffects(CompletionHandler<void()>&& completionHandler)
+{
+    m_effectDelayTimer.stop();
+    m_effectDurationTimer.stop();
+    if (m_effectCompletionHandler)
+        m_effectCompletionHandler(false);
+
+    manette_device_rumble(m_device.get(), 0, 0, 0);
+
+    if (completionHandler)
+        completionHandler();
+}
+
+void ManetteGamepad::effectDelayTimerFired()
+{
+    startRumble(std::exchange(m_pendingEffectParameters, { }));
+}
+
+void ManetteGamepad::startRumble(const GamepadEffectParameters& parameters)
+{
+#if LIBMANETTE_CHECK_VERSION(0, 2, 13)
+    manette_device_rumble(m_device.get(), parameters.strongMagnitude, parameters.weakMagnitude, static_cast<guint>(parameters.duration));
+#else
+    manette_device_rumble(m_device.get(), parameters.strongMagnitude * G_MAXUINT16, parameters.weakMagnitude * G_MAXUINT16, static_cast<guint>(parameters.duration));
+#endif
+
+    if (parameters.duration)
+        m_effectDurationTimer.startOneShot(Seconds::fromMilliseconds(parameters.duration));
+    else
+        m_effectCompletionHandler(true);
+}
+
+void ManetteGamepad::effectDurationTimerFired()
+{
+    m_effectCompletionHandler(true);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepad.h
@@ -27,10 +27,11 @@
 
 #if ENABLE(GAMEPAD) && OS(LINUX)
 
+#include "GamepadEffectParameters.h"
 #include "PlatformGamepad.h"
 
 #include <libmanette.h>
-#include <wtf/HashMap.h>
+#include <wtf/RunLoop.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/glib/GRefPtr.h>
 
@@ -72,17 +73,26 @@ public:
     ManetteGamepad(ManetteDevice*, unsigned index);
     virtual ~ManetteGamepad();
 
-    const Vector<SharedGamepadValue>& axisValues() const LIFETIME_BOUND final { return m_axisValues; }
-    const Vector<SharedGamepadValue>& buttonValues() const LIFETIME_BOUND final { return m_buttonValues; }
-
     void absoluteAxisChanged(ManetteDevice*, StandardGamepadAxis, double value);
     void buttonPressedOrReleased(ManetteDevice*, StandardGamepadButton, bool pressed);
 
 private:
+    const Vector<SharedGamepadValue>& axisValues() const LIFETIME_BOUND final { return m_axisValues; }
+    const Vector<SharedGamepadValue>& buttonValues() const LIFETIME_BOUND final { return m_buttonValues; }
+    void playEffect(GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
+    void stopEffects(CompletionHandler<void()>&&) final;
+    void effectDelayTimerFired();
+    void effectDurationTimerFired();
+    void startRumble(const GamepadEffectParameters&);
+
     GRefPtr<ManetteDevice> m_device;
 
     Vector<SharedGamepadValue> m_buttonValues;
     Vector<SharedGamepadValue> m_axisValues;
+    RunLoop::Timer m_effectDelayTimer;
+    RunLoop::Timer m_effectDurationTimer;
+    CompletionHandler<void(bool)> m_effectCompletionHandler;
+    GamepadEffectParameters m_pendingEffectParameters;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp
+++ b/Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp
@@ -173,22 +173,35 @@ std::unique_ptr<ManetteGamepad> ManetteGamepadProvider::removeGamepadForDevice(M
     ASSERT(result);
 
     auto index = m_gamepadVector.find(result.get());
-    if (index != notFound)
+    if (index != notFound) {
+        auto gamepad = m_gamepadVector[index];
+        gamepad->stopEffects({ });
         m_gamepadVector[index] = nullptr;
+    }
 
     return result;
 }
 
-void ManetteGamepadProvider::playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&& completionHandler)
+void ManetteGamepadProvider::playEffect(unsigned gamepadIndex, const String& gamepadID, GamepadHapticEffectType type, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
 {
-    // Not supported by this provider.
-    completionHandler(false);
+    if (gamepadIndex >= m_gamepadVector.size())
+        return completionHandler(false);
+    auto gamepad = m_gamepadVector[gamepadIndex];
+    if (!gamepad || gamepad->id() != gamepadID)
+        return completionHandler(false);
+
+    gamepad->playEffect(type, parameters, WTF::move(completionHandler));
 }
 
-void ManetteGamepadProvider::stopEffects(unsigned, const String&, CompletionHandler<void()>&& completionHandler)
+void ManetteGamepadProvider::stopEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&& completionHandler)
 {
-    // Not supported by this provider.
-    completionHandler();
+    if (gamepadIndex >= m_gamepadVector.size())
+        return completionHandler();
+    auto gamepad = m_gamepadVector[gamepadIndex];
+    if (!gamepad || gamepad->id() != gamepadID)
+        return completionHandler();
+
+    gamepad->stopEffects(WTF::move(completionHandler));
 }
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -243,7 +243,7 @@ bool defaultShowModalDialogEnabled()
 #if ENABLE(GAMEPAD)
 bool defaultGamepadVibrationActuatorEnabled()
 {
-#if HAVE(WIDE_GAMECONTROLLER_SUPPORT) || ENABLE(WPE_PLATFORM)
+#if HAVE(WIDE_GAMECONTROLLER_SUPPORT) || ENABLE(WPE_PLATFORM) || PLATFORM(GTK)
     return true;
 #else
     return false;


### PR DESCRIPTION
#### 2e1369350dab08147264e9881efbb475e48ee422
<pre>
[GTK] Implement playEffect by supporting gamepad rumble
<a href="https://bugs.webkit.org/show_bug.cgi?id=309274">https://bugs.webkit.org/show_bug.cgi?id=309274</a>

Reviewed by Carlos Garcia Campos.

Implemented playEffect (and stopEffects) using libmanette&apos;s rumble. This
gates the effect by checking if the type is supported, then applies the
right rumble parameters depending on the libmanette version used.

Tested against <a href="https://hardwaretester.com/gamepad.">https://hardwaretester.com/gamepad.</a>

* Source/WebCore/platform/gamepad/manette/ManetteGamepad.cpp:
(WebCore::ManetteGamepad::ManetteGamepad):
(WebCore::ManetteGamepad::playEffect):
(WebCore::ManetteGamepad::stopEffects):
(WebCore::ManetteGamepad::effectDelayTimerFired):
(WebCore::ManetteGamepad::startRumble):
(WebCore::ManetteGamepad::effectDurationTimerFired):
* Source/WebCore/platform/gamepad/manette/ManetteGamepad.h:
* Source/WebCore/platform/gamepad/manette/ManetteGamepadProvider.cpp:
(WebCore::ManetteGamepadProvider::removeGamepadForDevice):
(WebCore::ManetteGamepadProvider::playEffect):
(WebCore::ManetteGamepadProvider::stopEffects):
* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultGamepadVibrationActuatorEnabled):

Canonical link: <a href="https://commits.webkit.org/308799@main">https://commits.webkit.org/308799@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0df725113d338d10410b6e210c7c0d5dda31a0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157200 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21107 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114493 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95263 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/147837 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15813 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13645 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4636 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159535 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2667 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12761 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122542 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122763 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33376 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21009 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133034 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77162 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18113 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9803 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20617 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20349 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20494 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20403 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->