### PR TITLE
MediaCapabilities will always return unsupported if spatialRendering is set to true

### DIFF
--- a/LayoutTests/media/mediacapabilities/mediacapabilities-decodingInfo-spatialRendering-expected.txt
+++ b/LayoutTests/media/mediacapabilities/mediacapabilities-decodingInfo-spatialRendering-expected.txt
@@ -1,0 +1,8 @@
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', audio: { contentType: 'audio/mp4;codecs=ec-3', channels: 6, spatialRendering: true } });)
+Promise resolved OK
+EXPECTED (info.supported == 'true') OK
+RUN(promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', audio: { contentType: 'audio/mp4;codecs=ec-3', channels: 2, spatialRendering: true } });)
+Promise resolved OK
+EXPECTED (info.supported == 'false') OK
+END OF TEST
+

--- a/LayoutTests/media/mediacapabilities/mediacapabilities-decodingInfo-spatialRendering.html
+++ b/LayoutTests/media/mediacapabilities/mediacapabilities-decodingInfo-spatialRendering.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src=../video-test.js></script>
+    <script type="text/javascript">
+    var promise;
+    var info;
+
+    async function doTest()
+    {
+        run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', audio: { contentType: 'audio/mp4;codecs=ec-3', channels: 6, spatialRendering: true } });");
+        info = await shouldResolve(promise);
+        testExpected('info.supported', true);
+
+        run("promise = navigator.mediaCapabilities.decodingInfo({ type: 'media-source', audio: { contentType: 'audio/mp4;codecs=ec-3', channels: 2, spatialRendering: true } });");
+        info = await shouldResolve(promise);
+        testExpected('info.supported', false);
+
+        endTest();
+    }
+    </script>
+</head>
+<body onload="doTest()" />
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3557,6 +3557,8 @@ webkit.org/b/174242 media/video-suppress-hdr-fullscreen.html [ Skip ]
 # Requires unsupported captive portal codec and container restrictions
 webkit.org/b/242145 media/mediacapabilities/mediacapabilities-allowed-codecs.html [ Skip ]
 webkit.org/b/242145 media/mediacapabilities/mediacapabilities-allowed-containers.html [ Skip ]
+# Reports supported for <= 2 channels
+webkit.org/b/309552 media/mediacapabilities/mediacapabilities-decodingInfo-spatialRendering.html [ Failure ]
 
 # These tests require platform support.
 media/media-allowed-codecs.html [ Skip ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4104,6 +4104,9 @@ webkit.org/b/251219 fast/images/animated-avif.html [ ImageOnlyFailure ]
 media/mediacapabilities/mediacapabilities-allowed-codecs.html [ Failure ]
 media/mediacapabilities/mediacapabilities-allowed-containers.html [ Failure ]
 
+# Simulator doesn't support Spatial Audio Playback
+media/mediacapabilities/mediacapabilities-decodingInfo-spatialRendering.html [ Failure ]
+
 # Screen Orientation API doesn't support nested frames yet
 # TODO: figure out if this still applies.
 # imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -73,6 +73,9 @@ media/media-source/remoteplayback-from-source-element.html [ Pass ]
 # Prior Tahoe, attempting to paint stereo MV-HEVC either errors or crashes.
 [ Sonoma Sequoia ] media/media-source/media-source-paint-stereo-to-canvas.html [ Skip ]
 
+# EWS doesn't have Spatial Audio Playback supported output. Will work on macbooks.
+media/mediacapabilities/mediacapabilities-decodingInfo-spatialRendering.html [ Failure ]
+
 # macOS 14 and above support word-break: auto-phrase.
 # Individually failing tests should be marked in separate expectations.
 [ Sonoma+ ] imported/w3c/web-platform-tests/css/css-text/word-break/auto-phrase [ Pass ]

--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -287,12 +287,14 @@ platform/audio/ios/MediaDeviceRoute.mm @nonARC @no-unify
 platform/audio/ios/MediaDeviceRouteController.mm @nonARC
 platform/audio/ios/MediaSessionHelperIOS.mm @nonARC @no-unify
 platform/audio/ios/MediaSessionManagerIOS.mm @nonARC @no-unify
+platform/audio/ios/SpatialAudioPlaybackHelperIOS.mm @nonARC @no-unify
 platform/audio/mac/AudioBusMac.mm @nonARC
 platform/audio/mac/AudioOutputUnitAdaptorMac.cpp
 platform/audio/mac/AudioHardwareListenerMac.cpp
 platform/audio/mac/AudioSessionMac.mm @nonARC
 platform/audio/mac/FFTFrameMac.cpp
 platform/audio/mac/SharedRoutingArbitrator.mm @nonARC
+platform/audio/mac/SpatialAudioPlaybackHelperMac.cpp
 platform/cf/KeyedDecoderCF.cpp
 platform/cf/KeyedEncoderCF.cpp
 platform/cf/MainThreadSharedTimerCF.cpp

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp
@@ -559,15 +559,6 @@ void MediaSessionManagerInterface::setIsPlayingToAutomotiveHeadUnit(bool isPlayi
     m_isPlayingToAutomotiveHeadUnit = isPlayingToAutomotiveHeadUnit;
 }
 
-void MediaSessionManagerInterface::setSupportsSpatialAudioPlayback(bool supportsSpatialAudioPlayback)
-{
-    if (supportsSpatialAudioPlayback == m_supportsSpatialAudioPlayback)
-        return;
-
-    ALWAYS_LOG(LOGIDENTIFIER, supportsSpatialAudioPlayback);
-    m_supportsSpatialAudioPlayback = supportsSpatialAudioPlayback;
-}
-
 void MediaSessionManagerInterface::addAudioCaptureSource(AudioCaptureSource& source)
 {
     ASSERT(!m_audioCaptureSources.contains(source));

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -136,9 +136,6 @@ public:
     virtual void setIsPlayingToAutomotiveHeadUnit(bool);
     virtual bool isPlayingToAutomotiveHeadUnit() const { return m_isPlayingToAutomotiveHeadUnit; };
 
-    virtual void setSupportsSpatialAudioPlayback(bool);
-    virtual std::optional<bool> supportsSpatialAudioPlaybackForConfiguration(const PlatformMediaConfiguration&) { return m_supportsSpatialAudioPlayback; }
-
     virtual void addAudioCaptureSource(AudioCaptureSource&);
     virtual void removeAudioCaptureSource(AudioCaptureSource&);
     virtual void audioCaptureSourceStateChanged() { updateSessionState(); }
@@ -183,8 +180,6 @@ protected:
 
     int countActiveAudioCaptureSources();
 
-    std::optional<bool> supportsSpatialAudioPlayback() { return m_supportsSpatialAudioPlayback; }
-
     bool computeSupportsSeeking() const;
 
     void scheduleUpdateSessionState();
@@ -208,7 +203,6 @@ private:
 
     std::array<MediaSessionRestrictions, static_cast<unsigned>(PlatformMediaSessionMediaType::DOMMediaSession) + 1> m_restrictions;
 
-    std::optional<bool> m_supportsSpatialAudioPlayback;
     std::optional<PlatformMediaSessionInterruptionType> m_currentInterruption;
 
     WeakHashSet<AudioCaptureSource> m_audioCaptureSources;

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -116,8 +116,6 @@ private:
 
     void possiblyChangeAudioCategory();
 
-    std::optional<bool> supportsSpatialAudioPlaybackForConfiguration(const PlatformMediaConfiguration&) final;
-
 #if USE(NOW_PLAYING_ACTIVITY_SUPPRESSION)
     static void updateNowPlayingSuppression(const NowPlayingInfo*);
 #endif

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -36,14 +36,12 @@
 #import "MediaStrategy.h"
 #import "NowPlayingInfo.h"
 #import "Page.h"
-#import "PlatformMediaConfiguration.h"
 #import "PlatformMediaSession.h"
 #import "PlatformStrategies.h"
 #import "Settings.h"
 #import "SharedBuffer.h"
 #import "VP9UtilitiesCocoa.h"
 #import <pal/SessionID.h>
-#import <pal/spi/cocoa/AudioToolboxSPI.h>
 #import <wtf/BlockObjCExceptions.h>
 #import <wtf/Function.h>
 #import <wtf/MathExtras.h>
@@ -733,50 +731,6 @@ void MediaSessionManagerCocoa::audioOutputDeviceChanged()
     AudioSession::singleton().audioOutputDeviceChanged();
     updateSessionState();
 }
-
-#if PLATFORM(MAC)
-std::optional<bool> MediaSessionManagerCocoa::supportsSpatialAudioPlaybackForConfiguration(const PlatformMediaConfiguration& configuration)
-{
-    ASSERT(configuration.audio);
-    if (!configuration.audio)
-        return { false };
-
-    auto supportsSpatialAudioPlayback = this->supportsSpatialAudioPlayback();
-    if (supportsSpatialAudioPlayback.has_value())
-        return supportsSpatialAudioPlayback;
-
-    auto calculateSpatialAudioSupport = [](const PlatformMediaConfiguration& configuration) {
-        if (!PAL::canLoad_AudioToolbox_AudioGetDeviceSpatialPreferencesForContentType())
-            return false;
-
-        SpatialAudioPreferences spatialAudioPreferences { };
-        auto contentType = configuration.video ? kAudioSpatialContentType_Audiovisual : kAudioSpatialContentType_AudioOnly;
-
-        if (noErr != PAL::AudioGetDeviceSpatialPreferencesForContentType(nullptr, static_cast<SpatialContentTypeID>(contentType), &spatialAudioPreferences))
-            return false;
-
-        if (!spatialAudioPreferences.spatialAudioSourceCount)
-            return false;
-
-        auto channelCount = configuration.audio->channels.toDouble();
-        if (channelCount <= 0)
-            return true;
-
-        for (auto& source : std::span { spatialAudioPreferences.spatialAudioSources }.first(spatialAudioPreferences.spatialAudioSourceCount)) {
-            if (source == kSpatialAudioSource_Multichannel && channelCount > 2)
-                return true;
-            if (source == kSpatialAudioSource_MonoOrStereo && channelCount >= 1)
-                return true;
-        }
-
-        return false;
-    };
-
-    setSupportsSpatialAudioPlayback(calculateSpatialAudioSupport(configuration));
-
-    return this->supportsSpatialAudioPlayback();
-}
-#endif
 
 #if USE(NOW_PLAYING_ACTIVITY_SUPPRESSION)
 

--- a/Source/WebCore/platform/audio/cocoa/SpatialAudioPlaybackHelper.h
+++ b/Source/WebCore/platform/audio/cocoa/SpatialAudioPlaybackHelper.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Platform.h>
+#if PLATFORM(COCOA)
+
+namespace WebCore {
+
+struct PlatformMediaConfiguration;
+
+class WEBCORE_EXPORT SpatialAudioPlaybackHelper {
+public:
+    static bool supportsSpatialAudioPlaybackForConfiguration(const PlatformMediaConfiguration&);
+};
+
+} // namespace WebCore
+
+#endif // PLATFORM(COCOA)

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h
@@ -40,8 +40,6 @@ enum class HasAvailableTargets : bool { No, Yes };
 enum class PlayingToAutomotiveHeadUnit : bool { No, Yes };
 enum class ShouldPause : bool { No, Yes };
 enum class SupportsAirPlayVideo : bool { No, Yes };
-enum class SupportsSpatialAudioPlayback : bool { No, Yes };
-
 class MediaSessionHelperClient : public AbstractRefCountedAndCanMakeWeakPtr<MediaSessionHelperClient> {
 public:
     virtual ~MediaSessionHelperClient() = default;
@@ -63,9 +61,6 @@ public:
 
     using SupportsAirPlayVideo = WebCore::SupportsAirPlayVideo;
     virtual void activeVideoRouteDidChange(SupportsAirPlayVideo, Ref<MediaPlaybackTarget>&&) = 0;
-
-    using SupportsSpatialAudioPlayback = WebCore::SupportsSpatialAudioPlayback;
-    virtual void activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback) = 0;
 };
 
 class WEBCORE_EXPORT MediaSessionHelper
@@ -107,16 +102,12 @@ public:
     using ShouldPause = MediaSessionHelperClient::ShouldPause;
     using SupportsAirPlayVideo = MediaSessionHelperClient::SupportsAirPlayVideo;
     using SuspendedUnderLock = MediaSessionHelperClient::SuspendedUnderLock;
-    using SupportsSpatialAudioPlayback = MediaSessionHelperClient::SupportsSpatialAudioPlayback;
 
     void activeAudioRouteDidChange(ShouldPause);
     void applicationWillEnterForeground(SuspendedUnderLock);
     void applicationDidEnterBackground(SuspendedUnderLock);
     void applicationWillBecomeInactive();
     void applicationDidBecomeActive();
-
-    void setActiveAudioRouteSupportsSpatialPlayback(bool);
-    void updateActiveAudioRouteSupportsSpatialPlayback();
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
     void activeRoutesDidChange(MediaDeviceRouteController&) final;
@@ -126,7 +117,6 @@ protected:
     void externalOutputDeviceAvailableDidChange(HasAvailableTargets);
     void isPlayingToAutomotiveHeadUnitDidChange(PlayingToAutomotiveHeadUnit);
     void activeVideoRouteDidChange(SupportsAirPlayVideo, Ref<MediaPlaybackTarget>&&);
-    void activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback);
 
 private:
     virtual void startMonitoringWirelessRoutesInternal() = 0;
@@ -137,7 +127,6 @@ private:
     uint32_t m_monitoringWirelessRoutesCount { 0 };
     bool m_activeVideoRouteSupportsAirPlayVideo { false };
     bool m_isPlayingToAutomotiveHeadUnit { false };
-    SupportsSpatialAudioPlayback m_activeAudioRouteSupportsSpatialPlayback { SupportsSpatialAudioPlayback::No };
     RefPtr<MediaPlaybackTarget> m_playbackTarget;
 };
 

--- a/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm
@@ -226,17 +226,6 @@ void MediaSessionHelper::activeVideoRouteDidChange(SupportsAirPlayVideo supports
     });
 }
 
-void MediaSessionHelper::activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback supportsSpatialPlayback)
-{
-    if (m_activeAudioRouteSupportsSpatialPlayback == supportsSpatialPlayback)
-        return;
-
-    m_activeAudioRouteSupportsSpatialPlayback = supportsSpatialPlayback;
-    m_clients.forEach([&](auto& client) {
-        client.activeAudioRouteSupportsSpatialPlaybackDidChange(supportsSpatialPlayback);
-    });
-}
-
 void MediaSessionHelper::startMonitoringWirelessRoutes()
 {
     if (m_monitoringWirelessRoutesCount++)
@@ -263,24 +252,6 @@ std::optional<ProcessID> MediaSessionHelper::presentedApplicationPID() const
 
 void MediaSessionHelper::providePresentingApplicationPID(ProcessID)
 {
-}
-
-void MediaSessionHelper::updateActiveAudioRouteSupportsSpatialPlayback()
-{
-    AVAudioSession* audioSession = [PAL::getAVAudioSessionClassSingleton() sharedInstance];
-    for (AVAudioSessionPortDescription* output in audioSession.currentRoute.outputs) {
-        if (output.spatialAudioEnabled) {
-            setActiveAudioRouteSupportsSpatialPlayback(true);
-            return;
-        }
-    }
-
-    setActiveAudioRouteSupportsSpatialPlayback(false);
-}
-
-void MediaSessionHelper::setActiveAudioRouteSupportsSpatialPlayback(bool supports)
-{
-    activeAudioRouteSupportsSpatialPlaybackDidChange(supports ? SupportsSpatialAudioPlayback::Yes : SupportsSpatialAudioPlayback::No);
 }
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
@@ -444,7 +415,6 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
     [center addObserver:self selector:@selector(applicationDidEnterBackground:) name:PAL::get_UIKit_UIApplicationDidEnterBackgroundNotificationSingleton() object:nil];
     [center addObserver:self selector:@selector(applicationDidEnterBackground:) name:WebUIApplicationDidEnterBackgroundNotification object:nil];
     [center addObserver:self selector:@selector(activeOutputDeviceDidChange:) name:PAL::get_AVFoundation_AVAudioSessionRouteChangeNotificationSingleton() object:nil];
-    [center addObserver:self selector:@selector(spatialPlaybackCapabilitiesChanged:) name:PAL::get_AVFoundation_AVAudioSessionSpatialPlaybackCapabilitiesChangedNotificationSingleton() object:nil];
 
 #if HAVE(MEDIAEXPERIENCE_AVSYSTEMCONTROLLER)
     [center addObserver:self selector:@selector(mediaServerConnectionDied:) name:getAVSystemController_ServerConnectionDiedNotificationSingleton() object:nil];
@@ -647,14 +617,6 @@ void MediaSessionHelperIOS::externalOutputDeviceAvailableDidChange()
     });
 }
 
-- (void)spatialPlaybackCapabilitiesChanged:(NSNotification *)notification
-{
-    LOG(Media, "-[WebMediaSessionHelper spatialPlaybackCapabilitiesChanged:]");
-    callOnWebThreadOrDispatchAsyncOnMainThread([self, protectedSelf = retainPtr(self)]() {
-        if (RefPtr callback = _callback.get())
-            callback->updateActiveAudioRouteSupportsSpatialPlayback();
-    });
-}
 @end
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h
@@ -89,7 +89,6 @@ private:
     void activeAudioRouteDidChange(ShouldPause) final;
     void activeVideoRouteDidChange(SupportsAirPlayVideo, Ref<MediaPlaybackTarget>&&) final;
     void isPlayingToAutomotiveHeadUnitDidChange(PlayingToAutomotiveHeadUnit) final;
-    void activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback) final;
 
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const override;

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -31,7 +31,6 @@
 #import "Logging.h"
 #import "MediaPlaybackTargetCocoa.h"
 #import "MediaPlayer.h"
-#import "PlatformMediaConfiguration.h"
 #import "PlatformMediaSession.h"
 #import "SystemMemory.h"
 #import "WebCoreThreadRun.h"
@@ -174,28 +173,6 @@ void MediaSessionManageriOS::externalOutputDeviceAvailableDidChange(HasAvailable
 void MediaSessionManageriOS::isPlayingToAutomotiveHeadUnitDidChange(PlayingToAutomotiveHeadUnit playingToAutomotiveHeadUnit)
 {
     setIsPlayingToAutomotiveHeadUnit(playingToAutomotiveHeadUnit == PlayingToAutomotiveHeadUnit::Yes);
-}
-
-void MediaSessionManageriOS::activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback supportsSpatialPlayback)
-{
-    setSupportsSpatialAudioPlayback(supportsSpatialPlayback == SupportsSpatialAudioPlayback::Yes);
-}
-
-std::optional<bool> MediaSessionManagerCocoa::supportsSpatialAudioPlaybackForConfiguration(const PlatformMediaConfiguration& configuration)
-{
-    ASSERT(configuration.audio);
-
-    // Only multichannel audio can be spatially rendered on iOS.
-    if (!configuration.audio || configuration.audio->channels.toDouble() <= 2)
-        return { false };
-
-    auto supportsSpatialAudioPlayback = this->supportsSpatialAudioPlayback();
-    if (supportsSpatialAudioPlayback.has_value())
-        return supportsSpatialAudioPlayback;
-
-    MediaSessionHelper::sharedHelper().updateActiveAudioRouteSupportsSpatialPlayback();
-
-    return this->supportsSpatialAudioPlayback();
 }
 
 void MediaSessionManageriOS::activeAudioRouteDidChange(ShouldPause shouldPause)

--- a/Source/WebCore/platform/audio/ios/SpatialAudioPlaybackHelperIOS.mm
+++ b/Source/WebCore/platform/audio/ios/SpatialAudioPlaybackHelperIOS.mm
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "SpatialAudioPlaybackHelper.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "Logging.h"
+#import "PlatformMediaConfiguration.h"
+#import "WebCoreThreadRun.h"
+#import <AVFoundation/AVAudioSession.h>
+#import <pal/spi/cocoa/AVFoundationSPI.h>
+#import <wtf/BlockObjCExceptions.h>
+#import <wtf/CheckedPtr.h>
+#import <wtf/NeverDestroyed.h>
+#import <wtf/TZoneMalloc.h>
+#import <wtf/WeakPtr.h>
+
+#import <pal/cocoa/AVFoundationSoftLink.h>
+
+namespace WebCore {
+class SpatialAudioPlaybackHelperIOS;
+}
+
+using namespace WebCore;
+
+@interface WebSpatialAudioPlaybackObserver : NSObject {
+    WeakPtr<WebCore::SpatialAudioPlaybackHelperIOS> _callback;
+}
+- (id)initWithCallback:(WebCore::SpatialAudioPlaybackHelperIOS&)callback;
+- (void)spatialPlaybackCapabilitiesChanged:(NSNotification *)notification;
+- (void)shutdown;
+@end
+
+namespace WebCore {
+
+class SpatialAudioPlaybackHelperIOS final
+    : public CanMakeWeakPtr<SpatialAudioPlaybackHelperIOS>
+    , public CanMakeCheckedPtr<SpatialAudioPlaybackHelperIOS> {
+    WTF_MAKE_TZONE_ALLOCATED(SpatialAudioPlaybackHelperIOS);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SpatialAudioPlaybackHelperIOS);
+public:
+    static SpatialAudioPlaybackHelperIOS& singleton();
+
+    SpatialAudioPlaybackHelperIOS();
+    ~SpatialAudioPlaybackHelperIOS();
+
+    void updateActiveAudioRouteSupportsSpatialPlayback();
+    bool activeAudioRouteSupportsSpatialPlayback() const { return m_activeAudioRouteSupportsSpatialPlayback; }
+
+private:
+    RetainPtr<WebSpatialAudioPlaybackObserver> m_observer;
+    bool m_activeAudioRouteSupportsSpatialPlayback { false };
+};
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SpatialAudioPlaybackHelperIOS);
+
+SpatialAudioPlaybackHelperIOS& SpatialAudioPlaybackHelperIOS::singleton()
+{
+    static const NeverDestroyed<std::unique_ptr<SpatialAudioPlaybackHelperIOS>> instance = makeUnique<SpatialAudioPlaybackHelperIOS>();
+
+    return *instance.get();
+}
+
+SpatialAudioPlaybackHelperIOS::SpatialAudioPlaybackHelperIOS()
+{
+    m_observer = adoptNS([[WebSpatialAudioPlaybackObserver alloc] initWithCallback:*this]);
+
+    // Initialize with current state
+    updateActiveAudioRouteSupportsSpatialPlayback();
+}
+
+SpatialAudioPlaybackHelperIOS::~SpatialAudioPlaybackHelperIOS()
+{
+    [m_observer shutdown];
+    m_observer = nil;
+}
+
+void SpatialAudioPlaybackHelperIOS::updateActiveAudioRouteSupportsSpatialPlayback()
+{
+    AVAudioSession* audioSession = [PAL::getAVAudioSessionClassSingleton() sharedInstance];
+    for (AVAudioSessionPortDescription* output in audioSession.currentRoute.outputs) {
+        if (output.spatialAudioEnabled) {
+            m_activeAudioRouteSupportsSpatialPlayback = true;
+            return;
+        }
+    }
+
+    m_activeAudioRouteSupportsSpatialPlayback = false;
+}
+
+bool SpatialAudioPlaybackHelper::supportsSpatialAudioPlaybackForConfiguration(const PlatformMediaConfiguration& configuration)
+{
+    ASSERT(configuration.audio);
+
+    // Only multichannel audio can be spatially rendered on iOS.
+    if (!configuration.audio || configuration.audio->channels.toDouble() <= 2)
+        return false;
+
+    return SpatialAudioPlaybackHelperIOS::singleton().activeAudioRouteSupportsSpatialPlayback();
+}
+
+} // namespace WebCore
+
+@implementation WebSpatialAudioPlaybackObserver
+
+- (id)initWithCallback:(WebCore::SpatialAudioPlaybackHelperIOS&)callback
+{
+    assertIsMainThread();
+    LOG(Media, "-[WebSpatialAudioPlaybackObserver initWithCallback]");
+
+    if (!(self = [super init]))
+        return nil;
+
+    _callback = &callback;
+
+    RetainPtr center = [NSNotificationCenter defaultCenter];
+    [center addObserver:self selector:@selector(spatialPlaybackCapabilitiesChanged:) name:PAL::get_AVFoundation_AVAudioSessionSpatialPlaybackCapabilitiesChangedNotificationSingleton() object:nil];
+
+    return self;
+}
+
+- (void)shutdown
+{
+    LOG(Media, "-[WebSpatialAudioPlaybackObserver shutdown]");
+    assertIsMainThread();
+    RetainPtr center = [NSNotificationCenter defaultCenter];
+    [center removeObserver:self];
+    _callback = nil;
+}
+
+- (void)dealloc
+{
+    LOG(Media, "-[WebSpatialAudioPlaybackObserver dealloc]");
+    [super dealloc];
+}
+
+- (void)spatialPlaybackCapabilitiesChanged:(NSNotification *)notification
+{
+    UNUSED_PARAM(notification);
+    LOG(Media, "-[WebSpatialAudioPlaybackObserver spatialPlaybackCapabilitiesChanged:]");
+    callOnWebThreadOrDispatchAsyncOnMainThread([protectedSelf = retainPtr(self)]() {
+        if (CheckedPtr callback = protectedSelf->_callback.get())
+            callback->updateActiveAudioRouteSupportsSpatialPlayback();
+    });
+}
+
+@end
+
+#endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/platform/audio/mac/SpatialAudioPlaybackHelperMac.cpp
+++ b/Source/WebCore/platform/audio/mac/SpatialAudioPlaybackHelperMac.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SpatialAudioPlaybackHelper.h"
+
+#if PLATFORM(MAC)
+
+#include "PlatformMediaConfiguration.h"
+#include <pal/spi/cocoa/AudioToolboxSPI.h>
+#include <span>
+
+namespace WebCore {
+
+bool SpatialAudioPlaybackHelper::supportsSpatialAudioPlaybackForConfiguration(const PlatformMediaConfiguration& configuration)
+{
+    ASSERT(configuration.audio);
+    if (!configuration.audio)
+        return false;
+
+    if (!PAL::canLoad_AudioToolbox_AudioGetDeviceSpatialPreferencesForContentType())
+        return false;
+
+    SpatialAudioPreferences spatialAudioPreferences { };
+    auto contentType = configuration.video ? kAudioSpatialContentType_Audiovisual : kAudioSpatialContentType_AudioOnly;
+
+    if (noErr != PAL::AudioGetDeviceSpatialPreferencesForContentType(nullptr, static_cast<SpatialContentTypeID>(contentType), &spatialAudioPreferences))
+        return false;
+
+    if (!spatialAudioPreferences.spatialAudioSourceCount)
+        return false;
+
+    auto channelCount = configuration.audio->channels.toDouble();
+
+    for (auto& source : std::span { spatialAudioPreferences.spatialAudioSources }.first(spatialAudioPreferences.spatialAudioSourceCount)) {
+        if (source == kSpatialAudioSource_Multichannel && channelCount > 2)
+            return true;
+        if (source == kSpatialAudioSource_MonoOrStereo && channelCount >= 1)
+            return true;
+    }
+
+    return false;
+}
+
+} // namespace WebCore
+
+#endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/graphics/cocoa/PlatformMediaEngineConfigurationFactoryCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/PlatformMediaEngineConfigurationFactoryCocoa.cpp
@@ -32,11 +32,10 @@
 #include "AV1UtilitiesCocoa.h"
 #include "HEVCUtilitiesCocoa.h"
 #include "MediaPlayer.h"
-#include "MediaSessionHelperIOS.h"
 #include "PlatformMediaCapabilitiesDecodingInfo.h"
 #include "PlatformMediaDecodingConfiguration.h"
 #include "PlatformMediaEngineConfigurationFactory.h"
-#include "PlatformMediaSessionManager.h"
+#include "SpatialAudioPlaybackHelper.h"
 #include "VP9UtilitiesCocoa.h"
 #include <pal/avfoundation/OutputContext.h>
 #include <pal/avfoundation/OutputDevice.h>
@@ -172,15 +171,7 @@ static std::optional<PlatformMediaCapabilitiesInfo> computeMediaCapabilitiesInfo
     if (!configuration.audio->spatialRendering.value_or(false))
         return info;
 
-    RefPtr manager = configuration.pageIdentifier ? PlatformMediaEngineConfigurationFactory::mediaSessionManagerForPageIdentifier(configuration.pageIdentifier.value()) : nullptr;
-    if (!manager)
-        return std::nullopt;
-
-    auto supportsSpatialPlayback = manager->supportsSpatialAudioPlaybackForConfiguration(configuration);
-    if (!supportsSpatialPlayback.has_value())
-        return std::nullopt;
-
-    info.supported = supportsSpatialPlayback.value();
+    info.supported = SpatialAudioPlaybackHelper::supportsSpatialAudioPlaybackForConfiguration(configuration);
 
     return info;
 }

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
@@ -135,12 +135,6 @@ void RemoteMediaSessionHelperProxy::activeVideoRouteDidChange(SupportsAirPlayVid
         connection->connection().send(Messages::RemoteMediaSessionHelper::ActiveVideoRouteDidChange(supportsAirPlayVideo, MediaPlaybackTargetContextSerialized { target.get() }), { });
 }
 
-void RemoteMediaSessionHelperProxy::activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback supportsSpatialPlayback)
-{
-    if (RefPtr connection = m_gpuConnection.get())
-        connection->connection().send(Messages::RemoteMediaSessionHelper::ActiveAudioRouteSupportsSpatialPlaybackDidChange(supportsSpatialPlayback), { });
-}
-
 std::optional<SharedPreferencesForWebProcess> RemoteMediaSessionHelperProxy::sharedPreferencesForWebProcess() const
 {
     if (RefPtr gpuConnectionToWebProcess = m_gpuConnection.get())

--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h
@@ -71,7 +71,6 @@ private:
     void isPlayingToAutomotiveHeadUnitDidChange(PlayingToAutomotiveHeadUnit) final;
     void activeAudioRouteDidChange(ShouldPause) final;
     void activeVideoRouteDidChange(SupportsAirPlayVideo, Ref<WebCore::MediaPlaybackTarget>&&) final;
-    void activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback) final;
 
     bool m_isMonitoringWirelessRoutes { false };
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnection;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1401,7 +1401,6 @@ def headers_for_type(type, for_implementation_file=False):
         'WebCore::StrokeStyle': ['<WebCore/GraphicsTypes.h>'],
         'WebCore::SupportedPluginIdentifier': ['<WebCore/PluginData.h>'],
         'WebCore::SupportsAirPlayVideo': ['<WebCore/MediaSessionHelperIOS.h>'],
-        'WebCore::SupportsSpatialAudioPlayback': ['<WebCore/MediaSessionHelperIOS.h>'],
         'WebCore::SuspendedUnderLock': ['<WebCore/MediaSessionHelperIOS.h>'],
         'WebCore::SWServerConnectionIdentifier': ['<WebCore/ServiceWorkerTypes.h>'],
         'WebCore::TargetedElementAdjustment': ['<WebCore/ElementTargetingTypes.h>'],

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in
@@ -46,5 +46,4 @@ enum class WebCore::HasAvailableTargets : bool
 enum class WebCore::SupportsAirPlayVideo : bool
 enum class WebCore::PlayingToAutomotiveHeadUnit : bool
 enum class WebCore::SuspendedUnderLock : bool
-enum class WebCore::SupportsSpatialAudioPlayback : bool
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp
@@ -86,11 +86,6 @@ void RemoteMediaSessionHelper::activeVideoRouteDidChange(SupportsAirPlayVideo su
     }
 }
 
-void RemoteMediaSessionHelper::activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback supportsSpatialAudioPlayback)
-{
-    WebCore::MediaSessionHelper::activeAudioRouteSupportsSpatialPlaybackDidChange(supportsSpatialAudioPlayback);
-}
-
 }
 
 #endif

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h
@@ -70,7 +70,6 @@ private:
 
     // Messages
     void activeVideoRouteDidChange(SupportsAirPlayVideo, MediaPlaybackTargetContextSerialized&&);
-    void activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback);
 
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
 };

--- a/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.messages.in
@@ -36,7 +36,6 @@ messages -> RemoteMediaSessionHelper {
     IsPlayingToAutomotiveHeadUnitDidChange(enum:bool WebCore::PlayingToAutomotiveHeadUnit isPlayingToAutomotiveHeadUnit)
     ActiveAudioRouteDidChange(enum:bool WebCore::ShouldPause shouldPause)
     ActiveVideoRouteDidChange(enum:bool WebCore::SupportsAirPlayVideo supportsAirPlayVideo, WebKit::MediaPlaybackTargetContextSerialized target)
-    ActiveAudioRouteSupportsSpatialPlaybackDidChange(enum:bool WebCore::SupportsSpatialAudioPlayback supportsSpatialPlayback)
 }
 
 #endif


### PR DESCRIPTION
#### 8bab7e486b9e9b8bc8042aa39f34ec0532cacb4e
<pre>
MediaCapabilities will always return unsupported if spatialRendering is set to true
<a href="https://bugs.webkit.org/show_bug.cgi?id=309336">https://bugs.webkit.org/show_bug.cgi?id=309336</a>
<a href="https://rdar.apple.com/171733202">rdar://171733202</a>

Reviewed by Eric Carlson.

MediaCapabilities failed to properly resolve the promise if the spatialRendering
attribute was set on the AudioConfiguration.
The reason was that computeMediaCapabilitiesInfo was looking for a MediaSessionManager
that did not exist in the GPU process.

We extract the handling of Spatial Audio Support detection from MediaSessionManagerCocoa
into its own SpatialAudioPlaybackHelper and have the PlatformMediaEngineConfigurationFactoryCocoa
directly queries it for support check.

There was no use for the web process to know about the state of spatial audio support,
so we can remove the client listeners used to propagate the changes from the MediaSessionHelper
back to the MediaSessionManager. It was also incorrectly reporting the support state as changing
if the last queried returned false (like if query for a particular configuration contained less than 3 channels)

SpatialAudioPlaybackHelper.h - Simple header with a single public static method `supportsSpatialAudioPlaybackForConfiguration`

Design Decisions:
* Mac implementation is stateless (no singleton needed) - queries AudioToolbox directly
* iOS implementation maintains cached state with notification observer for route changes

* LayoutTests/media/mediacapabilities/mediacapabilities-decodingInfo-spatialRendering-expected.txt: Added.
* LayoutTests/media/mediacapabilities/mediacapabilities-decodingInfo-spatialRendering.html: Added. Test will fail unless hardware supports spatial rendering (e.g. real iPhone or macbooks)
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::setSupportsSpatialAudioPlayback): Deleted.
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::supportsSpatialAudioPlaybackForConfiguration): Deleted.
* Source/WebCore/platform/audio/cocoa/SpatialAudioPlaybackHelper.h: Added.
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(-[WebMediaSessionHelper initWithCallback:]):
(MediaSessionHelper::activeAudioRouteSupportsSpatialPlaybackDidChange): Deleted.
(MediaSessionHelper::updateActiveAudioRouteSupportsSpatialPlayback): Deleted.
(MediaSessionHelper::setActiveAudioRouteSupportsSpatialPlayback): Deleted.
(-[WebMediaSessionHelper spatialPlaybackCapabilitiesChanged:]): Deleted.
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.h:
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm:
(WebCore::MediaSessionManageriOS::activeAudioRouteSupportsSpatialPlaybackDidChange): Deleted.
(WebCore::MediaSessionManagerCocoa::supportsSpatialAudioPlaybackForConfiguration): Deleted.
* Source/WebCore/platform/audio/ios/SpatialAudioPlaybackHelperIOS.mm: Added.
(WebCore::SpatialAudioPlaybackHelperIOS::singleton):
(WebCore::SpatialAudioPlaybackHelperIOS::SpatialAudioPlaybackHelperIOS):
(WebCore::SpatialAudioPlaybackHelperIOS::~SpatialAudioPlaybackHelperIOS):
(WebCore::SpatialAudioPlaybackHelperIOS::updateActiveAudioRouteSupportsSpatialPlayback):
(WebCore::SpatialAudioPlaybackHelper::supportsSpatialAudioPlaybackForConfiguration):
(-[WebSpatialAudioPlaybackObserver initWithCallback:]):
(-[WebSpatialAudioPlaybackObserver shutdown]):
(-[WebSpatialAudioPlaybackObserver dealloc]):
(-[WebSpatialAudioPlaybackObserver spatialPlaybackCapabilitiesChanged:]):
* Source/WebCore/platform/audio/mac/SpatialAudioPlaybackHelperMac.cpp: Added.
(WebCore::SpatialAudioPlaybackHelper::supportsSpatialAudioPlaybackForConfiguration):
* Source/WebCore/platform/graphics/cocoa/PlatformMediaEngineConfigurationFactoryCocoa.cpp:
(WebCore::computeMediaCapabilitiesInfo):
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp:
(WebKit::RemoteMediaSessionHelperProxy::activeAudioRouteSupportsSpatialPlaybackDidChange): Deleted.
* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.h:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSessionConfiguration.serialization.in:
* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.cpp:
(WebKit::RemoteMediaSessionHelper::activeAudioRouteSupportsSpatialPlaybackDidChange): Deleted.
* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.h:
* Source/WebKit/WebProcess/GPU/media/ios/RemoteMediaSessionHelper.messages.in:

Canonical link: <a href="https://commits.webkit.org/308963@main">https://commits.webkit.org/308963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8efb5882b7b2fe22871b14fa8d31b8d63503202

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21732 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/15302 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157707 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52d3d5dd-b653-4247-9632-1923995ef47f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150892 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22186 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21610 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/114880 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/60b9ea2f-062f-41fa-b718-c6249397cc65) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17069 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95638 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b870685-63d7-405d-9a7a-238cd61c0d66) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/148340 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/5557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/11668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160189 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/13190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/122935 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21534 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123162 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33477 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/133461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/10220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21144 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84946 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20876 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/21024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->