### PR TITLE
Minor adoption of queueTaskKeepingNodeAlive()

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -18,7 +18,6 @@ animation/KeyframeEffect.cpp
 contentextensions/ContentExtensionsBackend.cpp
 crypto/SubtleCrypto.cpp
 css/CSSValue.cpp
-dom/ContentVisibilityDocumentState.cpp
 dom/CustomElementDefaultARIA.cpp
 dom/RejectedPromiseTracker.cpp
 inspector/agents/page/PageDOMDebuggerAgent.cpp

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -168,14 +168,15 @@ bool ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement(El
     auto isSkippedContent = target.isRelevantToUser() ? IsSkippedContent::No : IsSkippedContent::Yes;
     target.invalidateStyle();
     updateAnimations(target, wasSkippedContent, isSkippedContent);
-    target.queueTaskKeepingThisNodeAlive(TaskSource::DOMManipulation, [&, isSkippedContent] {
-        if (target.isConnected()) {
-            ContentVisibilityAutoStateChangeEvent::Init init {
-                { false, false, false },
-                isSkippedContent == IsSkippedContent::Yes
-            };
-            target.dispatchEvent(ContentVisibilityAutoStateChangeEvent::create(eventNames().contentvisibilityautostatechangeEvent, WTF::move(init)));
-        }
+    Node::queueTaskKeepingNodeAlive(target, TaskSource::DOMManipulation, [isSkippedContent](auto& element) {
+        if (!element.isConnected())
+            return;
+
+        ContentVisibilityAutoStateChangeEvent::Init init {
+            { false, false, false },
+            isSkippedContent == IsSkippedContent::Yes
+        };
+        element.dispatchEvent(ContentVisibilityAutoStateChangeEvent::create(eventNames().contentvisibilityautostatechangeEvent, WTF::move(init)));
     });
     return true;
 }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -44,11 +44,9 @@
 #include "ElementTraversal.h"
 #include "EventDispatcher.h"
 #include "EventHandler.h"
-#include "EventLoop.h"
 #include "EventNames.h"
 #include "EventTargetInlines.h"
 #include "FrameInlines.h"
-#include "GCReachableRef.h"
 #include "HTMLAreaElement.h"
 #include "HTMLBodyElement.h"
 #include "HTMLDialogElement.h"
@@ -1480,17 +1478,10 @@ Node& Node::getRootNode(const GetRootNodeOptions& options) const
     return options.composed ? shadowIncludingRoot() : rootNode();
 }
 
-void Node::queueTaskKeepingThisNodeAlive(TaskSource source, Function<void ()>&& task)
-{
-    document().eventLoop().queueTask(source, [protectedThis = GCReachableRef(*this), task = WTF::move(task)] () {
-        task();
-    });
-}
-
 void Node::queueTaskToDispatchEvent(TaskSource source, Ref<Event>&& event)
 {
-    queueTaskKeepingThisNodeAlive(source, [protectedThis = Ref { *this }, event = WTF::move(event)]() {
-        protectedThis->dispatchEvent(event);
+    queueTaskKeepingNodeAlive(*this, source, [event = WTF::move(event)](Node& node) {
+        node.dispatchEvent(event);
     });
 }
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -321,7 +321,7 @@ public:
     inline WebCoreOpaqueRoot opaqueRoot() const;
     WebCoreOpaqueRoot NODELETE traverseToOpaqueRoot() const;
 
-    void queueTaskKeepingThisNodeAlive(TaskSource, Function<void ()>&&);
+    template<typename T, typename Task> static void queueTaskKeepingNodeAlive(T&, TaskSource, Task&&);
     void queueTaskToDispatchEvent(TaskSource, Ref<Event>&&);
 
     // Use when it's guaranteed to that shadowHost is null.

--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -23,6 +23,8 @@
 #include <WebCore/CharacterData.h>
 #include <WebCore/Document.h>
 #include <WebCore/Element.h>
+#include <WebCore/EventLoop.h>
+#include <WebCore/GCReachableRef.h>
 #include <WebCore/InspectorInstrumentationPublic.h>
 #include <WebCore/LayoutRect.h>
 #include <WebCore/Node.h>
@@ -271,6 +273,15 @@ inline void collectChildNodes(Node& node, NodeVector& children)
 {
     for (SUPPRESS_UNCOUNTED_LOCAL Node* child = node.firstChild(); child; child = child->nextSibling())
         children.append(*child);
+}
+
+template<typename T, typename Task>
+void Node::queueTaskKeepingNodeAlive(T& node, TaskSource source, Task&& task)
+{
+    protect(protect(node.document())->eventLoop())->queueTask(source, [protectedThis = GCReachableRef(node), task = std::forward<Task>(task)]() mutable {
+        // Static analyzer does not know about GCReachableRef.
+        SUPPRESS_UNCOUNTED_ARG task(protectedThis.get());
+    });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ToggleEventTask.cpp
+++ b/Source/WebCore/dom/ToggleEventTask.cpp
@@ -27,6 +27,7 @@
 #include "ToggleEventTask.h"
 
 #include "EventNames.h"
+#include "NodeInlines.h"
 #include "TaskSource.h"
 #include "ToggleEvent.h"
 
@@ -47,7 +48,7 @@ void ToggleEventTask::queue(ToggleState oldState, ToggleState newState, Element*
         return;
 
     m_data = { oldState, newState, source };
-    element->queueTaskKeepingThisNodeAlive(TaskSource::DOMManipulation, [task = Ref { *this }, element, newState] {
+    Node::queueTaskKeepingNodeAlive(*element, TaskSource::DOMManipulation, [task = Ref { *this }, newState](auto& element) {
         if (!task->m_data || task->m_data->newState != newState)
             return;
 
@@ -60,7 +61,7 @@ void ToggleEventTask::queue(ToggleState oldState, ToggleState newState, Element*
         init.oldState = stringForState(data.oldState);
         init.newState = stringForState(data.newState);
         init.source = data.source;
-        element->dispatchEvent(ToggleEvent::create(eventNames().toggleEvent, init, Event::IsCancelable::No));
+        element.dispatchEvent(ToggleEvent::create(eventNames().toggleEvent, init, Event::IsCancelable::No));
     });
 }
 

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -29,7 +29,6 @@
 #include "ContainerNodeInlines.h"
 #include "CSSSelector.h"
 #include "DocumentPage.h"
-#include "EventLoop.h"
 #include "EventNames.h"
 #include "FocusOptions.h"
 #include "HTMLButtonElement.h"
@@ -206,7 +205,7 @@ void HTMLDialogElement::requestClose(const String& returnValue, Element* source)
     if (!isOpen())
         return;
 
-    auto cancelEvent = Event::create(eventNames().cancelEvent, Event::CanBubble::No, Event::IsCancelable::Yes);
+    Ref cancelEvent = Event::create(eventNames().cancelEvent, Event::CanBubble::No, Event::IsCancelable::Yes);
     dispatchEvent(cancelEvent);
     if (!cancelEvent->defaultPrevented())
         close(returnValue, source);
@@ -247,14 +246,11 @@ bool HTMLDialogElement::handleCommandInternal(HTMLButtonElement& invoker, const 
 
 void HTMLDialogElement::queueCancelTask()
 {
-    queueTaskKeepingThisNodeAlive(TaskSource::UserInteraction, [weakThis = WeakPtr { *this }] {
-        RefPtr protectedThis = weakThis.get();
-        if (!protectedThis)
-            return;
-        auto cancelEvent = Event::create(eventNames().cancelEvent, Event::CanBubble::No, Event::IsCancelable::Yes);
-        protectedThis->dispatchEvent(cancelEvent);
+    queueTaskKeepingNodeAlive(*this, TaskSource::UserInteraction, [](auto& dialog) {
+        Ref cancelEvent = Event::create(eventNames().cancelEvent, Event::CanBubble::No, Event::IsCancelable::Yes);
+        dialog.dispatchEvent(cancelEvent);
         if (!cancelEvent->defaultPrevented())
-            protectedThis->close(nullString());
+            dialog.close(nullString());
     });
 }
 

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -31,7 +31,6 @@
 #include "CommonVM.h"
 #include "ContainerNodeInlines.h"
 #include "ContentSecurityPolicy.h"
-#include "DocumentEventLoop.h"
 #include "DocumentLoader.h"
 #include "DocumentPage.h"
 #include "DocumentSecurityOrigin.h"
@@ -39,12 +38,10 @@
 #include "ElementInlines.h"
 #include "Event.h"
 #include "EventHandler.h"
-#include "EventLoop.h"
 #include "EventNames.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "FrameTree.h"
-#include "GCReachableRef.h"
 #include "HTMLImageLoader.h"
 #include "HTMLNames.h"
 #include "HitTestResult.h"
@@ -463,13 +460,13 @@ bool HTMLPlugInElement::requestObject(const String& relativeURL, const String& m
     if (ScriptDisallowedScope::InMainThread::isScriptAllowed())
         return document->frame()->loader().subframeLoader().requestObject(*this, relativeURL, getNameAttribute(), mimeType, paramNames, paramValues);
 
-    protect(document->eventLoop())->queueTask(TaskSource::Networking, [this, protectedThis = Ref { *this }, relativeURL, nameAttribute = getNameAttribute(), mimeType, paramNames, paramValues, document]() mutable {
-        if (!this->isConnected() || &this->document() != document.ptr())
+    queueTaskKeepingNodeAlive(*this, TaskSource::Networking, [relativeURL, nameAttribute = getNameAttribute(), mimeType, paramNames, paramValues, document](auto& element) mutable {
+        if (!element.isConnected() || &element.document() != document.ptr())
             return;
-        RefPtr frame = this->document().frame();
+        RefPtr frame = element.document().frame();
         if (!frame)
             return;
-        frame->loader().subframeLoader().requestObject(*this, relativeURL, nameAttribute, mimeType, paramNames, paramValues);
+        frame->loader().subframeLoader().requestObject(element, relativeURL, nameAttribute, mimeType, paramNames, paramValues);
     });
     return true;
 }
@@ -514,8 +511,8 @@ void HTMLPlugInElement::scheduleUpdateForAfterStyleResolution()
 
     m_hasUpdateScheduledForAfterStyleResolution = true;
 
-    protect(document->eventLoop())->queueTask(TaskSource::DOMManipulation, [element = GCReachableRef { *this }] {
-        element->updateAfterStyleResolution();
+    queueTaskKeepingNodeAlive(*this, TaskSource::DOMManipulation, [](auto& element) {
+        element.updateAfterStyleResolution();
     });
 }
 

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -38,10 +38,8 @@
 #include "ElementInlines.h"
 #include "ElementTextDirection.h"
 #include "Event.h"
-#include "EventLoop.h"
 #include "EventNames.h"
 #include "FrameSelection.h"
-#include "GCReachableRef.h"
 #include "HTMLBRElement.h"
 #include "HTMLFormElement.h"
 #include "HTMLInputElement.h"
@@ -594,9 +592,9 @@ void HTMLTextFormControlElement::scheduleSelectionChangeEvent()
         return;
 
     m_hasScheduledSelectionChangeEvent = true;
-    document().eventLoop().queueTask(TaskSource::UserInteraction, [textControl = GCReachableRef { *this }] {
-        textControl->m_hasScheduledSelectionChangeEvent = false;
-        textControl->dispatchEvent(Event::create(eventNames().selectionchangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
+    queueTaskKeepingNodeAlive(*this, TaskSource::UserInteraction, [](auto& textControl) {
+        textControl.m_hasScheduledSelectionChangeEvent = false;
+        textControl.dispatchEvent(Event::create(eventNames().selectionchangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
     });
 }
 


### PR DESCRIPTION
#### 2b9471c6465fab8aba60db07fd201eea91ee5614
<pre>
Minor adoption of queueTaskKeepingNodeAlive()
<a href="https://bugs.webkit.org/show_bug.cgi?id=309352">https://bugs.webkit.org/show_bug.cgi?id=309352</a>

Reviewed by Ryosuke Niwa.

We also rename queueTaskKeepingThisNodeAlive() to
queueTaskKeepingNodeAlive() as you now need to pass this as an argument
to make the method work with Safer CPP. No functional changes and
therefore no tests.

Canonical link: <a href="https://commits.webkit.org/308882@main">https://commits.webkit.org/308882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dbc0c9334266c8b563f4010d81b81670f2c63cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157411 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102156 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b09ec863-b950-4cbd-9c49-8f03e09562f3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114653 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81643 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f4756b54-5109-4a4f-a020-5708b78f7100) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133507 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95423 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d127f6e4-fbbd-41db-9557-bf9f0fa343da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15964 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13811 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4846 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159746 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2886 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12949 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122718 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21241 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17819 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122942 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133221 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77403 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22915 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18242 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9983 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20851 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84653 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20583 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20730 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20639 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->