### PR TITLE
[WebKit][Main] [76d1bb47f067ac21] ASAN_SEGV | WebCore::Highlight::clearFromSetLike; WebCore::HighlightRegistry::clear; WebCore::Document::commonTeardown

### DIFF
--- a/JSTests/stress/map-forEach.js
+++ b/JSTests/stress/map-forEach.js
@@ -1,0 +1,41 @@
+function startScan() {
+    for (let i = 0; i < 5; i++) {
+        new WebAssembly.Memory({
+            initial: 256
+        });
+    }
+}
+
+function main() {
+    const object = {
+        key: 1
+    };
+
+    let map = new Map();
+    map.set({0: 1.1}, 1);
+
+    function inlinee(value, key) {
+        object.key = key;
+    }
+
+    for (let i = 0; i < 200; i++) {
+       map.forEach(inlinee);
+    }
+
+    for (let i = 0; i < 100; i++) {
+        startScan();
+
+        (new Map([[{0: 1.1}, 1]])).forEach(inlinee);
+
+        const spray = [];
+        for (let j = 0; j < 1000; j++) {
+            spray.push({0: 2.2});
+        }
+
+        if (object.key[0] === 2.2) {
+            throw new Error("bad");
+        }
+    }
+}
+
+main();

--- a/LayoutTests/highlight/highlight-crash-2-expected.txt
+++ b/LayoutTests/highlight/highlight-crash-2-expected.txt
@@ -1,0 +1,2 @@
+This passes if it doesn't crash.
+

--- a/LayoutTests/highlight/highlight-crash-2.html
+++ b/LayoutTests/highlight/highlight-crash-2.html
@@ -1,0 +1,31 @@
+<script>
+ function gc()
+ {
+     if (window.GCController)
+         return GCController.collect();
+
+     for (var i = 0; i < 10000; ++i)
+         var s = new String("AAAA");
+ }
+
+ function main() {
+     let d = f.contentDocument;
+     let hr = f.contentWindow.CSS.highlights;
+     let h = new Highlight(d.createRange());
+     g.contentWindow.CSS.highlights.set("g", h);
+     f.remove();
+     hr.set("f", h);
+     hr = 0;
+     d = 0;
+     gc();
+     g.remove();
+ }
+
+ window.testRunner?.dumpAsText();
+ window.onload = main;
+</script>
+<div>
+    This passes if it doesn't crash.
+</div>
+<iframe id="f" src="about:blank"></iframe>
+<iframe id="g" src="about:blank"></iframe>

--- a/LayoutTests/svg/filters/filter-insert-button-crash-expected.txt
+++ b/LayoutTests/svg/filters/filter-insert-button-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it doesn't crash
+
+

--- a/LayoutTests/svg/filters/filter-insert-button-crash.html
+++ b/LayoutTests/svg/filters/filter-insert-button-crash.html
@@ -1,0 +1,23 @@
+<script>
+ function main() {
+     range = document.createRange();
+     range.selectNodeContents(button);
+     feImage.before(button);
+     range.surroundContents(ol);
+ }
+ window.testRunner?.dumpAsText();
+</script>
+<body onload=main()>
+    <h1>This test passes if it doesn't crash</h1>
+    <u style="visibility: hidden;">
+        <button id="button">
+        </button>
+        <svg id="svgObject">
+            <path filter="url(#filter)" />
+            <filter id="filter">
+                <feImage xlink:href="#svgObject" id="feImage" />
+            </filter>
+        </svg>
+        <ol id="ol"/>
+    </u>
+</body>

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -594,7 +594,7 @@ namespace JSC { namespace DFG {
     macro(MapStorageOrSentinel, NodeResultJS) /* If the map storage is not materialized, return the sentinel. */ \
     macro(MapIterationNext, NodeResultJS) \
     macro(MapIterationEntry, NodeResultJS) \
-    macro(MapIterationEntryKey, NodeResultInt32) \
+    macro(MapIterationEntryKey, NodeResultJS) \
     macro(MapIterationEntryValue, NodeResultJS) \
     macro(MapOrSetSize, NodeResultInt32) \
     macro(SetAdd, NodeMustGenerate) \

--- a/Source/WebCore/Modules/highlight/Highlight.cpp
+++ b/Source/WebCore/Modules/highlight/Highlight.cpp
@@ -77,7 +77,9 @@ void Highlight::clearFromSetLike()
 {
     for (auto& highlightRange : std::exchange(m_highlightRanges, { }))
         repaintRange(highlightRange->range());
-    m_highlightRanges.clear();
+
+    // Exchange with an empty vector, as this function might reenter when m_highlightRanges' contents are released.
+    std::exchange(m_highlightRanges, { });
 }
 
 bool Highlight::addToSetLike(AbstractRange& range)

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -110,6 +110,19 @@ private:
 };
 #endif
 
+RepaintBlocker::RepaintBlocker(Document& document)
+    : m_document(document)
+{
+    if (CheckedPtr view = m_document->view())
+        view->layoutContext().blockRepaints();
+}
+
+RepaintBlocker::~RepaintBlocker()
+{
+    if (CheckedPtr view = m_document->view())
+        view->layoutContext().allowRepaints();
+}
+
 class LayoutFrameScope {
 public:
     LayoutFrameScope(LocalFrameViewLayoutContext& layoutContext)

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -174,6 +174,8 @@ public:
     void invalidateAnchorDependenciesForScroller(const RenderBox& scroller);
     void removeScrollerFromAnchorScrollAdjusters(const RenderBox& scroller);
 
+    bool repaintsBlocked() const { return m_repaintsBlocked; }
+
 private:
     friend class LayoutFrameScope;
     friend class LayoutStateMaintainer;
@@ -181,6 +183,7 @@ private:
     friend class SubtreeLayoutStateMaintainer;
     friend class FlexPercentResolveDisabler;
     friend class ContentVisibilityOverrideScope;
+    friend class RepaintBlocker;
 
     bool needsLayoutInternal() const;
 
@@ -228,6 +231,9 @@ private:
     void disablePercentHeightResolveFor(const RenderBox& flexItem);
     void enablePercentHeightResolveFor(const RenderBox& flexItem);
 
+    void allowRepaints() { m_repaintsBlocked = false; }
+    void blockRepaints() { m_repaintsBlocked = true; }
+
     LocalFrame& frame() const;
     LocalFrameView& NODELETE view() const;
     RenderView* renderView() const;
@@ -247,6 +253,7 @@ private:
     bool m_visiblityAutoIsIgnored { false };
     bool m_revealedWhenFoundIgnored { false };
     bool m_updateCompositingLayersIsPending { false };
+    bool m_repaintsBlocked { false };
     LayoutPhase m_layoutPhase { LayoutPhase::OutsideLayout };
     enum class LayoutNestedState : uint8_t  { NotInLayout, NotNested, Nested };
     LayoutNestedState m_layoutNestedState { LayoutNestedState::NotInLayout };
@@ -289,6 +296,15 @@ private:
         SegmentedVector<std::unique_ptr<RenderObject>, 50> m_renderers;
     };
     mutable DetachedRendererList m_detachedRendererList;
+};
+
+class RepaintBlocker {
+public:
+    explicit RepaintBlocker(Document&);
+    ~RepaintBlocker();
+
+private:
+    const Ref<Document> m_document;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1036,6 +1036,9 @@ void RenderObject::issueRepaint(std::optional<LayoutRect> partialRepaintRect, Cl
 
 void RenderObject::repaint(ForceRepaint forceRepaint) const
 {
+    if (view().frameView().layoutContext().repaintsBlocked())
+        return;
+
     ASSERT(isDescendantOf(&view()) || is<RenderScrollbarPart>(this) || is<RenderReplica>(this));
 
     if (view().printing())

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
@@ -227,6 +227,8 @@ void RenderTreeBuilder::Inline::attachIgnoringContinuation(RenderInline& parent,
 
 void RenderTreeBuilder::Inline::splitFlow(RenderInline& parent, RenderObject* beforeChild, RenderPtr<RenderBlock> newBlockBox, RenderPtr<RenderObject> child, RenderBoxModelObject* oldCont)
 {
+    RepaintBlocker blocker(parent.document());
+
     ASSERT(m_buildsContinuations);
     ASSERT(newBlockBox);
     auto& addedBlockBox = *newBlockBox;


### PR DESCRIPTION
#### e01d2548ff09a4ef0e2ad56fd736e804670ae0f3
<pre>
[WebKit][Main] [76d1bb47f067ac21] ASAN_SEGV | WebCore::Highlight::clearFromSetLike; WebCore::HighlightRegistry::clear; WebCore::Document::commonTeardown
<a href="https://bugs.webkit.org/show_bug.cgi?id=304176">https://bugs.webkit.org/show_bug.cgi?id=304176</a>
<a href="https://rdar.apple.com/166163089">rdar://166163089</a>

Reviewed by Chris Dumez.

With the right disposing order, it is possible to cause reentrancy to
Highlight::clearFromSetLike(). This is due to the ownership relationship
between Document-&gt;HighlightRegistry-&gt;Highlight-&gt;HighlightRange-&gt;Range-&gt;Document.

The attached test shows an example of how to achieve this (a dangling document
that is only attached to a Range gets disposed during another Document&apos;s disposing,
causing a reentrant call to Highlight::clearFromSetLike()).

Ensure Highlight::clearFromSetLike() is safely reentrant by exchanging
Highlight::m_highlightRanges with an empty vector so that any potentially reentrant
call is a no-op.

Test: highlight/highlight-crash-2.html

* LayoutTests/highlight/highlight-crash-2-expected.txt: Added.
* LayoutTests/highlight/highlight-crash-2.html: Added.
* Source/WebCore/Modules/highlight/Highlight.cpp:
(WebCore::Highlight::clearFromSetLike):

Originally-landed-as: 302196.10@webkit-2025.11-embargoed (ae3502b8b960). <a href="https://rdar.apple.com/170270576">rdar://170270576</a>
Canonical link: <a href="https://commits.webkit.org/308854@main">https://commits.webkit.org/308854@main</a>
</pre>
----------------------------------------------------------------------
#### 3f6f7836068abd20f974c605e04af3c7c5ce88fa
<pre>
[JSC] MapIterationEntryKey should have NodeResultJS, not NodeResultInt32
<a href="https://bugs.webkit.org/show_bug.cgi?id=304950">https://bugs.webkit.org/show_bug.cgi?id=304950</a>
<a href="https://rdar.apple.com/167200795">rdar://167200795</a>

Reviewed by Marcus Plutowski.

MapIterationEntryKey returns arbitrary JSValues (map keys can be any type),
so it should be declared with NodeResultJS to match MapIterationEntryValue.

Test: JSTests/stress/map-forEach.js

Originally-landed-as: 301765.392@safari-7623-branch (47b55468bf82). <a href="https://rdar.apple.com/171557100">rdar://171557100</a>
Canonical link: <a href="https://commits.webkit.org/308853@main">https://commits.webkit.org/308853@main</a>
</pre>
----------------------------------------------------------------------
#### 2efbd919e75cb36a5e50ebaeef2ba26f7565f2fb
<pre>
Cherry-pick 302196.2@webkit-2025.11-embargoed (6c8a256d475b). <a href="https://rdar.apple.com/137178583">rdar://137178583</a>

    [SVG] Don&apos;t repaint when referenced resources change if the renderer is not in-tree yet
    <a href="https://bugs.webkit.org/show_bug.cgi?id=301140">https://bugs.webkit.org/show_bug.cgi?id=301140</a>
    <a href="https://rdar.apple.com/137178583">rdar://137178583</a>

    Reviewed by Alan Baradlay.

    When moving svg resources around it&apos;s possible to end up
    triggering a repaint before the renderer is in-tree. To
    fix that, add API for blocking repaints and start using that
    while in RenderTreeBuilder::Inline::splitFlow.

    Test: svg/filters/filter-insert-button-crash.html

    * LayoutTests/svg/filters/filter-insert-button-crash-expected.txt: Added.
    * LayoutTests/svg/filters/filter-insert-button-crash.html: Added.
    * Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
    (WebCore::RepaintBlocker::RepaintBlocker):
    (WebCore::RepaintBlocker::~RepaintBlocker):
    * Source/WebCore/page/LocalFrameViewLayoutContext.h:
    * Source/WebCore/rendering/RenderObject.cpp:
    (WebCore::RenderObject::repaint const):
    * Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
    (WebCore::RenderTreeBuilder::Inline::splitFlow):

    Canonical link: <a href="https://commits.webkit.org/302196.2@webkit-2025.11-embargoed">https://commits.webkit.org/302196.2@webkit-2025.11-embargoed</a>

Originally-landed-as: 301765.361@safari-7623-branch (e218dd58cf7e). <a href="https://rdar.apple.com/171559006">rdar://171559006</a>
Canonical link: <a href="https://commits.webkit.org/308852@main">https://commits.webkit.org/308852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a1547f999aa3e545ae64bace4ecb489634fbb66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157285 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102031 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/03bd6b73-ae7c-4bc3-a41a-392e2d48dc0c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21766 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114555 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81566 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6011fddd-e760-428f-b83a-3ab665d6fca5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151561 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16754 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133395 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95325 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a25e7ee3-c161-4563-a4bb-983ac44f2db4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15857 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13710 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4721 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140568 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125471 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159620 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9388 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2761 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12832 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122613 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17708 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122838 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33415 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133105 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77253 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18154 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9870 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180029 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20725 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84528 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46081 "Found 10 new JSC stress test failures: stress/map-forEach.js.bytecode-cache, stress/map-forEach.js.default, stress/map-forEach.js.dfg-eager, stress/map-forEach.js.dfg-eager-no-cjit-validate, stress/map-forEach.js.eager-jettison-no-cjit, stress/map-forEach.js.mini-mode, stress/map-forEach.js.no-cjit-collect-continuously, stress/map-forEach.js.no-cjit-validate-phases, stress/map-forEach.js.no-llint, stress/stack-overflow-llint-large-params-and-large-locals.js.no-llint (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20458 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20604 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20514 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->