### PR TITLE
[AutoFill Debugging] Adjust the format of node selector paths to use JSON internally

### DIFF
--- a/Source/WebCore/page/ElementTargetingTypes.cpp
+++ b/Source/WebCore/page/ElementTargetingTypes.cpp
@@ -27,34 +27,63 @@
 #include "ElementTargetingTypes.h"
 
 #include "SharedBuffer.h"
-#include <wtf/persistence/PersistentCoders.h>
+#include <wtf/JSONValues.h>
 
 namespace WebCore {
 
 Ref<SharedBuffer> serializeTargetedElementSelectors(const TargetedElementSelectors& selectors)
 {
-    static constexpr unsigned currentVersion = 1;
+    Ref rootObject = JSON::Object::create();
+    rootObject->setInteger("version"_s, 1);
 
-    WTF::Persistence::Encoder encoder;
+    Ref selectorsArray = JSON::Array::create();
+    for (auto selectorSet : selectors) {
+        Ref selectorSetArray = JSON::Array::create();
+        for (auto selector : selectorSet)
+            selectorSetArray->pushString(selector);
+        selectorsArray->pushArray(WTF::move(selectorSetArray));
+    }
+    rootObject->setArray("selectors"_s, WTF::move(selectorsArray));
 
-    encoder << currentVersion;
-    encoder << selectors;
-    return SharedBuffer::create(encoder.span());
+    auto jsonString = rootObject->toJSONString();
+    return SharedBuffer::create(jsonString.utf8().span());
 }
 
 std::optional<TargetedElementSelectors> deserializeTargetedElementSelectors(std::span<const uint8_t> data)
 {
-    static constexpr unsigned maxAllowedVersion = 1;
-
-    WTF::Persistence::Decoder decoder { data };
-
-    std::optional<unsigned> version;
-    decoder >> version;
-    if (!version || *version > maxAllowedVersion)
+    auto jsonString = String::fromUTF8(data);
+    RefPtr parsedValue = JSON::Value::parseJSON(jsonString);
+    if (!parsedValue)
         return { };
 
-    std::optional<TargetedElementSelectors> result;
-    decoder >> result;
+    RefPtr rootObject = parsedValue->asObject();
+    if (!rootObject)
+        return { };
+
+    auto version = rootObject->getInteger("version"_s);
+    if (!version || *version > 1)
+        return { };
+
+    RefPtr selectorsArray = rootObject->getArray("selectors"_s);
+    if (!selectorsArray)
+        return { };
+
+    TargetedElementSelectors result;
+    for (size_t i = 0; i < selectorsArray->length(); ++i) {
+        RefPtr selectorSetArray = selectorsArray->get(i)->asArray();
+        if (!selectorSetArray)
+            return { };
+
+        HashSet<String> selectorSet;
+        for (size_t j = 0; j < selectorSetArray->length(); ++j) {
+            auto selectorString = selectorSetArray->get(j)->asString();
+            if (selectorString.isNull())
+                return { };
+            selectorSet.add(selectorString);
+        }
+        result.append(WTF::move(selectorSet));
+    }
+
     return result;
 }
 


### PR DESCRIPTION
#### a1e43a5ceda2524bfc9bbae8b13114348527b0ce
<pre>
[AutoFill Debugging] Adjust the format of node selector paths to use JSON internally
<a href="https://bugs.webkit.org/show_bug.cgi?id=309354">https://bugs.webkit.org/show_bug.cgi?id=309354</a>
<a href="https://rdar.apple.com/171907724">rdar://171907724</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Change the internal format of node selector path data to use minified JSON, rather than WTF
persistence encoders / decoders, to make them easier to interpret and debug in telemetry reports.

No new tests, since there should be no change in behavior for clients.

* Source/WebCore/page/ElementTargetingTypes.cpp:
(WebCore::serializeTargetedElementSelectors):
(WebCore::deserializeTargetedElementSelectors):

Canonical link: <a href="https://commits.webkit.org/308843@main">https://commits.webkit.org/308843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41a0762a69341ceedae0c17d17d2c99895cc556d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157269 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114537 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5be52d65-d575-4a11-9591-eddcd6d11216) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151545 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/16750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133373 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95307 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a084a19-5553-44bf-9794-a10533ab6fc2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13692 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4705 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159604 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2738 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12808 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122591 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122816 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33408 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133081 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77237 "Built successfully") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9848 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20709 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84512 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20442 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20588 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20498 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->