### PR TITLE
Add helper to check if an object has any of a set of types

### DIFF
--- a/Source/WTF/wtf/CheckedPtr.h
+++ b/Source/WTF/wtf/CheckedPtr.h
@@ -266,6 +266,18 @@ inline bool is(const CheckedPtr<ArgType, ArgPtrTraits>& source)
     return is<ExpectedType>(source.get());
 }
 
+template<typename... ExpectedTypes, typename ArgType, typename ArgPtrTraits>
+inline bool isAnyOf(CheckedPtr<ArgType, ArgPtrTraits>& source)
+{
+    return is<ExpectedTypes...>(source.get());
+}
+
+template<typename... ExpectedTypes, typename ArgType, typename ArgPtrTraits>
+inline bool isAnyOf(const CheckedPtr<ArgType, ArgPtrTraits>& source)
+{
+    return isAnyOf<ExpectedTypes...>(source.get());
+}
+
 template<typename ExpectedType, typename ArgType, typename ArgPtrTraits>
 inline ExpectedType& downcast(CheckedPtr<ArgType, ArgPtrTraits>& source)
 {

--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -235,6 +235,18 @@ inline bool is(const CheckedRef<ArgType, ArgPtrTraits>& source)
     return is<ExpectedType>(source.get());
 }
 
+template<typename... ExpectedTypes, typename ArgType, typename ArgPtrTraits>
+inline bool isAnyOf(CheckedRef<ArgType, ArgPtrTraits>& source)
+{
+    return isAnyOf<ExpectedTypes...>(source.get());
+}
+
+template<typename... ExpectedTypes, typename ArgType, typename ArgPtrTraits>
+inline bool isAnyOf(const CheckedRef<ArgType, ArgPtrTraits>& source)
+{
+    return isAnyOf<ExpectedTypes...>(source.get());
+}
+
 template<typename ExpectedType, typename ArgType, typename ArgPtrTraits>
 inline ExpectedType& downcast(CheckedRef<ArgType, ArgPtrTraits>& source)
 {

--- a/Source/WTF/wtf/Ref.h
+++ b/Source/WTF/wtf/Ref.h
@@ -382,6 +382,12 @@ inline bool is(const Ref<ArgType, PtrTraits, RefDerefTraits>& source)
     return is<ExpectedType>(source.get());
 }
 
+template<typename... ExpectedTypes, typename ArgType, typename PtrTraits, typename RefDerefTraits>
+inline bool isAnyOf(const Ref<ArgType, PtrTraits, RefDerefTraits>& source)
+{
+    return isAnyOf<ExpectedTypes...>(source.get());
+}
+
 template<typename Target, typename Source, typename PtrTraits, typename RefDerefTraits>
 inline Ref<match_constness_t<Source, Target>> uncheckedDowncast(Ref<Source, PtrTraits, RefDerefTraits> source)
 {

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -332,6 +332,12 @@ inline bool is(const RefPtr<ArgType, PtrTraits, RefDerefTraits>& source)
     return is<ExpectedType>(source.get());
 }
 
+template<typename... ExpectedTypes, typename ArgType, typename PtrTraits, typename RefDerefTraits>
+inline bool isAnyOf(const RefPtr<ArgType, PtrTraits, RefDerefTraits>& source)
+{
+    return isAnyOf<ExpectedTypes...>(source.get());
+}
+
 template<typename Target, typename Source, typename PtrTraits, typename RefDerefTraits>
 inline RefPtr<match_constness_t<Source, Target>> uncheckedDowncast(RefPtr<Source, PtrTraits, RefDerefTraits> source)
 {

--- a/Source/WTF/wtf/TypeCasts.h
+++ b/Source/WTF/wtf/TypeCasts.h
@@ -33,7 +33,7 @@
 
 namespace WTF {
 
-template <typename ExpectedType, typename ArgType, bool isBaseType = std::is_base_of_v<ExpectedType, ArgType>>
+template<typename ExpectedType, typename ArgType, bool isBaseType = std::is_base_of_v<ExpectedType, ArgType>>
 struct TypeCastTraits {
     static bool isOfType(ArgType&)
     {
@@ -49,28 +49,39 @@ struct TypeCastTraits {
 
 // Template specialization for the case where ExpectedType is a base of ArgType,
 // so we can return return true unconditionally.
-template <typename ExpectedType, typename ArgType>
+template<typename ExpectedType, typename ArgType>
 struct TypeCastTraits<ExpectedType, ArgType, true /* isBaseType */> {
     static bool isOfType(ArgType&) { return true; }
 };
 
 // Type checking function, to use before casting with downcast<>().
-template <typename ExpectedType, typename ArgType>
+template<typename ExpectedType, typename ArgType>
 inline bool is(const ArgType& source)
 {
     static_assert(std::is_base_of_v<ArgType, ExpectedType>, "Unnecessary type check");
     return TypeCastTraits<const ExpectedType, const ArgType>::isOfType(source);
 }
 
-template <typename ExpectedType, typename ArgType>
+template<typename ExpectedType, typename ArgType>
 inline bool is(ArgType* source)
 {
-    static_assert(std::is_base_of_v<ArgType, ExpectedType>, "Unnecessary type check");
-    return source && TypeCastTraits<const ExpectedType, const ArgType>::isOfType(*source);
+    return source && is<ExpectedType>(*source);
+}
+
+template<typename... ExpectedTypes, typename ArgType>
+inline bool isAnyOf(const ArgType& source)
+{
+    return (is<ExpectedTypes>(source) || ...);
+}
+
+template<typename... ExpectedTypes, typename ArgType>
+inline bool isAnyOf(ArgType* source)
+{
+    return source && (is<ExpectedTypes>(*source) || ...);
 }
 
 // Update T's constness to match Reference's.
-template <typename Reference, typename T>
+template<typename Reference, typename T>
 using match_constness_t =
     typename std::conditional_t<std::is_const_v<Reference>, typename std::add_const_t<T>, typename std::remove_const_t<T>>;
 
@@ -129,7 +140,7 @@ inline match_constness_t<Source, Target>* dynamicDowncast(Source* source)
 // Add support for type checking / casting using is<>() / downcast<>() helpers for a specific class.
 #define SPECIALIZE_TYPE_TRAITS_BEGIN(ClassName) \
 namespace WTF { \
-template <typename ArgType> \
+template<typename ArgType> \
 class TypeCastTraits<const ClassName, ArgType, false /* isBaseType */> { \
 public: \
     static bool isOfType(ArgType& source) { return isType(source); } \
@@ -153,10 +164,23 @@ inline bool is(const std::unique_ptr<ArgType, Deleter>& source)
     return is<ExpectedType>(source.get());
 }
 
+template<typename... ExpectedTypes, typename ArgType, typename Deleter>
+inline bool isAnyOf(std::unique_ptr<ArgType, Deleter>& source)
+{
+    return isAnyOf<ExpectedTypes...>(source.get());
+}
+
+template<typename... ExpectedTypes, typename ArgType, typename Deleter>
+inline bool isAnyOf(const std::unique_ptr<ArgType, Deleter>& source)
+{
+    return isAnyOf<ExpectedTypes...>(source.get());
+}
+
 } // namespace WTF
 
 using WTF::TypeCastTraits;
 using WTF::is;
+using WTF::isAnyOf;
 using WTF::downcast;
 using WTF::dynamicDowncast;
 using WTF::uncheckedDowncast;

--- a/Source/WTF/wtf/UniqueRef.h
+++ b/Source/WTF/wtf/UniqueRef.h
@@ -131,6 +131,18 @@ inline bool is(const UniqueRef<ArgType>& source)
     return is<ExpectedType>(source.get());
 }
 
+template<typename... ExpectedTypes, typename ArgType>
+inline bool isAnyOf(UniqueRef<ArgType>& source)
+{
+    return isAnyOf<ExpectedTypes...>(source.get());
+}
+
+template<typename... ExpectedTypes, typename ArgType>
+inline bool is(const UniqueRef<ArgType>& source)
+{
+    return isAnyOf<ExpectedTypes...>(source.get());
+}
+
 template<typename T>
 inline bool arePointingToEqualData(const UniqueRef<T>& a, const UniqueRef<T>& b)
 {

--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -365,6 +365,18 @@ inline bool is(const WeakPtr<ArgType, WeakPtrImpl, PtrTraits>& source)
     return is<ExpectedType>(source.get());
 }
 
+template<typename... ExpectedTypes, typename ArgType, typename WeakPtrImpl, typename PtrTraits>
+inline bool isAnyOf(WeakPtr<ArgType, WeakPtrImpl, PtrTraits>& source)
+{
+    return isAnyOf<ExpectedTypes...>(source.get());
+}
+
+template<typename... ExpectedTypes, typename ArgType, typename WeakPtrImpl, typename PtrTraits>
+inline bool is(const WeakPtr<ArgType, WeakPtrImpl, PtrTraits>& source)
+{
+    return isAnyOf<ExpectedTypes...>(source.get());
+}
+
 template<typename Target, typename Source, typename WeakPtrImpl, typename PtrTraits>
 inline WeakPtr<match_constness_t<Source, Target>, WeakPtrImpl, PtrTraits> downcast(WeakPtr<Source, WeakPtrImpl, PtrTraits> source)
 {

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -207,6 +207,18 @@ inline bool is(const WeakRef<ArgType, WeakPtrImpl>& source)
     return is<ExpectedType>(source.get());
 }
 
+template<typename... ExpectedTypes, typename ArgType, typename WeakPtrImpl>
+inline bool isAnyOf(WeakRef<ArgType, WeakPtrImpl>& source)
+{
+    return isAnyOf<ExpectedTypes...>(source.get());
+}
+
+template<typename... ExpectedTypes, typename ArgType, typename WeakPtrImpl>
+inline bool isAnyOf(const WeakRef<ArgType, WeakPtrImpl>& source)
+{
+    return isAnyOf<ExpectedTypes...>(source.get());
+}
+
 template<typename Target, typename Source, typename WeakPtrImpl>
 inline WeakRef<match_constness_t<Source, Target>, WeakPtrImpl> downcast(WeakRef<Source, WeakPtrImpl> source)
 {

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -240,7 +240,7 @@ static inline CheckedPtr<RenderObject> firstChildConsideringContinuation(RenderO
 
 static inline RenderObject* lastChildConsideringContinuation(RenderObject& renderer)
 {
-    if (!is<RenderInline>(renderer) && !is<RenderBlock>(renderer))
+    if (!isAnyOf<RenderInline, RenderBlock>(renderer))
         return &renderer;
 
     auto& boxModelObject = uncheckedDowncast<RenderBoxModelObject>(renderer);
@@ -308,7 +308,7 @@ static inline RenderInline* startOfContinuations(RenderObject& renderer)
 
 static inline CheckedPtr<RenderObject> endOfContinuations(RenderObject& renderer)
 {
-    if (!is<RenderInline>(renderer) && !is<RenderBlock>(renderer))
+    if (!isAnyOf<RenderInline, RenderBlock>(renderer))
         return &renderer;
 
     CheckedPtr previous = uncheckedDowncast<RenderBoxModelObject>(&renderer);
@@ -402,7 +402,7 @@ AccessibilityObject* AccessibilityRenderObject::nextSibling() const
     if (!m_renderer)
         return AccessibilityNodeObject::nextSibling();
 
-    if (is<RenderView>(m_renderer))
+    if (is<RenderView>(*m_renderer))
         return nullptr;
 
     CheckedPtr<RenderObject> nextSibling;

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -83,9 +83,7 @@ static bool isAcceptableCSSStyleSheetParent(Node* parentNode)
     // Only these nodes can be parents of StyleSheets, and they need to call clearOwnerNode() when moved out of document.
     return !parentNode
         || parentNode->isDocumentNode()
-        || is<HTMLLinkElement>(*parentNode)
-        || is<HTMLStyleElement>(*parentNode)
-        || is<SVGStyleElement>(*parentNode)
+        || isAnyOf<HTMLLinkElement, HTMLStyleElement, SVGStyleElement>(*parentNode)
         || parentNode->nodeType() == NodeType::ProcessingInstruction;
 }
 #endif // ASSERT_ENABLED

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -72,7 +72,7 @@ void SelectorFilter::collectElementIdentifierHashes(const Element& element, Vect
 
 bool SelectorFilter::parentStackIsConsistent(const ContainerNode* parentNode) const
 {
-    if (!parentNode || is<Document>(parentNode) || is<ShadowRoot>(parentNode))
+    if (!parentNode || isAnyOf<Document, ShadowRoot>(*parentNode))
         return m_parentStack.isEmpty();
 
     return !m_parentStack.isEmpty() && m_parentStack.last().element == parentNode;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4204,7 +4204,7 @@ HTMLElement* Document::bodyOrFrameset() const
     if (!is<HTMLHtmlElement>(element))
         return nullptr;
     for (SUPPRESS_UNCHECKED_LOCAL auto& child : childrenOfType<HTMLElement>(*element)) {
-        if (is<HTMLBodyElement>(child) || is<HTMLFrameSetElement>(child))
+        if (isAnyOf<HTMLBodyElement, HTMLFrameSetElement>(child))
             return &child;
     }
     return nullptr;
@@ -6710,7 +6710,7 @@ static bool NODELETE shouldResetFocusNavigationStartingNode(Node& node)
 {
     // Setting focus navigation starting node to the following nodes means that we should start
     // the search from the beginning of the document.
-    return is<HTMLHtmlElement>(node) || is<HTMLDocument>(node);
+    return isAnyOf<HTMLHtmlElement, HTMLDocument>(node);
 }
 
 void Document::setFocusNavigationStartingNode(Node* node)

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -193,7 +193,7 @@ void DocumentFullscreen::requestFullscreen(Ref<Element>&& element, FullscreenChe
         return handleError("Cannot request fullscreen on a document that is not fully active."_s, EmitErrorEvent::No, WTF::move(completionHandler));
 
     auto isElementTypeAllowedForFullscreen = [] (const auto& element) {
-        if (is<HTMLElement>(element) || is<SVGSVGElement>(element))
+        if (isAnyOf<HTMLElement, SVGSVGElement>(element))
             return true;
 #if ENABLE(MATHML)
         if (is<MathMLMathElement>(element))

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -379,8 +379,7 @@ bool Element::isNonceable() const
     if (hasDuplicateAttribute())
         return false;
 
-    if (hasAttributes()
-        && (is<HTMLScriptElement>(*this) || is<SVGScriptElement>(*this))) {
+    if (hasAttributes() && isAnyOf<HTMLScriptElement, SVGScriptElement>(*this)) {
         static constexpr auto scriptString = "<script"_s;
         static constexpr auto styleString = "<style"_s;
 
@@ -2344,7 +2343,7 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
         elementData()->setHasNameAttribute(!newValue.isNull());
         break;
     case AttributeNames::nonceAttr:
-        if (is<HTMLElement>(*this) || is<SVGElement>(*this))
+        if (isAnyOf<HTMLElement, SVGElement>(*this))
             setNonce(newValue.isNull() ? emptyAtom() : newValue);
         break;
     case AttributeNames::useragentpartAttr:

--- a/Source/WebCore/dom/ElementAndTextDescendantIterator.h
+++ b/Source/WebCore/dom/ElementAndTextDescendantIterator.h
@@ -62,7 +62,7 @@ public:
     unsigned depth() const { return m_depth; }
 
 private:
-    static bool isElementOrText(const Node& node) { return is<Element>(node) || is<Text>(node); }
+    static bool isElementOrText(const Node& node) { return isAnyOf<Element, Text>(node); }
     static Node* firstChild(const Node&);
     static Node* nextSibling(const Node&);
     static Node* previousSibling(const Node&);

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -136,7 +136,7 @@ static bool shouldSuppressEventDispatchInDOM(Node& node, Event& event)
     if (auto* textEvent = dynamicDowncast<TextEvent>(event))
         return textEvent->isKeyboard() || textEvent->isComposition();
 
-    return is<CompositionEvent>(event) || is<InputEvent>(event) || is<KeyboardEvent>(event);
+    return isAnyOf<CompositionEvent, InputEvent, KeyboardEvent>(event);
 }
 
 static HTMLInputElement* NODELETE findInputElementInEventPath(const EventPath& path)

--- a/Source/WebCore/dom/EventPath.cpp
+++ b/Source/WebCore/dom/EventPath.cpp
@@ -89,8 +89,8 @@ EventPath::EventPath(Node& originalTarget, Event& event)
 
 void EventPath::buildPath(Node& originalTarget, Event& event)
 {
-    EventContext::Type contextType = [&]() {
-        if (is<MouseEvent>(event) || is<FocusEvent>(event))
+    auto contextType = [&] {
+        if (isAnyOf<MouseEvent, FocusEvent>(event))
             return EventContext::Type::MouseOrFocus;
 #if ENABLE(TOUCH_EVENTS)
         if (is<TouchEvent>(event))

--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -66,24 +66,21 @@ static bool NODELETE isSearchInvisible(const Node& node)
         return true;
     
     // FIXME: If the node serializes as void.
-    
-    if (is<HTMLIFrameElement>(node)
-        || is<HTMLImageElement>(node)
-        || is<HTMLMeterElement>(node)
-        || is<HTMLObjectElement>(node)
-        || is<HTMLProgressElement>(node)
-        || is<HTMLStyleElement>(node)
-        || is<HTMLScriptElement>(node)
-#if ENABLE(VIDEO)
-        || is<HTMLVideoElement>(node)
-        || is<HTMLAudioElement>(node)
-#endif // ENABLE(VIDEO)
-        )
-        return true;
-    
     // FIXME: Is a select element whose multiple content attribute is absent.
-    
-    return false;
+
+    return isAnyOf<
+#if ENABLE(VIDEO)
+        HTMLVideoElement,
+        HTMLAudioElement,
+#endif // ENABLE(VIDEO)
+        HTMLIFrameElement,
+        HTMLImageElement,
+        HTMLMeterElement,
+        HTMLObjectElement,
+        HTMLProgressElement,
+        HTMLStyleElement,
+        HTMLScriptElement
+    >(node);
 }
 
 // https://wicg.github.io/scroll-to-text-fragment/#non-searchable-subtree

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -998,7 +998,7 @@ bool Position::isCandidate() const
         return false;
 
     if (CheckedPtr block = dynamicDowncast<RenderBlock>(*renderer)) {
-        if (is<RenderBlockFlow>(*block) || is<RenderGrid>(*block) || is<RenderFlexibleBox>(*block)) {
+        if (isAnyOf<RenderBlockFlow, RenderGrid, RenderFlexibleBox>(*block)) {
             if (block->logicalHeight() || is<HTMLBodyElement>(*m_anchorNode) || m_anchorNode->isRootEditableElement()) {
                 if (!Position::hasRenderedNonAnonymousDescendantsWithHeight(*block))
                     return atFirstEditingPositionForNode() && !Position::nodeIsUserSelectNone(node.get());

--- a/Source/WebCore/dom/PositionIterator.cpp
+++ b/Source/WebCore/dom/PositionIterator.cpp
@@ -185,7 +185,7 @@ bool PositionIterator::isCandidate() const
         return false;
 
     if (CheckedPtr block = dynamicDowncast<RenderBlock>(*renderer)) {
-        if (is<RenderBlockFlow>(*block) || is<RenderGrid>(*block) || is<RenderFlexibleBox>(*block)) {
+        if (isAnyOf<RenderBlockFlow, RenderGrid, RenderFlexibleBox>(*block)) {
             if (block->logicalHeight() || is<HTMLBodyElement>(*anchorNode) || anchorNode->isRootEditableElement()) {
                 if (!Position::hasRenderedNonAnonymousDescendantsWithHeight(*block))
                     return atStartOfNode() && !Position::nodeIsUserSelectNone(anchorNode.get());

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -735,7 +735,7 @@ ExceptionOr<Ref<DocumentFragment>> Range::createContextualFragment(Variant<Ref<T
         return stringValueHolder.releaseException();
 
     RefPtr<Element> element;
-    if (is<Document>(node) || is<DocumentFragment>(node))
+    if (isAnyOf<Document, DocumentFragment>(node))
         element = nullptr;
     else if (auto* maybeElement = dynamicDowncast<Element>(node.ptr()))
         element = maybeElement;

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -644,7 +644,7 @@ void ScriptElement::setTrustedScriptText(const String& text)
 
 bool isScriptElement(Node& node)
 {
-    return is<HTMLScriptElement>(node) || is<SVGScriptElement>(node);
+    return isAnyOf<HTMLScriptElement, SVGScriptElement>(node);
 }
 
 ScriptElement* dynamicDowncastScriptElement(Element& element)

--- a/Source/WebCore/dom/UIEventWithKeyState.cpp
+++ b/Source/WebCore/dom/UIEventWithKeyState.cpp
@@ -80,7 +80,7 @@ void UIEventWithKeyState::setModifierKeys(bool ctrlKey, bool altKey, bool shiftK
 RefPtr<UIEventWithKeyState> findEventWithKeyState(Event* event)
 {
     for (RefPtr e = event; e; e = e->underlyingEvent()) {
-        if (is<KeyboardEvent>(*e) || is<MouseEvent>(*e))
+        if (isAnyOf<KeyboardEvent, MouseEvent>(*e))
             return downcast<UIEventWithKeyState>(WTF::move(e));
     }
     return nullptr;

--- a/Source/WebCore/editing/ChangeListTypeCommand.cpp
+++ b/Source/WebCore/editing/ChangeListTypeCommand.cpp
@@ -47,7 +47,7 @@ static std::optional<std::pair<ChangeListTypeCommand::Type, Ref<HTMLElement>>> l
     RefPtr commonAncestor = commonInclusiveAncestor<ComposedTree>(*startNode, *endNode);
 
     RefPtr<HTMLElement> listToReplace;
-    if (RefPtr htmlElement = dynamicDowncast<HTMLElement>(commonAncestor); is<HTMLUListElement>(htmlElement) || is<HTMLOListElement>(htmlElement))
+    if (RefPtr htmlElement = dynamicDowncast<HTMLElement>(commonAncestor); isAnyOf<HTMLUListElement, HTMLOListElement>(htmlElement))
         listToReplace = htmlElement;
     else
         listToReplace = enclosingList(commonAncestor);

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -608,7 +608,7 @@ void DeleteSelectionCommand::makeStylingElementsDirectChildrenOfEditableRootToPr
     Vector<Ref<HTMLElement>> stylingElements;
     while (nodes) {
         Ref node = *nodes;
-        auto shouldMove = is<HTMLLinkElement>(node) || is<HTMLStyleElement>(node);
+        auto shouldMove = isAnyOf<HTMLLinkElement, HTMLStyleElement>(node);
         if (shouldMove) {
             nodes.advanceSkippingChildren();
             stylingElements.append(downcast<HTMLElement>(WTF::move(node)));

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -496,7 +496,7 @@ VisiblePosition closestEditablePositionInElementForAbsolutePoint(const Element& 
 
 bool isListHTMLElement(Node* node)
 {
-    return node && (is<HTMLUListElement>(*node) || is<HTMLOListElement>(*node) || is<HTMLDListElement>(*node));
+    return isAnyOf<HTMLUListElement, HTMLOListElement, HTMLDListElement>(node);
 }
 
 bool isListItem(const Node& node)
@@ -605,7 +605,7 @@ RefPtr<HTMLElement> enclosingList(Node* node)
     
     for (RefPtr ancestor = node->parentNode(); ancestor; ancestor = ancestor->parentNode()) {
         auto* htmlElement = dynamicDowncast<HTMLElement>(*ancestor);
-        if (htmlElement && (is<HTMLUListElement>(*htmlElement) || is<HTMLOListElement>(*htmlElement)))
+        if (htmlElement && (isAnyOf<HTMLUListElement, HTMLOListElement>(*htmlElement)))
             return htmlElement;
         if (ancestor == root)
             return nullptr;

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4629,7 +4629,7 @@ static Vector<TextList> editableTextListsAtPositionInDescendingOrder(const Posit
         if (!ancestor->renderer())
             continue;
 
-        if (is<HTMLUListElement>(ancestor) || is<HTMLOListElement>(ancestor))
+        if (isAnyOf<HTMLUListElement, HTMLOListElement>(ancestor))
             enclosingLists.append(WTF::move(ancestor));
     }
 

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -256,7 +256,7 @@ void ReplacementFragment::removeContentsWithSideEffects()
     while (it != end) {
         Ref element = *it;
         if (isScriptElement(element) || (is<HTMLStyleElement>(element) && element->getAttribute(classAttr) != WebKitMSOListQuirksStyle)
-            || is<HTMLBaseElement>(element) || is<HTMLLinkElement>(element) || is<HTMLMetaElement>(element) || is<HTMLTitleElement>(element)) {
+            || isAnyOf<HTMLBaseElement, HTMLLinkElement, HTMLMetaElement, HTMLTitleElement>(element)) {
             elementsToRemove.append(WTF::move(element));
             it.traverseNextSkippingChildren();
             continue;

--- a/Source/WebCore/editing/TextIterator.cpp
+++ b/Source/WebCore/editing/TextIterator.cpp
@@ -291,7 +291,7 @@ bool isRendererReplacedElement(RenderObject* renderer, TextIteratorBehaviors beh
         return true;
 
     if (RefPtr element = dynamicDowncast<Element>(renderer->node())) {
-        if (is<HTMLFormControlElement>(*element) || is<HTMLLegendElement>(*element) || is<HTMLProgressElement>(*element) || element->hasTagName(meterTag))
+        if (isAnyOf<HTMLFormControlElement, HTMLLegendElement, HTMLProgressElement>(*element) || element->hasTagName(meterTag))
             return true;
         if (equalLettersIgnoringASCIICase(element->attributeWithoutSynchronization(roleAttr), "img"_s))
             return true;
@@ -984,7 +984,7 @@ static bool shouldEmitExtraNewlineForNode(Node& node)
 
     // NOTE: We only do this for a select set of nodes, and WinIE appears not to do this at all.
     RefPtr element = dynamicDowncast<HTMLElement>(node);
-    if (!element || (!is<HTMLHeadingElement>(*element) && !is<HTMLParagraphElement>(*element)))
+    if (!element || !isAnyOf<HTMLHeadingElement, HTMLParagraphElement>(*element))
         return false;
 
     auto bottomMargin = renderBox->collapsedMarginAfter();

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -450,7 +450,7 @@ static void simplifyFragmentForSingleTextAttachment(NSAttributedString *string, 
 
     RefPtr pictureOrImage = [&] -> RefPtr<HTMLElement> {
         for (Ref element : descendantsOfType<HTMLElement>(fragment)) {
-            if (is<HTMLPictureElement>(element) || is<HTMLImageElement>(element))
+            if (isAnyOf<HTMLPictureElement, HTMLImageElement>(element))
                 return WTF::move(element);
         }
         return { };

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1545,7 +1545,7 @@ static Vector<Ref<HTMLElement>> collectElementsToRemoveFromFragment(ContainerNod
             collectElementsToRemoveFromFragment(WTF::move(element));
             continue;
         }
-        if (is<HTMLHeadElement>(element) || is<HTMLBodyElement>(element))
+        if (isAnyOf<HTMLHeadElement, HTMLBodyElement>(element))
             toRemove.append(WTF::move(element));
     }
     return toRemove;

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -368,7 +368,7 @@ bool HTMLAnchorElement::isSystemPreviewLink()
         return false;
 
     if (auto* child = firstElementChild()) {
-        if (is<HTMLImageElement>(child) || is<HTMLPictureElement>(child)) {
+        if (isAnyOf<HTMLImageElement, HTMLPictureElement>(child)) {
             auto numChildren = childElementCount();
             // FIXME: We've documented that it should be the only child, but some early demos have two children.
             return numChildren == 1 || numChildren == 2;

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -918,13 +918,7 @@ bool HTMLElement::willRespondToMouseClickEventsWithEditability(Editability edita
 
 bool HTMLElement::canBeActuallyDisabled() const
 {
-    if (is<HTMLButtonElement>(*this)
-        || is<HTMLInputElement>(*this)
-        || is<HTMLSelectElement>(*this)
-        || is<HTMLTextAreaElement>(*this)
-        || is<HTMLOptGroupElement>(*this)
-        || is<HTMLOptionElement>(*this)
-        || is<HTMLFieldSetElement>(*this))
+    if (isAnyOf<HTMLButtonElement, HTMLInputElement, HTMLSelectElement, HTMLTextAreaElement, HTMLOptGroupElement, HTMLOptionElement, HTMLFieldSetElement>(*this))
         return true;
     auto* customElement = dynamicDowncast<HTMLMaybeFormAssociatedCustomElement>(*this);
     return customElement && customElement->isFormAssociatedCustomElement();

--- a/Source/WebCore/html/HTMLFrameElementBase.h
+++ b/Source/WebCore/html/HTMLFrameElementBase.h
@@ -77,7 +77,7 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::HTMLFrameElementBase)
-    static bool isType(const WebCore::HTMLElement& element) { return is<WebCore::HTMLFrameElement>(element) || is<WebCore::HTMLIFrameElement>(element); }
+    static bool isType(const WebCore::HTMLElement& element) { return isAnyOf<WebCore::HTMLFrameElement, WebCore::HTMLIFrameElement>(element); }
     static bool isType(const WebCore::Node& node)
     {
         auto* htmlElement = dynamicDowncast<WebCore::HTMLElement>(node);

--- a/Source/WebCore/html/HTMLNameCollection.cpp
+++ b/Source/WebCore/html/HTMLNameCollection.cpp
@@ -47,10 +47,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(DocumentNameCollection);
 
 bool WindowNameCollection::elementMatchesIfNameAttributeMatch(const Element& element)
 {
-    return is<HTMLEmbedElement>(element)
-        || is<HTMLFormElement>(element)
-        || is<HTMLImageElement>(element)
-        || is<HTMLObjectElement>(element);
+    return isAnyOf<HTMLEmbedElement, HTMLFormElement, HTMLImageElement, HTMLObjectElement>(element);
 }
 
 bool WindowNameCollection::elementMatches(const Element& element, const AtomString& name)
@@ -76,10 +73,7 @@ bool DocumentNameCollection::elementMatchesIfIdAttributeMatch(const Element& ele
 bool DocumentNameCollection::elementMatchesIfNameAttributeMatch(const Element& element)
 {
     return isObjectElementForDocumentNameCollection(element)
-        || is<HTMLEmbedElement>(element)
-        || is<HTMLFormElement>(element)
-        || is<HTMLIFrameElement>(element)
-        || is<HTMLImageElement>(element);
+        || isAnyOf<HTMLEmbedElement, HTMLFormElement, HTMLIFrameElement, HTMLImageElement>(element);
 }
 
 bool DocumentNameCollection::elementMatches(const Element& element, const AtomString& name)

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -506,7 +506,7 @@ String HTMLOptionElement::textIndentedToRespectGroupLabel() const
     for (Ref ancestor : ancestorsOfType<HTMLElement>(*this)) {
         if (is<HTMLOptGroupElement>(ancestor))
             return makeString("    "_s, label());
-        if (is<HTMLDataListElement>(ancestor) || is<HTMLSelectElement>(ancestor) || is<HTMLOptionElement>(ancestor) || is<HTMLHRElement>(ancestor))
+        if (isAnyOf<HTMLDataListElement, HTMLSelectElement, HTMLOptionElement, HTMLHRElement>(ancestor))
             return label();
     }
     return label();
@@ -525,7 +525,7 @@ bool HTMLOptionElement::isDisabledFormControl() const
     for (Ref ancestor : ancestorsOfType<HTMLElement>(*this)) {
         if (RefPtr optGroup = dynamicDowncast<HTMLOptGroupElement>(ancestor))
             return optGroup->isDisabledFormControl();
-        if (is<HTMLDataListElement>(ancestor) || is<HTMLSelectElement>(ancestor) || is<HTMLOptionElement>(ancestor) || is<HTMLHRElement>(ancestor))
+        if (isAnyOf<HTMLDataListElement, HTMLSelectElement, HTMLOptionElement, HTMLHRElement>(ancestor))
             return false;
     }
     return false;

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -207,7 +207,7 @@ HTMLSelectElement* HTMLSelectElement::findOwnerSelect(ContainerNode* startNode, 
             return nullptr;
         return findOwnerSelect(startNode->parentNode(), ExcludeOptGroup::Yes);
     }
-    if (is<HTMLDataListElement>(*startNode) || is<HTMLHRElement>(*startNode) || is<HTMLOptionElement>(*startNode))
+    if (isAnyOf<HTMLDataListElement, HTMLHRElement, HTMLOptionElement>(*startNode))
         return nullptr;
     return findOwnerSelect(startNode->parentNode(), excludeOptGroup);
 }
@@ -563,7 +563,7 @@ bool HTMLSelectElement::childShouldCreateRenderer(const Node& child) const
     if (!HTMLFormControlElement::childShouldCreateRenderer(child))
         return false;
     if (!usesMenuList())
-        return is<HTMLOptionElement>(child) || is<HTMLOptGroupElement>(child) || validationMessageShadowTreeContains(child);
+        return isAnyOf<HTMLOptionElement, HTMLOptGroupElement>(child) || validationMessageShadowTreeContains(child);
     if (child.isInShadowTree() && child.containingShadowRoot() == userAgentShadowRoot())
         return true;
     if (isFirstElementChildButton(child))
@@ -1085,10 +1085,7 @@ void HTMLSelectElement::recalcListItems(bool updateSelectedStates, AllowStyleInv
                         optGroupIt.traverseNextSkippingChildren();
                         continue;
                     }
-                    if (is<HTMLOptGroupElement>(optGroupDescendant)
-                        || is<HTMLDataListElement>(optGroupDescendant)
-                        || is<HTMLSelectElement>(optGroupDescendant)
-                        || is<HTMLHRElement>(optGroupDescendant)) {
+                    if (isAnyOf<HTMLOptGroupElement, HTMLDataListElement, HTMLSelectElement, HTMLHRElement>(optGroupDescendant)) {
                         optGroupIt.traverseNextSkippingChildren();
                         continue;
                     }
@@ -1102,7 +1099,7 @@ void HTMLSelectElement::recalcListItems(bool updateSelectedStates, AllowStyleInv
                 it.traverseNextSkippingChildren();
                 continue;
             }
-            if (is<HTMLDataListElement>(descendant) || is<HTMLSelectElement>(descendant)) {
+            if (isAnyOf<HTMLDataListElement, HTMLSelectElement>(descendant)) {
                 it.traverseNextSkippingChildren();
                 continue;
             }

--- a/Source/WebCore/html/HTMLSelectedContentElement.cpp
+++ b/Source/WebCore/html/HTMLSelectedContentElement.cpp
@@ -76,7 +76,7 @@ void HTMLSelectedContentElement::didFinishInsertingNode()
             m_isDisabled = true;
             break;
         }
-        if (is<HTMLOptionElement>(ancestor) || is<HTMLSelectedContentElement>(ancestor)) {
+        if (isAnyOf<HTMLOptionElement, HTMLSelectedContentElement>(ancestor)) {
             m_isDisabled = true;
             break;
         }

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -130,7 +130,7 @@ static void flattenAssignedNodes(Vector<Ref<Node>>& nodes, const HTMLSlotElement
         for (RefPtr<Node> child = slot.firstChild(); child; child = child->nextSibling()) {
             if (auto* slot = dynamicDowncast<HTMLSlotElement>(*child))
                 flattenAssignedNodes(nodes, *slot);
-            else if (is<Text>(*child) || is<Element>(*child))
+            else if (isAnyOf<Text, Element>(*child))
                 nodes.append(*child);
         }
         return;

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -165,7 +165,7 @@ static void buildRendererHighlight(RenderObject* renderer, const InspectorOverla
         renderer->absoluteQuads(highlight.quads);
         for (auto& quad : highlight.quads)
             contentsQuadToCoordinateSystem(mainView, containingView, quad, coordinateSystem);
-    } else if (is<RenderBox>(*renderer) || is<RenderInline>(*renderer)) {
+    } else if (isAnyOf<RenderBox, RenderInline>(*renderer)) {
         LayoutRect contentBox;
         LayoutRect paddingBox;
         LayoutRect borderBox;

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -2664,7 +2664,7 @@ void InspectorDOMAgent::addEventListenersToNode(Node& node)
     };
 
 #if ENABLE(FULLSCREEN_API)
-    if (is<Document>(node) || is<HTMLMediaElement>(node))
+    if (isAnyOf<Document, HTMLMediaElement>(node))
         createEventListener(eventNames().webkitfullscreenchangeEvent);
 #endif // ENABLE(FULLSCREEN_API)
 

--- a/Source/WebCore/layout/Verification.cpp
+++ b/Source/WebCore/layout/Verification.cpp
@@ -262,7 +262,7 @@ static bool outputMismatchingBlockBoxInformationIfNeeded(TextStream& stream, con
         if (!shouldCheckPaddingAndContentBox)
             return false;
         // FIXME: Figure out why trunk/rendering comes back with odd values for <tbody> and <td> content box.
-        if (is<RenderTableCell>(renderer) || is<RenderTableSection>(renderer))
+        if (isAnyOf<RenderTableCell, RenderTableSection>(renderer))
             return false;
         // Tables have 0 content box size for some reason when border collapsing is on.
         auto* renderTable = dynamicDowncast<RenderTable>(renderer);

--- a/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp
@@ -305,7 +305,7 @@ static std::optional<InlineItemPosition> inlineItemPositionForDamagedContentPosi
         return candidatePosition;
     }
     auto candidateInlineItem = inlineItemList[candidatePosition.index];
-    if (&candidateInlineItem.layoutBox() != &damagedContent.layoutBox || (!is<InlineTextItem>(candidateInlineItem) && !is<InlineSoftLineBreakItem>(candidateInlineItem)))
+    if (&candidateInlineItem.layoutBox() != &damagedContent.layoutBox || !isAnyOf<InlineTextItem, InlineSoftLineBreakItem>(candidateInlineItem))
         return candidatePosition;
     if (!damagedContent.offset) {
         // When damage points to "after" the layout box, whatever InlineItem we found is surely before the damage.

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
@@ -390,7 +390,7 @@ static std::optional<LayoutUnit> lastInflowBoxBaseline(const RenderBlock& blockC
             continue;
         }
 
-        if (is<RenderFlexibleBox>(*inflowBox) || is<RenderGrid>(*inflowBox) || is<RenderBlockFlow>(*inflowBox) || is<RenderTextControlInnerContainer>(*inflowBox) || is<RenderMenuList>(*inflowBox)) {
+        if (isAnyOf<RenderFlexibleBox, RenderGrid, RenderBlockFlow, RenderTextControlInnerContainer, RenderMenuList>(*inflowBox)) {
             if (auto baseline = baselineForBox(*inflowBox)) {
                 auto baselineValue = inflowBox->logicalTop() + *baseline;
                 return LayoutUnit { snapToInt(baselineValue, *inflowBox, SnapDirection::Floor) };
@@ -416,16 +416,20 @@ static std::optional<LayoutUnit> baselineForBox(const RenderBox& renderBox)
     if (writingMode.computedWritingMode() != renderBox.writingMode().computedWritingMode())
         return { };
 
-    if (is<RenderIFrame>(renderBox)
-        || is<RenderEmbeddedObject>(renderBox)
-        || is<LegacyRenderSVGRoot>(renderBox)
-        || is<RenderHTMLCanvas>(renderBox)
-        || is<RenderViewTransitionCapture>(renderBox)
-        || is<RenderTextControlMultiLine>(renderBox)
+    bool noBoxBaseline = isAnyOf<
+        RenderIFrame,
+        RenderEmbeddedObject,
+        LegacyRenderSVGRoot,
+        RenderHTMLCanvas,
+        RenderViewTransitionCapture,
+        RenderTextControlMultiLine,
 #if ENABLE(MODEL_ELEMENT)
-        || is<RenderModel>(renderBox)
+        RenderModel,
 #endif
-        || is<RenderSVGRoot>(renderBox))
+        RenderSVGRoot
+    >(renderBox);
+
+    if (noBoxBaseline)
         return { };
 
     auto borderBoxBottom = renderBox.height();
@@ -503,12 +507,12 @@ static std::optional<LayoutUnit> baselineForBox(const RenderBox& renderBox)
     if (is<RenderTable>(renderBox))
         return renderBox.firstLineBaseline();
 
-    if (is<RenderMenuList>(renderBox) || is<RenderTextControlInnerContainer>(renderBox)) {
+    if (isAnyOf<RenderMenuList, RenderTextControlInnerContainer>(renderBox)) {
         // Both menu list and inner container are types of flex box but they behave slightly differently so always check them before checking for flex.
         return lastInflowBoxBaseline(downcast<RenderBlock>(renderBox));
     }
 
-    if (is<RenderFlexibleBox>(renderBox) || is<RenderGrid>(renderBox))
+    if (isAnyOf<RenderFlexibleBox, RenderGrid>(renderBox))
         return renderBox.firstLineBaseline();
 
     if (renderBox.isFieldset()) {
@@ -606,24 +610,31 @@ static inline void setIntegrationBaseline(const RenderBox& renderBox)
         if (auto* renderListMarker = dynamicDowncast<RenderListMarker>(renderBox))
             return !renderListMarker->isImage();
 
-        if ((is<RenderReplaced>(renderBox) && renderBox.style().display() == Style::DisplayType::InlineFlow)
-            || is<RenderListBox>(renderBox)
-            || is<RenderSlider>(renderBox)
-            || is<RenderTextControlMultiLine>(renderBox)
-            || is<RenderTable>(renderBox)
-            || is<RenderGrid>(renderBox)
-            || is<RenderFlexibleBox>(renderBox)
-            || is<RenderDeprecatedFlexibleBox>(renderBox)
+        if (is<RenderReplaced>(renderBox) && renderBox.style().display() == Style::DisplayType::InlineFlow)
+            return true;
+
+        // These are special RenderBlock renderers that override the default baseline position behavior of the inline block box.
+
+        bool overrideDefaultBaselineBehavior = isAnyOf<
+            RenderListBox,
+            RenderSlider,
+            RenderTextControlMultiLine,
+            RenderTable,
+            RenderGrid,
+            RenderFlexibleBox,
+            RenderDeprecatedFlexibleBox,
 #if ENABLE(ATTACHMENT_ELEMENT)
-            || is<RenderAttachment>(renderBox)
+            RenderAttachment,
 #endif
 #if ENABLE(MATHML)
-            || is<RenderMathMLBlock>(renderBox)
+            RenderMathMLBlock,
 #endif
-            || is<RenderButton>(renderBox)) {
-            // These are special RenderBlock renderers that override the default baseline position behavior of the inline block box.
+            RenderButton
+        >(renderBox);
+
+        if (overrideDefaultBaselineBehavior)
             return true;
-        }
+
         auto* blockFlow = dynamicDowncast<RenderBlockFlow>(renderBox);
         if (!blockFlow)
             return false;

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -82,7 +82,7 @@ static Layout::Box::ElementAttributes elementAttributes(const RenderElement& ren
             return Layout::Box::NodeType::ListMarker;
         if (is<RenderReplaced>(renderer))
             return is<RenderImage>(renderer) ? Layout::Box::NodeType::Image : Layout::Box::NodeType::ReplacedElement;
-        if (is<RenderButton>(renderer) || is<RenderMenuList>(renderer) || is<RenderTextControlInnerContainer>(renderer) || is<RenderSlider>(renderer) || renderer.isRenderSliderContainer())
+        if (isAnyOf<RenderButton, RenderMenuList, RenderTextControlInnerContainer, RenderSlider>(renderer) || renderer.isRenderSliderContainer())
             return Layout::Box::NodeType::ImplicitFlexBox;
         if (auto* renderLineBreak = dynamicDowncast<RenderLineBreak>(renderer))
             return renderLineBreak->isWBR() ? Layout::Box::NodeType::WordBreakOpportunity : Layout::Box::NodeType::LineBreak;

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -348,7 +348,7 @@ bool canUseForPreferredWidthComputation(const RenderBlockFlow& blockContainer)
         if (!renderer->isInFlow())
             return false;
 
-        auto isFullySupportedInFlowRenderer = renderer->isRenderText() || is<RenderLineBreak>(renderer.get()) || is<RenderInline>(renderer.get()) || is<RenderListMarker>(renderer.get());
+        auto isFullySupportedInFlowRenderer = isAnyOf<RenderText, RenderLineBreak, RenderInline, RenderListMarker>(renderer);
         if (isFullySupportedInFlowRenderer)
             continue;
 

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -162,7 +162,7 @@ static bool shouldInvalidateLineLayoutAfterChangeFor(const RenderBlockFlow& root
             if (shouldOnlyCheckForRelativeDimension && !siblingHasRelativeDimensions)
                 continue;
 
-            if (siblingHasRelativeDimensions || (!is<RenderText>(*sibling) && !is<RenderLineBreak>(*sibling) && !is<RenderReplaced>(*sibling)))
+            if (siblingHasRelativeDimensions || (!isAnyOf<RenderText, RenderLineBreak, RenderReplaced>(*sibling)))
                 return true;
         }
         return !canUseForLineLayout(rootBlockContainer);

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -192,7 +192,7 @@ static void prepareContextForQRCode(ContextMenuContext& context)
 
     RefPtr<Element> element;
     for (Ref lineage : lineageOfType<Element>(*nodeElement)) {
-        if (is<HTMLTableElement>(lineage) || is<HTMLCanvasElement>(lineage) || is<HTMLImageElement>(lineage) || is<SVGSVGElement>(lineage)) {
+        if (isAnyOf<HTMLTableElement, HTMLCanvasElement, HTMLImageElement, SVGSVGElement>(lineage)) {
             element = lineage.ptr();
             break;
         }

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -2184,7 +2184,7 @@ ScrollableArea* EventHandler::enclosingScrollableArea(Node* node) const
         if (is<HTMLIFrameElement>(*ancestor))
             return nullptr;
 
-        if (is<HTMLHtmlElement>(*ancestor) || is<HTMLDocument>(*ancestor))
+        if (isAnyOf<HTMLHtmlElement, HTMLDocument>(*ancestor))
             break;
 
         CheckedPtr renderer = ancestor->renderer();

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -786,7 +786,7 @@ static ContainerNode* findEnclosingScrollableContainer(ContainerNode* node, cons
         if (is<HTMLIFrameElement>(*candidate))
             continue;
 
-        if (is<HTMLHtmlElement>(*candidate) || is<HTMLDocument>(*candidate))
+        if (isAnyOf<HTMLHtmlElement, HTMLDocument>(*candidate))
             return nullptr;
 
         CheckedPtr box = candidate->renderBox();

--- a/Source/WebCore/platform/ScrollingEffectsController.cpp
+++ b/Source/WebCore/platform/ScrollingEffectsController.cpp
@@ -548,7 +548,7 @@ void ScrollingEffectsController::scrollAnimationDidEnd(ScrollAnimation& animatio
     UNUSED_PARAM(animation);
 #endif
 
-    if (is<ScrollAnimationKeyboard>(animation) || is<ScrollAnimationSmooth>(animation))
+    if (isAnyOf<ScrollAnimationKeyboard, ScrollAnimationSmooth>(animation))
         m_client.didStopAnimatedScroll();
 
     if (is<ScrollAnimationKeyboard>(animation)) {

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -229,7 +229,7 @@ static bool shouldScaleColumnsForParent(const RenderTable& table)
         // logical width. In such situations no table logical width will be large enough to satisfy the constraint
         // set by the contents. So the idea is to use ~infinity to make sure we use all available size in the containing
         // block. However, this just doesn't work if this is a flex or grid item, so disallow scaling in that case.
-        if (is<RenderFlexibleBox>(containingBlock) || is<RenderGrid>(containingBlock))
+        if (isAnyOf<RenderFlexibleBox, RenderGrid>(containingBlock))
             return false;
         containingBlock = containingBlock->containingBlock();
     }

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -481,11 +481,7 @@ URL HitTestResult::absoluteImageURL() const
         return { };
 
     if (RefPtr element = dynamicDowncast<Element>(*imageNode); element
-        && (is<HTMLEmbedElement>(*element)
-        || is<HTMLImageElement>(*element)
-        || is<HTMLInputElement>(*element)
-        || is<HTMLObjectElement>(*element)
-        || is<SVGImageElement>(*element))) {
+        && isAnyOf<HTMLEmbedElement, HTMLImageElement, HTMLInputElement, HTMLObjectElement, SVGImageElement>(*element)) {
         auto imageURL = imageNode->document().completeURL(element->imageSourceURL());
         if (RefPtr page = imageNode->document().page())
             return page->applyLinkDecorationFiltering(imageURL, LinkDecorationFilteringTrigger::Unspecified);

--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -64,7 +64,7 @@ ReferencePathOperation::ReferencePathOperation(const Style::URL& url, const Atom
     , m_url(url)
     , m_fragment(fragment)
 {
-    if (is<SVGPathElement>(element) || is<SVGGeometryElement>(element))
+    if (isAnyOf<SVGPathElement, SVGGeometryElement>(element))
         m_path = pathFromGraphicsElement(*element);
 }
 

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1605,7 +1605,7 @@ GapRects RenderBlock::blockSelectionGaps(RenderBlock& rootBlock, const LayoutPoi
         }
 
         // FIXME: Eventually we won't special-case table and other layout roots like this.
-        auto propagatesSelectionToChildren = is<RenderTable>(*curr) || is<RenderFlexibleBox>(*curr) || is<RenderDeprecatedFlexibleBox>(*curr) || is<RenderGrid>(*curr);
+        auto propagatesSelectionToChildren = isAnyOf<RenderTable, RenderFlexibleBox, RenderDeprecatedFlexibleBox, RenderGrid>(*curr);
         auto paintsOwnSelection = curr->shouldPaintSelectionGaps() || propagatesSelectionToChildren;
         bool fillBlockGaps = paintsOwnSelection || (curr->canBeSelectionLeaf() && childState != HighlightState::None);
         if (fillBlockGaps) {
@@ -2561,7 +2561,7 @@ std::pair<RenderObject*, RenderElement*> RenderBlock::firstLetterAndContainer(Re
                 break;
             }
             firstLetter = current.nextSibling();
-        } else if (current.isBlockLevelReplacedOrAtomicInline() || is<RenderButton>(current) || is<RenderMenuList>(current))
+        } else if (current.isBlockLevelReplacedOrAtomicInline() || isAnyOf<RenderButton, RenderMenuList>(current))
             break;
         else if (current.isFlexibleBoxIncludingDeprecated() || current.isRenderGrid())
             return { };

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1019,7 +1019,7 @@ void RenderBlockFlow::simplifiedNormalFlowLayout()
             }
             continue;
         }
-        if (is<RenderText>(renderer) || is<RenderInline>(renderer))
+        if (isAnyOf<RenderText, RenderInline>(renderer))
             renderer.clearNeedsLayout();
     }
 
@@ -4122,7 +4122,7 @@ RenderBlockFlow::InlineContentStatus RenderBlockFlow::markInlineContentDirtyForL
         // Inline boxes report normal-child-needs-layout when their children need (any) layout.
         contentNeedsNormalChildLayoutOnly = contentNeedsNormalChildLayoutOnly.value_or(true) && (!renderer.needsLayout() || renderer.needsNormalChildOrSimplifiedLayoutOnly());
 
-        if (is<RenderLineBreak>(renderer) || is<RenderInline>(renderer) || is<RenderText>(renderer))
+        if (isAnyOf<RenderLineBreak, RenderInline, RenderText>(renderer))
             renderer.clearNeedsLayout();
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3075,7 +3075,7 @@ bool RenderBox::sizesPreferredLogicalWidthToFitContent() const
     // stretching column flexbox.
     // FIXME: Think about block-flow here.
     // https://bugs.webkit.org/show_bug.cgi?id=46473
-    if (logicalWidth.isAuto() && !isStretchingColumnFlexItem() && element() && (is<HTMLInputElement>(*element()) || is<HTMLSelectElement>(*element()) || is<HTMLButtonElement>(*element()) || is<HTMLTextAreaElement>(*element()) || is<HTMLLegendElement>(*element())))
+    if (logicalWidth.isAuto() && !isStretchingColumnFlexItem() && isAnyOf<HTMLInputElement, HTMLSelectElement, HTMLButtonElement, HTMLTextAreaElement, HTMLLegendElement>(element()))
         return true;
 
     if (isHorizontalWritingMode() != containingBlock()->isHorizontalWritingMode())

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2281,7 +2281,7 @@ RenderBoxModelObject* RenderElement::offsetParent() const
     CheckedPtr current = parent();
     while (current && (!current->element() || (!current->isBody() && !(isFixedPositioned() ? current->canContainFixedPositionObjects() : current->canContainAbsolutelyPositionedObjects())))) {
         RefPtr element = current->element();
-        if (!skipTables && element && (is<HTMLTableElement>(*element) || is<HTMLTableCellElement>(*element)))
+        if (!skipTables && isAnyOf<HTMLTableElement, HTMLTableCellElement>(element))
             break;
 
         float newZoom = current->style().usedZoom();

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -90,7 +90,7 @@ RenderStyle RenderListItem::computeMarkerStyle() const
 
 bool isHTMLListElement(const Node& node)
 {
-    return is<HTMLUListElement>(node) || is<HTMLOListElement>(node);
+    return isAnyOf<HTMLUListElement, HTMLOListElement>(node);
 }
 
 // Returns the enclosing list with respect to the DOM order.

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -270,7 +270,7 @@ RenderObject::FragmentedFlowState RenderObject::computedFragmentedFlowState(cons
     auto inheritedFlowState = RenderObject::FragmentedFlowState::NotInsideFlow;
     if (is<RenderText>(renderer))
         inheritedFlowState = renderer.parent()->fragmentedFlowState();
-    else if (is<RenderSVGBlock>(renderer) || is<RenderSVGInline>(renderer) || is<LegacyRenderSVGModelObject>(renderer)) {
+    else if (isAnyOf<RenderSVGBlock, RenderSVGInline, LegacyRenderSVGModelObject>(renderer)) {
         // containingBlock() skips svg boundary (SVG root is a RenderReplaced).
         if (CheckedPtr svgRoot = SVGRenderSupport::findTreeRootObject(downcast<RenderElement>(renderer)))
             inheritedFlowState = svgRoot->fragmentedFlowState();
@@ -765,7 +765,7 @@ RenderBlock* RenderObject::containingBlockForPositionType(PositionType positionT
 RenderBlock* RenderObject::containingBlock() const
 {
     // FIXME: See https://bugs.webkit.org/show_bug.cgi?id=270977 for RenderLineBreak special treatment.
-    if (is<RenderText>(*this) || is<RenderLineBreak>(*this))
+    if (isAnyOf<RenderText, RenderLineBreak>(*this))
         return containingBlockForPositionType(PositionType::Static, *this);
 
     auto containingBlockForRenderer = [](const auto& renderer) -> RenderBlock* {
@@ -1649,7 +1649,7 @@ static inline RenderElement* containerForElement(const RenderObject& renderer, c
     // containingBlock() skips to the non-anonymous containing block.
     // This does mean that computeOutOfFlowPositionedLogicalWidth and computeOutOfFlowPositionedLogicalHeight have to use container().
     // FIXME: See https://bugs.webkit.org/show_bug.cgi?id=270977 for RenderLineBreak special treatment.
-    if (!is<RenderElement>(renderer) || is<RenderText>(renderer) || is<RenderLineBreak>(renderer))
+    if (!is<RenderElement>(renderer) || isAnyOf<RenderText, RenderLineBreak>(renderer))
         return renderer.parent();
 
     auto* renderElement = dynamicDowncast<RenderElement>(renderer);

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -132,7 +132,7 @@ StyleAppearance RenderTheme::adjustAppearanceForElement(RenderStyle& style, cons
 
     auto appearance = style.usedAppearance();
     if (appearance == StyleAppearance::BaseSelect) {
-        if (is<HTMLSelectElement>(element) || is<SelectPopoverElement>(element)) [[likely]] {
+        if (isAnyOf<HTMLSelectElement, SelectPopoverElement>(element)) [[likely]] {
             style.setUsedAppearance(StyleAppearance::Base);
             return StyleAppearance::Base;
         }

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -530,9 +530,7 @@ static inline void writeSVGRenderer(TextStream& ts, const RenderObject& renderer
 void write(TextStream& ts, const RenderObject& renderer, OptionSet<RenderAsTextFlag> behavior)
 {
 
-    if (is<LegacyRenderSVGShape>(renderer) || is<RenderSVGGradientStop>(renderer) || is<LegacyRenderSVGResourceContainer>(renderer)
-        || is<LegacyRenderSVGContainer>(renderer) || is<LegacyRenderSVGRoot>(renderer) || is<RenderSVGText>(renderer)
-        || is<RenderSVGInlineText>(renderer) || is<LegacyRenderSVGImage>(renderer)) {
+    if (isAnyOf<LegacyRenderSVGShape, RenderSVGGradientStop, LegacyRenderSVGResourceContainer, LegacyRenderSVGContainer, LegacyRenderSVGRoot, RenderSVGText, RenderSVGInlineText, LegacyRenderSVGImage>(renderer)) {
         writeSVGRenderer(ts, renderer, behavior);
         return;
     }
@@ -556,7 +554,7 @@ void write(TextStream& ts, const RenderObject& renderer, OptionSet<RenderAsTextF
     if (auto* renderWidget = dynamicDowncast<RenderWidget>(renderer); renderWidget && renderWidget->widget() && is<FrameView>(renderWidget->widget()))
         dynamicDowncast<FrameView>(renderWidget->widget())->writeRenderTreeAsText(ts, behavior);
 
-    if (is<RenderSVGModelObject>(renderer) || is<RenderSVGRoot>(renderer))
+    if (isAnyOf<RenderSVGModelObject, RenderSVGRoot>(renderer))
         writeResources(ts, renderer, behavior);
 }
 

--- a/Source/WebCore/rendering/TransformOperationData.cpp
+++ b/Source/WebCore/rendering/TransformOperationData.cpp
@@ -36,7 +36,7 @@ TransformOperationData::TransformOperationData(FloatRect boundingBox, const Rend
 {
     if (renderer) {
         motionPathData = MotionPath::motionPathDataForRenderer(*renderer);
-        isSVGRenderer = is<RenderSVGModelObject>(renderer) || is<LegacyRenderSVGModelObject>(renderer);
+        isSVGRenderer = isAnyOf<RenderSVGModelObject, LegacyRenderSVGModelObject>(renderer);
     }
 }
 

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -424,7 +424,7 @@ void RenderThemeIOS::adjustRoundBorderRadius(RenderStyle& style, RenderBox& box)
     auto minDimension = std::min(box.width(), box.height());
     auto unzoomedMinDimension = minDimension / usedZoom.value;
 
-    if ((is<RenderButton>(box) || is<RenderMenuList>(box)) && boxLogicalHeight >= largeButtonSize) {
+    if ((isAnyOf<RenderButton, RenderMenuList>(box)) && boxLogicalHeight >= largeButtonSize) {
         auto largeButtonBorderRadius = Style::LengthPercentage<CSS::NonnegativeUnzoomed>::Dimension { unzoomedMinDimension * largeButtonBorderRadiusRatio };
         style.setBorderRadius({ largeButtonBorderRadius, largeButtonBorderRadius });
         return;

--- a/Source/WebCore/rendering/mathml/MathMLStyle.cpp
+++ b/Source/WebCore/rendering/mathml/MathMLStyle.cpp
@@ -73,7 +73,7 @@ RenderObject* MathMLStyle::getMathMLParentNode(RenderObject* renderer)
 {
     auto* parentRenderer = renderer->parent();
 
-    while (parentRenderer && !(is<RenderMathMLTable>(parentRenderer) || is<RenderMathMLBlock>(parentRenderer)))
+    while (parentRenderer && !isAnyOf<RenderMathMLTable, RenderMathMLBlock>(parentRenderer))
         parentRenderer = parentRenderer->parent();
 
     return parentRenderer;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.cpp
@@ -82,14 +82,14 @@ void RenderSVGResourceFilterPrimitive::styleDidChange(Style::Difference diff, co
         return;
 
     CheckedRef newStyle = style();
-    if (is<SVGFEFloodElement>(filterPrimitiveElement()) || is<SVGFEDropShadowElement>(filterPrimitiveElement())) {
+    if (isAnyOf<SVGFEFloodElement, SVGFEDropShadowElement>(filterPrimitiveElement())) {
         if (newStyle->floodColor() != oldStyle->floodColor())
             filterPrimitiveElement().primitiveAttributeChanged(SVGNames::flood_colorAttr);
         if (newStyle->floodOpacity() != oldStyle->floodOpacity())
             filterPrimitiveElement().primitiveAttributeChanged(SVGNames::flood_opacityAttr);
         return;
     }
-    if (is<SVGFEDiffuseLightingElement>(filterPrimitiveElement()) || is<SVGFESpecularLightingElement>(filterPrimitiveElement())) {
+    if (isAnyOf<SVGFEDiffuseLightingElement, SVGFESpecularLightingElement>(filterPrimitiveElement())) {
         if (newStyle->lightingColor() != oldStyle->lightingColor())
             filterPrimitiveElement().primitiveAttributeChanged(SVGNames::lighting_colorAttr);
     }

--- a/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
+++ b/Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp
@@ -63,17 +63,17 @@ FloatRect SVGBoundingBoxComputation::computeDecoratedBoundingBox(const SVGBoundi
     // - a shape (RenderSVGShape)
     // - a text content element (RenderSVGText or RenderSVGInline)
     // - an "a" element within a text content element (-> creates RenderSVGInline)
-    if (is<RenderSVGShape>(m_renderer) || is<RenderSVGText>(m_renderer) || is<RenderSVGInline>(m_renderer))
+    if (isAnyOf<RenderSVGShape, RenderSVGText, RenderSVGInline>(m_renderer))
         return handleShapeOrTextOrInline(options, boundingBoxValid);
 
     // - a container element (RenderSVGRoot / RenderSVGContainer)
     // - "use" (RenderSVGTransformableContainer)
-    if (is<RenderSVGRoot>(m_renderer) || is<RenderSVGContainer>(m_renderer))
+    if (isAnyOf<RenderSVGRoot, RenderSVGContainer>(m_renderer))
         return handleRootOrContainer(options, boundingBoxValid);
 
     // - "foreignObject"
     // - "image"
-    if (is<RenderSVGForeignObject>(m_renderer) || is<RenderSVGImage>(m_renderer))
+    if (isAnyOf<RenderSVGForeignObject, RenderSVGImage>(m_renderer))
         return handleForeignObjectOrImage(options, boundingBoxValid);
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
+++ b/Source/WebCore/rendering/svg/SVGContainerLayout.cpp
@@ -118,7 +118,7 @@ void SVGContainerLayout::positionChildrenRelativeToContainer()
         ASSERT(!renderer.isRenderSVGRoot()); // There is only one outermost RenderSVGRoot object
         ASSERT(!renderer.isRenderSVGInline()); // Inlines are only allowed within a RenderSVGText tree
 
-        if (is<RenderSVGModelObject>(renderer) || is<RenderSVGBlock>(renderer))
+        if (isAnyOf<RenderSVGModelObject, RenderSVGBlock>(renderer))
             return;
 
         ASSERT_NOT_REACHED();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp
@@ -62,12 +62,12 @@ void LegacyRenderSVGResourceFilterPrimitive::styleDidChange(Style::Difference di
         return;
 
     CheckedRef newStyle = style();
-    if (is<SVGFEFloodElement>(filterPrimitiveElement()) || is<SVGFEDropShadowElement>(filterPrimitiveElement())) {
+    if (isAnyOf<SVGFEFloodElement, SVGFEDropShadowElement>(filterPrimitiveElement())) {
         if (newStyle->floodColor() != oldStyle->floodColor())
             filterPrimitiveElement().primitiveAttributeChanged(SVGNames::flood_colorAttr);
         if (newStyle->floodOpacity() != oldStyle->floodOpacity())
             filterPrimitiveElement().primitiveAttributeChanged(SVGNames::flood_opacityAttr);
-    } else if (is<SVGFEDiffuseLightingElement>(filterPrimitiveElement()) || is<SVGFESpecularLightingElement>(filterPrimitiveElement())) {
+    } else if (isAnyOf<SVGFEDiffuseLightingElement, SVGFESpecularLightingElement>(filterPrimitiveElement())) {
         if (newStyle->lightingColor() != oldStyle->lightingColor())
             filterPrimitiveElement().primitiveAttributeChanged(SVGNames::lighting_colorAttr);
     }

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -711,7 +711,7 @@ void RenderTreeBuilder::normalizeTreeAfterStyleChange(RenderElement& renderer, R
     if (is<RenderBlock>(parent))
         noLongerAffectsParent = (!wasFloating && isFloating) || (!wasOutOfFlowPositioned && isOutOfFlowPositioned);
 
-    if (is<RenderBlockFlow>(parent) || is<RenderInline>(parent)) {
+    if (isAnyOf<RenderBlockFlow, RenderInline>(parent)) {
         startsAffectingParent = (wasFloating || wasOutOfFlowPositioned) && !isFloating && !isOutOfFlowPositioned;
         ASSERT(!startsAffectingParent || !noLongerAffectsParent);
     }
@@ -1108,7 +1108,7 @@ void RenderTreeBuilder::reportVisuallyNonEmptyContent(const RenderElement& paren
             m_view.frameView().incrementVisuallyNonEmptyCharacterCount(textRenderer->text());
         return;
     }
-    if (is<RenderHTMLCanvas>(child) || is<RenderEmbeddedObject>(child)) {
+    if (isAnyOf<RenderHTMLCanvas, RenderEmbeddedObject>(child)) {
         // Actual size is not known yet, report the default intrinsic size for replaced elements.
         auto& replacedRenderer = downcast<RenderReplaced>(child);
         m_view.frameView().incrementVisuallyNonEmptyPixelCount(roundedIntSize(replacedRenderer.intrinsicSize()));

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
@@ -326,7 +326,7 @@ void RenderTreeBuilder::Block::removeLeftoverAnonymousBlock(RenderBlock& anonymo
         return;
 
     auto* parent = anonymousBlock.parent();
-    if (is<RenderButton>(*parent) || is<RenderTextControl>(*parent))
+    if (isAnyOf<RenderButton, RenderTextControl>(*parent))
         return;
 
     m_builder.removeFloatingObjects(anonymousBlock);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderTable.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderTable.cpp
@@ -129,7 +129,7 @@ RenderElement& RenderTreeBuilder::Table::findOrCreateParentForChild(RenderTableS
 
 RenderElement& RenderTreeBuilder::Table::findOrCreateParentForChild(RenderTable& parent, const RenderObject& child, RenderObject*& beforeChild)
 {
-    if (is<RenderTableCaption>(child) || is<RenderTableSection>(child))
+    if (isAnyOf<RenderTableCaption, RenderTableSection>(child))
         return parent;
 
     if (CheckedPtr tableColumn = dynamicDowncast<RenderTableCol>(child)) {

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -589,7 +589,7 @@ Ref<CSSValue> Builder::resolveInternalAutoBaseFunction(CSSValue& value)
             return true;
         if (m_state->style().appearance() != StyleAppearance::BaseSelect)
             return false;
-        return is<HTMLSelectElement>(m_state->element()) || is<SelectPopoverElement>(m_state->element());
+        return isAnyOf<HTMLSelectElement, SelectPopoverElement>(m_state->element());
     }();
     RefPtr result = const_cast<CSSValue*>(isAppearanceBase ? functionValue->item(1) : functionValue->item(0));
 

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -429,7 +429,7 @@ auto Scope::collectActiveStyleSheets() -> ActiveStyleSheetCollection
             if (sheet)
                 styleSheetsForStyleSheetsList.append(*sheet);
             LOG_WITH_STREAM(StyleSheets, stream << " adding sheet " << sheet << " from ProcessingInstruction node " << node);
-        } else if (is<HTMLLinkElement>(node) || is<HTMLStyleElement>(node) || is<SVGStyleElement>(node)) {
+        } else if (isAnyOf<HTMLLinkElement, HTMLStyleElement, SVGStyleElement>(node)) {
             Ref element = uncheckedDowncast<Element>(node);
             AtomString title = element->isInShadowTree() ? nullAtom() : element->attributeWithoutSynchronization(titleAttr);
             bool enabledViaScript = false;

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -375,8 +375,7 @@ auto TreeResolver::resolveElement(Element& element, const RenderStyle* existingS
 
     // FIXME: These elements should not change renderer based on appearance property.
     if (RefPtr input = dynamicDowncast<HTMLInputElement>(element); (input && input->isSearchField())
-        || is<HTMLMeterElement>(element)
-        || is<HTMLProgressElement>(element)) {
+        || isAnyOf<HTMLMeterElement, HTMLProgressElement>(element)) {
         if (existingStyle && update.style->usedAppearance() != existingStyle->usedAppearance()) {
             update.changes.add(Change::Renderer);
             descendantsToResolve = DescendantsToResolve::All;

--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -212,7 +212,7 @@ void UserAgentStyle::ensureDefaultStyleSheetsForElement(const Element& element)
             addToDefaultStyle(*popoverStyleSheet);
         }
 
-        if ((is<HTMLFormControlElement>(element) || is<HTMLMeterElement>(element) || is<HTMLProgressElement>(element)) && !element.document().settings().verticalFormControlsEnabled()) {
+        if (isAnyOf<HTMLFormControlElement, HTMLMeterElement, HTMLProgressElement>(element) && !element.document().settings().verticalFormControlsEnabled()) {
             if (!horizontalFormControlsStyleSheet) {
                 horizontalFormControlsStyleSheet = parseUASheet(StringImpl::createWithoutCopying(horizontalFormControlsUserAgentStyleSheet));
                 addToDefaultStyle(*horizontalFormControlsStyleSheet);

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -236,7 +236,7 @@ SVGElement* SVGElement::viewportElement(ViewportElementType type) const
     // to determine the "overflow" property. <use> on <symbol> wouldn't work otherwise.
     auto* node = parentNode();
     while (node) {
-        if (is<SVGSVGElement>(*node) || is<SVGImageElement>(*node))
+        if (isAnyOf<SVGSVGElement, SVGImageElement>(*node))
             return dynamicDowncast<SVGElement>(node);
 
         if (type == ViewportElementType::Any && node->hasTagName(SVGNames::symbolTag))


### PR DESCRIPTION
#### 0467fa650649ba3749777694dd3a48d7013111a4
<pre>
Add helper to check if an object has any of a set of types
<a href="https://bugs.webkit.org/show_bug.cgi?id=309305">https://bugs.webkit.org/show_bug.cgi?id=309305</a>

Reviewed by Darin Adler.

Adds support for using `isAnyOf&lt;T1, T2, ...&gt;(foo)` as sugar for `(is&lt;T1&gt; || is&lt;T2&gt; || ...)`
and does some adoption in WebCore.

* Source/WTF/wtf/CheckedPtr.h:
* Source/WTF/wtf/CheckedRef.h:
* Source/WTF/wtf/Ref.h:
* Source/WTF/wtf/RefPtr.h:
* Source/WTF/wtf/TypeCasts.h:
* Source/WTF/wtf/UniqueRef.h:
* Source/WTF/wtf/WeakPtr.h:
* Source/WTF/wtf/WeakRef.h:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/css/CSSStyleSheet.cpp:
* Source/WebCore/css/SelectorFilter.cpp:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/dom/DocumentFullscreen.cpp:
* Source/WebCore/dom/Element.cpp:
* Source/WebCore/dom/ElementAndTextDescendantIterator.h:
* Source/WebCore/dom/EventDispatcher.cpp:
* Source/WebCore/dom/EventPath.cpp:
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
* Source/WebCore/dom/Position.cpp:
* Source/WebCore/dom/PositionIterator.cpp:
* Source/WebCore/dom/Range.cpp:
* Source/WebCore/dom/ScriptElement.cpp:
* Source/WebCore/dom/UIEventWithKeyState.cpp:
* Source/WebCore/editing/ChangeListTypeCommand.cpp:
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
* Source/WebCore/editing/Editing.cpp:
* Source/WebCore/editing/Editor.cpp:
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
* Source/WebCore/editing/TextIterator.cpp:
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
* Source/WebCore/editing/markup.cpp:
* Source/WebCore/html/HTMLAnchorElement.cpp:
* Source/WebCore/html/HTMLElement.cpp:
* Source/WebCore/html/HTMLFrameElementBase.h:
* Source/WebCore/html/HTMLNameCollection.cpp:
* Source/WebCore/html/HTMLOptionElement.cpp:
* Source/WebCore/html/HTMLSelectElement.cpp:
* Source/WebCore/html/HTMLSelectedContentElement.cpp:
* Source/WebCore/html/HTMLSlotElement.cpp:
* Source/WebCore/inspector/InspectorOverlay.cpp:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
* Source/WebCore/layout/Verification.cpp:
* Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp:
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp:
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
* Source/WebCore/page/ContextMenuController.cpp:
* Source/WebCore/page/EventHandler.cpp:
* Source/WebCore/page/mac/EventHandlerMac.mm:
* Source/WebCore/platform/ScrollingEffectsController.cpp:
* Source/WebCore/rendering/AutoTableLayout.cpp:
* Source/WebCore/rendering/HitTestResult.cpp:
* Source/WebCore/rendering/PathOperation.cpp:
* Source/WebCore/rendering/RenderBlock.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/rendering/RenderListItem.cpp:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/rendering/RenderTheme.cpp:
* Source/WebCore/rendering/RenderTreeAsText.cpp:
* Source/WebCore/rendering/TransformOperationData.cpp:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
* Source/WebCore/rendering/mathml/MathMLStyle.cpp:
* Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.cpp:
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
* Source/WebCore/rendering/svg/SVGContainerLayout.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderTable.cpp:
* Source/WebCore/style/StyleBuilder.cpp:
* Source/WebCore/style/StyleScope.cpp:
* Source/WebCore/style/StyleTreeResolver.cpp:
* Source/WebCore/style/UserAgentStyle.cpp:
* Source/WebCore/svg/SVGElement.cpp:

Canonical link: <a href="https://commits.webkit.org/308801@main">https://commits.webkit.org/308801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc6101d66c4fae00ca0bffc0df3a0eeae3f94368

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157122 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101868 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150311 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114440 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81517 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95210 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15768 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13592 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4558 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140405 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125379 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159455 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9225 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2589 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122474 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122696 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33377 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132984 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77083 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18073 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9733 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179865 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20539 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84324 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46054 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20271 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20416 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20325 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->