### PR TITLE
[webkitcorepy] Add support for dynamic configuration files

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/render-config
+++ b/Tools/Scripts/libraries/webkitcorepy/render-config
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import logging
+import os
+import platform
+import sys
+
+libraries = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, libraries)
+
+from webkitcorepy import AutoInstall, Package, Version
+from webkitcorepy.config import Config
+
+AutoInstall.set_directory(os.path.join(libraries, 'autoinstalled', 'python-{}-{}'.format(sys.version_info[0], platform.machine())))
+
+
+def main(*args):
+    parser = argparse.ArgumentParser(description='Render a templated JSON or YAML config')
+    parser.add_argument(
+        'config_file',
+        nargs='?',
+        default=None,
+        help='Path to JSON or YAML configuration file (reads from stdin if omitted)',
+    )
+    parser.add_argument(
+        '--format', '-f',
+        choices=list(Config.Mode),
+        type=lambda v: Config.Mode[v.upper()],
+        metavar='{' + ','.join(mode.name.lower() for mode in Config.Mode) + '}',
+        help='Output format (default: matches input format)',
+    )
+    for mode in Config.Mode:
+        parser.add_argument(
+            '--{}'.format(mode.name.lower()),
+            dest='format',
+            action='store_const',
+            const=mode,
+            help='Output as {} (shorthand for --format {})'.format(mode.name, mode.name.lower()),
+        )
+    args = parser.parse_args(args)
+
+    if args.config_file and args.config_file != '-':
+        with open(args.config_file, 'r', encoding='utf-8') as f:
+            config = Config.load(f)
+    else:
+        if sys.stdin.isatty():
+            print('Error: no input provided. Specify a file or pipe content to stdin.', file=sys.stderr)
+            return 1
+        config = Config.loads(sys.stdin.read())
+
+    print(config.dumps(mode=args.format))
+    return 0
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.WARNING)
+    sys.exit(main(*sys.argv[1:]))

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -79,6 +79,8 @@ AutoInstall.register(Package('urllib3', Version(1, 26, 17)))
 AutoInstall.register(Package('wheel', Version(0, 35, 1)))
 AutoInstall.register(Package('cffi', Version(1, 17, 1), aliases=['_cffi_backend']))
 AutoInstall.register(Package('OpenSSL', Version(23, 2, 0), pypi_name='pyOpenSSL'))
+AutoInstall.register(Package('pyyaml', Version(6, 0, 2), pypi_name='PyYAML'))
+AutoInstall.register(Package('jsone', Version(4, 8, 1), pypi_name='json-e'))
 
 # There are no prebuilt binaries for arm-32 of 'cryptography' and building it requires cargo/rust
 # Since this dep is not really needed for the current arm-32 bots we skip it instead of

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/config.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/config.py
@@ -1,0 +1,155 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import io
+import json
+import os
+from collections.abc import Iterable, Mapping
+from enum import Enum, auto
+from typing import Callable, Dict, IO, List, Optional, Tuple, Union
+
+
+class Config(dict[str, 'Config.Values']):
+    class Mode(Enum):
+        JSON = auto()
+        YAML = auto()
+
+    CONTEXT_SYMBOL: str = '$context'
+    Values = Union[str, int, float, bool, None, List['Config.Values'], Dict[str, 'Config.Values']]
+
+    @classmethod
+    def render(cls, value: 'Config.Values', context: Optional[Dict[str, Union['Config.Values', Callable[..., 'Config.Values']]]] = None) -> 'Config.Values':
+        import jsone
+        from jsone.render import parse as jsone_parse
+
+        def dynamic_pop(jsone_context: Mapping[str, Union['Config.Values', Callable[..., 'Config.Values']]], collection: Union[List['Config.Values'], Mapping[str, 'Config.Values']], *args: Union[int, str]) -> 'Config.Values':
+            """Pop an item from a mapping or list which matches some criteria, usable as a jsone built-in.
+
+            For mappings, requires a key argument.
+
+            For lists, accepts an optional index (int) or a jsone filter expression
+            (str) that is evaluated against each item to find the first match. Intended
+            to allow, for example, a configuration to progressively consume a pre-existing
+            list of machines with listed properties.
+            """
+            if isinstance(collection, list):
+                if args and isinstance(args[0], str):
+                    filter_expr = args[0]
+                    for i, item in enumerate(collection):
+                        subcontext = dict(jsone_context)
+                        if isinstance(item, Mapping):
+                            subcontext.update(item)
+                        else:
+                            subcontext['it'] = item
+                        if jsone_parse(filter_expr, subcontext):
+                            return collection.pop(i)
+                    raise ValueError(f'No item in list matches filter: {filter_expr!r}')
+                return collection.pop(int(args[0])) if args else collection.pop(0)
+            if isinstance(collection, Mapping):
+                if not args:
+                    raise TypeError('pop() on a mapping requires a key argument')
+                return collection.pop(args[0])
+            raise TypeError('pop() requires a list or mapping')
+
+        # Treat pop as a jsone built-in so we can apply a filter against it
+        dynamic_pop._jsone_builtin = True
+
+        context = dict(context or {})
+        context.setdefault('pop', dynamic_pop)
+
+        if not isinstance(value, Mapping):
+            return jsone.render(value, context=context)
+
+        if cls.CONTEXT_SYMBOL in value:
+            result = Config()
+            context = dict(**context)
+            context.update(cls.render(value[cls.CONTEXT_SYMBOL], context=context))
+            for key, content in value.items():
+                if key == cls.CONTEXT_SYMBOL:
+                    continue
+                result[key] = cls.render(content, context=context)
+                if isinstance(result[key], list):
+                    context[key] = [x for x in result[key]]
+                elif isinstance(result[key], Mapping):
+                    result[key] = dict(**result[key])
+                    context[key] = dict(**result[key])
+                else:
+                    context[key] = result[key]
+            return result
+
+        result = jsone.render(value, context=context)
+        if isinstance(result, Mapping):
+            return Config(**result)
+        return result
+
+    @classmethod
+    def loads(cls, string: str, mode: Optional['Config.Mode'] = None) -> 'Config':
+        return cls.load(io.StringIO(string), mode=mode)
+
+    @classmethod
+    def load(cls, file: IO[str], mode: Optional['Config.Mode'] = None) -> 'Config':
+        if mode is None and hasattr(file, 'name'):
+            ext = os.path.splitext(file.name)[1].lower()
+            if ext == '.json':
+                mode = cls.Mode.JSON
+            elif ext in ('.yaml', '.yml'):
+                mode = cls.Mode.YAML
+        if mode is cls.Mode.JSON:
+            result = cls.render(json.load(file))
+        else:
+            import yaml
+
+            # yaml.safe_load_all returns a generator, not a sequence.
+            documents = list(yaml.safe_load_all(file))
+            if not documents:
+                result = cls()
+            elif len(documents) == 1:
+                if not isinstance(documents[0], dict):
+                    raise TypeError('yaml sub-document is not a dictionary')
+                result = cls.render(documents[0])
+            else:
+                data = {cls.CONTEXT_SYMBOL: documents[0]}
+                for doc in documents[1:]:
+                    if not isinstance(doc, dict):
+                        raise TypeError('yaml sub-document is not a dictionary')
+                    data.update(doc)
+                result = cls.render(data)
+            mode = cls.Mode.YAML
+        result.mode = mode
+        return result
+
+    def __init__(self, mapping: Union[Mapping[str, 'Config.Values'], Iterable[Tuple[str, 'Config.Values']], None] = None, **kwargs: 'Config.Values') -> None:
+        super().__init__(**kwargs) if mapping is None else super().__init__(mapping, **kwargs)
+        self.mode: 'Config.Mode' = self.Mode.YAML
+
+    def dump(self, file: IO[str], mode: Optional['Config.Mode'] = None, indent: int = 4) -> None:
+        mode = mode or self.mode
+        if mode is self.Mode.JSON:
+            json.dump(dict(self), file, indent=indent)
+        else:
+            import yaml
+            yaml.dump(dict(self), file, indent=indent, default_flow_style=False)
+
+    def dumps(self, mode: Optional['Config.Mode'] = None, indent: int = 4) -> str:
+        file = io.StringIO()
+        self.dump(file, mode=mode, indent=indent)
+        return file.getvalue()

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/config_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/config_unittest.py
@@ -1,0 +1,236 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import io
+import json
+import unittest
+
+from webkitcorepy.config import Config
+
+
+class ConfigRenderTestCase(unittest.TestCase):
+    def test_render_string(self):
+        self.assertEqual(Config.render('hello'), 'hello')
+
+    def test_render_number(self):
+        self.assertEqual(Config.render(42), 42)
+
+    def test_render_list(self):
+        self.assertEqual(Config.render([1, 2, 3]), [1, 2, 3])
+
+    def test_render_simple_dict_returns_config(self):
+        result = Config.render({'key': 'value'})
+        self.assertIsInstance(result, Config)
+        self.assertDictEqual(result, {'key': 'value'})
+
+    def test_render_dict_with_context_symbol_returns_config(self):
+        result = Config.render({'$context': {}, 'key': 'value'})
+        self.assertIsInstance(result, Config)
+        self.assertDictEqual(result, {'key': 'value'})
+
+    def test_render_context_symbol_excluded_from_result(self):
+        result = Config.render({'$context': {'x': 1}, 'key': 'value'})
+        self.assertDictEqual(result, {'key': 'value'})
+
+    def test_render_context_symbol_values_available_in_keys(self):
+        result = Config.render({
+            '$context': {'greeting': 'hello'},
+            'message': {'$eval': 'greeting'},
+        })
+        self.assertDictEqual(result, {'message': 'hello'})
+
+    def test_render_external_context_available(self):
+        result = Config.render({'value': {'$eval': 'x'}}, context={'x': 42})
+        self.assertDictEqual(result, {'value': 42})
+
+    def test_render_rendered_key_available_to_subsequent_keys(self):
+        result = Config.render({
+            '$context': {},
+            'a': 1,
+            'b': {'$eval': 'a + 1'},
+        })
+        self.assertDictEqual(result, {'a': 1, 'b': 2})
+
+    def test_render_list_value_available_to_subsequent_keys(self):
+        result = Config.render({
+            '$context': {},
+            'items': [10, 20, 30],
+            'count': {'$eval': 'len(items)'},
+        })
+        self.assertDictEqual(result, {'items': [10, 20, 30], 'count': 3})
+
+    def test_render_dict_value_available_to_subsequent_keys(self):
+        result = Config.render({
+            '$context': {},
+            'info': {'name': 'webkit'},
+            'label': {'$eval': 'info["name"]'},
+        })
+        self.assertDictEqual(result, {'info': {'name': 'webkit'}, 'label': 'webkit'})
+
+    def test_render_does_not_mutate_external_context(self):
+        original = {'x': 1}
+        Config.render({'$context': {'y': 2}, 'z': 3}, context=original)
+        self.assertDictEqual(original, {'x': 1})
+
+    def test_render_context_symbol_rendered_with_templates(self):
+        result = Config.render({
+            '$context': {'doubled': {'$eval': 'x * 2'}},
+            'value': {'$eval': 'doubled'},
+        }, context={'x': 5})
+        self.assertDictEqual(result, {'value': 10})
+
+
+class ConfigLoadsTestCase(unittest.TestCase):
+    def test_loads_yaml(self):
+        result = Config.loads('key: value\n')
+        self.assertIsInstance(result, Config)
+        self.assertDictEqual(result, {'key': 'value'})
+
+    def test_loads_yaml_explicit_mode(self):
+        result = Config.loads('key: value\n', mode=Config.Mode.YAML)
+        self.assertDictEqual(result, {'key': 'value'})
+
+    def test_loads_json(self):
+        result = Config.loads('{"key": "value"}', mode=Config.Mode.JSON)
+        self.assertIsInstance(result, Config)
+        self.assertDictEqual(result, {'key': 'value'})
+
+    def test_loads_json_via_yaml(self):
+        result = Config.loads('{"key": "value"}')
+        self.assertDictEqual(result, {'key': 'value'})
+
+    def test_loads_renders_templates(self):
+        result = Config.loads('key: "${1 + 1}"\n')
+        self.assertDictEqual(result, {'key': '2'})
+
+    def test_loads_yaml_multikey(self):
+        result = Config.loads('a: 1\nb: 2\n')
+        self.assertDictEqual(result, {'a': 1, 'b': 2})
+
+    def test_loads_json_multikey(self):
+        result = Config.loads('{"a": 1, "b": 2}', mode=Config.Mode.JSON)
+        self.assertDictEqual(result, {'a': 1, 'b': 2})
+
+
+class ConfigLoadTestCase(unittest.TestCase):
+    def test_load_yaml(self):
+        result = Config.load(io.StringIO('key: value\n'))
+        self.assertIsInstance(result, Config)
+        self.assertDictEqual(result, {'key': 'value'})
+
+    def test_load_json(self):
+        result = Config.load(io.StringIO('{"key": "value"}'), mode=Config.Mode.JSON)
+        self.assertIsInstance(result, Config)
+        self.assertDictEqual(result, {'key': 'value'})
+
+    def test_load_infers_json_from_extension(self):
+        f = io.StringIO('{"key": "value"}')
+        f.name = 'config.json'
+        self.assertDictEqual(Config.load(f), {'key': 'value'})
+
+    def test_load_infers_yaml_from_extension(self):
+        for ext in ('.yaml', '.yml'):
+            f = io.StringIO('key: value\n')
+            f.name = f'config{ext}'
+            self.assertDictEqual(Config.load(f), {'key': 'value'})
+
+    def test_load_falls_back_to_yaml_without_extension(self):
+        f = io.StringIO('key: value\n')
+        f.name = 'config.txt'
+        self.assertDictEqual(Config.load(f), {'key': 'value'})
+
+
+class ConfigDumpsTestCase(unittest.TestCase):
+    def test_dumps_yaml_default(self):
+        result = Config(a=1, b=2).dumps()
+        import yaml
+        self.assertDictEqual(yaml.safe_load(result), {'a': 1, 'b': 2})
+
+    def test_dumps_yaml_explicit_mode(self):
+        result = Config(a=1, b=2).dumps(mode=Config.Mode.YAML)
+        import yaml
+        self.assertDictEqual(yaml.safe_load(result), {'a': 1, 'b': 2})
+
+    def test_dumps_json(self):
+        result = Config(a=1, b=2).dumps(mode=Config.Mode.JSON)
+        self.assertDictEqual(json.loads(result), {'a': 1, 'b': 2})
+
+    def test_dumps_json_indent(self):
+        result = Config(key='value').dumps(mode=Config.Mode.JSON, indent=4)
+        self.assertEqual(result, json.dumps({'key': 'value'}, indent=4))
+
+    def test_dumps_roundtrip_yaml(self):
+        original = Config(x=1, y='hello')
+        self.assertDictEqual(Config.loads(original.dumps()), dict(original))
+
+    def test_dumps_roundtrip_json(self):
+        original = Config(x=1, y='hello')
+        self.assertDictEqual(Config.loads(original.dumps(mode=Config.Mode.JSON), mode=Config.Mode.JSON), dict(original))
+
+
+class ConfigPopTestCase(unittest.TestCase):
+    def test_render_pop_subsequent_key_sees_reduced_list(self):
+        result = Config.render({
+            '$context': {},
+            'items': [1, 2, 3],
+            'first': {'$eval': 'pop(items)'},
+            'count': {'$eval': 'len(items)'},
+        })
+        self.assertEqual(result['first'], 1)
+        self.assertEqual(result['count'], 2)
+
+    def test_render_pop_filter_matches_dict_items(self):
+        result = Config.render({
+            '$context': {},
+            'items': [{'kind': 'a', 'val': 1}, {'kind': 'b', 'val': 2}, {'kind': 'a', 'val': 3}],
+            'matched': {'$eval': "pop(items, \"kind == 'b'\")"},
+            'count': {'$eval': 'len(items)'},
+        })
+        self.assertDictEqual(result['matched'], {'kind': 'b', 'val': 2})
+        self.assertEqual(result['count'], 2)
+
+    def test_render_pop_filter_no_match_raises(self):
+        with self.assertRaises(ValueError):
+            Config.render({
+                '$context': {},
+                'items': [{'kind': 'a'}],
+                'matched': {'$eval': "pop(items, \"kind == 'b'\")"},
+            })
+
+    def test_render_pop_exhausted_list_raises(self):
+        with self.assertRaises(IndexError):
+            Config.render({
+                '$context': {},
+                'items': [1, 2],
+                'a': {'$eval': 'pop(items)'},
+                'b': {'$eval': 'pop(items)'},
+                'c': {'$eval': 'pop(items)'},
+            })
+
+    def test_render_pop_filter_exhausted_list_raises(self):
+        with self.assertRaises(ValueError):
+            Config.render({
+                '$context': {},
+                'items': [{'kind': 'a'}],
+                'first': {'$eval': "pop(items, \"kind == 'a'\")"},
+                'second': {'$eval': "pop(items, \"kind == 'a'\")"},
+            })

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/example-config.yaml
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/example-config.yaml
@@ -1,0 +1,48 @@
+# Context:
+machine_counts:
+  - model: Mac16,10
+    count: 10
+  - model: Mac14,3
+    count: 10
+names:
+  $map: {$eval: "range(100, 120)"}
+  each(i): bot${i}
+versions:
+  macos:
+    [Tahoe, Sequoia, Sonoma]
+build_types: [Release, Debug]
+---
+workers:
+  $flatten:
+    $map: {$eval: machine_counts}
+    each(entry):
+      $map: {$eval: "range(0, entry.count)"}
+      each(n):
+        name: {$eval: pop(names)}
+        model: {$eval: entry.model}
+
+builders:
+  $flatten:
+    $map: {$eval: versions.macos}
+    each(version):
+      $map: {$eval: build_types}
+      each(build_type):
+        name: Apple-${version}-${build_type}-Build
+        factory: BuildFactory
+        platform: mac-${lowercase(version)}
+        configuration: {$eval: lowercase(build_type)}
+        architectures: [x86_64, arm64]
+        workernames:
+          - $if: "build_type == 'Debug'"
+            then: {$eval: "pop(workers, \"model == 'Mac16,10'\").name"}
+            else: {$eval: "pop(workers, \"model == 'Mac14,3'\").name"}
+          - $if: "build_type == 'Debug'"
+            then: {$eval: "pop(workers, \"model == 'Mac16,10'\").name"}
+            else: {$eval: "pop(workers, \"model == 'Mac14,3'\").name"}
+          - $if: "build_type == 'Debug'"
+            then: {$eval: "pop(workers, \"model == 'Mac16,10'\").name"}
+            else: {$eval: "pop(workers, \"model == 'Mac14,3'\").name"}
+
+unused-workers:
+  $map: {$eval: workers}
+  each(w): {$eval: w.name}


### PR DESCRIPTION
#### 202dd979c6efc278bd38506b3e3ff8ca5f75eccb
<pre>
[webkitcorepy] Add support for dynamic configuration files
<a href="https://bugs.webkit.org/show_bug.cgi?id=308058">https://bugs.webkit.org/show_bug.cgi?id=308058</a> <a href="https://rdar.apple.com/problem/170556228">rdar://problem/170556228</a>

Reviewed by Aakash Jain.

Build a dynamic configuration renderer based on the json-e module.

* Tools/Scripts/libraries/webkitcorepy/render-config: Add stand-alone script to render a dynamic configuration.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py: Add pyyaml and jsone.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/config.py: Added.
(Config.Mode): Enum for different display modes.
(Config.render): Recursively render a dictionary. If a $context is provided, render each child with this function.
Otherwise, invoke jsone&apos;s render on all children.
(Config.render.dynamic_pop):
(Config.loads): Load YAML or JSON configuration from a string.
(Config.load): Load YAML or JSON configuration from a file.
(Config.__init__): Pass display mode on construction.
(Config.dump): Print the rendered configuration to a file.
(Config.dumps): Print the rendered configuration as a string.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/config_unittest.py: Added.
(ConfigRenderTestCase): Added.
(ConfigLoadsTestCase): Added.
(ConfigLoadTestCase): Added.
(ConfigDumpsTestCase): Added.
(ConfigPopTestCase): Added.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/example-config.yaml: Add an example configuration to
demonstrate the features of the configuration renderer.

Canonical link: <a href="https://commits.webkit.org/311395@main">https://commits.webkit.org/311395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01d925a15d3b6898d105b9aa80df2dd6c7e93612

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165253 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/110512 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121152 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85165 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23374 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101821 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/156180 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22438 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 4 new passes 2 flakes 13 failures; Uploaded test results; 4 new passes 1 flakes 15 failures; Running compile-webkit-without-change") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/20616 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13025 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167735 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129276 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/155830 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129387 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29290 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140112 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87086 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23877 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24213 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16911 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29000 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28526 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28754 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28650 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->