### PR TITLE
REGRESSION(307092@main): Use of uninitialized value in subroutine entry at /home/mcatanzaro/Projects/WebKit/Source/WebInspectorUI/Scripts/copy-user-interface-resources.pl line 283

### DIFF
--- a/Source/WebInspectorUI/Scripts/copy-user-interface-resources.pl
+++ b/Source/WebInspectorUI/Scripts/copy-user-interface-resources.pl
@@ -280,9 +280,11 @@ sub combineOrStripResourcesForWebKitAdditions() {
     }
 
     # Copy the contents of the Protocol/Legacy directory from WebKitAdditions/WebInspectorUI/ if it exists
-    my $protocolLegacyAdditionsDir = File::Spec->catdir($webInspectorUIAdditionsDir, 'Protocol', 'Legacy');
-    if (-d $protocolLegacyAdditionsDir) {
-        ditto($protocolLegacyAdditionsDir, File::Spec->catdir($protocolDir, 'Legacy'));
+    if (defined $webInspectorUIAdditionsDir) {
+        my $protocolLegacyAdditionsDir = File::Spec->catdir($webInspectorUIAdditionsDir, 'Protocol', 'Legacy');
+        if (-d $protocolLegacyAdditionsDir) {
+            ditto($protocolLegacyAdditionsDir, File::Spec->catdir($protocolDir, 'Legacy'));
+        }
     }
 }
 


### PR DESCRIPTION
#### 35382277dbb09cfca07ab6a970d4551e03af2c4b
<pre>
REGRESSION(307092@main): Use of uninitialized value in subroutine entry at /home/mcatanzaro/Projects/WebKit/Source/WebInspectorUI/Scripts/copy-user-interface-resources.pl line 283
<a href="https://bugs.webkit.org/show_bug.cgi?id=309391">https://bugs.webkit.org/show_bug.cgi?id=309391</a>

Reviewed by Devin Rousso.

If the UI additions directory is not defined, do not try to use it.

Canonical link: <a href="https://commits.webkit.org/308981@main">https://commits.webkit.org/308981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42a981754caba4eee117830f026da033633ee77d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157310 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102056 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114569 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81579 "4 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133415 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95339 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15868 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13729 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4746 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159645 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2786 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122630 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122854 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33492 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133126 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77278 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18168 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9890 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20750 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84553 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20483 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20629 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20539 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->