### PR TITLE
[Smart Lists] Can’t create a numbered list using a RTL language

### DIFF
--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -143,7 +143,7 @@ bool InsertTextCommand::applySmartListsIfNeeded()
     if (!selectionAllowsSmartLists(m_text, endingSelection()))
         return false;
 
-    auto lineStart = startOfLine(endingSelection().visibleBase());
+    auto lineStart = logicalStartOfLine(endingSelection().visibleBase());
     if (lineStart.isNull() || lineStart.isOrphan()) {
         ASSERT_NOT_REACHED();
         return false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
@@ -96,10 +96,10 @@ static RetainPtr<NSMenu> invokeContextMenu(TestWKWebView *webView)
 
 #endif // PLATFORM(MAC)
 
-static void runTest(NSString *input, NSString *expectedHTML, NSString *expectedSelectionPath, NSInteger selectionOffset, NSString *stylesheet = nil)
+static void runTest(NSString *input, NSString *expectedHTML, NSString *expectedSelectionPath, NSInteger selectionOffset, NSString *stylesheet = nil, bool isRTL = false)
 {
     RetainPtr expectedSelection = [SmartListsTestSelectionConfiguration caretSelectionWithPath:expectedSelectionPath offset:selectionOffset];
-    RetainPtr configuration = [[SmartListsTestConfiguration alloc] initWithExpectedHTML:expectedHTML expectedSelection:expectedSelection.get() input:input stylesheet:stylesheet];
+    RetainPtr configuration = adoptNS([[SmartListsTestConfiguration alloc] initWithExpectedHTML:expectedHTML expectedSelection:expectedSelection.get() input:input stylesheet:stylesheet isRTL:isRTL]);
 
     __block bool finished = false;
     __block RetainPtr<SmartListsTestResult> result;
@@ -527,6 +527,17 @@ TEST(SmartLists, GeneratedSmartListsHaveAssociatedClassNames)
     RetainPtr expectedHTML = WTF::makeStringByReplacingAll(expectedHTMLTemplate, "<DASH_MARKER>"_s, dashMarker).createNSString();
 
     runTest(@"* A\n\n1. B\n\n- C", expectedHTML.get(), @"//body/div/div/ul/li/text()", 1, css.createNSString().get());
+}
+
+TEST(SmartLists, OrderedSmartListWithRTL)
+{
+    RetainPtr expectedHTML = @"<body dir=\"rtl\" contenteditable=\"\">"
+    "<ol start=\"1\" style=\"list-style-type: decimal;\" class=\"Apple-decimal-list\" webkitsmartlistmarker=\"1.\">"
+        "<li>تفاحة</li>"
+    "</ol>"
+    "</body>";
+
+    runTest(@"1. تفاحة", expectedHTML.get(), @"//body/ol/li[1]/text()", @"تفاحة".length, nullptr, true);
 }
 
 #endif // ENABLE_SWIFTUI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.h
@@ -51,7 +51,7 @@ NS_SWIFT_UI_ACTOR
 NS_SWIFT_UI_ACTOR
 @interface SmartListsTestConfiguration : NSObject
 
-- (instancetype)initWithExpectedHTML:(NSString *)expectedHTML expectedSelection:(SmartListsTestSelectionConfiguration *)expectedSelection input:(NSString *)input stylesheet:(nullable NSString *)stylesheet;
+- (instancetype)initWithExpectedHTML:(NSString *)expectedHTML expectedSelection:(SmartListsTestSelectionConfiguration *)expectedSelection input:(NSString *)input stylesheet:(nullable NSString *)stylesheet isRTL:(BOOL)isRTL;
 
 @end
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.swift
@@ -49,12 +49,14 @@ extension SmartListsTestConfiguration {
     fileprivate let expectedSelection: SmartListsTestSelectionConfiguration
     fileprivate let input: String
     fileprivate let stylesheet: String?
+    fileprivate let isRTL: Bool
 
-    init(expectedHTML: String, expectedSelection: SmartListsTestSelectionConfiguration, input: String, stylesheet: String?) {
+    init(expectedHTML: String, expectedSelection: SmartListsTestSelectionConfiguration, input: String, stylesheet: String?, isRTL: Bool) {
         self.expectedHTML = expectedHTML
         self.expectedSelection = expectedSelection
         self.input = input
         self.stylesheet = stylesheet
+        self.isRTL = isRTL
     }
 }
 
@@ -88,6 +90,7 @@ extension SmartListsSupport {
         #endif
 
         let template = """
+            \(configuration.isRTL ? "<html dir='rtl'>" : "<html>")
             <head>
               <meta charset="UTF-8">
             </head>


### PR DESCRIPTION
#### 32f01c92749cdfc19b67488b6b7cf0363eb0ebb4
<pre>
[Smart Lists] Can’t create a numbered list using a RTL language
<a href="https://bugs.webkit.org/show_bug.cgi?id=309314">https://bugs.webkit.org/show_bug.cgi?id=309314</a>
<a href="https://rdar.apple.com/167786169">rdar://167786169</a>

Reviewed by Richard Robinson, Ryosuke Niwa, Wenson Hsieh, and Abrar Rahman Protyasha.

Smart lists do not work with RTL languages because
InsertTextCommand::applySmartListsIfNeeded() uses
startOfLine() which does not support bidi levels.
To fix this, use logicalStartOfLine() instead which
does support bidi levels.

Additionally, write an API test for creating ordered
smart lists with RTL languages. The current SmartListsSupport
does not support RTL so include a check if in RTL, then add the
dir attribute to specify the text direction.

Lastly, fix the memory leak in runTest by using adoptNS.

* Source/WebCore/editing/InsertTextCommand.cpp:
(WebCore::InsertTextCommand::applySmartListsIfNeeded):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm:
(runTest):
((SmartLists, OrderedSmartListWithRTL)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.swift:
(SmartListsSupport.processConfiguration(_:)):

Canonical link: <a href="https://commits.webkit.org/308811@main">https://commits.webkit.org/308811@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b2eeb585e67387987f934fd7513c4ede1375872

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157169 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150358 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114466 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b82839cb-5245-4be1-97a8-573a7ba41321) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151445 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133302 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95236 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15793 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13620 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4605 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125405 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159502 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2636 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12735 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122514 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20969 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122736 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33384 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20978 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133010 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77130 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18086 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9777 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20586 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84420 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20318 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20463 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20372 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->