### PR TITLE
[Cocoa]  Limit playback rate of spotify.com HLS streams to avoid stutter

### DIFF
--- a/LayoutTests/http/tests/media/hls/hls-limit-play-rate-expected.txt
+++ b/LayoutTests/http/tests/media/hls/hls-limit-play-rate-expected.txt
@@ -1,0 +1,25 @@
+
+RUN(video.defaultPlaybackRate = 2.1)
+EVENT(ratechange)
+EXPECTED (video.defaultPlaybackRate == '2.1') OK
+EXPECTED (video.playbackRate == '1') OK
+
+RUN(video.playbackRate = 2.1)
+EVENT(ratechange)
+EXPECTED (video.defaultPlaybackRate == '2.1') OK
+EXPECTED (video.playbackRate == '2.1') OK
+
+RUN(video.src = '../resources/hls/audio-tracks.m3u8')
+EVENT(canplaythrough)
+EXPECTED (video.playbackRate == '2') OK
+
+RUN(video.playbackRate = 1)
+EVENT(ratechange)
+EXPECTED (video.playbackRate == '1') OK
+
+RUN(video.playbackRate = 2.5)
+EVENT(ratechange)
+EXPECTED (video.playbackRate == '2') OK
+
+END OF TEST
+

--- a/LayoutTests/http/tests/media/hls/hls-limit-play-rate.html
+++ b/LayoutTests/http/tests/media/hls/hls-limit-play-rate.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <script src=../../media-resources/video-test.js></script>
+        <script>
+            if (window.testRunner) {
+                testRunner.dumpAsText();
+                testRunner.setAlwaysAcceptCookies(true);
+                testRunner.waitUntilDone();
+            }
+            async function start() 
+            {
+                setTimeout(function () {
+                    consoleWrite("FAIL: test timed out.");
+                    endTest();
+                }, 20000);
+
+                video = document.getElementById('video');
+                window.internals?.setTopDocumentURLForQuirks("https://open.spotify.com");
+
+                waitForEvent('error', () => {
+                    consoleWrite(`video.error = ${video.error ? video.error.code : 'null'}`);
+                });
+
+                // We can't detect HLS before HAVE_METADATA, so setting high defaultPlaybackRate
+                // and playbackRate should be possible.
+                run(`video.defaultPlaybackRate = 2.1`);
+                await waitFor(video, 'ratechange');
+                testExpected(`video.defaultPlaybackRate`, 2.1, '==');
+                testExpected(`video.playbackRate`, 1.0, '==');
+
+                consoleWrite(``);
+                run(`video.playbackRate = 2.1`);
+                await waitFor(video, 'ratechange');
+                testExpected(`video.defaultPlaybackRate`, 2.1, '==');
+                testExpected(`video.playbackRate`, 2.1, '==');
+
+                // Once the file loads and we know it is HLS, the rate should be reset
+                // to 2.0
+                consoleWrite(``);
+                run(`video.src = '../resources/hls/audio-tracks.m3u8'`);
+                await waitFor(video, 'canplaythrough');
+                testExpected(`video.playbackRate`, 2, '==');
+
+                consoleWrite(``);
+                run(`video.playbackRate = 1`);
+                await waitFor(video, 'ratechange');
+                testExpected(`video.playbackRate`, 1, '==');
+
+                consoleWrite(``);
+                run(`video.playbackRate = 2.5`);
+                await waitFor(video, 'ratechange');
+                testExpected(`video.playbackRate`, 2, '==');
+
+                consoleWrite(``);
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video id='video' controls></video>
+    </body>
+</html>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1628,6 +1628,9 @@ webkit.org/b/228189 http/tests/media/hls/hls-webvtt-seek-backwards.html [ Pass T
 
 webkit.org/b/230411 http/tests/media/hls/video-controller-getStartDate.html [ Pass Failure ]
 
+# HLS stream fails to become ready to play on headless bots
+http/tests/media/hls/hls-limit-play-rate.html
+
 # rdar://65641438 ([WebGL2] tex-srgb-mipmap test fails on macOS Intel + iOS (but passes on macOS Apple Silicon) (214392))
 [ arm64 ] webgl/2.0.0/conformance2/textures/misc/tex-srgb-mipmap.html [ Failure ]
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -278,6 +278,8 @@ static const double AutoplayInterferenceTimeThreshold = 10;
 static const Seconds hideMediaControlsAfterEndedDelay { 6_s };
 static const Seconds WatchtimeTimerInterval { 5_min };
 
+static constexpr double maximumHLSPlaybackRate = 2;
+
 #if ENABLE(MEDIA_SOURCE)
 // URL protocol used to signal that the media source API is being used.
 static constexpr auto mediaSourceBlobProtocol = "blob"_s;
@@ -3319,6 +3321,9 @@ void HTMLMediaElement::setReadyState(MediaPlayer::ReadyState state)
             scheduleResizeEvent(player->naturalSize());
             scheduleEvent(eventNames().loadedmetadataEvent);
 
+            if (m_requestedPlaybackRate > maximumHLSPlaybackRate && protect(document())->quirks().shouldLimitHLSPlaybackRate() && movieLoadType() == HTMLMediaElement::MovieLoadType::HttpLiveStream)
+                setPlaybackRate(m_requestedPlaybackRate);
+
             if (m_defaultPlaybackStartPosition > MediaTime::zeroTime()) {
                 // We reset it before to cause currentMediaTime() to return the actual current time (not
                 // defaultPlaybackPosition) and avoid the seek code to think that the seek was already done.
@@ -4350,6 +4355,11 @@ void HTMLMediaElement::setPlaybackRate(double rate)
     if (m_mediaStreamSrcObject)
         return;
 #endif
+
+    if (rate > maximumHLSPlaybackRate && protect(document())->quirks().shouldLimitHLSPlaybackRate() && movieLoadType() == HTMLMediaElement::MovieLoadType::HttpLiveStream) {
+        ALWAYS_LOG(LOGIDENTIFIER, "Limiting rate to ", maximumHLSPlaybackRate);
+        rate = maximumHLSPlaybackRate;
+    }
 
     if (m_player && potentiallyPlaying() && !m_mediaController)
         RefPtr { m_player }->setRate(rate);

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2090,6 +2090,14 @@ bool Quirks::needsMozillaFileTypeForDataTransfer() const
     return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsMozillaFileTypeForDataTransferQuirk);
 }
 
+// spotify.com rdar://171119015
+bool Quirks::shouldLimitHLSPlaybackRate() const
+{
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldLimitHLSPlaybackRate);
+}
+
 // spotify.com rdar://140707449
 bool Quirks::shouldAvoidStartingSelectionOnMouseDownOverPointerCursor(const Node& target) const
 {
@@ -3223,6 +3231,7 @@ static void handleSpotifyQuirks(QuirksData& quirksData, const URL& quirksURL, co
         // spotify.com rdar://138918575
         QuirksData::SiteSpecificQuirk::NeedsBodyScrollbarWidthNoneDisabledQuirk,
         QuirksData::SiteSpecificQuirk::ShouldAvoidStartingSelectionOnMouseDownOverPointerCursor,
+        QuirksData::SiteSpecificQuirk::ShouldLimitHLSPlaybackRate,
     });
 }
 

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -324,6 +324,8 @@ public:
 
     bool shouldComparareUsedValuesForBorderWidthForTriggeringTransitions() const;
 
+    bool shouldLimitHLSPlaybackRate() const;
+
     void determineRelevantQuirks();
 
 private:

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -243,6 +243,7 @@ struct QuirksData {
 #if PLATFORM(IOS_FAMILY)
         NeedsChromeOSNavigatorUserAgentQuirk,
 #endif
+        ShouldLimitHLSPlaybackRate,
 
         NumberOfQuirks
     };


### PR DESCRIPTION
#### d1cf1ce59abb8c7e1a1f64efdeb4f50d8c9f83ce
<pre>
[Cocoa]  Limit playback rate of spotify.com HLS streams to avoid stutter
<a href="https://bugs.webkit.org/show_bug.cgi?id=309378">https://bugs.webkit.org/show_bug.cgi?id=309378</a>
<a href="https://rdar.apple.com/171119015">rdar://171119015</a>

Reviewed by Andy Estes.

When the playback rate of an HLS stream is greater than 2.0, it enters iframe-only mode.
If a stream does not have an iframe-only variant, it speeds up playback by pausing, seeking,
playing, causing the audio to &quot;stutter&quot;.

Spotify HLS streams do not have iframe variants, so add a quirk to limit the maximum
playback rate of their HLS streams to 2.0.

Test: http/tests/media/hls/hls-limit-play-rate.html

* LayoutTests/http/tests/media/hls/hls-limit-play-rate-expected.txt: Added.
* LayoutTests/http/tests/media/hls/hls-limit-play-rate.html: Added.
* LayoutTests/platform/mac/TestExpectations: The HLS stream fails to become ready to play
on headless machines and times out. Not all macOS EWS have monitors or headless adapters,
so skip the test on macOS for now.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setReadyState):
(WebCore::HTMLMediaElement::setPlaybackRate):
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldLimitHLSPlaybackRate const):
(WebCore::handleSpotifyQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/308983@main">https://commits.webkit.org/308983@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d50277650b831b034644f804d5a508ba5b0c758

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148950 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157638 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102380 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21541 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114829 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81767 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13e01138-e249-4c4a-8758-f8b5a1067d9a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151910 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133688 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95587 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16131 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13989 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5486 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125733 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160119 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3110 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13131 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122885 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123113 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33493 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21473 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133403 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77661 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18400 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10165 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21075 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84877 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20807 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20955 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20863 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->