### PR TITLE
fix test failures when UseUIProcessForBackForwardItemLoading is enabled

### DIFF
--- a/LayoutTests/fast/css/target-fragment-match.html
+++ b/LayoutTests/fast/css/target-fragment-match.html
@@ -19,14 +19,15 @@ function test()
 function runTest() {
     window.location.hash ='#target-01';
     document.body.offsetTop;
-    window.history.back(); // This queues up a navigation, so we need to delay the call to notifyDone.
-    if (window.testRunner)
-        setTimeout(function() {
-            // Second setTimeout is because iOS WK2 updates the scroll position after history navigation via the UI process.
+    window.history.back(); // This queues up a navigation, so we need to wait for it to complete.
+    if (window.testRunner) {
+        window.addEventListener('popstate', function() {
+            // Extra setTimeout because iOS WK2 updates the scroll position after history navigation via the UI process.
             setTimeout(function() {
                 testRunner.notifyDone()
             }, 0);
-        }, 0);
+        }, { once: true });
+    }
 }
 </script>
 </head>

--- a/LayoutTests/fast/dom/location-hash.html
+++ b/LayoutTests/fast/dom/location-hash.html
@@ -84,10 +84,13 @@
         }
         
         state ++;
-        
-        // Do the step in a timeout to give asynchornous history.back/forward()
-        // calls a chance to run.
-        setTimeout(step, 0);
+
+        // For steps after history.back/forward, wait for popstate event.
+        // For other steps, proceed immediately.
+        if (state == 4 || state == 5 || state == 6)
+            window.addEventListener('popstate', step, { once: true });
+        else
+            setTimeout(step, 0);
     }
         
     async function runTests() {

--- a/LayoutTests/fast/history/history-scroll-restoration.html
+++ b/LayoutTests/fast/history/history-scroll-restoration.html
@@ -31,13 +31,16 @@
         history.pushState(null, '', '#1');
         window.scrollTo(0, 0);
         history.back();
-        
-        window.setTimeout(function () {
-            shouldBe('window.scrollX', '123');
-            shouldBe('window.scrollY', '456');
 
-            testManualScrollRestoration();
-        }, 0);
+        window.addEventListener('popstate', function () {
+            // Scroll restoration may happen asynchronously via the UI process.
+            setTimeout(function () {
+                shouldBe('window.scrollX', '123');
+                shouldBe('window.scrollY', '456');
+
+                testManualScrollRestoration();
+            }, 0);
+        }, { once: true });
     }
 
     function testManualScrollRestoration()
@@ -49,13 +52,16 @@
         history.pushState(null, '', '#2');
         window.scrollTo(333, 555);
         history.back();
-        
-        window.setTimeout(function() {
-            shouldBe('window.scrollX', '333');
-            shouldBe('window.scrollY', '555');
-            window.scrollTo(0, 0);
-            finishJSTest();
-        }, 0);
+
+        window.addEventListener('popstate', function() {
+            // Scroll restoration may happen asynchronously via the UI process.
+            setTimeout(function() {
+                shouldBe('window.scrollX', '333');
+                shouldBe('window.scrollY', '555');
+                window.scrollTo(0, 0);
+                finishJSTest();
+            }, 0);
+        }, { once: true });
     }
 
 </script>

--- a/LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache-expected.txt
@@ -1,4 +1,4 @@
-Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled.
+Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled, including JS-driven history.back().
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
@@ -10,7 +10,9 @@ Page2 displayed first time.
 Other page loaded
 Other page displayed.
 Page2 loaded
-PASS Page2 displayed twice.
+Page2 displayed after browser back.
+Page1 loaded
+PASS Page1 displayed again after JS history.back().
 PASS successfullyParsed is true
 
 TEST COMPLETE
@@ -18,4 +20,5 @@ Open a new window with back-iframe-popup.html. It has a same-site iframe with pa
 Navigate iframe to cross-site page2.
 Navigate main frame to other (same-site).
 Go back. (back-iframe-popup.html with iframe showing cross-site page2)
-... and ensures the nested iframe content is correctly restored to page2.
+Go back again. (iframe back to same-site page1)
+Ensures nested iframe content is correctly restored via both browser back and JS history.back().

--- a/LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html
+++ b/LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html
@@ -6,7 +6,7 @@
 <script src="/navigation/resources/navigation-utils.js"></script>
 <script>
 
-description("Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled.");
+description("Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled, including JS-driven history.back().");
 jsTestIsAsync = true;
 
 const page = "opener";
@@ -42,8 +42,11 @@ window.onmessage = (event) => dispatchMessage(event.data, {
             if (page1ShowCount == 1) {
                 debug("Page1 displayed first time.");
                 sendMessageToPopup("navigate-to-page2-cross-site-iframe");
+            } else if (page1ShowCount == 2) {
+                testPassed("Page1 displayed again after JS history.back().");
+                finishJSTest();
             } else {
-                testFailed("Page1 should be displayed only once.");
+                testFailed("Page1 displayed too many times.");
                 finishJSTest();
             }
         }
@@ -62,10 +65,10 @@ window.onmessage = (event) => dispatchMessage(event.data, {
                 debug("Page2 displayed first time.");
                 sendMessageToPopup("navigate-to-other");
             } else if (page2ShowCount == 2) {
-                testPassed("Page2 displayed twice.");
-                finishJSTest();
+                debug("Page2 displayed after browser back.");
+                sendMessageToPopup("back");
             } else {
-                testFailed("Page2 should be displayed only twice.");
+                testFailed("Page2 displayed too many times.");
                 finishJSTest();
             }
         }
@@ -87,7 +90,8 @@ window.onmessage = (event) => dispatchMessage(event.data, {
     <li>Navigate iframe to cross-site page2.</li>
     <li>Navigate main frame to other (same-site).</li>
     <li>Go back. (back-iframe-popup.html with iframe showing cross-site page2)</li>
+    <li>Go back again. (iframe back to same-site page1)</li>
 </ul>
-<p>... and ensures the nested iframe content is correctly restored to page2.</p>
+<p>Ensures nested iframe content is correctly restored via both browser back and JS history.back().</p>
 </body>
 </html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8840,7 +8840,8 @@ UseSystemAppearance:
 
 UseUIProcessForBackForwardItemLoading:
   type: bool
-  status: unstable
+  status: testable
+  category: security
   exposed: [ WebKit ]
   humanReadableName: "Use UIProcess for Back/Forward Item Loading"
   humanReadableDescription: "Enable UIProcess-side BackForwardListFrameItem lookup for child frames during Back/Forward navigation"

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -1070,6 +1070,10 @@ void EmptyFrameLoaderClient::shouldGoToHistoryItemAsync(HistoryItem&, Completion
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+void EmptyFrameLoaderClient::dispatchGoToBackForwardItemAtIndex(int, FrameLoadType)
+{
+}
+
 void EmptyFrameLoaderClient::saveViewStateToItem(HistoryItem&)
 {
 }

--- a/Source/WebCore/loader/EmptyFrameLoaderClient.h
+++ b/Source/WebCore/loader/EmptyFrameLoaderClient.h
@@ -164,6 +164,7 @@ private:
     ShouldGoToHistoryItem NODELETE shouldGoToHistoryItem(HistoryItem&, IsSameDocumentNavigation) const final;
     bool NODELETE supportsAsyncShouldGoToHistoryItem() const final;
     void NODELETE shouldGoToHistoryItemAsync(HistoryItem&, CompletionHandler<void(ShouldGoToHistoryItem)>&&) const final;
+    void NODELETE dispatchGoToBackForwardItemAtIndex(int steps, FrameLoadType) final;
 
     void NODELETE saveViewStateToItem(HistoryItem&) final;
     bool NODELETE canCachePage() const final;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -831,6 +831,7 @@ void FrameLoader::didBeginDocument(bool dispatch, LocalDOMWindow* previousWindow
 {
     m_needsClear = true;
     m_isComplete = false;
+    m_asyncBackForwardNavigationState = AsyncBackForwardNavigationState::None;
     m_didCallImplicitClose = false;
     Ref frame = m_frame.get();
     Ref document = *frame->document();
@@ -1959,6 +1960,7 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
     }
 
     protect(frame->navigationScheduler())->cancel(NewLoadInProgress::Yes);
+    cancelPendingAsyncBackForwardNavigation();
 
     if (shouldTreatCurrentLoadAsContinuingLoad()) {
         continueLoadAfterNavigationPolicy(loader->request(), formSubmission.get(), NavigationPolicyDecision::ContinueLoad, allowNavigationToInvalidURL);
@@ -4666,6 +4668,23 @@ void FrameLoader::setRequestedHistoryItem(HistoryItem& item)
 
     item.setFrameID(frame->frameID());
     m_requestedHistoryItem = item;
+}
+
+void FrameLoader::setPendingAsyncBackForwardNavigation()
+{
+    m_asyncBackForwardNavigationState = AsyncBackForwardNavigationState::Pending;
+}
+
+void FrameLoader::cancelPendingAsyncBackForwardNavigation()
+{
+    if (m_asyncBackForwardNavigationState == AsyncBackForwardNavigationState::Pending)
+        m_asyncBackForwardNavigationState = AsyncBackForwardNavigationState::Cancelled;
+}
+
+bool FrameLoader::shouldProceedWithAsyncBackForwardNavigation()
+{
+    auto state = std::exchange(m_asyncBackForwardNavigationState, AsyncBackForwardNavigationState::None);
+    return state != AsyncBackForwardNavigationState::Cancelled;
 }
 
 void FrameLoader::loadRequestedHistoryItem(FrameLoadType loadType, PolicyAlreadyDecided policyAlreadyDecided)

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3784,6 +3784,9 @@ void FrameLoader::continueFragmentScrollAfterNavigationPolicy(const ResourceRequ
     // frame to be deallocated.
     Ref frame = m_frame.get();
 
+    // A fragment scroll should cancel any pending async back-forward navigation.
+    cancelPendingAsyncBackForwardNavigation();
+
     // If we have a provisional request for a different document, a fragment scroll should cancel it.
     if (m_provisionalDocumentLoader && !equalIgnoringFragmentIdentifier(m_provisionalDocumentLoader->request().url(), request.url())) {
         protect(m_provisionalDocumentLoader)->stopLoading();

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1103,6 +1103,7 @@ bool FrameLoader::loadChildHistoryItemIntoFrame(LocalFrame& childFrame)
 {
     ASSERT(isBackForwardLoadType(loadType()));
     ASSERT(!m_frame->document()->loadEventFinished());
+    ASSERT(!m_frame->page() || !m_frame->page()->settings().useUIProcessForBackForwardItemLoading());
 
     RefPtr parentItem = history().currentItem();
     if (!parentItem || !parentItem->children().size())
@@ -4668,6 +4669,15 @@ void FrameLoader::setRequestedHistoryItem(HistoryItem& item)
 
     item.setFrameID(frame->frameID());
     m_requestedHistoryItem = item;
+
+    // When UseUIProcessForBackForwardItemLoading is enabled, each child frame receives
+    // its HistoryItem individually from UIProcess. Add it to the parent's current
+    // HistoryItem so the tree structure matches what createItemTree would have produced
+    // during a normal navigation.
+    if (RefPtr parentFrame = dynamicDowncast<LocalFrame>(frame->tree().parent())) {
+        if (RefPtr parentItem = parentFrame->loader().history().currentItem())
+            parentItem->setChildItem(Ref { item });
+    }
 }
 
 void FrameLoader::setPendingAsyncBackForwardNavigation()

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -269,7 +269,7 @@ public:
     void loadDone(LoadCompletionType);
     void subresourceLoadDone(LoadCompletionType);
     void finishedParsing();
-    void checkCompleted();
+    WEBCORE_EXPORT void checkCompleted();
 
     bool isComplete() const { return m_isComplete; }
 
@@ -359,6 +359,11 @@ public:
     WEBCORE_EXPORT void loadRequestedHistoryItem(FrameLoadType, PolicyAlreadyDecided = PolicyAlreadyDecided::No);
 
     void updateURLAndHistory(const URL&, RefPtr<SerializedScriptValue>&& stateObject, NavigationHistoryBehavior = NavigationHistoryBehavior::Replace);
+
+    WEBCORE_EXPORT void setPendingAsyncBackForwardNavigation();
+    WEBCORE_EXPORT void cancelPendingAsyncBackForwardNavigation();
+    WEBCORE_EXPORT bool shouldProceedWithAsyncBackForwardNavigation();
+    bool isWaitingForAsyncBackForwardNavigation() const { return m_asyncBackForwardNavigationState != AsyncBackForwardNavigationState::None; }
 
     void setRequiredCookiesVersion(uint64_t version) { m_requiredCookiesVersion = version; }
     uint64_t requiredCookiesVersion() const { return m_requiredCookiesVersion; }
@@ -548,6 +553,9 @@ private:
 
     URL m_previousURL;
     RefPtr<HistoryItem> m_requestedHistoryItem;
+
+    enum class AsyncBackForwardNavigationState : uint8_t { None, Pending, Cancelled };
+    AsyncBackForwardNavigationState m_asyncBackForwardNavigationState { AsyncBackForwardNavigationState::None };
 
     bool m_alwaysAllowLocalWebarchive { false };
 

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -49,6 +49,7 @@
 #include "LocalFrameView.h"
 #include "Logging.h"
 #include "Navigation.h"
+#include "NavigationScheduler.h"
 #include "Page.h"
 #include "ProcessSwapDisposition.h"
 #include "ScrollingCoordinator.h"
@@ -200,6 +201,7 @@ void HistoryController::restoreScrollPositionAndViewState()
 
 void HistoryController::updateBackForwardListForFragmentScroll()
 {
+    m_frame->navigationScheduler().adjustPendingHistoryNavigationForNewBackForwardEntry();
     updateBackForwardListClippedAtTarget(false);
 }
 
@@ -1071,6 +1073,7 @@ void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, c
 
     LOG(History, "HistoryController %p pushState: Adding top item %p, setting url of current item %p to %s, scrollRestoration is %s", this, topItem.ptr(), m_currentItem.get(), urlString.ascii().data(), topItem->shouldRestoreScrollPosition() ? "auto" : "manual");
 
+    m_frame->navigationScheduler().adjustPendingHistoryNavigationForNewBackForwardEntry();
     protect(page->backForward())->addItem(WTF::move(topItem));
 
     if (!canRecordHistoryForFrame(frame))

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -230,6 +230,7 @@ public:
     virtual ShouldGoToHistoryItem shouldGoToHistoryItem(HistoryItem&, IsSameDocumentNavigation) const = 0;
     virtual bool supportsAsyncShouldGoToHistoryItem() const = 0;
     virtual void shouldGoToHistoryItemAsync(HistoryItem&, CompletionHandler<void(ShouldGoToHistoryItem)>&&) const = 0;
+    virtual void dispatchGoToBackForwardItemAtIndex(int steps, FrameLoadType) = 0;
 
     virtual bool shouldFallBack(const ResourceError&) const = 0;
 

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -51,6 +51,7 @@
 #include "HistoryItem.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrameInlines.h"
+#include "LocalFrameLoaderClient.h"
 #include "Logging.h"
 #include "Navigation.h"
 #include "NavigationDisabler.h"
@@ -99,7 +100,10 @@ public:
     virtual void didStartTimer(Frame&, Timer&) { }
     virtual void didStopTimer(Frame&, NewLoadInProgress) { }
     virtual bool targetIsCurrentFrame() const { return true; }
-    virtual bool isSameDocumentNavigation(Frame&) const { return false; }
+    virtual bool isSameDocumentNavigation(Frame&) { return false; }
+
+    // Returns true if this scheduled navigation should be cancelled.
+    virtual bool adjustForNewBackForwardEntry() { return false; }
 
     double NODELETE delay() const { return m_delay; }
     LockHistory NODELETE lockHistory() const { return m_lockHistory; }
@@ -170,7 +174,7 @@ protected:
     const URL& NODELETE url() const { return m_url; }
     const String& NODELETE referrer() const { return m_referrer; }
 
-    bool isSameDocumentNavigation(Frame&) const final { return equalIgnoringFragmentIdentifier(initiatingDocument().url(), url()); }
+    bool isSameDocumentNavigation(Frame&) final { return equalIgnoringFragmentIdentifier(initiatingDocument().url(), url()); }
 
 private:
     const Ref<Document> m_initiatingDocument;
@@ -290,49 +294,83 @@ public:
 
 class ScheduledHistoryNavigation : public ScheduledNavigation {
 public:
-    explicit ScheduledHistoryNavigation(Ref<HistoryItem>&& historyItem)
+    explicit ScheduledHistoryNavigation(int steps)
         : ScheduledNavigation(0, LockHistory::No, LockBackForwardList::No, false, true)
-        , m_historyItem(WTF::move(historyItem))
+        , m_steps(steps)
     {
     }
 
-    void fire(Frame& frame) override
+    void fire(Frame& frame) final
     {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             return;
 
         RefPtr page { localFrame->page() };
-        if (!page || !protect(page->backForward())->containsItem(m_historyItem))
+        if (!page)
             return;
 
         UserGestureIndicator gestureIndicator(userGestureToForward());
+
+        if (page->settings().useUIProcessForBackForwardItemLoading()) {
+            localFrame->loader().setPendingAsyncBackForwardNavigation();
+            localFrame->loader().client().dispatchGoToBackForwardItemAtIndex(m_steps, FrameLoadType::IndexedBackForward);
+            return;
+        }
+
+        RefPtr historyItem = targetHistoryItem(*localFrame);
+        if (!historyItem)
+            return;
+
+        if (!protect(page->backForward())->containsItem(*historyItem))
+            return;
 
         if (RefPtr currentItem = protect(page->backForward())->currentItem(); currentItem && currentItem->itemID() == m_historyItem->itemID()) {
             localFrame->loader().changeLocation(localFrame->document()->url(), selfTargetFrameName(), 0, ReferrerPolicy::EmptyString, shouldOpenExternalURLs(), std::nullopt, nullAtom(), std::nullopt, NavigationHistoryBehavior::Reload);
             return;
         }
-        
+
         Ref rootFrame = localFrame->rootFrame();
-        page->goToItem(rootFrame, m_historyItem, FrameLoadType::IndexedBackForward, ShouldTreatAsContinuingLoad::No);
+        page->goToItem(rootFrame, *historyItem, FrameLoadType::IndexedBackForward, ShouldTreatAsContinuingLoad::No);
     }
 
-    bool isSameDocumentNavigation(Frame& frame) const final
+    bool isSameDocumentNavigation(Frame& frame) final
     {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
             return false;
 
-        RefPtr page { localFrame->page() };
-        if (!page || !protect(page->backForward())->containsItem(m_historyItem))
+        RefPtr historyItem = targetHistoryItem(*localFrame);
+        if (!historyItem)
             return false;
 
-        URL url { m_historyItem->url() };
-        return equalIgnoringFragmentIdentifier(localFrame->document()->url(), url);
+        RefPtr currentItem = localFrame->loader().history().currentItem();
+        return currentItem && historyItem->shouldDoSameDocumentNavigationTo(*currentItem);
+    }
+
+    bool adjustForNewBackForwardEntry() final
+    {
+        if (m_steps > 0)
+            return true;
+        if (m_steps < 0)
+            m_steps--;
+        return false;
     }
 
 private:
-    const Ref<HistoryItem> m_historyItem;
+    HistoryItem* targetHistoryItem(LocalFrame& localFrame)
+    {
+        if (!m_historyItem) {
+            RefPtr page = localFrame.page();
+            if (!page)
+                return nullptr;
+            m_historyItem = protect(page->backForward())->itemAtIndex(m_steps, localFrame.rootFrame().frameID());
+        }
+        return m_historyItem.get();
+    }
+
+    mutable RefPtr<HistoryItem> m_historyItem;
+    int m_steps;
 };
 
 // This matches ScheduledHistoryNavigation, but instead of having a HistoryItem provided, it finds
@@ -414,7 +452,7 @@ public:
         completionHandler(ScheduleHistoryNavigationResult::Completed);
     }
 
-    bool isSameDocumentNavigation(Frame& frame) const final
+    bool isSameDocumentNavigation(Frame& frame) final
     {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
         if (!localFrame)
@@ -758,14 +796,7 @@ void NavigationScheduler::scheduleHistoryNavigation(int steps)
         return;
     }
 
-    RefPtr historyItem = backForward->itemAtIndex(steps, localFrame->rootFrame().frameID());
-    if (!historyItem) {
-        cancel();
-        return;
-    }
-
-    // In all other cases, schedule the history traversal to occur asynchronously.
-    schedule(makeUnique<ScheduledHistoryNavigation>(historyItem.releaseNonNull()));
+    schedule(makeUnique<ScheduledHistoryNavigation>(steps));
 }
 
 void NavigationScheduler::scheduleHistoryNavigationByKey(const String& key, CompletionHandler<void(ScheduleHistoryNavigationResult)>&& completionHandler)
@@ -855,6 +886,14 @@ void NavigationScheduler::startTimer()
     Seconds delay = 1_s * m_redirect->delay();
     m_timer.startOneShot(delay);
     m_redirect->didStartTimer(frame, m_timer); // m_redirect may be null on return (e.g. the client canceled the load)
+}
+
+void NavigationScheduler::adjustPendingHistoryNavigationForNewBackForwardEntry()
+{
+    if (!m_redirect)
+        return;
+    if (m_redirect->adjustForNewBackForwardEntry())
+        cancel();
 }
 
 void NavigationScheduler::cancel(NewLoadInProgress newLoadInProgress)

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -312,6 +312,12 @@ public:
 
         UserGestureIndicator gestureIndicator(userGestureToForward());
 
+        // history.go(0) is a reload, not a back-forward navigation.
+        if (!m_steps) {
+            localFrame->loader().changeLocation(localFrame->document()->url(), selfTargetFrameName(), 0, ReferrerPolicy::EmptyString, shouldOpenExternalURLs(), std::nullopt, nullAtom(), std::nullopt, NavigationHistoryBehavior::Reload);
+            return;
+        }
+
         if (page->settings().useUIProcessForBackForwardItemLoading()) {
             localFrame->loader().setPendingAsyncBackForwardNavigation();
             localFrame->loader().client().dispatchGoToBackForwardItemAtIndex(m_steps, FrameLoadType::IndexedBackForward);
@@ -324,11 +330,6 @@ public:
 
         if (!protect(page->backForward())->containsItem(*historyItem))
             return;
-
-        if (RefPtr currentItem = protect(page->backForward())->currentItem(); currentItem && currentItem->itemID() == m_historyItem->itemID()) {
-            localFrame->loader().changeLocation(localFrame->document()->url(), selfTargetFrameName(), 0, ReferrerPolicy::EmptyString, shouldOpenExternalURLs(), std::nullopt, nullAtom(), std::nullopt, NavigationHistoryBehavior::Reload);
-            return;
-        }
 
         Ref rootFrame = localFrame->rootFrame();
         page->goToItem(rootFrame, *historyItem, FrameLoadType::IndexedBackForward, ShouldTreatAsContinuingLoad::No);

--- a/Source/WebCore/loader/NavigationScheduler.h
+++ b/Source/WebCore/loader/NavigationScheduler.h
@@ -76,6 +76,8 @@ public:
     void cancel(NewLoadInProgress = NewLoadInProgress::No);
     void clear();
 
+    void adjustPendingHistoryNavigationForNewBackForwardEntry();
+
     bool NODELETE hasQueuedNavigation() const;
 
 private:

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -381,6 +381,8 @@ void LocalFrame::frameDetached()
 
 bool LocalFrame::preventsParentFromBeingComplete() const
 {
+    if (loader().isWaitingForAsyncBackForwardNavigation())
+        return true;
     return !loader().isComplete() && (!ownerElement() || !ownerElement()->isLazyLoadObserverActive());
 }
 

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -150,6 +150,11 @@ void WebBackForwardListFrameItem::updateFrameID(FrameIdentifier newFrameID)
     m_frameState->frameID = newFrameID;
 }
 
+Ref<FrameState> WebBackForwardListFrameItem::copyFrameState()
+{
+    return protect(this->frameState())->copy();
+}
+
 Ref<FrameState> WebBackForwardListFrameItem::copyFrameStateWithChildren()
 {
     Ref frameState = protect(this->frameState())->copy();

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -46,6 +46,7 @@ public:
     FrameState& frameState() const { return m_frameState; }
     void setFrameState(Ref<FrameState>&&);
 
+    Ref<FrameState> copyFrameState();
     Ref<FrameState> copyFrameStateWithChildren();
 
     std::optional<WebCore::FrameIdentifier> NODELETE frameID() const;

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -689,11 +689,11 @@ void WebBackForwardList::backForwardUpdateItem(IPC::Connection& connection, Ref<
         auto newFrameID = frameItem->frameID();
 
         if (oldFrameID && newFrameID && oldFrameID != newFrameID)
-            updateAllFrameIDs(*oldFrameID, *newFrameID);
+            updateFrameIdentifier(*oldFrameID, *newFrameID);
     }
 }
 
-void WebBackForwardList::updateAllFrameIDs(FrameIdentifier oldFrameID, FrameIdentifier newFrameID)
+void WebBackForwardList::updateFrameIdentifier(FrameIdentifier oldFrameID, FrameIdentifier newFrameID)
 {
     for (auto& entry : m_entries)
         entry->updateFrameID(oldFrameID, newFrameID);

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -98,6 +98,7 @@ public:
     void backForwardGoToItemShared(WebCore::BackForwardItemIdentifier, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
 
     FrameState* findFrameStateInItem(WebCore::BackForwardItemIdentifier, WebCore::FrameIdentifier, uint64_t);
+    void updateFrameIdentifier(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);
 
     String loggingString();
 
@@ -110,8 +111,6 @@ private:
     const BackForwardListItemVector& entries() const LIFETIME_BOUND { return m_entries; }
     WebBackForwardListCounts NODELETE counts() const;
     Ref<FrameState> completeFrameStateForNavigation(Ref<FrameState>&&);
-
-    void updateAllFrameIDs(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);
 
     // IPC messages
     void backForwardAddItem(IPC::Connection&, Ref<FrameState>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2727,7 +2727,10 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFram
     if (protect(preferences())->siteIsolationEnabled()) {
         if (RefPtr frame = WebFrameProxy::webFrame(frameItem.frameID()); frame && frame->page() == this) {
             process = frame->process();
-            frameState = frameItem.copyFrameStateWithChildren();
+            if (protect(preferences())->useUIProcessForBackForwardItemLoading())
+                frameState = frameItem.copyFrameState();
+            else
+                frameState = frameItem.copyFrameStateWithChildren();
         }
     }
     auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(URL(item->url()));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2784,6 +2784,23 @@ void WebPageProxy::shouldGoToBackForwardListItemSync(BackForwardItemIdentifier i
     shouldGoToBackForwardListItem(itemID, false, WTF::move(completionHandler));
 }
 
+void WebPageProxy::goToBackForwardItemAtIndex(int32_t steps, FrameLoadType frameLoadType)
+{
+    WEBPAGEPROXY_RELEASE_LOG(Loading, "goToBackForwardItemAtIndex: steps=%d", steps);
+
+    RefPtr item = backForwardList().itemAtIndex(steps);
+    if (!item)
+        return;
+
+    Ref frameItem = item->mainFrameItem();
+    if (RefPtr currentItem = backForwardList().currentItem()) {
+        if (RefPtr childItem = currentItem->navigatedFrameID() ? frameItem->childItemForFrameID(*currentItem->navigatedFrameID()) : nullptr)
+            frameItem = childItem.releaseNonNull();
+    }
+
+    goToBackForwardItem(frameItem, frameLoadType);
+}
+
 bool WebPageProxy::shouldKeepCurrentBackForwardListItemInList(WebBackForwardListItem& item)
 {
     RefPtr protectedPageClient { pageClient() };
@@ -5661,7 +5678,10 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
             // The FrameState from the BackForwardList may contain an old frameID from a
             // previous incarnation of this child frame. Update it to the current frameID
             // so the new process can find the correct frame to navigate.
-            frameState->frameID = frame.frameID();
+            if (auto currentFrameID = frameState->frameID; currentFrameID != frame.frameID()) {
+                frameState->frameID = frame.frameID();
+                backForwardList().updateFrameIdentifier(*currentFrameID, frame.frameID());
+            }
 
             WEBPAGEPROXY_RELEASE_LOG(Loading, "continueNavigationInNewProcess: Sending GoToBackForwardItem for child frame to new process, URL=%" SENSITIVE_LOG_STRING, frameState->urlString.utf8().data());
             auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(navigation.currentRequest().url());
@@ -8584,7 +8604,20 @@ RefPtr<FrameState> WebPageProxy::frameStateForBackForwardChildFrame(WebFrameProx
     if (!index)
         return nullptr;
 
-    return backForwardList().findFrameStateInItem(targetBackForwardItemIdentifier, frame.parentFrame()->frameID(), *index);
+    auto* frameState = backForwardList().findFrameStateInItem(targetBackForwardItemIdentifier, frame.parentFrame()->frameID(), *index);
+    if (!frameState)
+        return nullptr;
+
+    // The FrameState from the back/forward list may contain an old frameID from
+    // a previous incarnation of this child frame (child frames are recreated with
+    // new frameIDs during BF navigation). Update it across all entries so that:
+    // 1) Grandchild frames can find their parent's FrameState by the new frameID.
+    // 2) The navigatedFrameID on back/forward items stays consistent.
+    // This mirrors the same pattern used in continueNavigationInNewProcess.
+    if (auto currentFrameID = frameState->frameID; currentFrameID && *currentFrameID != frame.frameID())
+        backForwardList().updateFrameIdentifier(*currentFrameID, frame.frameID());
+
+    return frameState;
 }
 
 void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& process, WebFrameProxy& frame, NavigationActionData&& navigationActionData, CompletionHandler<void(PolicyDecision&&)>&& originalCompletionHandler)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1027,6 +1027,7 @@ public:
     void didChangeBackForwardList(WebBackForwardListItem* addedItem, Vector<Ref<WebBackForwardListItem>>&& removed);
     void shouldGoToBackForwardListItem(WebCore::BackForwardItemIdentifier, bool inBackForwardCache, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&);
     void shouldGoToBackForwardListItemSync(WebCore::BackForwardItemIdentifier, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&);
+    void goToBackForwardItemAtIndex(int32_t steps, WebCore::FrameLoadType);
 
     bool shouldKeepCurrentBackForwardListItemInList(WebBackForwardListItem&);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -239,6 +239,7 @@ messages -> WebPageProxy {
     # BackForward messages
     ShouldGoToBackForwardListItem(WebCore::BackForwardItemIdentifier itemID, bool inBackForwardCache) -> (enum:uint8_t WebCore::ShouldGoToHistoryItem shouldGoToHistoryItem)
     ShouldGoToBackForwardListItemSync(WebCore::BackForwardItemIdentifier itemID) -> (enum:uint8_t WebCore::ShouldGoToHistoryItem shouldGoToHistoryItem) Synchronous
+    GoToBackForwardItemAtIndex(int32_t steps, enum:uint8_t WebCore::FrameLoadType frameLoadType)
 
     # Undo/Redo messages
     RegisterEditCommandForUndo(WebKit::WebUndoStepID commandID, String label) AllowedWhenWaitingForSyncReply

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1210,11 +1210,17 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForBackForwardNavigationActi
             if (!historyItem) {
                 // Fallback: FrameState not found, use normal load path
                 RELEASE_LOG(Loading, "dispatchDecidePolicyForBackForwardNavigationAction: FrameState not found, using fallback normal load path");
-
+                localFrame->loader().cancelPendingAsyncBackForwardNavigation();
                 if (RefPtr parent = dynamicDowncast<LocalFrame>(localFrame->tree().parent()))
                     parent->loader().continueLoadURLIntoChildFrame(URL { url }, referer, *localFrame);
                 return;
             }
+
+            // The async wait is over — UIProcess has resolved the HistoryItem
+            // and the actual loading begins via normal DocumentLoader mechanisms.
+            // Clear the async state so that frame completion tracking behaves
+            // identically to the non-flag path.
+            localFrame->loader().shouldProceedWithAsyncBackForwardNavigation();
 
             localFrame->loader().loadRequestedHistoryItem(loadType, PolicyAlreadyDecided::Yes);
         }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1172,6 +1172,7 @@ void WebLocalFrameLoaderClient::dispatchBackForwardItemLoading(const URL& url, c
 void WebLocalFrameLoaderClient::dispatchDecidePolicyForBackForwardNavigationAction(WebCore::FrameLoadRequest&& frameLoadRequest, const String& referer, WebCore::FrameLoadType loadType)
 {
     Ref localFrame = m_localFrame.get();
+    localFrame->loader().setPendingAsyncBackForwardNavigation();
 
     NavigationAction navigationAction { frameLoadRequest, NavigationType::BackForward, nullptr };
 
@@ -1192,12 +1193,18 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForBackForwardNavigationActi
         localFrame->effectiveSandboxFlags(),
         PolicyDecisionMode::Asynchronous,
         [weakLocalFrame = WeakPtr { localFrame.ptr() }, url = request.url(), referer, loadType](PolicyAction action) {
-            if (action != PolicyAction::Use)
-                return;
-
             RefPtr localFrame = weakLocalFrame.get();
             if (!localFrame)
                 return;
+
+            if (action != PolicyAction::Use) {
+                // Reset the pending async state and re-check completeness
+                // on the parent since this child won't be loading.
+                localFrame->loader().cancelPendingAsyncBackForwardNavigation();
+                if (RefPtr parent = dynamicDowncast<LocalFrame>(localFrame->tree().parent()))
+                    parent->loader().checkCompleted();
+                return;
+            }
 
             RefPtr historyItem = localFrame->loader().requestedHistoryItem();
             if (!historyItem) {
@@ -1413,6 +1420,15 @@ void WebLocalFrameLoaderClient::shouldGoToHistoryItemAsync(HistoryItem& item, Co
     }
 
     webPage->sendWithAsyncReply(Messages::WebPageProxy::ShouldGoToBackForwardListItem(item.itemID(), item.isInBackForwardCache()), WTF::move(completionHandler));
+}
+
+void WebLocalFrameLoaderClient::dispatchGoToBackForwardItemAtIndex(int steps, FrameLoadType frameLoadType)
+{
+    RefPtr webPage = m_frame->page();
+    if (!webPage)
+        return;
+
+    webPage->send(Messages::WebPageProxy::GoToBackForwardItemAtIndex(steps, frameLoadType));
 }
 
 bool WebLocalFrameLoaderClient::shouldFallBack(const ResourceError& error) const

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -177,6 +177,8 @@ private:
     bool supportsAsyncShouldGoToHistoryItem() const final;
     void shouldGoToHistoryItemAsync(WebCore::HistoryItem&, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&) const final;
 
+    void dispatchGoToBackForwardItemAtIndex(int steps, WebCore::FrameLoadType) final;
+
     void didFinishServiceWorkerPageRegistration(bool success) final;
     
     void loadStorageAccessQuirksIfNeeded() final;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2479,8 +2479,13 @@ void WebPage::goToBackForwardItem(GoToBackForwardItemParameters&& parameters)
     if (RefPtr historyItemFrame = WebProcess::singleton().webFrame(item->frameID()); historyItemFrame && historyItemFrame->page() == this)
         targetFrame = historyItemFrame.releaseNonNull();
 
-    if (RefPtr targetLocalFrame = targetFrame->provisionalFrame() ? targetFrame->provisionalFrame() : targetFrame->coreLocalFrame())
+    if (RefPtr targetLocalFrame = targetFrame->provisionalFrame() ? targetFrame->provisionalFrame() : targetFrame->coreLocalFrame()) {
+        if (!targetLocalFrame->loader().shouldProceedWithAsyncBackForwardNavigation()) {
+            WEBPAGE_RELEASE_LOG(Loading, "goToBackForwardItem: Skipping because pending async back/forward traversal was cancelled");
+            return;
+        }
         protect(corePage())->goToItem(*targetLocalFrame, *item, parameters.backForwardType, parameters.shouldTreatAsContinuingLoad);
+    }
 }
 
 // GoToBackForwardItemWaitingForProcessLaunch should never be sent to the WebProcess. It must always be converted to a GoToBackForwardItem message.

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
@@ -163,6 +163,8 @@ private:
     bool supportsAsyncShouldGoToHistoryItem() const final;
     void shouldGoToHistoryItemAsync(WebCore::HistoryItem&, CompletionHandler<void(WebCore::ShouldGoToHistoryItem)>&&) const final;
 
+    void dispatchGoToBackForwardItemAtIndex(int steps, WebCore::FrameLoadType) final;
+
     void loadStorageAccessQuirksIfNeeded() final { }
 
     bool shouldFallBack(const WebCore::ResourceError&) const final;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1121,6 +1121,11 @@ void WebFrameLoaderClient::shouldGoToHistoryItemAsync(WebCore::HistoryItem&, Com
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+void WebFrameLoaderClient::dispatchGoToBackForwardItemAtIndex(int, WebCore::FrameLoadType)
+{
+    // Not needed in WebKitLegacy — single process, useUIProcessForBackForwardItemLoading is never enabled.
+}
+
 bool WebFrameLoaderClient::shouldFallBack(const WebCore::ResourceError& error) const
 {
     // FIXME: Needs to check domain.


### PR DESCRIPTION
#### 605dd739a520cdbac4dbd820af47273fc8f902d6
<pre>
fix test failures when UseUIProcessForBackForwardItemLoading is enabled

This commit fixes 6 test failures that occur when the
UseUIProcessForBackForwardItemLoading flag is enabled.

Fix 1: Handle history.go(0) as reload before the flag check

history.go(0) is semantically a reload, not a back-forward navigation.
The flag-OFF path detected this by comparing the current item&apos;s ID with
the target item&apos;s ID (which required sync IPC). Since m_steps == 0
is sufficient to identify go(0), we can handle it before the flag check
with no IPC needed, and remove the old go(0) detection code that is now
unreachable.

Fixed tests:
- fast/dom/DOMImplementation/createDocument-with-used-doctype.html
- fast/frames/url-selected-crash.html
- imported/.../navigate-event/navigate-history-go-0.html
- imported/.../iframe_history_go_0.html

Fix 2: Cancel pending async back-forward navigation on fragment scroll

cancelPendingAsyncBackForwardNavigation() was only called in
loadWithDocumentLoader(). Fragment navigations go through
continueFragmentScrollAfterNavigationPolicy() which did not cancel
pending async BF navigations. A fragment change (e.g. location=&apos;#foo&apos;)
after history.back() should cancel the pending back navigation, but
without this fix the UIProcess response would arrive later and proceed
with the stale navigation.

Fixed test:
- http/tests/history/back-with-fragment-change.py

Fix 3: Clear async BF navigation state when child frame load begins

When UseUIProcessForBackForwardItemLoading is enabled, child frame
back-forward loading goes through dispatchBackForwardItemLoading →
UIProcess → policy callback → loadRequestedHistoryItem. The
setPendingAsyncBackForwardNavigation() call in the policy dispatch
set m_asyncBackForwardNavigationState to Pending, but it was never
reset to None when the actual load began.

This caused preventsParentFromBeingComplete() to return true
(via isWaitingForAsyncBackForwardNavigation()) even after the child
frame&apos;s load was underway. In the specific case of an uncached POST
iframe, the retryAfterFailedCacheOnlyMainResourceLoad() calls
stopAllLoaders() which would normally allow the child frame to
complete (as about:blank) and cascade to parent completion. With the
Pending state stuck, the parent was blocked from completing, the retry
had time to re-submit the POST, and the iframe showed content that
should not have appeared.

The fix clears the async state by calling
shouldProceedWithAsyncBackForwardNavigation() just before
loadRequestedHistoryItem(), since at that point the UIProcess has
resolved the HistoryItem and the load proceeds via normal
DocumentLoader mechanisms. Also adds cancelPendingAsyncBackForwardNavigation()
in the fallback path where no HistoryItem is found.

Fixed test:
- http/tests/navigation/post-frames-goback1-uncached.html

Co-Authored-By: Claude Opus 4.6 (1M context) &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### 925bda8783bff67d54decdbcbb292dc93a032f60
<pre>
make sure historyItem tree after BF navigation is as same as normal navigation
</pre>
----------------------------------------------------------------------
#### 5cf0f3e9114c445032627105b54eb9610dca8dda
<pre>
reduce the frame info to the target frame only
</pre>
----------------------------------------------------------------------
#### 56f68126fcfc276a95c642ce47e8371078b5665f
<pre>
[Site Isolation] Support history.back() for cross-site iframe back-forward navigation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=309366">https://bugs.webkit.org/show_bug.cgi?id=309366</a>
<a href="https://rdar.apple.com/171918182">rdar://171918182</a>

Reviewed by NOBODY (OOPS!).

With site isolation enabled, history.back() and history.go(n) triggered from
JavaScript in a page containing cross-site iframes does not work correctly.
The NavigationScheduler bypasses the UIProcess-driven back-forward navigation
path and directly calls page-&gt;goToItem(), which fails because the correct
frame state is not resolved for cross-site iframes.

The fix sends the step count to the UIProcess via a new GoToBackForwardItemAtIndex
IPC message, letting the UIProcess resolve the correct back-forward item and
child frame state before initiating navigation. This eliminates sync IPCs from
the scheduling path and aligns with the UIProcess-driven architecture.

Key changes:

1. New async traversal mechanism: ScheduledHistoryNavigation now sends only the
   step count to the UIProcess via dispatchGoToBackForwardItemAtIndex, instead of
   resolving the HistoryItem locally. The UIProcess looks up the item via
   itemAtIndex(), resolves the navigated child frame, and calls goToBackForwardItem().

2. Deferred HistoryItem lookup: ScheduledHistoryNavigation no longer fetches the
   HistoryItem at schedule time (which required a sync IPC). Instead, it lazily
   resolves the item only when needed for isSameDocumentNavigation() checks. When
   the flag is enabled, fire() only uses the step count, avoiding the sync IPC
   entirely. When the flag is disabled, the lazy lookup produces identical behavior
   to the previous eager lookup.

3. Async back-forward navigation state machine: A tri-state (None/Pending/Cancelled)
   in FrameLoader tracks the lifecycle of async traversals. The state is only set to
   Pending when the flag is enabled. Fragment navigations and other new loads set it
   to Cancelled; WebPage::goToBackForwardItem() checks and skips cancelled traversals.
   Both Pending and Cancelled prevent parent frame early completion via
   preventsParentFromBeingComplete().

4. Steps adjustment for overlapping same-document navigations: Per spec, same-document
   navigations (fragment changes, pushState) must not cancel traversals. When they add
   a new back-forward entry, the pending step count is adjusted (decremented for back,
   cancelled for forward) so the UIProcess resolves the correct target item despite
   the shifted list. This adjustment is only meaningful when the flag is enabled, as
   the non-flag path uses the already-resolved HistoryItem directly.

All behavioral changes are guarded by the UseUIProcessForBackForwardItemLoading
preference flag (currently &quot;unstable&quot; status). When the flag is disabled, the
existing code paths are unchanged (except 2).

Tests: http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html

* LayoutTests/fast/css/target-fragment-match.html:
* LayoutTests/fast/dom/location-hash.html:
* LayoutTests/fast/history/history-scroll-restoration.html:
* LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache-expected.txt:
* LayoutTests/http/tests/site-isolation/history/back-iframe-cross-site-no-bf-cache.html:
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::EmptyFrameLoaderClient::dispatchGoToBackForwardItemAtIndex):
* Source/WebCore/loader/EmptyFrameLoaderClient.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didBeginDocument):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::continueFragmentScrollAfterNavigationPolicy):
(WebCore::FrameLoader::setPendingAsyncBackForwardNavigation):
(WebCore::FrameLoader::cancelPendingAsyncBackForwardNavigation):
(WebCore::FrameLoader::shouldProceedWithAsyncBackForwardNavigation):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::updateBackForwardListForFragmentScroll):
(WebCore::HistoryController::pushState):
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledNavigation::isSameDocumentNavigation):
(WebCore::ScheduledNavigation::adjustForNewBackForwardEntry):
(WebCore::ScheduledHistoryNavigation::fire):
(WebCore::ScheduledHistoryNavigation::isSameDocumentNavigation):
(WebCore::ScheduledHistoryNavigation::adjustForNewBackForwardEntry):
(WebCore::ScheduledHistoryNavigation::targetHistoryItem):
(WebCore::NavigationScheduler::scheduleHistoryNavigation):
(WebCore::NavigationScheduler::adjustPendingHistoryNavigationForNewBackForwardEntry):
* Source/WebCore/loader/NavigationScheduler.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::preventsParentFromBeingComplete const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::goToBackForwardItemAtIndex):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchGoToBackForwardItemAtIndex):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::goToBackForwardItem):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::dispatchGoToBackForwardItemAtIndex):
</pre>
----------------------------------------------------------------------
#### b1b67ae05030fc3476ae59613cec9fa57cc83d06
<pre>
set the flag testable
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/605dd739a520cdbac4dbd820af47273fc8f902d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157964 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102703 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21863 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115095 "Found 8 new test failures: fast/loader/form-state-restore-with-frames.html http/tests/misc/resource-timing-navigation-in-restored-iframe.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/popstate_event.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal.html imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/history_back_cross_realm_method.html imported/w3c/web-platform-tests/html/browsers/history/the-history-interface/history_go_cross_realm_method.html imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81909 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/39073d06-2046-4098-8f08-c27a1ef43199) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152232 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17254 "Found 1 new test failure: fast/loader/form-state-restore-with-frames.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133940 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95844 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/06db06cd-ae9f-4b6a-be13-c7839f03b4f5) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16353 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/popstate_event.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14227 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5814 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141242 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125953 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160446 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10063 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3442 "Found 1 new failure in UIProcess/WebPageProxy.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13409 "Found 3 new test failures: fast/loader/form-state-restore-with-frames.html http/tests/misc/resource-timing-navigation-in-restored-iframe.html imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123136 "Found 4 new test failures: fast/loader/form-state-restore-with-frames.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal.html imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21788 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18267 "Found 6 new test failures: fast/history/history-subframe-with-name.html fast/loader/form-state-restore-with-frames.html http/tests/misc/resource-timing-navigation-in-restored-iframe.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-cross-document-traversal.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/overlapping-navigations-and-traversals/cross-document-traversal-same-document-traversal.html imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123354 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133673 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77996 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18598 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10419 "Found 2 new test failures: fast/loader/form-state-restore-with-frames.html http/tests/misc/resource-timing-navigation-in-restored-iframe.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180701 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21397 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85210 "Found 1 new failure in UIProcess/WebPageProxy.cpp") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46305 "Build was cancelled. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21129 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21278 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21186 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->