### PR TITLE
Block text fragments in cross-origin window.open() popups.

### DIFF
--- a/LayoutTests/http/tests/security/resources/page-with-text.html
+++ b/LayoutTests/http/tests/security/resources/page-with-text.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body { height: 3000px; }
+        .content { margin-top: 2000px; }
+    </style>
+</head>
+<body>
+    <h1>Test Page</h1>
+    <div class="content">
+        <p>This is some text before the secret.</p>
+        <p>SecretText is located here in the middle of the page.</p>
+        <p>This is some text after the secret.</p>
+    </div>
+</body>
+<script defer>
+    function report() {
+        opener.postMessage({ scrollTop: document.documentElement.scrollTop }, "*");
+    }
+
+    window.addEventListener('message', report);
+    setTimeout(report, 10);
+</script>
+</html>

--- a/LayoutTests/http/tests/security/text-fragment/popup-cross-origin-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/text-fragment/popup-cross-origin-blocked-expected.txt
@@ -1,0 +1,10 @@
+Tests that text fragment is blocked in cross-origin window.open() popup.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Text fragment correctly blocked in cross-origin popup (no scroll)
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/text-fragment/popup-cross-origin-blocked.html
+++ b/LayoutTests/http/tests/security/text-fragment/popup-cross-origin-blocked.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script>
+        description("Tests that text fragment is blocked in cross-origin window.open() popup.");
+        jsTestIsAsync = true;
+
+        async function sleep(ms) {
+            return new Promise((resolve) => setTimeout(resolve, ms));
+        }
+
+        async function getScrollTop() {
+            return new Promise((resolve) => addEventListener('message', ({ data }) => resolve(data.scrollTop)));
+        }
+
+        async function runTest() {
+            const BaseURL = "http://localhost:8000/security/resources/page-with-text.html";
+
+            const popup = window.open("");
+            if (!popup) {
+                testFailed("Failed to open popup");
+                finishJSTest();
+                return;
+            }
+
+            // Initially navigate to cross-origin url.
+            popup.location = BaseURL;
+            let scrollTop = await getScrollTop();
+
+            if (scrollTop !== 0) {
+                testFailed("Initial scroll position must be 0 - page scrolled to: " + scrollTop);
+                popup.close();
+                finishJSTest();
+                return;
+            }
+
+            // Navigate to same-document text fragment synchronously.
+            popup.location = BaseURL + "#:~:text=SecretText";
+            popup.postMessage('ping', '*');
+
+            scrollTop = await getScrollTop();
+            if (scrollTop === 0)
+                testPassed("Text fragment correctly blocked in cross-origin popup (no scroll)");
+            else
+                testFailed("Text fragment was NOT blocked - page scrolled to: " + scrollTop);
+
+            popup.close();
+            finishJSTest();
+        }
+
+        runTest();
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/text-fragment/popup-same-origin-allowed-expected.txt
+++ b/LayoutTests/http/tests/security/text-fragment/popup-same-origin-allowed-expected.txt
@@ -1,0 +1,10 @@
+Tests that text fragment works in same-origin window.open() popup.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Text fragment correctly activated in same-origin popup (scrollTop > 0)
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/security/text-fragment/popup-same-origin-allowed.html
+++ b/LayoutTests/http/tests/security/text-fragment/popup-same-origin-allowed.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<body>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script>
+        description("Tests that text fragment works in same-origin window.open() popup.");
+        jsTestIsAsync = true;
+
+        async function waitNavigationComplete() {
+            return new Promise((resolve) => addEventListener('message', ({ data }) => resolve(data)));
+        }
+
+        async function runTest() {
+            // Open popup to same-origin page with text fragment.
+            var popup = window.open("/security/resources/page-with-text.html#:~:text=SecretText");
+            if (!popup) {
+                testFailed("Failed to open popup");
+                finishJSTest();
+                return;
+            }
+
+            const { scrollTop } = await waitNavigationComplete();
+
+            // Check if text fragment was activated by checking scroll position.
+            if (scrollTop > 0)
+                testPassed("Text fragment correctly activated in same-origin popup (scrollTop > 0)");
+            else
+                testFailed("Text fragment was blocked in same-origin popup (unexpected)");
+
+            popup.close();
+            finishJSTest();
+        }
+
+        runTest();
+    </script>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3005,6 +3005,31 @@ bool LocalFrameView::scrollToFragment(const URL& url)
     return false;
 }
 
+static bool checkTextFragmentSecurity(LocalFrame& frame)
+{
+    RefPtr openerFrame = frame.opener();
+    if (!openerFrame)
+        return true;
+
+    RefPtr localOpener = dynamicDowncast<LocalFrame>(openerFrame.get());
+    if (!localOpener)
+        return false;
+
+    auto* openerDocument = localOpener->document();
+    auto* currentDocument = frame.document();
+    if (!openerDocument || !currentDocument)
+        return true;
+
+    auto& openerOrigin = openerDocument->securityOrigin();
+    auto& currentOrigin = currentDocument->securityOrigin();
+
+    // Block if cross-origin popup
+    if (!openerOrigin.isSameOriginAs(currentOrigin))
+        return false;
+
+    return true;
+}
+
 bool LocalFrameView::scrollToTextFragment(IsRetry isRetry)
 {
     static constexpr auto scrollToTextFragmentRetryInterval = 500_ms;
@@ -3017,6 +3042,10 @@ bool LocalFrameView::scrollToTextFragment(IsRetry isRetry)
         return false;
 
     if (!m_frame->isMainFrame())
+        return false;
+
+    // Block text fragments in cross-origin window.open() popups
+    if (!checkTextFragmentSecurity(m_frame.get()))
         return false;
 
     document->fragmentHighlightRegistry().clear();


### PR DESCRIPTION
#### 1d0507379606f129194d9a40f93a3eae5232fabf
<pre>
Block text fragments in cross-origin window.open() popups.
<a href="https://rdar.apple.com/163804356">rdar://163804356</a>

Reviewed by Chris Dumez.

This implements a security defense against timing side-channel attacks
using Text Fragments in cross-origin popups.

The exploit pattern:
w = window.open(&quot;attacker.com&quot;);
w.location = &quot;victim.com&quot;;
w.location = &quot;victim.com#:~:text=secret&quot;;
w.location = &quot;about:blank&quot;;
// Measure timing to detect if text was found

Defense mechanism:
- Add checkTextFragmentSecurity() in LocalFrameView.cpp
- Block text fragments when opener origin ≠ current document origin
- Allow text fragments in same-origin popups (legitimate use)
- Allow text fragments in top-level navigation (no opener)

This aligns with Chrome&apos;s 2019 defense (commit c0d3c4cca8b16),
which uses RelatedPages().size() check. WebKit uses a simpler
cross-origin check that achieves the same security goal.

The fix does not affect about:blank origin inheritance or WPT tests,
as those don&apos;t use text fragments.

Tests: http/tests/security/text-fragment/popup-cross-origin-blocked.html
       http/tests/security/text-fragment/popup-same-origin-allowed.html
* LayoutTests/http/tests/security/resources/page-with-text.html: Added.
* LayoutTests/http/tests/security/text-fragment/popup-cross-origin-blocked-expected.txt: Added.
* LayoutTests/http/tests/security/text-fragment/popup-cross-origin-blocked.html: Added.
* LayoutTests/http/tests/security/text-fragment/popup-same-origin-allowed-expected.txt: Added.
* LayoutTests/http/tests/security/text-fragment/popup-same-origin-allowed.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::checkTextFragmentSecurity):
(WebCore::LocalFrameView::scrollToTextFragment):

Originally-landed-as: <a href="https://commits.webkit.org/301765.417@safari-7623-branch">301765.417@safari-7623-branch</a> (75bcb9f43cbe). rdar://171553529
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d0507379606f129194d9a40f93a3eae5232fabf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148403 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157087 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101831 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aceb13d3-056e-4e51-965c-b286d532a3e4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20994 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114409 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-security.sub.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81496 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64ff408a-e820-4b8a-a7ce-9b6d8558119b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16631 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133238 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95179 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c07a941c-7058-435d-867c-bf496c3350a2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15745 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13569 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4523 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125356 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11144 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159420 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2554 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12663 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122446 "Found 1 new test failure: imported/w3c/web-platform-tests/scroll-to-text-fragment/scroll-to-text-fragment-security.sub.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20887 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122667 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20896 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132958 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77048 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18052 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9707 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20504 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84289 "Found 4 new failures in page/LocalFrameView.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20236 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20381 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20290 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->