### PR TITLE
[IndexedDB] Recover IndexedDB connections after network process crash without page reload

### DIFF
--- a/LayoutTests/storage/indexeddb/modern/idb-operations-during-network-process-crash-expected.txt
+++ b/LayoutTests/storage/indexeddb/modern/idb-operations-during-network-process-crash-expected.txt
@@ -1,0 +1,12 @@
+Database opened successfully
+Initial write completed, terminating network process
+Database connection closed by crash
+Attempting recovery without page reload
+PASS window.indexedDB is the same object after crash
+PASS Test A: Existing connection is dead (InvalidStateError)
+PASS Test B: Re-opened database and read back data
+PASS Test C: Created and wrote to a brand new database
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This test verifies IndexedDB recovers after the network process is terminated while active operations are in progress. New indexedDB.open() calls should succeed without a page reload.

--- a/LayoutTests/storage/indexeddb/modern/idb-operations-during-network-process-crash.html
+++ b/LayoutTests/storage/indexeddb/modern/idb-operations-during-network-process-crash.html
@@ -1,0 +1,143 @@
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/shared.js"></script>
+<body>
+<div id="description">
+This test verifies IndexedDB recovers after the network process is terminated
+while active operations are in progress. New indexedDB.open() calls should
+succeed without a page reload.
+</div>
+</body>
+<script>
+
+var db;
+var dbname = setDBNameFromPath() + Date.now();
+var objectStoreName = "testStore";
+var idbRef = window.indexedDB;
+
+// Phase 1: Open database and populate it with initial data.
+function setupDatabase()
+{
+    var request = indexedDB.open(dbname, 1);
+    request.onupgradeneeded = function(event) {
+        db = event.target.result;
+        db.createObjectStore(objectStoreName, { keyPath: "id" });
+    };
+
+    request.onsuccess = function(event) {
+        db = event.target.result;
+        debug("Database opened successfully");
+
+        var tx = db.transaction(objectStoreName, "readwrite");
+        tx.objectStore(objectStoreName).put({ id: "key1", value: "value1" });
+        tx.oncomplete = function() {
+            debug("Initial write completed, terminating network process");
+
+            // Keep db open and listen for onclose as crash signal.
+            db.onclose = function() {
+                debug("Database connection closed by crash");
+                attemptRecovery();
+            };
+
+            if (window.testRunner)
+                testRunner.terminateNetworkProcess();
+        };
+    };
+
+    request.onerror = function(event) {
+        testFailed("Failed to open database: " + event.target.error);
+        finishJSTest();
+    };
+}
+
+// Phase 2: After the crash, attempt to use IndexedDB again WITHOUT reloading.
+function attemptRecovery()
+{
+    debug("Attempting recovery without page reload");
+
+    // Verify window.indexedDB identity.
+    if (idbRef !== window.indexedDB) {
+        testFailed("window.indexedDB returned a different object after crash");
+        finishJSTest();
+        return;
+    }
+    testPassed("window.indexedDB is the same object after crash");
+
+    // Test A: Existing db handle should be dead.
+    try {
+        db.transaction(objectStoreName, "readonly");
+        testFailed("Test A: Transaction on dead connection should have thrown");
+    } catch (e) {
+        testPassed("Test A: Existing connection is dead (" + e.name + ")");
+    }
+
+    // Test B: Re-open the same database with a fresh indexedDB.open().
+    var request = indexedDB.open(dbname, 1);
+    request.onsuccess = function(event) {
+        var newDb = event.target.result;
+        var tx = newDb.transaction(objectStoreName, "readonly");
+        var getReq = tx.objectStore(objectStoreName).get("key1");
+
+        tx.oncomplete = function() {
+            if (getReq.result && getReq.result.value === "value1")
+                testPassed("Test B: Re-opened database and read back data");
+            else
+                testFailed("Test B: Data mismatch: " + JSON.stringify(getReq.result));
+            newDb.close();
+            attemptNewDatabaseOpen();
+        };
+
+        tx.onerror = function(event) {
+            testFailed("Test B: Transaction error: " + event.target.error);
+            newDb.close();
+            attemptNewDatabaseOpen();
+        };
+    };
+
+    request.onerror = function(event) {
+        testFailed("Test B: Failed to re-open database: " + event.target.error);
+        attemptNewDatabaseOpen();
+    };
+}
+
+// Test C: Open an entirely new database.
+function attemptNewDatabaseOpen()
+{
+    var newDbName = dbname + "-recovery";
+    var request = indexedDB.open(newDbName, 1);
+
+    request.onupgradeneeded = function(event) {
+        event.target.result.createObjectStore("recoveryStore", { keyPath: "id" });
+    };
+
+    request.onsuccess = function(event) {
+        var newDb = event.target.result;
+        var tx = newDb.transaction("recoveryStore", "readwrite");
+        tx.objectStore("recoveryStore").put({ id: "test", value: "recovery-succeeded" });
+
+        tx.oncomplete = function() {
+            testPassed("Test C: Created and wrote to a brand new database");
+            newDb.close();
+            finishJSTest();
+        };
+
+        tx.onerror = function(event) {
+            testFailed("Test C: Write error: " + event.target.error);
+            newDb.close();
+            finishJSTest();
+        };
+    };
+
+    request.onerror = function(event) {
+        testFailed("Test C: Failed to open new database: " + event.target.error);
+        finishJSTest();
+    };
+}
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+setupDatabase();
+
+</script>

--- a/LayoutTests/storage/indexeddb/modern/opendatabase-after-storage-crash-expected.txt
+++ b/LayoutTests/storage/indexeddb/modern/opendatabase-after-storage-crash-expected.txt
@@ -1,2 +1,5 @@
-PASS localStorage[storageKey] is "Made it"
-Successfully opened database with version 3.
+Database connection closed by network process crash.
+PASS window.indexedDB is the same object after crash
+Successfully opened database with version 2 after network process crash.
+PASS indexedDB.open() recovered after network process crash without page reload
+This test verifies when the network process crashes, indexedDB.open() recovers without a page reload.

--- a/LayoutTests/storage/indexeddb/modern/opendatabase-after-storage-crash.html
+++ b/LayoutTests/storage/indexeddb/modern/opendatabase-after-storage-crash.html
@@ -1,80 +1,58 @@
 <script src="../../../resources/js-test.js"></script>
 <script src="../resources/shared.js"></script>
 <body>
-This test verifies when storage process crashes, indexedDB operation should not hang indefinitely.
+This test verifies when the network process crashes, indexedDB.open() recovers without a page reload.
 </body>
 <script>
 
 var dbname = setDBNameFromPath() + Date();
-var storageKey = "opendatabase-after-storage-crash.html";
+var idbRef = window.indexedDB;
 
-function continueTest()
-{
-	var request = window.indexedDB.open(dbname, 2);
-	request.onupgradeneeded = function(e) {
-		document.body.innerHTML = "Unexpected upgradeneeded after storage process termination. Database: name " + dbname + ", version 2.";
-		if (window.testRunner)
-			testRunner.notifyDone();
-	}
-
-	request.onerror = function(e) {
-		// Good, we received an expected error.
-		// Now reload to see if a new document connects successfully
-		if (localStorage[storageKey]) {
-			document.body.innerHTML = "Received error more than once unexpectedly. Database: name " + dbname + ", version 2.";
-			if (window.testRunner)
-				testRunner.notifyDone();
-			return;
-		}
-
-		localStorage[storageKey] = "Made it";
-		location.reload();
-	}
-
-	request.onsuccess = function(e) {
-		document.body.innerHTML = "Unexpected upgradeneeded after storage process termination. Database: name " + dbname + ", version 2. localStorage value: " + sessionStorage[storageKey] + ".";
-		if (window.testRunner)
-			testRunner.notifyDone();
-	}
-}
-
-var versionToOpen = localStorage.doneFirstLoad ? 3 : 1;
-var request = window.indexedDB.open(dbname, versionToOpen);
+var request = window.indexedDB.open(dbname, 1);
 
 request.onupgradeneeded = function(e) {
-	if (localStorage.doneFirstLoad) {
-		document.body.innerHTML = "Successfully opened database with version " + versionToOpen + ".";
-		shouldBeEqualToString('localStorage[storageKey]', 'Made it');
-
-		if (window.testRunner) {
-			testRunner.notifyDone();
-			return;
-		}
-	}
-
-	localStorage.doneFirstLoad = true;
-
-	// Set an error handler on the database connection so once the storage process terminates we know to continue the test
-	e.target.result.onerror = function(e) {
-		setTimeout(continueTest, 0);
-	}
-
-	if (window.testRunner) {
-		testRunner.waitUntilDone();
-		// Make sure localStorage is flushed to disk before crashing network process.
-		testRunner.syncLocalStorage();
-		testRunner.terminateNetworkProcess();
-	}
-}
-
-request.onerror = function(e) {
-	if (versionToOpen == 1)
-		document.body.innerHTML = "Error on opening reuqest for database version 1. (FAIL: test should stop at opening version 3.)"; 
+    e.target.result.createObjectStore("test");
 }
 
 request.onsuccess = function(e) {
-	if (versionToOpen == 1)
-		document.body.innerHTML = "Success on opening reuqest for database version 1. (FAIL: test should stop at opening version 3.)";
+    var db = e.target.result;
+    // Keep the database open so we receive the onclose event on crash.
+    db.onclose = function() {
+        debug("Database connection closed by network process crash.");
+
+        if (idbRef !== window.indexedDB) {
+            testFailed("window.indexedDB returned a different object after crash");
+            if (window.testRunner)
+                testRunner.notifyDone();
+            return;
+        }
+        testPassed("window.indexedDB is the same object after crash");
+
+        var reopenRequest = window.indexedDB.open(dbname, 2);
+        reopenRequest.onupgradeneeded = function(e) {
+            debug("Successfully opened database with version 2 after network process crash.");
+            testPassed("indexedDB.open() recovered after network process crash without page reload");
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+
+        reopenRequest.onerror = function(e) {
+            testFailed("indexedDB.open() failed after network process crash: " + e.target.error);
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+    };
+
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.terminateNetworkProcess();
+    }
+}
+
+request.onerror = function(e) {
+    testFailed("Error on initial database open: " + e.target.error);
+    if (window.testRunner)
+        testRunner.notifyDone();
 }
 
 </script>

--- a/LayoutTests/storage/indexeddb/modern/resources/worker-idb-after-network-crash.js
+++ b/LayoutTests/storage/indexeddb/modern/resources/worker-idb-after-network-crash.js
@@ -1,0 +1,60 @@
+// Worker script for testing IndexedDB recovery after network process crash.
+var dbname = "worker-idb-crash-test-" + Date.now();
+
+self.onmessage = function(event) {
+    if (event.data === "open-db")
+        openInitialDatabase();
+    else if (event.data === "idb-after-crash")
+        attemptRecoveryOpen();
+};
+
+function openInitialDatabase()
+{
+    var request = indexedDB.open(dbname, 1);
+    request.onupgradeneeded = function(e) {
+        e.target.result.createObjectStore("store", { keyPath: "id" });
+    };
+    request.onsuccess = function(e) {
+        var db = e.target.result;
+        var tx = db.transaction("store", "readwrite");
+        tx.objectStore("store").put({ id: "key1", value: "hello" });
+        tx.oncomplete = function() {
+            // Keep DB open — main page will use its own onclose as the crash signal.
+            self.postMessage("db-ready");
+        };
+        tx.onerror = function(e) {
+            self.postMessage("recovery-fail:initial write: " + e.target.error);
+        };
+    };
+    request.onerror = function(e) {
+        self.postMessage("recovery-fail:initial open: " + e.target.error);
+    };
+}
+
+function attemptRecoveryOpen()
+{
+    var newDbName = dbname + "-after-crash";
+    var request = indexedDB.open(newDbName, 1);
+
+    request.onupgradeneeded = function(e) {
+        e.target.result.createObjectStore("recoveryStore", { keyPath: "id" });
+    };
+
+    request.onsuccess = function(e) {
+        var db = e.target.result;
+        var tx = db.transaction("recoveryStore", "readwrite");
+        tx.objectStore("recoveryStore").put({ id: "recovered", value: "it works" });
+        tx.oncomplete = function() {
+            db.close();
+            self.postMessage("recovery-ok");
+        };
+        tx.onerror = function(e) {
+            db.close();
+            self.postMessage("recovery-fail:write tx: " + e.target.error);
+        };
+    };
+
+    request.onerror = function(e) {
+        self.postMessage("recovery-fail:open: " + e.target.error);
+    };
+}

--- a/LayoutTests/storage/indexeddb/modern/worker-idb-after-network-crash-expected.txt
+++ b/LayoutTests/storage/indexeddb/modern/worker-idb-after-network-crash-expected.txt
@@ -1,0 +1,12 @@
+Starting worker and asking it to open an IDB database.
+[Worker] db-ready
+Worker has an open IDB connection. Opening main page DB before crash.
+Terminating network process.
+Main page DB closed by crash. Verifying main page recovery...
+Main page IDB recovered. Now testing worker...
+[Worker] recovery-ok
+PASS Worker opened a new IndexedDB database after network process crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This test verifies that IndexedDB operations in a dedicated worker recover after the network process is terminated, without needing to recreate the worker.

--- a/LayoutTests/storage/indexeddb/modern/worker-idb-after-network-crash.html
+++ b/LayoutTests/storage/indexeddb/modern/worker-idb-after-network-crash.html
@@ -1,0 +1,87 @@
+<script src="../../../resources/js-test.js"></script>
+<script src="../resources/shared.js"></script>
+<body>
+<div id="description">
+This test verifies that IndexedDB operations in a dedicated worker recover after
+the network process is terminated, without needing to recreate the worker.
+</div>
+</body>
+<script>
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+var worker = new Worker("resources/worker-idb-after-network-crash.js");
+var mainDb;
+
+worker.onmessage = function(event)
+{
+    var data = event.data;
+    debug("[Worker] " + data);
+
+    if (data === "db-ready") {
+        debug("Worker has an open IDB connection. Opening main page DB before crash.");
+
+        // Open a main-page database so we can use its onclose as crash signal.
+        var request = indexedDB.open("main-page-crash-signal-" + Date.now(), 1);
+        request.onupgradeneeded = function(e) {
+            e.target.result.createObjectStore("test", { keyPath: "id" });
+        };
+        request.onsuccess = function(e) {
+            mainDb = e.target.result;
+            mainDb.onclose = function() {
+                debug("Main page DB closed by crash. Verifying main page recovery...");
+                verifyMainPageRecovery();
+            };
+
+            debug("Terminating network process.");
+            if (window.testRunner)
+                testRunner.terminateNetworkProcess();
+        };
+        request.onerror = function(e) {
+            testFailed("Failed to open main page signal DB: " + e.target.error);
+            finishJSTest();
+        };
+
+    } else if (data === "recovery-ok") {
+        testPassed("Worker opened a new IndexedDB database after network process crash");
+        worker.terminate();
+        finishJSTest();
+
+    } else if (data.indexOf("recovery-fail:") === 0) {
+        testFailed("Worker IndexedDB recovery failed: " + data.substring("recovery-fail:".length));
+        worker.terminate();
+        finishJSTest();
+    }
+};
+
+worker.onerror = function(event)
+{
+    testFailed("Worker error: " + event.message);
+    finishJSTest();
+};
+
+function verifyMainPageRecovery()
+{
+    var request = indexedDB.open("main-page-recovery-test-" + Date.now(), 1);
+    request.onupgradeneeded = function(e) {
+        e.target.result.createObjectStore("test", { keyPath: "id" });
+    };
+    request.onsuccess = function(e) {
+        var db = e.target.result;
+        db.close();
+        debug("Main page IDB recovered. Now testing worker...");
+        worker.postMessage("idb-after-crash");
+    };
+    request.onerror = function(e) {
+        testFailed("Main page IDB recovery failed: " + e.target.error);
+        finishJSTest();
+    };
+}
+
+debug("Starting worker and asking it to open an IDB database.");
+worker.postMessage("open-db");
+
+</script>

--- a/Source/WebCore/Modules/indexeddb/IDBFactory.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBFactory.cpp
@@ -80,8 +80,17 @@ ExceptionOr<Ref<IDBOpenDBRequest>> IDBFactory::open(ScriptExecutionContext& cont
     return openInternal(context, name, version.value_or(0));
 }
 
+Ref<IDBClient::IDBConnectionProxy> IDBFactory::ensureConnectionProxy(ScriptExecutionContext& context)
+{
+    if (RefPtr currentProxy = context.idbConnectionProxy(); currentProxy && currentProxy != m_connectionProxy.ptr())
+        m_connectionProxy = *currentProxy;
+    return m_connectionProxy;
+}
+
 ExceptionOr<Ref<IDBOpenDBRequest>> IDBFactory::openInternal(ScriptExecutionContext& context, const String& name, uint64_t version)
 {
+    Ref connectionProxy = ensureConnectionProxy(context);
+
     if (name.isNull())
         return Exception { ExceptionCode::TypeError, "IDBFactory.open() called without a database name"_s };
 
@@ -96,12 +105,14 @@ ExceptionOr<Ref<IDBOpenDBRequest>> IDBFactory::openInternal(ScriptExecutionConte
 
     LOG(IndexedDBOperations, "IDB opening database: %s %" PRIu64, name.utf8().data(), version);
 
-    return m_connectionProxy->openDatabase(context, databaseIdentifier, version);
+    return connectionProxy->openDatabase(context, databaseIdentifier, version);
 }
 
 ExceptionOr<Ref<IDBOpenDBRequest>> IDBFactory::deleteDatabase(ScriptExecutionContext& context, const String& name)
 {
     LOG(IndexedDB, "IDBFactory::deleteDatabase - %s", name.utf8().data());
+
+    Ref connectionProxy = ensureConnectionProxy(context);
 
     if (name.isNull())
         return Exception { ExceptionCode::TypeError, "IDBFactory.deleteDatabase() called without a database name"_s };
@@ -117,7 +128,7 @@ ExceptionOr<Ref<IDBOpenDBRequest>> IDBFactory::deleteDatabase(ScriptExecutionCon
 
     LOG(IndexedDBOperations, "IDB deleting database: %s", name.utf8().data());
 
-    return m_connectionProxy->deleteDatabase(context, databaseIdentifier);
+    return connectionProxy->deleteDatabase(context, databaseIdentifier);
 }
 
 ExceptionOr<short> IDBFactory::cmp(JSGlobalObject& execState, JSValue firstValue, JSValue secondValue)
@@ -140,6 +151,8 @@ void IDBFactory::databases(ScriptExecutionContext& context, IDBDatabasesResponse
 {
     LOG(IndexedDB, "IDBFactory::databases");
 
+    Ref connectionProxy = ensureConnectionProxy(context);
+
     if (shouldThrowSecurityException(context)) {
         promise.reject(ExceptionCode::SecurityError);
         return;
@@ -147,7 +160,7 @@ void IDBFactory::databases(ScriptExecutionContext& context, IDBDatabasesResponse
 
     ASSERT(context.securityOrigin());
 
-    m_connectionProxy->getAllDatabaseNamesAndVersions(context, [promise = WTF::move(promise)](auto&& result) mutable {
+    connectionProxy->getAllDatabaseNamesAndVersions(context, [promise = WTF::move(promise)](auto&& result) mutable {
         if (!result) {
             promise.reject(Exception { ExceptionCode::UnknownError });
             return;
@@ -161,7 +174,9 @@ void IDBFactory::databases(ScriptExecutionContext& context, IDBDatabasesResponse
 
 void IDBFactory::getAllDatabaseNames(ScriptExecutionContext& context, Function<void(const Vector<String>&)>&& callback)
 {
-    m_connectionProxy->getAllDatabaseNamesAndVersions(context, [callback = WTF::move(callback)](auto&& result) mutable {
+    Ref connectionProxy = ensureConnectionProxy(context);
+
+    connectionProxy->getAllDatabaseNamesAndVersions(context, [callback = WTF::move(callback)](auto&& result) mutable {
         if (!result) {
             callback({ });
             return;

--- a/Source/WebCore/Modules/indexeddb/IDBFactory.h
+++ b/Source/WebCore/Modules/indexeddb/IDBFactory.h
@@ -76,8 +76,9 @@ private:
     explicit IDBFactory(IDBClient::IDBConnectionProxy&);
 
     ExceptionOr<Ref<IDBOpenDBRequest>> openInternal(ScriptExecutionContext&, const String& name, uint64_t version);
+    Ref<IDBClient::IDBConnectionProxy> ensureConnectionProxy(ScriptExecutionContext&);
 
-    const Ref<IDBClient::IDBConnectionProxy> m_connectionProxy;
+    Ref<IDBClient::IDBConnectionProxy> m_connectionProxy;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4960,6 +4960,11 @@ IDBClient::IDBConnectionProxy* Document::idbConnectionProxy()
     return m_idbConnectionProxy.get();
 }
 
+void Document::clearIDBConnectionProxy()
+{
+    m_idbConnectionProxy = nullptr;
+}
+
 StorageConnection* Document::storageConnection()
 {
     return page() ? &page()->storageConnection() : nullptr;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -917,6 +917,7 @@ public:
     bool requiresTrustedTypes() const { return m_requiresTrustedTypes && !shouldBypassMainWorldContentSecurityPolicy(); }
 
     IDBClient::IDBConnectionProxy* idbConnectionProxy() final;
+    void clearIDBConnectionProxy();
     StorageConnection* storageConnection();
     SocketProvider* NODELETE socketProvider() final;
     RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -213,6 +213,7 @@
 #include "Widget.h"
 #include "WindowEventLoop.h"
 #include "WindowFeatures.h"
+#include "WorkerGlobalScope.h"
 #include "WorkerOrWorkletScriptController.h"
 #include <JavaScriptCore/VM.h>
 #include <ranges>
@@ -4198,6 +4199,19 @@ IDBClient::IDBConnectionToServer* Page::optionalIDBConnection()
 void Page::clearIDBConnection()
 {
     m_idbConnectionToServer = nullptr;
+}
+
+void Page::clearIDBConnectionOnAllDocuments()
+{
+    clearIDBConnection();
+    forEachDocument([](Document& document) {
+        document.clearIDBConnectionProxy();
+    });
+}
+
+void Page::refreshIDBConnectionForWorkers()
+{
+    WorkerGlobalScope::replaceIDBConnectionProxyOnAllWorkers(idbConnection().proxy());
 }
 
 #if ENABLE(RESOURCE_USAGE)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1076,6 +1076,8 @@ public:
     IDBClient::IDBConnectionToServer& idbConnection();
     WEBCORE_EXPORT IDBClient::IDBConnectionToServer* NODELETE optionalIDBConnection();
     WEBCORE_EXPORT void clearIDBConnection();
+    WEBCORE_EXPORT void clearIDBConnectionOnAllDocuments();
+    WEBCORE_EXPORT void refreshIDBConnectionForWorkers();
 
     void setShowAllPlugins(bool showAll) { m_showAllPlugins = showAll; }
     bool showAllPlugins() const;

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -175,8 +175,8 @@ void WorkerGlobalScope::prepareForDestruction()
     if (settingsValues().serviceWorkersEnabled)
         swClientConnection().unregisterServiceWorkerClient(identifier());
 
-    if (m_connectionProxy)
-        m_connectionProxy->abortActivitiesForCurrentThread();
+    if (RefPtr connectionProxy = m_connectionProxy)
+        connectionProxy->abortActivitiesForCurrentThread();
 
     if (m_storageConnection)
         m_storageConnection->scopeClosed();
@@ -244,6 +244,21 @@ IDBClient::IDBConnectionProxy* WorkerGlobalScope::idbConnectionProxy()
     return m_connectionProxy.get();
 }
 
+void WorkerGlobalScope::replaceIDBConnectionProxy(RefPtr<IDBClient::IDBConnectionProxy>&& proxy)
+{
+    m_connectionProxy = WTF::move(proxy);
+}
+
+void WorkerGlobalScope::replaceIDBConnectionProxyOnAllWorkers(RefPtr<IDBClient::IDBConnectionProxy>&& proxy)
+{
+    Locker locker { allWorkerGlobalScopeIdentifiersLock };
+    for (auto& globalScopeIdentifier : allWorkerGlobalScopeIdentifiers()) {
+        postTaskTo(globalScopeIdentifier, [proxy](auto& context) {
+            downcast<WorkerGlobalScope>(context).replaceIDBConnectionProxy(RefPtr { proxy });
+        });
+    }
+}
+
 GraphicsClient* WorkerGlobalScope::graphicsClient()
 {
     return workerClient();
@@ -251,8 +266,8 @@ GraphicsClient* WorkerGlobalScope::graphicsClient()
 
 void WorkerGlobalScope::suspend()
 {
-    if (m_connectionProxy)
-        m_connectionProxy->setContextSuspended(*this, true);
+    if (RefPtr connectionProxy = m_connectionProxy)
+        connectionProxy->setContextSuspended(*this, true);
 
     if (settingsValues().serviceWorkersEnabled)
         swClientConnection().unregisterServiceWorkerClient(identifier());
@@ -263,8 +278,8 @@ void WorkerGlobalScope::resume()
     if (settingsValues().serviceWorkersEnabled)
         updateServiceWorkerClientData();
 
-    if (m_connectionProxy)
-        m_connectionProxy->setContextSuspended(*this, false);
+    if (RefPtr connectionProxy = m_connectionProxy)
+        connectionProxy->setContextSuspended(*this, false);
 }
 
 WorkerStorageConnection& WorkerGlobalScope::storageConnection()

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -97,6 +97,8 @@ public:
     const String& inspectorIdentifier() const LIFETIME_BOUND { return m_inspectorIdentifier; }
 
     IDBClient::IDBConnectionProxy* NODELETE idbConnectionProxy() final;
+    void replaceIDBConnectionProxy(RefPtr<IDBClient::IDBConnectionProxy>&&);
+    WEBCORE_EXPORT static void replaceIDBConnectionProxyOnAllWorkers(RefPtr<IDBClient::IDBConnectionProxy>&&);
     void suspend() final;
     void resume() final;
     GraphicsClient* graphicsClient() final;
@@ -229,7 +231,7 @@ private:
 
     const Ref<SecurityOrigin> m_topOrigin;
 
-    const RefPtr<IDBClient::IDBConnectionProxy> m_connectionProxy;
+    RefPtr<IDBClient::IDBConnectionProxy> m_connectionProxy;
 
     const RefPtr<SocketProvider> m_socketProvider;
 

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -223,8 +223,15 @@ void NetworkProcessConnection::didClose(IPC::Connection&)
     Ref<NetworkProcessConnection> protector(*this);
     WebProcess::singleton().networkProcessConnectionClosed(this);
 
-    if (auto idbConnection = std::exchange(m_webIDBConnection, nullptr))
+    if (auto idbConnection = std::exchange(m_webIDBConnection, nullptr)) {
         idbConnection->connectionToServerLost();
+
+        // Mark that workers need their IDB proxies refreshed. The actual refresh
+        // is deferred until the network process is relaunched for another reason
+        // (e.g. a document calling indexedDB.open()), to avoid unnecessarily
+        // relaunching the network process just for workers.
+        WebProcess::singleton().setNeedsIDBConnectionRefreshForWorkers();
+    }
 
     if (auto swConnection = std::exchange(m_swConnection, nullptr))
         swConnection->connectionToServerLost();

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -147,6 +147,7 @@
 #include <WebCore/SharedWorkerThreadProxy.h>
 #include <WebCore/UserGestureIndicator.h>
 #include <WebCore/WebKitJSHandle.h>
+#include <WebCore/WorkerGlobalScope.h>
 #include <algorithm>
 #include <pal/Logging.h>
 #include <wtf/CallbackAggregator.h>
@@ -1398,6 +1399,9 @@ NetworkProcessConnection& WebProcess::ensureNetworkProcessConnection()
             for (auto& webPage : m_pageMap.values())
                 webPage->synchronizeCORSDisablingPatternsWithNetworkProcess();
         });
+
+        if (std::exchange(m_needsIDBConnectionRefreshForWorkers, false))
+            refreshIDBConnectionForWorkers();
     }
     
     return *m_networkProcessConnection;
@@ -1447,7 +1451,7 @@ void WebProcess::networkProcessConnectionClosed(NetworkProcessConnection* connec
         
         if (RefPtr existingIDBConnectionToServer = connection->existingIDBConnectionToServer()) {
             ASSERT_UNUSED(existingIDBConnectionToServer, idbConnection.get() == &existingIDBConnectionToServer->coreConnectionToServer());
-            corePage->clearIDBConnection();
+            corePage->clearIDBConnectionOnAllDocuments();
         }
     }
 
@@ -1491,6 +1495,14 @@ void WebProcess::networkProcessConnectionClosed(NetworkProcessConnection* connec
     for (auto& weakSession : sessions) {
         if (RefPtr webtransportSession = weakSession.get())
             webtransportSession->didFail(std::nullopt, String(emptyString()));
+    }
+}
+
+void WebProcess::refreshIDBConnectionForWorkers()
+{
+    for (auto& page : m_pageMap.values()) {
+        if (RefPtr corePage = page->corePage())
+            corePage->refreshIDBConnectionForWorkers();
     }
 }
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -289,6 +289,8 @@ public:
     NetworkProcessConnection& ensureNetworkProcessConnection();
 
     void networkProcessConnectionClosed(NetworkProcessConnection*);
+    void refreshIDBConnectionForWorkers();
+    void setNeedsIDBConnectionRefreshForWorkers() { m_needsIDBConnectionRefreshForWorkers = true; }
     NetworkProcessConnection* existingNetworkProcessConnection() { return m_networkProcessConnection.get(); }
     WebLoaderStrategy& NODELETE webLoaderStrategy() LIFETIME_BOUND;
     WebFileSystemStorageConnection& fileSystemStorageConnection();
@@ -810,6 +812,7 @@ private:
 
     String m_uiProcessBundleIdentifier;
     RefPtr<NetworkProcessConnection> m_networkProcessConnection;
+    bool m_needsIDBConnectionRefreshForWorkers { false };
     const UniqueRef<WebLoaderStrategy> m_webLoaderStrategy;
     RefPtr<WebFileSystemStorageConnection> m_fileSystemStorageConnection;
 


### PR DESCRIPTION
#### 3c147a65020032532b2d3e4440846e80727b1f86
<pre>
[IndexedDB] Recover IndexedDB connections after network process crash without page reload
<a href="https://bugs.webkit.org/show_bug.cgi?id=309386">https://bugs.webkit.org/show_bug.cgi?id=309386</a>
<a href="https://rdar.apple.com/171932720">rdar://171932720</a>

Reviewed by Sihui Liu.

When the network process crashes, all IDB connections become invalid. Previously
this required a page reload to re-establish IndexedDB access. This change makes
recovery automatic by clearing and lazily recreating the IDB connection proxy at
each layer of the stack.

On crash, networkProcessConnectionClosed now calls clearIDBConnectionOnAllDocuments
(replacing clearIDBConnection) so each Document&apos;s cached m_idbConnectionProxy is
nulled out alongside the Page&apos;s own connection. On the next indexedDB access,
Document::idbConnectionProxy() lazily recreates the proxy from the Page&apos;s freshly
established IDB connection.

IDBFactory (window.indexedDB) stays alive across crashes to satisfy the spec
requirement that it always returns the same object. Each IDBFactory entry point
calls ensureConnectionProxy(), which detects when the ScriptExecutionContext&apos;s
proxy has changed (because the Document re-derived it from a new Page connection)
and swaps in the new proxy.

Worker proxy refresh is deferred: NetworkProcessConnection::didClose sets a
m_needsIDBConnectionRefreshForWorkers flag on WebProcess rather than refreshing
immediately, to avoid relaunching the network process just for workers. When the
network process is relaunched for another reason (e.g. a document calling
indexedDB.open()), ensureNetworkProcessConnection drains the flag and pushes the
new proxy to all workers via replaceIDBConnectionProxyOnAllWorkers.

Open IDBDatabase connections receive an onclose event when the network process
terminates, which tests use as a reliable signal that crash processing is complete.

Tests: storage/indexeddb/modern/idb-operations-during-network-process-crash.html
       storage/indexeddb/modern/worker-idb-after-network-crash.html

* LayoutTests/storage/indexeddb/modern/idb-operations-during-network-process-crash-expected.txt: Added.
* LayoutTests/storage/indexeddb/modern/idb-operations-during-network-process-crash.html: Added.
* LayoutTests/storage/indexeddb/modern/opendatabase-after-storage-crash-expected.txt:
* LayoutTests/storage/indexeddb/modern/opendatabase-after-storage-crash.html:
* LayoutTests/storage/indexeddb/modern/resources/worker-idb-after-network-crash.js: Added.
(self.onmessage):
(openInitialDatabase.request.onupgradeneeded):
(openInitialDatabase.tx.oncomplete):
(openInitialDatabase.tx.onerror):
(openInitialDatabase.request.onsuccess):
(openInitialDatabase.request.onerror):
(openInitialDatabase):
(attemptRecoveryOpen.request.onupgradeneeded):
(attemptRecoveryOpen.tx.oncomplete):
(attemptRecoveryOpen.tx.onerror):
(attemptRecoveryOpen.request.onsuccess):
(attemptRecoveryOpen.request.onerror):
(attemptRecoveryOpen):
* LayoutTests/storage/indexeddb/modern/worker-idb-after-network-crash-expected.txt: Added.
* LayoutTests/storage/indexeddb/modern/worker-idb-after-network-crash.html: Added.
* Source/WebCore/Modules/indexeddb/IDBFactory.cpp:
(WebCore::IDBFactory::ensureConnectionProxy):
(WebCore::IDBFactory::openInternal):
(WebCore::IDBFactory::deleteDatabase):
(WebCore::IDBFactory::databases):
(WebCore::IDBFactory::getAllDatabaseNames):
* Source/WebCore/Modules/indexeddb/IDBFactory.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::clearIDBConnectionProxy):
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::clearIDBConnectionOnAllDocuments):
(WebCore::Page::refreshIDBConnectionForWorkers):
* Source/WebCore/page/Page.h:
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::prepareForDestruction):
(WebCore::WorkerGlobalScope::replaceIDBConnectionProxy):
(WebCore::WorkerGlobalScope::replaceIDBConnectionProxyOnAllWorkers):
(WebCore::WorkerGlobalScope::suspend):
(WebCore::WorkerGlobalScope::resume):
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::didClose):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::ensureNetworkProcessConnection):
(WebKit::WebProcess::networkProcessConnectionClosed):
(WebKit::WebProcess::refreshIDBConnectionForWorkers):
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/309032@main">https://commits.webkit.org/309032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22e1e5c179010ccf23b14001fde93915201d5f01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149164 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21877 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15447 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157852 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102595 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5f98b5a-eaff-49fa-a815-ac6e3a3ed6d0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151037 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21755 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115000 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81857 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8cc57823-358e-4947-83af-985840eaeb36) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152124 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17170 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133858 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95755 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/461ffa3d-5ae9-4ae2-91ba-74684cba6520) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16270 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14143 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5705 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125870 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160337 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3324 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123047 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18178 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123274 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33517 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21687 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133586 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77888 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18523 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10335 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; 12 flakes 20 failures; Uploaded test results; layout-tests (exception)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21289 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85091 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21021 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21169 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21077 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->