### PR TITLE
[JSC] `Array#includes(undefined, fromIndex)` should not find holes before fromIndex

### DIFF
--- a/JSTests/stress/array-includes-undefined-hole-before-fromindex.js
+++ b/JSTests/stress/array-includes-undefined-hole-before-fromindex.js
@@ -1,0 +1,79 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error("FAIL: " + msg + " | got " + actual + ", expected " + expected);
+}
+
+{
+    function test(arr, search, from) {
+        return arr.includes(search, from);
+    }
+    noInline(test);
+
+    let warmup = [0, 1, 2];
+    for (let i = 0; i < testLoopCount; ++i)
+        shouldBe(test(warmup, 99, 0), false, "warmup");
+
+    let arr = [, 1, 2];
+    shouldBe(test(arr, undefined, 1), false, "Int32: [,1,2].includes(undefined, 1)");
+    shouldBe(test(arr, undefined, 2), false, "Int32: [,1,2].includes(undefined, 2)");
+    shouldBe(test(arr, undefined, 3), false, "Int32: [,1,2].includes(undefined, 3)");
+    shouldBe(test(arr, undefined, 0), true, "Int32: [,1,2].includes(undefined, 0)");
+
+    let arr2 = [1, , 3];
+    shouldBe(test(arr2, undefined, 0), true,  "Int32: [1,,3].includes(undefined, 0)");
+    shouldBe(test(arr2, undefined, 1), true,  "Int32: [1,,3].includes(undefined, 1)");
+    shouldBe(test(arr2, undefined, 2), false, "Int32: [1,,3].includes(undefined, 2)");
+}
+
+{
+    function test(arr, search, from) {
+        return arr.includes(search, from);
+    }
+    noInline(test);
+
+    let warmup = [0.5, 1.5, 2.5];
+    for (let i = 0; i < testLoopCount; ++i)
+        shouldBe(test(warmup, 99.9, 0), false, "warmup");
+
+    let arr = [, 1.5, 2.5];
+    shouldBe(test(arr, undefined, 1), false, "Double: [,1.5,2.5].includes(undefined, 1)");
+    shouldBe(test(arr, undefined, 2), false, "Double: [,1.5,2.5].includes(undefined, 2)");
+    shouldBe(test(arr, undefined, 0), true,  "Double: [,1.5,2.5].includes(undefined, 0)");
+
+    let arr2 = [1.5, , 3.5];
+    shouldBe(test(arr2, undefined, 2), false, "Double: [1.5,,3.5].includes(undefined, 2)");
+}
+
+{
+    function test(arr, search, from) {
+        return arr.includes(search, from);
+    }
+    noInline(test);
+
+    let o1 = {};
+    let o2 = {};
+    let warmup = [o1, o2, o1];
+    for (let i = 0; i < testLoopCount; ++i) {
+        shouldBe(test(warmup, undefined, 0), false, "warmup");
+        shouldBe(test(warmup, null, 0), false, "warmup");
+    }
+
+    let arr = [, o1, o2];
+    shouldBe(test(arr, undefined, 1), false, "Contiguous: [,o1,o2].includes(undefined, 1)");
+    shouldBe(test(arr, undefined, 2), false, "Contiguous: [,o1,o2].includes(undefined, 2)");
+    shouldBe(test(arr, undefined, 0), true,  "Contiguous: [,o1,o2].includes(undefined, 0)");
+}
+
+{
+    shouldBe(eval("[, 1, 2].includes(undefined, 1)"), false, "LLInt Int32");
+    shouldBe(eval("[, 1.5, 2.5].includes(undefined, 1)"), false, "LLInt Double");
+    shouldBe(eval("[1, , 3].includes(undefined, 2)"), false, "LLInt Int32 middle");
+    shouldBe(eval("[1.5, , 3.5].includes(undefined, 2)"), false, "LLInt Double middle");
+}
+
+{
+    shouldBe([, 1, 2].includes(undefined, -1), false, "Int32 negative fromIndex");
+    shouldBe([, 1, 2].includes(undefined, -2), false, "Int32 negative fromIndex -2");
+    shouldBe([, 1, 2].includes(undefined, -3), true,  "Int32 negative fromIndex -3 (covers hole)");
+    shouldBe([, 1.5, 2.5].includes(undefined, -1), false, "Double negative fromIndex");
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4343,7 +4343,7 @@ JSC_DEFINE_JIT_OPERATION(operationArrayIncludesValueInt32, UCPUStrictInt32, (JSG
 
     JSValue searchElement = JSValue::decode(encodedValue);
 
-    if (searchElement.isUndefined() && containsHole(data, length))
+    if (searchElement.isUndefined() && containsHole(data + index, length - index))
         OPERATION_RETURN(scope, toUCPUStrictInt32(1));
 
     int32_t int32Value = 0;
@@ -4366,7 +4366,10 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationArrayIncludesValueDouble, UCPUStrictI
     const double* data = butterfly->contiguousDouble().data();
     int32_t length = butterfly->publicLength();
 
-    if (searchElement.isUndefined() && containsHole(data, length))
+    if (index >= length)
+        return toUCPUStrictInt32(0);
+
+    if (searchElement.isUndefined() && containsHole(data + index, length - index))
         return toUCPUStrictInt32(1);
     if (!searchElement.isNumber())
         return toUCPUStrictInt32(0);
@@ -4394,7 +4397,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationArrayIncludesNonStringIdentityValueCo
         return toUCPUStrictInt32(1);
 
     JSValue searchElementValue = JSValue::decode(searchElement);
-    if (searchElementValue.isUndefined() && containsHole(data, length))
+    if (searchElementValue.isUndefined() && containsHole(data + index, length - index))
         return toUCPUStrictInt32(1);
     return toUCPUStrictInt32(0);
 }

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -764,7 +764,7 @@ std::optional<bool> JSArray::fastIncludes(JSGlobalObject* globalObject, JSValue 
         if (searchElement.isInt32AsAnyInt())
             int32Value = searchElement.asInt32AsAnyInt();
         else if (searchElement.isUndefined()) [[unlikely]]
-            return containsHole(data, length64);
+            return containsHole(data + index, length - index);
         else if (!searchElement.isNumber() || searchElement.asNumber() != 0.0) [[unlikely]]
             return false;
 
@@ -803,7 +803,7 @@ std::optional<bool> JSArray::fastIncludes(JSGlobalObject* globalObject, JSValue 
         auto data = butterfly.contiguousDouble().data();
 
         if (searchElement.isUndefined())
-            return containsHole(data, length64);
+            return containsHole(data + index, length - index);
         if (!searchElement.isNumber())
             return false;
 


### PR DESCRIPTION
#### b2cf11dd2959c8ea114ad48b2696d9677394fef1
<pre>
[JSC] `Array#includes(undefined, fromIndex)` should not find holes before fromIndex
<a href="https://bugs.webkit.org/show_bug.cgi?id=309342">https://bugs.webkit.org/show_bug.cgi?id=309342</a>

Reviewed by Yusuke Suzuki.

`[, 1, 2].includes(undefined, 1)` returned true instead of false.
containsHole() scanned from index 0 instead of fromIndex.
indexOf is unaffected (it skips holes via HasProperty).

Test: JSTests/stress/array-includes-undefined-hole-before-fromindex.js

* JSTests/stress/array-includes-undefined-hole-before-fromindex.js: Added.
(shouldBe):
(throw.new.Error.test):
(throw.new.Error):
(shouldBe.test):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
(JSC::DFG::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastIncludes):

Canonical link: <a href="https://commits.webkit.org/308830@main">https://commits.webkit.org/308830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7588350949a8da5061cb688e6e73e01b51c2e2a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14780 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157182 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101928 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21089 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114475 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81534 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16694 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133305 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95245 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15799 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13629 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4618 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140465 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159516 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9285 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2649 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122523 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17620 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122744 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33395 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133012 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77143 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18104 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9780 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179926 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20599 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84424 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46061 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20331 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20476 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20385 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->