### PR TITLE
[visionOS] Make WKSeparatedImageView compliant with Swift Strict Safety

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Analysis.swift
+++ b/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Analysis.swift
@@ -63,7 +63,7 @@ extension WKSeparatedImageView {
             return .unknown
         }
 
-        guard let imageData = await self.imageData else {
+        guard let imageData = await self.ensureImageData() else {
             try Task.checkCancellation()
             Logger.separatedImage.error("\(logPrefix) - ImageAnalysis result: bad imageData.")
             return .failed

--- a/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Generation.swift
+++ b/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Generation.swift
@@ -60,7 +60,7 @@ extension WKSeparatedImageView {
 
         try Task.checkCancellation()
 
-        guard let imageData = await self.imageData, let imgSource = CGImageSourceCreateWithData(imageData as CFData, nil),
+        guard let imageData = await self.ensureImageData(), let imgSource = CGImageSourceCreateWithData(imageData as CFData, nil),
             let spatial3DImage = try? await ImagePresentationComponent.Spatial3DImage(imageSource: imgSource)
         else { return }
 
@@ -75,7 +75,7 @@ extension WKSeparatedImageView {
             self.preparePortalEntity()
 
             let start = Date()
-            try await captured.generate()
+            try await unsafe captured.generate()
             Logger.separatedImage.log("\(self.logPrefix) - Generation took \(Date().timeIntervalSince(start))")
             ImagePresentationCache.shared[imageHash] =
                 ImagePresentationCache.StoredData(spatial3DImage: spatial3DImage, desiredViewingModeSpatial: self.desiredViewingModeSpatial)

--- a/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Surface.swift
+++ b/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Surface.swift
@@ -23,7 +23,7 @@
 
 #if HAVE_CORE_ANIMATION_SEPARATED_LAYERS && compiler(>=6.2)
 
-internal import CommonCrypto
+internal import CryptoKit
 internal import CoreGraphics
 internal import CoreImage
 import os
@@ -47,97 +47,60 @@ extension WKSeparatedImageView {
         computeHashTask = Task { [weak self] in
             try await Task.sleep(for: SeparatedImageViewConstants.cancellationDelay)
 
-            guard let self, let (data, hash) = await self.computeHash() else { return }
+            guard let self, let cgImage, let newImageHash = await computeHash(cgImage) else { return }
+            guard self.cgImage != nil, imageHash != newImageHash else { return }
 
-            Task { @MainActor [weak self] in
-                try Task.checkCancellation()
+            imageData = nil
+            imageHash = newImageHash
 
-                guard let self, self.cgImage != nil, self.imageHash != hash else { return }
-
-                self.imageData = data
-                self.imageHash = hash
-
-                if let (oldImageHash, cachedMode) = self.cachedViewModeInfo, oldImageHash == hash {
-                    self.viewMode = cachedMode
-                } else {
-                    self.viewMode = .unknown
-                }
-
-                if self.viewMode == .unknown {
-                    Logger.separatedImage.log("\(self.logPrefix) - New image, generated hash.")
-                    Task {
-                        await self.pickViewMode()
-                    }
-                } else {
-                    Logger.separatedImage.log("\(self.logPrefix) - Known image (\(self.viewMode.description)).")
-                }
-
-                self.scheduleUpdate()
+            if let (oldImageHash, cachedMode) = cachedViewModeInfo, oldImageHash == newImageHash {
+                viewMode = cachedMode
+            } else {
+                viewMode = .unknown
             }
+
+            if viewMode == .unknown {
+                Logger.separatedImage.log("\(self.logPrefix) - New image, generated hash.")
+                Task {
+                    await self.pickViewMode()
+                }
+            } else {
+                Logger.separatedImage.log("\(self.logPrefix) - Known image (\(self.viewMode.description)).")
+            }
+
+            self.scheduleUpdate()
         }
+    }
+
+    func ensureImageData() async -> Data? {
+        guard let cgImage else { return nil }
+        if let imageData { return imageData }
+        imageData = await encode(cgImage)
+        return imageData
     }
 
     @concurrent
-    func computeHash() async -> (Data, NSString)? {
-        guard let cgImage = await self.cgImage else { return nil }
-        return cgImageAsDataWithHash(cgImage)
-    }
-}
-
-// TODO: rdar://164555610 - https://github.com/WebKit/WebKit/wiki/Safer-Swift-Guidelines
-class StreamHasher {
-    var hashContext = CC_SHA256_CTX()
-    var outputStream: OutputStream
-
-    init(outputStream: OutputStream) {
-        self.outputStream = outputStream
-        CC_SHA256_Init(&hashContext)
-    }
-}
-
-func cgImageAsDataWithHash(_ cgImage: CGImage) -> (Data, NSString)? {
-    let outputStream = OutputStream(toMemory: ())
-    outputStream.open()
-    defer {
-        outputStream.close()
+    func computeHash(_ cgImage: CGImage) async -> NSString? {
+        guard let provider = cgImage.dataProvider, let cfData = provider.data else { return nil }
+        let digest = SHA256.hash(data: cfData as Data)
+        return NSString(string: digest.description)
     }
 
-    let streamHasher = StreamHasher(outputStream: outputStream)
-    let streamHasherRef = Unmanaged.passRetained(streamHasher).toOpaque()
-
-    var callbacks = CGDataConsumerCallbacks(
-        putBytes: { (info, buffer, count) -> Int in
-            guard let info = info else { return 0 }
-
-            let streamHasher = Unmanaged<StreamHasher>.fromOpaque(info).takeUnretainedValue()
-            let dataBuffer = buffer.assumingMemoryBound(to: UInt8.self)
-
-            CC_SHA256_Update(&streamHasher.hashContext, dataBuffer, CC_LONG(count))
-            return streamHasher.outputStream.write(dataBuffer, maxLength: count)
-        },
-        releaseConsumer: { info in
-            if let info = info {
-                Unmanaged<StreamHasher>.fromOpaque(info).release()
-            }
-        }
-    )
-
-    guard let consumer = CGDataConsumer(info: streamHasherRef, cbks: &callbacks),
-        let destination = CGImageDestinationCreateWithDataConsumer(consumer, UTType.bmp.identifier as CFString, 1, nil)
-    else {
-        return nil
+    @concurrent
+    func encode(_ cgImage: CGImage) async -> Data? {
+        let data = NSMutableData()
+        guard
+            let destination = CGImageDestinationCreateWithData(
+                data as CFMutableData,
+                UTType.bmp.identifier as CFString,
+                1,
+                nil
+            )
+        else { return nil }
+        CGImageDestinationAddImage(destination, cgImage, nil)
+        guard CGImageDestinationFinalize(destination) else { return nil }
+        return data as Data
     }
-
-    CGImageDestinationAddImage(destination, cgImage, nil)
-
-    if CGImageDestinationFinalize(destination), let finalData = outputStream.property(forKey: .dataWrittenToMemoryStreamKey) as? Data {
-        var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
-        CC_SHA256_Final(&hash, &streamHasher.hashContext)
-        let hashString = hash.map { String(format: "%02x", $0) }.joined()
-        return (finalData, NSString(string: hashString))
-    }
-
-    return nil
 }
 
 // Protects access to the shared CIContext, needs to run outside of the MainActor.

--- a/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView.swift
+++ b/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView.swift
@@ -133,9 +133,7 @@ extension WKSeparatedImageView {
             return
         }
         Task {
-            // The compiler can't guarantee (yet) this closure won't be called multiple times.
-            nonisolated(unsafe) let captured = surface
-            await processSurface(captured)
+            await processSurface(surface)
         }
     }
 
@@ -174,10 +172,9 @@ extension WKSeparatedImageView: WKObservingLayerDelegate {
     }
 }
 
-@objc
-protocol WKObservingLayerDelegate {
-    nonisolated func layerSeparatedDidChange()
-    nonisolated func layerWasCleared()
+protocol WKObservingLayerDelegate: AnyObject {
+    func layerSeparatedDidChange()
+    func layerWasCleared()
 }
 
 class WKObservingLayer: CALayer {


### PR DESCRIPTION
#### 59afaf76b51affaad6d3e5d28c243b9ea00da36b
<pre>
[visionOS] Make WKSeparatedImageView compliant with Swift Strict Safety
<a href="https://bugs.webkit.org/show_bug.cgi?id=309357">https://bugs.webkit.org/show_bug.cgi?id=309357</a>
&lt;<a href="https://rdar.apple.com/164555610">rdar://164555610</a>&gt;

Reviewed by Richard Robinson and Mike Wyrzykowski.

Move away from the single-pass hashing + encoding of the CGImage, which
used a lot of unsafe calls. Use a simpler 2 step process instead.

We make up for the potential performance impact by lazily generating the
encoded image data. Which means that on cache hits we never need to go
through the encoder (the most expensive part).

* Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Analysis.swift:
(WKSeparatedImageView.analyze):
Use the new lazy `ensureImageData()`.
* Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Generation.swift:
(WKSeparatedImageView.generate):
Use the new lazy `ensureImageData()`.
Add the unsafe keyword to the `generate()` call (known issue).

* Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Surface.swift:
(WKSeparatedImageView.didReceiveImage):
(WKSeparatedImageView.ensureImageData):
(WKSeparatedImageView.computeHash(_:)):
(WKSeparatedImageView.encode(_:)):
(WKSeparatedImageView.computeHash() async -&gt; (Data:NSString:)): Deleted.
(StreamHasher.outputStream): Deleted.
(cgImageAsDataWithHash(_:NSString:)): Deleted.
Use the new 2-step hash, then encode for the CGImage.
This lets run return early without paying the encoding cost on cache
hits.
Both `computeHash` and `encode` are tagged as `@concurrent`.

* Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView.swift:
(WKSeparatedImageView.setSurface(_:)):
(WKObservingLayerDelegate.layerSeparatedDidChange):
(WKObservingLayerDelegate.layerWasCleared):
Remove an unsafe capture that&apos;s no longer needed.
Drive-by: remove the `@objc` on the Swift-only `WKObservingLayerDelegate`,
and the nonisolated that are not longer needed.

Canonical link: <a href="https://commits.webkit.org/308864@main">https://commits.webkit.org/308864@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a26b282c0ac98a9837143b1b99803f94130ef88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157364 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102109 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dac8e34e-19d1-403b-8221-b0477386899c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21270 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114611 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9fb686e7-362d-491c-82e5-34dd7c22d7f0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151639 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133462 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95381 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22ca8a1b-a143-4498-b708-0081ad647821) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15922 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13766 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4799 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125521 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159699 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2839 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12904 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122675 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122899 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33419 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21202 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133176 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77332 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18194 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9938 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20804 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84606 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20536 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20683 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20592 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->