### PR TITLE
[Site Isolation] Update existing ews bots to run newly added tests with site isolation enabled

### DIFF
--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -192,6 +192,7 @@ class StressTestFactory(TestFactory):
         self.getProduct()
         self.addStep(WaitForCrashCollection())
         self.addStep(RunWebKitTestsInStressMode())
+        self.addStep(RunWebKitTestsInSiteIsolationMode())
         self.addStep(TriggerCrashLogSubmission())
         self.addStep(SetBuildSummary())
 

--- a/Tools/CISupport/ews-build/factories_unittest.py
+++ b/Tools/CISupport/ews-build/factories_unittest.py
@@ -389,6 +389,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'extract-built-product',
             'wait-for-crash-collection',
             'run-layout-tests-in-stress-mode',
+            'run-layout-tests-in-site-isolation',
             'trigger-crash-log-submission',
             'set-build-summary'
         ],

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -4483,6 +4483,7 @@ class RunWebKitTestsInStressMode(RunWebKitTests):
             self.descriptionDone = message
             self.build.results = SUCCESS
             self.setProperty('build_summary', message)
+            self.setProperty('stress_mode_passed', True)
         else:
             self.setProperty('build_summary', self.FAILURE_MSG_IN_STRESS_MODE)
             steps_to_add += [
@@ -4501,6 +4502,29 @@ class RunWebKitTestsInStressGuardmallocMode(RunWebKitTestsInStressMode):
     name = 'run-layout-tests-in-guard-malloc-stress-mode'
     suffix = 'guard-malloc'
     ENABLE_GUARD_MALLOC = True
+
+
+class RunWebKitTestsInSiteIsolationMode(RunWebKitTestsInStressMode):
+    name = 'run-layout-tests-in-site-isolation'
+    suffix = 'site-isolation'
+    FAILURE_MSG_IN_STRESS_MODE = 'Found test failures in site isolation mode'
+
+    def __init__(self, layout_test_class=RunWebKitTests):
+        self.layout_test_class = layout_test_class
+        RunWebKitTests.__init__(self)
+
+    def setLayoutTestCommand(self):
+        if self.layout_test_class == RunWebKit1Tests:
+            self.setProperty('use-dump-render-tree', True)
+        RunWebKitTests.setLayoutTestCommand(self)
+
+        self.command += ['--site-isolation']
+        modified_tests = self.getProperty('modified_tests')
+        if modified_tests:
+            self.command += modified_tests
+
+    def doStepIf(self, step):
+        return self.getProperty('modified_tests', False) and self.getProperty('stress_mode_passed', False)
 
 
 class ReRunWebKitTests(RunWebKitTests):

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -2496,6 +2496,90 @@ class TestRunWebKitTestsInStressGuardmallocMode(BuildStepMixinAdditions, unittes
         return rc
 
 
+class TestRunWebKitTestsInSiteIsolationMode(BuildStepMixinAdditions, unittest.TestCase):
+    def setUp(self):
+        self.longMessage = True
+        self.jsonFileName = 'layout-test-results/full_results.json'
+        return self.setup_test_build_step()
+
+    def tearDown(self):
+        return self.tear_down_test_build_step()
+
+    def configureStep(self):
+        self.setup_step(RunWebKitTestsInSiteIsolationMode())
+        self.property_exceed_failure_limit = 'first_results_exceed_failure_limit'
+        self.property_failures = 'first_run_failures'
+
+    def test_success(self):
+        self.configureStep()
+        self.setProperty('fullPlatform', 'ios-simulator')
+        self.setProperty('configuration', 'release')
+        self.setProperty('modified_tests', ['test1', 'test2'])
+        self.setProperty('stress_mode_passed', True)
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 10 --skipped always --site-isolation test1 test2 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        )
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
+        rc = self.run_step()
+        self.expect_property('build_summary', 'Passed layout tests')
+        return rc
+
+    def test_success_wk1(self):
+        self.setup_step(RunWebKitTestsInSiteIsolationMode(layout_test_class=RunWebKit1Tests))
+        self.property_exceed_failure_limit = 'first_results_exceed_failure_limit'
+        self.property_failures = 'first_run_failures'
+        self.setProperty('fullPlatform', 'ios-simulator')
+        self.setProperty('configuration', 'release')
+        self.setProperty('modified_tests', ['test1', 'test2'])
+        self.setProperty('stress_mode_passed', True)
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --dump-render-tree --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 10 --skipped always --site-isolation test1 test2 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        )
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Passed layout tests')
+        return self.run_step()
+
+    def test_failure(self):
+        self.configureStep()
+        self.setProperty('fullPlatform', 'ios-simulator')
+        self.setProperty('configuration', 'release')
+        self.setProperty('modified_tests', ['test'])
+        self.setProperty('stress_mode_passed', True)
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        logfiles={'json': self.jsonFileName},
+                        log_environ=False,
+                        timeout=19800,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 10 --skipped always --site-isolation test 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        )
+            .log('stdio', stdout='9 failures found.')
+            .exit(2),
+        )
+        self.expect_outcome(result=FAILURE, state_string='layout-tests (failure)')
+        rc = self.run_step()
+        self.expect_property('build_summary', 'Found test failures in site isolation mode')
+        return rc
+
+    def test_skipped_if_stress_mode_not_passed(self):
+        self.configureStep()
+        self.setProperty('fullPlatform', 'ios-simulator')
+        self.setProperty('configuration', 'release')
+        self.setProperty('modified_tests', ['test1', 'test2'])
+        self.expect_outcome(result=SKIPPED)
+        return self.run_step()
+
+
 class TestRunWebKitTestsWithoutChange(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):
         self.longMessage = True


### PR DESCRIPTION
#### 37389e8950594833a01270c2a42e2f8bceb1e1e0
<pre>
[Site Isolation] Update existing ews bots to run newly added tests with site isolation enabled
<a href="https://rdar.apple.com/160387897">rdar://160387897</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308777">https://bugs.webkit.org/show_bug.cgi?id=308777</a>

Reviewed by Jonathan Bedard.

Re-land change with follow-up fix for how to appropriatly lable a test run with pass or fail.
This change is to add a step to the macOS-Release-WK2-Stress-Tests-EWS queue that will run a
second test run after run-layout-tests-in-stress-mode by running the same tests, but with
--site-isolation.

* Tools/CISupport/ews-build/factories.py:
(StressTestFactory.__init__):
* Tools/CISupport/ews-build/steps.py:
(RunWebKitTestsInStressMode.evaluateCommand):
(RunWebKitTestsInSiteIsolationMode):
(RunWebKitTestsInSiteIsolationMode.__init__):
(RunWebKitTestsInSiteIsolationMode.setLayoutTestCommand):
(RunWebKitTestsInSiteIsolationMode.doStepIf):
* Tools/CISupport/ews-build/steps_unittest.py:
(TestRunWebKitTestsInSiteIsolationMode):
(TestRunWebKitTestsInSiteIsolationMode.setUp):
(TestRunWebKitTestsInSiteIsolationMode.tearDown):
(TestRunWebKitTestsInSiteIsolationMode.configureStep):
(TestRunWebKitTestsInSiteIsolationMode.test_success):
(TestRunWebKitTestsInSiteIsolationMode.test_success_wk1):
(TestRunWebKitTestsInSiteIsolationMode.test_failure):
(TestRunWebKitTestsInSiteIsolationMode.test_skipped_if_stress_mode_not_passed):

Canonical link: <a href="https://commits.webkit.org/308999@main">https://commits.webkit.org/308999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/addd3ff374b86076b4b3facec49e9c66f43c84ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21275 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157270 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102016 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6c7255b-2aae-4423-b18a-f2116ba67c93) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150459 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114538 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81561 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95308 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afb95757-108c-49dd-b821-57f21074d04f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15859 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13694 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4706 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125473 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159605 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12810 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122593 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/147984 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21098 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122818 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33502 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21109 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133083 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77238 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18149 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9850 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20710 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20443 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20932 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20499 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->