### PR TITLE
Adopt `LIFETIME_BOUND` annotation in more places in WebCore/style

### DIFF
--- a/Source/WebCore/css/StyleSheetList.cpp
+++ b/Source/WebCore/css/StyleSheetList.cpp
@@ -45,13 +45,14 @@ StyleSheetList::StyleSheetList(ShadowRoot& shadowRoot)
 
 StyleSheetList::~StyleSheetList() = default;
 
-inline const Vector<Ref<StyleSheet>>& StyleSheetList::styleSheets() const
+template<typename Func>
+auto StyleSheetList::callOnStyleSheets(NOESCAPE const Func& apply) const
 {
     if (RefPtr document = m_document.get())
-        return document->styleScope().styleSheetsForStyleSheetList();
-    if (RefPtr shadowRoot = m_shadowRoot.get())
-        return protect(shadowRoot->styleScope())->styleSheetsForStyleSheetList();
-    return m_detachedStyleSheets;
+        return apply(protect(document->styleScope())->styleSheetsForStyleSheetList());
+    if (m_shadowRoot)
+        return apply(protect(m_shadowRoot->styleScope())->styleSheetsForStyleSheetList());
+    return apply(m_detachedStyleSheets);
 }
 
 Node* StyleSheetList::ownerNode() const
@@ -77,13 +78,16 @@ void StyleSheetList::detach()
 
 unsigned StyleSheetList::length() const
 {
-    return styleSheets().size();
+    return callOnStyleSheets([](auto& sheets) {
+        return sheets.size();
+    });
 }
 
-StyleSheet* StyleSheetList::item(unsigned index)
+RefPtr<StyleSheet> StyleSheetList::item(unsigned index) const
 {
-    const Vector<Ref<StyleSheet>>& sheets = styleSheets();
-    return index < sheets.size() ? sheets[index].ptr() : nullptr;
+    return callOnStyleSheets([index](auto& sheets) -> RefPtr<StyleSheet> {
+        return index < sheets.size() ? sheets[index].ptr() : nullptr;
+    });
 }
 
 CSSStyleSheet* StyleSheetList::namedItem(const AtomString& name) const

--- a/Source/WebCore/css/StyleSheetList.h
+++ b/Source/WebCore/css/StyleSheetList.h
@@ -43,7 +43,7 @@ public:
 
     bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }
     WEBCORE_EXPORT unsigned length() const;
-    WEBCORE_EXPORT StyleSheet* item(unsigned index);
+    WEBCORE_EXPORT RefPtr<StyleSheet> item(unsigned index) const;
 
     CSSStyleSheet* namedItem(const AtomString&) const;
     bool isSupportedPropertyName(const AtomString&) const;
@@ -56,7 +56,9 @@ public:
 private:
     StyleSheetList(Document&);
     StyleSheetList(ShadowRoot&);
-    const Vector<Ref<StyleSheet>>& styleSheets() const;
+
+    template<typename Func>
+    auto callOnStyleSheets(NOESCAPE const Func&) const;
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     WeakPtr<ShadowRoot, WeakPtrImplWithEventTargetData> m_shadowRoot;

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -73,7 +73,7 @@ public:
     void clearMatchedRules();
 
     EnumSet<PseudoElementType> matchedPseudoElements() const { return m_matchedPseudoElements; }
-    const Relations& styleRelations() const { return m_styleRelations; }
+    const Relations& styleRelations() const LIFETIME_BOUND { return m_styleRelations; }
 
     void addAuthorKeyframeRules(const StyleRuleKeyframe&);
 

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -91,22 +91,22 @@ public:
     bool isEmpty() const { return m_propertyIsPresent.isEmpty() && !m_seenLogicalGroupPropertyCount; }
 
     bool hasNormalProperty(CSSPropertyID) const;
-    const Property& normalProperty(CSSPropertyID) const;
+    const Property& normalProperty(CSSPropertyID) const LIFETIME_BOUND;
 
     bool hasLogicalGroupProperty(CSSPropertyID) const;
-    const Property& logicalGroupProperty(CSSPropertyID) const;
-    const Property* lastPropertyResolvingLogicalPropertyPair(CSSPropertyID, WritingMode) const;
+    const Property& logicalGroupProperty(CSSPropertyID) const LIFETIME_BOUND;
+    const Property* lastPropertyResolvingLogicalPropertyPair(CSSPropertyID, WritingMode) const LIFETIME_BOUND;
 
     bool hasCustomProperty(const AtomString&) const;
-    const Property& customProperty(const AtomString&) const;
+    const Property& customProperty(const AtomString&) const LIFETIME_BOUND;
 
-    std::span<const CSSPropertyID> logicalGroupPropertyIDs() const;
-    const HashMap<AtomString, Property>& customProperties() const { return m_customProperties; }
+    std::span<const CSSPropertyID> logicalGroupPropertyIDs() const LIFETIME_BOUND;
+    const HashMap<AtomString, Property>& customProperties() const LIFETIME_BOUND { return m_customProperties; }
 
     const HashSet<AnimatableCSSProperty> overriddenAnimatedProperties() const;
 
-    PropertyBitSet& propertyIsPresent() { return m_propertyIsPresent; }
-    const PropertyBitSet& propertyIsPresent() const { return m_propertyIsPresent; }
+    PropertyBitSet& propertyIsPresent() LIFETIME_BOUND { return m_propertyIsPresent; }
+    const PropertyBitSet& propertyIsPresent() const LIFETIME_BOUND { return m_propertyIsPresent; }
 
     bool applyLowPriorityOnly() const { return !m_includedProperties.ids.isEmpty(); }
 

--- a/Source/WebCore/style/PseudoElementRequest.h
+++ b/Source/WebCore/style/PseudoElementRequest.h
@@ -51,10 +51,10 @@ public:
     {
     }
 
-    const PseudoElementIdentifier& identifier() const { return m_identifier; }
+    const PseudoElementIdentifier& identifier() const LIFETIME_BOUND { return m_identifier; }
     PseudoElementType type() const { return m_identifier.type; }
-    const AtomString& nameOrPart() const { return m_identifier.nameOrPart; }
-    const std::optional<StyleScrollbarState>& scrollbarState() const { return m_scrollbarState; }
+    const AtomString& nameOrPart() const LIFETIME_BOUND { return m_identifier.nameOrPart; }
+    const std::optional<StyleScrollbarState>& scrollbarState() const LIFETIME_BOUND { return m_scrollbarState; }
 
 private:
     PseudoElementIdentifier m_identifier;

--- a/Source/WebCore/style/RuleData.h
+++ b/Source/WebCore/style/RuleData.h
@@ -70,7 +70,7 @@ public:
     bool isEnabled() const { return m_isEnabled; }
     void setEnabled(bool value) { m_isEnabled = value; }
 
-    const SelectorFilter::Hashes& descendantSelectorIdentifierHashes() const { return m_descendantSelectorIdentifierHashes; }
+    const SelectorFilter::Hashes& descendantSelectorIdentifierHashes() const LIFETIME_BOUND { return m_descendantSelectorIdentifierHashes; }
 
     void disableSelectorFiltering() { m_descendantSelectorIdentifierHashes[0] = 0; }
 

--- a/Source/WebCore/style/RuleSet.h
+++ b/Source/WebCore/style/RuleSet.h
@@ -94,34 +94,34 @@ public:
 
     std::optional<DynamicMediaQueryEvaluationChanges> evaluateDynamicMediaQueryRules(const MQ::MediaQueryEvaluator&);
 
-    const RuleFeatureSet& features() const { return m_features; }
+    const RuleFeatureSet& features() const LIFETIME_BOUND { return m_features; }
 
-    const RuleDataVector* idRules(const AtomString& key) const { return m_idRules.get(key); }
-    const RuleDataVector* classRules(const AtomString& key) const { return m_classRules.get(key); }
-    const RuleDataVector* attributeRules(const AtomString& key, bool isHTMLName) const;
-    const RuleDataVector* tagRules(const AtomString& key, bool isHTMLName) const;
-    const RuleDataVector* userAgentPartRules(const AtomString& key) const { return m_userAgentPartRules.get(key); }
-    const RuleDataVector& linkPseudoClassRules() const { return m_linkPseudoClassRules; }
-    const RuleDataVector* namedPseudoElementRules(const AtomString& key) const { return m_namedPseudoElementRules.get(key); }
+    const RuleDataVector* idRules(const AtomString& key) const LIFETIME_BOUND { return m_idRules.get(key); }
+    const RuleDataVector* classRules(const AtomString& key) const LIFETIME_BOUND { return m_classRules.get(key); }
+    const RuleDataVector* attributeRules(const AtomString& key, bool isHTMLName) const LIFETIME_BOUND;
+    const RuleDataVector* tagRules(const AtomString& key, bool isHTMLName) const LIFETIME_BOUND;
+    const RuleDataVector* userAgentPartRules(const AtomString& key) const LIFETIME_BOUND { return m_userAgentPartRules.get(key); }
+    const RuleDataVector& linkPseudoClassRules() const LIFETIME_BOUND { return m_linkPseudoClassRules; }
+    const RuleDataVector* namedPseudoElementRules(const AtomString& key) const LIFETIME_BOUND { return m_namedPseudoElementRules.get(key); }
 #if ENABLE(VIDEO)
-    const RuleDataVector& cuePseudoRules() const { return m_cuePseudoRules; }
+    const RuleDataVector& cuePseudoRules() const LIFETIME_BOUND { return m_cuePseudoRules; }
 #endif
-    const RuleDataVector& hostPseudoClassRules() const { return m_hostPseudoClassRules; }
-    const RuleDataVector& slottedPseudoElementRules() const { return m_slottedPseudoElementRules; }
-    const RuleDataVector& partPseudoElementRules() const { return m_partPseudoElementRules; }
-    const RuleDataVector& focusPseudoClassRules() const { return m_focusPseudoClassRules; }
-    const RuleDataVector& focusVisiblePseudoClassRules() const { return m_focusVisiblePseudoClassRules; }
-    const RuleDataVector& fullscreenPseudoClassRules() const { return m_fullscreenPseudoClassRules; }
-    const RuleDataVector& rootElementRules() const { return m_rootElementRules; }
-    const RuleDataVector& universalRules() const { return m_universalRules; }
+    const RuleDataVector& hostPseudoClassRules() const LIFETIME_BOUND { return m_hostPseudoClassRules; }
+    const RuleDataVector& slottedPseudoElementRules() const LIFETIME_BOUND { return m_slottedPseudoElementRules; }
+    const RuleDataVector& partPseudoElementRules() const LIFETIME_BOUND { return m_partPseudoElementRules; }
+    const RuleDataVector& focusPseudoClassRules() const LIFETIME_BOUND { return m_focusPseudoClassRules; }
+    const RuleDataVector& focusVisiblePseudoClassRules() const LIFETIME_BOUND { return m_focusVisiblePseudoClassRules; }
+    const RuleDataVector& fullscreenPseudoClassRules() const LIFETIME_BOUND { return m_fullscreenPseudoClassRules; }
+    const RuleDataVector& rootElementRules() const LIFETIME_BOUND { return m_rootElementRules; }
+    const RuleDataVector& universalRules() const LIFETIME_BOUND { return m_universalRules; }
     // For pseudo-element rules that apply to all elements or all HTML elements like "::marker".
-    const RuleDataVector& universalPseudoElementRules() const { return m_universalPseudoElementRules; }
+    const RuleDataVector& universalPseudoElementRules() const LIFETIME_BOUND { return m_universalPseudoElementRules; }
     // Pseudo element types applying to all elements in HTML namespace.
     EnumSet<PseudoElementType> universalHTMLPseudoElementTypes() const { return m_universalHTMLPseudoElementTypes; }
     // Pseudo element types applying to all elements.
     EnumSet<PseudoElementType> universalPseudoElementTypes() const { return m_universalPseudoElementTypes; }
 
-    const Vector<StyleRulePage*>& pageRules() const { return m_pageRules; }
+    const Vector<StyleRulePage*>& pageRules() const LIFETIME_BOUND { return m_pageRules; }
 
     unsigned ruleCount() const { return m_ruleCount; }
 
@@ -177,8 +177,8 @@ private:
         CascadeLayerIdentifier parentIdentifier;
         CascadeLayerPriority priority { 0 };
     };
-    CascadeLayer& cascadeLayerForIdentifier(CascadeLayerIdentifier identifier) { return m_cascadeLayers[identifier - 1]; }
-    const CascadeLayer& cascadeLayerForIdentifier(CascadeLayerIdentifier identifier) const { return m_cascadeLayers[identifier - 1]; }
+    CascadeLayer& cascadeLayerForIdentifier(CascadeLayerIdentifier identifier) LIFETIME_BOUND { return m_cascadeLayers[identifier - 1]; }
+    const CascadeLayer& cascadeLayerForIdentifier(CascadeLayerIdentifier identifier) const LIFETIME_BOUND { return m_cascadeLayers[identifier - 1]; }
     CascadeLayerPriority cascadeLayerPriorityForIdentifier(CascadeLayerIdentifier) const;
 
     struct ScopeAndParent {

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -81,10 +81,10 @@ private:
 
     void applyPageSizeDescriptor(CSSValue&);
 
-    const PropertyCascade* ensureRollbackCascadeForRevert();
-    const PropertyCascade* ensureRollbackCascadeForRevertLayer();
-    const PropertyCascade* ensureRollbackCascadeForRevertRule();
-    const PropertyCascade& parentCascadeForRollback();
+    const PropertyCascade* ensureRollbackCascadeForRevert() LIFETIME_BOUND;
+    const PropertyCascade* ensureRollbackCascadeForRevertLayer() LIFETIME_BOUND;
+    const PropertyCascade* ensureRollbackCascadeForRevertRule() LIFETIME_BOUND;
+    const PropertyCascade& parentCascadeForRollback() LIFETIME_BOUND;
 
     using RollbackCascadeKey = std::tuple<const PropertyCascade*, unsigned, unsigned, unsigned, bool>;
     RollbackCascadeKey makeRollbackCascadeKey(const PropertyCascade& parentCascade, PropertyCascade::Origin, ScopeOrdinal = ScopeOrdinal::Element, CascadeLayerPriority = 0);

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -110,14 +110,14 @@ public:
     ComputedStyle& style() { return m_style.computedStyle(); }
     const ComputedStyle& style() const { return m_style.computedStyle(); }
 
-    RenderStyle& renderStyle() { return m_style; }
-    const RenderStyle& renderStyle() const { return m_style; }
+    RenderStyle& renderStyle() LIFETIME_BOUND { return m_style; }
+    const RenderStyle& renderStyle() const LIFETIME_BOUND { return m_style; }
 
     const ComputedStyle& parentStyle() const { return m_context.parentStyle->computedStyle(); }
-    const RenderStyle& parentRenderStyle() const { return *m_context.parentStyle; }
+    const RenderStyle& parentRenderStyle() const LIFETIME_BOUND { return *m_context.parentStyle; }
 
     const ComputedStyle* rootElementStyle() const { return m_context.rootElementStyle ? &m_context.rootElementStyle->computedStyle() : nullptr; }
-    const RenderStyle* rootElementRenderStyle() const { return m_context.rootElementStyle; }
+    const RenderStyle* rootElementRenderStyle() const LIFETIME_BOUND { return m_context.rootElementStyle; }
 
     const Document& document() const { return *m_context.document; }
     const Element* element() const { return m_context.element.get(); }
@@ -130,8 +130,8 @@ public:
     bool fontDirty() const { return m_fontDirty; }
     void setFontDirty() { m_fontDirty = true; }
 
-    inline const FontCascadeDescription& fontDescription();
-    inline const FontCascadeDescription& parentFontDescription();
+    inline const FontCascadeDescription& fontDescription() LIFETIME_BOUND;
+    inline const FontCascadeDescription& parentFontDescription() LIFETIME_BOUND;
 
     bool applyPropertyToRegularStyle() const { return m_linkMatch != SelectorChecker::MatchVisited; }
     bool applyPropertyToVisitedLinkStyle() const { return m_linkMatch != SelectorChecker::MatchLink; }
@@ -145,10 +145,10 @@ public:
 
     RefPtr<Image> createStyleImage(const CSSValue&) const;
 
-    const Vector<AtomString>& registeredContentAttributes() const { return m_registeredContentAttributes; }
+    const Vector<AtomString>& registeredContentAttributes() const LIFETIME_BOUND { return m_registeredContentAttributes; }
     void registerContentAttribute(const AtomString& attributeLocalName);
 
-    const CSSToLengthConversionData& cssToLengthConversionData() const { return m_cssToLengthConversionData; }
+    const CSSToLengthConversionData& cssToLengthConversionData() const LIFETIME_BOUND { return m_cssToLengthConversionData; }
 
     void setIsBuildingKeyframeStyle() { m_isBuildingKeyframeStyle = true; }
     bool hasRevertRuleOrLayerInKeyframeStyle() const { return m_hasRevertRuleOrLayerInKeyframeStyle; }
@@ -172,8 +172,8 @@ public:
     unsigned siblingCount();
     unsigned siblingIndex();
 
-    AnchorPositionedStates* anchorPositionedStates() { return m_context.treeResolutionState ? &m_context.treeResolutionState->anchorPositionedStates : nullptr; }
-    const std::optional<BuilderPositionTryFallback>& positionTryFallback() const { return m_context.positionTryFallback; }
+    AnchorPositionedStates* anchorPositionedStates() LIFETIME_BOUND { return m_context.treeResolutionState ? &m_context.treeResolutionState->anchorPositionedStates : nullptr; }
+    const std::optional<BuilderPositionTryFallback>& positionTryFallback() const LIFETIME_BOUND { return m_context.positionTryFallback; }
 
     // FIXME: Copying a FontCascadeDescription is really inefficient. Migrate all callers to
     // setFontDescriptionXXX() variants below, then remove these functions.

--- a/Source/WebCore/style/StyleCustomProperty.h
+++ b/Source/WebCore/style/StyleCustomProperty.h
@@ -84,8 +84,8 @@ public:
     static Ref<const CustomProperty> createForValue(const AtomString& name, Value&&);
     static Ref<const CustomProperty> createForValueList(const AtomString& name, ValueList&&);
 
-    const AtomString& name() const { return m_name; }
-    const Kind& value() const { return m_value; }
+    const AtomString& name() const LIFETIME_BOUND { return m_name; }
+    const Kind& value() const LIFETIME_BOUND { return m_value; }
 
     const Vector<CSSParserToken>& tokens() const;
 

--- a/Source/WebCore/style/StyleCustomPropertyRegistry.h
+++ b/Source/WebCore/style/StyleCustomPropertyRegistry.h
@@ -50,7 +50,7 @@ public:
     void registerFromStylesheet(const StyleRuleProperty::Descriptor&);
     void clearRegisteredFromStylesheets();
 
-    const RenderStyle& initialValuePrototypeStyle() const;
+    const RenderStyle& initialValuePrototypeStyle() const LIFETIME_BOUND;
 
     bool invalidatePropertiesWithViewportUnits(Document&);
 

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -120,10 +120,10 @@ public:
 
     void appendAuthorStyleSheets(std::span<const Ref<CSSStyleSheet>>);
 
-    ScopeRuleSets& ruleSets() { return m_ruleSets; }
-    const ScopeRuleSets& ruleSets() const { return m_ruleSets; }
+    ScopeRuleSets& ruleSets() LIFETIME_BOUND { return m_ruleSets; }
+    const ScopeRuleSets& ruleSets() const LIFETIME_BOUND { return m_ruleSets; }
 
-    const MQ::MediaQueryEvaluator& mediaQueryEvaluator() const { return m_mediaQueryEvaluator; }
+    const MQ::MediaQueryEvaluator& mediaQueryEvaluator() const LIFETIME_BOUND { return m_mediaQueryEvaluator; }
 
     void addCurrentSVGFontFaceRules();
 
@@ -166,12 +166,12 @@ public:
     void invalidateMatchedDeclarationsCache();
     void clearCachedDeclarationsAffectedByViewportUnits();
 
-    InspectorCSSOMWrappers& inspectorCSSOMWrappers() { return m_inspectorCSSOMWrappers; }
+    InspectorCSSOMWrappers& inspectorCSSOMWrappers() LIFETIME_BOUND { return m_inspectorCSSOMWrappers; }
 
     bool isSharedBetweenShadowTrees() const { return m_isSharedBetweenShadowTrees; }
     void setSharedBetweenShadowTrees() { m_isSharedBetweenShadowTrees = true; }
 
-    const RenderStyle* rootDefaultStyle() const { return m_rootDefaultStyle.get(); }
+    const RenderStyle* rootDefaultStyle() const LIFETIME_BOUND { return m_rootDefaultStyle.get(); }
 
 private:
     Resolver(Document&, ScopeType);

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -84,9 +84,9 @@ public:
 
     ~Scope();
 
-    const Vector<Ref<CSSStyleSheet>>& activeStyleSheets() const { return m_activeStyleSheets; }
+    const Vector<Ref<CSSStyleSheet>>& activeStyleSheets() const LIFETIME_BOUND { return m_activeStyleSheets; }
 
-    const Vector<Ref<StyleSheet>>& styleSheetsForStyleSheetList();
+    const Vector<Ref<StyleSheet>>& styleSheetsForStyleSheetList() LIFETIME_BOUND;
     const Vector<Ref<CSSStyleSheet>> activeStyleSheetsForInspector();
 
     void addStyleSheetCandidateNode(Node&, bool createdByParser);
@@ -144,7 +144,7 @@ public:
 
     void clearViewTransitionStyles();
 
-    MatchResultCache& matchResultCache();
+    MatchResultCache& matchResultCache() LIFETIME_BOUND;
 
     const Document& document() const { return m_document; }
     Document& document() { return m_document; }
@@ -167,13 +167,13 @@ public:
     };
     bool invalidateForLayoutDependencies(LayoutDependencyUpdateContext&);
 
-    const CustomPropertyRegistry& customPropertyRegistry() const { return m_customPropertyRegistry.get(); }
-    CustomPropertyRegistry& customPropertyRegistry() { return m_customPropertyRegistry.get(); }
-    const CSSCounterStyleRegistry& counterStyleRegistry() const { return m_counterStyleRegistry.get(); }
-    CSSCounterStyleRegistry& counterStyleRegistry() { return m_counterStyleRegistry.get(); }
+    const CustomPropertyRegistry& customPropertyRegistry() const LIFETIME_BOUND { return m_customPropertyRegistry.get(); }
+    CustomPropertyRegistry& customPropertyRegistry() LIFETIME_BOUND { return m_customPropertyRegistry.get(); }
+    const CSSCounterStyleRegistry& counterStyleRegistry() const LIFETIME_BOUND { return m_counterStyleRegistry.get(); }
+    CSSCounterStyleRegistry& counterStyleRegistry() LIFETIME_BOUND { return m_counterStyleRegistry.get(); }
 
-    AnchorPositionedToAnchorMap& anchorPositionedToAnchorMap() { return m_anchorPositionedToAnchorMap; }
-    const AnchorPositionedToAnchorMap& anchorPositionedToAnchorMap() const { return m_anchorPositionedToAnchorMap; }
+    AnchorPositionedToAnchorMap& anchorPositionedToAnchorMap() LIFETIME_BOUND { return m_anchorPositionedToAnchorMap; }
+    const AnchorPositionedToAnchorMap& anchorPositionedToAnchorMap() const LIFETIME_BOUND { return m_anchorPositionedToAnchorMap; }
     void updateAnchorPositioningStateAfterStyleResolution();
 
     std::optional<size_t> lastSuccessfulPositionOptionIndexFor(const Styleable&);

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -71,16 +71,16 @@ public:
     RuleSet* userStyle() const;
     RuleSet* styleForDeclarationOrigin(DeclarationOrigin);
 
-    const RuleFeatureSet& features() const;
+    const RuleFeatureSet& features() const LIFETIME_BOUND;
     RuleSet* scopeBreakingHasPseudoClassInvalidationRuleSet() const { return m_scopeBreakingHasPseudoClassInvalidationRuleSet.get(); }
 
-    const Vector<InvalidationRuleSet>* idInvalidationRuleSets(const AtomString&) const;
-    const Vector<InvalidationRuleSet>* classInvalidationRuleSets(const AtomString&) const;
-    const Vector<InvalidationRuleSet>* attributeInvalidationRuleSets(const AtomString&) const;
-    const Vector<InvalidationRuleSet>* pseudoClassInvalidationRuleSets(const PseudoClassInvalidationKey&) const;
-    const Vector<InvalidationRuleSet>* hasPseudoClassInvalidationRuleSets(const PseudoClassInvalidationKey&) const;
+    const Vector<InvalidationRuleSet>* idInvalidationRuleSets(const AtomString&) const LIFETIME_BOUND;
+    const Vector<InvalidationRuleSet>* classInvalidationRuleSets(const AtomString&) const LIFETIME_BOUND;
+    const Vector<InvalidationRuleSet>* attributeInvalidationRuleSets(const AtomString&) const LIFETIME_BOUND;
+    const Vector<InvalidationRuleSet>* pseudoClassInvalidationRuleSets(const PseudoClassInvalidationKey&) const LIFETIME_BOUND;
+    const Vector<InvalidationRuleSet>* hasPseudoClassInvalidationRuleSets(const PseudoClassInvalidationKey&) const LIFETIME_BOUND;
 
-    const HashSet<AtomString>& customPropertyNamesInStyleContainerQueries() const;
+    const HashSet<AtomString>& customPropertyNamesInStyleContainerQueries() const LIFETIME_BOUND;
 
     SelectorsForStyleAttribute selectorsForStyleAttribute() const;
 
@@ -100,14 +100,14 @@ public:
 
     std::optional<DynamicMediaQueryEvaluationChanges> evaluateDynamicMediaQueryRules(const MQ::MediaQueryEvaluator&);
 
-    RuleFeatureSet& mutableFeatures();
+    RuleFeatureSet& mutableFeatures() LIFETIME_BOUND;
 
     void setDynamicViewTransitionsStyle(RuleSet* ruleSet)
     {
         m_dynamicViewTransitionsStyle = ruleSet;
     }
 
-    bool& isInvalidatingStyleWithRuleSets() { return m_isInvalidatingStyleWithRuleSets; }
+    bool& isInvalidatingStyleWithRuleSets() LIFETIME_BOUND { return m_isInvalidatingStyleWithRuleSets; }
 
     bool hasMatchingUserOrAuthorStyle(NOESCAPE const WTF::Function<bool(RuleSet&)>&);
 

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -145,8 +145,8 @@ private:
     Scope& scope() { return m_scopeStack.last(); }
     const Scope& scope() const { return m_scopeStack.last(); }
 
-    Parent& parent() { return m_parentStack.last(); }
-    const Parent& parent() const { return m_parentStack.last(); }
+    Parent& parent() LIFETIME_BOUND { return m_parentStack.last(); }
+    const Parent& parent() const LIFETIME_BOUND { return m_parentStack.last(); }
 
     void pushScope(ShadowRoot&);
     void pushEnclosingScope();
@@ -167,9 +167,9 @@ private:
     ResolutionContext makeResolutionContext();
     ResolutionContext makeResolutionContextForPseudoElement(const ElementUpdate&, const PseudoElementIdentifier&);
     std::optional<ResolutionContext> makeResolutionContextForInheritedFirstLine(const ElementUpdate&, const RenderStyle& inheritStyle);
-    const Parent* boxGeneratingParent() const;
-    const RenderStyle* parentBoxStyle() const;
-    const RenderStyle* parentBoxStyleForPseudoElement(const ElementUpdate&) const;
+    const Parent* boxGeneratingParent() const LIFETIME_BOUND;
+    const RenderStyle* parentBoxStyle() const LIFETIME_BOUND;
+    const RenderStyle* parentBoxStyleForPseudoElement(const ElementUpdate&) const LIFETIME_BOUND;
     const RenderStyle* NODELETE documentElementStyle() const;
 
     LayoutInterleavingAction updateAnchorPositioningState(Element&, const RenderStyle*);

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -63,7 +63,7 @@ public:
     Update(Document&);
     ~Update();
 
-    const ListHashSet<Ref<ContainerNode>>& roots() const { return m_roots; }
+    const ListHashSet<Ref<ContainerNode>>& roots() const LIFETIME_BOUND { return m_roots; }
     ListHashSet<Ref<Element>> takeRebuildRoots() { return WTF::move(m_rebuildRoots); }
 
     const ElementUpdate* NODELETE elementUpdate(const Element&) const;
@@ -71,7 +71,7 @@ public:
 
     const TextUpdate* NODELETE textUpdate(const Text&) const;
 
-    const RenderStyle* initialContainingBlockUpdate() const { return m_initialContainingBlockUpdate.get(); }
+    const RenderStyle* initialContainingBlockUpdate() const LIFETIME_BOUND { return m_initialContainingBlockUpdate.get(); }
 
     const RenderStyle* NODELETE elementStyle(const Element&) const;
     RenderStyle* NODELETE elementStyle(const Element&);

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -576,7 +576,7 @@ public:
     // MARK: - Pseudo element/style
 
     inline std::optional<PseudoElementType> pseudoElementType() const;
-    const AtomString& pseudoElementNameArgument() const;
+    const AtomString& pseudoElementNameArgument() const LIFETIME_BOUND;
 
     std::optional<PseudoElementIdentifier> NODELETE pseudoElementIdentifier() const;
     void setPseudoElementIdentifier(std::optional<PseudoElementIdentifier>&&);
@@ -589,12 +589,12 @@ public:
     RenderStyle* addCachedPseudoStyle(std::unique_ptr<RenderStyle>);
 
     bool hasCachedPseudoStyles() const { return !m_cachedPseudoStyles.isEmpty(); }
-    const PseudoStyleCache& cachedPseudoStyles() const { return m_cachedPseudoStyles; }
+    const PseudoStyleCache& cachedPseudoStyles() const LIFETIME_BOUND { return m_cachedPseudoStyles; }
 
     // MARK: - Custom properties
 
-    inline const CustomPropertyData& inheritedCustomProperties() const;
-    inline const CustomPropertyData& nonInheritedCustomProperties() const;
+    inline const CustomPropertyData& inheritedCustomProperties() const LIFETIME_BOUND;
+    inline const CustomPropertyData& nonInheritedCustomProperties() const LIFETIME_BOUND;
     const CustomProperty* customPropertyValue(const AtomString&) const;
     void setCustomPropertyValue(Ref<const CustomProperty>&&, bool isInherited);
     bool customPropertyValueEqual(const ComputedStyleBase&, const AtomString&) const;
@@ -629,7 +629,7 @@ public:
     WEBCORE_EXPORT void setFontDescription(FontCascadeDescription&&);
     bool setFontDescriptionWithoutUpdate(FontCascadeDescription&&);
 
-    WEBCORE_EXPORT const FontMetrics& metricsOfPrimaryFont() const;
+    WEBCORE_EXPORT const FontMetrics& metricsOfPrimaryFont() const LIFETIME_BOUND;
     std::pair<FontOrientation, NonCJKGlyphOrientation> NODELETE fontAndGlyphOrientation();
     float NODELETE computedFontSize() const;
     inline WebkitLocale computedLocale() const;
@@ -667,36 +667,36 @@ public:
 
     // MARK: - Aggregates
 
-    inline Animations& ensureAnimations();
-    inline BackgroundLayers& ensureBackgroundLayers();
-    inline MaskLayers& ensureMaskLayers();
-    inline Transitions& ensureTransitions();
-    inline ScrollTimelines& ensureScrollTimelines();
-    inline ViewTimelines& ensureViewTimelines();
+    inline Animations& ensureAnimations() LIFETIME_BOUND;
+    inline BackgroundLayers& ensureBackgroundLayers() LIFETIME_BOUND;
+    inline MaskLayers& ensureMaskLayers() LIFETIME_BOUND;
+    inline Transitions& ensureTransitions() LIFETIME_BOUND;
+    inline ScrollTimelines& ensureScrollTimelines() LIFETIME_BOUND;
+    inline ViewTimelines& ensureViewTimelines() LIFETIME_BOUND;
 
-    inline const BorderData& border() const;
-    inline const BorderValue& borderBottom() const;
-    inline const BorderValue& borderLeft() const;
-    inline const BorderValue& borderRight() const;
-    inline const BorderValue& borderTop() const;
-    inline const BorderValue& columnRule() const;
-    inline const OutlineValue& outline() const;
-    inline const Animations& animations() const;
-    inline const BackgroundLayers& backgroundLayers() const;
-    inline const BorderImage& borderImage() const;
-    inline const BorderRadius& borderRadii() const;
-    inline const InsetBox& insetBox() const;
-    inline const MarginBox& marginBox() const;
-    inline const MaskBorder& maskBorder() const;
-    inline const MaskLayers& maskLayers() const;
-    inline const PaddingBox& paddingBox() const;
-    inline const PerspectiveOrigin& perspectiveOrigin() const;
-    inline const ScrollMarginBox& scrollMarginBox() const;
-    inline const ScrollPaddingBox& scrollPaddingBox() const;
-    inline const ScrollTimelines& scrollTimelines() const;
-    inline const TransformOrigin& transformOrigin() const;
-    inline const Transitions& transitions() const;
-    inline const ViewTimelines& viewTimelines() const;
+    inline const BorderData& border() const LIFETIME_BOUND;
+    inline const BorderValue& borderBottom() const LIFETIME_BOUND;
+    inline const BorderValue& borderLeft() const LIFETIME_BOUND;
+    inline const BorderValue& borderRight() const LIFETIME_BOUND;
+    inline const BorderValue& borderTop() const LIFETIME_BOUND;
+    inline const BorderValue& columnRule() const LIFETIME_BOUND;
+    inline const OutlineValue& outline() const LIFETIME_BOUND;
+    inline const Animations& animations() const LIFETIME_BOUND;
+    inline const BackgroundLayers& backgroundLayers() const LIFETIME_BOUND;
+    inline const BorderImage& borderImage() const LIFETIME_BOUND;
+    inline const BorderRadius& borderRadii() const LIFETIME_BOUND;
+    inline const InsetBox& insetBox() const LIFETIME_BOUND;
+    inline const MarginBox& marginBox() const LIFETIME_BOUND;
+    inline const MaskBorder& maskBorder() const LIFETIME_BOUND;
+    inline const MaskLayers& maskLayers() const LIFETIME_BOUND;
+    inline const PaddingBox& paddingBox() const LIFETIME_BOUND;
+    inline const PerspectiveOrigin& perspectiveOrigin() const LIFETIME_BOUND;
+    inline const ScrollMarginBox& scrollMarginBox() const LIFETIME_BOUND;
+    inline const ScrollPaddingBox& scrollPaddingBox() const LIFETIME_BOUND;
+    inline const ScrollTimelines& scrollTimelines() const LIFETIME_BOUND;
+    inline const TransformOrigin& transformOrigin() const LIFETIME_BOUND;
+    inline const Transitions& transitions() const LIFETIME_BOUND;
+    inline const ViewTimelines& viewTimelines() const LIFETIME_BOUND;
 
     inline void setBackgroundLayers(BackgroundLayers&&);
     inline void setBorderImage(BorderImage&&);
@@ -719,7 +719,7 @@ public:
     inline CursorType cursorType() const;
 
     // `@page size`
-    inline const PageSize& pageSize() const;
+    inline const PageSize& pageSize() const LIFETIME_BOUND;
     inline void setPageSize(PageSize&&);
 
     struct NonInheritedFlags {
@@ -827,14 +827,14 @@ protected:
 
     ComputedStyleBase(ComputedStyleBase&, ComputedStyleBase&&);
 
-    const NonInheritedFlags& nonInheritedFlags() const { return m_nonInheritedFlags; }
-    const NonInheritedData& nonInheritedData() const { return m_nonInheritedData; }
+    const NonInheritedFlags& nonInheritedFlags() const LIFETIME_BOUND { return m_nonInheritedFlags; }
+    const NonInheritedData& nonInheritedData() const LIFETIME_BOUND { return m_nonInheritedData; }
 
-    const InheritedFlags& inheritedFlags() const { return m_inheritedFlags; }
-    const InheritedData& inheritedData() const { return m_inheritedData; }
-    const InheritedRareData& inheritedRareData() const { return m_inheritedRareData; }
+    const InheritedFlags& inheritedFlags() const LIFETIME_BOUND { return m_inheritedFlags; }
+    const InheritedData& inheritedData() const LIFETIME_BOUND { return m_inheritedData; }
+    const InheritedRareData& inheritedRareData() const LIFETIME_BOUND { return m_inheritedRareData; }
 
-    const SVGData& svgData() const { return m_svgData; }
+    const SVGData& svgData() const LIFETIME_BOUND { return m_svgData; }
 
     // Non-inherited and inherited flags
     NonInheritedFlags m_nonInheritedFlags;

--- a/Source/WebCore/style/values/animations/StyleAnimation.h
+++ b/Source/WebCore/style/values/animations/StyleAnimation.h
@@ -77,18 +77,18 @@ struct Animation {
     Animation();
     Animation(SingleAnimationName&&);
 
-    const SingleAnimationName& name() const { return m_data->m_name; }
+    const SingleAnimationName& name() const LIFETIME_BOUND { return m_data->m_name; }
     SingleAnimationDelay delay() const { return m_data->m_delay; }
     AnimationDirection direction() const { return static_cast<AnimationDirection>(m_data->m_direction); }
     SingleAnimationDuration duration() const { return m_data->m_duration; }
     AnimationFillMode fillMode() const { return static_cast<AnimationFillMode>(m_data->m_fillMode); }
     SingleAnimationIterationCount iterationCount() const { return m_data->m_iterationCount; }
     AnimationPlayState playState() const { return static_cast<AnimationPlayState>(m_data->m_playState); }
-    const SingleAnimationTimeline& timeline() const { return m_data->m_timeline; }
-    const EasingFunction& timingFunction() const { return m_data->m_timingFunction; }
+    const SingleAnimationTimeline& timeline() const LIFETIME_BOUND { return m_data->m_timeline; }
+    const EasingFunction& timingFunction() const LIFETIME_BOUND { return m_data->m_timingFunction; }
     CompositeOperation compositeOperation() const { return static_cast<CompositeOperation>(m_data->m_compositeOperation); }
-    const SingleAnimationRangeStart& rangeStart() const { return m_data->m_rangeStart; }
-    const SingleAnimationRangeEnd& rangeEnd() const { return m_data->m_rangeEnd; }
+    const SingleAnimationRangeStart& rangeStart() const LIFETIME_BOUND { return m_data->m_rangeStart; }
+    const SingleAnimationRangeEnd& rangeEnd() const LIFETIME_BOUND { return m_data->m_rangeEnd; }
 
     static SingleAnimationName initialName() { return CSS::Keyword::None { }; }
     static SingleAnimationDelay initialDelay() { return 0; }
@@ -103,7 +103,7 @@ struct Animation {
     static SingleAnimationRangeStart initialRangeStart() { return CSS::Keyword::Normal { }; }
     static SingleAnimationRangeEnd initialRangeEnd() { return CSS::Keyword::Normal { }; }
 
-    const std::optional<EasingFunction>& defaultTimingFunctionForKeyframes() const { return m_data->m_defaultTimingFunctionForKeyframes; }
+    const std::optional<EasingFunction>& defaultTimingFunctionForKeyframes() const LIFETIME_BOUND { return m_data->m_defaultTimingFunctionForKeyframes; }
     void setDefaultTimingFunctionForKeyframes(std::optional<EasingFunction>&& function) { m_data->m_defaultTimingFunctionForKeyframes = WTF::move(function); }
 
     FOR_EACH_ANIMATION_REFERENCE(DECLARE_COORDINATED_VALUE_LIST_GETTER_AND_SETTERS_REFERENCE)
@@ -165,8 +165,8 @@ private:
     };
 
     // Needed by macros to access members.
-    Data& data() { return m_data.get(); }
-    const Data& data() const { return m_data.get(); }
+    Data& data() LIFETIME_BOUND { return m_data.get(); }
+    const Data& data() const LIFETIME_BOUND { return m_data.get(); }
 
     Animation(Ref<Data>&& data)
         : m_data { WTF::move(data) }

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationRange.h
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationRange.h
@@ -124,7 +124,7 @@ struct SingleAnimationRangeEdge {
     }
 
     Name name() const { return m_name; }
-    const Offset& offset() const { return m_offset; }
+    const Offset& offset() const LIFETIME_BOUND { return m_offset; }
 
     bool hasDefaultOffset() const { return m_offset.isDefault(type); }
 

--- a/Source/WebCore/style/values/backgrounds/StyleBackgroundLayer.h
+++ b/Source/WebCore/style/values/backgrounds/StyleBackgroundLayer.h
@@ -75,11 +75,11 @@ struct BackgroundLayer {
     BackgroundLayer(ImageOrNone&&);
     BackgroundLayer(RefPtr<Image>&&);
 
-    const ImageOrNone& image() const { return m_image; }
-    const PositionX& positionX() const { return m_positionX; }
-    const PositionY& positionY() const { return m_positionY; }
-    const BackgroundSize& size() const { return m_size; }
-    const RepeatStyle& repeat() const { return m_repeat; }
+    const ImageOrNone& image() const LIFETIME_BOUND { return m_image; }
+    const PositionX& positionX() const LIFETIME_BOUND { return m_positionX; }
+    const PositionY& positionY() const LIFETIME_BOUND { return m_positionY; }
+    const BackgroundSize& size() const LIFETIME_BOUND { return m_size; }
+    const RepeatStyle& repeat() const LIFETIME_BOUND { return m_repeat; }
     FillAttachment attachment() const { return static_cast<FillAttachment>(m_attachment); }
     FillBox clip() const { return static_cast<FillBox>(m_clip); }
     FillBox origin() const { return static_cast<FillBox>(m_origin); }

--- a/Source/WebCore/style/values/fonts/StyleFontVariantAlternates.h
+++ b/Source/WebCore/style/values/fonts/StyleFontVariantAlternates.h
@@ -52,7 +52,7 @@ struct FontVariantAlternates {
     {
     }
 
-    const Platform& platform() const { return m_platform; }
+    const Platform& platform() const LIFETIME_BOUND { return m_platform; }
     Platform takePlatform() { return WTF::move(m_platform); }
 
     bool isNormal() const { return m_platform.isNormal(); }

--- a/Source/WebCore/style/values/grid/StyleGridTrackBreadth.h
+++ b/Source/WebCore/style/values/grid/StyleGridTrackBreadth.h
@@ -131,7 +131,7 @@ public:
     bool isLength() const { return m_type == GridTrackBreadthType::Length; }
     bool isFlex() const { return m_type == GridTrackBreadthType::Flex; }
 
-    const GridTrackBreadthLength& length() const { ASSERT(isLength()); return m_length; }
+    const GridTrackBreadthLength& length() const LIFETIME_BOUND { ASSERT(isLength()); return m_length; }
     Flex flex() const { ASSERT(isFlex()); return m_flex; }
 
     bool isPercentOrCalculated() const { return m_type == GridTrackBreadthType::Length && m_length.isPercentOrCalculated(); }

--- a/Source/WebCore/style/values/grid/StyleGridTrackSize.h
+++ b/Source/WebCore/style/values/grid/StyleGridTrackSize.h
@@ -158,10 +158,10 @@ struct GridTrackSize {
         cacheMinMaxTrackBreadthTypes();
     }
 
-    const GridTrackFitContentLength& fitContentTrackLength() const { ASSERT(m_type == Type::FitContent); return m_fitContentTrackLength; }
+    const GridTrackFitContentLength& fitContentTrackLength() const LIFETIME_BOUND { ASSERT(m_type == Type::FitContent); return m_fitContentTrackLength; }
 
-    const GridTrackBreadth& minTrackBreadth() const { return m_minTrackBreadth; }
-    const GridTrackBreadth& maxTrackBreadth() const { return m_maxTrackBreadth; }
+    const GridTrackBreadth& minTrackBreadth() const LIFETIME_BOUND { return m_minTrackBreadth; }
+    const GridTrackBreadth& maxTrackBreadth() const LIFETIME_BOUND { return m_maxTrackBreadth; }
 
     bool isBreadth() const { return m_type == Type::Breadth; }
     bool isMinMax() const { return m_type == Type::MinMax; }

--- a/Source/WebCore/style/values/images/kinds/StyleFilterImage.h
+++ b/Source/WebCore/style/values/images/kinds/StyleFilterImage.h
@@ -53,7 +53,7 @@ public:
     bool equalInputImages(const FilterImage&) const;
 
     RefPtr<Image> inputImage() const { return m_image; }
-    const Filter& filter() const { return m_filter; }
+    const Filter& filter() const LIFETIME_BOUND { return m_filter; }
 
     static constexpr bool isFixedSize = true;
 

--- a/Source/WebCore/style/values/masking/StyleMaskLayer.h
+++ b/Source/WebCore/style/values/masking/StyleMaskLayer.h
@@ -75,13 +75,13 @@ struct MaskLayer {
     MaskLayer(ImageOrNone&&);
     MaskLayer(RefPtr<Image>&&);
 
-    const ImageOrNone& image() const { return m_image; }
-    const PositionX& positionX() const { return m_positionX; }
-    const PositionY& positionY() const { return m_positionY; }
-    const BackgroundSize& size() const { return m_size; }
+    const ImageOrNone& image() const LIFETIME_BOUND { return m_image; }
+    const PositionX& positionX() const LIFETIME_BOUND { return m_positionX; }
+    const PositionY& positionY() const LIFETIME_BOUND { return m_positionY; }
+    const BackgroundSize& size() const LIFETIME_BOUND { return m_size; }
     FillBox clip() const { return static_cast<FillBox>(m_clip); }
     FillBox origin() const { return static_cast<FillBox>(m_origin); }
-    const RepeatStyle& repeat() const { return m_repeat; }
+    const RepeatStyle& repeat() const LIFETIME_BOUND { return m_repeat; }
     CompositeOperator composite() const { return static_cast<CompositeOperator>(m_composite); }
     MaskMode maskMode() const { return static_cast<MaskMode>(m_maskMode); }
 

--- a/Source/WebCore/style/values/scroll-animations/StyleScrollTimeline.h
+++ b/Source/WebCore/style/values/scroll-animations/StyleScrollTimeline.h
@@ -82,8 +82,8 @@ private:
     };
 
     // Needed by macros to access members.
-    Data& data() { return m_data; }
-    const Data& data() const { return m_data; }
+    Data& data() LIFETIME_BOUND { return m_data; }
+    const Data& data() const LIFETIME_BOUND { return m_data; }
 
     ScrollTimeline(Data&& data)
         : m_data { WTF::move(data) }

--- a/Source/WebCore/style/values/scroll-animations/StyleViewTimeline.h
+++ b/Source/WebCore/style/values/scroll-animations/StyleViewTimeline.h
@@ -87,8 +87,8 @@ private:
     };
 
     // Needed by macros to access members.
-    Data& data() { return m_data; }
-    const Data& data() const { return m_data; }
+    Data& data() LIFETIME_BOUND { return m_data; }
+    const Data& data() const LIFETIME_BOUND { return m_data; }
 
     ViewTimeline(Data&& data)
         : m_data { WTF::move(data) }

--- a/Source/WebCore/style/values/svg/StyleSVGPaint.h
+++ b/Source/WebCore/style/values/svg/StyleSVGPaint.h
@@ -110,8 +110,8 @@ struct SVGPaint {
     std::optional<Color> tryAnyColor() const { return hasColor() ? std::make_optional(m_color) : std::nullopt; }
     std::optional<URL> tryAnyURL() const { return hasURL() ? std::make_optional(m_url) : std::nullopt; }
 
-    const Color& colorDisregardingType() const { return m_color; }
-    const URL& urlDisregardingType() const { return m_url; }
+    const Color& colorDisregardingType() const LIFETIME_BOUND { return m_color; }
+    const URL& urlDisregardingType() const LIFETIME_BOUND { return m_url; }
 
     template<typename... F> decltype(auto) switchOn(F&&... f) const
     {

--- a/Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.h
@@ -60,8 +60,8 @@ public:
 
     TransformFunctionBase::Type primitiveType() const override { return isRepresentableIn2D() ? Type::Translate : Type::Translate3D; }
 
-    const LengthPercentage& x() const { return m_x; }
-    const LengthPercentage& y() const { return m_y; }
+    const LengthPercentage& x() const LIFETIME_BOUND { return m_x; }
+    const LengthPercentage& y() const LIFETIME_BOUND { return m_y; }
     Length z() const { return m_z; }
 
     bool isIdentity() const override { return m_x.isKnownZero() && m_y.isKnownZero() && m_z.isZero(); }

--- a/Source/WebCore/style/values/transitions/StyleTransition.h
+++ b/Source/WebCore/style/values/transitions/StyleTransition.h
@@ -62,10 +62,10 @@ struct Transition {
     Transition();
     Transition(SingleTransitionProperty&&);
 
-    const SingleTransitionProperty& property() const { return m_data->m_property; }
+    const SingleTransitionProperty& property() const LIFETIME_BOUND { return m_data->m_property; }
     SingleTransitionDelay delay() const { return m_data->m_delay; }
     SingleTransitionDuration duration() const { return m_data->m_duration; }
-    const EasingFunction& timingFunction() const { return m_data->m_timingFunction; }
+    const EasingFunction& timingFunction() const LIFETIME_BOUND { return m_data->m_timingFunction; }
     TransitionBehavior behavior() const { return static_cast<TransitionBehavior>(m_data->m_behavior); }
 
     static SingleTransitionProperty initialProperty() { return CSS::Keyword::All { }; }
@@ -111,8 +111,8 @@ private:
     };
 
     // Needed by macros to access members.
-    Data& data() { return m_data.get(); }
-    const Data& data() const { return m_data.get(); }
+    Data& data() LIFETIME_BOUND { return m_data.get(); }
+    const Data& data() const LIFETIME_BOUND { return m_data.get(); }
 
     Transition(Ref<Data>&& data)
         : m_data { WTF::move(data) }


### PR DESCRIPTION
#### 6e6fa640273d026658bd6a23885a52ad03f675eb
<pre>
Adopt `LIFETIME_BOUND` annotation in more places in WebCore/style
<a href="https://bugs.webkit.org/show_bug.cgi?id=309341">https://bugs.webkit.org/show_bug.cgi?id=309341</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/css/StyleSheetList.cpp:
(WebCore::StyleSheetList::callOnStyleSheets const):
(WebCore::StyleSheetList::length const):
(WebCore::StyleSheetList::item const):
(WebCore::StyleSheetList::styleSheets const):
(WebCore::StyleSheetList::item): Deleted.
* Source/WebCore/css/StyleSheetList.h:
* Source/WebCore/style/ElementRuleCollector.h:
(WebCore::Style::ElementRuleCollector::styleRelations const): Deleted.
* Source/WebCore/style/PropertyCascade.h:
(WebCore::Style::PropertyCascade::customProperties const): Deleted.
(WebCore::Style::PropertyCascade::propertyIsPresent): Deleted.
(WebCore::Style::PropertyCascade::propertyIsPresent const): Deleted.
* Source/WebCore/style/PseudoElementRequest.h:
(WebCore::Style::PseudoElementRequest::identifier const): Deleted.
(WebCore::Style::PseudoElementRequest::nameOrPart const): Deleted.
(WebCore::Style::PseudoElementRequest::scrollbarState const): Deleted.
* Source/WebCore/style/RuleData.h:
(WebCore::Style::RuleData::descendantSelectorIdentifierHashes const): Deleted.
* Source/WebCore/style/RuleSet.h:
(WebCore::Style::RuleSet:: const):
(WebCore::Style::RuleSet::features const): Deleted.
(WebCore::Style::RuleSet::idRules const): Deleted.
(WebCore::Style::RuleSet::classRules const): Deleted.
(WebCore::Style::RuleSet::userAgentPartRules const): Deleted.
(WebCore::Style::RuleSet::linkPseudoClassRules const): Deleted.
(WebCore::Style::RuleSet::namedPseudoElementRules const): Deleted.
(WebCore::Style::RuleSet::cuePseudoRules const): Deleted.
(WebCore::Style::RuleSet::hostPseudoClassRules const): Deleted.
(WebCore::Style::RuleSet::slottedPseudoElementRules const): Deleted.
(WebCore::Style::RuleSet::partPseudoElementRules const): Deleted.
(WebCore::Style::RuleSet::focusPseudoClassRules const): Deleted.
(WebCore::Style::RuleSet::focusVisiblePseudoClassRules const): Deleted.
(WebCore::Style::RuleSet::fullscreenPseudoClassRules const): Deleted.
(WebCore::Style::RuleSet::rootElementRules const): Deleted.
(WebCore::Style::RuleSet::universalRules const): Deleted.
(WebCore::Style::RuleSet::universalPseudoElementRules const): Deleted.
(WebCore::Style::RuleSet::cascadeLayerForIdentifier): Deleted.
(WebCore::Style::RuleSet::cascadeLayerForIdentifier const): Deleted.
* Source/WebCore/style/StyleBuilder.h:
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::renderStyle): Deleted.
(WebCore::Style::BuilderState::renderStyle const): Deleted.
(WebCore::Style::BuilderState::parentRenderStyle const): Deleted.
(WebCore::Style::BuilderState::rootElementRenderStyle const): Deleted.
(WebCore::Style::BuilderState::registeredContentAttributes const): Deleted.
(WebCore::Style::BuilderState::cssToLengthConversionData const): Deleted.
(WebCore::Style::BuilderState::anchorPositionedStates): Deleted.
(WebCore::Style::BuilderState::positionTryFallback const): Deleted.
* Source/WebCore/style/StyleCustomProperty.h:
* Source/WebCore/style/StyleCustomPropertyRegistry.h:
* Source/WebCore/style/StyleResolver.h:
(WebCore::Style::Resolver::ruleSets): Deleted.
(WebCore::Style::Resolver::ruleSets const): Deleted.
(WebCore::Style::Resolver::mediaQueryEvaluator const): Deleted.
(WebCore::Style::Resolver::inspectorCSSOMWrappers): Deleted.
(WebCore::Style::Resolver::rootDefaultStyle const): Deleted.
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleScopeRuleSets.h:
(WebCore::Style::ScopeRuleSets::isInvalidatingStyleWithRuleSets): Deleted.
* Source/WebCore/style/StyleTreeResolver.h:
(WebCore::Style::TreeResolver::parent): Deleted.
(WebCore::Style::TreeResolver::parent const): Deleted.
* Source/WebCore/style/StyleUpdate.h:
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
(WebCore::Style::ComputedStyleBase::cachedPseudoStyles const): Deleted.
(WebCore::Style::ComputedStyleBase::nonInheritedFlags const): Deleted.
(WebCore::Style::ComputedStyleBase::nonInheritedData const): Deleted.
(WebCore::Style::ComputedStyleBase::inheritedFlags const): Deleted.
(WebCore::Style::ComputedStyleBase::inheritedData const): Deleted.
(WebCore::Style::ComputedStyleBase::inheritedRareData const): Deleted.
(WebCore::Style::ComputedStyleBase::svgData const): Deleted.
* Source/WebCore/style/values/animations/StyleAnimation.h:
(WebCore::Style::Animation::name const): Deleted.
(WebCore::Style::Animation::timeline const): Deleted.
(WebCore::Style::Animation::timingFunction const): Deleted.
(WebCore::Style::Animation::rangeStart const): Deleted.
(WebCore::Style::Animation::rangeEnd const): Deleted.
(WebCore::Style::Animation::defaultTimingFunctionForKeyframes const): Deleted.
(WebCore::Style::Animation::data): Deleted.
(WebCore::Style::Animation::data const): Deleted.
* Source/WebCore/style/values/animations/StyleSingleAnimationRange.h:
(WebCore::Style::SingleAnimationRangeEdge::offset const): Deleted.
* Source/WebCore/style/values/backgrounds/StyleBackgroundLayer.h:
(WebCore::Style::BackgroundLayer::image const): Deleted.
(WebCore::Style::BackgroundLayer::positionX const): Deleted.
(WebCore::Style::BackgroundLayer::positionY const): Deleted.
(WebCore::Style::BackgroundLayer::size const): Deleted.
(WebCore::Style::BackgroundLayer::repeat const): Deleted.
* Source/WebCore/style/values/fonts/StyleFontVariantAlternates.h:
(WebCore::Style::FontVariantAlternates::platform const): Deleted.
* Source/WebCore/style/values/grid/StyleGridTrackBreadth.h:
(WebCore::Style::GridTrackBreadth::length const): Deleted.
* Source/WebCore/style/values/grid/StyleGridTrackSize.h:
(WebCore::Style::GridTrackSize::fitContentTrackLength const): Deleted.
(WebCore::Style::GridTrackSize::minTrackBreadth const): Deleted.
(WebCore::Style::GridTrackSize::maxTrackBreadth const): Deleted.
* Source/WebCore/style/values/images/kinds/StyleFilterImage.h:
* Source/WebCore/style/values/masking/StyleMaskLayer.h:
(WebCore::Style::MaskLayer::image const): Deleted.
(WebCore::Style::MaskLayer::positionX const): Deleted.
(WebCore::Style::MaskLayer::positionY const): Deleted.
(WebCore::Style::MaskLayer::size const): Deleted.
(WebCore::Style::MaskLayer::repeat const): Deleted.
* Source/WebCore/style/values/scroll-animations/StyleScrollTimeline.h:
(WebCore::Style::ScrollTimeline::data): Deleted.
(WebCore::Style::ScrollTimeline::data const): Deleted.
* Source/WebCore/style/values/scroll-animations/StyleViewTimeline.h:
(WebCore::Style::ViewTimeline::data): Deleted.
(WebCore::Style::ViewTimeline::data const): Deleted.
* Source/WebCore/style/values/svg/StyleSVGPaint.h:
(WebCore::Style::SVGPaint::colorDisregardingType const): Deleted.
(WebCore::Style::SVGPaint::urlDisregardingType const): Deleted.
* Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.h:
* Source/WebCore/style/values/transitions/StyleTransition.h:
(WebCore::Style::Transition::property const): Deleted.
(WebCore::Style::Transition::timingFunction const): Deleted.
(WebCore::Style::Transition::data): Deleted.
(WebCore::Style::Transition::data const): Deleted.

Canonical link: <a href="https://commits.webkit.org/308839@main">https://commits.webkit.org/308839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3401b2bdcee28377aaca3072da8cb6af9d0d2b5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157203 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101949 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/480e1729-2436-4044-a8e7-2a0a7eadc8b2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114495 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81543 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab4f0263-3227-4f1b-b3a2-31e5216b52a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95265 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a98395d4-8e86-4674-8b1f-521377d18048) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15815 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13647 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4639 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125430 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159538 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2670 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122544 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122765 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33403 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133037 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77165 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18117 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9806 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20620 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84445 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20352 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20497 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20406 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->