### PR TITLE
[JSC] Add tracing to HandlerIC

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -54,6 +54,7 @@
 #include "JSWebAssemblyInstance.h"
 #include "LLIntThunks.h"
 #include "LinkBuffer.h"
+#include "MacroAssemblerPrinter.h"
 #include "MaxFrameExtentForSlowPathCall.h"
 #include "MegamorphicCache.h"
 #include "ModuleNamespaceAccessCase.h"
@@ -76,6 +77,19 @@ namespace JSC {
 
 namespace InlineCacheCompilerInternal {
 static constexpr bool verbose = false;
+static constexpr bool traceHandlerExecution = false;
+}
+
+template<typename... Args>
+static void traceHandler(CCallHelpers& jit, Args&&... args)
+{
+    if constexpr (InlineCacheCompilerInternal::traceHandlerExecution) {
+#if CPU(ARM64)
+        jit.println("IC: ", std::forward<Args>(args)..., " ", Printer::PCRegister(), " ", CCallHelpers::linkRegister);
+#else
+        jit.println("IC: ", std::forward<Args>(args)..., " ", Printer::PCRegister());
+#endif
+    }
 }
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(PolymorphicAccess);
@@ -1302,6 +1316,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByIdSlowPathCodeGenerator(VM& vm
     using BaselineJITRegisters::GetById::stubInfoGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "GetById slow path");
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1330,6 +1345,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByIdWithThisSlowPathCodeGenerato
     using BaselineJITRegisters::GetByIdWithThis::stubInfoGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "GetByIdWithThis slow path");
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1359,6 +1375,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValSlowPathCodeGenerator(VM& v
     using BaselineJITRegisters::GetByVal::profileGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "GetByVal slow path");
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1387,6 +1404,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getPrivateNameSlowPathCodeGenerator
     using BaselineJITRegisters::PrivateBrand::stubInfoGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "GetPrivateName slow path");
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1418,6 +1436,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithThisSlowPathCodeGenerat
     using BaselineJITRegisters::GetByValWithThis::profileGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "GetByValWithThis slow path");
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1447,6 +1466,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByIdSlowPathCodeGenerator(VM& vm
     using BaselineJITRegisters::PutById::stubInfoGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "PutById slow path");
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1477,6 +1497,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValSlowPathCodeGenerator(VM& v
     using BaselineJITRegisters::PutByVal::stubInfoGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "PutByVal slow path");
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1508,6 +1529,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> instanceOfSlowPathCodeGenerator(VM&
     using BaselineJITRegisters::Instanceof::stubInfoGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "InstanceOf slow path");
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1535,6 +1557,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> delByIdSlowPathCodeGenerator(VM& vm
     using BaselineJITRegisters::DelById::stubInfoGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "DeleteById slow path");
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1563,6 +1586,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> delByValSlowPathCodeGenerator(VM& v
     using BaselineJITRegisters::DelByVal::stubInfoGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "DeleteByVal slow path");
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -5220,6 +5244,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByIdLoadHandlerImpl(VM& vm)
     using BaselineJITRegisters::GetById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "GetById Load ", ownProperty ? "OwnProperty" : "PrototypeProperty", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5259,6 +5284,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdMissHandler(VM&)
     using BaselineJITRegisters::GetById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "GetById Miss handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5322,6 +5348,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByIdCustomHandlerImpl(VM& vm)
     using BaselineJITRegisters::GetById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "GetById Custom ", isAccessor ? "Accessor" : "Value", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5418,6 +5445,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdGetterHandler(VM& vm)
     using BaselineJITRegisters::GetById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "GetById Getter handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5444,6 +5472,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdProxyObjectLoadHandler(VM&)
     using BaselineJITRegisters::GetById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "GetById ProxyObjectLoad handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5519,6 +5548,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdModuleNamespaceLoadHandler(VM&)
     using BaselineJITRegisters::GetById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "GetById ModuleNamespaceLoad handler");
 
     CCallHelpers::JumpList fallThrough;
     CCallHelpers::JumpList failAndIgnore;
@@ -5555,6 +5585,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> putByIdReplaceHandler(VM&)
     using BaselineJITRegisters::PutById::scratch2GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "PutById Replace handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5653,6 +5684,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByIdTransitionHandlerImpl(VM& vm
     using BaselineJITRegisters::PutById::scratch4GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "PutById Transition handler");
 
     CCallHelpers::JumpList fallThrough;
     CCallHelpers::JumpList allocationFailure;
@@ -5714,6 +5746,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> putByIdTransitionReallocatingOutOfLineHand
     using BaselineJITRegisters::PutById::scratch1GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "PutById TransitionReallocatingOutOfLine handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5781,6 +5814,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByIdCustomHandlerImpl(VM& vm)
     using BaselineJITRegisters::PutById::scratch3GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "PutById Custom ", isAccessor ? "Accessor" : "Value", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5885,6 +5919,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByIdSetterHandlerImpl(VM& vm)
     using BaselineJITRegisters::PutById::scratch2GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "PutById ", isStrict ? "Strict" : "Sloppy", " Setter handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5924,6 +5959,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> inByIdInHandlerImpl(VM&)
     using BaselineJITRegisters::InById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "InById ", hit ? "Hit" : "Miss", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5963,6 +5999,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> deleteByIdDeleteHandler(VM&)
     using BaselineJITRegisters::DelById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "DeleteById Delete handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5994,6 +6031,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> deleteByIdIgnoreHandlerImpl(VM&)
     using BaselineJITRegisters::DelById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "DeleteById ", returnValue ? "Miss" : "NonConfigurable", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6034,6 +6072,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> instanceOfHandlerImpl(VM&)
     using BaselineJITRegisters::Instanceof::scratch1GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "InstanceOf ", hit ? "Hit" : "Miss", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6076,6 +6115,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValLoadHandlerImpl(VM& vm)
     using BaselineJITRegisters::GetByVal::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "GetByVal Load ", ownProperty ? "OwnProperty" : "PrototypeProperty", isSymbol ? " Symbol" : " String", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6133,6 +6173,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValMissHandlerImpl(VM&)
     using BaselineJITRegisters::GetByVal::profileGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "GetByVal Miss ", isSymbol ? "Symbol" : "String", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6176,6 +6217,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValCustomHandlerImpl(VM& vm)
     using BaselineJITRegisters::GetByVal::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "GetByVal Custom ", isAccessor ? "Accessor" : "Value", isSymbol ? " Symbol" : " String", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6234,6 +6276,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValGetterHandlerImpl(VM& vm)
     using BaselineJITRegisters::GetByVal::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "GetByVal Getter ", isSymbol ? "Symbol" : "String", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6276,6 +6319,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValReplaceHandlerImpl(VM&)
     using BaselineJITRegisters::PutByVal::scratch2GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "PutByVal Replace ", isSymbol ? "Symbol" : "String", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6320,6 +6364,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValTransitionHandlerImpl(VM& v
     using BaselineJITRegisters::PutByVal::profileGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "PutByVal Transition ", isSymbol ? "Symbol" : "String", " handler");
 
     CCallHelpers::JumpList fallThrough;
     CCallHelpers::JumpList allocationFailure;
@@ -6413,6 +6458,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValTransitionOutOfLineHandlerI
     using BaselineJITRegisters::PutByVal::scratch1GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "PutByVal TransitionOutOfLine ", isSymbol ? "Symbol" : "String", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6461,6 +6507,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValCustomHandlerImpl(VM& vm)
     using BaselineJITRegisters::PutByVal::profileGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "PutByVal Custom ", isAccessor ? "Accessor" : "Value", isSymbol ? " Symbol" : " String", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6522,6 +6569,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValSetterHandlerImpl(VM& vm)
     using BaselineJITRegisters::PutByVal::profileGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "PutByVal ", isStrict ? "Strict" : "Sloppy", " Setter ", isSymbol ? "Symbol" : "String", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6578,6 +6626,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> inByValInHandlerImpl(VM&)
     using BaselineJITRegisters::InByVal::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "InByVal ", hit ? "Hit" : "Miss", isSymbol ? " Symbol" : " String", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6636,6 +6685,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> deleteByValDeleteHandlerImpl(VM&)
     using BaselineJITRegisters::DelByVal::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "DeleteByVal Delete ", isSymbol ? "Symbol" : "String", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6669,6 +6719,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> deleteByValIgnoreHandlerImpl(VM&)
     using BaselineJITRegisters::DelByVal::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "DeleteByVal ", returnValue ? "Miss" : "NonConfigurable", isSymbol ? " Symbol" : " String", " handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6735,6 +6786,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> checkPrivateBrandHandler(VM&)
     using BaselineJITRegisters::PrivateBrand::scratch1GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "CheckPrivateBrand handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6761,6 +6813,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> setPrivateBrandHandler(VM&)
     using BaselineJITRegisters::PrivateBrand::scratch1GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "SetPrivateBrand handler");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -7549,6 +7602,7 @@ AccessGenerationResult InlineCacheCompiler::compileOneAccessCaseHandler(const Ve
     m_jit = &jit;
 
     emitDataICPrologue(*m_jit);
+    traceHandler(jit, "Compiled handler");
 
     m_preservedReusedRegisterState = allocator.preserveReusedRegistersByPushing(jit, ScratchRegisterAllocator::ExtraStackSpace::NoExtraSpace);
 
@@ -7671,6 +7725,7 @@ MacroAssemblerCodeRef<JITStubRoutinePtrTag> InlineCacheCompiler::compileGetByDOM
     m_jit = &jit;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
+    traceHandler(jit, "DOMJIT handler");
 
     CCallHelpers::JumpList fallThrough;
 


### PR DESCRIPTION
#### d0488c39341e2804b3e47064edf7ac3490e3b377
<pre>
[JSC] Add tracing to HandlerIC
<a href="https://bugs.webkit.org/show_bug.cgi?id=309325">https://bugs.webkit.org/show_bug.cgi?id=309325</a>
<a href="https://rdar.apple.com/171863050">rdar://171863050</a>

Reviewed by Yusuke Suzuki.

When debugging HandlerIC it can be difficult to know which cases you
passed through as HandlerIC is built on tail calling the next handler.
This patch adds a compile time tracing flag so it will print each
handler case as it executes. On ARM64 it also prints the callers return
address as it&apos;s still in the link register.

No new tests, code is compiled out by default.

Canonical link: <a href="https://commits.webkit.org/308773@main">https://commits.webkit.org/308773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38d0611c01417a53ae36d25da6eed46bd3f4fdea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21137 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/14733 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/157135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/21594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21042 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/157135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151411 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/21594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/157135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/21594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/4571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/140418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/21594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/11177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159468 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/9238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/2602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/12696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/122482 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/20935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/17578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122704 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33359 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/132988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77096 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/9740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/179878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/20552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/179878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->