### PR TITLE
AX: Make accessibility/mac/scroll-to-visible-action.html asynchronous

### DIFF
--- a/LayoutTests/accessibility/mac/scroll-to-visible-action.html
+++ b/LayoutTests/accessibility/mac/scroll-to-visible-action.html
@@ -31,18 +31,22 @@ test test test test <br>
 <script>
 var output = "This tests that the scrollToMakeVisible accessibility action works as expected on the Mac.\n\n";
 
+var newButtonX, newButtonY, initialButtonX, initialButtonY;
 if (window.accessibilityController) {
     window.jsTestIsAsync = true;
 
-    var button = accessibilityController.accessibleElementById("button");
-    var initialButtonX = button.x;
-    var initialButtonY = button.y;
-
-    output += "Gathered initial button position and now scrolling to make it visible.\n";
-    button.scrollToMakeVisible();
-
-    var newButtonX, newButtonY;
     setTimeout(async function() {
+        await waitFor(() => {
+            return accessibilityController.rootElement.x != 0;
+        });
+
+        var button = accessibilityController.accessibleElementById("button");
+        initialButtonX = button.x;
+        initialButtonY = button.y;
+
+        output += "Gathered initial button position and now scrolling to make it visible.\n";
+        button.scrollToMakeVisible();
+
         await waitFor(() => button.y != initialButtonY);
         newButtonX = button.x;
         newButtonY = button.y;

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -801,8 +801,7 @@ webkit.org/b/160042 accessibility/mac/value-change/value-change-user-info-conten
 
 # Skipped because ACCESSIBILITY_LOCAL_FRAME is not compatable with relative frames.
 accessibility/mac/iframe-relative-frame.html [ Failure ]
-# Skipped because ACCESSIBILITY_LOCAL_FRAME doesn't yet account for dynamic position changes (like scroll).
-accessibility/mac/scroll-to-visible-action.html [ Failure ]
+
 # Regression from ENABLE(ACCESSIBILITY_LOCAL_FRAME).
 accessibility/mac/visible-content-search-in-scrolled-iframe.html [ Failure ]
 platform/mac-wk2/accessibility/content-inset-scrollview-frame.html [ Failure ]


### PR DESCRIPTION
#### 5491d4094f4cbd040984e6a38d7152d19f1d4da7
<pre>
AX: Make accessibility/mac/scroll-to-visible-action.html asynchronous
<a href="https://bugs.webkit.org/show_bug.cgi?id=309280">https://bugs.webkit.org/show_bug.cgi?id=309280</a>
<a href="https://rdar.apple.com/171827085">rdar://171827085</a>

Reviewed by Tyler Wilcock.

After 308698@main, the main frame&apos;s screen position in asynchronously populated,
so we need to make sure layout tests wait for it to be initialized.

* LayoutTests/accessibility/mac/scroll-to-visible-action.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/309002@main">https://commits.webkit.org/309002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d4cedb893922c515b593d35ef86cdf31d042fab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149076 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157764 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/705d5341-f49b-4330-b4ea-6b2bdfca34e2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21667 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114930 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8bb16658-4388-4be1-af57-21f540102e8e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17116 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95689 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/63b9e5ae-3d70-4825-be0a-700adcd236be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16213 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14083 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5617 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125819 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160247 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122982 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123211 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33503 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133510 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77800 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18471 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10269 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21201 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20933 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21081 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20989 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->