### PR TITLE
[JSC] Array#flat should skip IsArray at depth 0 and bail fast path for DerivedArrayType

### DIFF
--- a/JSTests/stress/array-flat-cross-realm-array-prototype.js
+++ b/JSTests/stress/array-flat-cross-realm-array-prototype.js
@@ -1,0 +1,67 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}`);
+}
+
+{
+    let other = createGlobalObject();
+    other.Array.prototype.length = 2;
+    other.Array.prototype[0] = "A";
+    other.Array.prototype[1] = "B";
+
+    let result = [other.Array.prototype].flat();
+    shouldBe(result.length, 2);
+    shouldBe(result[0], "A");
+    shouldBe(result[1], "B");
+}
+
+{
+    let other = createGlobalObject();
+    other.Array.prototype.length = 3;
+    other.Array.prototype[0] = 10;
+    other.Array.prototype[1] = 20;
+    other.Array.prototype[2] = 30;
+
+    let result = [1, other.Array.prototype, 2].flat();
+    shouldBe(result.length, 5);
+    shouldBe(result[0], 1);
+    shouldBe(result[1], 10);
+    shouldBe(result[2], 20);
+    shouldBe(result[3], 30);
+    shouldBe(result[4], 2);
+}
+
+{
+    let other = createGlobalObject();
+    other.Array.prototype.length = 2;
+    other.Array.prototype[0] = "x";
+    other.Array.prototype[1] = "y";
+
+    let result = [[other.Array.prototype]].flat(2);
+    shouldBe(result.length, 2);
+    shouldBe(result[0], "x");
+    shouldBe(result[1], "y");
+}
+
+{
+    let other = createGlobalObject();
+    let result = [other.Array.prototype, 42].flat();
+    shouldBe(result.length, 1);
+    shouldBe(result[0], 42);
+}
+
+{
+    let other = createGlobalObject();
+    other.Array.prototype.length = 2;
+    other.Array.prototype[0] = "A";
+    other.Array.prototype[1] = "B";
+
+    let result = [other.Array.prototype].flat(0);
+    shouldBe(result.length, 1);
+    shouldBe(result[0], other.Array.prototype);
+}
+
+{
+    let other = createGlobalObject();
+    shouldBe(Array.isArray(other.Array.prototype), true);
+}

--- a/JSTests/stress/array-flat-depth-zero-revoked-proxy.js
+++ b/JSTests/stress/array-flat-depth-zero-revoked-proxy.js
@@ -1,0 +1,63 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}`);
+}
+
+{
+    let { proxy, revoke } = Proxy.revocable([], {});
+    revoke();
+
+    let result = [proxy].flat(0);
+    shouldBe(result.length, 1);
+    shouldBe(result[0], proxy);
+}
+
+{
+    let { proxy, revoke } = Proxy.revocable([1, 2, 3], {});
+    revoke();
+
+    let result = [proxy].flat(-1);
+    shouldBe(result.length, 1);
+    shouldBe(result[0], proxy);
+}
+
+{
+    let lengthAccessed = false;
+    let proxy = new Proxy({}, {
+        get(t, k) {
+            if (k === "length")
+                lengthAccessed = true;
+            return Reflect.get(t, k);
+        }
+    });
+    let result = [proxy, 42].flat(0);
+    shouldBe(result.length, 2);
+    shouldBe(result[0], proxy);
+    shouldBe(result[1], 42);
+    shouldBe(lengthAccessed, false);
+}
+
+{
+    let { proxy, revoke } = Proxy.revocable([], {});
+    revoke();
+
+    let didThrow = false;
+    try {
+        [proxy].flat(1);
+    } catch (e) {
+        didThrow = true;
+        shouldBe(e instanceof TypeError, true);
+    }
+    shouldBe(didThrow, true);
+}
+
+{
+    let { proxy, revoke } = Proxy.revocable([], {});
+    revoke();
+
+    let arrayLike = { length: 2, 0: proxy, 1: "x" };
+    let result = Array.prototype.flat.call(arrayLike, 0);
+    shouldBe(result.length, 2);
+    shouldBe(result[0], proxy);
+    shouldBe(result[1], "x");
+}

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -2130,9 +2130,9 @@ static uint64_t flatIntoArray(JSGlobalObject* globalObject, JSObject* target, JS
         if (!element)
             continue;
 
-        bool elementIsArray = isArray(globalObject, element);
+        bool elementIsArray = depth > 0 && isArray(globalObject, element);
         RETURN_IF_EXCEPTION(scope, { });
-        if (depth > 0 && elementIsArray) {
+        if (elementIsArray) {
             uint64_t newDepth = depth - 1;
             if (depth == std::numeric_limits<uint64_t>::max()) [[unlikely]]
                 newDepth = depth;

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -2277,8 +2277,8 @@ static uint64_t calculateFlattenedLength(JSGlobalObject* globalObject, JSArray* 
                 }
             } else {
                 if (element.isObject()) {
-                    auto elementObject = asObject(element);
-                    if (elementObject->isProxy()) [[unlikely]]
+                    JSType type = asObject(element)->type();
+                    if (type == ProxyObjectType || type == DerivedArrayType) [[unlikely]]
                         return std::numeric_limits<uint64_t>::max();
                 }
                 resultLength++;


### PR DESCRIPTION
#### 58336b9e2fcd6c2c769c4226ba8cd94474da9009
<pre>
[JSC] Array#flat should skip IsArray at depth 0 and bail fast path for DerivedArrayType
<a href="https://bugs.webkit.org/show_bug.cgi?id=309396">https://bugs.webkit.org/show_bug.cgi?id=309396</a>

Reviewed by Yusuke Suzuki.

Two spec bugs were introduced in 546d47afe6:

1. flat(0) with a revoked Proxy element throws TypeError.
   FlattenIntoArray step 5.c.iv requires IsArray only when depth &gt; 0.
   Short-circuit the check so isArray() is not called at depth 0.

2. fastFlat fails to flatten a cross-realm Array.prototype.
     isJSArray() checks ArrayType only, but Array.prototype has
     DerivedArrayType. Bail to the slow path for DerivedArrayType,
     matching the existing concat fast path check.

Tests: JSTests/stress/array-flat-cross-realm-array-prototype.js
       JSTests/stress/array-flat-depth-zero-revoked-proxy.js

* JSTests/stress/array-flat-cross-realm-array-prototype.js: Added.
(shouldBe):
* JSTests/stress/array-flat-depth-zero-revoked-proxy.js: Added.
(shouldBe):
(shouldBe.get let):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::flatIntoArray):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::calculateFlattenedLength):

Canonical link: <a href="https://commits.webkit.org/308887@main">https://commits.webkit.org/308887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ef1dffbd857675806513e002960d187e20687f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148627 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157311 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102057 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21218 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114570 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81580 "3 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95340 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15869 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13728 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4747 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140594 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125483 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159646 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9414 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2787 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12853 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122628 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21142 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17726 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122852 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33434 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133125 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77279 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18171 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9889 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180055 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20751 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84554 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46085 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20484 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20630 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20540 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->