### PR TITLE
Adopt `LIFETIME_BOUND` annotation in more places in WebCore

### DIFF
--- a/Source/WebCore/PAL/pal/ThreadGlobalData.h
+++ b/Source/WebCore/PAL/pal/ThreadGlobalData.h
@@ -42,7 +42,7 @@ class ThreadGlobalData : public WTF::Thread::ClientData {
 public:
     PAL_EXPORT virtual ~ThreadGlobalData();
 
-    ICUConverterWrapper& cachedConverterICU() { return m_cachedConverterICU; }
+    ICUConverterWrapper& cachedConverterICU() LIFETIME_BOUND { return m_cachedConverterICU; }
 
 protected:
     PAL_EXPORT explicit ThreadGlobalData(Type);

--- a/Source/WebCore/PAL/pal/avfoundation/OutputContext.h
+++ b/Source/WebCore/PAL/pal/avfoundation/OutputContext.h
@@ -46,7 +46,7 @@ public:
 
     Vector<OutputDevice> outputDevices() const;
 
-    AVOutputContext* platformContext() const { return m_context.get(); }
+    AVOutputContext* platformContext() const LIFETIME_BOUND { return m_context.get(); }
 private:
     friend class NeverDestroyed<OutputContext>;
     OutputContext(RetainPtr<AVOutputContext>&&);

--- a/Source/WebCore/PAL/pal/avfoundation/OutputDevice.h
+++ b/Source/WebCore/PAL/pal/avfoundation/OutputDevice.h
@@ -46,7 +46,7 @@ public:
     };
     uint8_t deviceFeatures() const;
 
-    AVOutputDevice* platformDevice() const { return m_device.get(); }
+    AVOutputDevice* platformDevice() const LIFETIME_BOUND { return m_device.get(); }
 private:
     friend class OutputContext;
     OutputDevice(RetainPtr<AVOutputDevice>&&);

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -624,7 +624,7 @@ AXCoreObject* AXCoreObject::nextSiblingIncludingIgnored(bool updateChildrenIfNee
     return indexOfThis + 1 < siblings.size() ? siblings[indexOfThis + 1].unsafePtr() : nullptr;
 }
 
-AXCoreObject* AXCoreObject::previousSiblingIncludingIgnored(bool updateChildrenIfNeeded)
+RefPtr<AXCoreObject> AXCoreObject::previousSiblingIncludingIgnored(bool updateChildrenIfNeeded)
 {
     RefPtr parent = parentObject();
     if (!parent)
@@ -632,10 +632,10 @@ AXCoreObject* AXCoreObject::previousSiblingIncludingIgnored(bool updateChildrenI
 
     const auto& siblings = parent->childrenIncludingIgnored(updateChildrenIfNeeded);
     size_t indexOfThis = indexInSiblings(siblings);
-    if (indexOfThis == notFound)
+    if (indexOfThis == notFound || indexOfThis < 1)
         return nullptr;
 
-    return indexOfThis >= 1 ? siblings[indexOfThis - 1].ptr() : nullptr;
+    return siblings[indexOfThis - 1].copyRef();
 }
 
 AXCoreObject* AXCoreObject::nextUnignoredSibling(bool updateChildrenIfNeeded, AXCoreObject* unignoredParent) const

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1067,9 +1067,9 @@ public:
     // When it is not, it returns unignored children. After ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     // is the default, we should rename this function to childrenIncludingIgnored, and all callers
     // should be audited to either use that, or unignoredChildren.
-    virtual const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) = 0;
+    virtual const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) LIFETIME_BOUND = 0;
 
-    const AccessibilityChildrenVector& childrenIncludingIgnored(bool updateChildrenIfNeeded = true)
+    const AccessibilityChildrenVector& childrenIncludingIgnored(bool updateChildrenIfNeeded = true) LIFETIME_BOUND
     {
         return children(updateChildrenIfNeeded);
     };
@@ -1079,7 +1079,7 @@ public:
     AccessibilityChildrenVector unignoredChildren(bool updateChildrenIfNeeded = true);
     bool hasUnignoredChild();
 #else
-    const AccessibilityChildrenVector& unignoredChildren(bool updateChildrenIfNeeded = true) { return children(updateChildrenIfNeeded); }
+    const AccessibilityChildrenVector& unignoredChildren(bool updateChildrenIfNeeded = true) LIFETIME_BOUND { return children(updateChildrenIfNeeded); }
     bool hasUnignoredChild()
     {
         const auto& children = this->children();
@@ -1127,7 +1127,7 @@ public:
     }
 
     RefPtr<AXCoreObject> previousInPreOrder(bool updateChildrenIfNeeded = true, AXCoreObject* stayWithin = nullptr);
-    AXCoreObject* previousSiblingIncludingIgnored(bool updateChildrenIfNeeded);
+    RefPtr<AXCoreObject> previousSiblingIncludingIgnored(bool updateChildrenIfNeeded);
     AXCoreObject* deepestLastChildIncludingIgnored(bool updateChildrenIfNeeded);
 
     void setIndexInParent(unsigned index)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -267,7 +267,7 @@ public:
     AccessibilityReplacedText() = default;
     AccessibilityReplacedText(const VisibleSelection&);
     void postTextStateChangeNotification(AXObjectCache*, AXTextEditType, const String&, const VisibleSelection&);
-    const VisiblePositionIndexRange& replacedRange() { return m_replacedRange; }
+    const VisiblePositionIndexRange& replacedRange() LIFETIME_BOUND { return m_replacedRange; }
 protected:
     String m_replacedText;
     VisiblePositionIndexRange m_replacedRange;
@@ -322,8 +322,8 @@ public:
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     WEBCORE_EXPORT void setFrameInheritedState(LocalFrame&, const InheritedFrameState&);
     WEBCORE_EXPORT void setFrameGeometry(LocalFrame&, const FrameGeometry&);
-    const std::optional<FrameGeometry>& frameGeometry() const { return m_frameGeometry; }
-    const std::optional<FrameGeometry>& getAndUpdateFrameGeometry();
+    const std::optional<FrameGeometry>& frameGeometry() const LIFETIME_BOUND { return m_frameGeometry; }
+    const std::optional<FrameGeometry>& getAndUpdateFrameGeometry() LIFETIME_BOUND;
 #endif
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     WEBCORE_EXPORT void buildIsolatedTreeIfNeeded();
@@ -690,7 +690,7 @@ public:
     void startCachingComputedObjectAttributesUntilTreeMutates();
     void stopCachingComputedObjectAttributes();
 
-    AXComputedObjectAttributeCache* computedObjectAttributeCache() { return m_computedObjectAttributeCache.get(); }
+    AXComputedObjectAttributeCache* computedObjectAttributeCache() LIFETIME_BOUND { return m_computedObjectAttributeCache.get(); }
 
     Document* document() const { return m_document; }
     FrameIdentifier frameID() const { return m_frameID; }

--- a/Source/WebCore/accessibility/AXObjectRareData.h
+++ b/Source/WebCore/accessibility/AXObjectRareData.h
@@ -41,8 +41,8 @@ public:
     AXObjectRareData() = default;
 
     // Begin table-related methods.
-    const AXCoreObject::AccessibilityChildrenVector& tableRows() const { return m_tableRows; }
-    const AXCoreObject::AccessibilityChildrenVector& tableColumns() const { return m_tableColumns; }
+    const AXCoreObject::AccessibilityChildrenVector& tableRows() const LIFETIME_BOUND { return m_tableRows; }
+    const AXCoreObject::AccessibilityChildrenVector& tableColumns() const LIFETIME_BOUND { return m_tableColumns; }
     unsigned rowCount() const { return m_tableRows.size(); }
     unsigned columnCount() const { return m_tableColumns.size(); }
     void appendColumn(AccessibilityObject& columnObject) { m_tableColumns.append(columnObject); }
@@ -52,8 +52,8 @@ public:
     AccessibilityObject* tableHeaderContainer() const { return m_tableHeaderContainer.get(); }
     void setTableHeaderContainer(AccessibilityObject& object) { m_tableHeaderContainer = object; }
 
-    const Vector<Vector<Markable<AXID>>>& cellSlots() const { return m_cellSlots; }
-    Vector<Vector<Markable<AXID>>>& mutableCellSlots() { return m_cellSlots; }
+    const Vector<Vector<Markable<AXID>>>& cellSlots() const LIFETIME_BOUND { return m_cellSlots; }
+    Vector<Vector<Markable<AXID>>>& mutableCellSlots() LIFETIME_BOUND { return m_cellSlots; }
 
     void resetChildrenDependentTableFields();
     // End table-related methods.

--- a/Source/WebCore/accessibility/AXSearchManager.h
+++ b/Source/WebCore/accessibility/AXSearchManager.h
@@ -166,7 +166,7 @@ public:
     bool isRemoteFrame() const { return m_type == Type::RemoteFrame; }
 
     RefPtr<AXCoreObject> objectIfLocalResult() const { return isLocalResult() ? m_object : nullptr; }
-    const std::optional<FrameIdentifier>& frameID() const { return m_frameID; }
+    const std::optional<FrameIdentifier>& frameID() const LIFETIME_BOUND { return m_frameID; }
     size_t streamIndex() const { return m_streamIndex; }
 
 private:
@@ -204,7 +204,7 @@ public:
         m_entries.append(SearchResultEntry::remoteFrame(frameID, nextIndex()));
     }
 
-    const Vector<SearchResultEntry>& entries() const { return m_entries; }
+    const Vector<SearchResultEntry>& entries() const LIFETIME_BOUND { return m_entries; }
     size_t entryCount() const { return m_entries.size(); }
 
     void setResultsLimit(unsigned limit) { m_resultsLimit = limit; }
@@ -235,7 +235,7 @@ public:
     bool isRemote() const { return m_remoteToken.has_value(); }
 
     RefPtr<AXCoreObject> objectIfLocalResult() const { return isLocal() ? m_localObject : nullptr; }
-    const std::optional<AccessibilityRemoteToken>& remoteToken() const { return m_remoteToken; }
+    const std::optional<AccessibilityRemoteToken>& remoteToken() const LIFETIME_BOUND { return m_remoteToken; }
 
 private:
     AccessibilitySearchResult(RefPtr<AXCoreObject> object, std::optional<AccessibilityRemoteToken> token)

--- a/Source/WebCore/accessibility/AXStitchGroup.h
+++ b/Source/WebCore/accessibility/AXStitchGroup.h
@@ -70,7 +70,7 @@ public:
         return m_members.isEmpty() || m_members.contains(representativeID());
     }
 
-    const FixedVector<AXID>& members() const { return m_members; }
+    const FixedVector<AXID>& members() const LIFETIME_BOUND { return m_members; }
     AXID representativeID() const { return m_representativeID; }
 
 private:

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -564,7 +564,7 @@ public:
 
     void updateRole();
     bool childrenInitialized() const { return m_childrenInitialized; }
-    const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) final;
+    const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) LIFETIME_BOUND final;
     virtual void addChildren() { }
     enum class DescendIfIgnored : bool { No, Yes };
     void insertChild(AccessibilityObject&, unsigned, DescendIfIgnored = DescendIfIgnored::Yes);
@@ -835,8 +835,8 @@ public:
         }
     };
 
-    InlineTextPrediction& lastPresentedTextPrediction() { return m_lastPresentedTextPrediction; }
-    InlineTextPrediction& lastPresentedTextPredictionComplete() { return m_lastPresentedTextPredictionComplete; }
+    InlineTextPrediction& lastPresentedTextPrediction() LIFETIME_BOUND { return m_lastPresentedTextPrediction; }
+    InlineTextPrediction& lastPresentedTextPredictionComplete() LIFETIME_BOUND { return m_lastPresentedTextPredictionComplete; }
     void setLastPresentedTextPrediction(Node&, CompositionState, const String&, size_t, bool);
 #endif // PLATFORM(IOS_FAMILY)
 

--- a/Source/WebCore/accessibility/AccessibilityObjectInlines.h
+++ b/Source/WebCore/accessibility/AccessibilityObjectInlines.h
@@ -253,7 +253,7 @@ inline bool AccessibilityObject::ariaIsMultiline() const
     return equalLettersIgnoringASCIICase(getAttribute(HTMLNames::aria_multilineAttr), "true"_s);
 }
 
-inline const AccessibilityObject::AccessibilityChildrenVector& AccessibilityObject::children(bool updateChildrenIfNeeded)
+inline const AccessibilityObject::AccessibilityChildrenVector& AccessibilityObject::children(bool updateChildrenIfNeeded) LIFETIME_BOUND
 {
     if (updateChildrenIfNeeded)
         updateChildrenIfNecessary();

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -67,7 +67,7 @@ public:
     AffineTransform frameScreenTransform() const final { return frameGeometry().screenTransform; }
 
     void setInheritedFrameState(InheritedFrameState);
-    const InheritedFrameState& inheritedFrameState() const { return m_inheritedFrameState; }
+    const InheritedFrameState& inheritedFrameState() const LIFETIME_BOUND { return m_inheritedFrameState; }
     bool isAXHidden() const final;
     bool isARIAHidden() const final;
     void updateHostedFrameInheritedState();

--- a/Source/WebCore/accessibility/AccessibleSetValueEvent.h
+++ b/Source/WebCore/accessibility/AccessibleSetValueEvent.h
@@ -40,7 +40,7 @@ public:
 
     virtual ~AccessibleSetValueEvent();
 
-    const AtomString& value() const { return m_value; }
+    const AtomString& value() const LIFETIME_BOUND { return m_value; }
 
 private:
     AccessibleSetValueEvent(const AtomString& type, const AtomString& value);

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h
@@ -62,7 +62,7 @@ public:
         TableCell = 1 << 11,
         Collection =  1 << 12
     };
-    const OptionSet<Interface>& interfaces() const { return m_interfaces; }
+    const OptionSet<Interface>& interfaces() const LIFETIME_BOUND { return m_interfaces; }
 
     void setParent(std::optional<AccessibilityObjectAtspi*>);
     WEBCORE_EXPORT std::optional<AccessibilityObjectAtspi*> parent() const;

--- a/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.h
@@ -44,7 +44,7 @@ public:
     void unregisterObject();
     void setPath(String&&);
 
-    const String& path() const { return m_path; }
+    const String& path() const LIFETIME_BOUND { return m_path; }
     GVariant* reference() const;
     GVariant* parentReference() const;
     GVariant* applicationReference() const;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -77,7 +77,7 @@ public:
     bool hasMarkTag() const final { return elementName() == ElementName::HTML_mark; }
     bool hasRowGroupTag() const final;
 
-    const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) final;
+    const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) LIFETIME_BOUND final;
     AXIsolatedObject* parentObject() const final { return tree().objectForID(parent()); }
     AXIsolatedObject* parentObjectUnignored() const final { return downcast<AXIsolatedObject>(AXCoreObject::parentObjectUnignored()); }
     bool isEditableWebArea() const final { return boolAttributeValue(AXProperty::IsEditableWebArea); }

--- a/Source/WebCore/animation/AnimationTimeline.h
+++ b/Source/WebCore/animation/AnimationTimeline.h
@@ -56,7 +56,7 @@ public:
     bool isMonotonic() const { return !m_duration; }
     bool isProgressBased() const { return !isMonotonic(); }
 
-    const AnimationCollection& relevantAnimations() const { return m_animations; }
+    const AnimationCollection& relevantAnimations() const LIFETIME_BOUND { return m_animations; }
 
     virtual void animationTimingDidChange(WebAnimation&);
     virtual void removeAnimation(WebAnimation&);
@@ -83,7 +83,7 @@ public:
     virtual bool canBeAccelerated() const { return false; }
     Ref<AcceleratedTimeline> acceleratedRepresentation();
     void runPostRenderingUpdateTasks();
-    const TimelineIdentifier& acceleratedTimelineIdentifier() const { return m_acceleratedTimelineIdentifier; }
+    const TimelineIdentifier& acceleratedTimelineIdentifier() const LIFETIME_BOUND { return m_acceleratedTimelineIdentifier; }
 #endif
 
 protected:

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -74,7 +74,7 @@ public:
     bool animationsAreSuspended() const { return m_isSuspended; }
 
 #if ENABLE(THREADED_ANIMATIONS)
-    AcceleratedEffectStackUpdater* existingAcceleratedEffectStackUpdater() const { return m_acceleratedEffectStackUpdater.get(); }
+    AcceleratedEffectStackUpdater* existingAcceleratedEffectStackUpdater() const LIFETIME_BOUND { return m_acceleratedEffectStackUpdater.get(); }
     void scheduleAcceleratedEffectStackUpdateForTarget(const Styleable&);
     void runPostRenderingUpdateTasks();
 #endif

--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -76,14 +76,14 @@ public:
     bool isBlendingKeyframe() const final { return true; }
 
     void addProperty(const AnimatableCSSProperty&);
-    const HashSet<AnimatableCSSProperty>& properties() const { return m_properties; }
+    const HashSet<AnimatableCSSProperty>& properties() const LIFETIME_BOUND { return m_properties; }
 
-    const Offset& specifiedOffset() const { return m_specifiedOffset; }
+    const Offset& specifiedOffset() const LIFETIME_BOUND { return m_specifiedOffset; }
     void setComputedOffset(double offset) { m_computedOffset = offset; }
 
     bool NODELETE usesRangeOffset() const;
 
-    const RenderStyle* style() const { return m_style.get(); }
+    const RenderStyle* style() const LIFETIME_BOUND { return m_style.get(); }
     void setStyle(std::unique_ptr<RenderStyle>&& style) { m_style = WTF::move(style); }
 
     TimingFunction* timingFunction() const { return m_timingFunction.get(); }
@@ -122,15 +122,15 @@ public:
     BlendingKeyframes& operator=(BlendingKeyframes&&) = default;
     bool operator==(const BlendingKeyframes&) const;
 
-    const KeyframesIdentifier& identifier() const { return m_identifier; }
-    const AtomString& keyframesName() const { return std::holds_alternative<AtomString>(m_identifier) ? std::get<AtomString>(m_identifier) : nullAtom(); }
-    const String& acceleratedAnimationName() const;
+    const KeyframesIdentifier& identifier() const LIFETIME_BOUND { return m_identifier; }
+    const AtomString& keyframesName() const LIFETIME_BOUND { return std::holds_alternative<AtomString>(m_identifier) ? std::get<AtomString>(m_identifier) : nullAtom(); }
+    const String& acceleratedAnimationName() const LIFETIME_BOUND;
 
     void insert(BlendingKeyframe&&);
 
     void addProperty(const AnimatableCSSProperty&);
     bool containsProperty(const AnimatableCSSProperty&) const;
-    const HashSet<AnimatableCSSProperty>& properties() const { return m_properties; }
+    const HashSet<AnimatableCSSProperty>& properties() const LIFETIME_BOUND { return m_properties; }
 
     bool containsAnimatableCSSProperty() const;
     bool NODELETE containsDirectionAwareProperty() const;
@@ -153,7 +153,7 @@ public:
     bool hasCSSVariableReferences() const { return m_containsCSSVariableReferences; }
     bool hasColorSetToCurrentColor() const;
     bool NODELETE hasPropertySetToCurrentColor() const;
-    const HashSet<AnimatableCSSProperty>& NODELETE propertiesSetToInherit() const;
+    const HashSet<AnimatableCSSProperty>& NODELETE propertiesSetToInherit() const LIFETIME_BOUND;
     bool hasPropertiesWithRevertRuleOrLayer() const { return m_hasPropertiesWithRevertRuleOrLayer; }
 
     void updatePropertiesMetadata(const StyleProperties&);

--- a/Source/WebCore/animation/CSSAnimation.h
+++ b/Source/WebCore/animation/CSSAnimation.h
@@ -43,8 +43,8 @@ public:
     static Ref<CSSAnimation> create(const Styleable&, Style::Animation&&, const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
     ~CSSAnimation() = default;
 
-    const String& animationName() const { return m_animationName.name; }
-    const Style::ScopedName& scopedAnimationName() const { return m_animationName; }
+    const String& animationName() const LIFETIME_BOUND { return m_animationName.name; }
+    const Style::ScopedName& scopedAnimationName() const LIFETIME_BOUND { return m_animationName; }
 
     void effectTimingWasUpdatedUsingBindings(const OptionalEffectTiming&);
     void NODELETE effectKeyframesWereSetUsingBindings();
@@ -54,7 +54,7 @@ public:
 
     void syncStyleOriginatedTimeline();
 
-    const Style::Animation& backingStyleAnimation() const { return m_backingStyleAnimation; }
+    const Style::Animation& backingStyleAnimation() const LIFETIME_BOUND { return m_backingStyleAnimation; }
     void setBackingStyleAnimation(const Style::Animation&);
 
 private:

--- a/Source/WebCore/animation/CSSAnimationEvent.h
+++ b/Source/WebCore/animation/CSSAnimationEvent.h
@@ -50,7 +50,7 @@ public:
 
     virtual ~CSSAnimationEvent();
 
-    const String& animationName() const { return m_animationName; }
+    const String& animationName() const LIFETIME_BOUND { return m_animationName; }
 
 private:
     CSSAnimationEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&, const String& animationName);

--- a/Source/WebCore/animation/CSSTransition.h
+++ b/Source/WebCore/animation/CSSTransition.h
@@ -50,11 +50,11 @@ public:
     const AtomString transitionProperty() const;
     AnimatableCSSProperty property() const { return m_property; }
     MonotonicTime generationTime() const { return m_generationTime; }
-    const RenderStyle& targetStyle() const { return *m_targetStyle; }
-    const RenderStyle& reversingAdjustedStartStyle() const { return *m_reversingAdjustedStartStyle; }
+    const RenderStyle& targetStyle() const LIFETIME_BOUND { return *m_targetStyle; }
+    const RenderStyle& reversingAdjustedStartStyle() const LIFETIME_BOUND { return *m_reversingAdjustedStartStyle; }
     double reversingShorteningFactor() const { return m_reversingShorteningFactor; }
 
-    const Style::Transition& backingStyleTransition() const { return m_backingStyleTransition; }
+    const Style::Transition& backingStyleTransition() const LIFETIME_BOUND { return m_backingStyleTransition; }
 
 private:
     CSSTransition(const Styleable&, const AnimatableCSSProperty&, MonotonicTime generationTime, const Style::Transition&, const RenderStyle& targetStyle, const RenderStyle& reversingAdjustedStartStyle, double);

--- a/Source/WebCore/animation/CSSTransitionEvent.h
+++ b/Source/WebCore/animation/CSSTransitionEvent.h
@@ -51,7 +51,7 @@ public:
 
     virtual ~CSSTransitionEvent();
 
-    const String& propertyName() const { return m_propertyName; }
+    const String& propertyName() const LIFETIME_BOUND { return m_propertyName; }
 
 private:
     CSSTransitionEvent(const AtomString& type, WebAnimation*, std::optional<Seconds> scheduledTime, double elapsedTime, const std::optional<Style::PseudoElementIdentifier>&, const String propertyName);

--- a/Source/WebCore/animation/ElementAnimationRareData.h
+++ b/Source/WebCore/animation/ElementAnimationRareData.h
@@ -44,15 +44,15 @@ public:
     explicit ElementAnimationRareData();
     ~ElementAnimationRareData();
 
-    KeyframeEffectStack* keyframeEffectStack() { return m_keyframeEffectStack.get(); }
+    KeyframeEffectStack* keyframeEffectStack() LIFETIME_BOUND { return m_keyframeEffectStack.get(); }
     KeyframeEffectStack& ensureKeyframeEffectStack();
 
-    AnimationCollection& animations() { return m_animations; }
-    CSSAnimationCollection& animationsCreatedByMarkup() { return m_animationsCreatedByMarkup; }
+    AnimationCollection& animations() LIFETIME_BOUND { return m_animations; }
+    CSSAnimationCollection& animationsCreatedByMarkup() LIFETIME_BOUND { return m_animationsCreatedByMarkup; }
     void setAnimationsCreatedByMarkup(CSSAnimationCollection&&);
-    AnimatableCSSPropertyToTransitionMap& completedTransitionsByProperty() { return m_completedTransitionsByProperty; }
-    AnimatableCSSPropertyToTransitionMap& runningTransitionsByProperty() { return m_runningTransitionsByProperty; }
-    const RenderStyle* lastStyleChangeEventStyle() const { return m_lastStyleChangeEventStyle.get(); }
+    AnimatableCSSPropertyToTransitionMap& completedTransitionsByProperty() LIFETIME_BOUND { return m_completedTransitionsByProperty; }
+    AnimatableCSSPropertyToTransitionMap& runningTransitionsByProperty() LIFETIME_BOUND { return m_runningTransitionsByProperty; }
+    const RenderStyle* lastStyleChangeEventStyle() const LIFETIME_BOUND { return m_lastStyleChangeEventStyle.get(); }
     void setLastStyleChangeEventStyle(std::unique_ptr<const RenderStyle>&&);
     void cssAnimationsDidUpdate() { m_hasPendingKeyframesUpdate = false; }
     void keyframesRuleDidChange() { m_hasPendingKeyframesUpdate = true; }

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -110,7 +110,7 @@ public:
         ~ParsedKeyframe();
     };
 
-    const Vector<ParsedKeyframe>& parsedKeyframes() const { return m_parsedKeyframes; }
+    const Vector<ParsedKeyframe>& parsedKeyframes() const LIFETIME_BOUND { return m_parsedKeyframes; }
 
     Element* target() const { return m_target.get(); }
     void setTarget(RefPtr<Element>&&);
@@ -148,7 +148,7 @@ public:
 
     Document* document() const final;
     RenderElement* renderer() const final;
-    const RenderStyle& currentStyle() const final;
+    const RenderStyle& currentStyle() const LIFETIME_BOUND final;
     bool triggersStackingContext() const { return m_triggersStackingContext; }
     bool isRunningAccelerated() const;
     bool isAboutToRunAccelerated() const;
@@ -156,11 +156,11 @@ public:
     std::optional<unsigned> transformFunctionListPrefix() const override;
 
     void computeStyleOriginatedAnimationBlendingKeyframes(const RenderStyle* oldStyle, const RenderStyle& newStyle, const Style::ResolutionContext&);
-    const BlendingKeyframes& blendingKeyframes() const { return m_blendingKeyframes; }
-    const HashSet<AnimatableCSSProperty>& animatedProperties();
+    const BlendingKeyframes& blendingKeyframes() const LIFETIME_BOUND { return m_blendingKeyframes; }
+    const HashSet<AnimatableCSSProperty>& animatedProperties() LIFETIME_BOUND;
     bool animatesProperty(const AnimatableCSSProperty&) const;
-    const HashSet<AnimatableCSSProperty>& acceleratedProperties() const { return m_acceleratedProperties; }
-    const HashSet<AnimatableCSSProperty>& acceleratedPropertiesWithImplicitKeyframe() const { return m_acceleratedPropertiesWithImplicitKeyframe; }
+    const HashSet<AnimatableCSSProperty>& acceleratedProperties() const LIFETIME_BOUND { return m_acceleratedProperties; }
+    const HashSet<AnimatableCSSProperty>& acceleratedPropertiesWithImplicitKeyframe() const LIFETIME_BOUND { return m_acceleratedPropertiesWithImplicitKeyframe; }
 
     bool animatesMotionPath() const;
     bool computeExtentOfTransformAnimation(LayoutRect&) const;
@@ -294,7 +294,7 @@ private:
     // KeyframeInterpolation
     CompositeOperation compositeOperation() const final { return m_compositeOperation; }
     IterationCompositeOperation iterationCompositeOperation() const final { return m_iterationCompositeOperation; }
-    const KeyframeInterpolation::Keyframe& keyframeAtIndex(size_t) const final;
+    const KeyframeInterpolation::Keyframe& keyframeAtIndex(size_t) const LIFETIME_BOUND final;
     size_t numberOfKeyframes() const final { return m_blendingKeyframes.size(); }
     const TimingFunction* timingFunctionForKeyframe(const KeyframeInterpolation::Keyframe&) const final;
     bool isPropertyAdditiveOrCumulative(KeyframeInterpolation::Property) const final;

--- a/Source/WebCore/animation/KeyframeEffectStack.h
+++ b/Source/WebCore/animation/KeyframeEffectStack.h
@@ -60,8 +60,8 @@ public:
     bool addEffect(KeyframeEffect&);
     void removeEffect(KeyframeEffect&);
     bool hasEffects() const { return !m_effects.isEmpty(); }
-    const Vector<WeakPtr<KeyframeEffect>>& sortedEffects();
-    const std::optional<Style::Animations>& cssAnimationList() const { return m_cssAnimationList; }
+    const Vector<WeakPtr<KeyframeEffect>>& sortedEffects() LIFETIME_BOUND;
+    const std::optional<Style::Animations>& cssAnimationList() const LIFETIME_BOUND { return m_cssAnimationList; }
     void setCSSAnimationList(std::optional<Style::Animations>&&);
     bool containsProperty(CSSPropertyID) const;
     bool isCurrentlyAffectingProperty(CSSPropertyID) const;
@@ -80,7 +80,7 @@ public:
     void lastStyleChangeEventStyleDidChange(const RenderStyle* previousStyle, const RenderStyle* currentStyle);
     void cascadeDidOverrideProperties(const HashSet<AnimatableCSSProperty>&, const Document&);
 
-    const HashSet<AnimatableCSSProperty>& acceleratedPropertiesOverriddenByCascade() const { return m_acceleratedPropertiesOverriddenByCascade; }
+    const HashSet<AnimatableCSSProperty>& acceleratedPropertiesOverriddenByCascade() const LIFETIME_BOUND { return m_acceleratedPropertiesOverriddenByCascade; }
 
     void applyPendingAcceleratedActions() const;
 

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -51,7 +51,7 @@ public:
     static Ref<ScrollTimeline> create(Scroller, ScrollAxis);
     static Ref<ScrollTimeline> createInactiveStyleOriginatedTimeline(const AtomString& name);
 
-    const WeakStyleable& sourceStyleable() const { return m_source; }
+    const WeakStyleable& sourceStyleable() const LIFETIME_BOUND { return m_source; }
     virtual RefPtr<Element> bindingsSource() const;
     virtual RefPtr<Element> source() const;
     void setSource(Element*);
@@ -60,7 +60,7 @@ public:
     ScrollAxis axis() const { return m_axis; }
     void setAxis(ScrollAxis axis) { m_axis = axis; }
 
-    const AtomString& name() const { return m_name; }
+    const AtomString& name() const LIFETIME_BOUND { return m_name; }
     void setName(const AtomString& name) { m_name = name; }
 
     bool isInactiveStyleOriginatedTimeline() const { return m_isInactiveStyleOriginatedTimeline; }

--- a/Source/WebCore/animation/StyleOriginatedAnimation.h
+++ b/Source/WebCore/animation/StyleOriginatedAnimation.h
@@ -56,8 +56,8 @@ public:
     WebAnimation::PlayState bindingsPlayState() const final;
     WebAnimation::ReplaceState bindingsReplaceState() const final;
     bool bindingsPending() const final;
-    WebAnimation::ReadyPromise& bindingsReady() final;
-    WebAnimation::FinishedPromise& bindingsFinished() final;
+    WebAnimation::ReadyPromise& bindingsReady() LIFETIME_BOUND final;
+    WebAnimation::FinishedPromise& bindingsFinished() LIFETIME_BOUND final;
     ExceptionOr<void> bindingsPlay() override;
     ExceptionOr<void> bindingsPause() override;
 

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.h
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.h
@@ -77,7 +77,7 @@ public:
     void styleableWasRemoved(const Styleable&);
 
 private:
-    Vector<Ref<ScrollTimeline>>& timelinesForName(const AtomString&);
+    Vector<Ref<ScrollTimeline>>& timelinesForName(const AtomString&) LIFETIME_BOUND;
     Vector<WeakStyleable> relatedTimelineScopeElements(const CustomIdentifier&);
     void updateCSSAnimationsAssociatedWithNamedTimeline(const AtomString&);
 

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -79,7 +79,7 @@ public:
     void setSubject(Element*);
     void setSubject(const Styleable&);
 
-    const Style::ViewTimelineInsetItem& insets() const { return m_insets; }
+    const Style::ViewTimelineInsetItem& insets() const LIFETIME_BOUND { return m_insets; }
     void setInsets(const Style::ViewTimelineInsetItem& insets) { m_insets = insets; }
 
     Ref<CSSNumericValue> startOffset() const;

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -82,7 +82,7 @@ public:
 
     bool isSkippedContentAnimation() const;
 
-    const String& id() const { return m_id; }
+    const String& id() const LIFETIME_BOUND { return m_id; }
     void setId(String&&);
 
     AnimationEffect* bindingsEffect() const { return effect(); }
@@ -112,10 +112,10 @@ public:
     bool pending() const { return hasPendingPauseTask() || hasPendingPlayTask(); }
 
     using ReadyPromise = DOMPromiseProxyWithResolveCallback<IDLInterface<WebAnimation>>;
-    ReadyPromise& ready() { return m_readyPromise.get(); }
+    ReadyPromise& ready() LIFETIME_BOUND { return m_readyPromise.get(); }
 
     using FinishedPromise = DOMPromiseProxyWithResolveCallback<IDLInterface<WebAnimation>>;
-    FinishedPromise& finished() { return m_finishedPromise.get(); }
+    FinishedPromise& finished() LIFETIME_BOUND { return m_finishedPromise.get(); }
 
     enum class Silently : bool { No, Yes };
     virtual void cancel(Silently = Silently::No);
@@ -138,8 +138,8 @@ public:
     virtual PlayState bindingsPlayState() const { return playState(); }
     virtual ReplaceState bindingsReplaceState() const { return replaceState(); }
     virtual bool bindingsPending() const { return pending(); }
-    virtual ReadyPromise& bindingsReady() { return ready(); }
-    virtual FinishedPromise& bindingsFinished() { return finished(); }
+    virtual ReadyPromise& bindingsReady() LIFETIME_BOUND { return ready(); }
+    virtual FinishedPromise& bindingsFinished() LIFETIME_BOUND { return finished(); }
     virtual ExceptionOr<void> bindingsPlay() { return play(); }
     virtual ExceptionOr<void> bindingsPause() { return pause(); }
     std::optional<WebAnimationTime> holdTime() const { return m_holdTime; }
@@ -156,7 +156,7 @@ public:
     virtual void setBindingsRangeEnd(TimelineRangeValue&&);
     void setRangeStart(Style::SingleAnimationRangeStart&&);
     void setRangeEnd(Style::SingleAnimationRangeEnd&&);
-    const Style::SingleAnimationRange& range();
+    const Style::SingleAnimationRange& range() LIFETIME_BOUND;
 
     bool needsTick() const;
     virtual void tick();

--- a/Source/WebCore/bindings/js/DOMWrapperWorld.h
+++ b/Source/WebCore/bindings/js/DOMWrapperWorld.h
@@ -81,13 +81,13 @@ public:
     void setIsMediaControls() { m_isMediaControls = true; }
     bool isMediaControls() const { return m_isMediaControls; }
 
-    DOMObjectWrapperMap& wrappers() { return m_wrappers; }
+    DOMObjectWrapperMap& wrappers() LIFETIME_BOUND { return m_wrappers; }
 
     Type type() const { return m_type; }
     bool isNormal() const { return m_type == Type::Normal; }
     bool isUser() const { return m_type == Type::User; }
 
-    const String& name() const { return m_name; }
+    const String& name() const LIFETIME_BOUND { return m_name; }
 
     JSC::VM& vm() const { return m_vm; }
 

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.h
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.h
@@ -115,7 +115,7 @@ public:
     ScriptExecutionContext* NODELETE scriptExecutionContext() const;
     JSC::JSObject* constructor() { return m_constructor.get(); }
 
-    const QualifiedName& name() const { return m_name; }
+    const QualifiedName& name() const LIFETIME_BOUND { return m_name; }
 
     bool isUpgradingElement() const { return !m_constructionStack.isEmpty(); }
     Element* lastElementInConstructionStack() const { return m_constructionStack.last().get(); }

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -65,20 +65,20 @@ public:
 
     static void destroy(JSC::JSCell*);
 
-    Lock& gcLock() WTF_RETURNS_LOCK(m_gcLock) { return m_gcLock; }
+    Lock& gcLock() LIFETIME_BOUND WTF_RETURNS_LOCK(m_gcLock) { return m_gcLock; }
 
-    JSDOMStructureMap& structures() WTF_REQUIRES_LOCK(m_gcLock) { return m_structures; }
-    DOMGuardedObjectSet& guardedObjects() WTF_REQUIRES_LOCK(m_gcLock) { return m_guardedObjects; }
-    DOMConstructors& constructors() { return m_constructors; }
+    JSDOMStructureMap& structures() LIFETIME_BOUND WTF_REQUIRES_LOCK(m_gcLock) { return m_structures; }
+    DOMGuardedObjectSet& guardedObjects() LIFETIME_BOUND WTF_REQUIRES_LOCK(m_gcLock) { return m_guardedObjects; }
+    DOMConstructors& constructors() LIFETIME_BOUND { return m_constructors; }
 
     // No locking is necessary for call sites that do not mutate the containers and are not on a GC thread.
-    const JSDOMStructureMap& structures() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS { ASSERT(!Thread::mayBeGCThread()); return m_structures; }
-    const DOMGuardedObjectSet& guardedObjects() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS { ASSERT(!Thread::mayBeGCThread()); return m_guardedObjects; }
-    const DOMConstructors& constructors() const { ASSERT(!Thread::mayBeGCThread()); return m_constructors; }
+    const JSDOMStructureMap& structures() const LIFETIME_BOUND WTF_IGNORES_THREAD_SAFETY_ANALYSIS { ASSERT(!Thread::mayBeGCThread()); return m_structures; }
+    const DOMGuardedObjectSet& guardedObjects() const LIFETIME_BOUND WTF_IGNORES_THREAD_SAFETY_ANALYSIS { ASSERT(!Thread::mayBeGCThread()); return m_guardedObjects; }
+    const DOMConstructors& constructors() const LIFETIME_BOUND { ASSERT(!Thread::mayBeGCThread()); return m_constructors; }
 
     // The following don't require grabbing the gcLock first and should only be called when the Heap says that mutators don't have to be fenced.
-    inline JSDOMStructureMap& structures(NoLockingNecessaryTag);
-    inline DOMGuardedObjectSet& guardedObjects(NoLockingNecessaryTag);
+    inline JSDOMStructureMap& structures(NoLockingNecessaryTag) LIFETIME_BOUND;
+    inline DOMGuardedObjectSet& guardedObjects(NoLockingNecessaryTag) LIFETIME_BOUND;
 
     ScriptExecutionContext* scriptExecutionContext() const;
 
@@ -99,7 +99,7 @@ public:
     bool worldIsNormal() const { return m_worldIsNormal; }
     static constexpr ptrdiff_t offsetOfWorldIsNormal() { return OBJECT_OFFSETOF(JSDOMGlobalObject, m_worldIsNormal); }
 
-    JSBuiltinInternalFunctions& builtinInternalFunctions() { return m_builtinInternalFunctions; }
+    JSBuiltinInternalFunctions& builtinInternalFunctions() LIFETIME_BOUND { return m_builtinInternalFunctions; }
 
     static void reportUncaughtExceptionAtEventLoop(JSGlobalObject*, JSC::Exception*);
     static JSC::JSGlobalObject* deriveShadowRealmGlobalObject(JSC::JSGlobalObject*);

--- a/Source/WebCore/bindings/js/JSDOMGlobalObjectInlines.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObjectInlines.h
@@ -37,7 +37,7 @@ inline JSC::Structure* JSDOMGlobalObject::createStructure(JSC::VM& vm, JSC::JSVa
     return JSC::Structure::create(vm, 0, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info());
 }
 
-inline JSDOMStructureMap& JSDOMGlobalObject::structures(NoLockingNecessaryTag)
+inline JSDOMStructureMap& JSDOMGlobalObject::structures(NoLockingNecessaryTag) LIFETIME_BOUND
 {
     ASSERT(!vm().heap.mutatorShouldBeFenced());
     IGNORE_CLANG_WARNINGS_BEGIN("thread-safety-reference-return")
@@ -45,7 +45,7 @@ inline JSDOMStructureMap& JSDOMGlobalObject::structures(NoLockingNecessaryTag)
     IGNORE_CLANG_WARNINGS_END
 }
 
-inline DOMGuardedObjectSet& JSDOMGlobalObject::guardedObjects(NoLockingNecessaryTag)
+inline DOMGuardedObjectSet& JSDOMGlobalObject::guardedObjects(NoLockingNecessaryTag) LIFETIME_BOUND
 {
     ASSERT(!vm().heap.mutatorShouldBeFenced());
     IGNORE_CLANG_WARNINGS_BEGIN("thread-safety-reference-return")

--- a/Source/WebCore/bindings/js/WebCoreJSClientData.h
+++ b/Source/WebCore/bindings/js/WebCoreJSClientData.h
@@ -49,10 +49,10 @@ public:
 
     static JSHeapData* ensureHeapData(JSC::Heap&);
 
-    Lock& lock() { return m_lock; }
-    ExtendedDOMIsoSubspaces& subspaces() { return m_subspaces; }
+    Lock& lock() LIFETIME_BOUND { return m_lock; }
+    ExtendedDOMIsoSubspaces& subspaces() LIFETIME_BOUND { return m_subspaces; }
 
-    Vector<JSC::IsoSubspace*>& outputConstraintSpaces() { return m_outputConstraintSpaces; }
+    Vector<JSC::IsoSubspace*>& outputConstraintSpaces() LIFETIME_BOUND { return m_outputConstraintSpaces; }
 
     template<typename Func>
     void forEachOutputConstraintSpace(const Func& func)
@@ -144,24 +144,24 @@ public:
 
     JSHeapData& heapData() { return *m_heapData; }
 
-    WebCoreBuiltinNames& builtinNames() { return m_builtinNames; }
-    JSBuiltinFunctions& builtinFunctions() { return m_builtinFunctions; }
-    
-    JSC::GCClient::IsoSubspace& domBuiltinConstructorSpace() { return m_domBuiltinConstructorSpace; }
-    JSC::GCClient::IsoSubspace& domConstructorSpace() { return m_domConstructorSpace; }
-    JSC::GCClient::IsoSubspace& domNamespaceObjectSpace() { return m_domNamespaceObjectSpace; }
-    JSC::GCClient::IsoSubspace& domWindowPropertiesSpace() { return m_domWindowPropertiesSpace; }
-    JSC::GCClient::IsoSubspace& runtimeArraySpace() { return m_runtimeArraySpace; }
-#if PLATFORM(COCOA)
-    JSC::GCClient::IsoSubspace& objcFallbackObjectImpSpace() { return m_objcFallbackObjectImpSpace; }
-#endif
-    JSC::GCClient::IsoSubspace& observableArraySpace() { return m_observableArraySpace; }
-    JSC::GCClient::IsoSubspace& runtimeMethodSpace() { return m_runtimeMethodSpace; }
-    JSC::GCClient::IsoSubspace& runtimeObjectSpace() { return m_runtimeObjectSpace; }
-    JSC::GCClient::IsoSubspace& windowProxySpace() { return m_windowProxySpace; }
-    JSC::GCClient::IsoSubspace& idbSerializationSpace() { return m_idbSerializationSpace; }
+    WebCoreBuiltinNames& builtinNames() LIFETIME_BOUND { return m_builtinNames; }
+    JSBuiltinFunctions& builtinFunctions() LIFETIME_BOUND { return m_builtinFunctions; }
 
-    ExtendedDOMClientIsoSubspaces& clientSubspaces() { return m_clientSubspaces; }
+    JSC::GCClient::IsoSubspace& domBuiltinConstructorSpace() LIFETIME_BOUND { return m_domBuiltinConstructorSpace; }
+    JSC::GCClient::IsoSubspace& domConstructorSpace() LIFETIME_BOUND { return m_domConstructorSpace; }
+    JSC::GCClient::IsoSubspace& domNamespaceObjectSpace() LIFETIME_BOUND { return m_domNamespaceObjectSpace; }
+    JSC::GCClient::IsoSubspace& domWindowPropertiesSpace() LIFETIME_BOUND { return m_domWindowPropertiesSpace; }
+    JSC::GCClient::IsoSubspace& runtimeArraySpace() LIFETIME_BOUND { return m_runtimeArraySpace; }
+#if PLATFORM(COCOA)
+    JSC::GCClient::IsoSubspace& objcFallbackObjectImpSpace() LIFETIME_BOUND { return m_objcFallbackObjectImpSpace; }
+#endif
+    JSC::GCClient::IsoSubspace& observableArraySpace() LIFETIME_BOUND { return m_observableArraySpace; }
+    JSC::GCClient::IsoSubspace& runtimeMethodSpace() LIFETIME_BOUND { return m_runtimeMethodSpace; }
+    JSC::GCClient::IsoSubspace& runtimeObjectSpace() LIFETIME_BOUND { return m_runtimeObjectSpace; }
+    JSC::GCClient::IsoSubspace& windowProxySpace() LIFETIME_BOUND { return m_windowProxySpace; }
+    JSC::GCClient::IsoSubspace& idbSerializationSpace() LIFETIME_BOUND { return m_idbSerializationSpace; }
+
+    ExtendedDOMClientIsoSubspaces& clientSubspaces() LIFETIME_BOUND { return m_clientSubspaces; }
 
     void addClient(JSVMClientDataClient& client) { m_clients.add(client); }
 

--- a/Source/WebCore/bridge/objc/WebScriptObject.mm
+++ b/Source/WebCore/bridge/objc/WebScriptObject.mm
@@ -570,13 +570,12 @@ static void getListFromNSArray(JSC::JSGlobalObject* lexicalGlobalObject, NSArray
 
         if (auto* jsHTMLElement = JSC::jsDynamicCast<JSHTMLElement*>(object)) {
             // Plugin elements cache the instance internally.
-            if (RefPtr instance = downcast<ObjcInstance>(pluginInstance(jsHTMLElement->wrapped())))
+            if (auto* instance = downcast<ObjcInstance>(pluginInstance(jsHTMLElement->wrapped())))
                 return instance->getObject();
         } else if (auto* runtimeObject = JSC::jsDynamicCast<ObjCRuntimeObject*>(object)) {
-            RefPtr instance = runtimeObject->getInternalObjCInstance();
-            if (!instance)
-                return nil;
-            return instance->getObject();
+            if (auto* instance = runtimeObject->getInternalObjCInstance())
+                return instance->getObject();
+            return nil;
         }
 
         return [WebScriptObject scriptObjectForJSObject:toRef(object) originRootObject:originRootObject rootObject:rootObject];

--- a/Source/WebCore/bridge/objc/objc_instance.h
+++ b/Source/WebCore/bridge/objc/objc_instance.h
@@ -51,7 +51,7 @@ public:
     JSValue getValueOfUndefinedField(JSGlobalObject*, PropertyName) const;
     virtual bool setValueOfUndefinedField(JSGlobalObject*, PropertyName, JSValue);
 
-    ObjectStructPtr getObject() const { return _instance.get(); }
+    ObjectStructPtr getObject() const LIFETIME_BOUND { return _instance.get(); }
     
     JSValue stringValue(JSGlobalObject*) const;
     JSValue NODELETE numberValue(JSGlobalObject*) const;

--- a/Source/WebCore/bridge/objc/objc_runtime.h
+++ b/Source/WebCore/bridge/objc/objc_runtime.h
@@ -62,9 +62,9 @@ public:
 
     bool isFallbackMethod() const;
     void setJavaScriptName(CFStringRef n) { _javaScriptName = n; }
-    CFStringRef javaScriptName() const { return _javaScriptName.get(); }
+    CFStringRef javaScriptName() const LIFETIME_BOUND { return _javaScriptName.get(); }
     
-    SELStructPtr selector() const { return _selector; }
+    SELStructPtr selector() const LIFETIME_BOUND { return _selector; }
 
 private:
     bool isObjcMethod() const final { return true; }
@@ -83,7 +83,7 @@ public:
     virtual unsigned int getLength() const;
 
 #ifdef __OBJC__
-    ObjectStructPtr getObjcArray() const { return _array.get(); }
+    ObjectStructPtr getObjcArray() const LIFETIME_BOUND { return _array.get(); }
 #endif
 
 private:
@@ -114,7 +114,7 @@ public:
 
     DECLARE_INFO;
 
-    const String& propertyName() const { return m_item; }
+    const String& propertyName() const LIFETIME_BOUND { return m_item; }
 
     static ObjectPrototype* createPrototype(VM&, JSGlobalObject& globalObject)
     {

--- a/Source/WebCore/crypto/keys/CryptoKeyAES.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyAES.h
@@ -58,7 +58,7 @@ public:
 
     CryptoKeyClass keyClass() const final { return CryptoKeyClass::AES; }
 
-    const Vector<uint8_t>& key() const { return m_key; }
+    const Vector<uint8_t>& key() const LIFETIME_BOUND { return m_key; }
     JsonWebKey exportJwk() const;
 
     static ExceptionOr<std::optional<size_t>> getKeyLength(const CryptoAlgorithmParameters&);

--- a/Source/WebCore/crypto/keys/CryptoKeyEC.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyEC.h
@@ -94,7 +94,7 @@ public:
     size_t keySizeInBytes() const { return std::ceil(keySizeInBits() / 8.); }
     NamedCurve namedCurve() const { return m_curve; }
     String namedCurveString() const;
-    const PlatformECKeyContainer& platformKey() const { return m_platformKey; }
+    const PlatformECKeyContainer& platformKey() const LIFETIME_BOUND { return m_platformKey; }
 
     static bool NODELETE isValidECAlgorithm(CryptoAlgorithmIdentifier);
 

--- a/Source/WebCore/crypto/keys/CryptoKeyHMAC.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyHMAC.h
@@ -50,7 +50,7 @@ public:
 
     CryptoKeyClass keyClass() const final { return CryptoKeyClass::HMAC; }
 
-    const Vector<uint8_t>& key() const { return m_key; }
+    const Vector<uint8_t>& key() const LIFETIME_BOUND { return m_key; }
     JsonWebKey exportJwk() const;
 
     CryptoAlgorithmIdentifier hashAlgorithmIdentifier() const { return m_hash; }

--- a/Source/WebCore/crypto/keys/CryptoKeyOKP.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyOKP.h
@@ -63,7 +63,7 @@ public:
 
     size_t keySizeInBits() const { return platformKey().size() * 8; }
     size_t keySizeInBytes() const { return platformKey().size(); }
-    const KeyMaterial& platformKey() const { return m_data; }
+    const KeyMaterial& platformKey() const LIFETIME_BOUND { return m_data; }
 
 private:
     CryptoKeyOKP(CryptoAlgorithmIdentifier, NamedCurve, CryptoKeyType, Vector<uint8_t>&&, bool extractable, CryptoKeyUsageBitmap);

--- a/Source/WebCore/crypto/keys/CryptoKeyRSAComponents.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyRSAComponents.h
@@ -74,15 +74,15 @@ public:
     Type type() const { return m_type; }
 
     // Private and public keys.
-    const Vector<uint8_t>& modulus() const { return m_modulus; }
-    const Vector<uint8_t>& exponent() const { return m_exponent; }
+    const Vector<uint8_t>& modulus() const LIFETIME_BOUND { return m_modulus; }
+    const Vector<uint8_t>& exponent() const LIFETIME_BOUND { return m_exponent; }
 
     // Only private keys.
-    const Vector<uint8_t>& privateExponent() const { return m_privateExponent; }
+    const Vector<uint8_t>& privateExponent() const LIFETIME_BOUND { return m_privateExponent; }
     bool hasAdditionalPrivateKeyParameters() const { return m_hasAdditionalPrivateKeyParameters; }
-    const PrimeInfo& firstPrimeInfo() const { return m_firstPrimeInfo; }
-    const PrimeInfo& secondPrimeInfo() const { return m_secondPrimeInfo; }
-    const Vector<PrimeInfo>& otherPrimeInfos() const { return m_otherPrimeInfos; }
+    const PrimeInfo& firstPrimeInfo() const LIFETIME_BOUND { return m_firstPrimeInfo; }
+    const PrimeInfo& secondPrimeInfo() const LIFETIME_BOUND { return m_secondPrimeInfo; }
+    const Vector<PrimeInfo>& otherPrimeInfos() const LIFETIME_BOUND { return m_otherPrimeInfos; }
 
 private:
     CryptoKeyRSAComponents(const Vector<uint8_t>& modulus, const Vector<uint8_t>& exponent);

--- a/Source/WebCore/crypto/keys/CryptoKeyRaw.h
+++ b/Source/WebCore/crypto/keys/CryptoKeyRaw.h
@@ -36,7 +36,7 @@ public:
         return adoptRef(*new CryptoKeyRaw(identifier, WTF::move(keyData), usages));
     }
 
-    const Vector<uint8_t>& key() const { return m_key; }
+    const Vector<uint8_t>& key() const LIFETIME_BOUND { return m_key; }
 
 private:
     CryptoKeyRaw(CryptoAlgorithmIdentifier, Vector<uint8_t>&& keyData, CryptoKeyUsageBitmap);

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParams.h
@@ -55,7 +55,7 @@ public:
 
     Class parametersClass() const final { return Class::AesCbcCfbParams; }
 
-    const Vector<uint8_t>& ivVector() const
+    const Vector<uint8_t>& ivVector() const LIFETIME_BOUND
     {
         if (!m_ivVector.isEmpty() || !iv || !iv->byteLength())
             return m_ivVector;

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParams.h
@@ -52,7 +52,7 @@ public:
 
     Class parametersClass() const final { return Class::AesCtrParams; }
 
-    const Vector<uint8_t>& counterVector() const
+    const Vector<uint8_t>& counterVector() const LIFETIME_BOUND
     {
         if (!m_counterVector.isEmpty() || !counter || !counter->byteLength())
             return m_counterVector;

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h
@@ -55,7 +55,7 @@ public:
 
     Class parametersClass() const final { return Class::AesGcmParams; }
 
-    const Vector<uint8_t>& ivVector() const
+    const Vector<uint8_t>& ivVector() const LIFETIME_BOUND
     {
         if (!m_ivVector.isEmpty() || !iv || !iv->byteLength())
             return m_ivVector;
@@ -65,7 +65,7 @@ public:
         return m_ivVector;
     }
 
-    const Vector<uint8_t>& additionalDataVector() const
+    const Vector<uint8_t>& additionalDataVector() const LIFETIME_BOUND
     {
         if (!m_additionalDataVector.isEmpty() || !additionalData)
             return m_additionalDataVector;

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParams.h
@@ -57,7 +57,7 @@ public:
     {
     }
 
-    const Vector<uint8_t>& saltVector() const
+    const Vector<uint8_t>& saltVector() const LIFETIME_BOUND
     {
         if (!m_saltVector.isEmpty() || !salt || !salt->byteLength())
             return m_saltVector;
@@ -67,7 +67,7 @@ public:
         return m_saltVector;
     }
 
-    const Vector<uint8_t>& infoVector() const
+    const Vector<uint8_t>& infoVector() const LIFETIME_BOUND
     {
         if (!m_infoVector.isEmpty() || !info || !info->byteLength())
             return m_infoVector;

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2Params.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2Params.h
@@ -57,7 +57,7 @@ public:
     {
     }
 
-    const Vector<uint8_t>& saltVector() const
+    const Vector<uint8_t>& saltVector() const LIFETIME_BOUND
     {
         if (!m_saltVector.isEmpty() || !salt || !salt->byteLength())
             return m_saltVector;

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h
@@ -47,7 +47,7 @@ public:
 
     Class parametersClass() const override { return Class::RsaKeyGenParams; }
 
-    const Vector<uint8_t>& publicExponentVector() const
+    const Vector<uint8_t>& publicExponentVector() const LIFETIME_BOUND
     {
         if (!m_publicExponentVector.isEmpty() || !publicExponent->byteLength())
             return m_publicExponentVector;

--- a/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h
+++ b/Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h
@@ -51,7 +51,7 @@ public:
 
     Class parametersClass() const final { return Class::RsaOaepParams; }
 
-    const Vector<uint8_t>& labelVector() const
+    const Vector<uint8_t>& labelVector() const LIFETIME_BOUND
     {
         if (!m_labelVector.isEmpty() || !label)
             return m_labelVector;

--- a/Source/WebCore/fileapi/Blob.h
+++ b/Source/WebCore/fileapi/Blob.h
@@ -111,7 +111,7 @@ public:
     virtual ~Blob();
 
     URL url() const { return m_internalURL; }
-    const String& type() const { return m_type; }
+    const String& type() const LIFETIME_BOUND { return m_type; }
 
     WEBCORE_EXPORT unsigned long long size() const;
     virtual bool isFile() const { return false; }

--- a/Source/WebCore/fileapi/File.h
+++ b/Source/WebCore/fileapi/File.h
@@ -75,12 +75,12 @@ public:
 
     static Ref<File> createWithRelativePath(ScriptExecutionContext*, const String& path, const String& relativePath);
 
-    const String& path() const { return m_path; }
-    const String& relativePath() const { return m_relativePath; }
+    const String& path() const LIFETIME_BOUND { return m_path; }
+    const String& relativePath() const LIFETIME_BOUND { return m_relativePath; }
     void setRelativePath(const String& relativePath) { m_relativePath = relativePath; }
-    const String& name() const { return m_name; }
+    const String& name() const LIFETIME_BOUND { return m_name; }
     WEBCORE_EXPORT int64_t lastModified() const; // Number of milliseconds since Epoch.
-    const std::optional<int64_t>& lastModifiedOverride() const { return m_lastModifiedDateOverride; } // Number of milliseconds since Epoch.
+    const std::optional<int64_t>& lastModifiedOverride() const LIFETIME_BOUND { return m_lastModifiedDateOverride; } // Number of milliseconds since Epoch.
     const std::optional<FileSystem::PlatformFileID> fileID() const { return m_fileID; }
 
     WEBCORE_EXPORT static String contentTypeForFile(const String& path);

--- a/Source/WebCore/fileapi/FileList.h
+++ b/Source/WebCore/fileapi/FileList.h
@@ -56,7 +56,7 @@ public:
     bool isEmpty() const { return m_files.isEmpty(); }
     Vector<String> paths() const;
 
-    const Vector<Ref<File>>& files() const { return m_files; }
+    const Vector<Ref<File>>& files() const LIFETIME_BOUND { return m_files; }
     const File& file(unsigned index) const { return m_files[index].get(); }
 
 private:

--- a/Source/WebCore/fileapi/FileReaderLoader.h
+++ b/Source/WebCore/fileapi/FileReaderLoader.h
@@ -92,7 +92,7 @@ public:
     void setEncoding(StringView);
     void setDataType(const String& dataType) { m_dataType = dataType; }
 
-    const URL& url() { return m_urlForReading; }
+    const URL& url() LIFETIME_BOUND { return m_urlForReading; }
 
     bool isCompleted() const;
 

--- a/Source/WebCore/fileapi/URLKeepingBlobAlive.h
+++ b/Source/WebCore/fileapi/URLKeepingBlobAlive.h
@@ -44,8 +44,8 @@ public:
     URLKeepingBlobAlive(const URLKeepingBlobAlive&) = delete;
     URLKeepingBlobAlive& operator=(const URLKeepingBlobAlive&) = delete;
 
-    operator const URL&() const { return m_url; }
-    const URL& url() const { return m_url; }
+    operator const URL&() const LIFETIME_BOUND { return m_url; }
+    const URL& url() const LIFETIME_BOUND { return m_url; }
     bool isEmpty() const { return m_url.isEmpty(); }
     std::optional<SecurityOriginData> topOrigin() const { return m_topOrigin; }
 

--- a/Source/WebCore/history/CachedFrame.h
+++ b/Source/WebCore/history/CachedFrame.h
@@ -51,7 +51,7 @@ public:
 
     Document* document() const { return m_document.get(); }
     FrameView* view() const { return m_view.get(); }
-    const URL& url() const { return m_url; }
+    const URL& url() const LIFETIME_BOUND { return m_url; }
     bool isMainFrame() { return m_isMainFrame; }
 
 protected:
@@ -84,7 +84,7 @@ public:
     void destroy();
 
     WEBCORE_EXPORT void setCachedFramePlatformData(std::unique_ptr<CachedFramePlatformData>);
-    WEBCORE_EXPORT CachedFramePlatformData* NODELETE cachedFramePlatformData();
+    WEBCORE_EXPORT CachedFramePlatformData* NODELETE cachedFramePlatformData() LIFETIME_BOUND;
 
     HasInsecureContent hasInsecureContent() const;
     UsedLegacyTLS NODELETE usedLegacyTLS() const;

--- a/Source/WebCore/history/CachedPage.h
+++ b/Source/WebCore/history/CachedPage.h
@@ -55,7 +55,7 @@ public:
 
     bool hasExpired() const;
     
-    CachedFrame* cachedMainFrame() const { return m_cachedMainFrame.get(); }
+    CachedFrame* cachedMainFrame() const LIFETIME_BOUND { return m_cachedMainFrame.get(); }
 
 #if ENABLE(VIDEO)
     void markForCaptionPreferencesChanged() { m_needsCaptionPreferencesChanged = true; }

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -84,7 +84,7 @@ public:
 
     BackForwardItemIdentifier itemID() const { return m_itemID; }
     BackForwardFrameItemIdentifier frameItemID() const { return m_frameItemID; }
-    const WTF::UUID& uuidIdentifier() const { return m_uuidIdentifier; }
+    const WTF::UUID& uuidIdentifier() const LIFETIME_BOUND { return m_uuidIdentifier; }
     void setUUIDIdentifier(const WTF::UUID& uuidIdentifier) { m_uuidIdentifier = uuidIdentifier; }
 
     // Resets the HistoryItem to its initial state, as returned by create().
@@ -92,20 +92,20 @@ public:
 
     bool operator==(const HistoryItem& other) const { return itemID() == other.itemID(); }
 
-    WEBCORE_EXPORT const String& NODELETE originalURLString() const;
-    WEBCORE_EXPORT const String& NODELETE urlString() const;
-    WEBCORE_EXPORT const String& NODELETE title() const;
+    WEBCORE_EXPORT const String& NODELETE originalURLString() const LIFETIME_BOUND;
+    WEBCORE_EXPORT const String& NODELETE urlString() const LIFETIME_BOUND;
+    WEBCORE_EXPORT const String& NODELETE title() const LIFETIME_BOUND;
     
     WEBCORE_EXPORT bool isInBackForwardCache() const;
     WEBCORE_EXPORT bool hasCachedPageExpired() const;
 
     WEBCORE_EXPORT void setAlternateTitle(const String&);
-    WEBCORE_EXPORT const String& NODELETE alternateTitle() const;
+    WEBCORE_EXPORT const String& NODELETE alternateTitle() const LIFETIME_BOUND;
     
     WEBCORE_EXPORT URL url() const;
     WEBCORE_EXPORT URL originalURL() const;
-    WEBCORE_EXPORT const String& NODELETE referrer() const;
-    WEBCORE_EXPORT const AtomString& NODELETE target() const;
+    WEBCORE_EXPORT const String& NODELETE referrer() const LIFETIME_BOUND;
+    WEBCORE_EXPORT const AtomString& NODELETE target() const LIFETIME_BOUND;
     std::optional<FrameIdentifier> frameID() const { return m_frameID; }
     bool isTargetItem() const { return m_isTargetItem; }
     
@@ -114,7 +114,7 @@ public:
     
     bool lastVisitWasFailure() const { return m_lastVisitWasFailure; }
 
-    WEBCORE_EXPORT const IntPoint& NODELETE scrollPosition() const;
+    WEBCORE_EXPORT const IntPoint& NODELETE scrollPosition() const LIFETIME_BOUND;
     WEBCORE_EXPORT void NODELETE setScrollPosition(const IntPoint&);
     void NODELETE clearScrollPosition();
 
@@ -124,7 +124,7 @@ public:
     WEBCORE_EXPORT float NODELETE pageScaleFactor() const;
     WEBCORE_EXPORT void NODELETE setPageScaleFactor(float);
     
-    WEBCORE_EXPORT const Vector<AtomString>& NODELETE documentState() const;
+    WEBCORE_EXPORT const Vector<AtomString>& NODELETE documentState() const LIFETIME_BOUND;
     WEBCORE_EXPORT void setDocumentState(const Vector<AtomString>&);
     void clearDocumentState();
 
@@ -164,7 +164,7 @@ public:
     WEBCORE_EXPORT HistoryItem* NODELETE childItemWithTarget(const AtomString&);
     WEBCORE_EXPORT HistoryItem* NODELETE childItemWithFrameID(FrameIdentifier);
     HistoryItem* NODELETE childItemWithDocumentSequenceNumber(long long number);
-    WEBCORE_EXPORT const Vector<Ref<HistoryItem>>& NODELETE children() const;
+    WEBCORE_EXPORT const Vector<Ref<HistoryItem>>& NODELETE children() const LIFETIME_BOUND;
     void clearChildren();
 
     bool NODELETE shouldDoSameDocumentNavigationTo(HistoryItem& otherItem) const;
@@ -188,7 +188,7 @@ public:
     IntRect unobscuredContentRect() const { return m_unobscuredContentRect; }
     void setUnobscuredContentRect(IntRect unobscuredContentRect) { m_unobscuredContentRect = unobscuredContentRect; }
 
-    const FloatBoxExtent& obscuredInsets() const { return m_obscuredInsets; }
+    const FloatBoxExtent& obscuredInsets() const LIFETIME_BOUND { return m_obscuredInsets; }
     void setObscuredInsets(const FloatBoxExtent& insets) { m_obscuredInsets = insets; }
 
     FloatSize minimumLayoutSizeInScrollViewCoordinates() const { return m_minimumLayoutSizeInScrollViewCoordinates; }
@@ -206,7 +206,7 @@ public:
         m_scaleIsInitial = isInitial;
     }
 
-    const ViewportArguments& viewportArguments() const { return m_viewportArguments; }
+    const ViewportArguments& viewportArguments() const LIFETIME_BOUND { return m_viewportArguments; }
     void setViewportArguments(const ViewportArguments& viewportArguments) { m_viewportArguments = viewportArguments; }
 #endif
 
@@ -222,7 +222,7 @@ public:
     String logString() const;
 #endif
 
-    const std::optional<PolicyContainer>& policyContainer() const { return m_policyContainer; }
+    const std::optional<PolicyContainer>& policyContainer() const LIFETIME_BOUND { return m_policyContainer; }
     void setPolicyContainer(const PolicyContainer& policyContainer) { m_policyContainer = policyContainer; }
 
 private:

--- a/Source/WebCore/inspector/InspectorCanvas.h
+++ b/Source/WebCore/inspector/InspectorCanvas.h
@@ -61,7 +61,7 @@ class InspectorCanvas final : public RefCountedAndCanMakeWeakPtr<InspectorCanvas
 public:
     static Ref<InspectorCanvas> create(CanvasRenderingContext&);
 
-    const String& identifier() const { return m_identifier; }
+    const String& identifier() const LIFETIME_BOUND { return m_identifier; }
 
     const CanvasRenderingContext& canvasContext() const { return m_context; }
     CanvasRenderingContext& canvasContext() { return m_context; }

--- a/Source/WebCore/inspector/InspectorNodeFinder.h
+++ b/Source/WebCore/inspector/InspectorNodeFinder.h
@@ -43,7 +43,7 @@ class InspectorNodeFinder {
 public:
     InspectorNodeFinder(const String& query, bool caseSensitive);
     void performSearch(Node*);
-    const ListHashSet<Node*>& results() const { return m_results; }
+    const ListHashSet<Node*>& results() const LIFETIME_BOUND { return m_results; }
 
 private:
     bool checkEquals(const String&, const String&);

--- a/Source/WebCore/inspector/InspectorShaderProgram.h
+++ b/Source/WebCore/inspector/InspectorShaderProgram.h
@@ -38,7 +38,7 @@ class InspectorShaderProgram final : public RefCounted<InspectorShaderProgram> {
 public:
     static Ref<InspectorShaderProgram> create(WebGLProgram&, InspectorCanvas&);
 
-    const String& identifier() const { return m_identifier; }
+    const String& identifier() const LIFETIME_BOUND { return m_identifier; }
     InspectorCanvas& canvas() const { return m_canvas; }
     WebGLProgram& program() const { return m_program; }
 

--- a/Source/WebCore/inspector/InspectorStyleSheet.h
+++ b/Source/WebCore/inspector/InspectorStyleSheet.h
@@ -72,7 +72,7 @@ public:
 
     bool isEmpty() const { return m_styleSheetId.isEmpty(); }
 
-    const String& styleSheetId() const { return m_styleSheetId; }
+    const String& styleSheetId() const LIFETIME_BOUND { return m_styleSheetId; }
     unsigned ordinal() const { return m_ordinal; }
 
     // ID type is either Inspector::Protocol::CSS::CSSStyleId or Inspector::Protocol::CSS::CSSRuleId.

--- a/Source/WebCore/inspector/NetworkResourcesData.h
+++ b/Source/WebCore/inspector/NetworkResourcesData.h
@@ -52,17 +52,17 @@ public:
     public:
         ResourceData(const String& requestId, const String& loaderId);
 
-        const String& requestId() const { return m_requestId; }
-        const String& loaderId() const { return m_loaderId; }
+        const String& requestId() const LIFETIME_BOUND { return m_requestId; }
+        const String& loaderId() const LIFETIME_BOUND { return m_loaderId; }
 
-        const String& frameId() const { return m_frameId; }
+        const String& frameId() const LIFETIME_BOUND { return m_frameId; }
         void setFrameId(const String& frameId) { m_frameId = frameId; }
 
-        const String& url() const { return m_url; }
+        const String& url() const LIFETIME_BOUND { return m_url; }
         void setURL(const String& url) { m_url = url; }
 
         bool hasContent() const { return !m_content.isNull(); }
-        const String& content() const { return m_content; }
+        const String& content() const LIFETIME_BOUND { return m_content; }
         void setContent(const String&, bool base64Encoded);
 
         bool base64Encoded() const { return m_base64Encoded; }
@@ -77,13 +77,13 @@ public:
         int httpStatusCode() const { return m_httpStatusCode; }
         void setHTTPStatusCode(int httpStatusCode) { m_httpStatusCode = httpStatusCode; }
         
-        const String& httpStatusText() const { return m_httpStatusText; }
+        const String& httpStatusText() const LIFETIME_BOUND { return m_httpStatusText; }
         void setHTTPStatusText(const String& httpStatusText) { m_httpStatusText = httpStatusText; }
 
-        const String& textEncodingName() const { return m_textEncodingName; }
+        const String& textEncodingName() const LIFETIME_BOUND { return m_textEncodingName; }
         void setTextEncodingName(const String& textEncodingName) { m_textEncodingName = textEncodingName; }
         
-        const String& mimeType() const { return m_mimeType; }
+        const String& mimeType() const LIFETIME_BOUND { return m_mimeType; }
         void setMIMEType(const String& mimeType) { m_mimeType = mimeType; }
 
         RefPtr<TextResourceDecoder> decoder() const { return m_decoder.copyRef(); }
@@ -92,7 +92,7 @@ public:
         RefPtr<FragmentedSharedBuffer> buffer() const { return m_buffer.copyRef(); }
         void setBuffer(RefPtr<FragmentedSharedBuffer>&& buffer) { m_buffer = WTF::move(buffer); }
 
-        const std::optional<CertificateInfo>& certificateInfo() const { return m_certificateInfo; }
+        const std::optional<CertificateInfo>& certificateInfo() const LIFETIME_BOUND { return m_certificateInfo; }
         void setCertificateInfo(const std::optional<CertificateInfo>& certificateInfo) { m_certificateInfo = certificateInfo; }
 
         CachedResource* cachedResource() const { return m_cachedResource; }

--- a/Source/WebCore/inspector/PageInspectorController.h
+++ b/Source/WebCore/inspector/PageInspectorController.h
@@ -123,7 +123,7 @@ public:
     WEBCORE_EXPORT unsigned flexOverlayCount() const;
     WEBCORE_EXPORT unsigned paintRectCount() const;
 
-    InspectorBackendClient* inspectorBackendClient() const { return m_inspectorBackendClient.get(); }
+    InspectorBackendClient* inspectorBackendClient() const LIFETIME_BOUND { return m_inspectorBackendClient.get(); }
     InspectorFrontendClient* inspectorFrontendClient() const { return m_inspectorFrontendClient; }
 
     InstrumentingAgents& instrumentingAgents() const { return m_instrumentingAgents.get(); }

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.h
@@ -227,7 +227,7 @@ public:
     void inspect(Node*);
     void focusNode();
 
-    InspectorHistory* history() { return m_history.get(); }
+    InspectorHistory* history() LIFETIME_BOUND { return m_history.get(); }
     Vector<Document*> documents();
     Vector<size_t> flexibleBoxRendererCachedItemsAtStartOfLine(const RenderObject&);
     void reset();

--- a/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorTimelineAgent.h
@@ -147,7 +147,7 @@ protected:
     virtual bool shouldStartHeapInstrument() const { return true; }
     void autoCaptureStarted() const;
 
-    const Vector<Inspector::Protocol::Timeline::Instrument>& instruments() const { return m_instruments; }
+    const Vector<Inspector::Protocol::Timeline::Instrument>& instruments() const LIFETIME_BOUND { return m_instruments; }
 
     enum class InstrumentState { Start, Stop };
     void toggleInstruments(InstrumentState);

--- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.h
@@ -49,7 +49,7 @@ class InspectorWorkerAgent : public InspectorAgentBase, public Inspector::Worker
 public:
     ~InspectorWorkerAgent();
 
-    Inspector::WorkerFrontendDispatcher& frontendDispatcher() { return m_frontendDispatcher; }
+    Inspector::WorkerFrontendDispatcher& frontendDispatcher() LIFETIME_BOUND { return m_frontendDispatcher; }
 
     // InspectorAgentBase
     void didCreateFrontendAndBackend();

--- a/Source/WebCore/mathml/MathMLFractionElement.h
+++ b/Source/WebCore/mathml/MathMLFractionElement.h
@@ -36,7 +36,7 @@ class MathMLFractionElement final : public MathMLRowElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLFractionElement);
 public:
     static Ref<MathMLFractionElement> create(const QualifiedName& tagName, Document&);
-    const Length& lineThickness();
+    const Length& lineThickness() LIFETIME_BOUND;
     enum class FractionAlignment : uint8_t {
         Center,
         Left,

--- a/Source/WebCore/mathml/MathMLOperatorElement.h
+++ b/Source/WebCore/mathml/MathMLOperatorElement.h
@@ -42,16 +42,16 @@ public:
         bool isVertical { true };
     };
     static OperatorChar parseOperatorChar(const String&);
-    const OperatorChar& operatorChar();
+    const OperatorChar& operatorChar() LIFETIME_BOUND;
     void setOperatorFormDirty() { m_dictionaryProperty = std::nullopt; }
     MathMLOperatorDictionary::Form form() { return dictionaryProperty().form; }
     bool hasProperty(MathMLOperatorDictionary::Flag);
     Length defaultLeadingSpace();
     Length defaultTrailingSpace();
-    const Length& leadingSpace();
-    const Length& trailingSpace();
-    const Length& minSize();
-    const Length& maxSize();
+    const Length& leadingSpace() LIFETIME_BOUND;
+    const Length& trailingSpace() LIFETIME_BOUND;
+    const Length& minSize() LIFETIME_BOUND;
+    const Length& maxSize() LIFETIME_BOUND;
 
 private:
     MathMLOperatorElement(const QualifiedName&, Document&);
@@ -63,7 +63,7 @@ private:
 
     std::optional<MathMLOperatorDictionary::Property> m_dictionaryProperty;
     MathMLOperatorDictionary::Property computeDictionaryProperty();
-    const MathMLOperatorDictionary::Property& dictionaryProperty();
+    const MathMLOperatorDictionary::Property& dictionaryProperty() LIFETIME_BOUND;
 
     struct OperatorProperties {
         unsigned short flags;

--- a/Source/WebCore/mathml/MathMLPaddedElement.h
+++ b/Source/WebCore/mathml/MathMLPaddedElement.h
@@ -37,11 +37,11 @@ class MathMLPaddedElement final : public MathMLRowElement {
 public:
     static Ref<MathMLPaddedElement> create(const QualifiedName& tagName, Document&);
     // FIXME: Pseudo-units are not supported yet (https://bugs.webkit.org/show_bug.cgi?id=85730).
-    const Length& width();
-    const Length& height();
-    const Length& depth();
-    const Length& lspace();
-    const Length& voffset();
+    const Length& width() LIFETIME_BOUND;
+    const Length& height() LIFETIME_BOUND;
+    const Length& depth() LIFETIME_BOUND;
+    const Length& lspace() LIFETIME_BOUND;
+    const Length& voffset() LIFETIME_BOUND;
 private:
     MathMLPaddedElement(const QualifiedName& tagName, Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;

--- a/Source/WebCore/mathml/MathMLScriptsElement.h
+++ b/Source/WebCore/mathml/MathMLScriptsElement.h
@@ -39,8 +39,8 @@ public:
 
     enum class ScriptType { Sub, Super, SubSup, Multiscripts, Under, Over, UnderOver };
     ScriptType scriptType() const { return m_scriptType; }
-    const Length& subscriptShift();
-    const Length& superscriptShift();
+    const Length& subscriptShift() LIFETIME_BOUND;
+    const Length& superscriptShift() LIFETIME_BOUND;
 
 protected:
     MathMLScriptsElement(const QualifiedName& tagName, Document&);

--- a/Source/WebCore/mathml/MathMLSpaceElement.h
+++ b/Source/WebCore/mathml/MathMLSpaceElement.h
@@ -36,9 +36,9 @@ class MathMLSpaceElement final : public MathMLPresentationElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLSpaceElement);
 public:
     static Ref<MathMLSpaceElement> create(const QualifiedName& tagName, Document&);
-    const Length& width();
-    const Length& height();
-    const Length& depth();
+    const Length& width() LIFETIME_BOUND;
+    const Length& height() LIFETIME_BOUND;
+    const Length& depth() LIFETIME_BOUND;
 private:
     MathMLSpaceElement(const QualifiedName& tagName, Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;

--- a/Source/WebCore/mathml/MathMLUnderOverElement.h
+++ b/Source/WebCore/mathml/MathMLUnderOverElement.h
@@ -36,8 +36,8 @@ class MathMLUnderOverElement final : public MathMLScriptsElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLUnderOverElement);
 public:
     static Ref<MathMLUnderOverElement> create(const QualifiedName& tagName, Document&);
-    const BooleanValue& accent();
-    const BooleanValue& accentUnder();
+    const BooleanValue& accent() LIFETIME_BOUND;
+    const BooleanValue& accentUnder() LIFETIME_BOUND;
 
 private:
     MathMLUnderOverElement(const QualifiedName& tagName, Document&);

--- a/Source/WebCore/plugins/DOMPlugin.h
+++ b/Source/WebCore/plugins/DOMPlugin.h
@@ -36,7 +36,7 @@ public:
     static Ref<DOMPlugin> create(Navigator&, const PluginInfo&);
     ~DOMPlugin();
 
-    const PluginInfo& info() const { return m_info; }
+    const PluginInfo& info() const LIFETIME_BOUND { return m_info; }
 
     String name() const;
     String filename() const;
@@ -50,7 +50,7 @@ public:
     Vector<AtomString> supportedPropertyNames() const;
     bool isSupportedPropertyName(const AtomString&) const;
 
-    const Vector<Ref<DOMMimeType>>& mimeTypes() const { return m_mimeTypes; }
+    const Vector<Ref<DOMMimeType>>& mimeTypes() const LIFETIME_BOUND { return m_mimeTypes; }
 
     Navigator* navigator() { return m_navigator.get(); }
 

--- a/Source/WebCore/plugins/PluginData.h
+++ b/Source/WebCore/plugins/PluginData.h
@@ -65,8 +65,8 @@ class PluginData : public RefCounted<PluginData> {
 public:
     static Ref<PluginData> create(Page& page) { return adoptRef(*new PluginData(page)); }
 
-    const Vector<PluginInfo>& plugins() const { return m_plugins; }
-    WEBCORE_EXPORT const Vector<PluginInfo>& webVisiblePlugins() const;
+    const Vector<PluginInfo>& plugins() const LIFETIME_BOUND { return m_plugins; }
+    WEBCORE_EXPORT const Vector<PluginInfo>& webVisiblePlugins() const LIFETIME_BOUND;
     WEBCORE_EXPORT Vector<MimeClassInfo> webVisibleMimeTypes() const;
 
     enum AllowedPluginTypes {
@@ -79,7 +79,7 @@ public:
 
     String pluginFileForWebVisibleMimeType(const String& mimeType) const;
 
-    const std::optional<PluginInfo>& builtInPDFPlugin() const { return m_builtInPDFPluginInfo; }
+    const std::optional<PluginInfo>& builtInPDFPlugin() const LIFETIME_BOUND { return m_builtInPDFPluginInfo; }
 
     static PluginInfo dummyPDFPluginInfo();
 

--- a/Source/WebCore/storage/StorageEvent.h
+++ b/Source/WebCore/storage/StorageEvent.h
@@ -49,10 +49,10 @@ public:
     static Ref<StorageEvent> create(const AtomString&, Init&&, IsTrusted = IsTrusted::No);
     virtual ~StorageEvent();
 
-    const String& key() const { return m_key; }
-    const String& oldValue() const { return m_oldValue; }
-    const String& newValue() const { return m_newValue; }
-    const String& url() const { return m_url; }
+    const String& key() const LIFETIME_BOUND { return m_key; }
+    const String& oldValue() const LIFETIME_BOUND { return m_oldValue; }
+    const String& newValue() const LIFETIME_BOUND { return m_newValue; }
+    const String& url() const LIFETIME_BOUND { return m_url; }
     Storage* storageArea() const { return m_storageArea; }
 
     void initStorageEvent(const AtomString& type, bool canBubble, bool cancelable, const String& key, const String& oldValue, const String& newValue, const String& url, Storage* storageArea);

--- a/Source/WebCore/storage/StorageMap.h
+++ b/Source/WebCore/storage/StorageMap.h
@@ -51,7 +51,7 @@ public:
     WEBCORE_EXPORT bool contains(const String& key) const;
 
     WEBCORE_EXPORT void importItems(HashMap<String, String>&&);
-    const HashMap<String, String>& items() const { return m_impl->map; }
+    const HashMap<String, String>& items() const LIFETIME_BOUND { return m_impl->map; }
 
     unsigned quota() const { return m_quotaSize; }
 

--- a/Source/WebCore/testing/InternalsSetLike.h
+++ b/Source/WebCore/testing/InternalsSetLike.h
@@ -41,7 +41,7 @@ public:
     bool removeFromSetLike(const String& item) { return m_items.removeFirst(item); }
     void initializeSetLike(DOMSetAdapter&);
 
-    const Vector<String>& items() const { return m_items; }
+    const Vector<String>& items() const LIFETIME_BOUND { return m_items; }
 
 private:
     InternalsSetLike();

--- a/Source/WebCore/testing/MockCDMFactory.h
+++ b/Source/WebCore/testing/MockCDMFactory.h
@@ -50,13 +50,13 @@ public:
     void ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
-    const Vector<String>& supportedDataTypes() const { return m_supportedDataTypes; }
+    const Vector<String>& supportedDataTypes() const LIFETIME_BOUND { return m_supportedDataTypes; }
     void setSupportedDataTypes(Vector<String>&&);
 
-    const Vector<MediaKeySessionType>& supportedSessionTypes() const { return m_supportedSessionTypes; }
+    const Vector<MediaKeySessionType>& supportedSessionTypes() const LIFETIME_BOUND { return m_supportedSessionTypes; }
     void setSupportedSessionTypes(Vector<MediaKeySessionType>&& types) { m_supportedSessionTypes = WTF::move(types); }
 
-    const Vector<String>& supportedRobustness() const { return m_supportedRobustness; }
+    const Vector<String>& supportedRobustness() const LIFETIME_BOUND { return m_supportedRobustness; }
     void setSupportedRobustness(Vector<String>&& supportedRobustness) { m_supportedRobustness = WTF::move(supportedRobustness); }
 
     MediaKeysRequirement distinctiveIdentifiersRequirement() const { return m_distinctiveIdentifiersRequirement; }
@@ -74,7 +74,7 @@ public:
     bool supportsSessions() const { return m_supportsSessions; }
     void setSupportsSessions(bool flag) { m_supportsSessions = flag; }
 
-    const Vector<MediaKeyEncryptionScheme>& supportedEncryptionSchemes() const { return m_supportedEncryptionSchemes; }
+    const Vector<MediaKeyEncryptionScheme>& supportedEncryptionSchemes() const LIFETIME_BOUND { return m_supportedEncryptionSchemes; }
     void setSupportedEncryptionSchemes(Vector<MediaKeyEncryptionScheme>&& schemes) { m_supportedEncryptionSchemes = WTF::move(schemes); }
 
     void unregister();
@@ -110,7 +110,7 @@ public:
     MockCDM(WeakPtr<MockCDMFactory>, const String&);
 
     MockCDMFactory* factory() { return m_factory.get(); }
-    const String& mediaKeysHashSalt() const { return m_mediaKeysHashSalt; }
+    const String& mediaKeysHashSalt() const LIFETIME_BOUND { return m_mediaKeysHashSalt; }
 
 private:
     friend class MockCDMInstance;

--- a/Source/WebCore/testing/MockContentFilterSettings.h
+++ b/Source/WebCore/testing/MockContentFilterSettings.h
@@ -58,7 +58,7 @@ public:
     bool enabled() const { return m_enabled; }
     WEBCORE_TESTSUPPORT_EXPORT void setEnabled(bool);
 
-    const String& blockedString() const { return m_blockedString; }
+    const String& blockedString() const LIFETIME_BOUND { return m_blockedString; }
     WEBCORE_TESTSUPPORT_EXPORT void setBlockedString(const String&);
 
     DecisionPoint decisionPoint() const { return m_decisionPoint; }
@@ -70,9 +70,9 @@ public:
     Decision unblockRequestDecision() const { return m_unblockRequestDecision; }
     WEBCORE_TESTSUPPORT_EXPORT void setUnblockRequestDecision(Decision);
 
-    WEBCORE_TESTSUPPORT_EXPORT const String& unblockRequestURL() const;
+    WEBCORE_TESTSUPPORT_EXPORT const String& unblockRequestURL() const LIFETIME_BOUND;
 
-    const String& modifiedRequestURL() const { return m_modifiedRequestURL; }
+    const String& modifiedRequestURL() const LIFETIME_BOUND { return m_modifiedRequestURL; }
     WEBCORE_TESTSUPPORT_EXPORT void setModifiedRequestURL(const String&);
 
     double willSendRequestDecisionDelay() const { return m_willSendRequestDecisionDelay.value(); }

--- a/Source/WebCore/testing/MockGamepad.h
+++ b/Source/WebCore/testing/MockGamepad.h
@@ -38,8 +38,8 @@ class MockGamepad final : public PlatformGamepad {
 public:
     MockGamepad(unsigned index, const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble, bool wasConnected);
 
-    const Vector<SharedGamepadValue>& axisValues() const final { return m_axisValues; }
-    const Vector<SharedGamepadValue>& buttonValues() const final { return m_buttonValues; }
+    const Vector<SharedGamepadValue>& axisValues() const LIFETIME_BOUND final { return m_axisValues; }
+    const Vector<SharedGamepadValue>& buttonValues() const LIFETIME_BOUND final { return m_buttonValues; }
 
     void updateDetails(const String& gamepadID, const String& mapping, unsigned axisCount, unsigned buttonCount, bool supportsDualRumble, bool wasConnected);
     bool setAxisValue(unsigned index, double value);

--- a/Source/WebCore/testing/MockGamepadProvider.h
+++ b/Source/WebCore/testing/MockGamepadProvider.h
@@ -43,7 +43,7 @@ public:
 
     WEBCORE_TESTSUPPORT_EXPORT void startMonitoringGamepads(GamepadProviderClient&) final;
     WEBCORE_TESTSUPPORT_EXPORT void stopMonitoringGamepads(GamepadProviderClient&) final;
-    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() final { return m_connectedGamepadVector; }
+    const Vector<WeakPtr<PlatformGamepad>>& platformGamepads() LIFETIME_BOUND final { return m_connectedGamepadVector; }
     bool isMockGamepadProvider() const final { return true; }
     void playEffect(unsigned, const String&, GamepadHapticEffectType, const GamepadEffectParameters&, CompletionHandler<void(bool)>&&) final;
     void stopEffects(unsigned, const String&, CompletionHandler<void()>&&) final;

--- a/Source/WebCore/testing/MockPaymentCoordinator.h
+++ b/Source/WebCore/testing/MockPaymentCoordinator.h
@@ -70,15 +70,15 @@ public:
     void cancelPayment();
 
     void addSetupFeature(ApplePaySetupFeatureState, ApplePaySetupFeatureType, bool supportsInstallments);
-    const ApplePaySetupConfiguration& setupConfiguration() const { return m_setupConfiguration; }
+    const ApplePaySetupConfiguration& setupConfiguration() const LIFETIME_BOUND { return m_setupConfiguration; }
 
-    const ApplePayLineItem& total() const { return m_total; }
-    const Vector<ApplePayLineItem>& lineItems() const { return m_lineItems; }
-    const Vector<MockPaymentError>& errors() const { return m_errors; }
-    const Vector<ApplePayShippingMethod>& shippingMethods() const { return m_shippingMethods; }
-    const Vector<String>& supportedCountries() const { return m_supportedCountries; }
-    const MockPaymentContactFields& requiredBillingContactFields() const { return m_requiredBillingContactFields; }
-    const MockPaymentContactFields& requiredShippingContactFields() const { return m_requiredShippingContactFields; }
+    const ApplePayLineItem& total() const LIFETIME_BOUND { return m_total; }
+    const Vector<ApplePayLineItem>& lineItems() const LIFETIME_BOUND { return m_lineItems; }
+    const Vector<MockPaymentError>& errors() const LIFETIME_BOUND { return m_errors; }
+    const Vector<ApplePayShippingMethod>& shippingMethods() const LIFETIME_BOUND { return m_shippingMethods; }
+    const Vector<String>& supportedCountries() const LIFETIME_BOUND { return m_supportedCountries; }
+    const MockPaymentContactFields& requiredBillingContactFields() const LIFETIME_BOUND { return m_requiredBillingContactFields; }
+    const MockPaymentContactFields& requiredShippingContactFields() const LIFETIME_BOUND { return m_requiredShippingContactFields; }
 
 #if ENABLE(APPLE_PAY_INSTALLMENTS)
     ApplePayInstallmentConfiguration installmentConfiguration() const { return m_installmentConfiguration; }
@@ -86,7 +86,7 @@ public:
 
 #if ENABLE(APPLE_PAY_COUPON_CODE)
     std::optional<bool> supportsCouponCode() const { return m_supportsCouponCode; }
-    const String& couponCode() const { return m_couponCode; }
+    const String& couponCode() const LIFETIME_BOUND { return m_couponCode; }
 #endif
 
 #if ENABLE(APPLE_PAY_SHIPPING_CONTACT_EDITING_MODE)
@@ -94,23 +94,23 @@ public:
 #endif
 
 #if ENABLE(APPLE_PAY_RECURRING_PAYMENTS)
-    const std::optional<ApplePayRecurringPaymentRequest>& recurringPaymentRequest() const { return m_recurringPaymentRequest; }
+    const std::optional<ApplePayRecurringPaymentRequest>& recurringPaymentRequest() const LIFETIME_BOUND { return m_recurringPaymentRequest; }
 #endif
 
 #if ENABLE(APPLE_PAY_AUTOMATIC_RELOAD_PAYMENTS)
-    const std::optional<ApplePayAutomaticReloadPaymentRequest>& automaticReloadPaymentRequest() const { return m_automaticReloadPaymentRequest; }
+    const std::optional<ApplePayAutomaticReloadPaymentRequest>& automaticReloadPaymentRequest() const LIFETIME_BOUND { return m_automaticReloadPaymentRequest; }
 #endif
 
 #if ENABLE(APPLE_PAY_MULTI_MERCHANT_PAYMENTS)
-    const std::optional<Vector<ApplePayPaymentTokenContext>>& multiTokenContexts() const { return m_multiTokenContexts; }
+    const std::optional<Vector<ApplePayPaymentTokenContext>>& multiTokenContexts() const LIFETIME_BOUND { return m_multiTokenContexts; }
 #endif
 
 #if ENABLE(APPLE_PAY_DEFERRED_PAYMENTS)
-    const std::optional<ApplePayDeferredPaymentRequest>& deferredPaymentRequest() const { return m_deferredPaymentRequest; }
+    const std::optional<ApplePayDeferredPaymentRequest>& deferredPaymentRequest() const LIFETIME_BOUND { return m_deferredPaymentRequest; }
 #endif
 
 #if ENABLE(APPLE_PAY_DISBURSEMENTS)
-    const std::optional<ApplePayDisbursementRequest>& disbursementRequest() const { return m_disbursementRequest; }
+    const std::optional<ApplePayDisbursementRequest>& disbursementRequest() const LIFETIME_BOUND { return m_disbursementRequest; }
 #endif
 
 #if ENABLE(APPLE_PAY_LATER_AVAILABILITY)
@@ -118,7 +118,7 @@ public:
 #endif
 
 #if ENABLE(APPLE_PAY_MERCHANT_CATEGORY_CODE)
-    const String& merchantCategoryCode() const { return m_merchantCategoryCode; }
+    const String& merchantCategoryCode() const LIFETIME_BOUND { return m_merchantCategoryCode; }
 #endif
 
 #if ENABLE(APPLE_PAY_DELEGATED_REQUEST)

--- a/Source/WebCore/testing/TypeConversions.h
+++ b/Source/WebCore/testing/TypeConversions.h
@@ -108,40 +108,40 @@ public:
     float testUnrestrictedFloat() const { return m_unrestrictedFloat; }
     void setTestUnrestrictedFloat(float unrestrictedFloat) { m_unrestrictedFloat = unrestrictedFloat; }
 
-    const String& testString() const { return m_string; }
+    const String& testString() const LIFETIME_BOUND { return m_string; }
     void setTestString(const String& string) { m_string = string; }
-    const String& testUSVString() const { return m_usvstring; }
+    const String& testUSVString() const LIFETIME_BOUND { return m_usvstring; }
     void setTestUSVString(const String& usvstring) { m_usvstring = usvstring; }
-    const String& testByteString() const { return m_byteString; }
+    const String& testByteString() const LIFETIME_BOUND { return m_byteString; }
     void setTestByteString(const String& byteString) { m_byteString = byteString; }
-    const String& testTreatNullAsEmptyString() const { return m_treatNullAsEmptyString; }
+    const String& testTreatNullAsEmptyString() const LIFETIME_BOUND { return m_treatNullAsEmptyString; }
     void setTestTreatNullAsEmptyString(const String& string) { m_treatNullAsEmptyString = string; }
 
-    const Vector<KeyValuePair<String, int>>& testLongRecord() const { return m_longRecord; }
+    const Vector<KeyValuePair<String, int>>& testLongRecord() const LIFETIME_BOUND { return m_longRecord; }
     void setTestLongRecord(const Vector<KeyValuePair<String, int>>& value) { m_longRecord = value; }
-    const Vector<KeyValuePair<String, Ref<Node>>>& testNodeRecord() const { return m_nodeRecord; }
+    const Vector<KeyValuePair<String, Ref<Node>>>& testNodeRecord() const LIFETIME_BOUND { return m_nodeRecord; }
     void setTestNodeRecord(const Vector<KeyValuePair<String, Ref<Node>>>& value) { m_nodeRecord = value; }
-    const Vector<KeyValuePair<String, Vector<String>>>& testSequenceRecord() const { return m_sequenceRecord; }
+    const Vector<KeyValuePair<String, Vector<String>>>& testSequenceRecord() const LIFETIME_BOUND { return m_sequenceRecord; }
     void setTestSequenceRecord(const Vector<KeyValuePair<String, Vector<String>>>& value) { m_sequenceRecord = value; }
 
     using TestUnion = Variant<String, int, bool, Ref<Node>, Vector<int>>;
-    const TestUnion& testUnion() const { return m_union; }
+    const TestUnion& testUnion() const LIFETIME_BOUND { return m_union; }
     void setTestUnion(TestUnion&& value) { m_union = value; }
 
-    const Dictionary& testDictionary() const { return m_testDictionary; }
+    const Dictionary& testDictionary() const LIFETIME_BOUND { return m_testDictionary; }
     void setTestDictionary(Dictionary&& dictionary) { m_testDictionary = dictionary; }
     
 
     using TestClampUnion = Variant<String, int, Vector<int>>;
-    const TestClampUnion& testClampUnion() const { return m_clampUnion; }
+    const TestClampUnion& testClampUnion() const LIFETIME_BOUND { return m_clampUnion; }
     void setTestClampUnion(const TestClampUnion& value) { m_clampUnion = value; }
 
     using TestEnforceRangeUnion = Variant<String, int, Vector<int>>;
-    const TestEnforceRangeUnion& testEnforceRangeUnion() const { return m_enforceRangeUnion; }
+    const TestEnforceRangeUnion& testEnforceRangeUnion() const LIFETIME_BOUND { return m_enforceRangeUnion; }
     void setTestEnforceRangeUnion(const TestEnforceRangeUnion& value) { m_enforceRangeUnion = value; }
 
     using TestTreatNullAsEmptyStringUnion = Variant<String, int, Vector<String>>;
-    const TestTreatNullAsEmptyStringUnion& testTreatNullAsEmptyStringUnion() const { return m_treatNullAsEmptyStringUnion; }
+    const TestTreatNullAsEmptyStringUnion& testTreatNullAsEmptyStringUnion() const LIFETIME_BOUND { return m_treatNullAsEmptyStringUnion; }
     void setTestTreatNullAsEmptyStringUnion(const TestTreatNullAsEmptyStringUnion& value) { m_treatNullAsEmptyStringUnion = value; }
 
     double testImpureNaNUnrestrictedDouble() const { return std::bit_cast<double>(0xffff000000000000ll); }

--- a/Source/WebCore/testing/WebFakeXRDevice.h
+++ b/Source/WebCore/testing/WebFakeXRDevice.h
@@ -56,9 +56,9 @@ public:
     using Fov = PlatformXR::FrameData::Fov;
 
     XREye eye() const { return m_eye; }
-    const Pose& offset() const { return m_offset; }
-    const std::array<float, 16>& projection() const { return m_projection; }
-    const std::optional<Fov>& fieldOfView() const { return m_fov;}
+    const Pose& offset() const LIFETIME_BOUND { return m_offset; }
+    const std::array<float, 16>& projection() const LIFETIME_BOUND { return m_projection; }
+    const std::optional<Fov>& fieldOfView() const LIFETIME_BOUND { return m_fov; }
 
     void setResolution(FakeXRViewInit::DeviceResolution resolution) { m_resolution = resolution; }
     void setOffset(Pose&& offset) { m_offset = WTF::move(offset); }


### PR DESCRIPTION
#### 45155ba4c4dc398e9c99bd198c8756dd44e7f239
<pre>
Adopt `LIFETIME_BOUND` annotation in more places in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=309345">https://bugs.webkit.org/show_bug.cgi?id=309345</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/PAL/pal/ThreadGlobalData.h:
(PAL::ThreadGlobalData::cachedConverterICU): Deleted.
* Source/WebCore/PAL/pal/avfoundation/OutputContext.h:
(PAL::OutputContext::platformContext const): Deleted.
* Source/WebCore/PAL/pal/avfoundation/OutputDevice.h:
(PAL::OutputDevice::platformDevice const): Deleted.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::previousSiblingIncludingIgnored):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::childrenIncludingIgnored): Deleted.
(WebCore::AXCoreObject::unignoredChildren): Deleted.
* Source/WebCore/accessibility/AXObjectCache.h:
(WebCore::AccessibilityReplacedText::replacedRange): Deleted.
* Source/WebCore/accessibility/AXObjectRareData.h:
(WebCore::AXObjectRareData::tableRows const): Deleted.
(WebCore::AXObjectRareData::tableColumns const): Deleted.
(WebCore::AXObjectRareData::cellSlots const): Deleted.
(WebCore::AXObjectRareData::mutableCellSlots): Deleted.
* Source/WebCore/accessibility/AXSearchManager.h:
(WebCore::SearchResultEntry::frameID const): Deleted.
(WebCore::AccessibilitySearchResultStream::entries const): Deleted.
(WebCore::AccessibilitySearchResult::remoteToken const): Deleted.
* Source/WebCore/accessibility/AXStitchGroup.h:
(WebCore::AXStitchGroup::members const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
(WebCore::AccessibilityObject::lastPresentedTextPrediction): Deleted.
(WebCore::AccessibilityObject::lastPresentedTextPredictionComplete): Deleted.
* Source/WebCore/accessibility/AccessibilityObjectInlines.h:
(WebCore::AccessibilityObject::children): Deleted.
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/accessibility/AccessibleSetValueEvent.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.h:
* Source/WebCore/accessibility/atspi/AccessibilityRootAtspi.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/animation/AnimationTimeline.h:
(WebCore::AnimationTimeline::relevantAnimations const): Deleted.
(WebCore::AnimationTimeline::acceleratedTimelineIdentifier const): Deleted.
* Source/WebCore/animation/AnimationTimelinesController.h:
* Source/WebCore/animation/BlendingKeyframes.h:
(WebCore::BlendingKeyframes::identifier const): Deleted.
(WebCore::BlendingKeyframes::keyframesName const): Deleted.
(WebCore::BlendingKeyframes::properties const): Deleted.
* Source/WebCore/animation/CSSAnimation.h:
* Source/WebCore/animation/CSSAnimationEvent.h:
* Source/WebCore/animation/CSSTransition.h:
* Source/WebCore/animation/CSSTransitionEvent.h:
* Source/WebCore/animation/ElementAnimationRareData.h:
(WebCore::ElementAnimationRareData::keyframeEffectStack): Deleted.
(WebCore::ElementAnimationRareData::animations): Deleted.
(WebCore::ElementAnimationRareData::animationsCreatedByMarkup): Deleted.
(WebCore::ElementAnimationRareData::completedTransitionsByProperty): Deleted.
(WebCore::ElementAnimationRareData::runningTransitionsByProperty): Deleted.
(WebCore::ElementAnimationRareData::lastStyleChangeEventStyle const): Deleted.
* Source/WebCore/animation/KeyframeEffect.h:
* Source/WebCore/animation/KeyframeEffectStack.h:
(WebCore::KeyframeEffectStack::cssAnimationList const): Deleted.
(WebCore::KeyframeEffectStack::acceleratedPropertiesOverriddenByCascade const): Deleted.
* Source/WebCore/animation/ScrollTimeline.h:
(WebCore::ScrollTimeline::sourceStyleable const): Deleted.
(WebCore::ScrollTimeline::name const): Deleted.
* Source/WebCore/animation/StyleOriginatedAnimation.h:
* Source/WebCore/animation/StyleOriginatedTimelinesController.h:
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::id const): Deleted.
(WebCore::WebAnimation::ready): Deleted.
(WebCore::WebAnimation::finished): Deleted.
(WebCore::WebAnimation::bindingsReady): Deleted.
(WebCore::WebAnimation::bindingsFinished): Deleted.
* Source/WebCore/bindings/js/DOMWrapperWorld.h:
(WebCore::DOMWrapperWorld::wrappers): Deleted.
(WebCore::DOMWrapperWorld::name const): Deleted.
* Source/WebCore/bindings/js/JSCustomElementInterface.h:
(WebCore::JSCustomElementInterface::name const): Deleted.
* Source/WebCore/bindings/js/JSDOMGlobalObject.h:
* Source/WebCore/bindings/js/JSDOMGlobalObjectInlines.h:
(WebCore::JSDOMGlobalObject::structures): Deleted.
(WebCore::JSDOMGlobalObject::guardedObjects): Deleted.
* Source/WebCore/bindings/js/WebCoreJSClientData.h:
(WebCore::JSHeapData::lock): Deleted.
(WebCore::JSHeapData::subspaces): Deleted.
(WebCore::JSVMClientData::builtinNames): Deleted.
(WebCore::JSVMClientData::builtinFunctions): Deleted.
(WebCore::JSVMClientData::domBuiltinConstructorSpace): Deleted.
(WebCore::JSVMClientData::domConstructorSpace): Deleted.
(WebCore::JSVMClientData::domNamespaceObjectSpace): Deleted.
(WebCore::JSVMClientData::domWindowPropertiesSpace): Deleted.
(WebCore::JSVMClientData::runtimeArraySpace): Deleted.
(WebCore::JSVMClientData::objcFallbackObjectImpSpace): Deleted.
(WebCore::JSVMClientData::observableArraySpace): Deleted.
(WebCore::JSVMClientData::runtimeMethodSpace): Deleted.
(WebCore::JSVMClientData::runtimeObjectSpace): Deleted.
(WebCore::JSVMClientData::windowProxySpace): Deleted.
(WebCore::JSVMClientData::idbSerializationSpace): Deleted.
(WebCore::JSVMClientData::clientSubspaces): Deleted.
* Source/WebCore/bridge/objc/WebScriptObject.mm:
(+[WebScriptObject _convertValueToObjcValue:originRootObject:rootObject:]):
* Source/WebCore/bridge/objc/objc_instance.h:
(JSC::Bindings::ObjcInstance::getObject const): Deleted.
* Source/WebCore/bridge/objc/objc_runtime.h:
(JSC::Bindings::ObjcMethod::javaScriptName const): Deleted.
(JSC::Bindings::ObjcMethod::selector const): Deleted.
(JSC::Bindings::ObjcArray::getObjcArray const): Deleted.
* Source/WebCore/crypto/keys/CryptoKeyAES.h:
* Source/WebCore/crypto/keys/CryptoKeyEC.h:
* Source/WebCore/crypto/keys/CryptoKeyHMAC.h:
* Source/WebCore/crypto/keys/CryptoKeyOKP.h:
* Source/WebCore/crypto/keys/CryptoKeyRSAComponents.h:
(WebCore::CryptoKeyRSAComponents::modulus const): Deleted.
(WebCore::CryptoKeyRSAComponents::exponent const): Deleted.
(WebCore::CryptoKeyRSAComponents::privateExponent const): Deleted.
(WebCore::CryptoKeyRSAComponents::firstPrimeInfo const): Deleted.
(WebCore::CryptoKeyRSAComponents::secondPrimeInfo const): Deleted.
(WebCore::CryptoKeyRSAComponents::otherPrimeInfos const): Deleted.
* Source/WebCore/crypto/keys/CryptoKeyRaw.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesCbcCfbParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesCtrParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmAesGcmParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmHkdfParams.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmPbkdf2Params.h:
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaKeyGenParams.h:
(WebCore::CryptoAlgorithmRsaKeyGenParams::publicExponentVector const): Deleted.
* Source/WebCore/crypto/parameters/CryptoAlgorithmRsaOaepParams.h:
* Source/WebCore/fileapi/Blob.h:
(WebCore::Blob::type const): Deleted.
* Source/WebCore/fileapi/File.h:
* Source/WebCore/fileapi/FileList.h:
* Source/WebCore/fileapi/FileReaderLoader.h:
* Source/WebCore/fileapi/URLKeepingBlobAlive.h:
(WebCore::URLKeepingBlobAlive::operator const URL&amp; const): Deleted.
(WebCore::URLKeepingBlobAlive::url const): Deleted.
* Source/WebCore/history/CachedFrame.h:
(WebCore::CachedFrameBase::url const): Deleted.
* Source/WebCore/history/CachedPage.h:
* Source/WebCore/history/HistoryItem.h:
(WebCore::HistoryItem::uuidIdentifier const): Deleted.
(WebCore::HistoryItem::obscuredInsets const): Deleted.
(WebCore::HistoryItem::viewportArguments const): Deleted.
(WebCore::HistoryItem::policyContainer const): Deleted.
* Source/WebCore/inspector/InspectorCanvas.h:
* Source/WebCore/inspector/InspectorNodeFinder.h:
(WebCore::InspectorNodeFinder:: const):
* Source/WebCore/inspector/InspectorShaderProgram.h:
* Source/WebCore/inspector/InspectorStyleSheet.h:
(WebCore::InspectorCSSId::styleSheetId const): Deleted.
* Source/WebCore/inspector/NetworkResourcesData.h:
(WebCore::NetworkResourcesData::ResourceData::requestId const): Deleted.
(WebCore::NetworkResourcesData::ResourceData::loaderId const): Deleted.
(WebCore::NetworkResourcesData::ResourceData::frameId const): Deleted.
(WebCore::NetworkResourcesData::ResourceData::url const): Deleted.
(WebCore::NetworkResourcesData::ResourceData::content const): Deleted.
(WebCore::NetworkResourcesData::ResourceData::httpStatusText const): Deleted.
(WebCore::NetworkResourcesData::ResourceData::textEncodingName const): Deleted.
(WebCore::NetworkResourcesData::ResourceData::mimeType const): Deleted.
(WebCore::NetworkResourcesData::ResourceData::certificateInfo const): Deleted.
* Source/WebCore/inspector/PageInspectorController.h:
* Source/WebCore/inspector/agents/InspectorDOMAgent.h:
* Source/WebCore/inspector/agents/InspectorTimelineAgent.h:
(WebCore::InspectorTimelineAgent::instruments const): Deleted.
* Source/WebCore/inspector/agents/InspectorWorkerAgent.h:
(WebCore::InspectorWorkerAgent::frontendDispatcher): Deleted.
* Source/WebCore/mathml/MathMLFractionElement.h:
* Source/WebCore/mathml/MathMLOperatorElement.h:
* Source/WebCore/mathml/MathMLPaddedElement.h:
* Source/WebCore/mathml/MathMLScriptsElement.h:
* Source/WebCore/mathml/MathMLSpaceElement.h:
* Source/WebCore/mathml/MathMLUnderOverElement.h:
* Source/WebCore/plugins/DOMPlugin.h:
* Source/WebCore/plugins/PluginData.h:
(WebCore::PluginData::plugins const): Deleted.
(WebCore::PluginData::builtInPDFPlugin const): Deleted.
* Source/WebCore/storage/StorageEvent.h:
* Source/WebCore/storage/StorageMap.h:
(WebCore::StorageMap::items const): Deleted.
* Source/WebCore/testing/InternalsSetLike.h:
(WebCore::InternalsSetLike::items const): Deleted.
* Source/WebCore/testing/MockCDMFactory.h:
(WebCore::MockCDMFactory::supportedDataTypes const): Deleted.
(WebCore::MockCDMFactory::supportedSessionTypes const): Deleted.
(WebCore::MockCDMFactory::supportedRobustness const): Deleted.
(WebCore::MockCDMFactory::supportedEncryptionSchemes const): Deleted.
(WebCore::MockCDM::mediaKeysHashSalt const): Deleted.
* Source/WebCore/testing/MockContentFilterSettings.h:
(WebCore::MockContentFilterSettings::blockedString const): Deleted.
(WebCore::MockContentFilterSettings::modifiedRequestURL const): Deleted.
* Source/WebCore/testing/MockGamepad.h:
* Source/WebCore/testing/MockGamepadProvider.h:
* Source/WebCore/testing/MockPaymentCoordinator.h:
* Source/WebCore/testing/TypeConversions.h:
(WebCore::TypeConversions::testString const): Deleted.
(WebCore::TypeConversions::testUSVString const): Deleted.
(WebCore::TypeConversions::testByteString const): Deleted.
(WebCore::TypeConversions::testTreatNullAsEmptyString const): Deleted.
(WebCore::TypeConversions::testLongRecord const): Deleted.
(WebCore::TypeConversions::testNodeRecord const): Deleted.
(WebCore::TypeConversions::testSequenceRecord const): Deleted.
(WebCore::TypeConversions::testUnion const): Deleted.
(WebCore::TypeConversions::testDictionary const): Deleted.
(WebCore::TypeConversions::testClampUnion const): Deleted.
(WebCore::TypeConversions::testEnforceRangeUnion const): Deleted.
(WebCore::TypeConversions::testTreatNullAsEmptyStringUnion const): Deleted.
* Source/WebCore/testing/WebFakeXRDevice.h:

Canonical link: <a href="https://commits.webkit.org/308895@main">https://commits.webkit.org/308895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d53f031e017ceaa3f1d3d1922f9b17fedbd2927

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148720 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15002 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157405 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102150 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afb95095-5575-4cdb-8cc3-b44beb2cd22e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21311 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114647 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81637 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/390b552b-fabc-422a-bc8f-1244f9648006) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151680 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133499 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95417 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13516565-51a9-4b38-88da-be053ba0c88c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15958 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13805 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4840 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125557 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159740 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2880 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12941 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122712 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21235 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122936 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33438 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133213 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77396 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18233 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9975 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20845 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84647 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20577 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20724 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20633 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->