### PR TITLE
SHOULD NEVER BE REACHED in ScrollingStateNode::insertChild()

### DIFF
--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/sticky-in-scrollable-crash-expected.txt
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/sticky-in-scrollable-crash-expected.txt
@@ -1,0 +1,3 @@
+PASS if no crash.
+
+

--- a/LayoutTests/compositing/scrolling/async-overflow-scrolling/sticky-in-scrollable-crash.html
+++ b/LayoutTests/compositing/scrolling/async-overflow-scrolling/sticky-in-scrollable-crash.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script>
+  window.testRunner?.dumpAsText();
+</script>
+<style>
+  .c {
+      overflow: scroll;
+      block-size: 100px;
+      background: pink;
+  }
+  .x {
+      overflow: scroll;
+      position: sticky;
+      top: 0;
+      block-size: 200px;
+      background: green;
+  }
+  .y {
+      block-size: 500px;
+      inline-size: 500px;
+      background: cyan;
+  }
+</style>
+
+<p>PASS if no crash.</p>
+
+<div class=c>
+  <div class=x>
+    <div class=y></div>
+  </div>
+</div>
+

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -140,6 +140,9 @@ imported/w3c/web-platform-tests/svg/text/reftests/opacity.svg [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_media_queries.html [ Pass ]
 imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/embedded_style_media_queries_resized.html [ Pass ]
 
+compositing/scrolling/async-overflow-scrolling [ Pass ]
+compositing/scrolling/async-overflow-scrolling/mac [ Skip ]
+
 # RSA-PSS tests are for now skipped on all ports, so we for now explicitly enable the passing ones here.
 crypto/subtle/ecdh-import-pkcs8-key-p256-validate-ecprivatekey-parameters-publickey.html [ Pass ]
 crypto/subtle/ecdh-import-pkcs8-key-p384-validate-ecprivatekey-parameters-publickey.html [ Pass ]

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -5672,6 +5672,7 @@ std::optional<ScrollingNodeID> RenderLayerCompositor::updateScrollCoordinationFo
         newNodeID = updateScrollingNodeForPositioningRole(layer, compositingAncestor, *currentTreeState, changes);
         childTreeState.parentNodeID = newNodeID;
         childTreeState.hasParent = true;
+        childTreeState.nextChildIndex = 0;
         currentTreeState = &childTreeState;
     } else
         detachScrollCoordinatedLayer(layer, ScrollCoordinationRole::Positioning);
@@ -5681,6 +5682,7 @@ std::optional<ScrollingNodeID> RenderLayerCompositor::updateScrollCoordinationFo
         newNodeID = updateScrollingNodeForScrollingProxyRole(layer, *currentTreeState, changes);
         childTreeState.parentNodeID = newNodeID;
         childTreeState.hasParent = true;
+        childTreeState.nextChildIndex = 0;
         currentTreeState = &childTreeState;
     } else
         detachScrollCoordinatedLayer(layer, ScrollCoordinationRole::ScrollingProxy);
@@ -5691,6 +5693,7 @@ std::optional<ScrollingNodeID> RenderLayerCompositor::updateScrollCoordinationFo
         // ViewportConstrained nodes are the parent of same-layer scrolling nodes, so adjust the ScrollingTreeState.
         childTreeState.parentNodeID = newNodeID;
         childTreeState.hasParent = true;
+        childTreeState.nextChildIndex = 0;
         currentTreeState = &childTreeState;
     } else
         detachScrollCoordinatedLayer(layer, ScrollCoordinationRole::ViewportConstrained);


### PR DESCRIPTION
#### 53d54af388d64c83015cc8beeb75790d2d23aec5
<pre>
SHOULD NEVER BE REACHED in ScrollingStateNode::insertChild()
<a href="https://bugs.webkit.org/show_bug.cgi?id=309156">https://bugs.webkit.org/show_bug.cgi?id=309156</a>

Reviewed by Simon Fraser.

An assertion failed in ScrollingStateNode::insertChild() because the argument
`index` exceeded the child count.

RenderLayerCompositor::updateScrollCoordinationForLayer should reset
childTreeState.nextChildIndex if it sets a new parent.

Unskipped compositing/scrolling/async-overflow-scrolling test directory for
glib port as well as Mac and iOS ports do.

Test: compositing/scrolling/async-overflow-scrolling/sticky-in-scrollable-crash.html

* LayoutTests/compositing/scrolling/async-overflow-scrolling/sticky-in-scrollable-crash-expected.txt: Added.
* LayoutTests/compositing/scrolling/async-overflow-scrolling/sticky-in-scrollable-crash.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateScrollCoordinationForLayer):

Canonical link: <a href="https://commits.webkit.org/308838@main">https://commits.webkit.org/308838@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/213c91f13ccbf1ed711cdecea320126734a1015a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157147 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101893 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150336 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114450 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81526 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133284 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95220 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15777 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13607 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4583 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159480 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2614 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12713 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122494 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122717 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20956 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132999 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77108 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22899 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18081 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9757 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20564 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84349 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20296 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20441 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20350 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->