### PR TITLE
[visionOS] Move requiresTwoHandedInteractionProcessorEffect to the correct platform header

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -380,10 +380,3 @@ extern NSString * const kCASnapshotOriginY;
 extern NSString * const kCASnapshotTransform;
 extern NSString * const kCASnapshotTimeOffset;
 #endif
-
-#if PLATFORM(VISION) && !__has_feature(modules)
-// FIXME:rdar://160881286 - clean-up once in SDK.
-@interface CARemoteExternalEffect (Radar_160881286)
-+ (instancetype)rcp_requiresTwoHandedInteractionProcessorEffect;
-@end
-#endif // PLATFORM(VISION) && !__has_feature(modules)

--- a/Source/WebKit/Platform/spi/visionos/RealitySystemSupportSPI.h
+++ b/Source/WebKit/Platform/spi/visionos/RealitySystemSupportSPI.h
@@ -60,4 +60,8 @@ typedef NS_OPTIONS(NSUInteger, RCPGlowEffectContentRenderingHints) {
 - (void)setBrightnessMultiplier:(CGFloat)multiplier forInputTypes:(RCPRemoteEffectInputTypes)inputTypes;
 @end
 
+@interface CARemoteExternalEffect (RealitySystemSupport)
++ (instancetype)rcp_requiresTwoHandedInteractionProcessorEffect;
+@end
+
 #endif // USE(APPLE_INTERNAL_SDK)

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -122,6 +122,10 @@
 #include "WebKit-Swift.h"
 #endif
 
+#if PLATFORM(VISION)
+#import "RealitySystemSupportSPI.h"
+#endif
+
 #import <pal/ios/ManagedConfigurationSoftLink.h>
 
 #define FORWARD_ACTION_TO_WKCONTENTVIEW(_action) \


### PR DESCRIPTION
#### 1e5f6fcc4660352d33d0e39a9df337771dec4dc8
<pre>
[visionOS] Move requiresTwoHandedInteractionProcessorEffect to the correct platform header
<a href="https://bugs.webkit.org/show_bug.cgi?id=309291">https://bugs.webkit.org/show_bug.cgi?id=309291</a>
&lt;<a href="https://rdar.apple.com/160881286">rdar://160881286</a>&gt;

Reviewed by Simon Fraser.

We only need the forward declaration when building with a non-internal
SDK and it should live in the `RealitySystemSupportSPI.h` since it&apos;s
declared in `RealitySystemSupport.h`.

* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
* Source/WebKit/Platform/spi/visionos/RealitySystemSupportSPI.h:
Move the forward declaration.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
Import `RealitySystemSupportSPI.h`.

Canonical link: <a href="https://commits.webkit.org/308791@main">https://commits.webkit.org/308791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f24c697337a581cdbf079e57d5109146b77b5393

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157172 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3816e765-a8dd-4f2e-8cf3-0326fce98916) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21631 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114469 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/43633512-0fb7-4160-aea0-869e685b4c61) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95239 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e9433b3-52ed-4b29-b571-c6cef6644707) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15792 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13624 "Found 1 new API test failure: TestWebKitAPI.ResourceLoadStatistics.GrandfatherCallback (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4608 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11221 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159505 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2639 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12741 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122517 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122739 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33371 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20981 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133014 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77133 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18088 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9783 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20589 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20321 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20466 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20375 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->