### PR TITLE
[css-cascade] Invalidate keyframes for revert-rule

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL revert-rule in keyframes, reverted-to value changing (standard property) assert_equals: expected "160px" but got "150px"
-FAIL revert-rule in keyframes, reverted-to value changing (custom property) assert_equals: expected "160px" but got "150px"
+PASS revert-rule in keyframes, reverted-to value changing (standard property)
+PASS revert-rule in keyframes, reverted-to value changing (custom property)
 

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -321,6 +321,7 @@ void BlendingKeyframes::updatePropertiesMetadata(const StyleProperties& properti
             auto propertyID = propertyReference.id();
             auto valueId = primitiveValue->valueID();
 
+            // FIXME: All these should search inside complex values or be set during style resolution
             if (valueId == CSSValueInherit)
                 m_propertiesSetToInherit.add(propertyID);
             else if (valueId == CSSValueCurrentcolor)
@@ -388,11 +389,17 @@ void BlendingKeyframes::analyzeKeyframe(const BlendingKeyframe& keyframe)
             m_hasKeyframeNotUsingRangeOffset = !keyframe.usesRangeOffset();
     };
 
+    auto analyzeCSSWideKeywords = [&] {
+        if (keyframe.hasPropertiesWithRevertRuleOrLayer())
+            m_hasPropertiesWithRevertRuleOrLayer = true;
+    };
+
     analyzeSizeDependentTransform();
     analyzeDiscreteTransformInterval();
     analyzeExplicitlyInheritedKeyframeProperty();
     analyzeKeyframeForExplicitProperties();
     analyzeKeyframeRangeOffset();
+    analyzeCSSWideKeywords();
 }
 
 void BlendingKeyframes::updatedComputedOffsets(NOESCAPE const Function<double(const BlendingKeyframe::Offset&)>& callback)

--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -93,6 +93,8 @@ public:
 
     bool containsDirectionAwareProperty() const { return m_containsDirectionAwareProperty; }
     void setContainsDirectionAwareProperty(bool containsDirectionAwareProperty) { m_containsDirectionAwareProperty = containsDirectionAwareProperty; }
+    bool hasPropertiesWithRevertRuleOrLayer() const { return m_hasPropertiesWithRevertRuleOrLayer; }
+    void setHasPropertiesWithRevertRuleOrLayer(bool value) { m_hasPropertiesWithRevertRuleOrLayer = value; }
 
 private:
     Offset m_specifiedOffset;
@@ -102,6 +104,7 @@ private:
     RefPtr<TimingFunction> m_timingFunction;
     std::optional<CompositeOperation> m_compositeOperation;
     bool m_containsDirectionAwareProperty { false };
+    bool m_hasPropertiesWithRevertRuleOrLayer { false };
 };
 
 using KeyframesIdentifier = Variant<AtomString, uint64_t>;
@@ -151,6 +154,7 @@ public:
     bool hasColorSetToCurrentColor() const;
     bool NODELETE hasPropertySetToCurrentColor() const;
     const HashSet<AnimatableCSSProperty>& NODELETE propertiesSetToInherit() const;
+    bool hasPropertiesWithRevertRuleOrLayer() const { return m_hasPropertiesWithRevertRuleOrLayer; }
 
     void updatePropertiesMetadata(const StyleProperties&);
 
@@ -185,6 +189,7 @@ private:
     bool m_hasDiscreteTransformInterval { false };
     bool m_hasExplicitlyInheritedKeyframeProperty { false };
     bool m_hasKeyframeNotUsingRangeOffset { false };
+    bool m_hasPropertiesWithRevertRuleOrLayer { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2231,8 +2231,9 @@ std::optional<KeyframeEffect::RecomputationReason> KeyframeEffect::recomputeKeyf
     }();
 
     auto usesAnchorFunctions = m_blendingKeyframes.usesAnchorFunctions();
+    auto hasPropertiesWithRevert = m_blendingKeyframes.hasPropertiesWithRevertRuleOrLayer();
 
-    if (logicalPropertyChanged || fontSizeChanged() || fontWeightChanged() || cssVariableChanged() || hasPropertyExplicitlySetToInherit() || propertySetToCurrentColorChanged() || usesAnchorFunctions) {
+    if (logicalPropertyChanged || fontSizeChanged() || fontWeightChanged() || cssVariableChanged() || hasPropertyExplicitlySetToInherit() || propertySetToCurrentColorChanged() || usesAnchorFunctions || hasPropertiesWithRevert) {
         switch (m_animationType) {
         case WebAnimationType::CSSTransition:
             ASSERT_NOT_REACHED();

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -375,8 +375,10 @@ void Builder::applyProperty(CSSPropertyID id, CSSValue& value, SelectorChecker::
     if (isAnyRevert) {
         // In @keyframes, 'revert-layer' and 'revert-rule' roll back the cascaded value to the author level.
         // We can just not apply the property in order to keep the value from the base style.
-        if ((isRevertLayer || isRevertRule) && m_state->m_isBuildingKeyframeStyle)
+        if ((isRevertLayer || isRevertRule) && m_state->m_isBuildingKeyframeStyle) {
+            m_state->m_hasRevertRuleOrLayerInKeyframeStyle = true;
             return;
+        }
 
         auto* rollbackCascade = [&] -> const PropertyCascade* {
             if (isRevert)
@@ -524,8 +526,10 @@ void Builder::applyCustomProperty(const AtomString& name, Variant<Ref<const Styl
             if (isAnyRevert) {
                 // In @keyframes, 'revert-layer' and 'revert-rule' roll back the cascaded value to the author level.
                 // We can just not apply the property in order to keep the value from the base style.
-                if ((isRevertLayer || isRevertRule) && m_state->m_isBuildingKeyframeStyle)
+                if ((isRevertLayer || isRevertRule) && m_state->m_isBuildingKeyframeStyle) {
+                    m_state->m_hasRevertRuleOrLayerInKeyframeStyle = true;
                     return;
+                }
 
                 auto* rollbackCascade = [&] -> const PropertyCascade* {
                     if (isRevert)

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -151,6 +151,7 @@ public:
     const CSSToLengthConversionData& cssToLengthConversionData() const { return m_cssToLengthConversionData; }
 
     void setIsBuildingKeyframeStyle() { m_isBuildingKeyframeStyle = true; }
+    bool hasRevertRuleOrLayerInKeyframeStyle() const { return m_hasRevertRuleOrLayerInKeyframeStyle; }
 
     bool isAuthorOrigin() const
     {
@@ -261,6 +262,7 @@ private:
     Vector<AtomString> m_registeredContentAttributes;
 
     bool m_isBuildingKeyframeStyle { false };
+    bool m_hasRevertRuleOrLayerInKeyframeStyle { false };
 };
 
 } // namespace Style

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -442,6 +442,8 @@ std::unique_ptr<RenderStyle> Resolver::styleForKeyframe(Element& element, const 
     Adjuster adjuster(document(), *state.parentStyle(), nullptr, !pseudoElementIdentifier ? &element : nullptr);
     adjuster.adjust(*state.style());
 
+    blendingKeyframe.setHasPropertiesWithRevertRuleOrLayer(builder.state().hasRevertRuleOrLayerInKeyframeStyle());
+
     return state.takeStyle();
 }
 


### PR DESCRIPTION
#### d6b900fa473cd5504b359fe60e4a26a720bfcea0
<pre>
[css-cascade] Invalidate keyframes for revert-rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=309343">https://bugs.webkit.org/show_bug.cgi?id=309343</a>
<a href="https://rdar.apple.com/171889390">rdar://171889390</a>

Reviewed by Sam Weinig.

`revert-rule` makes the keyframe style depend on the parent element style.

* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/revert-rule-keyframes-dynamic-expected.txt:
* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::updatePropertiesMetadata):
(WebCore::BlendingKeyframes::analyzeKeyframe):
* Source/WebCore/animation/BlendingKeyframes.h:
(WebCore::BlendingKeyframes::hasPropertiesWithRevertRuleOrLayer const):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::recomputeKeyframesIfNecessary):

Recompute such keyframes when the parent style changes.

* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::applyProperty):
(WebCore::Style::Builder::applyCustomProperty):

Collect the use of reverts during style building.

* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::hasRevertRuleOrLayerInKeyframeStyle const):
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForKeyframe const):

Canonical link: <a href="https://commits.webkit.org/308805@main">https://commits.webkit.org/308805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/232be85f04ea0593789da9a3f0d1df4537a9d0d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14795 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157197 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e87d09ed-d9a9-4884-8132-105a83f218c4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150386 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114490 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd11af7e-1aa6-42ea-b5e3-a780b2b6a714) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16710 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95260 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2fcfd810-0bcd-472b-b300-97b6ffca4320) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15812 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13643 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4633 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159532 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2664 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12760 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122539 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122760 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33381 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21006 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133033 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77158 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18111 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9802 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20614 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20346 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20491 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20400 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->