### PR TITLE
Remove non isolated where it’s not needed

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift
@@ -27,7 +27,7 @@
 @_weakLinked @_spi(UsdLoaderAPI) internal import _USDKit_RealityKit
 @_spi(RealityCoreRendererAPI) import RealityKit
 
-nonisolated func makeParameters(
+func makeParameters(
     for function: any _Proto_LowLevelMaterialResource_v1.Function,
     renderContext: any _Proto_LowLevelRenderContext_v1,
     buffers: [_Proto_LowLevelBufferSpan_v1] = [],
@@ -43,7 +43,7 @@ nonisolated func makeParameters(
     )
 }
 
-nonisolated func makeParameters(
+func makeParameters(
     for material: _Proto_LowLevelMaterialResource_v1,
     renderContext: any _Proto_LowLevelRenderContext_v1,
     geometryBuffers: [_Proto_LowLevelBufferSpan_v1] = [],

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -35,7 +35,7 @@ internal struct CameraTransform {
     var scale: simd_float3
 }
 
-nonisolated class Renderer {
+class Renderer {
     let device: any MTLDevice
     let commandQueue: any MTLCommandQueue
     var renderContext: (any _Proto_LowLevelRenderContext_v1)?

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
@@ -30,7 +30,7 @@ internal import Metal
 @_spi(RealityCoreRendererAPI) import RealityKit
 @_spi(SGInternal) import RealityKit
 
-nonisolated func mapSemantic(_ semantic: LowLevelMesh.VertexSemantic) -> _Proto_LowLevelMeshResource_v1.VertexSemantic {
+func mapSemantic(_ semantic: LowLevelMesh.VertexSemantic) -> _Proto_LowLevelMeshResource_v1.VertexSemantic {
     switch semantic {
     case .position: .position
     case .color: .color
@@ -51,7 +51,7 @@ nonisolated func mapSemantic(_ semantic: LowLevelMesh.VertexSemantic) -> _Proto_
 }
 
 extension _Proto_LowLevelMeshResource_v1.Descriptor {
-    nonisolated static func fromLlmDescriptor(_ llmDescriptor: LowLevelMesh.Descriptor) -> Self {
+    static func fromLlmDescriptor(_ llmDescriptor: LowLevelMesh.Descriptor) -> Self {
         var descriptor = Self.init()
         descriptor.vertexCapacity = llmDescriptor.vertexCapacity
         descriptor.vertexAttributes = llmDescriptor.vertexAttributes.map { attribute in
@@ -73,7 +73,7 @@ extension _Proto_LowLevelMeshResource_v1.Descriptor {
 }
 
 extension _Proto_LowLevelMeshResource_v1 {
-    nonisolated func replaceVertexData(_ vertexData: [Data]) {
+    func replaceVertexData(_ vertexData: [Data]) {
         for (vertexBufferIndex, vertexData) in vertexData.enumerated() {
             let bufferSizeInByte = vertexData.bytes.byteCount
             self.replaceVertices(at: vertexBufferIndex) { vertexBytes in
@@ -87,7 +87,7 @@ extension _Proto_LowLevelMeshResource_v1 {
         }
     }
 
-    nonisolated func replaceIndexData(_ indexData: Data?) {
+    func replaceIndexData(_ indexData: Data?) {
         if let indexData = indexData {
             self.replaceIndices { indicesBytes in
                 // FIXME: (rdar://164559261) understand/document/remove unsafety
@@ -100,7 +100,7 @@ extension _Proto_LowLevelMeshResource_v1 {
         }
     }
 
-    nonisolated func replaceData(indexData: Data?, vertexData: [Data]) {
+    func replaceData(indexData: Data?, vertexData: [Data]) {
         // Copy index data
         self.replaceIndexData(indexData)
 
@@ -162,7 +162,7 @@ private func mapSemantic(_ semantic: Int) -> _Proto_LowLevelMeshResource_v1.Vert
 }
 
 extension _Proto_LowLevelMeshResource_v1.Descriptor {
-    nonisolated static func fromLlmDescriptor(_ llmDescriptor: WKBridgeMeshDescriptor) -> Self {
+    static func fromLlmDescriptor(_ llmDescriptor: WKBridgeMeshDescriptor) -> Self {
         var descriptor = Self.init()
         descriptor.vertexCapacity = Int(llmDescriptor.vertexCapacity)
         descriptor.vertexAttributes = llmDescriptor.vertexAttributes.map { attribute in

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -707,9 +707,6 @@ extension WKBridgeReceiver {
                         for partIndex in 0..<partCount {
                             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                             // swift-format-ignore: NeverForceUnwrap
-                            let meshInstance = meshToMeshInstances[identifier]![instanceIndex * data.parts.count + partIndex]
-                            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
-                            // swift-format-ignore: NeverForceUnwrap
                             meshTransforms[identifier]![instanceIndex * data.parts.count + partIndex] = instanceTransform
                         }
                     }
@@ -863,7 +860,7 @@ private func webUpdateMeshRequestFromUpdateMeshRequest(
     )
 }
 
-nonisolated func webUpdateMaterialRequestFromUpdateMaterialRequest(
+func webUpdateMaterialRequestFromUpdateMaterialRequest(
     _ request: _Proto_MaterialDataUpdate_v1
 ) -> WKBridgeUpdateMaterial {
     WKBridgeUpdateMaterial(
@@ -910,7 +907,6 @@ final class USDModelLoader: _Proto_UsdStageSession_v1.Delegate {
     }
 
     func meshUpdated(data: consuming sending _Proto_MeshDataUpdate_v1) {
-        let identifier = data.identifier
         self.dispatchSerialQueue.async {
             self.objcLoader.updateMesh(webRequest: webUpdateMeshRequestFromUpdateMeshRequest(data))
         }
@@ -921,7 +917,6 @@ final class USDModelLoader: _Proto_UsdStageSession_v1.Delegate {
     }
 
     func materialUpdated(data: consuming sending _Proto_MaterialDataUpdate_v1) {
-        let identifier = data.identifier
         self.dispatchSerialQueue.async {
             self.objcLoader.updateMaterial(webRequest: webUpdateMaterialRequestFromUpdateMaterialRequest(data))
         }
@@ -932,7 +927,6 @@ final class USDModelLoader: _Proto_UsdStageSession_v1.Delegate {
     }
 
     func textureUpdated(data: consuming sending _Proto_TextureDataUpdate_v1) {
-        let identifier = data.identifier
         self.dispatchSerialQueue.async {
             self.objcLoader.updateTexture(webRequest: webUpdateTextureRequestFromUpdateTextureRequest(data))
         }


### PR DESCRIPTION
#### dc270e22ff7fb31e80397f1959236724e75e2cc9
<pre>
Remove non isolated where it’s not needed
<a href="https://bugs.webkit.org/show_bug.cgi?id=309332">https://bugs.webkit.org/show_bug.cgi?id=309332</a>
<a href="https://rdar.apple.com/171873102">rdar://171873102</a>

Reviewed by Richard Robinson.

nonisolated is serviing no purpose on these free standing functions,
so we can remove it

* Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift:
(mapSemantic(_:)):
(_Proto_LowLevelMeshResource_v1.fromLlmDescriptor(_:)):
(_Proto_LowLevelMeshResource_v1.replaceVertexData(_:)):
(_Proto_LowLevelMeshResource_v1.replaceIndexData(_:)):
(_Proto_LowLevelMeshResource_v1.replaceData(_:vertexData:)):
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:

Canonical link: <a href="https://commits.webkit.org/308862@main">https://commits.webkit.org/308862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fb726406a69f3be366805900321818495838085

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21403 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/14972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157375 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c4bd19e-08d0-4a3b-9309-dd7b1377a802) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21281 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/114621 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f16b6b6-2c63-4f70-89b1-4575f3de310c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151650 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16817 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95391 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/30ca20c8-bd09-4e82-b67a-32c9c6152863) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15929 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13776 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4810 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125528 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159710 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2850 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/12912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/122687 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21205 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17783 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122911 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33416 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21213 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/133184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77352 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/18206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/9946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20815 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84617 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20547 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20694 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20603 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->