### PR TITLE
Fix HTML's get an optgroup element's label

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-legend-label-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-legend-label-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<select size="4">
+  <optgroup label="Foobar">
+    <option>Lion</option>
+  </optgroup>
+</select>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-legend-label-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-legend-label-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<select size="4">
+  <optgroup label="Foobar">
+    <option>Lion</option>
+  </optgroup>
+</select>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-legend-label.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-legend-label.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<link rel=help href="https://html.spec.whatwg.org/multipage/form-elements.html#concept-optgroup-label">
+<link rel=match href="select-optgroup-legend-label-ref.html">
+<meta name=assert content="An optgroup's label comes from its first child legend element when present">
+<select size="4">
+  <optgroup label="Animals">
+    <legend>Foobar</legend>
+    <option>Lion</option>
+  </optgroup>
+</select>

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -29,14 +29,18 @@
 #include "ElementAncestorIteratorInlines.h"
 #include "ElementIterator.h"
 #include "HTMLDivElement.h"
+#include "HTMLLegendElement.h"
 #include "HTMLNames.h"
 #include "HTMLOptionElement.h"
 #include "HTMLSelectElement.h"
 #include "HTMLSlotElement.h"
+#include "NodeTraversal.h"
 #include "PseudoClassChangeInvalidation.h"
 #include "NodeRenderStyle.h"
 #include "ScriptDisallowedScope.h"
+#include "ScriptElement.h"
 #include "StyleResolver.h"
+#include "Text.h"
 #include "TypedElementDescendantIteratorInlines.h"
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -239,16 +243,27 @@ void HTMLOptGroupElement::recalcSelectOptions()
 
 String HTMLOptGroupElement::groupLabelText() const
 {
+    if (document().settings().htmlEnhancedSelectEnabled() && m_legendChildCount) {
+        if (RefPtr legend = childrenOfType<HTMLLegendElement>(*this).first()) {
+            StringBuilder text;
+            for (RefPtr node = legend->firstChild(); node; node = isScriptElement(*node) ? NodeTraversal::nextSkippingChildren(*node, legend.get()) : NodeTraversal::next(*node, legend.get())) {
+                if (auto* textNode = dynamicDowncast<Text>(*node))
+                    text.append(textNode->data());
+            }
+            return text.toString().trim(isASCIIWhitespace).simplifyWhiteSpace(isASCIIWhitespace);
+        }
+    }
+
     String itemText = protect(document())->displayStringModifiedByEncoding(attributeWithoutSynchronization(labelAttr));
-    
+
     // In WinIE, leading and trailing whitespace is ignored in options and optgroups. We match this behavior.
     itemText = itemText.trim(deprecatedIsSpaceOrNewline);
     // We want to collapse our whitespace too.  This will match other browsers.
     itemText = itemText.simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
-        
+
     return itemText;
 }
-    
+
 HTMLSelectElement* HTMLOptGroupElement::ownerSelectElement() const
 {
     if (!document().settings().htmlEnhancedSelectParsingEnabled())
@@ -266,4 +281,4 @@ bool HTMLOptGroupElement::accessKeyAction(bool)
     return false;
 }
 
-} // namespace
+} // namespace WebCore


### PR DESCRIPTION
#### 1dbf607c40b277a58e773cf826e3c3e4065fbdb4
<pre>
Fix HTML&apos;s get an optgroup element&apos;s label
<a href="https://bugs.webkit.org/show_bug.cgi?id=309161">https://bugs.webkit.org/show_bug.cgi?id=309161</a>

Reviewed by Ryosuke Niwa.

We were missing this algorithm as it was not tested, so add a test.

Test: imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-legend-label.html

Upstream: <a href="https://github.com/web-platform-tests/wpt/pull/58329">https://github.com/web-platform-tests/wpt/pull/58329</a>
Canonical link: <a href="https://commits.webkit.org/308856@main">https://commits.webkit.org/308856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cd88307a079da1361529fd7e00f53fb24a5c98a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157194 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101940 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45a22c32-a578-4de9-8407-b244094d287e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114485 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81541 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a600ef61-e7ef-429c-b556-da6205c0dc77) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151470 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95255 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9a1c070-a112-4f21-bfeb-7b4f9726d703) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15807 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13639 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4630 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125420 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11234 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159529 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2661 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12754 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122534 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20994 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122755 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21003 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133027 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77155 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22905 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18103 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9796 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20611 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84436 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20343 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20488 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20397 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->