### PR TITLE
[GLIB] Encode/decode navigated frame ID when storing/restoring session

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp
@@ -49,9 +49,10 @@ struct _WebKitWebViewSessionState {
 G_DEFINE_BOXED_TYPE(WebKitWebViewSessionState, webkit_web_view_session_state, webkit_web_view_session_state_ref, webkit_web_view_session_state_unref)
 
 // Version information:
+//  - Version 3: added navigated frame ID to backforward list items.
 //  - Version 2: removed backforward list item identifier since it's always regenerated.
 //  - Version 1: initial version.
-static const guint16 g_sessionStateVersion = 2;
+static const guint16 g_sessionStateVersion = 3;
 #define HTTP_BODY_ELEMENT_TYPE_STRING_V1 "(uaysxmxmds)"
 #define HTTP_BODY_ELEMENT_FORMAT_STRING_V1 "(uay&sxmxmd&s)"
 #define HTTP_BODY_TYPE_STRING_V1 "m(sa" HTTP_BODY_ELEMENT_TYPE_STRING_V1 ")"
@@ -60,10 +61,13 @@ static const guint16 g_sessionStateVersion = 2;
 #define FRAME_STATE_FORMAT_STRING_V1  "(&s&s&s&sasmayxx(ii)d@" HTTP_BODY_TYPE_STRING_V1 "av)"
 #define BACK_FORWARD_LIST_ITEM_TYPE_STRING_V1  "(ts" FRAME_STATE_TYPE_STRING_V1 "u)"
 #define BACK_FORWARD_LIST_ITEM_TYPE_STRING_V2  "(s" FRAME_STATE_TYPE_STRING_V1 "u)"
+#define BACK_FORWARD_LIST_ITEM_TYPE_STRING_V3  "(s" FRAME_STATE_TYPE_STRING_V1 "mtu)"
 #define BACK_FORWARD_LIST_ITEM_FORMAT_STRING_V1  "(t&s@" FRAME_STATE_TYPE_STRING_V1 "u)"
 #define BACK_FORWARD_LIST_ITEM_FORMAT_STRING_V2  "(&s@" FRAME_STATE_TYPE_STRING_V1 "u)"
+#define BACK_FORWARD_LIST_ITEM_FORMAT_STRING_V3  "(&s@" FRAME_STATE_TYPE_STRING_V1 "mtu)"
 #define SESSION_STATE_TYPE_STRING_V1 "(qa" BACK_FORWARD_LIST_ITEM_TYPE_STRING_V1 "mu)"
 #define SESSION_STATE_TYPE_STRING_V2 "(qa" BACK_FORWARD_LIST_ITEM_TYPE_STRING_V2 "mu)"
+#define SESSION_STATE_TYPE_STRING_V3 "(qa" BACK_FORWARD_LIST_ITEM_TYPE_STRING_V3 "mu)"
 
 static constexpr uint32_t maximumFrameStateTargetLength = 16 * 1024;
 
@@ -210,28 +214,31 @@ static inline void encodeFrameState(GVariantBuilder* sessionBuilder, const Frame
     g_variant_builder_close(sessionBuilder);
 }
 
-static inline void encodeMainFrameState(GVariantBuilder* sessionBuilder, const FrameState& mainFrameState)
+static inline void encodeMainFrameState(GVariantBuilder* sessionBuilder, const BackForwardListItemState& state)
 {
-    g_variant_builder_add(sessionBuilder, "s", mainFrameState.title.utf8().data());
+    g_variant_builder_add(sessionBuilder, "s", state.frameState->title.utf8().data());
     g_variant_builder_open(sessionBuilder, G_VARIANT_TYPE(FRAME_STATE_TYPE_STRING_V1));
-    encodeFrameState(sessionBuilder, mainFrameState);
+    encodeFrameState(sessionBuilder, state.frameState);
     g_variant_builder_close(sessionBuilder);
-    g_variant_builder_add(sessionBuilder, "u", toExternalURLsPolicy(mainFrameState.shouldOpenExternalURLsPolicy));
+    if (state.navigatedFrameID)
+        g_variant_builder_add(sessionBuilder, "mt", TRUE, state.navigatedFrameID->toUInt64());
+    else
+        g_variant_builder_add(sessionBuilder, "mt", FALSE);
+    g_variant_builder_add(sessionBuilder, "u", toExternalURLsPolicy(state.frameState->shouldOpenExternalURLsPolicy));
 }
 
-static inline void encodeBackForwardListItemState(GVariantBuilder* sessionBuilder, const FrameState& mainFrameState)
+static inline void encodeBackForwardListItemState(GVariantBuilder* sessionBuilder, const BackForwardListItemState& state)
 {
-    g_variant_builder_open(sessionBuilder, G_VARIANT_TYPE(BACK_FORWARD_LIST_ITEM_TYPE_STRING_V2));
-    encodeMainFrameState(sessionBuilder, mainFrameState);
+    g_variant_builder_open(sessionBuilder, G_VARIANT_TYPE(BACK_FORWARD_LIST_ITEM_TYPE_STRING_V3));
+    encodeMainFrameState(sessionBuilder, state);
     g_variant_builder_close(sessionBuilder);
 }
 
 static inline void encodeBackForwardListState(GVariantBuilder* sessionBuilder, const BackForwardListState& backForwardListState)
 {
-    // FIXME: Encode navigatedFrameID for each item to support site isolation back/forward navigation after session restore.
-    g_variant_builder_open(sessionBuilder, G_VARIANT_TYPE("a" BACK_FORWARD_LIST_ITEM_TYPE_STRING_V2));
+    g_variant_builder_open(sessionBuilder, G_VARIANT_TYPE("a" BACK_FORWARD_LIST_ITEM_TYPE_STRING_V3));
     for (const auto& item : backForwardListState.items)
-        encodeBackForwardListItemState(sessionBuilder, item.frameState);
+        encodeBackForwardListItemState(sessionBuilder, item);
     g_variant_builder_close(sessionBuilder);
 
     if (backForwardListState.currentIndex)
@@ -243,7 +250,7 @@ static inline void encodeBackForwardListState(GVariantBuilder* sessionBuilder, c
 static GBytes* encodeSessionState(const SessionState& sessionState)
 {
     GVariantBuilder sessionBuilder;
-    g_variant_builder_init(&sessionBuilder, G_VARIANT_TYPE(SESSION_STATE_TYPE_STRING_V2));
+    g_variant_builder_init(&sessionBuilder, G_VARIANT_TYPE(SESSION_STATE_TYPE_STRING_V3));
     g_variant_builder_add(&sessionBuilder, "q", g_sessionStateVersion);
     encodeBackForwardListState(&sessionBuilder, sessionState.backForwardListState);
     GRefPtr<GVariant> variant = g_variant_builder_end(&sessionBuilder);
@@ -380,18 +387,8 @@ static inline void decodeBackForwardListItemStateV1(GVariantIter* backForwardLis
     }
 }
 
-static inline void decodeBackForwardListItemState(GVariantIter* backForwardListStateIter, BackForwardListState& backForwardListState, guint16 version)
+static inline void decodeBackForwardListItemStateV2(GVariantIter* backForwardListStateIter, BackForwardListState& backForwardListState)
 {
-    gsize backForwardListStateLength = g_variant_iter_n_children(backForwardListStateIter);
-    if (!backForwardListStateLength)
-        return;
-
-    backForwardListState.items.reserveInitialCapacity(backForwardListStateLength);
-    if (version == 1) {
-        decodeBackForwardListItemStateV1(backForwardListStateIter, backForwardListState);
-        return;
-    }
-
     const char* title;
     GVariant* frameStateVariant;
     unsigned shouldOpenExternalURLsPolicy;
@@ -404,9 +401,40 @@ static inline void decodeBackForwardListItemState(GVariantIter* backForwardListS
     }
 }
 
+static inline void decodeBackForwardListItemState(GVariantIter* backForwardListStateIter, BackForwardListState& backForwardListState, guint16 version)
+{
+    gsize backForwardListStateLength = g_variant_iter_n_children(backForwardListStateIter);
+    if (!backForwardListStateLength)
+        return;
+
+    backForwardListState.items.reserveInitialCapacity(backForwardListStateLength);
+    if (version == 1) {
+        decodeBackForwardListItemStateV1(backForwardListStateIter, backForwardListState);
+        return;
+    } else if (version == 2) {
+        decodeBackForwardListItemStateV2(backForwardListStateIter, backForwardListState);
+        return;
+    }
+
+    const char* title;
+    GVariant* frameStateVariant;
+    unsigned shouldOpenExternalURLsPolicy;
+    gboolean hasNavigatedFrameID;
+    uint64_t navigatedFrameID;
+
+    while (g_variant_iter_loop(backForwardListStateIter, BACK_FORWARD_LIST_ITEM_FORMAT_STRING_V3, &title, &frameStateVariant, &hasNavigatedFrameID, &navigatedFrameID, &shouldOpenExternalURLsPolicy)) {
+        Ref mainFrameState = FrameState::create();
+        mainFrameState->title = String::fromUTF8(title);
+        decodeFrameState(frameStateVariant, mainFrameState);
+        mainFrameState->shouldOpenExternalURLsPolicy = toWebCoreExternalURLsPolicy(shouldOpenExternalURLsPolicy);
+        backForwardListState.items.append({ WTF::move(mainFrameState), hasNavigatedFrameID ? std::optional<WebCore::FrameIdentifier>(navigatedFrameID) : std::nullopt });
+    }
+}
+
 static bool decodeSessionState(GBytes* data, SessionState& sessionState)
 {
-    static constexpr std::array<ASCIILiteral, 2> sessionStateTypeStringVersions = {
+    static constexpr std::array<ASCIILiteral, 3> sessionStateTypeStringVersions = {
+        SESSION_STATE_TYPE_STRING_V3,
         SESSION_STATE_TYPE_STRING_V2,
         SESSION_STATE_TYPE_STRING_V1,
     };


### PR DESCRIPTION
#### 3701e2aa897bb93d73e0debf3ab48263f8f83622
<pre>
[GLIB] Encode/decode navigated frame ID when storing/restoring session
<a href="https://bugs.webkit.org/show_bug.cgi?id=309349">https://bugs.webkit.org/show_bug.cgi?id=309349</a>

Reviewed by Patrick Griffis.

After 308501@main, a navigated frame ID was added to the backforward list state,
but it had not been encoded/decoded in the GLib API. Increase the format version
number and add support to encode and decode this.

* Source/WebKit/UIProcess/API/glib/WebKitWebViewSessionState.cpp:
(encodeMainFrameState):
(encodeBackForwardListItemState):
(encodeBackForwardListState):
(encodeSessionState):
(decodeBackForwardListItemStateV2):
(decodeBackForwardListItemState):
(decodeSessionState):

Canonical link: <a href="https://commits.webkit.org/308813@main">https://commits.webkit.org/308813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af91b720561e9e1a2434e4fa7440382aa64b979a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148518 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157202 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114494 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16712 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133329 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95264 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15814 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13648 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4638 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125429 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159537 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2669 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12762 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122543 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122764 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21011 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77164 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22888 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18114 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9804 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20619 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20351 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20496 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20405 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->