### PR TITLE
[Security] Null pointer dereference and wrong-field use in extensions toJSON

### DIFF
--- a/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp
@@ -121,17 +121,21 @@ AuthenticationExtensionsClientOutputsJSON AuthenticationExtensionsClientOutputs:
         blob = largeBlob->blob;
         result.largeBlob = AuthenticationExtensionsClientOutputsJSON::LargeBlobOutputsJSON {
             largeBlob->supported,
-            base64URLEncodeToString(blob->span()),
+            blob ? base64URLEncodeToString(blob->span()) : nullString(),
             largeBlob->written,
         };
     }
     if (prf) {
+        std::optional<AuthenticationExtensionsClientOutputsJSON::PRFValuesJSON> prfValues;
+        if (prf->results) {
+            prfValues = AuthenticationExtensionsClientOutputsJSON::PRFValuesJSON {
+                base64URLEncodeToString(prf->results->first->span()),
+                prf->results->second ? base64URLEncodeToString(prf->results->second->span()) : nullString(),
+            };
+        }
         result.prf = AuthenticationExtensionsClientOutputsJSON::PRFOutputsJSON {
             prf->enabled,
-            AuthenticationExtensionsClientOutputsJSON::PRFValuesJSON {
-                base64URLEncodeToString(blob->span()),
-                base64URLEncodeToString(blob->span()),
-            },
+            WTF::move(prfValues),
         };
     }
     return result;


### PR DESCRIPTION
#### 29f5a44e1532b66e0bbb45c4d69dbf87f08f99ff
<pre>
[Security] Null pointer dereference and wrong-field use in extensions toJSON
<a href="https://rdar.apple.com/165125522">rdar://165125522</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=302863">https://bugs.webkit.org/show_bug.cgi?id=302863</a>

Reviewed by Darin Adler.

Fix wrong field use when converting PRF to JSON
and add null checks.

* Source/WebCore/Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp:
(WebCore::AuthenticationExtensionsClientOutputs::toJSON const):

Originally-landed-as: 301765.381@safari-7623-branch (519126b0a4d8). <a href="https://rdar.apple.com/171557653">rdar://171557653</a>
Canonical link: <a href="https://commits.webkit.org/308821@main">https://commits.webkit.org/308821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/827e5f024f62a69dea4927427c665392db99b395

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157229 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7f83ab3-3d51-4f9e-903e-6f8c40d4afb9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150418 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21136 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114515 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1bf22632-7913-4bd3-9696-574239c7c0da) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133352 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95285 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97405fba-2c1c-498d-bcdb-458b13da1fb0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15831 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13665 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4665 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125445 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11265 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159564 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2696 "Found 2 new failures in Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12786 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122563 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17657 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122784 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21038 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133060 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77197 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22893 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18133 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9828 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20646 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84472 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20378 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20523 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20432 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->