### PR TITLE
[Site Isolation] Update existing ews bots to run newly added tests with site isolation enabled

### DIFF
--- a/Tools/CISupport/Shared/steps.py
+++ b/Tools/CISupport/Shared/steps.py
@@ -97,6 +97,7 @@ class SetBuildSummary(buildstep.BuildStep, AddToLogMixin):
     haltOnFailure = False
     flunkOnFailure = False
     FAILURE_MSG_IN_STRESS_MODE = 'Found test failures in stress mode'
+    FAILURE_MSG_IN_SITE_ISOLATION = 'Found test failures in site isolation'
 
     def doStepIf(self, step):
         return self.getProperty('build_summary', False)
@@ -109,7 +110,7 @@ class SetBuildSummary(buildstep.BuildStep, AddToLogMixin):
         build_summary = self.getProperty('build_summary', 'build successful')
         yield self._addToLog('stdio', f'Setting build summary as: {build_summary}')
         previous_build_summary = self.getProperty('build_summary', '')
-        if self.FAILURE_MSG_IN_STRESS_MODE in previous_build_summary:
+        if self.FAILURE_MSG_IN_STRESS_MODE in previous_build_summary or self.FAILURE_MSG_IN_SITE_ISOLATION in previous_build_summary:
             self.build.results = FAILURE
         elif any(s in previous_build_summary for s in ('Committed ', '@', 'Passed', 'Ignored pre-existing failure')):
             self.build.results = SUCCESS

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -4512,6 +4512,17 @@ class RunWebKitTestsInSiteIsolation(RunWebKitTestsInStressMode):
         if modified_tests:
             self.command += modified_tests
 
+    def evaluateCommand(self, cmd):
+        previous_build_summary = self.getProperty('build_summary', '')
+        rc = super().evaluateCommand(cmd)
+        if RunWebKitTestsInStressMode.FAILURE_MSG_IN_STRESS_MODE in previous_build_summary:
+            if rc == SUCCESS or rc == WARNINGS:
+                self.setProperty('build_summary', previous_build_summary)
+                self.build.results = FAILURE
+            else:
+                self.setProperty('build_summary', previous_build_summary + ', ' + self.FAILURE_MSG_IN_STRESS_MODE)
+        return rc
+
 
 class ReRunWebKitTests(RunWebKitTests):
     name = 're-run-layout-tests'

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -2496,6 +2496,101 @@ class TestRunWebKitTestsInStressGuardmallocMode(BuildStepMixinAdditions, unittes
         return rc
 
 
+class TestRunWebKitTestsInSiteIsolation(BuildStepMixinAdditions, unittest.TestCase):
+    def setUp(self):
+        self.longMessage = True
+        self.jsonFileName = 'layout-test-results/full_results.json'
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def configureStep(self):
+        self.setup_step(RunWebKitTestsInSiteIsolation())
+        self.property_exceed_failure_limit = 'first_results_exceed_failure_limit'
+        self.property_failures = 'first_run_failures'
+
+    def test_success(self):
+        self.configureStep()
+        self.setProperty('fullPlatform', 'ios-simulator')
+        self.setProperty('configuration', 'release')
+        self.setProperty('modified_tests', ['test1', 'test2'])
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 10 --skipped always --site-isolation test1 test2 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        )
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
+        rc = self.run_step()
+        self.expect_property('build_summary', 'Passed layout tests')
+        return rc
+
+    def test_failure(self):
+        self.configureStep()
+        self.setProperty('fullPlatform', 'ios-simulator')
+        self.setProperty('configuration', 'release')
+        self.setProperty('modified_tests', ['test'])
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 10 --skipped always --site-isolation test 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        )
+            .log('stdio', stdout='9 failures found.')
+            .exit(2),
+        )
+        self.expect_outcome(result=FAILURE, state_string='layout-tests (failure)')
+        rc = self.run_step()
+        self.expect_property('build_summary', 'Found test failures in site isolation')
+        return rc
+
+    def test_stress_failure_site_isolation_success(self):
+        self.configureStep()
+        self.setProperty('fullPlatform', 'ios-simulator')
+        self.setProperty('configuration', 'release')
+        self.setProperty('modified_tests', ['test1', 'test2'])
+        self.setProperty('build_summary', 'Found test failures in stress mode')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 10 --skipped always --site-isolation test1 test2 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        )
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
+        rc = self.run_step()
+        self.expect_property('build_summary', 'Found test failures in stress mode')
+        return rc
+
+    def test_stress_failure_site_isolation_failure(self):
+        self.configureStep()
+        self.setProperty('fullPlatform', 'ios-simulator')
+        self.setProperty('configuration', 'release')
+        self.setProperty('modified_tests', ['test'])
+        self.setProperty('build_summary', 'Found test failures in stress mode')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 10 --skipped always --site-isolation test 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        )
+            .log('stdio', stdout='9 failures found.')
+            .exit(2),
+        )
+        self.expect_outcome(result=FAILURE, state_string='layout-tests (failure)')
+        rc = self.run_step()
+        self.expect_property('build_summary', 'Found test failures in stress mode, Found test failures in site isolation')
+        return rc
+
+
 class TestRunWebKitTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):
         self.longMessage = True


### PR DESCRIPTION
#### 2d612781360d8b7845a0aad9155f278a9b1c6cf4
<pre>
[Site Isolation] Update existing ews bots to run newly added tests with site isolation enabled
<a href="https://rdar.apple.com/160387897">rdar://160387897</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308777">https://bugs.webkit.org/show_bug.cgi?id=308777</a>

Reviewed by NOBODY (OOPS!).

Follow-up fix for how to appropriatly lable a test run with pass or fail.

* Tools/CISupport/Shared/steps.py:
(SetBuildSummary):
(SetBuildSummary.run):
* Tools/CISupport/ews-build/steps.py:
(RunWebKitTestsInSiteIsolation.evaluateCommand):
* Tools/CISupport/ews-build/steps_unittest.py:
(TestRunWebKitTestsInSiteIsolation):
(TestRunWebKitTestsInSiteIsolation.setUp):
(TestRunWebKitTestsInSiteIsolation.tearDown):
(TestRunWebKitTestsInSiteIsolation.configureStep):
(TestRunWebKitTestsInSiteIsolation.test_success):
(TestRunWebKitTestsInSiteIsolation.test_failure):
(TestRunWebKitTestsInSiteIsolation.test_stress_failure_site_isolation_success):
(TestRunWebKitTestsInSiteIsolation.test_stress_failure_site_isolation_failure):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d612781360d8b7845a0aad9155f278a9b1c6cf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14673 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157075 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101819 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b44bb38-ee1e-47fc-b655-47c11a0ebdb5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150264 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21534 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20982 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114403 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81490 "Exiting early after 60 failures. 14949 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/828c904b-61bc-44c9-88bb-873b654f6a10) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133227 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95173 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/41e5a85f-312c-4bfa-905e-6dcfee7f2ace) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15739 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13560 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4511 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125350 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159408 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12652 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122433 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/147789 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20875 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122654 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132949 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77036 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18046 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9696 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20492 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20224 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20369 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20278 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->