### PR TITLE
Make StringBuilder in regExpProtoFuncReplace report OOM

### DIFF
--- a/JSTests/stress/regexp-accumulatedResult-overflow.js
+++ b/JSTests/stress/regexp-accumulatedResult-overflow.js
@@ -1,0 +1,46 @@
+//@ skip if $memoryLimited or $addressBits <= 32
+//@ runDefault()
+
+// Testcase: regExpProtoFuncReplace accumulatedResult StringBuilder
+// uses CrashOnOverflow instead of RecordOverflow.
+//
+// Variant of rdar://171058069 / https://bugs.webkit.org/show_bug.cgi?id=308836
+//
+// The accumulatedResult StringBuilder at RegExpPrototype.cpp:1049 uses
+// the default CrashOnOverflow policy. The hasOverflowed() checks at
+// lines 1178 and 1187 are dead code because CRASH() fires first.
+//
+// This testcase forces the generic slow path (regExpProtoFuncReplace)
+// by overriding RegExp.prototype.exec, then uses functional replace
+// to completely bypass getSubstitution() (which was already fixed).
+// The accumulated result overflows from many large replacements.
+//
+// Expected: Catches an out-of-memory exception
+// Actual (buggy): Crashes in StringBuilder::didOverflow() -> CRASH()
+
+// Step 1: Force the generic slow path by invalidating
+// regExpPrimordialPropertiesWatchpointSet.
+var origExec = RegExp.prototype.exec;
+RegExp.prototype.exec = function(s) { return origExec.call(this, s); };
+
+// Step 2: Build a large replacement string (~8MB).
+var bigRepl = "X";
+for (var i = 0; i < 23; i++)
+    bigRepl = bigRepl + bigRepl;
+// bigRepl.length = 2^23 = 8388608
+
+// Step 3: Source string with 300 matchable characters.
+// 300 * 8MB = 2.4GB > String::MaxLength (2^31-1 = ~2.1GB)
+var src = "A".repeat(300);
+
+// Step 4: Match each character individually.
+var re = /A/g;
+
+var caught = false;
+try {
+    src.replace(re, function() { return bigRepl; });
+} catch (e) {
+    caught = true;
+    if(e != "RangeError: Out of memory") throw new RuntimeError("unexpected exception "+e);
+}
+if(!caught) throw new RuntimeError("expected out of memory error");

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -1046,7 +1046,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncReplace, (JSGlobalObject* globalObject, 
     }
 
     // 13. Let accumulatedResult be the empty String.
-    StringBuilder accumulatedResult;
+    StringBuilder accumulatedResult(OverflowPolicy::RecordOverflow);
 
     // 14. Let nextSourcePosition be 0.
     unsigned nextSourcePosition = 0;


### PR DESCRIPTION
#### c6d06eb881b7317e68379fb5177b17adb76ac717
<pre>
Make StringBuilder in regExpProtoFuncReplace report OOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=309375">https://bugs.webkit.org/show_bug.cgi?id=309375</a>
<a href="https://rdar.apple.com/171925413">rdar://171925413</a>

Reviewed by Sosuke Suzuki.

Followup for <a href="https://rdar.apple.com/171058069">rdar://171058069</a> /
<a href="https://bugs.webkit.org/show_bug.cgi?id=308836">https://bugs.webkit.org/show_bug.cgi?id=308836</a> where
regExpProtoFuncReplace has the same problem as getSubstitution. Here too
the StringBuilder is updated to report an out of memory error instead of
crashing.

Test: JSTests/stress/regexp-accumulatedResult-overflow.js

* JSTests/stress/regexp-accumulatedResult-overflow.js: Added.
(RegExp.prototype.exec):
(catch):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/308921@main">https://commits.webkit.org/308921@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1a271807c53e2bfc793503a0d0db182314b780b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157280 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102026 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d77ad204-ca85-4a17-8cb7-38fff7b22627) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21761 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21187 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114545 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81564 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f192f298-7d5a-43f9-8510-9ac6eee1b5cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16751 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133385 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95315 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f80f7d89-3d7e-49ef-a4f3-c82b1848d01c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15854 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13702 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4716 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140563 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125468 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11299 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159615 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9383 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2756 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122602 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122827 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33456 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133094 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77248 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18150 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9860 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180024 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20720 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84523 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46079 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20453 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20599 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20509 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->