### PR TITLE
[JSC] Cloned SymbolTable needs to be cached per JSGlobalObject

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -1071,9 +1071,17 @@ Vector<unsigned> CodeBlock::setConstantRegisters(const FixedVector<WriteBarrier<
                             symbolTable->prepareForTypeProfiling(locker);
                         }
 
-                        SymbolTable* clone = symbolTable->cloneScopePart(vm);
+                        // We have to make sure to use a single code block for constant watchpointing.
+                        // If we didn't then we could jettison a compilation because that constant changed
+                        // but invalidate the clone. Then the next compilation would see the original
+                        // watchpoint intact and assume the value is still the original constant.
+                        SymbolTable* clone = globalObject->symbolTableCache().get(symbolTable);
+                        if (!clone) {
+                            clone = symbolTable->cloneScopePart(vm);
+                            globalObject->symbolTableCache().set(symbolTable, clone);
+                        }
                         if (wasCompiledWithDebuggingOpcodes())
-                            clone->setRareDataCodeBlock(this);
+                            clone->collectDebuggerInfo(this);
 
                         constant = clone;
                     } else if (jsDynamicCast<JSTemplateObjectDescriptor*>(cell))

--- a/Source/JavaScriptCore/debugger/DebuggerScope.cpp
+++ b/Source/JavaScriptCore/debugger/DebuggerScope.cpp
@@ -203,11 +203,7 @@ String DebuggerScope::name() const
     if (!symbolTable)
         return String();
 
-    CodeBlock* codeBlock = symbolTable->rareDataCodeBlock();
-    if (!codeBlock)
-        return String();
-
-    return String::fromUTF8(codeBlock->inferredName().span());
+    return symbolTable->inferredName();
 }
 
 DebuggerLocation DebuggerScope::location() const
@@ -216,12 +212,7 @@ DebuggerLocation DebuggerScope::location() const
     if (!symbolTable)
         return DebuggerLocation();
 
-    CodeBlock* codeBlock = symbolTable->rareDataCodeBlock();
-    if (!codeBlock)
-        return DebuggerLocation();
-
-    ScriptExecutable* executable = codeBlock->ownerExecutable();
-    return DebuggerLocation(executable);
+    return symbolTable->debuggerLocation();
 }
 
 JSValue DebuggerScope::caughtValue(JSGlobalObject* globalObject) const

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -914,6 +914,7 @@ JSGlobalObject::JSGlobalObject(VM& vm, Structure* structure, const GlobalObjectM
     , m_microtaskQueue(vm.defaultMicrotaskQueue())
     , m_linkTimeConstants(numberOfLinkTimeConstants)
     , m_structureCache(vm)
+    , m_symbolTableCache(vm)
     , m_masqueradesAsUndefinedWatchpointSet(WatchpointSet::create(IsWatched))
     , m_havingABadTimeWatchpointSet(WatchpointSet::create(IsWatched))
     , m_varInjectionWatchpointSet(WatchpointSet::create(IsWatched))

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -32,6 +32,7 @@
 #include <JavaScriptCore/SourceTaintedOrigin.h>
 #include <JavaScriptCore/StructureCache.h>
 #include <JavaScriptCore/Watchpoint.h>
+#include <JavaScriptCore/WeakGCMap.h>
 #include <JavaScriptCore/WeakGCSet.h>
 #include <wtf/FixedVector.h>
 #include <wtf/RetainPtr.h>
@@ -122,6 +123,7 @@ class ShadowRealmPrototype;
 class SourceCodeKey;
 class SourceOrigin;
 class StringConstructor;
+class SymbolTable;
 class WrapperMap;
 class WrapForValidIteratorPrototype;
 
@@ -476,6 +478,7 @@ public:
     FixedVector<LazyProperty<JSGlobalObject, JSCell>> m_linkTimeConstants;
 
     StructureCache m_structureCache;
+    WeakGCMap<SymbolTable*, SymbolTable> m_symbolTableCache;
 
     String m_name;
 
@@ -1046,6 +1049,7 @@ public:
     const String& name() const { return m_name; }
 
     StructureCache& structureCache() { return m_structureCache; }
+    WeakGCMap<SymbolTable*, SymbolTable>& symbolTableCache() { return m_symbolTableCache; }
 
     inline void setUnhandledRejectionCallback(VM&, JSObject*);
     JSObject* unhandledRejectionCallback() const { return m_unhandledRejectionCallback.get(); }

--- a/Source/JavaScriptCore/runtime/SymbolTable.cpp
+++ b/Source/JavaScriptCore/runtime/SymbolTable.cpp
@@ -30,8 +30,10 @@
 #include "SymbolTable.h"
 
 #include "CodeBlock.h"
+#include "DebuggerLocation.h"
 #include "JSCJSValueInlines.h"
 #include "ResourceExhaustion.h"
+#include "ScriptExecutable.h"
 #include "TypeProfiler.h"
 
 #include <wtf/CommaPrinter.h>
@@ -98,10 +100,8 @@ void SymbolTable::visitChildrenImpl(JSCell* thisCell, Visitor& visitor)
     Base::visitChildren(thisSymbolTable, visitor);
 
     visitor.append(thisSymbolTable->m_arguments);
-    
-    if (auto* rareData = thisSymbolTable->m_rareData.get())
-        visitor.append(rareData->m_codeBlock);
-    
+    visitor.append(thisSymbolTable->m_clonedFrom);
+
     // Save some memory. This is O(n) to rebuild and we do so on the fly.
     ConcurrentJSLocker locker(thisSymbolTable->m_lock);
     thisSymbolTable->m_localToEntry = nullptr;
@@ -213,7 +213,7 @@ SymbolTable* SymbolTable::cloneScopePart(VM& vm)
                 result->m_rareData->m_privateNames.add(name.key, name.value);
         }
     }
-    
+    result->m_clonedFrom.set(vm, result, this);
     return result;
 }
 
@@ -230,19 +230,31 @@ void SymbolTable::prepareForTypeProfiling(const ConcurrentJSLocker&)
     }
 }
 
-CodeBlock* SymbolTable::rareDataCodeBlock()
+String SymbolTable::inferredName()
 {
     if (!m_rareData)
-        return nullptr;
-
-    return m_rareData->m_codeBlock.get();
+        return String();
+    return m_rareData->m_inferredName;
 }
 
-void SymbolTable::setRareDataCodeBlock(CodeBlock* codeBlock)
+DebuggerLocation SymbolTable::debuggerLocation()
+{
+    if (!m_rareData)
+        return DebuggerLocation();
+    return DebuggerLocation(m_rareData->m_debuggerSourceID, m_rareData->m_debuggerLineColumn.line, m_rareData->m_debuggerLineColumn.column);
+}
+
+void SymbolTable::collectDebuggerInfo(CodeBlock* codeBlock)
 {
     auto& rareData = ensureRareData();
-    ASSERT(!rareData.m_codeBlock);
-    rareData.m_codeBlock.set(codeBlock->vm(), this, codeBlock);
+    if (!rareData.m_inferredName.isNull())
+        return;
+    rareData.m_inferredName = String::fromUTF8(codeBlock->inferredName().span());
+    ScriptExecutable* executable = codeBlock->ownerExecutable();
+    if (!executable->isHostFunction()) {
+        rareData.m_debuggerSourceID = executable->sourceID();
+        rareData.m_debuggerLineColumn = { static_cast<unsigned>(executable->firstLine()), executable->startColumn() };
+    }
 }
 
 GlobalVariableID SymbolTable::uniqueIDForVariable(const ConcurrentJSLocker&, UniquedStringImpl* key, VM& vm)

--- a/Source/JavaScriptCore/runtime/SymbolTable.h
+++ b/Source/JavaScriptCore/runtime/SymbolTable.h
@@ -32,7 +32,9 @@
 #include <JavaScriptCore/ConstantMode.h>
 #include <JavaScriptCore/InferredValue.h>
 #include <JavaScriptCore/JSObject.h>
+#include <JavaScriptCore/LineColumn.h>
 #include <JavaScriptCore/ScopedArgumentsTable.h>
+#include <JavaScriptCore/SourceID.h>
 #include <JavaScriptCore/TypeLocation.h>
 #include <JavaScriptCore/VarOffset.h>
 #include <JavaScriptCore/VariableEnvironment.h>
@@ -43,7 +45,9 @@
 
 namespace JSC {
 
+class CodeBlock;
 class SymbolTable;
+struct DebuggerLocation;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(SymbolTableEntryFatEntry);
 
@@ -744,8 +748,9 @@ public:
 
     void prepareForTypeProfiling(const ConcurrentJSLocker&);
 
-    CodeBlock* rareDataCodeBlock();
-    void setRareDataCodeBlock(CodeBlock*);
+    String inferredName();
+    DebuggerLocation debuggerLocation();
+    void collectDebuggerInfo(CodeBlock*);
     
     InferredValue<JSScope>& singleton() { return m_singleton; }
 
@@ -770,7 +775,9 @@ public:
         UniqueIDMap m_uniqueIDMap;
         OffsetToVariableMap m_offsetToVariableMap;
         UniqueTypeSetMap m_uniqueTypeSetMap;
-        WriteBarrier<CodeBlock> m_codeBlock;
+        String m_inferredName;
+        SourceID m_debuggerSourceID { 0 };
+        LineColumn m_debuggerLineColumn;
         PrivateNameEnvironment m_privateNames;
     };
 
@@ -800,6 +807,7 @@ private:
     std::unique_ptr<SymbolTableRareData> m_rareData;
 
     WriteBarrier<ScopedArgumentsTable> m_arguments;
+    WriteBarrier<SymbolTable> m_clonedFrom;
     InferredValue<JSScope> m_singleton;
     
     std::unique_ptr<LocalToEntryVec> m_localToEntry;


### PR DESCRIPTION
#### 5980a4242cc7c060f5f3367eaac2a6480d17eb76
<pre>
[JSC] Cloned SymbolTable needs to be cached per JSGlobalObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=309335">https://bugs.webkit.org/show_bug.cgi?id=309335</a>
<a href="https://rdar.apple.com/171878104">rdar://171878104</a>

Reviewed by Keith Miller.

We observed a failure JSTests/wasm/stress/bbq-parallel-move.js.
The reason is CodeBlock jettisoning. The DFG JIT incorrectly
constant-folds a captured let variable (log) in a closure. The
variable is reassigned in a loop (log = []), but DFG treats it
as constant because the WatchpointSet it observes is never invalidated.

The cause of this issue is that SymbolTable::cloneScopePart()
creates new SymbolTableEntry objects (slim, no WatchpointSet)
instead of copying them. When a CodeBlock is jettisoned and
re-created (common with eager jettison timing + async/await),
the new CodeBlock gets a fresh clone with a fresh WatchpointSet.
The op_put_to_scope in the new CodeBlock fires the new WatchpointSet,
but the live JSLexicalEnvironment still references the old clone&apos;s
WatchpointSet (which remains IsWatched). DFG reads the old clone
from the environment, sees IsWatched, and incorrectly constant-folds.

The right fix is we should use the same SymbolTable even when CodeBlock
is recreated per JSGlobalObject. So this patch creates WeakGCMap cache
in JSGlobalObject which dedupes cloned SymbolTable so long as cloned one
is still alive.

We also remove rareDataCodeBlock as SymbolTable and CodeBlock are not
one-on-one anymore.

* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::setConstantRegisters):
* Source/JavaScriptCore/debugger/DebuggerScope.cpp:
(JSC::DebuggerScope::name const):
(JSC::DebuggerScope::location const):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::JSGlobalObject):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
(JSC::JSGlobalObject::symbolTableCache):
* Source/JavaScriptCore/runtime/SymbolTable.cpp:
(JSC::SymbolTable::visitChildrenImpl):
(JSC::SymbolTable::cloneScopePart):
(JSC::SymbolTable::inferredName):
(JSC::SymbolTable::debuggerLocation):
(JSC::SymbolTable::collectDebuggerInfo):
(JSC::SymbolTable::rareDataCodeBlock): Deleted.
(JSC::SymbolTable::setRareDataCodeBlock):
* Source/JavaScriptCore/runtime/SymbolTable.h:

Canonical link: <a href="https://commits.webkit.org/308812@main">https://commits.webkit.org/308812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9030b9f30d7a7f9e3547e9866d389cf26038ceaa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148548 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/21237 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/14830 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/157232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/21691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21139 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/157232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151508 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/21691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/157232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/21691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/4668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140515 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/21691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/11264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159567 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9335 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/2699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/12785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/122572 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/17664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/122793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/133059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22887 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/9827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179976 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20649 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->