### PR TITLE
ASSERTION FAILED: !isSkippedContentRoot(*this) in WebCore::RenderBox::foregroundIsKnownToBeOpaqueInRect

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/div-in-hidden.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/div-in-hidden.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel="author" title="Fujii Hironori" href="mailto:fujii@igalia.com">
+<link rel="help" href="https://webkit.org/b/307963">
+<style>
+  div {
+      width: 100px;
+      height: 100px;
+  }
+  .a {
+      background: green;
+  }
+  .b {
+      content-visibility: hidden;
+  }
+  .c {
+      background: red;
+  }
+</style>
+
+<div class=a>
+  <div class=b>
+    <div class=c>
+    </div>
+  </div>
+</div>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1936,6 +1936,8 @@ bool RenderBox::foregroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect, u
             continue;
         if (childBox.backgroundIsKnownToBeOpaqueInRect(childLocalRect))
             return true;
+        if (isSkippedContentRoot(childBox))
+            continue;
         if (childBox.foregroundIsKnownToBeOpaqueInRect(childLocalRect, maxDepthToTest - 1))
             return true;
     }
@@ -1944,6 +1946,7 @@ bool RenderBox::foregroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect, u
 
 bool RenderBox::computeBackgroundIsKnownToBeObscured(const LayoutPoint& paintOffset)
 {
+    ASSERT(!isSkippedContentRoot(*this));
     // Test to see if the children trivially obscure the background.
     // FIXME: This test can be much more comprehensive.
     if (!hasBackground())


### PR DESCRIPTION
#### ca3b56d49b323f7aa52bcf48a61fc369020d6078
<pre>
ASSERTION FAILED: !isSkippedContentRoot(*this) in WebCore::RenderBox::foregroundIsKnownToBeOpaqueInRect
<a href="https://bugs.webkit.org/show_bug.cgi?id=307963">https://bugs.webkit.org/show_bug.cgi?id=307963</a>

Reviewed by Alan Baradlay.

An assertion failed in RenderBox::foregroundIsKnownToBeOpaqueInRect(). It
asserts `this` is not a skipped content root because a skipped content root
paints no foregrounds and never obscure the background.

In foregroundIsKnownToBeOpaqueInRect(), if isSkippedContentRoot(childBox), we
shound&apos;t recursively call childBox.foregroundIsKnownToBeOpaqueInRect().

RenderBox::computeBackgroundIsKnownToBeObscured also calls
foregroundIsKnownToBeOpaqueInRect(). However, in this functions, `this` is not
a skipped content root. Added an assertion to ensure that.

Test: imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/div-in-hidden.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/content-visibility/crashtests/div-in-hidden.html: Added.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::foregroundIsKnownToBeOpaqueInRect const):
(WebCore::RenderBox::computeBackgroundIsKnownToBeObscured):

Canonical link: <a href="https://commits.webkit.org/308897@main">https://commits.webkit.org/308897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e947ac22d57a2b06589202cc3abd1507fa2b1f55

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148725 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15007 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157410 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102155 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114651 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81641 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95421 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15965 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13810 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4845 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125564 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159745 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2885 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122716 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17818 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122940 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133219 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77412 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22920 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18237 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9981 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20850 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84652 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20582 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20729 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20638 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->