### PR TITLE
[WPE] Implement playEffect by supporting gamepad rumble

### DIFF
--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -243,7 +243,7 @@ bool defaultShowModalDialogEnabled()
 #if ENABLE(GAMEPAD)
 bool defaultGamepadVibrationActuatorEnabled()
 {
-#if HAVE(WIDE_GAMECONTROLLER_SUPPORT)
+#if HAVE(WIDE_GAMECONTROLLER_SUPPORT) || ENABLE(WPE_PLATFORM)
     return true;
 #else
     return false;

--- a/Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.cpp
@@ -80,8 +80,11 @@ void GamepadProviderWPE::gamepadDisconnected(WPEGamepad* gamepad)
         return;
 
     auto index = m_gamepadVector.find(device.get());
-    if (index != notFound)
+    if (index != notFound) {
+        auto pad = m_gamepadVector[index];
+        pad->stopEffects({ });
         m_gamepadVector[index] = nullptr;
+    }
 
     for (auto& client : m_clients)
         client.platformGamepadDisconnected(*device);
@@ -135,18 +138,26 @@ void GamepadProviderWPE::stopMonitoringGamepads(GamepadProviderClient& client)
     }
 }
 
-void GamepadProviderWPE::playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&& completionHandler)
+void GamepadProviderWPE::playEffect(unsigned gamepadIndex, const String& gamepadID, GamepadHapticEffectType type, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
 {
-    // Not supported by this provider.
-    notImplemented();
-    completionHandler(false);
+    if (gamepadIndex >= m_gamepadVector.size())
+        return completionHandler(false);
+    auto gamepad = m_gamepadVector[gamepadIndex];
+    if (!gamepad || gamepad->id() != gamepadID)
+        return completionHandler(false);
+
+    gamepad->playEffect(type, parameters, WTF::move(completionHandler));
 }
 
-void GamepadProviderWPE::stopEffects(unsigned, const String&, CompletionHandler<void()>&& completionHandler)
+void GamepadProviderWPE::stopEffects(unsigned gamepadIndex, const String& gamepadID, CompletionHandler<void()>&& completionHandler)
 {
-    // Not supported by this provider.
-    notImplemented();
-    completionHandler();
+    if (gamepadIndex >= m_gamepadVector.size())
+        return completionHandler();
+    auto gamepad = m_gamepadVector[gamepadIndex];
+    if (!gamepad || gamepad->id() != gamepadID)
+        return completionHandler();
+
+    gamepad->stopEffects(WTF::move(completionHandler));
 }
 
 void GamepadProviderWPE::startMonitoringInput()

--- a/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp
@@ -40,6 +40,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(PlatformGamepadWPE);
 PlatformGamepadWPE::PlatformGamepadWPE(WPEGamepad* gamepad, unsigned index)
     : PlatformGamepad(index)
     , m_gamepad(gamepad)
+    , m_effectDelayTimer(RunLoop::currentSingleton(), "PlatformGamepadWPE::EffectDelayTimer"_s, this, &PlatformGamepadWPE::effectDelayTimerFired)
+    , m_effectDurationTimer(RunLoop::currentSingleton(), "PlatformGamepadWPE::EffectDurationTimer"_s, this, &PlatformGamepadWPE::effectDurationTimerFired)
 {
     m_connectTime = m_lastUpdateTime = MonotonicTime::now();
 
@@ -53,6 +55,9 @@ PlatformGamepadWPE::PlatformGamepadWPE(WPEGamepad* gamepad, unsigned index)
     m_axisValues.resize(WPE_GAMEPAD_AXIS_RIGHT_Y + 1);
     for (auto& value : m_axisValues)
         value.setValue(0.0);
+
+    if (wpe_gamepad_has_rumble(m_gamepad.get()))
+        m_supportedEffectTypes.add(GamepadHapticEffectType::DualRumble);
 
     g_signal_connect_swapped(m_gamepad.get(), "button-event", G_CALLBACK(+[](PlatformGamepadWPE* gamepad, WPEGamepadButton button, gboolean isPressed) {
         gamepad->buttonEvent(static_cast<size_t>(button), isPressed);
@@ -79,6 +84,57 @@ void PlatformGamepadWPE::axisEvent(size_t axis, double value)
     m_lastUpdateTime = MonotonicTime::now();
     m_axisValues[axis].setValue(value);
     GamepadProviderWPE::singleton().notifyInput(*this, GamepadProviderWPE::ShouldMakeGamepadsVisible::No);
+}
+
+void PlatformGamepadWPE::playEffect(GamepadHapticEffectType type, const GamepadEffectParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
+{
+    if (!m_supportedEffectTypes.contains(type))
+        return completionHandler(false);
+
+    if (m_effectCompletionHandler)
+        stopEffects({ });
+
+    m_effectCompletionHandler = WTF::move(completionHandler);
+    if (parameters.startDelay) {
+        m_pendingEffectParameters = parameters;
+        m_effectDelayTimer.startOneShot(Seconds::fromMilliseconds(parameters.startDelay));
+        return;
+    }
+
+    startRumble(parameters);
+}
+
+void PlatformGamepadWPE::stopEffects(CompletionHandler<void()>&& completionHandler)
+{
+    m_effectDelayTimer.stop();
+    m_effectDurationTimer.stop();
+    if (m_effectCompletionHandler)
+        m_effectCompletionHandler(false);
+
+    wpe_gamepad_rumble(m_gamepad.get(), 0, 0, 0);
+
+    if (completionHandler)
+        completionHandler();
+}
+
+void PlatformGamepadWPE::effectDelayTimerFired()
+{
+    startRumble(std::exchange(m_pendingEffectParameters, { }));
+}
+
+void PlatformGamepadWPE::startRumble(const GamepadEffectParameters& parameters)
+{
+    wpe_gamepad_rumble(m_gamepad.get(), parameters.strongMagnitude, parameters.weakMagnitude, static_cast<guint>(parameters.duration));
+
+    if (parameters.duration)
+        m_effectDurationTimer.startOneShot(Seconds::fromMilliseconds(parameters.duration));
+    else
+        m_effectCompletionHandler(true);
+}
+
+void PlatformGamepadWPE::effectDurationTimerFired()
+{
+    m_effectCompletionHandler(true);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.h
+++ b/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #if ENABLE(GAMEPAD) && ENABLE(WPE_PLATFORM)
+#include <WebCore/GamepadEffectParameters.h>
 #include <WebCore/PlatformGamepad.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/glib/GRefPtr.h>
@@ -44,13 +45,23 @@ public:
 private:
     const Vector<WebCore::SharedGamepadValue>& buttonValues() const final { return m_buttonValues; }
     const Vector<WebCore::SharedGamepadValue>& axisValues() const final { return m_axisValues; }
+    void playEffect(GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
+    void stopEffects(CompletionHandler<void()>&&) final;
 
     void buttonEvent(size_t button, bool isPressed);
     void axisEvent(size_t axis, double value);
 
+    void effectDelayTimerFired();
+    void effectDurationTimerFired();
+    void startRumble(const GamepadEffectParameters&);
+
     GRefPtr<WPEGamepad> m_gamepad;
     Vector<WebCore::SharedGamepadValue> m_buttonValues;
     Vector<WebCore::SharedGamepadValue> m_axisValues;
+    RunLoop::Timer m_effectDelayTimer;
+    RunLoop::Timer m_effectDurationTimer;
+    CompletionHandler<void(bool)> m_effectCompletionHandler;
+    GamepadEffectParameters m_pendingEffectParameters;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WPEPlatform/wpe/WPEGamepad.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGamepad.cpp
@@ -230,3 +230,42 @@ void wpe_gamepad_axis_event(WPEGamepad* gamepad, WPEGamepadAxis axis, gdouble va
 
     g_signal_emit(gamepad, signals[AXIS_EVENT], 0, axis, value);
 }
+
+/**
+ * wpe_gamepad_has_rumble:
+ * @gamepad: a #WPEGamepad
+ *
+ * Checks whether a #WPEGamepad has rumble support.
+ * Returns %TRUE if the @gamepad has rumble, %FALSE otherwise.
+ */
+gboolean wpe_gamepad_has_rumble(WPEGamepad *gamepad)
+{
+    g_return_val_if_fail(WPE_IS_GAMEPAD(gamepad), FALSE);
+
+    auto* gamepadClass = WPE_GAMEPAD_GET_CLASS(gamepad);
+    if (gamepadClass->has_rumble)
+        return gamepadClass->has_rumble(gamepad);
+
+    return FALSE;
+}
+
+/**
+ * wpe_gamepad_rumble:
+ * @gamepad: a #WPEGamepad
+ * @strong_magnitude: the magnitude for the heavy motor
+ * @weak_magnitude: the magnitude for the light motor
+ * @duration_ms: the rumble effect play time, in milliseconds
+ *
+ * Attempts to make a #WPEGamepad rumble for @duration_ms milliseconds.
+ * Returns %TRUE if the rumble effect was played, %FALSE otherwise.
+ */
+gboolean wpe_gamepad_rumble(WPEGamepad *gamepad, gdouble strongMagnitude, gdouble weakMagnitude, guint durationMs)
+{
+    g_return_val_if_fail(WPE_IS_GAMEPAD(gamepad), FALSE);
+
+    auto* gamepadClass = WPE_GAMEPAD_GET_CLASS(gamepad);
+    if (gamepadClass->rumble)
+        return gamepadClass->rumble(gamepad, strongMagnitude, weakMagnitude, durationMs);
+
+    return FALSE;
+}

--- a/Source/WebKit/WPEPlatform/wpe/WPEGamepad.h
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGamepad.h
@@ -44,6 +44,11 @@ struct _WPEGamepadClass
 
     void (* start_input_monitor) (WPEGamepad *gamepad);
     void (* stop_input_monitor)  (WPEGamepad *gamepad);
+    gboolean (* has_rumble)      (WPEGamepad *gamepad);
+    gboolean (* rumble)          (WPEGamepad *gamepad,
+                                  gdouble     strong_magnitude,
+                                  gdouble     weak_magnitude,
+                                  guint       duration_ms);
 
     gpointer padding[32];
 };
@@ -115,6 +120,11 @@ WPE_API void        wpe_gamepad_button_event        (WPEGamepad      *gamepad,
 WPE_API void        wpe_gamepad_axis_event          (WPEGamepad      *gamepad,
                                                      WPEGamepadAxis   axis,
                                                      gdouble          value);
+WPE_API gboolean    wpe_gamepad_has_rumble          (WPEGamepad      *gamepad);
+WPE_API gboolean    wpe_gamepad_rumble              (WPEGamepad      *gamepad,
+                                                     gdouble          strong_magnitude,
+                                                     gdouble          weak_magnitude,
+                                                     guint            duration_ms);
 
 G_END_DECLS
 

--- a/Source/WebKit/WPEPlatform/wpe/WPEGamepadManette.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/WPEGamepadManette.cpp
@@ -164,6 +164,22 @@ static void wpeGamepadManetteStopInputMonitor(WPEGamepad* gamepad)
     g_signal_handlers_disconnect_by_data(priv->device.get(), gamepad);
 }
 
+static gboolean wpeGamepadManetteHasRumble(WPEGamepad* gamepad)
+{
+    auto* priv = WPE_GAMEPAD_MANETTE(gamepad)->priv;
+    return manette_device_has_rumble(priv->device.get());
+}
+
+static gboolean wpeGamepadManetteRumble(WPEGamepad* gamepad, gdouble strongMagnitude, gdouble weakMagnitude, guint durationMs)
+{
+    auto* priv = WPE_GAMEPAD_MANETTE(gamepad)->priv;
+#if LIBMANETTE_CHECK_VERSION(0, 2, 13)
+    return manette_device_rumble(priv->device.get(), strongMagnitude, weakMagnitude, durationMs);
+#else
+    return manette_device_rumble(priv->device.get(), strongMagnitude * G_MAXUINT16, weakMagnitude * G_MAXUINT16, durationMs);
+#endif
+}
+
 static void wpe_gamepad_manette_class_init(WPEGamepadManetteClass* gamepadManetteClass)
 {
     GObjectClass* objectClass = G_OBJECT_CLASS(gamepadManetteClass);
@@ -173,6 +189,8 @@ static void wpe_gamepad_manette_class_init(WPEGamepadManetteClass* gamepadManett
     WPEGamepadClass* gamepadClass = WPE_GAMEPAD_CLASS(gamepadManetteClass);
     gamepadClass->start_input_monitor = wpeGamepadManetteStartInputMonitor;
     gamepadClass->stop_input_monitor = wpeGamepadManetteStopInputMonitor;
+    gamepadClass->has_rumble = wpeGamepadManetteHasRumble;
+    gamepadClass->rumble = wpeGamepadManetteRumble;
 
     sObjProperties[PROP_DEVICE] =
         g_param_spec_object(


### PR DESCRIPTION
#### afb79e1a6b1c124a105769be957d7fe3c7b7b800
<pre>
[WPE] Implement playEffect by supporting gamepad rumble
<a href="https://bugs.webkit.org/show_bug.cgi?id=309269">https://bugs.webkit.org/show_bug.cgi?id=309269</a>

Reviewed by Carlos Garcia Campos.

This implements playEffect and stopEffects in GamepadProviderWPE by
dispatching a playEffect request to PlatformGamepadWPE, which routes it
to WPEGamepad.

WPEGamepad defines new has_rumble and rumble methods, and a
libmanette-based implementation is provided. playEffect is then mapped
into a rumble call, gating it by the specific effect being supported.

The concrete libmanette-based implementation does a version check, since
prior to 0.2.13 the API expected uints, and afterwards doubles like the
gamepad spec.

defaultGamepadVibrationActuatorEnabled is therefore enabled for WPE
Platform.

Tested manually on <a href="https://hardwaretester.com/gamepad.">https://hardwaretester.com/gamepad.</a>

* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultGamepadVibrationActuatorEnabled):
* Source/WebKit/UIProcess/Gamepad/wpe/GamepadProviderWPE.cpp:
(WebKit::GamepadProviderWPE::gamepadDisconnected):
(WebKit::GamepadProviderWPE::playEffect):
(WebKit::GamepadProviderWPE::stopEffects):
* Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp:
(WebKit::PlatformGamepadWPE::PlatformGamepadWPE):
(WebKit::PlatformGamepadWPE::playEffect):
(WebKit::PlatformGamepadWPE::stopEffects):
(WebKit::PlatformGamepadWPE::effectDelayTimerFired):
(WebKit::PlatformGamepadWPE::startRumble):
(WebKit::PlatformGamepadWPE::effectDurationTimerFired):
* Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.h:
* Source/WebKit/WPEPlatform/wpe/WPEGamepad.cpp:
(wpe_gamepad_has_rumble):
(wpe_gamepad_rumble):
* Source/WebKit/WPEPlatform/wpe/WPEGamepad.h:
* Source/WebKit/WPEPlatform/wpe/WPEGamepadManette.cpp:
(wpeGamepadManetteHasRumble):
(wpeGamepadManetteRumble):
(wpe_gamepad_manette_class_init):

Canonical link: <a href="https://commits.webkit.org/308792@main">https://commits.webkit.org/308792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9cd53f3d975039726f7e553bf96078267ca573dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157188 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114479 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16699 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133320 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95249 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15803 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13634 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4624 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125416 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159523 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2655 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12753 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122529 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122750 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33372 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133026 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77149 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18097 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9795 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20605 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20337 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20482 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20391 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->