### PR TITLE
[libpas] Increment pas_crash_report_version

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/jit_heap_config_root_data.h
+++ b/Source/bmalloc/libpas/src/libpas/jit_heap_config_root_data.h
@@ -35,6 +35,9 @@ struct pas_page_header_table;
 typedef struct jit_heap_config_root_data jit_heap_config_root_data;
 typedef struct pas_page_header_table pas_page_header_table;
 
+/* If the layout of this structure is changed, the value of
+ * pas_crash_report_version in pas_root.h should be incremented.
+ */
 struct jit_heap_config_root_data {
     pas_page_header_table* small_page_header_table;
     /* The JIT heap does not have a medium-segregated heap,

--- a/Source/bmalloc/libpas/src/libpas/pas_basic_heap_config_root_data.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_basic_heap_config_root_data.h
@@ -35,6 +35,9 @@ struct pas_page_header_table;
 typedef struct pas_basic_heap_config_root_data pas_basic_heap_config_root_data;
 typedef struct pas_page_header_table pas_page_header_table;
 
+/* If the layout of this structure is changed, the value of
+ * pas_crash_report_version in pas_root.h should be incremented.
+ */
 struct pas_basic_heap_config_root_data {
     pas_page_header_table* medium_segregated_page_header_table;
     pas_page_header_table* medium_bitfit_page_header_table;

--- a/Source/bmalloc/libpas/src/libpas/pas_report_crash_pgm_report.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_report_crash_pgm_report.h
@@ -66,7 +66,7 @@ typedef void *(*crash_reporter_memory_reader_t)(task_t task, vm_address_t addres
 
 /* This must be in sync between ReportCrash and libpas to generate a report. 
  * Make sure to bump version number after changing extraction structs and logic */
-static const unsigned pas_crash_report_version = 4;
+static const unsigned pas_crash_report_version = 5;
 
 /* Report sent back to the ReportCrash process. */
 typedef struct pas_report_crash_pgm_report pas_report_crash_pgm_report;

--- a/Source/bmalloc/libpas/src/libpas/pas_root.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.h
@@ -70,6 +70,24 @@ typedef struct pas_tiny_large_map_second_level_hashtable_in_flux_stash pas_tiny_
 typedef struct pas_ptr_hash_map pas_ptr_hash_map;
 typedef struct pas_ptr_hash_map_in_flux_stash pas_ptr_hash_map_in_flux_stash;
 
+/* This structure is ABI: if some process A attempts to enumerate
+ * the heap-data of a second process B, and that second process uses libpas,
+ * then it will eventually call into pas_root_enumerate_for_libmalloc,
+ * which relies on the layout of this structure.
+ * It is possible for the two processes to have different layouts for this
+ * structure: e.g. if process A is ReportCrash and was built with the system's
+ * WebKit.framework, while process B is a locally built Safari using a
+ * tip-of-tree build of WebKit.framework, the two structs could be different.
+ *
+ * If A's version is older than B's, this can be made safe by only appending
+ * fields to this struct (and its descendents).
+ * However, if B's version is older than A's, then that would be unsafe.
+ *
+ * As such, pas_crash_report_version should be incremented whenever the
+ * layout of this structure, or those of its child structures as visible
+ * to the enumerator, are modified.
+ * This includes the per-heap roots, e.g. pas_basic_heap_config_root_data
+ */
 struct pas_root {
     uintptr_t magic;
     uintptr_t* compact_heap_reservation_base;


### PR DESCRIPTION
#### c462503e3b3d43264bb009f270d1e9d1f79e3439
<pre>
[libpas] Increment pas_crash_report_version
<a href="https://bugs.webkit.org/show_bug.cgi?id=309301">https://bugs.webkit.org/show_bug.cgi?id=309301</a>
<a href="https://rdar.apple.com/171041439">rdar://171041439</a>

Reviewed by Dan Hecht.

This is necessary to account for the medium-page-header-table split
that took place in 307140@main. This can cause problems when ReportCrash
attempts to attach to an older Safari build, as it will sometimes
attempt to query PGM information when doing so, which in turn enumerates
libpas. ReportCrash itself would have been built with the system JSC,
and therefore could have a newer or older version of
pas_basic_heap_config_root_data than the target process. In the case
that it has a newer version (e.g. manually building an older Safari on a
newer OS) then this would cause ReportCrash to crash, as it would index
out-of-bounds of the struct and subsequently attempt to copy from that
garbage pointer.

Canonical link: <a href="https://commits.webkit.org/308767@main">https://commits.webkit.org/308767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b76bf2361471a3ef2fd6ffd67843d8a70e585c5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21070 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157068 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20975 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114396 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101812 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151344 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/16622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95166 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13557 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4504 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140351 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159401 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9171 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12641 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122431 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122652 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33355 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132940 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77029 "Built successfully") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9685 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179811 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20485 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20217 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20362 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->