### PR TITLE
run-webkit-tests: Add option to show fully-expanded text diff in test results

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -230,6 +230,8 @@ def parse_args(args):
             help="Show all failures in results.html, rather than only regressions"),
         optparse.make_option("--clobber-old-results", action="store_true",
             default=False, help="Clobbers test results from previous runs."),
+        optparse.make_option("--full-diff-context", action="store_true",
+            default=False, help="Show full context in text diffs instead of a few lines around changes"),
         optparse.make_option("--http", action="store_true", dest="http",
             default=True, help="Run HTTP and WebSocket tests (default)"),
         optparse.make_option("--no-http", action="store_false", dest="http",

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -390,10 +390,16 @@ class Port(object):
         in 'unified diff' format."""
         expected_filename = string_utils.decode(string_utils.encode(expected_filename), target_type=str)
         actual_filename = string_utils.decode(string_utils.encode(actual_filename), target_type=str)
+
+        kwargs = {}
+        if self.get_option('full_diff_context'):
+            kwargs['n'] = sys.maxsize
         diff = difflib.unified_diff(expected_text.splitlines(True),
                                     actual_text.splitlines(True),
                                     expected_filename,
-                                    actual_filename)
+                                    actual_filename,
+                                    **kwargs)
+
         result = ""
         for line in diff:
             result += line


### PR DESCRIPTION
#### 7a12d8fc678a139fdf5b24ab5b649260878d899a
<pre>
run-webkit-tests: Add option to show fully-expanded text diff in test results
<a href="https://bugs.webkit.org/show_bug.cgi?id=309309">https://bugs.webkit.org/show_bug.cgi?id=309309</a>

Reviewed by Ryosuke Niwa.

Add a --full-diff-context flag for this option. If set, pass
n=sys.maxsize to difflib.unified_diff that we use to generate the text
diff, which defaults to n=3 today.

* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(parse_args):
* Tools/Scripts/webkitpy/port/base.py:
(Port.diff_text):

Canonical link: <a href="https://commits.webkit.org/308997@main">https://commits.webkit.org/308997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c67cf38e9560ec3b0bb104b3dc34a7152eb526c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148414 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157098 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101842 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e713485-4fef-4b3d-8277-04863e3e7f29) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150287 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21005 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114416 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81524 "Exiting early after 60 failures. 15279 tests run. 60 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5e69e4f-97d2-4d44-aa1b-caa6968d61a0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151374 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16634 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95186 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1235aa58-d160-427c-b918-3d5e293c9aaf) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/147735 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15748 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13577 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4534 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125359 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159431 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122451 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17552 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122708 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20907 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132967 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77059 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22962 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18059 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9716 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20515 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20247 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20392 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20301 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->