### PR TITLE
AX: Make accessibility/dynamic-changes-update-position asynchronous

### DIFF
--- a/LayoutTests/accessibility/dynamic-changes-update-position-expected.txt
+++ b/LayoutTests/accessibility/dynamic-changes-update-position-expected.txt
@@ -1,8 +1,5 @@
 This test ensures that an AX element's position is updated after a dynamic page change.
 
-On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
-
-
 PASS: Link moved 90px in response to dynamic page change.
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/dynamic-changes-update-position.html
+++ b/LayoutTests/accessibility/dynamic-changes-update-position.html
@@ -14,36 +14,42 @@
 </div>
 
 <script>
-    description("This test ensures that an AX element's position is updated after a dynamic page change.");
+var output = "This test ensures that an AX element's position is updated after a dynamic page change.\n\n";
 
-    if (window.accessibilityController) {
-        window.jsTestIsAsync = true;
+var link, expectsZeroOrigin, startY, endY;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
 
-        var link = accessibilityController.accessibleElementById("link");
-        var startY = link.y;
-        var endY;
-        setTimeout(async function() {
-            document.getElementById("div").innerHTML = `
-                foo bar foo bar foo bar foo bar
-                <br>
-                foo bar foo bar foo bar foo bar
-                <br>
-                foo bar foo bar foo bar foo bar
-                <br>
-                foo bar foo bar foo bar foo bar
-                <br>
-                foo bar foo bar foo bar foo bar
-            `;
-            await waitFor(() => {
-                endY = link.y;
-                return startY !== endY;
-            });
+    expectsZeroOrigin = accessibilityController.platformName == "mac";
 
-            debug(`PASS: Link moved ${Math.abs(startY - endY)}px in response to dynamic page change.`);
-            document.getElementById("content").style.visibility = "hidden";
-            finishJSTest();
-        }, 0);
-    }
+    setTimeout(async function() {
+        await waitFor(() => accessibilityController.rootElement.x != 0 || !expectsZeroOrigin);
+
+        link = accessibilityController.accessibleElementById("link");
+        startY = link.y;
+        endY;
+        document.getElementById("div").innerHTML = `
+            foo bar foo bar foo bar foo bar
+            <br>
+            foo bar foo bar foo bar foo bar
+            <br>
+            foo bar foo bar foo bar foo bar
+            <br>
+            foo bar foo bar foo bar foo bar
+            <br>
+            foo bar foo bar foo bar foo bar
+        `;
+        await waitFor(() => {
+            endY = link.y;
+            return startY !== endY;
+        });
+
+        output += `PASS: Link moved ${Math.abs(startY - endY)}px in response to dynamic page change.`;
+        document.getElementById("content").style.visibility = "hidden";
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -121,9 +121,6 @@ webkit.org/b/21916 tables/mozilla_expected_failures/bugs/bug178855.xml [ Pass Im
 fast/dom/Window/slow-unload-handler.html
 fast/dom/Window/slow-unload-handler-only-frame-is-stopped.html
 
-# Skipped because ACCESSIBILITY_LOCAL_FRAME doesn't support dynamic updates yet.
-accessibility/dynamic-changes-update-position.html [ Failure ]
-
 webkit.org/b/306558 accessibility/mac/style-range.html [ Failure ]
 
 # Skip accessibility tests that use the accessibility client API on most builders;


### PR DESCRIPTION
#### 565759dc263088227293c5372d68420c9b381b9a
<pre>
AX: Make accessibility/dynamic-changes-update-position asynchronous
<a href="https://bugs.webkit.org/show_bug.cgi?id=309300">https://bugs.webkit.org/show_bug.cgi?id=309300</a>
<a href="https://rdar.apple.com/171844128">rdar://171844128</a>

Reviewed by Tyler Wilcock.

With ENABLE(ACCESSIBILITY_LOCAL_FRAME) enabled, the main frame&apos;s screen position
arrives asychronously. So, this test needs to wait for a non-zero screen position
on the web area.

* LayoutTests/TestExpectations:
* LayoutTests/accessibility/dynamic-changes-update-position-expected.txt:
* LayoutTests/accessibility/dynamic-changes-update-position.html:

Canonical link: <a href="https://commits.webkit.org/309037@main">https://commits.webkit.org/309037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27477376490903f2bbbab5b8d7edfdce2f9cac66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157807 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102550 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e50573df-094f-4a7c-af02-eb9b88b87913) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114961 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81839 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/edc34da9-e0f7-45a2-b939-4b143ae02f9b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17147 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133830 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95719 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6408d29e-65a7-4560-9bab-f616dc5f6ec0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16244 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14113 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5660 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125850 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160291 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123009 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18143 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123239 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33521 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21642 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133551 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77843 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18488 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10306 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21244 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20976 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21124 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21032 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->