### PR TITLE
[JSC] `TypedArray#sort` fails when comparator access `.buffer`

### DIFF
--- a/JSTests/stress/typedarray-sort-buffer-access-stale-pointer.js
+++ b/JSTests/stress/typedarray-sort-buffer-access-stale-pointer.js
@@ -1,0 +1,44 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error((msg || "") + " expected " + expected + " but got " + actual);
+}
+
+{
+    let ta = new Int32Array(100);
+    for (let i = 0; i < 100; i++) ta[i] = 100 - i;
+
+    ta.sort((a, b) => {
+        ta.buffer;
+        return a - b;
+    });
+
+    shouldBe(ta[0], 1, "ta[0] after sort with .buffer access");
+    shouldBe(ta[99], 100, "ta[99] after sort with .buffer access");
+    for (let i = 0; i < 99; i++)
+        shouldBe(ta[i] <= ta[i+1], true, "sorted at [" + i + "]");
+}
+
+{
+    let ta = new Float64Array(50);
+    for (let i = 0; i < 50; i++) ta[i] = Math.random();
+
+    let accessed = false;
+    ta.sort((a, b) => {
+        if (!accessed) { ta.buffer; accessed = true; }
+        return a - b;
+    });
+
+    for (let i = 0; i < 49; i++)
+        shouldBe(ta[i] <= ta[i+1], true, "Float64 sorted at [" + i + "]");
+}
+
+{
+    let ta = new Int32Array(100);
+    ta.buffer;
+    for (let i = 0; i < 100; i++) ta[i] = 100 - i;
+
+    ta.sort((a, b) => { ta.buffer; return a - b; });
+
+    shouldBe(ta[0], 1, "pre-wasteful ta[0]");
+    shouldBe(ta[99], 100, "pre-wasteful ta[99]");
+}

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -1592,8 +1592,10 @@ static ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSortImpl(VM& v
     if (thisObject->isDetached()) [[unlikely]]
         return JSValue::encode(thisObject);
 
+    // The comparator may trigger FastTypedArray -> WastefulTypedArray transition via .buffer access,
+    // which relocates the backing store. Do not reuse originalSpan here.
     size_t copyLength = std::min<size_t>(thisObject->length(), result.size());
-    WTF::copyElements(originalSpan, spanConstCast<const typename ViewClass::ElementType>(result.first(copyLength)));
+    WTF::copyElements(thisObject->typedSpan().first(copyLength), spanConstCast<const typename ViewClass::ElementType>(result.first(copyLength)));
 
     return JSValue::encode(thisObject);
 }


### PR DESCRIPTION
#### b9c004b3c5be25f15f6359c4e3a4d5fabd625ae9
<pre>
[JSC] `TypedArray#sort` fails when comparator access `.buffer`
<a href="https://bugs.webkit.org/show_bug.cgi?id=309346">https://bugs.webkit.org/show_bug.cgi?id=309346</a>

Reviewed by Yusuke Suzuki.

When sorting a FastTypedArray with a comparator, accessing `.buffer` inside
the comparator triggers slowDownAndWasteMemory(), which reallocates the
backing store into a new ArrayBuffer and updates m_vector. The sort
implementation was caching typedSpan() before invoking the comparator and
writing the sorted result back through this cached span, so the result
never reached the new backing store and the array appeared unsorted.

    let ta = new Int32Array(100);
    for (let i = 0; i &lt; 100; i++) ta[i] = 100 - i;
    ta.sort((a, b) =&gt; { ta.buffer; return a - b; });
    // ta[0] was 100, should be 1

The isDetached() guard does not help here because the FastTypedArray to
WastefulTypedArray transition is not detachment. Fix by re-fetching
typedSpan() for the write-back. length() was already being re-read at
this point, so this just adds one m_vector load after O(n log n)
comparator calls.

Test: JSTests/stress/typedarray-sort-buffer-access-stale-pointer.js

* JSTests/stress/typedarray-sort-buffer-access-stale-pointer.js: Added.
(shouldBe):
(throw.new.Error):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::genericTypedArrayViewProtoFuncSortImpl):

Canonical link: <a href="https://commits.webkit.org/308833@main">https://commits.webkit.org/308833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cddb46a575e9f189fa10a3c11bddf915e9b1abaa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157196 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101942 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114489 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81542 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16708 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95259 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15810 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13642 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4632 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140479 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125425 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159531 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9299 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2663 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122538 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17634 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122759 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33396 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133031 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77157 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18109 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9800 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179940 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20613 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84438 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46066 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20345 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20490 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20399 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->