### PR TITLE
[WTF] Make Deque branchless

### DIFF
--- a/Source/WTF/wtf/Deque.h
+++ b/Source/WTF/wtf/Deque.h
@@ -33,6 +33,7 @@
 // Deque doesn't actually use Vector.
 
 #include <algorithm>
+#include <bit>
 #include <iterator>
 #include <wtf/Vector.h>
 
@@ -63,7 +64,7 @@ public:
 
     void swap(Deque&);
 
-    size_t size() const { return m_start <= m_end ? m_end - m_start : m_end + m_buffer.capacity() - m_start; }
+    size_t size() const { return (m_end - m_start) & m_capacityMask; }
     bool isEmpty() const { return m_start == m_end; }
 
     iterator begin() LIFETIME_BOUND { return iterator(this, m_start); }
@@ -81,8 +82,8 @@ public:
     const T& first() const LIFETIME_BOUND { return m_buffer.capacitySpan()[m_start]; }
     T takeFirst();
 
-    T& last() LIFETIME_BOUND { return m_end ? m_buffer.capacitySpan()[m_end - 1] : m_buffer.capacitySpan().back(); }
-    const T& last() const LIFETIME_BOUND { return m_end ? m_buffer.capacitySpan()[m_end - 1] : m_buffer.capacitySpan().back(); }
+    T& last() LIFETIME_BOUND { return m_buffer.capacitySpan()[(m_end - 1) & m_capacityMask]; }
+    const T& last() const LIFETIME_BOUND { return m_buffer.capacitySpan()[(m_end - 1) & m_capacityMask]; }
     T takeLast();
 
     void append(T&& value) { append<T>(std::forward<T>(value)); }
@@ -124,7 +125,8 @@ public:
 private:
     friend class DequeIteratorBase<T, inlineCapacity>;
 
-    typedef VectorBuffer<T, inlineCapacity> Buffer;
+    static constexpr size_t roundedInlineCapacity = inlineCapacity ? std::bit_ceil(inlineCapacity) : 0;
+    typedef VectorBuffer<T, roundedInlineCapacity> Buffer;
     typedef VectorTypeOperations<T> TypeOperations;
     typedef DequeIteratorBase<T, inlineCapacity> IteratorBase;
 
@@ -138,6 +140,7 @@ private:
 
     size_t m_start;
     size_t m_end;
+    size_t m_capacityMask;
     Buffer m_buffer;
 #ifndef NDEBUG
     mutable IteratorBase* m_iterators;
@@ -262,16 +265,15 @@ template<typename T, size_t inlineCapacity> inline void Deque<T, inlineCapacity>
 template<typename T, size_t inlineCapacity>
 void Deque<T, inlineCapacity>::checkValidity() const
 {
-    // In this implementation a capacity of 1 would confuse append() and
-    // other places that assume the index after capacity - 1 is 0.
-    ASSERT(m_buffer.capacity() != 1);
-
     if (!m_buffer.capacity()) {
         ASSERT(!m_start);
         ASSERT(!m_end);
+        ASSERT(!m_capacityMask);
     } else {
-        ASSERT(m_start < m_buffer.capacity());
-        ASSERT(m_end < m_buffer.capacity());
+        ASSERT(std::has_single_bit(m_buffer.capacity()));
+        ASSERT(m_capacityMask == m_buffer.capacity() - 1);
+        ASSERT(m_start <= m_capacityMask);
+        ASSERT(m_end <= m_capacityMask);
     }
 }
 
@@ -305,6 +307,7 @@ template<typename T, size_t inlineCapacity>
 inline Deque<T, inlineCapacity>::Deque()
     : m_start(0)
     , m_end(0)
+    , m_capacityMask(roundedInlineCapacity ? roundedInlineCapacity - 1 : 0)
 #ifndef NDEBUG
     , m_iterators(0)
 #endif
@@ -324,6 +327,7 @@ template<typename T, size_t inlineCapacity>
 inline Deque<T, inlineCapacity>::Deque(const Deque& other)
     : m_start(other.m_start)
     , m_end(other.m_end)
+    , m_capacityMask(other.m_capacityMask)
     , m_buffer(other.m_buffer.capacity())
 #ifndef NDEBUG
     , m_iterators(0)
@@ -393,6 +397,7 @@ inline void Deque<T, inlineCapacity>::swap(Deque<T, inlineCapacity>& other)
     invalidateIterators();
     std::swap(m_start, other.m_start);
     std::swap(m_end, other.m_end);
+    std::swap(m_capacityMask, other.m_capacityMask);
     m_buffer.swap(other.m_buffer, 0, 0);
     checkValidity();
     other.checkValidity();
@@ -406,6 +411,7 @@ inline void Deque<T, inlineCapacity>::clear()
     destroyAll();
     m_start = 0;
     m_end = 0;
+    m_capacityMask = roundedInlineCapacity ? roundedInlineCapacity - 1 : 0;
     m_buffer.deallocateBuffer(m_buffer.buffer());
     checkValidity();
 }
@@ -427,13 +433,7 @@ inline auto Deque<T, inlineCapacity>::findIf(NOESCAPE const Predicate& predicate
 template<typename T, size_t inlineCapacity>
 inline void Deque<T, inlineCapacity>::expandCapacityIfNeeded()
 {
-    if (m_start) {
-        if (m_end + 1 != m_start)
-            return;
-    } else if (m_end) {
-        if (m_end != m_buffer.capacity() - 1)
-            return;
-    } else if (m_buffer.capacity())
+    if (((m_end + 1) & m_capacityMask) != m_start)
         return;
 
     expandCapacity();
@@ -445,7 +445,8 @@ void Deque<T, inlineCapacity>::expandCapacity()
     checkValidity();
     size_t oldCapacity = m_buffer.capacity();
     auto oldBuffer = m_buffer.capacitySpan();
-    m_buffer.allocateBuffer(std::max(static_cast<size_t>(16), oldCapacity + oldCapacity / 4 + 1));
+    size_t newCapacity = std::max(static_cast<size_t>(16), oldCapacity * 2);
+    m_buffer.allocateBuffer(newCapacity);
     if (m_start <= m_end)
         TypeOperations::move(oldBuffer.subspan(m_start, m_end - m_start), m_buffer.capacitySpan().subspan(m_start));
     else {
@@ -455,6 +456,7 @@ void Deque<T, inlineCapacity>::expandCapacity()
         m_start = newStart;
     }
     m_buffer.deallocateBuffer(oldBuffer.data());
+    m_capacityMask = m_buffer.capacity() - 1;
     checkValidity();
 }
 
@@ -488,10 +490,7 @@ inline void Deque<T, inlineCapacity>::append(U&& value)
     checkValidity();
     expandCapacityIfNeeded();
     new (NotNull, std::addressof(m_buffer.capacitySpan()[m_end])) T(std::forward<U>(value));
-    if (m_end == m_buffer.capacity() - 1)
-        m_end = 0;
-    else
-        ++m_end;
+    m_end = (m_end + 1) & m_capacityMask;
     checkValidity();
 }
 
@@ -500,10 +499,7 @@ inline void Deque<T, inlineCapacity>::prepend(U&& value)
 {
     checkValidity();
     expandCapacityIfNeeded();
-    if (!m_start)
-        m_start = m_buffer.capacity() - 1;
-    else
-        --m_start;
+    m_start = (m_start - 1) & m_capacityMask;
     new (NotNull, std::addressof(m_buffer.capacitySpan()[m_start])) T(std::forward<U>(value));
     checkValidity();
 }
@@ -515,10 +511,7 @@ inline void Deque<T, inlineCapacity>::removeFirst()
     invalidateIterators();
     RELEASE_ASSERT(!isEmpty());
     TypeOperations::destruct(m_buffer.capacitySpan().subspan(m_start, 1));
-    if (m_start == m_buffer.capacity() - 1)
-        m_start = 0;
-    else
-        ++m_start;
+    m_start = (m_start + 1) & m_capacityMask;
     checkValidity();
 }
 
@@ -528,10 +521,7 @@ inline void Deque<T, inlineCapacity>::removeLast()
     checkValidity();
     invalidateIterators();
     RELEASE_ASSERT(!isEmpty());
-    if (!m_end)
-        m_end = m_buffer.capacity() - 1;
-    else
-        --m_end;
+    m_end = (m_end - 1) & m_capacityMask;
     TypeOperations::destruct(m_buffer.capacitySpan().subspan(m_end, 1));
     checkValidity();
 }
@@ -565,10 +555,10 @@ inline void Deque<T, inlineCapacity>::remove(size_t position)
     // Find which segment of the circular buffer contained the remove element, and only move elements in that part.
     if (position >= m_start) {
         TypeOperations::moveOverlapping(buffer.subspan(m_start, position - m_start), buffer.subspan(m_start + 1));
-        m_start = (m_start + 1) % m_buffer.capacity();
+        m_start = (m_start + 1) & m_capacityMask;
     } else {
         TypeOperations::moveOverlapping(buffer.subspan(position + 1, m_end - (position + 1)), buffer.subspan(position));
-        m_end = (m_end - 1 + m_buffer.capacity()) % m_buffer.capacity();
+        m_end = (m_end - 1) & m_capacityMask;
     }
     checkValidity();
 }
@@ -775,14 +765,8 @@ inline void DequeIteratorBase<T, inlineCapacity>::increment(std::ptrdiff_t count
     if (!count)
         return;
     ASSERT(m_index != m_deque->m_end);
-    size_t capacity = m_deque->m_buffer.capacity();
-    ASSERT(capacity);
-    m_index += count;
-    do {
-        if (m_index < capacity)
-            break;
-        m_index -= capacity;
-    } while (true);
+    ASSERT(m_deque->m_capacityMask);
+    m_index = (m_index + count) & m_deque->m_capacityMask;
     checkValidity();
 }
 
@@ -791,11 +775,8 @@ inline void DequeIteratorBase<T, inlineCapacity>::decrement()
 {
     checkValidity();
     ASSERT(m_index != m_deque->m_start);
-    ASSERT(m_deque->m_buffer.capacity());
-    if (!m_index)
-        m_index = m_deque->m_buffer.capacity() - 1;
-    else
-        --m_index;
+    ASSERT(m_deque->m_capacityMask);
+    m_index = (m_index - 1) & m_deque->m_capacityMask;
     checkValidity();
 }
 
@@ -812,9 +793,7 @@ inline T* DequeIteratorBase<T, inlineCapacity>::before() const
 {
     checkValidity();
     ASSERT(m_index != m_deque->m_start);
-    if (!m_index)
-        return std::addressof(m_deque->m_buffer.capacitySpan()[m_deque->m_buffer.capacity() - 1]);
-    return std::addressof(m_deque->m_buffer.capacitySpan()[m_index - 1]);
+    return std::addressof(m_deque->m_buffer.capacitySpan()[(m_index - 1) & m_deque->m_capacityMask]);
 }
 
 } // namespace WTF

--- a/Tools/TestWebKitAPI/Tests/WTF/Deque.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Deque.cpp
@@ -188,4 +188,113 @@ TEST(WTF_Deque, MoveAssignmentOperator)
     }
 }
 
+TEST(WTF_Deque, WrapAroundAppendRemove)
+{
+    Deque<int> deque;
+
+    // Fill and drain repeatedly to force m_start to advance and wrap around.
+    for (int round = 0; round < 5; ++round) {
+        for (int i = 0; i < 20; ++i)
+            deque.append(round * 100 + i);
+
+        EXPECT_EQ(20u, deque.size());
+
+        for (int i = 0; i < 20; ++i) {
+            EXPECT_EQ(round * 100 + i, deque.first());
+            deque.removeFirst();
+        }
+
+        EXPECT_TRUE(deque.isEmpty());
+    }
+
+    // Interleave append/removeFirst to keep the deque small but force wrap.
+    for (int i = 0; i < 1000; ++i) {
+        deque.append(i);
+        if (i % 2 == 0) {
+            EXPECT_EQ(deque.size(), 1u);
+            deque.removeFirst();
+        }
+    }
+    // Should have 500 elements remaining (the odd iterations didn't remove).
+    EXPECT_EQ(500u, deque.size());
+}
+
+TEST(WTF_Deque, WrapAroundExpansion)
+{
+    Deque<int> deque;
+
+    // Create a wrapped state by appending and removing from front.
+    for (int i = 0; i < 10; ++i)
+        deque.append(i);
+    for (int i = 0; i < 8; ++i)
+        deque.removeFirst();
+    // Now m_start is advanced. Add more to wrap around and trigger expansion.
+    for (int i = 10; i < 30; ++i)
+        deque.append(i);
+
+    EXPECT_EQ(22u, deque.size()); // 2 remaining + 20 new
+
+    // Verify all elements are preserved in order.
+    for (int i = 0; i < 22; ++i) {
+        EXPECT_EQ(8 + i, deque.first());
+        deque.removeFirst();
+    }
+    EXPECT_TRUE(deque.isEmpty());
+}
+
+TEST(WTF_Deque, InlineCapacityNonPowerOfTwo)
+{
+    Deque<int, 5> deque; // Should round up to 8 internally.
+
+    for (int i = 0; i < 7; ++i)
+        deque.append(i);
+
+    EXPECT_EQ(7u, deque.size());
+
+    // Verify elements.
+    for (int i = 0; i < 7; ++i) {
+        EXPECT_EQ(i, deque.first());
+        deque.removeFirst();
+    }
+    EXPECT_TRUE(deque.isEmpty());
+
+    // Now force expansion beyond inline capacity.
+    for (int i = 0; i < 100; ++i)
+        deque.append(i);
+
+    EXPECT_EQ(100u, deque.size());
+
+    for (int i = 0; i < 100; ++i) {
+        EXPECT_EQ(i, deque.first());
+        deque.removeFirst();
+    }
+    EXPECT_TRUE(deque.isEmpty());
+}
+
+TEST(WTF_Deque, StressAppendPrepend)
+{
+    Deque<int> deque;
+
+    // Interleave appends and prepends, verify ordering.
+    for (int i = 0; i < 500; ++i) {
+        deque.append(i);
+        deque.prepend(-i - 1);
+    }
+
+    // Expected: [-500, -499, ..., -1, 0, 1, ..., 499]
+    EXPECT_EQ(1000u, deque.size());
+    EXPECT_EQ(-500, deque.first());
+    EXPECT_EQ(499, deque.last());
+
+    for (int i = 0; i < 500; ++i) {
+        EXPECT_EQ(-500 + i, deque.first());
+        deque.removeFirst();
+    }
+    for (int i = 0; i < 500; ++i) {
+        EXPECT_EQ(i, deque.first());
+        deque.removeFirst();
+    }
+    EXPECT_TRUE(deque.isEmpty());
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### f3b792ece3b92bd77169413bc240b83ac32bde5a
<pre>
[WTF] Make Deque branchless
<a href="https://bugs.webkit.org/show_bug.cgi?id=309385">https://bugs.webkit.org/show_bug.cgi?id=309385</a>
<a href="https://rdar.apple.com/171932808">rdar://171932808</a>

Reviewed by Dan Hecht.

Let&apos;s use the similar techniques used in HashMap.
By extending the storage x2, we can use bit-mask to round the cursor in
the Deque, which allows branchless operations in the many hot code in
Deque. Memory benchmark is neutral.

Test: Tools/TestWebKitAPI/Tests/WTF/Deque.cpp

* Source/WTF/wtf/Deque.h:
(WTF::inlineCapacity&gt;::checkValidity const):
(WTF::inlineCapacity&gt;::Deque):
(WTF::inlineCapacity&gt;::swap):
(WTF::inlineCapacity&gt;::clear):
(WTF::inlineCapacity&gt;::expandCapacityIfNeeded):
(WTF::inlineCapacity&gt;::expandCapacity):
(WTF::inlineCapacity&gt;::append):
(WTF::inlineCapacity&gt;::prepend):
(WTF::inlineCapacity&gt;::removeFirst):
(WTF::inlineCapacity&gt;::removeLast):
(WTF::inlineCapacity&gt;::remove):
(WTF::inlineCapacity&gt;::increment):
(WTF::inlineCapacity&gt;::decrement):
(WTF::inlineCapacity&gt;::before const):
* Tools/TestWebKitAPI/Tests/WTF/Deque.cpp:
(TestWebKitAPI::TEST(WTF_Deque, WrapAroundAppendRemove)):
(TestWebKitAPI::TEST(WTF_Deque, WrapAroundExpansion)):
(TestWebKitAPI::TEST(WTF_Deque, InlineCapacityNonPowerOfTwo)):
(TestWebKitAPI::TEST(WTF_Deque, StressAppendPrepend)):

Canonical link: <a href="https://commits.webkit.org/308841@main">https://commits.webkit.org/308841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed533602b3d2d84156882f800bcdaf2c6ce74d28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148614 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157298 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8244024-c5aa-4de6-a8b2-5e1bb9b7b0aa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150487 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/21779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21205 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114564 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151574 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/21779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133407 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95334 "Found 1 new API test failure: TestWTF:WTF_Deque.WrapAroundAppendRemove (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b1c73ff-340e-424f-b4ac-1a65dd5dcb11) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/21779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4734 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140581 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/21779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11324 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159633 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9401 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/2774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12846 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122626 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17719 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122850 "Found 1 new API test failure: TestWTF:WTF_Deque.WrapAroundAppendRemove (failure)") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133118 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22901 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9882 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180042 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/20738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->