### PR TITLE
[JSC] Add IRDump option with JITDump

### DIFF
--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -47,6 +47,7 @@ namespace JSC {
 size_t LinkBuffer::s_profileCummulativeLinkedSizes[LinkBuffer::numberOfProfiles];
 size_t LinkBuffer::s_profileCummulativeLinkedCounts[LinkBuffer::numberOfProfiles];
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(IRDumpDebugInfo);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LinkBuffer);
 
 static const char* profileName(LinkBuffer::Profile profile)
@@ -127,7 +128,7 @@ void LinkBuffer::logJITCodeForJITDump(CodeRef<LinkBufferPtrTag>& codeRef, ASCIIL
         GdbJIT::log(finalName, codeRef);
 
     if (Options::useJITDump()) [[unlikely]]
-        PerfLog::log(finalName, codeRef);
+        PerfLog::log(finalName, codeRef, WTF::move(m_irDumpDebugInfo));
 }
 
 LinkBuffer::CodeRef<LinkBufferPtrTag> LinkBuffer::finalizeCodeWithDisassemblyImpl(bool dumpDisassembly, ASCIILiteral simpleName, const char* format, ...)

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -40,10 +40,38 @@
 #include <JavaScriptCore/MacroAssemblerCodeRef.h>
 #include <wtf/DataLog.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/text/CString.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
+
+class IRDumpDebugInfo {
+    WTF_MAKE_TZONE_ALLOCATED(IRDumpDebugInfo);
+    WTF_MAKE_NONCOPYABLE(IRDumpDebugInfo);
+public:
+    // This is per-line either BasicBlock header annotation or actual IR node. Like,
+    //     BB#0
+    //         GetLocal
+    struct IRLine {
+        ASCIILiteral opName;
+        uint32_t blockIndex { 0 };
+    };
+
+    struct CodeEntry {
+        uint32_t codeOffset;
+        uint32_t irLineIndex;
+    };
+
+    IRDumpDebugInfo(CString&& name)
+        : functionName(WTF::move(name))
+    {
+    }
+
+    CString functionName;
+    Vector<IRLine> irLines;
+    Vector<CodeEntry> codeEntries;
+};
 
 // LinkBuffer:
 //
@@ -328,6 +356,8 @@ ALLOW_NONLITERAL_FORMAT_END
 
     void setIsThunk() { m_isThunk = true; }
 
+    void setIRDumpDebugInfo(std::unique_ptr<IRDumpDebugInfo>&& info) { m_irDumpDebugInfo = WTF::move(info); }
+
 private:
     JS_EXPORT_PRIVATE CodeRef<LinkBufferPtrTag> finalizeCodeWithoutDisassemblyImpl(ASCIILiteral);
     JS_EXPORT_PRIVATE CodeRef<LinkBufferPtrTag> finalizeCodeWithDisassemblyImpl(bool dumpDisassembly, ASCIILiteral, const char* format, ...) WTF_ATTRIBUTE_PRINTF(4, 5);
@@ -414,6 +444,7 @@ private:
     CodePtr<LinkBufferPtrTag> m_code;
     Vector<Ref<SharedTask<void(LinkBuffer&)>>> m_linkTasks;
     Vector<Ref<SharedTask<void(LinkBuffer&)>>> m_lateLinkTasks;
+    std::unique_ptr<IRDumpDebugInfo> m_irDumpDebugInfo;
 
     static size_t s_profileCummulativeLinkedSizes[numberOfProfiles];
     static size_t s_profileCummulativeLinkedCounts[numberOfProfiles];

--- a/Source/JavaScriptCore/assembler/PerfLog.cpp
+++ b/Source/JavaScriptCore/assembler/PerfLog.cpp
@@ -144,6 +144,22 @@ struct CodeLoadRecord {
     uint64_t codeIndex { 0 };
 };
 
+struct DebugInfoRecord {
+    RecordHeader header {
+        RecordType::JITCodeDebugInfo,
+        0,
+        0,
+    };
+    uint64_t codeAddress { 0 };
+    uint64_t nrEntry { 0 };
+};
+
+struct DebugEntry {
+    uint64_t codeAddress { 0 };
+    uint32_t line { 0 };
+    uint32_t discrim { 0 };
+};
+
 } // namespace JITDump
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PerfLog);
@@ -163,6 +179,9 @@ PerfLog::PerfLog()
     {
         m_file = FileSystem::createDumpFile(makeString("jit-"_s, ProfilerSupport::getCurrentThreadID(), "-"_s, WTF::getCurrentProcessID()), ".dump"_s, String::fromUTF8(Options::jitDumpDirectory()));
         RELEASE_ASSERT(m_file);
+
+        if (Options::useIRDump())
+            m_irDumpDirectory = Options::irDumpDirectory();
 
 #if OS(LINUX)
         // Linux perf command records this mmap operation in perf.data as a metadata to the JIT perf annotations.
@@ -192,11 +211,11 @@ void PerfLog::flush(const AbstractLocker&)
     m_file.flush();
 }
 
-void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> code)
+void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> code, std::unique_ptr<IRDumpDebugInfo>&& debugInfo)
 {
     auto timestamp = ProfilerSupport::generateTimestamp();
     auto tid = ProfilerSupport::getCurrentThreadID();
-    ProfilerSupport::singleton().queue().dispatch([name = name, code, tid, timestamp] {
+    ProfilerSupport::singleton().queue().dispatch([name = name, code, tid, timestamp, debugInfo = WTF::move(debugInfo)] {
         PerfLog& logger = singleton();
         size_t size = code.size();
         auto* executableAddress = code.code().untaggedPtr<const uint8_t*>();
@@ -205,7 +224,66 @@ void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> c
             return;
         }
 
+        CString irFilePath;
+        Vector<std::pair<uint32_t, uint32_t>> lineEntries;
+        if (debugInfo) {
+            auto baseName = makeString("irdump-"_s, String::fromUTF8(debugInfo->functionName.span()), "-"_s, WTF::getCurrentProcessID(), "-"_s, timestamp);
+
+            String filePath;
+            FileSystem::FileHandle handle;
+            const CString& irDumpDir = logger.m_irDumpDirectory;
+            if (irDumpDir.isNull()) {
+                auto result = FileSystem::openTemporaryFile(baseName, ".txt"_s);
+                filePath = result.first;
+                handle = WTF::move(result.second);
+            } else {
+                filePath = makeString(String::fromUTF8(irDumpDir.span()), FileSystem::pathSeparator, baseName, ".txt"_s);
+                handle = FileSystem::openFile(filePath, FileSystem::FileOpenMode::Truncate);
+            }
+
+            if (handle) {
+                // Write sequential IR dump file from irLines.
+                for (auto& irLine : debugInfo->irLines) {
+                    CString line;
+                    if (irLine.opName)
+                        line = toCString("  ", irLine.opName, "\n");
+                    else
+                        line = toCString("BB#", irLine.blockIndex, "\n");
+                    handle.write(WTF::asByteSpan(line.span()));
+                }
+                handle.flush();
+                irFilePath = FileSystem::fileSystemRepresentation(filePath);
+
+                // Convert code entries to (codeOffset, 1-based lineNumber) pairs.
+                for (auto& codeEntry : debugInfo->codeEntries)
+                    lineEntries.append({ codeEntry.codeOffset, codeEntry.irLineIndex + 1 });
+            }
+        }
+
         Locker locker { logger.m_lock };
+
+        if (!irFilePath.isNull() && !lineEntries.isEmpty()) {
+            JITDump::DebugInfoRecord debugRecord;
+            debugRecord.header.timestamp = timestamp;
+            debugRecord.codeAddress = std::bit_cast<uintptr_t>(executableAddress);
+            debugRecord.nrEntry = lineEntries.size();
+
+            uint32_t totalSize = sizeof(JITDump::DebugInfoRecord);
+            for (size_t i = 0; i < lineEntries.size(); ++i)
+                totalSize += sizeof(JITDump::DebugEntry) + (irFilePath.length() + 1);
+            debugRecord.header.totalSize = totalSize;
+
+            logger.write(locker, unsafeMakeSpan(std::bit_cast<char*>(&debugRecord), sizeof(JITDump::DebugInfoRecord)));
+
+            for (auto& [codeOffset, lineNumber] : lineEntries) {
+                JITDump::DebugEntry debugEntry;
+                debugEntry.codeAddress = std::bit_cast<uintptr_t>(executableAddress) + codeOffset;
+                debugEntry.line = lineNumber;
+                debugEntry.discrim = 0;
+                logger.write(locker, unsafeMakeSpan(std::bit_cast<char*>(&debugEntry), sizeof(JITDump::DebugEntry)));
+                logger.write(locker, irFilePath.spanIncludingNullTerminator());
+            }
+        }
 
         JITDump::CodeLoadRecord record;
         record.header.timestamp = timestamp;

--- a/Source/JavaScriptCore/assembler/PerfLog.h
+++ b/Source/JavaScriptCore/assembler/PerfLog.h
@@ -45,7 +45,7 @@ class PerfLog {
     WTF_MAKE_NONCOPYABLE(PerfLog);
     friend class LazyNeverDestroyed<PerfLog>;
 public:
-    static void log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag>);
+    static void log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag>, std::unique_ptr<IRDumpDebugInfo>&& = nullptr);
 
 private:
     PerfLog();
@@ -56,6 +56,7 @@ private:
     void flush(const AbstractLocker&) WTF_REQUIRES_LOCK(m_lock);
 
     WTF::FileSystemImpl::FileHandle m_file { };
+    CString m_irDumpDirectory;
     uint64_t m_codeIndex { 0 };
     Lock m_lock;
 };

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -50,6 +50,7 @@
 #include "GetterSetter.h"
 #include "JIT.h"
 #include "JSLexicalEnvironment.h"
+#include "LinkBuffer.h"
 #include "MaxFrameExtentForSlowPathCall.h"
 #include "OperandsInlines.h"
 #include "ProfilerSupport.h"
@@ -2219,6 +2220,24 @@ void Graph::appendIonGraphPass(const String& passName)
         pass->setObject("lir"_s, WTF::move(ionGraph)); // LIR stands for SpiderMonkey's low-level IR.
     }
     m_ionGraphPasses->pushObject(pass);
+}
+
+UncheckedKeyHashMap<Node*, uint32_t> Graph::collectIRDumpDebugInfo(IRDumpDebugInfo& debugInfo)
+{
+    UncheckedKeyHashMap<Node*, uint32_t> nodeToLineIndex;
+    for (BlockIndex blockIndex = 0; blockIndex < numBlocks(); ++blockIndex) {
+        auto* block = this->block(blockIndex);
+        if (!block)
+            continue;
+        debugInfo.irLines.append({ { }, blockIndex });
+        for (size_t i = 0; i < block->size(); ++i) {
+            Node* node = block->at(i);
+            uint32_t lineIndex = debugInfo.irLines.size();
+            nodeToLineIndex.add(node, lineIndex);
+            debugInfo.irLines.append({ Graph::opName(node->op()), 0 });
+        }
+    }
+    return nodeToLineIndex;
 }
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -57,6 +57,7 @@ namespace JSC {
 
 class CodeBlock;
 class CallFrame;
+class IRDumpDebugInfo;
 
 namespace DFG {
 
@@ -1320,6 +1321,8 @@ public:
     bool afterFixup() { return m_planStage >= PlanStage::AfterFixup; }
 
     RefPtr<JSON::Array> ionGraphPasses() const { return m_ionGraphPasses; }
+
+    UncheckedKeyHashMap<Node*, uint32_t> collectIRDumpDebugInfo(IRDumpDebugInfo&);
 
     StackCheck m_stackChecker;
     VM& m_vm;

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -39,6 +39,7 @@
 #include "DFGThunks.h"
 #include "JSCJSValueInlines.h"
 #include "LinkBuffer.h"
+#include "Options.h"
 #include "ProbeContext.h"
 #include "ThunkGenerators.h"
 #include "VM.h"
@@ -377,6 +378,30 @@ void JITCompiler::disassemble(LinkBuffer& linkBuffer)
 
     if (m_graph.m_plan.compilation()) [[unlikely]]
         m_disassembler->reportToProfiler(m_graph.m_plan.compilation(), linkBuffer);
+}
+
+void JITCompiler::collectIRDumpDebugInfo(LinkBuffer& linkBuffer)
+{
+    if (!Options::useIRDump())
+        return;
+
+    if (m_irDumpLabels.isEmpty())
+        return;
+
+    auto debugInfo = makeUnique<IRDumpDebugInfo>(m_graph.m_codeBlock->inferredName());
+    auto nodeToLineIndex = m_graph.collectIRDumpDebugInfo(*debugInfo);
+
+    void* codeStart = linkBuffer.entrypoint<DisassemblyPtrTag>().untaggedPtr();
+    for (auto& entry : m_irDumpLabels) {
+        auto it = nodeToLineIndex.find(entry.node);
+        if (it == nodeToLineIndex.end())
+            continue;
+        auto location = linkBuffer.locationOf<DisassemblyPtrTag>(entry.label);
+        uint32_t codeOffset = static_cast<uint32_t>(location.dataLocation<uintptr_t>() - reinterpret_cast<uintptr_t>(codeStart));
+        debugInfo->codeEntries.append({ codeOffset, it->value });
+    }
+
+    linkBuffer.setIRDumpDebugInfo(WTF::move(debugInfo));
 }
 
 #if USE(JSVALUE32_64)

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.h
@@ -115,6 +115,8 @@ public:
     
     void setForNode(Node* node)
     {
+        if (Options::useIRDump()) [[unlikely]]
+            m_irDumpLabels.append({ labelIgnoringWatchpoints(), node });
         if (!m_disassembler) [[likely]]
             return;
         m_disassembler->setForNode(node, labelIgnoringWatchpoints());
@@ -385,6 +387,7 @@ protected:
     void exitSpeculativeWithOSR(const OSRExit&, SpeculationRecovery*);
     void linkOSRExits();
     void disassemble(LinkBuffer&);
+    void collectIRDumpDebugInfo(LinkBuffer&);
 
     void makeCatchOSREntryBuffer();
 
@@ -442,6 +445,12 @@ protected:
     Vector<ExceptionHandlingOSRExitInfo> m_exceptionHandlerOSRExitCallSites;
     
     PCToCodeOriginMapBuilder m_pcToCodeOriginMapBuilder;
+
+    struct IRDumpLabel {
+        MacroAssembler::Label label;
+        Node* node;
+    };
+    Vector<IRDumpLabel> m_irDumpLabels;
 };
 
 } } // namespace JSC::DFG

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -182,6 +182,8 @@ void SpeculativeJIT::compile()
     link(linkBuffer);
     linkOSREntries(linkBuffer);
 
+    collectIRDumpDebugInfo(linkBuffer);
+
     disassemble(linkBuffer);
 
     auto codeRef = FINALIZE_DFG_CODE(linkBuffer, JSEntryPtrTag, "DFG JIT code for %s", toCString(CodeBlockWithJITType(m_codeBlock, JITType::DFGJIT)).data());
@@ -284,6 +286,8 @@ void SpeculativeJIT::compileFunction()
     }
     link(linkBuffer);
     linkOSREntries(linkBuffer);
+
+    collectIRDumpDebugInfo(linkBuffer);
 
     disassemble(linkBuffer);
 

--- a/Source/JavaScriptCore/ftl/FTLCompile.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCompile.cpp
@@ -36,12 +36,15 @@
 #include "B3ValueInlines.h"
 #include "CodeBlockWithJITType.h"
 #include "CCallHelpers.h"
+#include "DFGGraph.h"
 #include "DFGGraphSafepoint.h"
+#include "DFGNode.h"
 #include "FTLJITCode.h"
 #include "JITThunks.h"
 #include "LLIntEntrypoint.h"
 #include "LLIntThunks.h"
 #include "LinkBuffer.h"
+#include "Options.h"
 #include "PCToCodeOriginMap.h"
 #include "ThunkGenerators.h"
 #include <wtf/RecursableLambda.h>
@@ -201,6 +204,54 @@ void compile(State& state, Safepoint::Result& safepointResult)
     if (state.b3CodeLinkBuffer->didFailToAllocate()) {
         state.allocationFailed = true;
         return;
+    }
+
+    if (Options::useIRDump() && state.proc->needsPCToOriginMap()) {
+        auto debugInfo = makeUnique<IRDumpDebugInfo>(codeBlock->inferredName());
+        auto nodeToLineIndex = graph.collectIRDumpDebugInfo(*debugInfo);
+
+        auto& originMap = state.proc->pcToOriginMap();
+        void* codeStart = state.b3CodeLinkBuffer->entrypoint<DisassemblyPtrTag>().untaggedPtr();
+
+        DFG::Node* current = nullptr;
+        uint32_t currentLineIndex = 0;
+        std::optional<uint32_t> currentCodeOffset;
+        auto flush = [&] {
+            if (currentCodeOffset)
+                debugInfo->codeEntries.append({ currentCodeOffset.value(), currentLineIndex });
+            current = nullptr;
+            currentLineIndex = 0;
+            currentCodeOffset = std::nullopt;
+        };
+
+        auto append = [&](DFG::Node* node, uint32_t codeOffset, uint32_t lineIndex) {
+            if (current != node)
+                flush();
+            current = node;
+            currentLineIndex = lineIndex;
+            if (!currentCodeOffset)
+                currentCodeOffset = codeOffset;
+        };
+
+        for (auto& range : originMap.ranges()) {
+            auto origin = range.origin;
+            if (!origin || !origin.isDFGOrigin())
+                continue;
+            DFG::Node* node = origin.dfgOrigin();
+            if (!node)
+                continue;
+
+            auto it = nodeToLineIndex.find(node);
+            if (it == nodeToLineIndex.end())
+                continue;
+
+            auto location = state.b3CodeLinkBuffer->locationOf<DisassemblyPtrTag>(range.label);
+            uint32_t codeOffset = static_cast<uint32_t>(location.dataLocation<uintptr_t>() - reinterpret_cast<uintptr_t>(codeStart));
+            append(node, codeOffset, it->value);
+        }
+        flush();
+
+        state.b3CodeLinkBuffer->setIRDumpDebugInfo(WTF::move(debugInfo));
     }
 
     if (vm.shouldBuilderPCToCodeOriginMapping()) {

--- a/Source/JavaScriptCore/ftl/FTLState.cpp
+++ b/Source/JavaScriptCore/ftl/FTLState.cpp
@@ -36,6 +36,7 @@
 #include "FTLJITCode.h"
 #include "FTLJITFinalizer.h"
 #include "FTLPatchpointExceptionHandle.h"
+#include "Options.h"
 
 #include <wtf/RecursableLambda.h>
 
@@ -69,7 +70,7 @@ State::State(Graph& graph)
 
     proc = makeUniqueWithoutFastMallocCheck<Procedure>(/* usesSIMD = */ false);
 
-    if (graph.m_vm.shouldBuilderPCToCodeOriginMapping())
+    if (graph.m_vm.shouldBuilderPCToCodeOriginMapping() || Options::useIRDump())
         proc->setNeedsPCToOriginMap();
 
     proc->setOriginPrinter(

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -873,6 +873,9 @@ void Options::notifyOptionsChanged()
             || Options::useProfiler()) // For JIT comments in the profile.
             Options::needDisassemblySupport() = true;
 
+        if (Options::useIRDump() && !Options::useJITDump())
+            Options::useIRDump() = false;
+
         if (OptionsHelper::wasOverridden(jitPolicyScaleID))
             scaleJITPolicy();
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -149,6 +149,8 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useGdbJITInfo, false, Normal, "generates GDB JIT API side-data; to use with lldb on macos, add `settings set plugin.jit-loader.gdb.enable on` to .lldbinit") \
     v(Bool, useTextMarkers, false, Normal, "generates text markers side-data") \
     v(OptionString, jitDumpDirectory, nullptr, Normal, "Directory to place JITDump"_s) \
+    v(Bool, useIRDump, false, Normal, "generates IR dump files and JIT_CODE_DEBUG_INFO in JITDump"_s) \
+    v(OptionString, irDumpDirectory, nullptr, Normal, "Directory to place IR dump files"_s) \
     v(OptionString, textMarkersDirectory, nullptr, Normal, "Directory to place MarkerTxt") \
     v(OptionRange, bytecodeRangeToJITCompile, nullptr, Normal, "bytecode size range to allow compilation on, e.g. 1:100"_s) \
     v(OptionRange, bytecodeRangeToDFGCompile, nullptr, Normal, "bytecode size range to allow DFG compilation on, e.g. 1:100"_s) \


### PR DESCRIPTION
#### bccc78c952d78f6a940a1334dd44def586ea1423
<pre>
[JSC] Add IRDump option with JITDump
<a href="https://bugs.webkit.org/show_bug.cgi?id=309344">https://bugs.webkit.org/show_bug.cgi?id=309344</a>
<a href="https://rdar.apple.com/171891036">rdar://171891036</a>

Reviewed by Keith Miller.

This patch adds useIRDump and irDumpDirectory options.
They are effective only when useJITDump is enabled.
When it is enabled, we generate IRDump, which is just a very simple
sequence of DFG IR as a file. And we also generate JITDump&apos;s
JITCodeDebugInfo with this file. This debug info can associate a JIT
code range to a file line &amp; column. By using them, we associate JIT code
with this on-the-fly generated IRDump files so profiler can show samples
in IRDump as well.

* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
(JSC::LinkBuffer::logJITCodeForJITDump):
* Source/JavaScriptCore/assembler/LinkBuffer.h:
(JSC::IRDumpDebugInfo::IRDumpDebugInfo):
(JSC::LinkBuffer::setIRDumpDebugInfo):
* Source/JavaScriptCore/assembler/PerfLog.cpp:
(JSC::PerfLog::PerfLog):
(JSC::PerfLog::log):
* Source/JavaScriptCore/assembler/PerfLog.h:
* Source/JavaScriptCore/dfg/DFGGraph.cpp:
(JSC::DFG::Graph::collectIRDumpDebugInfo):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
(JSC::DFG::JITCompiler::collectIRDumpDebugInfo):
* Source/JavaScriptCore/dfg/DFGJITCompiler.h:
(JSC::DFG::JITCompiler::setForNode):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compile):
(JSC::DFG::SpeculativeJIT::compileFunction):
* Source/JavaScriptCore/ftl/FTLCompile.cpp:
(JSC::FTL::compile):
* Source/JavaScriptCore/ftl/FTLState.cpp:
(JSC::FTL::State::State):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/308822@main">https://commits.webkit.org/308822@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/319a8b12d7bb136043ee212fd1c2260e86e14116

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148595 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/21301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/14877 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157279 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/21760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21186 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/114552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151555 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/21760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/95322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/21760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4715 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140562 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/21760 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/11311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159614 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9382 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/2755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/12833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/122609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17702 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/122834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/133106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22894 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/9871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180023 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/20719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->