### PR TITLE
[macOS] Address NoDeleteChecker warnings in WTF

### DIFF
--- a/Source/WTF/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WTF/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -1,3 +1,1 @@
 [ iOS ] wtf/cocoa/FileSystemCocoa.mm
-wtf/text/StringImpl.cpp
-wtf/text/StringView.cpp

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -906,7 +906,7 @@ float StringImpl::toFloat(bool* ok)
     return charactersToFloat(span16(), ok);
 }
 
-size_t StringImpl::find(std::span<const Latin1Character> matchString, size_t start)
+SUPPRESS_NODELETE size_t StringImpl::find(std::span<const Latin1Character> matchString, size_t start)
 {
     ASSERT(!matchString.empty());
     ASSERT(isValidLength<Latin1Character>(matchString.size()));
@@ -1026,7 +1026,7 @@ size_t StringImpl::reverseFind(char16_t character, size_t start)
     return WTF::reverseFind(span16(), character, start);
 }
 
-size_t StringImpl::reverseFind(StringView matchString, size_t start)
+SUPPRESS_NODELETE size_t StringImpl::reverseFind(StringView matchString, size_t start)
 {
     // Check for null or empty string to match against
     if (!matchString)
@@ -1670,7 +1670,7 @@ unsigned StringImpl::concurrentHash() const
     return hash;
 }
 
-bool equalIgnoringNullity(std::span<const char16_t> a, StringImpl* b)
+SUPPRESS_NODELETE bool equalIgnoringNullity(std::span<const char16_t> a, StringImpl* b)
 {
     if (!b)
         return a.empty();

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -42,22 +42,22 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace WTF {
 
-bool StringView::containsIgnoringASCIICase(StringView matchString) const
+SUPPRESS_NODELETE bool StringView::containsIgnoringASCIICase(StringView matchString) const
 {
     return findIgnoringASCIICase(matchString) != notFound;
 }
 
-bool StringView::containsIgnoringASCIICase(StringView matchString, unsigned startOffset) const
+SUPPRESS_NODELETE bool StringView::containsIgnoringASCIICase(StringView matchString, unsigned startOffset) const
 {
     return findIgnoringASCIICase(matchString, startOffset) != notFound;
 }
 
-size_t StringView::findIgnoringASCIICase(StringView matchString) const
+SUPPRESS_NODELETE size_t StringView::findIgnoringASCIICase(StringView matchString) const
 {
     return ::WTF::findIgnoringASCIICase(*this, matchString, 0);
 }
 
-size_t StringView::findIgnoringASCIICase(StringView matchString, unsigned startOffset) const
+SUPPRESS_NODELETE size_t StringView::findIgnoringASCIICase(StringView matchString, unsigned startOffset) const
 {
     return ::WTF::findIgnoringASCIICase(*this, matchString, startOffset);
 }
@@ -128,7 +128,7 @@ size_t StringView::find(StringView matchString, unsigned start) const
     return findCommon(*this, matchString, start);
 }
 
-size_t StringView::find(AdaptiveStringSearcherTables& tables, StringView matchString, unsigned start) const
+SUPPRESS_NODELETE size_t StringView::find(AdaptiveStringSearcherTables& tables, StringView matchString, unsigned start) const
 {
     unsigned subjectLength = length();
     unsigned matchLength = matchString.length();
@@ -169,7 +169,7 @@ size_t StringView::find(std::span<const Latin1Character> match, unsigned start) 
     return findInner(span16().subspan(start), match, start);
 }
 
-size_t StringView::reverseFind(std::span<const Latin1Character> match, unsigned start) const
+SUPPRESS_NODELETE size_t StringView::reverseFind(std::span<const Latin1Character> match, unsigned start) const
 {
     ASSERT(!match.empty());
     if (match.size() > length())
@@ -418,7 +418,7 @@ bool equalRespectingNullity(StringView a, StringView b)
     return equalCommon(a, b);
 }
 
-size_t StringView::reverseFind(StringView matchString, unsigned start) const
+SUPPRESS_NODELETE size_t StringView::reverseFind(StringView matchString, unsigned start) const
 {
     if (isNull())
         return notFound;

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -165,8 +165,8 @@ public:
     WTF_EXPORT_PRIVATE size_t NODELETE find(StringView, unsigned start = 0) const;
     WTF_EXPORT_PRIVATE size_t NODELETE find(AdaptiveStringSearcherTables&, StringView, unsigned start = 0) const;
 
-    size_t reverseFind(char16_t, unsigned index = std::numeric_limits<unsigned>::max()) const;
-    ALWAYS_INLINE size_t reverseFind(ASCIILiteral literal, unsigned start = std::numeric_limits<unsigned>::max()) const { return reverseFind(literal.span8(), start); }
+    size_t NODELETE reverseFind(char16_t, unsigned index = std::numeric_limits<unsigned>::max()) const;
+    ALWAYS_INLINE size_t NODELETE reverseFind(ASCIILiteral literal, unsigned start = std::numeric_limits<unsigned>::max()) const { return reverseFind(literal.span8(), start); }
     WTF_EXPORT_PRIVATE size_t NODELETE reverseFind(StringView, unsigned start = std::numeric_limits<unsigned>::max()) const;
 
     WTF_EXPORT_PRIVATE size_t NODELETE findIgnoringASCIICase(StringView) const;
@@ -717,7 +717,7 @@ inline size_t StringView::find(CodeUnitMatchFunction&& matchFunction, unsigned s
     return WTF::find(span16(), std::forward<CodeUnitMatchFunction>(matchFunction), start);
 }
 
-inline size_t StringView::reverseFind(char16_t character, unsigned start) const
+SUPPRESS_NODELETE inline size_t StringView::reverseFind(char16_t character, unsigned start) const
 {
     if (is8Bit())
         return WTF::reverseFind(span8(), character, start);
@@ -1247,7 +1247,7 @@ inline size_t findCommon(StringView haystack, StringView needle, unsigned start)
     return findInner(haystack.span16().subspan(start), needle.span16(), start);
 }
 
-inline size_t findIgnoringASCIICase(StringView source, StringView stringToFind, unsigned start)
+SUPPRESS_NODELETE inline size_t findIgnoringASCIICase(StringView source, StringView stringToFind, unsigned start)
 {
     unsigned sourceStringLength = source.length();
     unsigned matchLength = stringToFind.length();


### PR DESCRIPTION
#### 4170c805c35519b4e6e2b68b30d34a6d07f60ded
<pre>
[macOS] Address NoDeleteChecker warnings in WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=309306">https://bugs.webkit.org/show_bug.cgi?id=309306</a>

Reviewed by Ryosuke Niwa and Geoffrey Garen.

* Source/WTF/SaferCPPExpectations/NoDeleteCheckerExpectations:
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::find):
(WTF::StringImpl::reverseFind):
(WTF::equalIgnoringNullity):
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::containsIgnoringASCIICase const):
(WTF::StringView::findIgnoringASCIICase const):
(WTF::StringView::find const):
(WTF::StringView::reverseFind const):
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::reverseFind const):
(WTF::findIgnoringASCIICase):

Canonical link: <a href="https://commits.webkit.org/308840@main">https://commits.webkit.org/308840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aed80c823ee9b8a27718f7eace5aebfd1ea3fc58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21169 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157167 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101913 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/791f5973-4340-49a2-8c14-ed2cb1e55828) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21074 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81532 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c011fda0-74c8-435d-8a20-fbfad1319c77) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151443 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133300 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/415f5b9e-703d-4818-bf26-ee4b4e96649e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15791 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13619 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4603 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140450 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125402 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11213 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159500 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9270 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2634 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12733 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122513 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20967 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17608 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122735 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33404 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20976 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133009 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77128 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18093 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9775 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179910 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20584 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84446 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46059 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20316 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20461 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20370 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->