### PR TITLE
SVG elements with unresolved filter references are not rendered

### DIFF
--- a/LayoutTests/imported/mozilla/svg/filter-basic-01.svg
+++ b/LayoutTests/imported/mozilla/svg/filter-basic-01.svg
@@ -8,6 +8,5 @@
 
 	<!-- From https://bugzilla.mozilla.org/show_bug.cgi?id=407463 -->
 
-	<rect x="0%" y="0%" width="100%" height="100%" fill="lime"/>
-	<rect x="0%" y="0%" width="100%" height="100%" fill="red" filter="url(#null)"/>		
+	<rect x="0%" y="0%" width="100%" height="100%" fill="lime" filter="url(#null)"/>
 </svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/svg-filter-unresolved-reference-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/svg-filter-unresolved-reference-expected.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<title>Reference: green rect without filter</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <rect x="0" y="0" width="100" height="100" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/svg-filter-unresolved-reference-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/svg-filter-unresolved-reference-ref.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<title>Reference: green rect without filter</title>
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <rect x="0" y="0" width="100" height="100" fill="green"/>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/svg-filter-unresolved-reference.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/svg-filter-unresolved-reference.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<title>SVG filter: unresolved reference should render</title>
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-1/#FilterProperty">
+<link rel="match" href="svg-filter-unresolved-reference-ref.html">
+<meta name="assert" content="An SVG element with a filter attribute referencing a non-existent ID should render without any filter applied.">
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+    <g filter="url(#does-not-exist)">
+        <rect x="0" y="0" width="100" height="100" fill="green"/>
+    </g>
+</svg>

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -151,9 +151,6 @@ void SVGRenderingContext::prepareToRenderSVGContent(RenderElement& renderer, Pai
         resources = SVGResourcesCache::cachedResourcesForRenderer(*m_renderer);
 
     if (!resources) {
-        if (style.filter().isReferenceFilter())
-            return;
-
         m_renderingFlags |= RenderingPrepared;
         return;
     }


### PR DESCRIPTION
#### 9b1b839a9e3e633aafd2663f310aa71ca78e9813
<pre>
SVG elements with unresolved filter references are not rendered
<a href="https://bugs.webkit.org/show_bug.cgi?id=309281">https://bugs.webkit.org/show_bug.cgi?id=309281</a>
<a href="https://rdar.apple.com/164046592">rdar://164046592</a>

Reviewed by Simon Fraser.

When an SVG element references a filter ID that doesn&apos;t exist in the
document, the element should still render without any filter applied.

User impact: On youtube.com in fullscreen mode, the arrow button in the
controls area that navigates to &quot;More videos&quot; is invisible because its
SVG markup references a filter ID that doesn&apos;t exist in the document.
Other browsers display the button correctly.

* LayoutTests/imported/mozilla/svg/filter-basic-01.svg:

Mozilla changed the markup to match the expectation:
<a href="https://hg-edge.mozilla.org/mozilla-central/diff/06480f550b00b750081427dd4b359f1dd37c8ebf/layout/reftests/svg/filter-basic-01.svg">https://hg-edge.mozilla.org/mozilla-central/diff/06480f550b00b750081427dd4b359f1dd37c8ebf/layout/reftests/svg/filter-basic-01.svg</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/svg-filter-unresolved-reference-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/svg-filter-unresolved-reference-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/render/reftests/svg-filter-unresolved-reference.html: Added.
* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
(WebCore::SVGRenderingContext::prepareToRenderSVGContent):

Canonical link: <a href="https://commits.webkit.org/308809@main">https://commits.webkit.org/308809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78bc563a8ea5d75557ff47191fd2c3eba13f8540

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21114 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157112 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101858 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6244f2cd-38c5-4797-9ad8-9879ee92fcf2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150301 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21019 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114424 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81510 "Exiting early after 60 failures. 15335 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/be8cc56d-7d3c-4cff-b2bc-268b3a16dd22) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133257 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95194 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e76d40ea-28ee-4761-9dc4-715027be5d51) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15764 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13583 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4548 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125375 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159445 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2579 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122463 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122684 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33383 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20921 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132978 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77073 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18067 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9726 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20529 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84314 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20261 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20406 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20315 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->