### PR TITLE
Move JSPIContext out of VM.h

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1170,6 +1170,8 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/JSCJSValue.h
     runtime/JSCJSValueCellInlines.h
     runtime/JSCJSValueInlines.h
+    runtime/JSPIContext.h
+    runtime/JSPIContextInlines.h
     runtime/JSCPtrTag.h
     runtime/JSCustomGetterFunction.h
     runtime/JSCustomSetterFunction.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -813,7 +813,10 @@
 		23968F0E2F295B1B001AED63 /* WebAssemblySuspending.h in Headers */ = {isa = PBXBuildFile; fileRef = 23968F0C2F295B1B001AED63 /* WebAssemblySuspending.h */; };
 		23968F0F2F295B1B001AED63 /* WebAssemblyPromising.h in Headers */ = {isa = PBXBuildFile; fileRef = 23968F0A2F295B1B001AED63 /* WebAssemblyPromising.h */; };
 		23A356912E9790F40039C82A /* PinballCompletion.h in Headers */ = {isa = PBXBuildFile; fileRef = 23A3568E2E9790F40039C82A /* PinballCompletion.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F04DFCBEDED74A4E92B8A9DA /* PinballHandlerContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 8791D173F2EE43A7E6469029 /* PinballHandlerContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		23A9696C2E95A903005A36F5 /* EvacuatedStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 23A969692E95A903005A36F5 /* EvacuatedStack.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		23D7A3E22F3D0F4C00A27B88 /* JSPIContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 23D7A3E02F3D0F4C00A27B88 /* JSPIContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		23D7A3E32F3D0F4C00A27B88 /* JSPIContextInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 23D7A3E12F3D0F4C00A27B88 /* JSPIContextInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2600B5A7152BAAA70091EE5F /* JSStringJoiner.h in Headers */ = {isa = PBXBuildFile; fileRef = 2600B5A5152BAAA70091EE5F /* JSStringJoiner.h */; };
 		262D85B71C0D650F006ACB61 /* AirFixPartialRegisterStalls.h in Headers */ = {isa = PBXBuildFile; fileRef = 262D85B51C0D650F006ACB61 /* AirFixPartialRegisterStalls.h */; };
 		2684D4381C00161C0081D663 /* AirLiveness.h in Headers */ = {isa = PBXBuildFile; fileRef = 2684D4371C00161C0081D663 /* AirLiveness.h */; };
@@ -3973,6 +3976,7 @@
 		1CAA8B4A0D32C39A0041BCFF /* JavaScript.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JavaScript.h; sourceTree = "<group>"; };
 		1CAA8B4B0D32C39A0041BCFF /* JavaScriptCore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JavaScriptCore.h; sourceTree = "<group>"; };
 		20ECB15EFC524624BC2F02D5 /* ModuleNamespaceAccessCase.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModuleNamespaceAccessCase.cpp; sourceTree = "<group>"; };
+		230F325B2F3D10AF00E9D286 /* JSPIContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSPIContext.cpp; sourceTree = "<group>"; };
 		233D76772E288A8600EB9FFB /* badModuleImportId.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = badModuleImportId.js; sourceTree = "<group>"; };
 		233D76782E288A8600EB9FFB /* bar.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = bar.js; sourceTree = "<group>"; };
 		233D76792E288A8600EB9FFB /* dependenciesEntry.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = dependenciesEntry.js; sourceTree = "<group>"; };
@@ -4003,9 +4007,12 @@
 		23968F0C2F295B1B001AED63 /* WebAssemblySuspending.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblySuspending.h; path = js/WebAssemblySuspending.h; sourceTree = "<group>"; };
 		23968F0D2F295B1B001AED63 /* WebAssemblySuspending.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblySuspending.cpp; path = js/WebAssemblySuspending.cpp; sourceTree = "<group>"; };
 		23A3568E2E9790F40039C82A /* PinballCompletion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PinballCompletion.h; sourceTree = "<group>"; };
+		8791D173F2EE43A7E6469029 /* PinballHandlerContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PinballHandlerContext.h; sourceTree = "<group>"; };
 		23A3568F2E9790F40039C82A /* PinballCompletion.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PinballCompletion.cpp; sourceTree = "<group>"; };
 		23A969692E95A903005A36F5 /* EvacuatedStack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EvacuatedStack.h; sourceTree = "<group>"; };
 		23A9696A2E95A903005A36F5 /* EvacuatedStack.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EvacuatedStack.cpp; sourceTree = "<group>"; };
+		23D7A3E02F3D0F4C00A27B88 /* JSPIContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSPIContext.h; sourceTree = "<group>"; };
+		23D7A3E12F3D0F4C00A27B88 /* JSPIContextInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSPIContextInlines.h; sourceTree = "<group>"; };
 		2600B5A4152BAAA70091EE5F /* JSStringJoiner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSStringJoiner.cpp; sourceTree = "<group>"; };
 		2600B5A5152BAAA70091EE5F /* JSStringJoiner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSStringJoiner.h; sourceTree = "<group>"; };
 		262D85B41C0D650F006ACB61 /* AirFixPartialRegisterStalls.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AirFixPartialRegisterStalls.cpp; path = b3/air/AirFixPartialRegisterStalls.cpp; sourceTree = "<group>"; };
@@ -8944,6 +8951,9 @@
 				A7F9935E0FD7325100A0B2D0 /* JSONObject.cpp */,
 				A7F9935D0FD7325100A0B2D0 /* JSONObject.h */,
 				276B38782A71D11700252F4E /* JSONObjectInlines.h */,
+				230F325B2F3D10AF00E9D286 /* JSPIContext.cpp */,
+				23D7A3E02F3D0F4C00A27B88 /* JSPIContext.h */,
+				23D7A3E12F3D0F4C00A27B88 /* JSPIContextInlines.h */,
 				7C184E1817BEDBD3007CB63A /* JSPromise.cpp */,
 				7C184E1917BEDBD3007CB63A /* JSPromise.h */,
 				AA785BEC2E77BECF0097F688 /* JSPromiseCombinatorsContext.cpp */,
@@ -9136,6 +9146,7 @@
 				37C738D11EDB5672003F2B0B /* ParseInt.h */,
 				23A3568F2E9790F40039C82A /* PinballCompletion.cpp */,
 				23A3568E2E9790F40039C82A /* PinballCompletion.h */,
+				8791D173F2EE43A7E6469029 /* PinballHandlerContext.h */,
 				CE20BD02237D3AD40046E520 /* PredictionFileCreatingFuzzerAgent.cpp */,
 				CE20BD01237D3AD40046E520 /* PredictionFileCreatingFuzzerAgent.h */,
 				86B8690224B8A20800487C95 /* PrivateFieldPutKind.cpp */,
@@ -11917,6 +11928,8 @@
 				E32FEA2C27448F3700FF41C1 /* JSONAtomStringCacheInlines.h in Headers */,
 				A7F9935F0FD7325100A0B2D0 /* JSONObject.h in Headers */,
 				276B387B2A71D11800252F4E /* JSONObjectInlines.h in Headers */,
+				23D7A3E22F3D0F4C00A27B88 /* JSPIContext.h in Headers */,
+				23D7A3E32F3D0F4C00A27B88 /* JSPIContextInlines.h in Headers */,
 				7C184E1B17BEDBD3007CB63A /* JSPromise.h in Headers */,
 				AA785BEB2E77BECA0097F688 /* JSPromiseCombinatorsContext.h in Headers */,
 				AA785BEE2E77BED70097F688 /* JSPromiseCombinatorsContextInlines.h in Headers */,
@@ -12166,6 +12179,7 @@
 				E38DAB532A95D23A0050B7A8 /* PerfLog.h in Headers */,
 				A5AB49DD1BEC8086007020FB /* PerGlobalObjectWrapperWorld.h in Headers */,
 				23A356912E9790F40039C82A /* PinballCompletion.h in Headers */,
+				F04DFCBEDED74A4E92B8A9DA /* PinballHandlerContext.h in Headers */,
 				0FE834181A6EF97B00D04847 /* PolymorphicCallStubRoutine.h in Headers */,
 				521131F71F82BF14007CCEEE /* PolyProtoAccessChain.h in Headers */,
 				0F070A4B1D543A98006E7232 /* PreciseAllocation.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -952,6 +952,7 @@ runtime/JSModuleRecord.cpp
 runtime/JSNativeStdFunction.cpp
 runtime/JSONObject.cpp
 runtime/JSObject.cpp
+runtime/JSPIContext.cpp
 runtime/JSPromise.cpp
 runtime/JSPromiseCombinatorsContext.cpp
 runtime/JSPromiseCombinatorsGlobalContext.cpp

--- a/Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp
+++ b/Source/JavaScriptCore/llint/LLIntOffsetsExtractor.cpp
@@ -62,6 +62,7 @@
 #include "MaxFrameExtentForSlowPathCall.h"
 #include "NativeExecutable.h"
 #include "PinballCompletion.h"
+#include "PinballHandlerContext.h"
 #include "PrivateFieldPutKind.h"
 #include "ProtoCallFrame.h"
 #include "PutByIdFlags.h"

--- a/Source/JavaScriptCore/runtime/EvacuatedStack.cpp
+++ b/Source/JavaScriptCore/runtime/EvacuatedStack.cpp
@@ -30,6 +30,7 @@
 
 #include "CallFrame.h"
 #include "JSCConfig.h"
+#include "JSPIContext.h"
 #include "NativeCallee.h"
 #include "WasmCallee.h"
 

--- a/Source/JavaScriptCore/runtime/JSPIContext.cpp
+++ b/Source/JavaScriptCore/runtime/JSPIContext.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSPIContext.h"
+
+#if ENABLE(WEBASSEMBLY)
+
+namespace JSC {
+
+JSPIContext::~JSPIContext()
+{
+    ASSERT_WITH_MESSAGE(!limitFrame, "JSPIContext is still active when leaving its scope");
+}
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/JSPIContext.h
+++ b/Source/JavaScriptCore/runtime/JSPIContext.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include <JavaScriptCore/CallFrame.h>
+#include <JavaScriptCore/JSPromise.h>
+#include <JavaScriptCore/PinballCompletion.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
+
+namespace JSC {
+
+class VM;
+
+// Tracks the state of an active JSPI (JavaScript Promise Integration) activation. An
+// activation begins when either a WebAssembly.promising() wrapper or a PinballCompletion
+// fulfillment handler starts executing Wasm code which may potentially trigger a JSPI
+// suspension. It ends when that code stops executing by suspending, returning normally,
+// or throwing.
+//
+// JSPIContext is always allocated on the C++ stack. On creation, it is registered with
+// the VM as the topJSPIContext. When the JSPI activation ends, the context must be
+// deactivated by calling .deactivate(), which deregisters it with the VM.
+//
+// The 'limitFrame' identifies the call frame of the promising wrapper or fulfillment
+// handler that created this context. When a WebAssembly.Suspending wrapper triggers
+// suspension, the stack walker uses limitFrame to determine which frames to evacuate:
+// everything between the suspending call site and this frame. After evacuation, the
+// suspending function "teleports" by returning into the limitFrame, skipping the
+// evacuated frames.
+//
+// The 'completion' field is set by the suspending function if suspension actually occurs.
+// It points to the PinballCompletion object that owns the evacuated stack slices and will
+// orchestrate their replay when the suspension promise resolves.
+struct JSPIContext {
+    WTF_FORBID_HEAP_ALLOCATION_ALLOWING_PLACEMENT_NEW;
+    WTF_MAKE_NONCOPYABLE(JSPIContext);
+    WTF_MAKE_NONMOVABLE(JSPIContext);
+
+public:
+    enum class Purpose {
+        Promising, // Started in a 'WebAssembly.promising()' wrapper function.
+        Completing // Started in a PinballCompletion fulfillment handler.
+    };
+
+    JSPIContext(Purpose, VM&, CallFrame*, JSPromise*);
+    ~JSPIContext();
+
+    void deactivate(VM&);
+
+    Purpose purpose;
+    JSPIContext* previousContext;
+    CallFrame* limitFrame;
+    PinballCompletion* completion { nullptr };
+    JSPromise* resultPromise;
+};
+
+} // namespace JSC
+
+#else // !ENABLE(WEBASSEMBLY)
+
+namespace JSC {
+
+struct JSPIContext { };
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/JSPIContextInlines.h
+++ b/Source/JavaScriptCore/runtime/JSPIContextInlines.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include <JavaScriptCore/JSPIContext.h>
+#include <JavaScriptCore/VM.h>
+
+namespace JSC {
+
+inline JSPIContext::JSPIContext(Purpose purpose, VM& vm, CallFrame* callFrame, JSPromise* resultPromise)
+    : purpose(purpose)
+    , previousContext(vm.topJSPIContext)
+    , limitFrame(callFrame)
+    , resultPromise(resultPromise)
+{
+    vm.topJSPIContext = this;
+}
+
+inline void JSPIContext::deactivate(VM& vm)
+{
+    vm.topJSPIContext = previousContext;
+    limitFrame = nullptr;
+}
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/PinballCompletion.cpp
+++ b/Source/JavaScriptCore/runtime/PinballCompletion.cpp
@@ -31,8 +31,9 @@
 #include "CallFrame.h"
 #include "EvacuatedStack.h"
 #include "Exception.h"
+#include "JSPIContextInlines.h"
 #include "JSPromise.h"
-#include "JSWebAssemblyException.h"
+#include "PinballHandlerContext.h"
 #include "TopExceptionScope.h"
 
 #include <wtf/StdLibExtras.h>

--- a/Source/JavaScriptCore/runtime/PinballCompletion.h
+++ b/Source/JavaScriptCore/runtime/PinballCompletion.h
@@ -28,7 +28,6 @@
 #if ENABLE(WEBASSEMBLY)
 
 #include <JavaScriptCore/EvacuatedStack.h>
-#include <JavaScriptCore/FPRInfo.h>
 #include <JavaScriptCore/GPRInfo.h>
 #include <JavaScriptCore/JSFunction.h>
 #include <JavaScriptCore/JSFunctionWithFields.h>
@@ -82,36 +81,6 @@ private:
 
 JSFunctionWithFields* createPinballCompletionFulfillHandler(VM&, JSGlobalObject*, PinballCompletion*);
 JSFunctionWithFields* createPinballCompletionRejectHandler(VM&, JSGlobalObject*, PinballCompletion*);
-
-// Allocated on the stack by assembly entry points of fulfill and reject handlers of a suspension promise.
-// Holds all state shared by assembly and C++ code implementing the fulfillment or rejection.
-
-struct PinballHandlerContext final {
-    WTF_FORBID_HEAP_ALLOCATION;
-public:
-    static constexpr size_t NumberOfWasmArgumentRegisters = GPRInfo::numberOfArgumentRegisters + FPRInfo::numberOfArgumentRegisters;
-
-#if ASSERT_ENABLED
-    size_t magic;
-#endif
-    JSGlobalObject* globalObject;
-    VM* vm;
-    JSFunctionWithFields* handler;
-    EvacuatedStackSlice* slice;
-    size_t sliceByteSize;
-    JSPIContext jspiContext;
-    // Callee saves to restore before entering the evacuated code (points into the PinballCompletion held by the handler).
-    CPURegister* evacuatedCalleeSaves;
-    // Callee saves captured on entry into the handler.
-    CPURegister handlerCalleeSaves[NUMBER_OF_CALLEE_SAVES_REGISTERS];
-    // A spill buffer for Wasm argument registers to carry their state between slices.
-    // The first element is also used to store the argument to pass into the top WasmToJS frame
-    // and the return value returned by the bottom JSToWasm frame.
-    CPURegister arguments[NumberOfWasmArgumentRegisters];
-    // The following fields are only used for handling rejections.
-    JSCallee* zombieFrameCallee;
-    Exception* exception;
-};
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/runtime/PinballHandlerContext.h
+++ b/Source/JavaScriptCore/runtime/PinballHandlerContext.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBASSEMBLY)
+
+#include <JavaScriptCore/FPRInfo.h>
+#include <JavaScriptCore/GPRInfo.h>
+#include <JavaScriptCore/JSPIContext.h>
+
+namespace JSC {
+
+class EvacuatedStackSlice;
+class Exception;
+class JSCallee;
+class JSFunctionWithFields;
+class JSGlobalObject;
+class Register;
+
+// Allocated on the stack by assembly entry points of fulfill and reject handlers of a suspension promise.
+// Holds all state shared by assembly and C++ code implementing the fulfillment or rejection.
+
+struct PinballHandlerContext final {
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
+    static constexpr size_t NumberOfWasmArgumentRegisters = GPRInfo::numberOfArgumentRegisters + FPRInfo::numberOfArgumentRegisters;
+
+#if ASSERT_ENABLED
+    size_t magic;
+#endif
+    JSGlobalObject* globalObject;
+    VM* vm;
+    JSFunctionWithFields* handler;
+    EvacuatedStackSlice* slice;
+    size_t sliceByteSize;
+    JSPIContext jspiContext;
+    // Callee saves to restore before entering the evacuated code (points into the PinballCompletion held by the handler).
+    CPURegister* evacuatedCalleeSaves;
+    // Callee saves captured on entry into the handler.
+    CPURegister handlerCalleeSaves[NUMBER_OF_CALLEE_SAVES_REGISTERS];
+    // A spill buffer for Wasm argument registers to carry their state between slices.
+    // The first element is also used to store the argument to pass into the top WasmToJS frame
+    // and the return value returned by the bottom JSToWasm frame.
+    CPURegister arguments[NumberOfWasmArgumentRegisters];
+    // The following fields are only used for handling rejections.
+    JSCallee* zombieFrameCallee;
+    Exception* exception;
+};
+
+} // namespace JSC
+
+#endif // ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -2053,9 +2053,4 @@ Wasm::DebugState* VM::debugState()
 }
 #endif
 
-JSPIContext::~JSPIContext()
-{
-    ASSERT_WITH_MESSAGE(!limitFrame, "JSPIContext is still active when leaving its scope");
-}
-
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -136,6 +136,7 @@ class IntlCache;
 class JSDestructibleObjectHeapCellType;
 class JSGlobalObject;
 class JSObject;
+struct JSPIContext;
 class JSPromise;
 class JSPropertyNameEnumerator;
 class JITSizeStatistics;
@@ -231,26 +232,6 @@ public:
 
 private:
     ScratchBuffer* m_scratchBuffer;
-};
-
-// A record marking the top (in memory address terms) of the "interesting" stack span when
-// handling a JSPI suspension. A pointer to it is saved in the VM as the 'topJSPIContext' field.
-struct JSPIContext {
-    enum class Purpose {
-        Promising, // Started in a 'WebAssembly.promising()' wrapper function.
-        Completing // Started in a PinballCompletion fulfillment handler.
-    };
-
-    JSPIContext(Purpose, VM&, CallFrame*, JSPromise*);
-    ~JSPIContext();
-
-    void deactivate(VM&);
-
-    Purpose purpose;
-    JSPIContext* previousContext;
-    CallFrame* limitFrame; // scan up to this frame, and return from it after evacuating the stack
-    PinballCompletion* completion { nullptr };
-    JSPromise* resultPromise;
 };
 
 enum VMIdentifierType { };
@@ -1394,22 +1375,6 @@ extern "C" void SYSV_ABI sanitizeStackForVMImpl(VM*);
 #endif
 
 JS_EXPORT_PRIVATE void sanitizeStackForVM(VM&);
-
-inline JSPIContext::JSPIContext(Purpose purpose, VM& vm, CallFrame* callFrame, JSPromise* resultPromise)
-    : purpose(purpose)
-    , previousContext(vm.topJSPIContext)
-    , limitFrame(callFrame)
-    , resultPromise(resultPromise)
-{
-    vm.topJSPIContext = this;
-}
-
-inline void JSPIContext::deactivate(VM& vm)
-{
-    vm.topJSPIContext = previousContext;
-    limitFrame = nullptr; // indicates that this has been deactivated
-}
-
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyPromising.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyPromising.cpp
@@ -32,6 +32,7 @@
 #include "ExceptionHelpers.h"
 #include "JSFunctionWithFields.h"
 #include "JSObjectInlines.h"
+#include "JSPIContextInlines.h"
 #include "JSPromise.h"
 
 namespace JSC {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp
@@ -35,6 +35,7 @@
 #include "InterpreterInlines.h"
 #include "JSFunctionWithFields.h"
 #include "JSObjectInlines.h"
+#include "JSPIContext.h"
 #include "JSPromise.h"
 #include "JSWebAssemblySuspendError.h"
 #include "PinballCompletion.h"


### PR DESCRIPTION
#### fcf736d4f9e9f7b75c3981cb936446a829241ae7
<pre>
Move JSPIContext out of VM.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=309295">https://bugs.webkit.org/show_bug.cgi?id=309295</a>
<a href="https://rdar.apple.com/170155664">rdar://170155664</a>

Reviewed by Keith Miller.

This addresses a polish to-do item created when first landing JSPI support. For better
code organization, struct JSPIContext is moved from VM.h into its own dedicated header
file.

To avoid circular includes this would otherwise create or forward declarations making
SaferCPP unhappy, struct PinballCompletionContext is also moved from PinballCompletion.h
into its own header.

Actual logic is unchanged.

Testing: covered by existing tests.
Canonical link: <a href="https://commits.webkit.org/308814@main">https://commits.webkit.org/308814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c61c37d495dd1e83cb45cdf4b2bf59f660855ad2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148469 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157153 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101899 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/961b5c12-3b03-4246-b1aa-11cf3996b045) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114459 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7584314b-4de0-4a0f-aae8-8f4333a4befd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133290 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95229 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8586612-03ae-4750-9028-ddfe1c331f78) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15783 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13610 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4589 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140436 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159486 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9256 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2620 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12721 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122501 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20953 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122723 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33385 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20962 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133003 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77114 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18090 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9763 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179896 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20570 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84355 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46057 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20302 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20447 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20356 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->