### PR TITLE
[macOS] TestWebKitAPI.GetUserMedia.ClearRemoteVideoFrameObjectHeapPixelConformerUnderMemoryPressure is flaky failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
@@ -1963,12 +1963,7 @@ TEST(WebKit2, OrientationNotAffectedByCSSOrientation)
 
 #endif
 
-// FIXME when webkit.org/b/309014 is resolved.
-#if PLATFORM(MAC)
-TEST(GetUserMedia, DISABLED_ClearRemoteVideoFrameObjectHeapPixelConformerUnderMemoryPressure)
-#else
 TEST(GetUserMedia, ClearRemoteVideoFrameObjectHeapPixelConformerUnderMemoryPressure)
-#endif
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     WKPreferencesSetBoolValueForKeyForTesting((__bridge WKPreferencesRef)[configuration preferences], true, WKStringCreateWithUTF8CString("CaptureAudioInGPUProcessEnabled"));

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/camera-to-canvas.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/camera-to-canvas.html
@@ -14,11 +14,16 @@ async function startCamera()
 
 async function paintCameraInCanvas()
 {
-    try {
-        await local.play();
-    } catch (e) {
-        window.webkit.messageHandlers.gum.postMessage("FAIL with " + e);
-    }
+    local.play().then(() => { }, e => {
+        window.webkit.messageHandlers.gum.postMessage("FAIL, element failed playing with " + e);
+    });
+    await new Promise((resolve, reject) => {
+        local.requestVideoFrameCallback(resolve);
+        setTimeout(() => {
+            window.webkit.messageHandlers.gum.postMessage("FAIL, no frame found in a timely manner");
+            reject("no frame found");
+        }, 10000);
+    });
 
     canvas.getContext('2d').fillStyle = "#FFFFFF";
     canvas.getContext('2d').fillRect(0, 0, 640, 480);
@@ -26,17 +31,17 @@ async function paintCameraInCanvas()
     const pixelData = canvas.getContext('2d').getImageData(0, 0, 1, 1,).data;
 
     if (pixelData[0] != 0) {
-        window.webkit.messageHandlers.gum.postMessage("FAIL r");
+        window.webkit.messageHandlers.gum.postMessage("FAIL r, got " + JSON.stringify(pixelData));
         return;
     }
 
     if (pixelData[1] != 0) {
-        window.webkit.messageHandlers.gum.postMessage("FAIL g");
+        window.webkit.messageHandlers.gum.postMessage("FAIL g, got " + JSON.stringify(pixelData));
         return;
     }
 
     if (pixelData[2] != 0) {
-        window.webkit.messageHandlers.gum.postMessage("FAIL b");
+        window.webkit.messageHandlers.gum.postMessage("FAIL b, got " + JSON.stringify(pixelData));
         return;
     }
 


### PR DESCRIPTION
#### 726302d582e6e5d98e6e6be0a389012667b1451b
<pre>
[macOS] TestWebKitAPI.GetUserMedia.ClearRemoteVideoFrameObjectHeapPixelConformerUnderMemoryPressure is flaky failure
<a href="https://rdar.apple.com/171561848">rdar://171561848</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309014">https://bugs.webkit.org/show_bug.cgi?id=309014</a>

Reviewed by Eric Carlson.

The test may be flaky as it may draw to canvas before getting a video frame.
To prevent this, we use requestVideoFrameCallback to wait for the first frame.

Canonical link: <a href="https://commits.webkit.org/308987@main">https://commits.webkit.org/308987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/827bc23e818c543cb9eade6770d45cb32d4972df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157745 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/107bf076-b63c-4da6-98dd-1e001c1bf97a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21648 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114918 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133774 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95674 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e0aa74ee-20fe-4111-a86c-02179b5aaa29) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16199 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14067 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5595 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11699 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160227 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13221 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122967 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21572 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18093 "Found 1 new test failure: imported/w3c/web-platform-tests/web-animations/timing-model/timelines/timelines.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123194 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33499 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21580 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133492 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77770 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18454 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10251 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21182 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20914 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21062 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20970 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->