### PR TITLE
[ews] Improve handling of failures in determine-label-owner step in merge queue

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -2307,16 +2307,28 @@ class DetermineLabelOwner(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
         query_body = '{repository(owner:"%s", name:"%s") { pullRequest(number: %s) {timelineItems(itemTypes: LABELED_EVENT, last: 5) {nodes {... on LabeledEvent {actor { login } label { name } createdAt } } } } } }' % (owner, name, pr_number)
         query = {'query': query_body}
 
-        response = yield self.query_graph_ql(query)
-        if 'errors' in response:
-            yield self._addToLog('stdio', response['errors'][0]['message'])
-            return defer.returnValue(FAILURE)
-        if response:
-            yield self._addToLog('stdio', 'Retrieved labels.\n')
-            label_events = response['data']['repository']['pullRequest']['timelineItems']['nodes']
-        else:
-            yield self._addToLog('stdio', 'Failed to retrieve label author.\n')
-            return defer.returnValue(FAILURE)
+        retry = 3
+        for attempt in range(retry + 1):
+            try:
+                response = yield self.query_graph_ql(query)
+                if not response:
+                    yield self._addToLog('stdio', 'Failed to retrieve label author.\n')
+                elif 'errors' in response:
+                    yield self._addToLog('stdio', response['errors'][0]['message'])
+                else:
+                    yield self._addToLog('stdio', 'Retrieved labels.\n')
+                    label_events = response['data']['repository']['pullRequest']['timelineItems']['nodes']
+                    break
+            except Exception as e:
+                yield self._addToLog('stdio', f'Failed to retrieve label author: {e}\n')
+
+            if attempt >= retry:
+                yield self._addToLog('stdio', 'Failed to determine label owner.\n')
+                self.build.addStepsAfterCurrentStep([RemoveLabelsFromPullRequest(alwaysRun=True)])
+                return defer.returnValue(FAILURE)
+            wait_for = (attempt + 1) * 15
+            yield self._addToLog('stdio', f'\nBacking off for {wait_for} seconds before retrying.\n')
+            yield task.deferLater(reactor, wait_for, lambda: None)
 
         owner = None
         label = builder_name.lower()
@@ -2343,7 +2355,7 @@ class DetermineLabelOwner(buildstep.BuildStep, GitHubMixin, AddToLogMixin):
         if self.results == SUCCESS:
             return {'step': f"Owner of PR {self.getProperty('github.number')} determined to be {self.getProperty('owners')[0]}\n"}
         elif self.results == FAILURE:
-            return {'step': f"Unable to determine owner of PR {self.getProperty('github.number')}\n"}
+            return {'step': f"Unable to determine owner of PR {self.getProperty('github.number')}\n", 'build': 'Unexpected issue with GitHub API, please try again by re-adding the merge-queue label on the PR\n'}
 
 
 class SetCommitQueueMinusFlagOnPatch(buildstep.BuildStep, BugzillaMixin):

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -7404,6 +7404,49 @@ class TestDetermineLabelOwner(BuildStepMixinAdditions, unittest.TestCase):
         self.expect_outcome(result=FAILURE, state_string="Unable to determine owner of PR 17518\n")
         self.run_step()
 
+    @classmethod
+    def mock_sleep(cls):
+        return patch('twisted.internet.task.deferLater', lambda *_, **__: None)
+
+    @defer.inlineCallbacks
+    def test_github_api_returns_none(self):
+        with self.mock_sleep():
+            self.setup_step(DetermineLabelOwner())
+            self.setProperty('github.number', 17518)
+            self.setProperty('buildername', 'Merge-Queue')
+            GitHubMixin.query_graph_ql = lambda self, query: None
+            next_steps = []
+            self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
+            self.expect_outcome(result=FAILURE, state_string='Unable to determine owner of PR 17518\n')
+            yield self.run_step()
+            self.assertTrue(any(isinstance(step, RemoveLabelsFromPullRequest) for step in next_steps))
+
+    @defer.inlineCallbacks
+    def test_github_api_returns_false(self):
+        with self.mock_sleep():
+            self.setup_step(DetermineLabelOwner())
+            self.setProperty('github.number', 17518)
+            self.setProperty('buildername', 'Merge-Queue')
+            GitHubMixin.query_graph_ql = lambda self, query: False
+            next_steps = []
+            self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
+            self.expect_outcome(result=FAILURE, state_string='Unable to determine owner of PR 17518\n')
+            yield self.run_step()
+            self.assertTrue(any(isinstance(step, RemoveLabelsFromPullRequest) for step in next_steps))
+
+    @defer.inlineCallbacks
+    def test_graphql_errors_response(self):
+        with self.mock_sleep():
+            self.setup_step(DetermineLabelOwner())
+            self.setProperty('github.number', 17518)
+            self.setProperty('buildername', 'Merge-Queue')
+            GitHubMixin.query_graph_ql = lambda self, query: {'errors': [{'message': 'API rate limit exceeded'}]}
+            next_steps = []
+            self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
+            self.expect_outcome(result=FAILURE, state_string='Unable to determine owner of PR 17518\n')
+            yield self.run_step()
+            self.assertTrue(any(isinstance(step, RemoveLabelsFromPullRequest) for step in next_steps))
+
 
 class TestDetermineLandedIdentifier(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
#### ed005ac27d3f0b4cd158db0249eb807d1072ee0a
<pre>
[ews] Improve handling of failures in determine-label-owner step in merge queue
<a href="https://bugs.webkit.org/show_bug.cgi?id=309277">https://bugs.webkit.org/show_bug.cgi?id=309277</a>
<a href="https://rdar.apple.com/171915505">rdar://171915505</a>

Reviewed by Brianna Fan and Jonathan Bedard.

- Handle unexpected GitHub API responses gracefully.
- Add retry logic (with linear backoff, 3 retries).
- Fail the build with appropriate error message and
  remove merge-queue labels on persistent failures.

* Tools/CISupport/ews-build/steps.py:
(DetermineLabelOwner.run):
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/309003@main">https://commits.webkit.org/309003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69901c933020a1dfed59d46dac30c1771672eb6a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148589 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/21278 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/14871 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/157273 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102019 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150462 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/21754 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/21180 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/157273 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102019 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151549 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/21754 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/14871 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/157273 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/21754 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/14871 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/4709 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/21754 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/14871 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/159608 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/14871 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/159608 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/147987 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21102 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/21180 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/159608 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21112 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/14871 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77241 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22966 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/14871 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/20713 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20446 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20592 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20502 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->