### PR TITLE
[WTF] Add a NotificationPoint API

### DIFF
--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -145,6 +145,7 @@
 #include "WeakGCMapInlines.h"
 #include "WideningNumberPredictionFuzzerAgent.h"
 #include <wtf/CryptographicallyRandomNumber.h>
+#include <wtf/NotificationPoint.h>
 #include <wtf/ProcessID.h>
 #include <wtf/ReadWriteLock.h>
 #include <wtf/SimpleStats.h>
@@ -402,16 +403,13 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         pathOut.print("JSCProfile-", getCurrentProcessID(), "-", m_perBytecodeProfiler->databaseID(), ".json");
         static NeverDestroyed<CString> pathOutString = pathOut.toCString();
 
-#if PLATFORM(COCOA)
+#if HAVE(NOTIFICATIONPOINT)
         static std::once_flag registerFlag;
         std::call_once(registerFlag, [this]() {
             int pid = getpid();
-            const char* key = "com.apple.WebKit.bytecode.profiler";
             dataLogF("<BYTECODE.STAT><%d> Registering callback for dumping profiles, dumping to %s.\n", pid, pathOutString->data());
-            dataLogF("<BYTECODE.STAT><%d> Use `notifyutil -v -p %s` to dump statistics.\n", pid, key);
-
-            int token;
-            notify_register_dispatch(key, &token, mainDispatchQueueSingleton(), ^(int) {
+            auto result = NotificationPoint::create("bytecode.profiler"_s, [this]() {
+                int pid = getpid();
                 dataLogF("<BYTECODE.STAT><%d> Dumping\n", pid);
                 if (!m_perBytecodeProfiler->save(pathOutString->data()))
                     dataLogF("<BYTECODE.STAT><%d> Failed to dump to %s. Do you need to add a sandbox extension? ((allow file-write* (subpath \"/private/tmp/\")) in WebProcess.sb.in\n", pid, pathOutString->data());
@@ -419,6 +417,13 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                     dataLogF("<BYTECODE.STAT><%d> Dumped to %s\n", pid, pathOutString->data());
                 dataLogF("<BYTECODE.STAT><%d> Dumping finished\n", pid);
             });
+            if (result.has_value()) {
+                RefPtr<NotificationPoint> point = result.value();
+#if PLATFORM(COCOA)
+                dataLogF("<BYTECODE.STAT><%d> Use `notifyutil -v -p %s` to dump statistics.\n", pid, point->key().utf8().data());
+#endif
+                (void)point.leakRef();
+            }
         });
 #endif
 

--- a/Source/JavaScriptCore/wasm/WasmOpcodeCounter.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOpcodeCounter.cpp
@@ -30,13 +30,9 @@
 #include <wtf/Atomics.h>
 #include <wtf/DataLog.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/NotificationPoint.h>
 #include <wtf/Vector.h>
 
-#if PLATFORM(COCOA)
-#include <notify.h>
-#include <unistd.h>
-#include <wtf/darwin/DispatchExtras.h>
-#endif
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -101,18 +97,22 @@ void WasmOpcodeCounter::dump()
 
 void WasmOpcodeCounter::registerDispatch()
 {
-#if PLATFORM(COCOA)
+#if HAVE(NOTIFICATIONPOINT)
     static std::once_flag registerFlag;
     std::call_once(registerFlag, [&]() {
         int pid = getpid();
-        const char* key = "com.apple.WebKit.wasm.op.stat";
         dataLogF("<WASM.OP.STAT><%d> Registering callback for wasm opcode statistics.\n", pid);
-        dataLogF("<WASM.OP.STAT><%d> Use `notifyutil -v -p %s` to dump statistics.\n", pid, key);
 
-        int token;
-        notify_register_dispatch(key, &token, mainDispatchQueueSingleton(), ^(int) {
+        auto result = NotificationPoint::create("wasm.op.stat"_s, []() {
             WasmOpcodeCounter::singleton().dump();
         });
+        if (result.has_value()) {
+            RefPtr<NotificationPoint> point = result.value();
+#if PLATFORM(COCOA)
+            dataLogF("<WASM.OP.STAT><%d> Use `notifyutil -v -p %s` to dump statistics.\n", pid, point->key().utf8().data());
+#endif
+            (void)point.leakRef();
+        }
     });
 #endif
 }

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -173,6 +173,7 @@
 		5FAD3AE221B9636600BEE178 /* URLHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5FAD3AE121B9636600BEE178 /* URLHelpers.cpp */; };
 		6311592628989A55006A9A12 /* LibraryPathDiagnostics.h in Headers */ = {isa = PBXBuildFile; fileRef = 6311592428989A55006A9A12 /* LibraryPathDiagnostics.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		6311592728989A55006A9A12 /* LibraryPathDiagnostics.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6311592528989A55006A9A12 /* LibraryPathDiagnostics.mm */; };
+        6311592728989A8500680A12 /* NotificationPoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6311592725289A8500680A24 /* NotificationPoint.cpp */; };
 		63F9BED42898D96400371416 /* CFPrivSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 63F9BED32898D96400371416 /* CFPrivSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		70A993FE1AD7151300FA615B /* SymbolRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70A993FC1AD7151300FA615B /* SymbolRegistry.cpp */; };
 		70ECA60D1B02426800449739 /* AtomStringImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 70ECA60A1B02426800449739 /* AtomStringImpl.cpp */; };
@@ -345,6 +346,7 @@
 		DD3DC89327A4BF8E007E5B61 /* BackwardsGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = DCEE22041CEB9869000C2396 /* BackwardsGraph.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC89427A4BF8E007E5B61 /* MathExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472C9151A825B004123FF /* MathExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC89527A4BF8E007E5B61 /* NotFound.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CEAE5AC1EA6E10F00DB6890 /* NotFound.h */; settings = {ATTRIBUTES = (Private, ); }; };
+        DD3DC89528A4B48E007E5B61 /* NotificationPoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CEAED2C1EA6E1AF00DB6890 /* NotificationPoint.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC89627A4BF8E007E5B61 /* SinglyLinkedList.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4730B151A825B004123FF /* SinglyLinkedList.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC89727A4BF8E007E5B61 /* Markable.h in Headers */ = {isa = PBXBuildFile; fileRef = 304CA4E41375437EBE931D03 /* Markable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC89927A4BF8E007E5B61 /* ProcessID.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC4488216FE9FE100844BE9 /* ProcessID.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1456,6 +1458,7 @@
 		5FAD3AE121B9636600BEE178 /* URLHelpers.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = URLHelpers.cpp; sourceTree = "<group>"; };
 		6311592428989A55006A9A12 /* LibraryPathDiagnostics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LibraryPathDiagnostics.h; sourceTree = "<group>"; };
 		6311592528989A55006A9A12 /* LibraryPathDiagnostics.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LibraryPathDiagnostics.mm; sourceTree = "<group>"; };
+        6311592725289A8500680A24 /* NotificationPoint.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NotificationPoint.cpp; sourceTree = "<group>"; };
 		63F9BED32898D96400371416 /* CFPrivSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CFPrivSPI.h; sourceTree = "<group>"; };
 		70A993FC1AD7151300FA615B /* SymbolRegistry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SymbolRegistry.cpp; sourceTree = "<group>"; };
 		70A993FD1AD7151300FA615B /* SymbolRegistry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SymbolRegistry.h; sourceTree = "<group>"; };
@@ -1497,6 +1500,7 @@
 		7CD4C26F1E2C82B900929470 /* StringConcatenateNumbers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringConcatenateNumbers.h; sourceTree = "<group>"; };
 		7CDD7FF9186D2A54007433CD /* IteratorRange.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IteratorRange.h; sourceTree = "<group>"; };
 		7CEAE5AC1EA6E10F00DB6890 /* NotFound.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotFound.h; sourceTree = "<group>"; };
+        7CEAED2C1EA6E1AF00DB6890 /* NotificationPoint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationPoint.h; sourceTree = "<group>"; };
 		7CEF23EB23D1257900F8B904 /* PlatformCallingConventions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlatformCallingConventions.h; sourceTree = "<group>"; };
 		7CFAF3C923D0AF1500D21BDD /* PlatformUse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlatformUse.h; sourceTree = "<group>"; };
 		7E29C33D15FFD79B00516D61 /* ObjCRuntimeExtras.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjCRuntimeExtras.h; sourceTree = "<group>"; };
@@ -2221,6 +2225,7 @@
 				6311592428989A55006A9A12 /* LibraryPathDiagnostics.h */,
 				6311592528989A55006A9A12 /* LibraryPathDiagnostics.mm */,
 				46335BEE2E778B1300860375 /* NetworkOSObject.h */,
+                6311592725289A8500680A24 /* NotificationPoint.cpp */,
 				53FC70CE23FB950C005B1990 /* OSLogPrintStream.h */,
 				53FC70CF23FB950C005B1990 /* OSLogPrintStream.mm */,
 				449EEC7D2D93788B008E7C80 /* TypeCastsOSObject.h */,
@@ -2603,6 +2608,7 @@
 				E3E64F0B22813428001E55B4 /* Nonmovable.h */,
 				526AEC911F6B4E5C00695F5D /* NoTailCalls.h */,
 				7CEAE5AC1EA6E10F00DB6890 /* NotFound.h */,
+                7CEAED2C1EA6E1AF00DB6890 /* NotificationPoint.h */,
 				9B56058F2D9691ED00FCE33E /* NoVirtualDestructorBase.h */,
 				A8A472D5151A825B004123FF /* NumberOfCores.cpp */,
 				A8A472D6151A825B004123FF /* NumberOfCores.h */,
@@ -3759,6 +3765,7 @@
 				DD3DC96127A4BF8E007E5B61 /* NoTailCalls.h in Headers */,
 				DD3DC89527A4BF8E007E5B61 /* NotFound.h in Headers */,
 				4448265228D18CA600D916F9 /* NotificationCenterCF.h in Headers */,
+                DD3DC89528A4B48E007E5B61 /* NotificationPoint.h in Headers */,
 				9B5605902D9691ED00FCE33E /* NoVirtualDestructorBase.h in Headers */,
 				DDF306E327C08654006A526F /* NSLocaleSPI.h in Headers */,
 				DDF306E227C08654006A526F /* NSObjCRuntimeSPI.h in Headers */,
@@ -4562,6 +4569,7 @@
 				A8A473EC151A825B004123FF /* MetaAllocator.cpp in Sources */,
 				0F66B28C1DC97BAB004A1D3F /* MonotonicTime.cpp in Sources */,
 				51B07F542AB8797300E14EE9 /* NativePromise.cpp in Sources */,
+                6311592728989A8500680A12 /* NotificationPoint.cpp in Sources */,
 				5CC0EE8A2162BC2200A1A842 /* NSURLExtras.mm in Sources */,
 				A8A473F4151A825B004123FF /* NumberOfCores.cpp in Sources */,
 				465F34932CD824AF000963B1 /* ObjCRuntimeExtras.mm in Sources */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -208,6 +208,7 @@ set(WTF_PUBLIC_HEADERS
     Noncopyable.h
     Nonmovable.h
     NotFound.h
+    NotificationPoint.h
     NumberOfCores.h
     OSAllocator.h
     OSObjectPtr.h

--- a/Source/WTF/wtf/FastMalloc.cpp
+++ b/Source/WTF/wtf/FastMalloc.cpp
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <wtf/Atomics.h>
 #include <wtf/CheckedArithmetic.h>
+#include <wtf/NotificationPoint.h>
 #include <wtf/PageBlock.h>
 
 #if OS(WINDOWS)
@@ -52,10 +53,6 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SetForScope.h>
 #include <wtf/StackShot.h>
-
-#if PLATFORM(COCOA)
-#include <notify.h>
-#endif
 
 #endif
 
@@ -207,10 +204,13 @@ MallocCallTracker& MallocCallTracker::singleton()
 
 MallocCallTracker::MallocCallTracker()
 {
-    int token;
-    notify_register_dispatch("com.apple.WebKit.dumpUntrackedMallocs", &token, mainDispatchQueueSingleton(), ^(int) {
+#if HAVE(NOTIFICATIONPOINT)
+    auto point = NotificationPoint::create("dumpUntrackedMallocs"_s, []() {
         MallocCallTracker::singleton().dumpStats();
     });
+    if (point.has_value())
+        (void)point.value().leakRef();
+#endif
 }
 
 void MallocCallTracker::recordMalloc(void* address, size_t allocationSize)

--- a/Source/WTF/wtf/NotificationPoint.h
+++ b/Source/WTF/wtf/NotificationPoint.h
@@ -1,0 +1,137 @@
+/*
+ *  Copyright (C) 2026 Igalia. S.L. . All rights reserved.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <wtf/CanMakeWeakPtr.h>
+#include <wtf/Expected.h>
+#include <wtf/Function.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
+#include <wtf/Platform.h>
+#include <wtf/RefPtr.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/Vector.h>
+#include <wtf/WeakPtr.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/WTFString.h>
+
+#if OS(DARWIN)
+#include <dispatch/dispatch.h>
+#include <notify.h>
+#elif USE(GLIB)
+#include <gio/gio.h>
+#include <glib.h>
+#endif
+
+#if PLATFORM(COCOA) || USE(GLIB)
+#define HAVE_NOTIFICATIONPOINT 1
+#endif
+
+namespace WTF {
+
+class OwnedNotificationPoint;
+
+class NotificationPoint : public ThreadSafeRefCounted<NotificationPoint>
+#if USE(GLIB)
+, public CanMakeWeakPtr<NotificationPoint>
+#endif
+{
+public:
+    enum class Error : int {
+        ConnectionError,
+        InvalidArgument,
+        PermissionError,
+        Other,
+    };
+    WTF_EXPORT_PRIVATE static Expected<RefPtr<NotificationPoint>, Error> create(ASCIILiteral providedPath, Function<void()>&& callback);
+    WTF_EXPORT_PRIVATE static Expected<RefPtr<NotificationPoint>, Error> createWithName(ASCIILiteral name, ASCIILiteral providedPath, Function<void()>&& callback = nullptr);
+    WTF_EXPORT_PRIVATE Expected<bool, Error> getAndClearNotificationsPosted();
+    bool isLive() const;
+    WTF_EXPORT_PRIVATE ~NotificationPoint();
+    WTF_EXPORT_PRIVATE Expected<uint64_t, Error> getState();
+    WTF_EXPORT_PRIVATE static Expected<uint64_t, Error> getState(ASCIILiteral providedName, String providedPath);
+    WTF_EXPORT_PRIVATE Expected<void, Error> setState(uint64_t);
+    WTF_EXPORT_PRIVATE static Expected<void, Error> setState(ASCIILiteral providedName, String providedPath, uint64_t state);
+    WTF_EXPORT_PRIVATE Expected<void, Error> notify();
+    WTF_EXPORT_PRIVATE static Expected<void, Error> notify(ASCIILiteral providedName, String providedPath);
+    static bool testWTFisEmpty();
+
+#if OS(DARWIN)
+    // Unfortunately, moving this def to the .cpp file causes `tap installapi`
+    // (in the XCode build) to fail, since it apparently uses an .mm file to
+    // import things, but dispatch_queue_t expands to NSObject<> there but a
+    // struct on the C++ side, so the decl doesn't match the definition..
+    static void testWTFsetDispatchQueue(dispatch_queue_t queue)
+    {
+        s_dispatchQueue = queue;
+    }
+    const String& key() const;
+#elif USE(GLIB)
+    void actionCallback();
+#endif // OS(DARWIN)
+
+private:
+#if OS(DARWIN)
+    static void dispatchCallback(const String&);
+    NotificationPoint(String key, int token);
+    int m_token;
+    const String m_key;
+    static std::optional<dispatch_queue_t> s_dispatchQueue;
+#elif USE(GLIB)
+    NotificationPoint(OwnedNotificationPoint*, Function<void()>&&);
+    bool m_notificationsPosted;
+    OwnedNotificationPoint* m_ownedNotificationPoint;
+    Function<void()> m_callback;
+#endif // OS(DARWIN)
+};
+
+#if USE(GLIB)
+class OwnedNotificationPoint {
+    friend class NotificationPoint;
+public:
+    OwnedNotificationPoint(String name, String path) WTF_REQUIRES_LOCK(ownedNotificationPointLock);
+    ~OwnedNotificationPoint() WTF_REQUIRES_LOCK(ownedNotificationPointLock);
+    void addNotificationPoint(WeakPtr<NotificationPoint>) WTF_REQUIRES_LOCK(ownedNotificationPointLock);
+    void removeNotificationPoint(WeakPtr<NotificationPoint>) WTF_REQUIRES_LOCK(ownedNotificationPointLock);
+private:
+    static Lock ownedNotificationPointLock;
+    bool isLive() const WTF_REQUIRES_LOCK(ownedNotificationPointLock);
+    uint64_t getState() WTF_REQUIRES_LOCK(ownedNotificationPointLock);
+    void setState(uint64_t) WTF_REQUIRES_LOCK(ownedNotificationPointLock);
+    void notify() WTF_REQUIRES_LOCK(ownedNotificationPointLock);
+    static OwnedNotificationPoint* ownedNotificationPoint(String name, String path) WTF_REQUIRES_LOCK(OwnedNotificationPoint::ownedNotificationPointLock);
+    static void addOwnedNotificationPoint(HashMap<String, HashMap<String, OwnedNotificationPoint*>>&, OwnedNotificationPoint*) WTF_REQUIRES_LOCK(ownedNotificationPointLock);
+    static void actionCallback(std::pair<String, String>*);
+    static void processPendingForName(String) WTF_REQUIRES_LOCK(ownedNotificationPointLock);
+    static void onBusNameAcquired(GDBusConnection*, const char*, void*);
+
+    const String m_name;
+    const String m_path;
+    guint m_exportID WTF_GUARDED_BY_LOCK(ownedNotificationPointLock);
+    GSimpleActionGroup* m_actionGroup WTF_GUARDED_BY_LOCK(ownedNotificationPointLock);
+    GSimpleAction* m_action WTF_GUARDED_BY_LOCK(ownedNotificationPointLock);
+    Vector<WeakPtr<NotificationPoint>> m_listeners WTF_GUARDED_BY_LOCK(ownedNotificationPointLock);
+};
+#endif
+
+} // namespace WTF
+
+using WTF::NotificationPoint;

--- a/Source/WTF/wtf/PlatformGTK.cmake
+++ b/Source/WTF/wtf/PlatformGTK.cmake
@@ -7,6 +7,7 @@ list(APPEND WTF_SOURCES
     glib/Application.cpp
     glib/ChassisType.cpp
     glib/FileSystemGlib.cpp
+    glib/NotificationPoint.cpp
     glib/GMallocString.cpp
     glib/GRefPtr.cpp
     glib/GSocketMonitor.cpp

--- a/Source/WTF/wtf/PlatformMac.cmake
+++ b/Source/WTF/wtf/PlatformMac.cmake
@@ -44,6 +44,7 @@ list(APPEND WTF_SOURCES
     cocoa/WorkQueueCocoa.cpp
 
     darwin/LibraryPathDiagnostics.mm
+    darwin/NotificationPoint.cpp
 
     mac/FileSystemMac.mm
 

--- a/Source/WTF/wtf/PlatformWPE.cmake
+++ b/Source/WTF/wtf/PlatformWPE.cmake
@@ -8,6 +8,7 @@ list(APPEND WTF_SOURCES
     glib/Application.cpp
     glib/ChassisType.cpp
     glib/FileSystemGlib.cpp
+    glib/NotificationPoint.cpp
     glib/GMallocString.cpp
     glib/GRefPtr.cpp
     glib/GResources.cpp

--- a/Source/WTF/wtf/darwin/NotificationPoint.cpp
+++ b/Source/WTF/wtf/darwin/NotificationPoint.cpp
@@ -1,0 +1,176 @@
+/*
+ *  Copyright (C) 2026 Igalia. S.L. . All rights reserved.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "config.h"
+#include <wtf/NotificationPoint.h>
+
+#include <wtf/DispatchExtras.h>
+
+namespace WTF {
+
+std::optional<dispatch_queue_t> NotificationPoint::s_dispatchQueue;
+
+static NotificationPoint::Error fromPlatformStatus(int status)
+{
+    switch (status) {
+    case NOTIFY_STATUS_OK:
+        RELEASE_ASSERT_NOT_REACHED();
+    case NOTIFY_STATUS_INVALID_NAME:
+    case NOTIFY_STATUS_INVALID_TOKEN:
+    case NOTIFY_STATUS_INVALID_PORT:
+    case NOTIFY_STATUS_INVALID_FILE:
+    case NOTIFY_STATUS_INVALID_SIGNAL:
+    case NOTIFY_STATUS_INVALID_REQUEST:
+    case NOTIFY_STATUS_NULL_INPUT:
+        return NotificationPoint::Error::InvalidArgument;
+    case NOTIFY_STATUS_NOT_AUTHORIZED:
+        return NotificationPoint::Error::PermissionError;
+    case NOTIFY_STATUS_OPT_DISABLE:
+        return NotificationPoint::Error::Other;
+    case NOTIFY_STATUS_SERVER_NOT_FOUND:
+        return NotificationPoint::Error::ConnectionError;
+    default:
+        return NotificationPoint::Error::Other;
+    }
+}
+
+NotificationPoint::NotificationPoint(String key, int token)
+    : m_token(token)
+    , m_key(key)
+{
+}
+
+const String& NotificationPoint::key() const
+{
+    return m_key;
+}
+
+Expected<RefPtr<NotificationPoint>, NotificationPoint::Error> NotificationPoint::create(ASCIILiteral path, Function<void()>&& callback)
+{
+    return createWithName("com.apple.WebKit"_s, path, WTF::move(callback));
+}
+
+Expected<RefPtr<NotificationPoint>, NotificationPoint::Error> NotificationPoint::createWithName(ASCIILiteral name, ASCIILiteral path, Function<void()>&& callback)
+{
+    auto key = makeString(name, '.', path);
+    int token = NOTIFY_TOKEN_INVALID, ret;
+    if (callback) {
+        __block auto capturedCallback = WTF::move(callback);
+        dispatch_queue_t queue = s_dispatchQueue ? *s_dispatchQueue : mainDispatchQueueSingleton();
+        ret = notify_register_dispatch(key.utf8().data(), &token, queue, ^(int)
+            {
+                capturedCallback();
+            });
+    } else
+        ret = notify_register_check(key.utf8().data(), &token);
+    if (ret)
+        return makeUnexpected(fromPlatformStatus(ret));
+    return adoptRef(new NotificationPoint(key, token));
+}
+
+NotificationPoint::~NotificationPoint()
+{
+    int ret = notify_cancel(m_token);
+    RELEASE_ASSERT(!ret);
+}
+
+Expected<bool, NotificationPoint::Error> NotificationPoint::getAndClearNotificationsPosted()
+{
+    int value;
+    auto status = notify_check(m_token, &value);
+    if (status != NOTIFY_STATUS_OK)
+        return makeUnexpected(fromPlatformStatus(status));
+    return value;
+}
+
+bool NotificationPoint::isLive() const
+{
+    return m_token > 0;
+}
+
+Expected<uint64_t, NotificationPoint::Error> NotificationPoint::getState()
+{
+    uint64_t state;
+    auto status = notify_get_state(m_token, &state);
+    if (status != NOTIFY_STATUS_OK)
+        return makeUnexpected(fromPlatformStatus(status));
+    return state;
+}
+
+Expected<uint64_t, NotificationPoint::Error> NotificationPoint::getState(ASCIILiteral name, String path)
+{
+    int token;
+    auto key = makeString(name, '.', path);
+    auto status = notify_register_check(key.utf8().data(), &token);
+    if (status != NOTIFY_STATUS_OK)
+        return makeUnexpected(fromPlatformStatus(status));
+    uint64_t state;
+    status = notify_get_state(token, &state);
+    notify_cancel(token);
+    if (status != NOTIFY_STATUS_OK)
+        return makeUnexpected(fromPlatformStatus(status));
+    return state;
+}
+
+Expected<void, NotificationPoint::Error> NotificationPoint::setState(uint64_t state)
+{
+    auto status = notify_set_state(m_token, state);
+    if (status != NOTIFY_STATUS_OK)
+        return makeUnexpected(fromPlatformStatus(status));
+    return { };
+}
+
+Expected<void, NotificationPoint::Error> NotificationPoint::setState(ASCIILiteral name, String path, uint64_t state)
+{
+    int token;
+    auto key = makeString(name, '.', path);
+    auto status = notify_register_check(key.utf8().data(), &token);
+    if (status != NOTIFY_STATUS_OK)
+        return makeUnexpected(fromPlatformStatus(status));
+    status = notify_set_state(token, state);
+    notify_cancel(token);
+    if (status != NOTIFY_STATUS_OK)
+        return makeUnexpected(fromPlatformStatus(status));
+    return { };
+}
+
+Expected<void, NotificationPoint::Error> NotificationPoint::notify()
+{
+    auto status = notify_post(m_key.utf8().data());
+    if (status != NOTIFY_STATUS_OK)
+        return makeUnexpected(fromPlatformStatus(status));
+    return { };
+}
+
+Expected<void, NotificationPoint::Error> NotificationPoint::notify(ASCIILiteral name, String path)
+{
+    auto key = makeString(name, '.', path);
+    auto status = notify_post(key.utf8().data());
+    if (status != NOTIFY_STATUS_OK)
+        return makeUnexpected(fromPlatformStatus(status));
+    return { };
+
+}
+
+bool NotificationPoint::testWTFisEmpty()
+{
+    return true;
+}
+
+};

--- a/Source/WTF/wtf/glib/NotificationPoint.cpp
+++ b/Source/WTF/wtf/glib/NotificationPoint.cpp
@@ -1,0 +1,510 @@
+/*
+ *  Copyright (C) 2026 Igalia. S.L. . All rights reserved.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "config.h"
+#include <wtf/NotificationPoint.h>
+
+#include <wtf/Assertions.h>
+#include <wtf/Logging.h>
+#include <wtf/NeverDestroyed.h>
+
+namespace WTF {
+
+Lock OwnedNotificationPoint::ownedNotificationPointLock;
+
+static void destroyPair(void* pair, GClosure*)
+{
+    auto namePath = static_cast<std::pair<String, String>*>(pair);
+    delete namePath;
+}
+
+OwnedNotificationPoint::OwnedNotificationPoint(String name, String path)
+    : m_name(name)
+    , m_path(path)
+    , m_exportID(0)
+    , m_listeners()
+{
+    m_actionGroup = g_simple_action_group_new();
+    m_action = g_simple_action_new_stateful("notify", nullptr, g_variant_new_int64(0));
+
+    // We can't store a reference to the OwnedNotificationPoint here, since the object might get destroyed before the invocation of the callback.
+    g_signal_connect_data(m_action, "activate", G_CALLBACK(&OwnedNotificationPoint::actionCallback), new std::pair(name, path), destroyPair, G_CONNECT_SWAPPED);
+    g_action_map_add_action(G_ACTION_MAP(m_actionGroup), G_ACTION(m_action));
+}
+
+void OwnedNotificationPoint::addNotificationPoint(WeakPtr<NotificationPoint> np)
+{
+    m_listeners.append(np);
+}
+
+void OwnedNotificationPoint::removeNotificationPoint(WeakPtr<NotificationPoint> np)
+{
+    m_listeners.removeAll(np);
+    if (m_listeners.isEmpty()) {
+        // We hold ownedNotificationPointLock here, so it's safe to delete this object.
+        delete this;
+    }
+
+}
+
+static GDBusConnection* s_connection;
+
+// Notification points that have truly been exported to the bus under the owned name.
+static HashMap<String, HashMap<String, OwnedNotificationPoint*>>& ownedNotificationPoints()
+{
+    static LazyNeverDestroyed<HashMap<String, HashMap<String, OwnedNotificationPoint*>>> map;
+    static std::once_flag once;
+    std::call_once(once, [] {
+        map.construct();
+    });
+    return map;
+}
+
+// Before we've acquired a connection or bus name, we don't want to block, so
+// we handle the export asynchronously.
+static HashMap<String, HashMap<String, OwnedNotificationPoint*>>& pendingNotificationPoints()
+{
+    static LazyNeverDestroyed<HashMap<String, HashMap<String, OwnedNotificationPoint*>>> map;
+    static std::once_flag once;
+    std::call_once(once, [] {
+        map.construct();
+    });
+    return map;
+}
+
+static OwnedNotificationPoint* findOwnedNotificationPoint(HashMap<String, HashMap<String, OwnedNotificationPoint*>>& container, String name, String path)
+{
+    auto nameMap = container.find(name);
+    if (nameMap == container.end())
+        return nullptr;
+    auto map = nameMap->value;
+    auto iter = map.find(path);
+    if (iter == map.end())
+        return nullptr;
+    return iter->value;
+}
+
+// It's important that we not try to do a d-bus call to owned objects or we'd
+// deadlock (we're the ones that need to respond to the message).
+OwnedNotificationPoint* OwnedNotificationPoint::ownedNotificationPoint(String name, String path)
+{
+    auto ownedPoint = findOwnedNotificationPoint(pendingNotificationPoints(), name, path);
+    if (ownedPoint != nullptr)
+        return ownedPoint;
+    ownedPoint = findOwnedNotificationPoint(ownedNotificationPoints(), name, path);
+    if (ownedPoint != nullptr)
+        return ownedPoint;
+    return nullptr;
+}
+
+static HashMap<String, guint>& ownerIDs()
+{
+    static LazyNeverDestroyed<HashMap<String, guint>> map;
+    static std::once_flag once;
+    std::call_once(once, [] {
+        map.construct();
+    });
+    return map;
+}
+
+static void deregisterOwnedName(String name)
+{
+    g_bus_unown_name(ownerIDs().get(name));
+    ownerIDs().remove(name);
+    ownedNotificationPoints().get(name).clear();
+    ownedNotificationPoints().remove(name);
+}
+
+static int ensureConnection()
+{
+    if (!s_connection) {
+        g_autoptr(GError) error = nullptr;
+        s_connection = g_bus_get_sync(G_BUS_TYPE_SESSION, nullptr, &error);
+        if (!s_connection) {
+            g_warning("Cannot connect to bus: %s", error->message);
+            return error->code;
+        }
+    }
+    return 0;
+}
+
+static void onBusAcquired(GDBusConnection* connection, const char*, void*)
+{
+    s_connection = connection;
+}
+
+static void onBusNameLost(GDBusConnection* connection, const char* name, void*)
+{
+    if (connection) {
+        RELEASE_LOG_ERROR(Process, "Lost D-Bus well-known name %s", name);
+        auto ownedName = String::fromUTF8(name);
+        pendingNotificationPoints().remove(ownedName);
+        ownedNotificationPoints().remove(ownedName);
+        ownerIDs().remove(ownedName);
+    } else {
+        RELEASE_LOG_ERROR(Process, "Lost D-Bus connection");
+        pendingNotificationPoints().clear();
+        ownedNotificationPoints().clear();
+        ownerIDs().clear();
+    }
+}
+
+#if PLATFORM(GTK)
+static const ASCIILiteral ownerNamePrefix = "org.webkitgtk-";
+#elif PLATFORM(WPE)
+static const ASCIILiteral ownerNamePrefix = "org.wpewebkit-";
+#else
+#error No platform name defined
+#endif
+
+bool OwnedNotificationPoint::isLive() const
+{
+    return m_exportID;
+}
+
+uint64_t OwnedNotificationPoint::getState()
+{
+    return static_cast<uint64_t>(g_variant_get_int64(g_action_get_state(G_ACTION(m_action))));
+}
+
+void OwnedNotificationPoint::setState(uint64_t state)
+{
+    g_action_change_state(G_ACTION(m_action), g_variant_new_int64(static_cast<int64_t>(state)));
+}
+
+void OwnedNotificationPoint::notify()
+{
+    for (auto np : m_listeners) {
+        NotificationPoint* point = np.get();
+        // We remove the point from m_listeners before destroying the object, so this shouldn't be possible.
+        RELEASE_ASSERT(point);
+        point->actionCallback();
+    }
+}
+
+void OwnedNotificationPoint::processPendingForName(String name)
+{
+    RELEASE_ASSERT(pendingNotificationPoints().contains(name));
+    for (auto [_, ownedPoint] : pendingNotificationPoints().get(name)) {
+        GActionGroup* actionGroup = G_ACTION_GROUP(ownedPoint->m_actionGroup);
+        g_autoptr(GError) error = nullptr;
+        RELEASE_LOG_INFO(Process, "Registering path %s for %s", ownedPoint->m_path.utf8().data(), ownedPoint->m_name.utf8().data());
+        guint exportID = g_dbus_connection_export_action_group(s_connection, ownedPoint->m_path.utf8().data(), actionGroup, &error);
+        if (!exportID)
+            g_warning("Cannot expose remote control interface to bus: %s", error->message);
+        ownedPoint->m_exportID = exportID;
+        addOwnedNotificationPoint(ownedNotificationPoints(), ownedPoint);
+    }
+    pendingNotificationPoints().remove(name);
+}
+
+void OwnedNotificationPoint::addOwnedNotificationPoint(HashMap<String, HashMap<String, OwnedNotificationPoint*>>& container, OwnedNotificationPoint* ownedPoint)
+{
+    auto iter = container.find(ownedPoint->m_name);
+    if (iter != container.end()) {
+        RELEASE_ASSERT(!iter->value.contains(ownedPoint->m_path));
+        iter->value.set(ownedPoint->m_path, ownedPoint);
+    } else {
+        auto map = HashMap<String, OwnedNotificationPoint*> { { ownedPoint->m_path, ownedPoint } };
+        container.set(ownedPoint->m_name, map);
+    }
+}
+
+void OwnedNotificationPoint::onBusNameAcquired(GDBusConnection*, const char* name, void*)
+{
+    RELEASE_LOG_INFO(Process, "Acquired D-Bus well-known name %s INFO", name);
+    Locker locker { ownedNotificationPointLock };
+    OwnedNotificationPoint::processPendingForName(String::fromUTF8(name));
+}
+
+void OwnedNotificationPoint::actionCallback(std::pair<String, String>* namePath)
+{
+    Locker locker { OwnedNotificationPoint::ownedNotificationPointLock };
+    auto ownedPoint = findOwnedNotificationPoint(ownedNotificationPoints(), namePath->first, namePath->second);
+    if (!ownedPoint)
+        return; // We raced against all registered notification points having been destroyed in another thread,
+    ownedPoint->notify();
+}
+
+OwnedNotificationPoint::~OwnedNotificationPoint()
+{
+    if (s_connection) {
+        // We may end up here if we destroy the notification point before we've
+        // managed to acquire a d-bus connection.
+        g_dbus_connection_unexport_action_group(s_connection, m_exportID);
+    }
+    g_action_map_remove_action(G_ACTION_MAP(m_actionGroup), "activate");
+    auto iter = pendingNotificationPoints().find(m_name);
+    if (iter != pendingNotificationPoints().end()) {
+        auto& map = iter->value;
+        RELEASE_ASSERT(map.remove(m_path));
+        if (map.isEmpty()) {
+            RELEASE_ASSERT(pendingNotificationPoints().remove(m_name));
+            if (!ownedNotificationPoints().contains(m_name)) {
+                // We don't want to own this name any more and it
+                // hasn't been registered, so simply drop it --
+                // no need to unown it.
+                ownerIDs().remove(m_name);
+            }
+        }
+        return;
+    }
+    auto map = ownedNotificationPoints().find(m_name);
+    RELEASE_ASSERT(map != ownedNotificationPoints().end());
+    RELEASE_ASSERT(map->value.remove(m_path));
+    if (map->value.isEmpty()) {
+        RELEASE_ASSERT(ownedNotificationPoints().remove(m_name));
+        deregisterOwnedName(m_name);
+    }
+    RELEASE_ASSERT(m_exportID);
+}
+
+bool NotificationPoint::isLive() const
+{
+    Locker locker { OwnedNotificationPoint::ownedNotificationPointLock };
+    return m_ownedNotificationPoint->isLive();
+}
+
+Expected<RefPtr<NotificationPoint>, NotificationPoint::Error> NotificationPoint::create(ASCIILiteral providedPath, Function<void()>&& callback)
+{
+    return createWithName(ownerNamePrefix, providedPath, WTF::move(callback));
+}
+
+Expected<RefPtr<NotificationPoint>, NotificationPoint::Error> NotificationPoint::createWithName(ASCIILiteral providedName, ASCIILiteral providedPath, Function<void()>&& callback)
+{
+    Locker locker { OwnedNotificationPoint::ownedNotificationPointLock };
+    String path = makeString('/', makeStringByReplacingAll(String(providedPath), '.', '/'));
+    auto name = makeString(providedName, '-', getpid());
+
+    OwnedNotificationPoint* ownedPoint = nullptr;
+    if (!(ownedPoint = findOwnedNotificationPoint(pendingNotificationPoints(), name, path)))
+        ownedPoint = findOwnedNotificationPoint(ownedNotificationPoints(), name, path);
+    if (ownedPoint) {
+        NotificationPoint* point = new NotificationPoint(ownedPoint, WTF::move(callback));
+        ownedPoint->addNotificationPoint(WeakPtr(point));
+        return adoptRef(point);
+    }
+
+    ownedPoint = new WTF::OwnedNotificationPoint(name, path);
+    NotificationPoint* point = new NotificationPoint(ownedPoint, WTF::move(callback));
+    ownedPoint->addNotificationPoint(WeakPtr(point));
+    bool needToRequestBusName = !ownerIDs().contains(name);
+
+    // If we haven't claimed the provided bus name yet, place the
+    // NotificationPoint in a worklist for the callback to find and then export.
+    OwnedNotificationPoint::addOwnedNotificationPoint(pendingNotificationPoints(), ownedPoint);
+
+    if (needToRequestBusName) {
+        // We need to wait for a bus address to do the export, will be
+        // handled in the callback we register here.
+        guint ownerId = g_bus_own_name(G_BUS_TYPE_SESSION,
+            name.utf8().data(),
+            G_BUS_NAME_OWNER_FLAGS_NONE,
+            onBusAcquired,
+            OwnedNotificationPoint::onBusNameAcquired,
+            onBusNameLost,
+            nullptr,
+            nullptr);
+        ownerIDs().set(name, ownerId);
+    } else if (ownedNotificationPoints().contains(name)) {
+        // We already have an address, we can do the export now.
+        OwnedNotificationPoint::processPendingForName(name);
+    }
+    return adoptRef(point);
+}
+
+Expected<bool, NotificationPoint::Error> NotificationPoint::getAndClearNotificationsPosted()
+{
+    auto ret = m_notificationsPosted;
+    m_notificationsPosted = false;
+    return ret;
+}
+
+NotificationPoint::~NotificationPoint()
+{
+    Locker locker { OwnedNotificationPoint::ownedNotificationPointLock };
+    m_ownedNotificationPoint->removeNotificationPoint(this);
+}
+
+Expected<uint64_t, NotificationPoint::Error> NotificationPoint::getState()
+{
+    Locker locker { OwnedNotificationPoint::ownedNotificationPointLock };
+    return m_ownedNotificationPoint->getState();
+}
+
+Expected<uint64_t, NotificationPoint::Error> NotificationPoint::getState(ASCIILiteral providedName, String providedPath)
+{
+
+    auto name = makeString(providedName, '-', getpid());
+    auto path = makeString('/', providedPath);
+    {
+        Locker locker { OwnedNotificationPoint::ownedNotificationPointLock };
+
+        if (auto ownedPoint = OwnedNotificationPoint::ownedNotificationPoint(name, path))
+            return ownedPoint->getState();
+    }
+    if (ensureConnection())
+        return makeUnexpected(NotificationPoint::Error::ConnectionError);
+    g_autoptr(GError) error = nullptr;
+    auto result = g_dbus_connection_call_sync(s_connection,
+        name.utf8().data(),
+        path.utf8().data(),
+        "org.gtk.Actions",
+        "Describe",
+        g_variant_new("(s)", "notify"),
+        g_variant_type_new("((bgav))"),
+        G_DBUS_CALL_FLAGS_NONE,
+        1000,
+        nullptr,
+        &error);
+    if (!result) {
+        g_warning("Couldn't getState for path %s under %s: %s", path.utf8().data(), name.utf8().data(), error->message);
+        return makeUnexpected(NotificationPoint::Error::Other);
+    }
+
+    GVariantIter* iter;
+    g_variant_get(result, "((bgav))", nullptr, nullptr, &iter);
+
+    GVariant* returnedValue;
+    RELEASE_ASSERT(g_variant_iter_loop(iter, "v", &returnedValue));
+    g_variant_iter_free(iter);
+
+    gint64 intValue = g_variant_get_int64(returnedValue);
+    return static_cast<uint64_t>(intValue);
+}
+
+Expected<void, NotificationPoint::Error> NotificationPoint::setState(uint64_t value)
+{
+    Locker locker { OwnedNotificationPoint::ownedNotificationPointLock };
+    m_ownedNotificationPoint->setState(value);
+    return { };
+}
+
+Expected<void, NotificationPoint::Error> NotificationPoint::setState(ASCIILiteral providedName, String providedPath, uint64_t value)
+{
+    auto path = makeString('/', providedPath);
+    auto name = makeString(providedName, '-', getpid());
+    {
+        Locker locker { OwnedNotificationPoint::ownedNotificationPointLock };
+        if (auto ownedPoint = OwnedNotificationPoint::ownedNotificationPoint(name, path)) {
+            ownedPoint->setState(value);
+            return { };
+        }
+    }
+    if (ensureConnection())
+        return makeUnexpected(NotificationPoint::Error::ConnectionError);
+    g_autoptr(GError) error = nullptr;
+    auto callSyncresult = g_dbus_connection_call_sync(s_connection,
+        name.utf8().data(),
+        path.utf8().data(),
+        "org.gtk.Actions",
+        "SetState",
+        g_variant_new_int64(value),
+        nullptr,
+        G_DBUS_CALL_FLAGS_NONE,
+        1000,
+        nullptr,
+        &error);
+    if (!callSyncresult) {
+        g_warning("Couldn't setState for path %s under %s: %s", path.utf8().data(), name.utf8().data(), error->message);
+        return makeUnexpected(NotificationPoint::Error::Other);
+    }
+    return { };
+}
+
+Expected<void, NotificationPoint::Error> NotificationPoint::notify()
+{
+    Locker locker { OwnedNotificationPoint::ownedNotificationPointLock };
+    m_ownedNotificationPoint->notify();
+    return { };
+}
+
+Expected<void, NotificationPoint::Error> NotificationPoint::notify(ASCIILiteral providedName, String providedPath)
+{
+    auto name = makeString(providedName, '-', getpid());
+    auto path = makeString('/', providedPath);
+    {
+        Locker locker { OwnedNotificationPoint::ownedNotificationPointLock };
+
+        if (auto ownedPoint = OwnedNotificationPoint::ownedNotificationPoint(name, path)) {
+            ownedPoint->notify();
+            return { };
+        }
+    }
+    if (ensureConnection())
+        return makeUnexpected(NotificationPoint::Error::ConnectionError);
+    g_dbus_connection_call(s_connection,
+        name.utf8().data(),
+        path.utf8().data(),
+        "org.gtk.Actions",
+        "Activate",
+        g_variant_new("(sava{sv})",
+            "notify",
+            nullptr,
+            nullptr),
+        nullptr,
+        G_DBUS_CALL_FLAGS_NONE,
+        -1,
+        nullptr,
+        nullptr,
+        nullptr);
+    return { };
+}
+
+bool NotificationPoint::testWTFisEmpty()
+{
+    if (!pendingNotificationPoints().isEmpty()) {
+        g_message("Pending notification points:");
+        for (auto [name, map] : pendingNotificationPoints()) {
+            for (auto [_, np] : map)
+                g_message("%s %s", name.utf8().data(), np->m_path.utf8().data());
+        }
+        return false;
+    }
+    if (!ownedNotificationPoints().isEmpty()) {
+        g_message("Active notification points:");
+        for (auto [name, map] : ownedNotificationPoints()) {
+            for (auto [path, _] : map)
+                g_message("%s %s", name.utf8().data(), path.utf8().data());
+        }
+        return false;
+    }
+    if (!ownerIDs().isEmpty()) {
+        g_message("Active owner IDs:");
+        for (auto [name, id] : ownerIDs())
+            g_message("%s %u", name.utf8().data(), id);
+        return false;
+    }
+    return true;
+}
+
+NotificationPoint::NotificationPoint(OwnedNotificationPoint* ownedPoint, Function<void()>&& callback)
+    : m_notificationsPosted(true)
+    , m_ownedNotificationPoint(ownedPoint)
+    , m_callback(WTF::move(callback))
+{
+}
+
+void NotificationPoint::actionCallback()
+{
+    m_notificationsPosted = true;
+    if (m_callback)
+        m_callback();
+}
+};

--- a/Source/WebCore/PAL/pal/Logging.cpp
+++ b/Source/WebCore/PAL/pal/Logging.cpp
@@ -26,23 +26,20 @@
 #include "config.h"
 #include "Logging.h"
 
+#include <wtf/NotificationPoint.h>
 #include <wtf/text/WTFString.h>
-
-#if PLATFORM(COCOA)
-#include <notify.h>
-#include <wtf/BlockPtr.h>
-#include <wtf/darwin/DispatchExtras.h>
-#endif
 
 namespace PAL {
 
 void registerNotifyCallback(ASCIILiteral notifyID, Function<void()>&& callback)
 {
-#if PLATFORM(COCOA)
-    int token;
-    notify_register_dispatch(notifyID.characters(), &token, mainDispatchQueueSingleton(), makeBlockPtr([callback = WTF::move(callback)](int) {
+#if HAVE(NOTIFICATIONPOINT)
+    auto adapter = [callback = WTF::move(callback)]() {
         callback();
-    }).get());
+    };
+    auto point = WTF::NotificationPoint::create(notifyID, WTF::move(adapter));
+    if (point.has_value())
+        (void)point.value().leakRef();
 #else
     UNUSED_PARAM(notifyID);
     UNUSED_PARAM(callback);

--- a/Source/WebCore/bindings/js/GarbageCollectionController.cpp
+++ b/Source/WebCore/bindings/js/GarbageCollectionController.cpp
@@ -63,7 +63,7 @@ GarbageCollectionController::GarbageCollectionController()
 {
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
-        PAL::registerNotifyCallback("com.apple.WebKit.dumpGCHeap"_s, [] {
+        PAL::registerNotifyCallback("dumpGCHeap"_s, [] {
             GarbageCollectionController::singleton().dumpHeap();
         });
     });

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -350,7 +350,7 @@ BackForwardCache::BackForwardCache()
 {
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
-        PAL::registerNotifyCallback("com.apple.WebKit.showBackForwardCache"_s, [] {
+        PAL::registerNotifyCallback("showBackForwardCache"_s, [] {
             BackForwardCache::singleton().dump();
         });
     });

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -380,7 +380,7 @@ bool canUseForFlexLayout(const RenderFlexibleBox& flexBox)
 #ifndef NDEBUG
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
-        PAL::registerNotifyCallback("com.apple.WebKit.showLegacyFlexReasons"_s, Function<void()> { printLegacyFlexReasons });
+        PAL::registerNotifyCallback("showLegacyFlexReasons"_s, Function<void()> { printLegacyFlexReasons });
     });
 #endif
     return canUseForFlexLayoutWithReason(flexBox, IncludeReasons::First).isEmpty();

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -782,7 +782,7 @@ bool canUseForGridLayout(const RenderGrid& renderGrid)
 #ifndef NDEBUG
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
-        PAL::registerNotifyCallback("com.apple.WebKit.showLegacyGridReasons"_s, Function<void()> { printLegacyGridReasons });
+        PAL::registerNotifyCallback("showLegacyGridReasons"_s, Function<void()> { printLegacyGridReasons });
     });
 #endif
     auto reasons = gridLayoutAvoidanceReason(renderGrid, ReasonCollectionMode::FirstOnly);

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -69,7 +69,7 @@ MemoryCache::MemoryCache()
 
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
-        PAL::registerNotifyCallback("com.apple.WebKit.showMemoryCache"_s, [] {
+        PAL::registerNotifyCallback("showMemoryCache"_s, [] {
             MemoryCache::singleton().dumpStats();
             MemoryCache::singleton().dumpLRULists(true);
         });

--- a/Source/WebCore/page/cocoa/PageCocoa.mm
+++ b/Source/WebCore/page/cocoa/PageCocoa.mm
@@ -58,16 +58,16 @@ void Page::platformInitialize()
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [] {
 #if ENABLE(TREE_DEBUGGING)
-        PAL::registerNotifyCallback("com.apple.WebKit.dumpAccessibilityTreeToStderr"_s, printAccessibilityTreeForLiveDocuments);
-        PAL::registerNotifyCallback("com.apple.WebKit.dumpAccessibilityTreeToStderrAfterDelay"_s, printAccessibilityTreeForLiveDocumentsAfterDelay);
-        PAL::registerNotifyCallback("com.apple.WebKit.showRenderTree"_s, printRenderTreeForLiveDocuments);
-        PAL::registerNotifyCallback("com.apple.WebKit.showLayerTree"_s, printLayerTreeForLiveDocuments);
-        PAL::registerNotifyCallback("com.apple.WebKit.showGraphicsLayerTree"_s, printGraphicsLayerTreeForLiveDocuments);
-        PAL::registerNotifyCallback("com.apple.WebKit.showPaintOrderTree"_s, printPaintOrderTreeForLiveDocuments);
-        PAL::registerNotifyCallback("com.apple.WebKit.showLayoutTree"_s, Layout::printLayoutTreeForLiveDocuments);
+        PAL::registerNotifyCallback("dumpAccessibilityTreeToStderr"_s, printAccessibilityTreeForLiveDocuments);
+        PAL::registerNotifyCallback("dumpAccessibilityTreeToStderrAfterDelay"_s, printAccessibilityTreeForLiveDocumentsAfterDelay);
+        PAL::registerNotifyCallback("showRenderTree"_s, printRenderTreeForLiveDocuments);
+        PAL::registerNotifyCallback("showLayerTree"_s, printLayerTreeForLiveDocuments);
+        PAL::registerNotifyCallback("showGraphicsLayerTree"_s, printGraphicsLayerTreeForLiveDocuments);
+        PAL::registerNotifyCallback("showPaintOrderTree"_s, printPaintOrderTreeForLiveDocuments);
+        PAL::registerNotifyCallback("showLayoutTree"_s, Layout::printLayoutTreeForLiveDocuments);
 #endif // ENABLE(TREE_DEBUGGING)
 
-        PAL::registerNotifyCallback("com.apple.WebKit.showAllDocuments"_s, [] {
+        PAL::registerNotifyCallback("showAllDocuments"_s, [] {
             unsigned numPages = 0;
             Page::forEachPage([&numPages](Page&) {
                 ++numPages;

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -269,9 +269,9 @@ void NetworkProcess::didClose(IPC::Connection&)
         session.notifyAdAttributionKitOfSessionTermination();
     });
 
-#if PLATFORM(COCOA)
-    if (m_mediaStreamingActivitityToken != NOTIFY_TOKEN_INVALID)
-        notify_cancel(m_mediaStreamingActivitityToken);
+#if HAVE(NOTIFICATIONPOINT)
+    if (m_mediaStreamingActivityNotificationPoint)
+        m_mediaStreamingActivityNotificationPoint = nullptr;
 #endif
 }
 
@@ -1571,24 +1571,26 @@ bool NetworkProcess::isEnhancedSecurityLinksEnabled() const
 
 void NetworkProcess::notifyMediaStreamingActivity(bool activity)
 {
-#if PLATFORM(COCOA)
-    static constexpr auto notifyMediaStreamingName = "com.apple.WebKit.mediaStreamingActivity"_s;
-
-    if (m_mediaStreamingActivitityToken == NOTIFY_TOKEN_INVALID) {
-        auto status = notify_register_check(notifyMediaStreamingName, &m_mediaStreamingActivitityToken);
-        if (status != NOTIFY_STATUS_OK || m_mediaStreamingActivitityToken == NOTIFY_TOKEN_INVALID) {
-            RELEASE_LOG_ERROR(IPC, "notify_register_check() for %s failed with status (%d) 0x%X", notifyMediaStreamingName.characters(), status, status);
-            m_mediaStreamingActivitityToken = NOTIFY_TOKEN_INVALID;
+#if HAVE(NOTIFICATIONPOINT)
+    static constexpr auto notifyMediaStreamingName = "mediaStreamingActivity"_s;
+    if (!m_mediaStreamingActivityNotificationPoint) {
+        auto point = NotificationPoint::create(notifyMediaStreamingName, nullptr);
+        if (point.has_value())
+            m_mediaStreamingActivityNotificationPoint = point.value();
+        else {
+            RELEASE_LOG_ERROR(IPC, "NotificationPoint::create() for %s failed with status (%d)", notifyMediaStreamingName.characters(), static_cast<int>(point.error()));
             return;
         }
     }
-    auto status = notify_set_state(m_mediaStreamingActivitityToken, activity ? 1 : 0);
-    if (status != NOTIFY_STATUS_OK) {
-        RELEASE_LOG_ERROR(IPC, "notify_set_state() for %s failed with status (%d) 0x%X", notifyMediaStreamingName.characters(), status, status);
+    RefPtr<NotificationPoint> point = m_mediaStreamingActivityNotificationPoint;
+    auto result = point->setState(activity ? 1 : 0);
+    if (!result.has_value()) {
+        RELEASE_LOG_ERROR(IPC, "NotificationPoint::setState() for %s failed with status (%d)", notifyMediaStreamingName.characters(), static_cast<int>(result.error()));
         return;
     }
-    status = notify_post(notifyMediaStreamingName);
-    RELEASE_LOG_ERROR_IF(status != NOTIFY_STATUS_OK, IPC, "notify_post() for %s failed with status (%d) 0x%X", notifyMediaStreamingName.characters(), status, status);
+    result = point->notify();
+    if (!result.has_value())
+        RELEASE_LOG_ERROR(IPC, "NotificationPoint::notify() for %s failed with status (%d)", notifyMediaStreamingName.characters(), static_cast<int>(result.error()));
 #else
     UNUSED_PARAM(activity);
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -61,6 +61,7 @@
 #include <wtf/Lock.h>
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/NotificationPoint.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -676,8 +677,10 @@ private:
     bool m_ftpEnabled { false };
     bool m_isSuspended { false };
     bool m_didSyncCookiesForClose { false };
+#if HAVE(NOTIFICATIONPOINT)
+    RefPtr<NotificationPoint> m_mediaStreamingActivityNotificationPoint;
+#endif
 #if PLATFORM(COCOA)
-    int m_mediaStreamingActivitityToken { NOTIFY_TOKEN_INVALID };
     bool m_isParentProcessFullWebBrowserOrRunningTest { false };
 #endif
     bool m_enableModernDownloadProgress { false };

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -47,6 +47,7 @@
 #include <wtf/FileSystem.h>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/NotificationPoint.h>
 #include <wtf/RunLoop.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -105,13 +106,6 @@ RefPtr<Cache> Cache::open(NetworkProcess& networkProcess, const String& cachePat
     return adoptRef(*new Cache(networkProcess, cachePath, storage.releaseNonNull(), options, sessionID));
 }
 
-#if PLATFORM(GTK) || PLATFORM(WPE)
-static void dumpFileChanged(Cache* cache)
-{
-    cache->dumpContentsToFile();
-}
-#endif
-
 Cache::Cache(NetworkProcess& networkProcess, const String& storageDirectory, Ref<Storage>&& storage, OptionSet<CacheOption> options, PAL::SessionID sessionID)
     : m_storage(WTF::move(storage))
     , m_networkProcess(networkProcess)
@@ -132,19 +126,13 @@ Cache::Cache(NetworkProcess& networkProcess, const String& storageDirectory, Ref
     }
 
     if (options.contains(CacheOption::RegisterNotify)) {
-#if PLATFORM(COCOA)
+#if HAVE(NOTIFICATIONPOINT)
         // Triggers with "notifyutil -p com.apple.WebKit.Cache.dump".
-        int token;
-        notify_register_dispatch("com.apple.WebKit.Cache.dump", &token, mainDispatchQueueSingleton(), ^(int) {
+        auto point = NotificationPoint::create("Cache.dump"_s, [this]() {
             dumpContentsToFile();
         });
-#endif
-#if PLATFORM(GTK) || PLATFORM(WPE)
-        // Triggers with "touch $cachePath/dump".
-        CString dumpFilePath = fileSystemRepresentation(pathByAppendingComponent(m_storage->basePathIsolatedCopy(), "dump"_s));
-        GRefPtr<GFile> dumpFile = adoptGRef(g_file_new_for_path(dumpFilePath.data()));
-        GFileMonitor* monitor = g_file_monitor_file(dumpFile.get(), G_FILE_MONITOR_NONE, nullptr, nullptr);
-        g_signal_connect_swapped(monitor, "changed", G_CALLBACK(dumpFileChanged), this);
+        if (point.has_value())
+            (void)point.value().leakRef();
 #endif
     }
 }

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -359,13 +359,13 @@ void WebProcessPool::platformInitialize(NeedsGlobalStaticInitialization needsGlo
     [WKWebInspectorPreferenceObserver sharedInstance];
 #endif
 
-    PAL::registerNotifyCallback("com.apple.WebKit.logProcessState"_s, [] {
+    PAL::registerNotifyCallback("logProcessState"_s, [] {
         for (const auto& pool : WebProcessPool::allProcessPools())
             logProcessPoolState(pool.get());
     });
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    PAL::registerNotifyCallback("com.apple.WebKit.restrictedDomains"_s, [] {
+    PAL::registerNotifyCallback("restrictedDomains"_s, [] {
         RestrictedOpenerDomainsController::singleton();
     });
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessProxyCocoa.mm
@@ -91,7 +91,7 @@ static const Seconds unexpectedActivityDuration = 10_s;
 
 void WebProcessProxy::registerNotifyObservers()
 {
-    PAL::registerNotifyCallback("com.apple.WebKit.logFrameTrees"_s, [] {
+    PAL::registerNotifyCallback("logFrameTrees"_s, [] {
         for (Ref page : WebProcessProxy::globalPages())
             page->logFrameTree();
     });

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -568,13 +568,13 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
         });
         memoryPressureHandler.install();
 
-        PAL::registerNotifyCallback("com.apple.WebKit.logMemStats"_s, [] {
+        PAL::registerNotifyCallback("logMemStats"_s, [] {
             WebCore::logMemoryStatistics(LogMemoryStatisticsReason::DebugNotification);
         });
     }
 
 #if !RELEASE_LOG_DISABLED
-    PAL::registerNotifyCallback("com.apple.WebKit.logPageState"_s, [this, protectedThis = Ref { *this }] {
+    PAL::registerNotifyCallback("logPageState"_s, [this, protectedThis = Ref { *this }] {
         for (auto& page : m_pageMap.values()) {
             int64_t loadCommitTime = 0;
 #if USE(OS_STATE)

--- a/Tools/TestWebKitAPI/PlatformGTK.cmake
+++ b/Tools/TestWebKitAPI/PlatformGTK.cmake
@@ -13,6 +13,8 @@ add_dependencies(TestWebKitAPIInjectedBundle TestWebKitAPI-forwarding-headers)
 
 # TestWTF
 list(APPEND TestWTF_SOURCES
+    Tests/WTF/NotificationPoint.cpp
+
     Tests/WTF/glib/ActivityObserver.cpp
     Tests/WTF/glib/GMallocString.cpp
     Tests/WTF/glib/GRefPtr.cpp

--- a/Tools/TestWebKitAPI/PlatformWPE.cmake
+++ b/Tools/TestWebKitAPI/PlatformWPE.cmake
@@ -17,6 +17,7 @@ set(test_main_SOURCES generic/main.cpp)
 list(APPEND TestWTF_SOURCES
     ${test_main_SOURCES}
 
+    Tests/WTF/NotificationPoint.cpp
     Tests/WTF/glib/ActivityObserver.cpp
     Tests/WTF/glib/GMallocString.cpp
     Tests/WTF/glib/GRefPtr.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1201,6 +1201,7 @@
 				WTF/NakedPtr.cpp,
 				WTF/NativePromise.cpp,
 				WTF/NeverDestroyed.cpp,
+                WTF/NotificationPoint.cpp,
 				WTF/Observer.cpp,
 				WTF/OptionCountedSet.cpp,
 				WTF/OptionSet.cpp,

--- a/Tools/TestWebKitAPI/Tests/WTF/NotificationPoint.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/NotificationPoint.cpp
@@ -1,0 +1,451 @@
+/*
+ *  Copyright (C) 2026 Igalia. S.L. . All rights reserved.
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+#include "config.h"
+#include <wtf/NotificationPoint.h>
+
+#include <wtf/BitSet.h>
+#include <wtf/Seconds.h>
+#if USE(GLIB)
+#include <glib.h>
+#else
+#include <dispatch/dispatch.h>
+#endif
+
+#define TEST_NOTIFICATION_POINT_OWNER "com.example.testme"_s
+
+#if USE(GLIB)
+class NotificationPointTestExecutor {
+public:
+    void waitForNotificationPointToGoLive(NotificationPoint* n)
+    {
+        for (; !n->isLive();)
+            g_main_context_iteration(g_main_context_default(), false);
+    }
+
+    void callbackHasRun(unsigned = 0) { }
+    void waitForNotification(unsigned = 0) { }
+    void waitForAllNotifications() { }
+    void synchronize() { }
+
+    void run(Function<void()>operation)
+    {
+        operation();
+        g_main_context_iteration(g_main_context_default(), false);
+    }
+
+    NotificationPointTestExecutor(long = 0)
+    {
+        m_loop = g_main_loop_new(g_main_context_default(), true);
+    }
+
+    ~NotificationPointTestExecutor()
+    {
+        g_main_loop_quit(m_loop);
+    }
+private:
+    GMainLoop* m_loop;
+};
+
+#elif OS(DARWIN)
+class NotificationPointTestExecutor {
+public:
+    void waitForNotificationPointToGoLive(NotificationPoint*) { }
+
+    void callbackHasRun(unsigned i = 0)
+    {
+        dispatch_semaphore_signal(m_semaphores[i]);
+    }
+
+    void waitForNotification(unsigned i = 0)
+    {
+        dispatch_semaphore_wait(m_semaphores[i], DISPATCH_TIME_FOREVER);
+    }
+
+    void waitForAllNotifications()
+    {
+        size_t count = m_semaphores.size();
+        WTF::BitSet<3> completed;
+        RELEASE_ASSERT(completed.size() <= m_semaphores.size());
+        static constexpr int64_t ns = 100 * MSEC_PER_SEC;
+
+        do {
+            for (size_t i = 0; i < count; ++i) {
+                if (dispatch_semaphore_wait(m_semaphores[i], dispatch_time(DISPATCH_TIME_NOW, ns)))
+                    continue;
+                completed.set(i);
+            }
+        } while (completed.count() < count);
+    }
+
+    void synchronize()
+    {
+        auto cb = [this]() {
+            callbackHasRun();
+        };
+        // We create a new notification point and do a round-trip, in the hopes
+        // that whatever notify/setState action we took before will also have
+        // completed. Would be great to have a better way to synchronize with
+        // setState.
+        auto result = NotificationPoint::createWithName(TEST_NOTIFICATION_POINT_OWNER, "internal"_s, WTF::move(cb));
+        ASSERT_TRUE(result.has_value());
+        RefPtr<NotificationPoint> point = result.value();
+        point->notify();
+        waitForNotification();
+    }
+
+    void run(Function<void()>operation)
+    {
+        operation();
+    }
+
+    NotificationPointTestExecutor(long count = 1)
+        : m_semaphores(count)
+    {
+        m_semaphores = Vector<dispatch_semaphore_t>();
+        for (long i = 0; i < count; ++i)
+            m_semaphores.append(dispatch_semaphore_create(0));
+        m_queue = dispatch_queue_create("testNotificationPointQueue", DISPATCH_QUEUE_CONCURRENT);
+        NotificationPoint::testWTFsetDispatchQueue(m_queue);
+    }
+
+    ~NotificationPointTestExecutor()
+    {
+        dispatch_release(m_queue);
+        for (auto sema : m_semaphores)
+            dispatch_release(sema);
+    }
+private :
+    Vector<dispatch_semaphore_t> m_semaphores;
+    dispatch_queue_t m_queue;
+};
+#endif
+
+TEST(WTF, TestNotificationPointNotify)
+{
+    auto executor = NotificationPointTestExecutor();
+    bool callbackHasRun = false;
+    {
+        RefPtr<NotificationPoint> point;
+        executor.run([&point, &callbackHasRun, &executor] {
+            auto f = [&callbackHasRun, &executor]() {
+                callbackHasRun = true;
+                executor.callbackHasRun();
+            };
+            auto result = NotificationPoint::createWithName(TEST_NOTIFICATION_POINT_OWNER, "test"_s, WTF::move(f));
+            ASSERT_TRUE(result.has_value());
+            point = result.value();
+            executor.waitForNotificationPointToGoLive(point);
+        });
+        executor.run([&] {
+            point->notify();
+            executor.waitForNotification();
+        });
+        executor.run([&callbackHasRun] {
+            ASSERT_TRUE(callbackHasRun);
+        });
+    }
+    ASSERT_TRUE(NotificationPoint::testWTFisEmpty());
+}
+
+TEST(WTF, TestNotificationPointState)
+{
+    auto executor = NotificationPointTestExecutor();
+    ASCIILiteral path = "stateful"_s;
+    {
+        RefPtr<NotificationPoint> point;
+        executor.run([&] {
+            auto result = NotificationPoint::createWithName(TEST_NOTIFICATION_POINT_OWNER, path, nullptr);
+            ASSERT_TRUE(result.has_value());
+            point = result.value();
+            executor.waitForNotificationPointToGoLive(point);
+        });
+        executor.run([&] {
+            auto state = point->getState();
+            ASSERT_TRUE(state.has_value());
+            ASSERT_EQ(state.value(), static_cast<uint64_t>(0));
+            state = NotificationPoint::getState(TEST_NOTIFICATION_POINT_OWNER, path);
+            ASSERT_TRUE(state.has_value());
+            ASSERT_EQ(state.value(), static_cast<uint64_t>(0));
+        });
+        executor.run([&] {
+
+            ASSERT_TRUE(point->setState(7).has_value());
+            executor.synchronize();
+
+            auto state = point->getState();
+            ASSERT_TRUE(state.has_value());
+            ASSERT_EQ(state.value(), static_cast<uint64_t>(7));
+
+            ASSERT_TRUE(NotificationPoint::setState(TEST_NOTIFICATION_POINT_OWNER, path, 8).has_value());
+            executor.synchronize();
+
+            state = NotificationPoint::getState(TEST_NOTIFICATION_POINT_OWNER, path);
+            ASSERT_TRUE(state.has_value());
+            ASSERT_EQ(state.value(), static_cast<uint64_t>(8));
+        });
+    }
+    ASSERT_TRUE(NotificationPoint::testWTFisEmpty());
+}
+
+TEST(WTF, TestNotificationPointStateWithCallback)
+{
+    auto executor = NotificationPointTestExecutor();
+    ASCIILiteral path = "stateful"_s;
+    {
+        RefPtr<NotificationPoint> point;
+        bool callbackHasRun = false;
+        auto callback = [&]() {
+            callbackHasRun = true;
+            executor.callbackHasRun();
+        };
+        executor.run([&] {
+            auto result = NotificationPoint::createWithName(TEST_NOTIFICATION_POINT_OWNER, path, WTF::move(callback));
+            ASSERT_TRUE(result.has_value());
+            point = result.value();
+            executor.waitForNotificationPointToGoLive(point);
+        });
+        executor.run([&] {
+            auto state = point->getState();
+            ASSERT_TRUE(state.has_value());
+            ASSERT_EQ(state.value(), static_cast<uint64_t>(0));
+            state = NotificationPoint::getState(TEST_NOTIFICATION_POINT_OWNER, path);
+            ASSERT_TRUE(state.has_value());
+            ASSERT_EQ(state.value(), static_cast<uint64_t>(0));
+        });
+        executor.run([&] {
+            ASSERT_TRUE(point->setState(7).has_value());
+            executor.synchronize();
+
+            auto state = point->getState();
+            ASSERT_TRUE(state.has_value());
+            ASSERT_EQ(state.value(), static_cast<uint64_t>(7));
+
+            ASSERT_TRUE(NotificationPoint::setState(TEST_NOTIFICATION_POINT_OWNER, path, 8).has_value());
+            executor.synchronize();
+
+            state = NotificationPoint::getState(TEST_NOTIFICATION_POINT_OWNER, path);
+            ASSERT_TRUE(state.has_value());
+            ASSERT_EQ(state.value(), static_cast<uint64_t>(8));
+        });
+        ASSERT_FALSE(callbackHasRun);
+    }
+    ASSERT_TRUE(NotificationPoint::testWTFisEmpty());
+}
+
+TEST(WTF, TestNotificationPointPendingNotifications)
+{
+    auto executor = NotificationPointTestExecutor();
+    ASCIILiteral path = "pending"_s;
+    {
+        RefPtr<NotificationPoint> point;
+
+        executor.run([&] {
+            auto result = NotificationPoint::createWithName(TEST_NOTIFICATION_POINT_OWNER, path, nullptr);
+            ASSERT_TRUE(result.has_value());
+            point = result.value();
+            executor.waitForNotificationPointToGoLive(point);
+        });
+        executor.run([&] {
+            auto posted = point->getAndClearNotificationsPosted();
+            ASSERT_TRUE(posted.has_value());
+            // Use same semantics as on Darwin, there's always a posted
+            // notification after creation.
+            ASSERT_TRUE(posted.value());
+        });
+        executor.run([&] {
+            auto posted = point->getAndClearNotificationsPosted();
+            ASSERT_TRUE(posted.has_value());
+            // But now that we've retrieved the peosted notification, this should be false.
+            ASSERT_FALSE(posted.value());
+        });
+        executor.run([&] {
+            // Post a notification.
+            ASSERT_TRUE(NotificationPoint::notify(TEST_NOTIFICATION_POINT_OWNER, path).has_value());
+            executor.synchronize();
+        });
+        executor.run([&] {
+            // Is the notification there?
+            auto posted = point->getAndClearNotificationsPosted();
+            ASSERT_TRUE(posted.has_value());
+            ASSERT_TRUE(posted.value());
+        });
+        executor.run([&] {
+            // Is it gone now?
+            auto posted = point->getAndClearNotificationsPosted();
+            ASSERT_TRUE(posted.has_value());
+            ASSERT_FALSE(posted.value());
+        });
+    }
+    ASSERT_TRUE(NotificationPoint::testWTFisEmpty());
+}
+
+TEST(WTF, TestNotificationPointSameNamePathWorks)
+{
+    auto executor = NotificationPointTestExecutor(3);
+    bool callback1HasRun = false;
+    auto callback1 = [&]() {
+        callback1HasRun = true;
+        executor.callbackHasRun(0);
+    };
+    bool callback2HasRun = false;
+    auto callback2 = [&]() {
+        callback2HasRun = true;
+        executor.callbackHasRun(1);
+    };
+    bool callback3HasRun = false;
+    auto callback3 = [&]() {
+        callback3HasRun = true;
+        executor.callbackHasRun(2);
+    };
+
+    ASCIILiteral path = "multiple"_s;
+    {
+        RefPtr<NotificationPoint> point1, point2, point3;
+
+        executor.run([&] {
+            auto result1 = NotificationPoint::createWithName(TEST_NOTIFICATION_POINT_OWNER, path, WTF::move(callback1));
+            ASSERT_TRUE(result1.has_value());
+            point1 = result1.value();
+            ASSERT_NE(point1, nullptr);
+            // Immediately try to create a duplicate, without giving the point
+            // time to register. This is handled asynchronously for glib, so
+            // test the "pending NotificationPoint" path.
+            auto result2 = NotificationPoint::createWithName(TEST_NOTIFICATION_POINT_OWNER, path, WTF::move(callback2));
+            ASSERT_TRUE(result2.has_value());
+            point2 = result2.value();
+            ASSERT_NE(point2, nullptr);
+            executor.waitForNotificationPointToGoLive(point1);
+            executor.waitForNotificationPointToGoLive(point2);
+        });
+        executor.run([&] {
+            // Try to create a duplicate after point1 is certainly live.
+            auto result3 = NotificationPoint::createWithName(TEST_NOTIFICATION_POINT_OWNER, path, WTF::move(callback3));
+            ASSERT_TRUE(result3.has_value());
+            point3 = result3.value();
+            ASSERT_NE(point3, nullptr);
+            executor.waitForNotificationPointToGoLive(point3);
+        });
+        ASSERT_FALSE(callback1HasRun);
+        ASSERT_FALSE(callback2HasRun);
+        ASSERT_FALSE(callback3HasRun);
+        executor.run([&] {
+            point1->notify();
+            executor.waitForAllNotifications();
+        });
+
+        ASSERT_TRUE(callback1HasRun);
+        ASSERT_TRUE(callback2HasRun);
+        ASSERT_TRUE(callback3HasRun);
+        ASSERT_TRUE(callback1HasRun && callback2HasRun && callback3HasRun);
+        callback1HasRun = callback2HasRun = callback3HasRun = false;
+        executor.run([&] {
+            point2->notify();
+            executor.waitForAllNotifications();
+        });
+        ASSERT_TRUE(callback1HasRun);
+        ASSERT_TRUE(callback2HasRun);
+        ASSERT_TRUE(callback3HasRun);
+        ASSERT_TRUE(callback1HasRun && callback2HasRun && callback3HasRun);
+        callback1HasRun = callback2HasRun = callback3HasRun = false;
+        executor.run([&] {
+            point3->notify();
+            executor.waitForAllNotifications();
+        });
+        ASSERT_TRUE(callback1HasRun);
+        ASSERT_TRUE(callback2HasRun);
+        ASSERT_TRUE(callback3HasRun);
+        ASSERT_TRUE(callback1HasRun && callback2HasRun && callback3HasRun);
+    }
+    ASSERT_TRUE(NotificationPoint::testWTFisEmpty());
+}
+
+TEST(WTF, TestNotificationPointPendingNotificationsWithCallback)
+{
+    auto executor = NotificationPointTestExecutor();
+    ASCIILiteral path = "pending"_s;
+    {
+        RefPtr<NotificationPoint> point;
+        bool callbackHasRun = false;
+        auto callback = [&]() {
+            callbackHasRun = true;
+            executor.callbackHasRun();
+        };
+
+        executor.run([&] {
+            auto result = NotificationPoint::createWithName(TEST_NOTIFICATION_POINT_OWNER, path, WTF::move(callback));
+            ASSERT_TRUE(result.has_value());
+            point = result.value();
+            executor.waitForNotificationPointToGoLive(point);
+        });
+        executor.run([&] {
+            auto posted = point->getAndClearNotificationsPosted();
+            ASSERT_TRUE(posted.has_value());
+            // Use same semantics as on Darwin, there's always a posted
+            // notification after creation.
+            ASSERT_TRUE(posted.value());
+        });
+        executor.run([&] {
+            auto posted = point->getAndClearNotificationsPosted();
+            ASSERT_TRUE(posted.has_value());
+            // But now that we've retrieved the peosted notification, this should be false.
+            ASSERT_FALSE(posted.value());
+        });
+        executor.run([&] {
+            // Post a notification.
+            ASSERT_TRUE(NotificationPoint::notify(TEST_NOTIFICATION_POINT_OWNER, path).has_value());
+        });
+        executor.run([&] {
+            // Is the notification there?
+            auto posted = point->getAndClearNotificationsPosted();
+            ASSERT_TRUE(posted.has_value());
+            ASSERT_TRUE(posted.value());
+        });
+        executor.run([&] {
+            // Is it gone now?
+            auto posted = point->getAndClearNotificationsPosted();
+            ASSERT_TRUE(posted.has_value());
+            ASSERT_FALSE(posted.value());
+        });
+    }
+    ASSERT_TRUE(NotificationPoint::testWTFisEmpty());
+}
+
+TEST(WTF, TestNotificationPointMultiple)
+{
+    {
+        Vector<RefPtr<NotificationPoint>> points;
+        auto executor = NotificationPointTestExecutor();
+        auto point = NotificationPoint::createWithName(TEST_NOTIFICATION_POINT_OWNER "-0", "J0", nullptr);
+        ASSERT_TRUE(point.has_value());
+        points.append(point.value());
+        point = NotificationPoint::createWithName(TEST_NOTIFICATION_POINT_OWNER "-0", "J1", nullptr);
+        ASSERT_TRUE(point.has_value());
+        points.append(point.value());
+        point = NotificationPoint::createWithName(TEST_NOTIFICATION_POINT_OWNER "-1", "J0", nullptr);
+        ASSERT_TRUE(point.has_value());
+        points.append(point.value());
+        point = NotificationPoint::createWithName(TEST_NOTIFICATION_POINT_OWNER "-1", "J1", nullptr);
+        ASSERT_TRUE(point.has_value());
+        points.append(point.value());
+        // Test immediate destruction of the NotificationPoints. This exercises the
+        // pendingNotificationPoints() destruction path in the glib implementation.
+    }
+    ASSERT_TRUE(NotificationPoint::testWTFisEmpty());
+}


### PR DESCRIPTION
#### e1346ce7c2cd25ddaf5967842bf1c18cef111f0d
<pre>
[WTF] Add a NotificationPoint API
<a href="https://bugs.webkit.org/show_bug.cgi?id=309350">https://bugs.webkit.org/show_bug.cgi?id=309350</a>

Reviewed by NOBODY (OOPS!).

Add WTF::NotificationPoint that essentially abstracts the Darwin
notify_* API. On USE(GLIB) platforms, implement the same semantics in
terms of D-Bus.

Since on D-Bus we need an owned name and a path to an object, have
NotificationPoint take those, but join them together to form the same
key as currently used for Darwin. The idea is that the external API
shouldn&apos;t change at all there.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a480936ef200ea57eee59228b8837d1d009e58a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/160255 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/33730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/26829 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/169157 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/114636 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/162124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/33829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/33728 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/124239 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/87794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/163213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/26483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/143941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/104838 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/25536 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/24032 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/16877 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/152311 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/135228 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/21704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/171635 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/21092 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/17639 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/23344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/132491 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/33401 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/28126 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/132517 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/33386 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/143499 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/91671 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/27135 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/20313 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/192654 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/32895 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/99308 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/49595 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/32393 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/32640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/32543 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->