### PR TITLE
[JSC] Combine HandlerIC with DataIC in PropertyInlineCache

### DIFF
--- a/JSTests/microbenchmarks/deltablue-varargs.js
+++ b/JSTests/microbenchmarks/deltablue-varargs.js
@@ -1,5 +1,4 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
-//@ requireOptions("--useDataICInFTL=true")
 
 // Copyright 2008 the V8 project authors. All rights reserved.
 // Copyright 1996 John Maloney and Mario Wolczko.

--- a/JSTests/microbenchmarks/richards-try-catch.js
+++ b/JSTests/microbenchmarks/richards-try-catch.js
@@ -1,6 +1,5 @@
 //@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
 //@ $skipModes << :lockdown if $buildType == "debug"
-//@ requireOptions("--useDataICInFTL=true")
 
 // Copyright 2006-2008 the V8 project authors. All rights reserved.
 // Redistribution and use in source and binary forms, with or without

--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -3684,21 +3684,6 @@ void CodeBlock::jitNextInvocation()
     m_unlinkedCode->llintExecuteCounter().setNewThreshold(0, this);
 }
 
-bool CodeBlock::useDataIC() const
-{
-#if ENABLE(DFG_JIT)
-    if (jitType() == JITType::DFGJIT) {
-        if (auto* jitCode = m_jitCode.get())
-            return static_cast<const DFG::JITCode*>(jitCode)->isUnlinked();
-    }
-#endif
-#if ENABLE(FTL_JIT)
-    if (jitType() == JITType::FTLJIT)
-        return Options::useDataICInFTL();
-#endif
-    return true;
-}
-
 CodePtr<JSEntryPtrTag> CodeBlock::addressForCallConcurrently(const ConcurrentJSLocker&, ArityCheckMode arityCheck) const
 {
     if (!m_jitCode)

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -390,8 +390,6 @@ public:
         return jitType() == JITType::BaselineJIT;
     }
 
-    bool useDataIC() const;
-
     CodePtr<JSEntryPtrTag> addressForCallConcurrently(const ConcurrentJSLocker&, ArityCheckMode) const;
 
 #if ENABLE(JIT)

--- a/Source/JavaScriptCore/bytecode/InlineAccess.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineAccess.cpp
@@ -179,7 +179,7 @@ bool InlineAccess::generateSelfPropertyAccess(PropertyInlineCache& propertyCache
     if (!hasConstantIdentifier(propertyCache.accessType))
         return false;
 
-    if (propertyCache.useDataIC)
+    if (propertyCache.useHandlerIC)
         return false;
 
     CCallHelpers jit;
@@ -236,7 +236,7 @@ bool InlineAccess::canGenerateSelfPropertyReplace(PropertyInlineCache& propertyC
     if (!hasConstantIdentifier(propertyCache.accessType))
         return false;
 
-    if (propertyCache.useDataIC)
+    if (propertyCache.useHandlerIC)
         return false;
 
     if (isInlineOffset(offset))
@@ -252,7 +252,7 @@ bool InlineAccess::generateSelfPropertyReplace(PropertyInlineCache& propertyCach
 
     ASSERT(canGenerateSelfPropertyReplace(propertyCache, offset));
 
-    if (propertyCache.useDataIC)
+    if (propertyCache.useHandlerIC)
         return false;
 
     CCallHelpers jit;
@@ -287,7 +287,7 @@ bool InlineAccess::isCacheableArrayLength(PropertyInlineCache& propertyCache, JS
     if (!hasConstantIdentifier(propertyCache.accessType))
         return false;
 
-    if (propertyCache.useDataIC)
+    if (propertyCache.useHandlerIC)
         return propertyCache.preconfiguredCacheType == CacheType::ArrayLength;
 
     if (!hasFreeRegister(propertyCache))
@@ -304,7 +304,7 @@ bool InlineAccess::generateArrayLength(PropertyInlineCache& propertyCache, JSArr
         return false;
 
     // ArrayLength fast path does not need any modification.
-    if (propertyCache.useDataIC)
+    if (propertyCache.useHandlerIC)
         return false;
 
     CCallHelpers jit;
@@ -329,7 +329,7 @@ bool InlineAccess::isCacheableStringLength(PropertyInlineCache& propertyCache)
     if (!hasConstantIdentifier(propertyCache.accessType))
         return false;
 
-    if (propertyCache.useDataIC)
+    if (propertyCache.useHandlerIC)
         return propertyCache.preconfiguredCacheType == CacheType::StringLength;
 
     return hasFreeRegister(propertyCache);
@@ -342,7 +342,7 @@ bool InlineAccess::generateStringLength(PropertyInlineCache& propertyCache)
     if (!hasConstantIdentifier(propertyCache.accessType))
         return false;
 
-    if (propertyCache.useDataIC)
+    if (propertyCache.useHandlerIC)
         return false;
 
     CCallHelpers jit;
@@ -378,7 +378,7 @@ bool InlineAccess::generateSelfInAccess(PropertyInlineCache& propertyCache, Stru
     if (!hasConstantIdentifier(propertyCache.accessType))
         return false;
 
-    if (propertyCache.useDataIC)
+    if (propertyCache.useHandlerIC)
         return false;
 
     GPRReg base = propertyCache.m_baseGPR;

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -1011,7 +1011,7 @@ void InlineCacheCompiler::restoreScratch()
 
 inline bool InlineCacheCompiler::useHandlerIC() const
 {
-    return m_propertyCache.useHandlerIC();
+    return m_propertyCache.useHandlerIC;
 }
 
 void InlineCacheCompiler::succeed()
@@ -1022,7 +1022,7 @@ void InlineCacheCompiler::succeed()
         m_jit->ret();
         return;
     }
-    if (m_propertyCache.useDataIC) {
+    if (m_propertyCache.useHandlerIC) {
         m_jit->farJump(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfDoneLocation()), JSInternalPtrTag);
         return;
     }
@@ -1064,7 +1064,7 @@ const ScalarRegisterSet& InlineCacheCompiler::calculateLiveRegistersForCallAndEx
         }
 
         auto liveRegistersForCall = RegisterSet(m_liveRegistersToPreserveAtExceptionHandlingCallSite.toRegisterSet(), m_allocator->usedRegisters());
-        if (m_propertyCache.useDataIC)
+        if (m_propertyCache.useHandlerIC)
             liveRegistersForCall.add(m_propertyCache.m_propertyCacheGPR, IgnoreVectors);
         liveRegistersForCall.exclude(calleeSaveRegisters().includeWholeRegisterWidth());
         m_liveRegistersForCall = liveRegistersForCall.toScalarRegisterSet();
@@ -1095,7 +1095,7 @@ auto InlineCacheCompiler::preserveLiveRegistersToStackForCall(const RegisterSet&
 auto InlineCacheCompiler::preserveLiveRegistersToStackForCallWithoutExceptions() -> SpillState
 {
     RegisterSet liveRegisters = m_allocator->usedRegisters();
-    if (m_propertyCache.useDataIC)
+    if (m_propertyCache.useHandlerIC)
         liveRegisters.add(m_propertyCache.m_propertyCacheGPR, IgnoreVectors);
     liveRegisters.exclude(calleeSaveRegisters().includeWholeRegisterWidth());
     liveRegisters.filter(RegisterSet::allScalarRegisters());
@@ -2950,7 +2950,7 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         {
             // Handle the case where we are allocating out-of-line using an operation.
             InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
-            if (m_propertyCache.useDataIC) {
+            if (m_propertyCache.useHandlerIC) {
                 callSiteIndexForExceptionHandlingOrOriginal();
                 jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
             } else
@@ -3081,7 +3081,7 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         {
             // Handle the case where we are allocating out-of-line using an operation.
             InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
-            if (m_propertyCache.useDataIC) {
+            if (m_propertyCache.useHandlerIC) {
                 callSiteIndexForExceptionHandlingOrOriginal();
                 jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
             } else
@@ -3277,7 +3277,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
         // exception handling call site.
         InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
 
-        if (m_propertyCache.useDataIC) {
+        if (m_propertyCache.useHandlerIC) {
             callSiteIndexForExceptionHandlingOrOriginal();
             jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
         } else
@@ -3413,7 +3413,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
         // exception handling call site.
         InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
 
-        if (m_propertyCache.useDataIC) {
+        if (m_propertyCache.useHandlerIC) {
             callSiteIndexForExceptionHandlingOrOriginal();
             jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
         } else
@@ -3503,7 +3503,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
         if (isGetter)
             jit.setupResults(valueRegs);
 
-        if (m_propertyCache.useDataIC) {
+        if (m_propertyCache.useHandlerIC) {
             jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), scratchGPR);
             if (useHandlerIC())
                 jit.addPtr(CCallHelpers::TrustedImm32(-(sizeof(CallerFrameAndPC) + maxFrameExtentForSlowPathCall + m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), scratchGPR);
@@ -3644,7 +3644,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
                 extraRegistersToPreserve.add(valueRegs, IgnoreVectors);
                 InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall(extraRegistersToPreserve);
 
-                if (m_propertyCache.useDataIC) {
+                if (m_propertyCache.useHandlerIC) {
                     callSiteIndexForExceptionHandlingOrOriginal();
                     jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
                 } else
@@ -3918,7 +3918,7 @@ void InlineCacheCompiler::emitDOMJITGetter(JSGlobalObject* globalObjectForDOMJIT
     GPRReg baseGPR = m_propertyCache.m_baseGPR;
     GPRReg scratchGPR = m_scratchGPR;
 
-    if (m_propertyCache.useDataIC) {
+    if (m_propertyCache.useHandlerIC) {
         callSiteIndexForExceptionHandlingOrOriginal();
         jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
     } else
@@ -4021,7 +4021,7 @@ void InlineCacheCompiler::emitDOMJITGetter(JSGlobalObject* globalObjectForDOMJIT
         usedRegisters.add(reg, IgnoreVectors);
     for (FPRReg reg : fpScratch)
         usedRegisters.add(reg, IgnoreVectors);
-    if (m_propertyCache.useDataIC)
+    if (m_propertyCache.useHandlerIC)
         usedRegisters.add(m_propertyCache.m_propertyCacheGPR, IgnoreVectors);
     auto registersToSpillForCCall = RegisterSet::registersToSaveForCCall(usedRegisters);
 
@@ -4077,7 +4077,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
 
     InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
 
-    if (m_propertyCache.useDataIC) {
+    if (m_propertyCache.useHandlerIC) {
         callSiteIndexForExceptionHandlingOrOriginal();
         jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
     } else
@@ -4234,7 +4234,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
         jit.setupResults(valueRegs);
 
 
-    if (m_propertyCache.useDataIC) {
+    if (m_propertyCache.useHandlerIC) {
         jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), m_scratchGPR);
         if (useHandlerIC())
             jit.addPtr(CCallHelpers::TrustedImm32(-(sizeof(CallerFrameAndPC) + maxFrameExtentForSlowPathCall + m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), m_scratchGPR);
@@ -4960,7 +4960,7 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
     m_jit = &jit;
 
     if (ASSERT_ENABLED) {
-        if (m_propertyCache.useDataIC) {
+        if (m_propertyCache.useHandlerIC) {
             jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), jit.scratchRegister());
             jit.addPtr(jit.scratchRegister(), GPRInfo::callFrameRegister, jit.scratchRegister());
         } else
@@ -5114,7 +5114,7 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
         // of something that isn't patchable. The slow path will decrement "countdown" and will only
         // patch things if the countdown reaches zero. We increment the slow path count here to ensure
         // that the slow path does not try to patch.
-        if (m_propertyCache.useDataIC)
+        if (m_propertyCache.useHandlerIC)
             jit.add8(CCallHelpers::TrustedImm32(1), CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCountdown()));
         else {
             jit.move(CCallHelpers::TrustedImmPtr(&m_propertyCache.countdown), m_scratchGPR);
@@ -5143,7 +5143,7 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
         InlineCacheCompiler::SpillState spillState = this->spillStateForJSCall();
         ASSERT(!spillState.isEmpty());
         jit.loadPtr(vm().addressOfCallFrameForCatch(), GPRInfo::callFrameRegister);
-        if (m_propertyCache.useDataIC) {
+        if (m_propertyCache.useHandlerIC) {
             ASSERT(!JITCode::isBaselineCode(m_jitType));
             jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), m_scratchGPR);
             jit.addPtr(CCallHelpers::TrustedImm32(-(m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), m_scratchGPR);
@@ -5175,7 +5175,7 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
     }
 
     CodeLocationLabel<JSInternalPtrTag> successLabel = m_propertyCache.doneLocation;
-    if (m_propertyCache.useDataIC) {
+    if (m_propertyCache.useHandlerIC) {
         JIT_COMMENT(jit, "failure far jump");
         failure.link(&jit);
         jit.farJump(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfSlowPathStartLocation()), JITStubRoutinePtrTag);
@@ -5191,7 +5191,7 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
     }
 
 
-    if (m_propertyCache.useDataIC)
+    if (m_propertyCache.useHandlerIC)
         ASSERT(m_success.empty());
 
     dataLogLnIf(InlineCacheCompilerInternal::verbose, FullCodeOrigin(codeBlock, m_propertyCache.codeOrigin), ": Generating polymorphic access stub for ", listDump(keys));
@@ -6865,7 +6865,7 @@ AccessGenerationResult InlineCacheCompiler::compileHandler(const GCSafeConcurren
         return compileOneAccessCaseHandler(poly, codeBlock, *megamorphicCase, WTF::move(additionalWatchpointSets));
 
     additionalWatchpointSets.appendVector(WTF::move(sets));
-    ASSERT(m_propertyCache.useDataIC);
+    ASSERT(m_propertyCache.useHandlerIC);
     return compileOneAccessCaseHandler(poly, codeBlock, accessCase, WTF::move(additionalWatchpointSets));
 }
 

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
@@ -154,7 +154,7 @@ AccessGenerationResult PropertyInlineCache::addAccessCase(const GCSafeConcurrent
     AccessGenerationResult result = ([&](Ref<AccessCase>&& accessCase) -> AccessGenerationResult {
         dataLogLnIf(PropertyInlineCacheInternal::verbose, "Adding access case: ", accessCase);
 
-        if (useHandlerIC()) {
+        if (useHandlerIC) {
             auto list = listedAccessCases(locker);
             auto result = upgradeForPolyProtoIfNecessary(locker, vm, codeBlock, list, accessCase.get());
             dataLogLnIf(PropertyInlineCacheInternal::verbose, "Had stub, result: ", result);
@@ -182,7 +182,7 @@ AccessGenerationResult PropertyInlineCache::addAccessCase(const GCSafeConcurrent
             return compiler.compileHandler(locker, WTF::move(list), codeBlock, accessCase.get());
         }
 
-        ASSERT(!useHandlerIC());
+        ASSERT(!useHandlerIC);
         AccessGenerationResult result;
         if (m_stub) {
             result = m_stub->addCases(locker, vm, codeBlock, *this, nullptr, accessCase);
@@ -245,7 +245,7 @@ AccessGenerationResult PropertyInlineCache::addAccessCase(const GCSafeConcurrent
             return result;
 
         // If we are using DataIC, we will continue using inlined code for the first case.
-        if (!useDataIC) {
+        if (!useHandlerIC) {
             // When we first transition to becoming a Stub, we might still be running the inline
             // access code. That's because when we first transition to becoming a Stub, we may
             // be buffered, and we have not yet generated any code. Once the Stub finally generates
@@ -262,7 +262,7 @@ AccessGenerationResult PropertyInlineCache::addAccessCase(const GCSafeConcurrent
         return result;
     })(accessCase.releaseNonNull());
     if (result.generatedSomeCode()) {
-        if (useHandlerIC())
+        if (useHandlerIC)
             prependHandler(codeBlock, Ref { *result.handler() }, result.generatedMegamorphicCode());
         else
             rewireStubAsJumpInAccess(codeBlock, Ref { *result.handler() });
@@ -464,7 +464,7 @@ void PropertyInlineCache::propagateTransitions(Visitor& visitor)
     if (Structure* structure = inlineAccessBaseStructure())
         structure->markIfCheap(visitor);
 
-    if (useHandlerIC()) {
+    if (useHandlerIC) {
         if (m_inlinedHandler)
             m_inlinedHandler->propagateTransitions(visitor);
         if (auto* cursor = m_handler.get()) {
@@ -484,7 +484,7 @@ template void PropertyInlineCache::propagateTransitions(SlotVisitor&);
 
 CallLinkInfo* PropertyInlineCache::callLinkInfoAt(const ConcurrentJSLocker& locker, unsigned index, const AccessCase& accessCase)
 {
-    if (!useDataIC) {
+    if (!useHandlerIC) {
         if (!m_handler)
             return nullptr;
         return m_handler->callLinkInfoAt(locker, index);
@@ -819,15 +819,10 @@ void PropertyInlineCache::initializeFromUnlinkedPropertyInlineCache(VM& vm, Code
     m_globalObject = codeBlock->globalObject();
     callSiteIndex = CallSiteIndex(BytecodeIndex(unlinkedPropertyCache.bytecodeIndex.offset()));
     codeOrigin = CodeOrigin(unlinkedPropertyCache.bytecodeIndex);
-    if (Options::useHandlerIC())
-        initializeWithUnitHandler(codeBlock, InlineCacheCompiler::generateSlowPathHandler(vm, accessType));
-    else {
-        initializeWithUnitHandler(codeBlock, InlineCacheHandler::createNonHandlerSlowPath(unlinkedPropertyCache.slowPathStartLocation));
-        slowPathStartLocation = unlinkedPropertyCache.slowPathStartLocation;
-    }
+    useHandlerIC = true;
+    initializeWithUnitHandler(codeBlock, InlineCacheCompiler::generateSlowPathHandler(vm, accessType));
     propertyIsInt32 = unlinkedPropertyCache.propertyIsInt32;
     canBeMegamorphic = unlinkedPropertyCache.canBeMegamorphic;
-    useDataIC = true;
 
     if (unlinkedPropertyCache.canBeMegamorphic)
         bufferingCountdown = 1;
@@ -859,19 +854,14 @@ void PropertyInlineCache::initializeFromDFGUnlinkedPropertyInlineCache(CodeBlock
         m_globalObject = baselineCodeBlockForInlineCallFrame(codeOrigin.inlineCallFrame())->globalObject();
     else
         m_globalObject = codeBlock->globalObject();
-    if (Options::useHandlerIC())
-        initializeWithUnitHandler(codeBlock, InlineCacheCompiler::generateSlowPathHandler(codeBlock->vm(), accessType));
-    else {
-        initializeWithUnitHandler(codeBlock, InlineCacheHandler::createNonHandlerSlowPath(unlinkedPropertyCache.slowPathStartLocation));
-        slowPathStartLocation = unlinkedPropertyCache.slowPathStartLocation;
-    }
+    useHandlerIC = true;
+    initializeWithUnitHandler(codeBlock, InlineCacheCompiler::generateSlowPathHandler(codeBlock->vm(), accessType));
 
     propertyIsInt32 = unlinkedPropertyCache.propertyIsInt32;
     propertyIsSymbol = unlinkedPropertyCache.propertyIsSymbol;
     propertyIsString = unlinkedPropertyCache.propertyIsString;
     prototypeIsKnownObject = unlinkedPropertyCache.prototypeIsKnownObject;
     canBeMegamorphic = unlinkedPropertyCache.canBeMegamorphic;
-    useDataIC = true;
 
     if (unlinkedPropertyCache.canBeMegamorphic)
         bufferingCountdown = 1;
@@ -922,7 +912,7 @@ void PropertyInlineCache::setInlinedHandler(CodeBlock* codeBlock, Ref<InlineCach
 
 void PropertyInlineCache::clearInlinedHandler(CodeBlock* codeBlock)
 {
-    ASSERT(useHandlerIC());
+    ASSERT(useHandlerIC);
     m_inlinedHandler->removeOwner(codeBlock);
     m_inlinedHandler = nullptr;
     m_inlineAccessBaseStructureID.clear();
@@ -930,7 +920,7 @@ void PropertyInlineCache::clearInlinedHandler(CodeBlock* codeBlock)
 
 void PropertyInlineCache::initializeWithUnitHandler(CodeBlock* codeBlock, Ref<InlineCacheHandler>&& handler)
 {
-    if (useHandlerIC()) {
+    if (useHandlerIC) {
         if (m_inlinedHandler)
             clearInlinedHandler(codeBlock);
         ASSERT(!m_inlinedHandler);
@@ -946,7 +936,7 @@ void PropertyInlineCache::initializeWithUnitHandler(CodeBlock* codeBlock, Ref<In
 
 void PropertyInlineCache::prependHandler(CodeBlock* codeBlock, Ref<InlineCacheHandler>&& handler, bool isMegamorphic)
 {
-    ASSERT(useHandlerIC());
+    ASSERT(useHandlerIC);
     if (isMegamorphic) {
         initializeWithUnitHandler(codeBlock, WTF::move(handler));
         return;
@@ -968,13 +958,13 @@ void PropertyInlineCache::rewireStubAsJumpInAccess(CodeBlock* codeBlock, Ref<Inl
 {
     CodeLocationLabel label { handler->callTarget() };
     initializeWithUnitHandler(codeBlock, WTF::move(handler));
-    if (!useDataIC)
+    if (!useHandlerIC)
         CCallHelpers::replaceWithJump(startLocation.retagged<JSInternalPtrTag>(), label);
 }
 
 void PropertyInlineCache::resetStubAsJumpInAccess(CodeBlock* codeBlock)
 {
-    if (useHandlerIC()) {
+    if (useHandlerIC) {
         if (m_inlinedHandler)
             clearInlinedHandler(codeBlock);
         auto* cursor = m_handler.get();
@@ -986,8 +976,6 @@ void PropertyInlineCache::resetStubAsJumpInAccess(CodeBlock* codeBlock)
         return;
     }
 
-    if (useDataIC)
-        m_inlineAccessBaseStructureID.clear(); // Clear out the inline access code.
     rewireStubAsJumpInAccess(codeBlock, InlineCacheHandler::createNonHandlerSlowPath(slowPathStartLocation));
 }
 

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
@@ -154,7 +154,7 @@ public:
 
     uint32_t inlineCodeSize() const
     {
-        if (useDataIC)
+        if (useHandlerIC)
             return 0;
         int32_t inlineSize = MacroAssembler::differenceBetweenCodePtr(startLocation, doneLocation);
         ASSERT(inlineSize >= 0);
@@ -231,7 +231,6 @@ public:
 
     CallLinkInfo* callLinkInfoAt(const ConcurrentJSLocker&, unsigned index, const AccessCase&);
 
-    bool useHandlerIC() const { return useDataIC && Options::useHandlerIC(); }
 
     Vector<AccessCase*, 16> listedAccessCases(const AbstractLocker&) const;
 
@@ -404,7 +403,7 @@ public:
     JSCell* m_inlineHolder { nullptr };
     CacheableIdentifier m_identifier;
     // This is either the start of the inline IC for *byId caches. or the location of patchable jump for 'instanceof' caches.
-    // If useDataIC is true, then it is nullptr.
+    // If useHandlerIC is true, then it is nullptr.
     CodeLocationLabel<JITStubRoutinePtrTag> startLocation;
     CodeLocationLabel<JSInternalPtrTag> doneLocation;
     CodeLocationLabel<JITStubRoutinePtrTag> slowPathStartLocation;
@@ -468,7 +467,7 @@ public:
     bool propertyIsInt32 : 1 { false };
     bool propertyIsSymbol : 1 { false };
     bool canBeMegamorphic : 1 { false };
-    bool useDataIC : 1 { false };
+    bool useHandlerIC : 1 { false };
 };
 
 inline CodeOrigin getPropertyInlineCacheCodeOrigin(PropertyInlineCache& propertyInlineCache)

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -322,7 +322,7 @@ void ftlThunkAwareRepatchCall(CodeBlock* codeBlock, CodeLocationCall<JSInternalP
 
 static void repatchSlowPathCall(CodeBlock* codeBlock, PropertyInlineCache& propertyCache, CodePtr<CFunctionPtrTag> newCalleeFunction)
 {
-    if (propertyCache.useDataIC) {
+    if (propertyCache.useHandlerIC) {
         propertyCache.m_slowOperation = newCalleeFunction.retagged<OperationPtrTag>();
         return;
     }

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1616,7 +1616,7 @@ private:
                 break;
 
             if (m_graph.m_plan.isFTL()) {
-                if (Options::useDataICInFTL())
+                if (Options::useHandlerICInFTL())
                     break;
             }
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -4654,7 +4654,7 @@ private:
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = Options::useDataICInFTL() ? 1 : 0;
+        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -4678,7 +4678,7 @@ private:
             GPRReg baseGPR = params[1].gpr();
             GPRReg thisValueGPR = params[2].gpr();
             GPRReg propertyGPR = params[3].gpr();
-            GPRReg propertyCacheGPR = Options::useDataICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
+            GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
 
             auto* propertyCache = state->addPropertyInlineCache();
             auto generator = Box<JITGetByValWithThisGenerator>::create(
@@ -4701,11 +4701,11 @@ private:
 
                 if (notCell.isSet())
                     notCell.link(&jit);
-                if (!Options::useDataICInFTL())
+                if (!Options::useHandlerICInFTL())
                     generator->slowPathJump().link(&jit);
                 CCallHelpers::Label slowPathBegin = jit.label();
                 CCallHelpers::Call slowPathCall;
-                if (Options::useDataICInFTL()) {
+                if (Options::useHandlerICInFTL()) {
                     jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
                     generator->propertyCache()->m_slowOperation = operationGetByValWithThisOptimize;
                     slowPathCall = callOperation(
@@ -4810,7 +4810,7 @@ private:
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = Options::useDataICInFTL() ? 1 : 0;
+        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -4834,7 +4834,7 @@ private:
                 GPRReg resultGPR = params[0].gpr();
                 GPRReg baseGPR = params[1].gpr();
                 GPRReg propertyGPR = params[2].gpr();
-                GPRReg propertyCacheGPR = Options::useDataICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
+                GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
 
                 auto* propertyCache = state->addPropertyInlineCache();
                 auto generator = Box<JITGetByValGenerator>::create(
@@ -4853,11 +4853,11 @@ private:
 
                     if (notCell.isSet())
                         notCell.link(&jit);
-                    if (!Options::useDataICInFTL())
+                    if (!Options::useHandlerICInFTL())
                         generator->slowPathJump().link(&jit);
                     CCallHelpers::Label slowPathBegin = jit.label();
                     CCallHelpers::Call slowPathCall;
-                    if (Options::useDataICInFTL()) {
+                    if (Options::useHandlerICInFTL()) {
                         jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
                         generator->propertyCache()->m_slowOperation = operationGetPrivateNameOptimize;
                         slowPathCall = callOperation(
@@ -4954,7 +4954,7 @@ private:
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = Options::useDataICInFTL() ? 1 : 0;
+        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -4977,7 +4977,7 @@ private:
 
             GPRReg baseGPR = params[0].gpr();
             GPRReg brandGPR = params[1].gpr();
-            GPRReg propertyCacheGPR = Options::useDataICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
+            GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
 
             auto* propertyCache = state->addPropertyInlineCache();
             auto generator = Box<JITPrivateBrandAccessGenerator>::create(
@@ -5008,11 +5008,11 @@ private:
 
                 if (notCell.isSet())
                     notCell.link(&jit);
-                if (!Options::useDataICInFTL())
+                if (!Options::useHandlerICInFTL())
                     generator->slowPathJump().link(&jit);
                 CCallHelpers::Label slowPathBegin = jit.label();
                 CCallHelpers::Call slowPathCall;
-                if (Options::useDataICInFTL()) {
+                if (Options::useHandlerICInFTL()) {
                     jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
                     generator->propertyCache()->m_slowOperation = appropriatePrivateAccessFunction(accessType);
                     slowPathCall = callOperation(
@@ -5187,7 +5187,7 @@ private:
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = Options::useDataICInFTL() ? 1 : 0;
+        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -5212,7 +5212,7 @@ private:
             GPRReg baseGPR = params[0].gpr();
             GPRReg propertyGPR = params[1].gpr();
             GPRReg valueGPR = params[2].gpr();
-            GPRReg propertyCacheGPR = Options::useDataICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
+            GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
 
             auto* propertyCache = state->addPropertyInlineCache();
             auto generator = Box<JITPutByValGenerator>::create(
@@ -5227,11 +5227,11 @@ private:
             params.addLatePath([=] (CCallHelpers& jit) {
                 AllowMacroScratchRegisterUsage allowScratch(jit);
 
-                if (!Options::useDataICInFTL())
+                if (!Options::useHandlerICInFTL())
                     generator->slowPathJump().link(&jit);
                 CCallHelpers::Label slowPathBegin = jit.label();
                 CCallHelpers::Call slowPathCall;
-                if (Options::useDataICInFTL()) {
+                if (Options::useHandlerICInFTL()) {
                     jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
                     generator->propertyCache()->m_slowOperation = operation;
                     slowPathCall = callOperation(
@@ -5543,7 +5543,7 @@ private:
         patchpoint->append(m_notCellMask, ValueRep::reg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::reg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = Options::useDataICInFTL() ? 3 : 0;
+        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 3 : 0;
 
         // FIXME: If this is a PutByIdFlush, we might want to late-clobber volatile registers.
         // https://bugs.webkit.org/show_bug.cgi?id=152848
@@ -5570,7 +5570,7 @@ private:
                 GPRReg propertyCacheGPR = InvalidGPRReg;
                 GPRReg scratchGPR = InvalidGPRReg;
                 GPRReg scratch2GPR = InvalidGPRReg;
-                if (Options::useDataICInFTL()) {
+                if (Options::useHandlerICInFTL()) {
                     propertyCacheGPR = params.gpScratch(0);
                     scratchGPR = params.gpScratch(1);
                     scratch2GPR = params.gpScratch(2);
@@ -5593,12 +5593,12 @@ private:
                     [=] (CCallHelpers& jit) {
                         AllowMacroScratchRegisterUsage allowScratch(jit);
 
-                        if (!Options::useDataICInFTL())
+                        if (!Options::useHandlerICInFTL())
                             generator->slowPathJump().link(&jit);
                         CCallHelpers::Label slowPathBegin = jit.label();
                         CCallHelpers::Call slowPathCall;
                         auto* operation = appropriatePutByIdOptimizeFunction(accessType);
-                        if (Options::useDataICInFTL()) {
+                        if (Options::useHandlerICInFTL()) {
                             jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
                             generator->propertyCache()->m_slowOperation = operation;
                             slowPathCall = callOperation(
@@ -6502,7 +6502,7 @@ IGNORE_CLANG_WARNINGS_END
             patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
             patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
             patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-            patchpoint->numGPScratchRegisters = Options::useDataICInFTL() ? 1 : 0;
+            patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
 
             RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -6525,7 +6525,7 @@ IGNORE_CLANG_WARNINGS_END
                 GPRReg resultGPR = params[0].gpr();
                 GPRReg baseGPR = params[1].gpr();
                 GPRReg propertyGPR = params[2].gpr();
-                GPRReg propertyCacheGPR = Options::useDataICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
+                GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
 
                 auto* propertyCache = state->addPropertyInlineCache();
                 auto generator = Box<JITGetByValGenerator>::create(
@@ -6548,11 +6548,11 @@ IGNORE_CLANG_WARNINGS_END
 
                     if (notCell.isSet())
                         notCell.link(&jit);
-                    if (!Options::useDataICInFTL())
+                    if (!Options::useHandlerICInFTL())
                         generator->slowPathJump().link(&jit);
                     CCallHelpers::Label slowPathBegin = jit.label();
                     CCallHelpers::Call slowPathCall;
-                    if (Options::useDataICInFTL()) {
+                    if (Options::useHandlerICInFTL()) {
                         jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
                         generator->propertyCache()->m_slowOperation = operationGetByValOptimize;
                         slowPathCall = callOperation(
@@ -7232,7 +7232,7 @@ IGNORE_CLANG_WARNINGS_END
             patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
             patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
             patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-            patchpoint->numGPScratchRegisters = Options::useDataICInFTL() ? 1 : 0;
+            patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
 
             RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -7257,7 +7257,7 @@ IGNORE_CLANG_WARNINGS_END
                 GPRReg baseGPR = params[0].gpr();
                 GPRReg propertyGPR = params[1].gpr();
                 GPRReg valueGPR = params[2].gpr();
-                GPRReg propertyCacheGPR = Options::useDataICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
+                GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
 
                 auto* propertyCache = state->addPropertyInlineCache();
                 auto generator = Box<JITPutByValGenerator>::create(
@@ -7274,12 +7274,12 @@ IGNORE_CLANG_WARNINGS_END
                 params.addLatePath([=] (CCallHelpers& jit) {
                     AllowMacroScratchRegisterUsage allowScratch(jit);
 
-                    if (!Options::useDataICInFTL())
+                    if (!Options::useHandlerICInFTL())
                         generator->slowPathJump().link(&jit);
                     CCallHelpers::Label slowPathBegin = jit.label();
                     CCallHelpers::Call slowPathCall;
                     auto operation = isDirect ? (ecmaMode.isStrict() ? operationDirectPutByValStrictOptimize : operationDirectPutByValSloppyOptimize) : (ecmaMode.isStrict() ? operationPutByValStrictOptimize : operationPutByValSloppyOptimize);
-                    if (Options::useDataICInFTL()) {
+                    if (Options::useHandlerICInFTL()) {
                         jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
                         generator->propertyCache()->m_slowOperation = operation;
                         slowPathCall = callOperation(
@@ -7856,7 +7856,7 @@ IGNORE_CLANG_WARNINGS_END
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = Options::useDataICInFTL() ? 1 : 0;
+        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle =
             preparePatchpointForExceptions(patchpoint);
@@ -7889,7 +7889,7 @@ IGNORE_CLANG_WARNINGS_END
 
                 auto base = JSValueRegs(params[1].gpr());
                 auto returnGPR = params[0].gpr();
-                GPRReg propertyCacheGPR = Options::useDataICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
+                GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
                 ASSERT(base.gpr() != returnGPR);
 
                 if (child1UseKind)
@@ -7935,7 +7935,7 @@ IGNORE_CLANG_WARNINGS_END
                 }();
 
                 generator->generateFastPath(jit);
-                if (!Options::useDataICInFTL())
+                if (!Options::useHandlerICInFTL())
                     slowCases.append(generator->slowPathJump());
                 CCallHelpers::Label done = jit.label();
 
@@ -7948,7 +7948,7 @@ IGNORE_CLANG_WARNINGS_END
                         CCallHelpers::Call slowPathCall;
 
                         if constexpr (kind == DelByKind::ByIdStrict || kind == DelByKind::ByIdSloppy) {
-                            if (Options::useDataICInFTL()) {
+                            if (Options::useHandlerICInFTL()) {
                                 jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
                                 generator->propertyCache()->m_slowOperation = optimizationFunction;
                                 slowPathCall = callOperation(
@@ -7962,7 +7962,7 @@ IGNORE_CLANG_WARNINGS_END
                                     base, CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
                             }
                         } else {
-                            if (Options::useDataICInFTL()) {
+                            if (Options::useHandlerICInFTL()) {
                                 jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
                                 generator->propertyCache()->m_slowOperation = optimizationFunction;
                                 slowPathCall = callOperation(
@@ -16167,9 +16167,9 @@ IGNORE_CLANG_WARNINGS_END
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
         if constexpr (type == AccessType::InById)
-            patchpoint->numGPScratchRegisters = Options::useDataICInFTL() ? 2 : 0;
+            patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 2 : 0;
         else
-            patchpoint->numGPScratchRegisters = Options::useDataICInFTL() ? 1 : 0;
+            patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -16190,7 +16190,7 @@ IGNORE_CLANG_WARNINGS_END
 
                 GPRReg propertyCacheGPR = InvalidGPRReg;
                 GPRReg scratchGPR = InvalidGPRReg;
-                if (Options::useDataICInFTL()) {
+                if (Options::useHandlerICInFTL()) {
                     propertyCacheGPR = params.gpScratch(0);
                     if constexpr (type == AccessType::InById)
                         scratchGPR = params.gpScratch(1);
@@ -16238,7 +16238,7 @@ IGNORE_CLANG_WARNINGS_END
 
                 CCallHelpers::JumpList slowCases;
                 generator->generateFastPath(jit);
-                if (!Options::useDataICInFTL())
+                if (!Options::useHandlerICInFTL())
                     slowCases.append(generator->slowPathJump());
                 CCallHelpers::Label done = jit.label();
 
@@ -16250,7 +16250,7 @@ IGNORE_CLANG_WARNINGS_END
                         CCallHelpers::Label slowPathBegin = jit.label();
                         CCallHelpers::Call slowPathCall;
                         if constexpr (type == AccessType::InById) {
-                            if (Options::useDataICInFTL()) {
+                            if (Options::useHandlerICInFTL()) {
                                 jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
                                 generator->propertyCache()->m_slowOperation = optimizationFunction;
                                 slowPathCall = callOperation(
@@ -16264,7 +16264,7 @@ IGNORE_CLANG_WARNINGS_END
                                     base, CCallHelpers::TrustedImmPtr(generator->propertyCache())).call();
                             }
                         } else if constexpr (type == AccessType::InByVal) {
-                            if (Options::useDataICInFTL()) {
+                            if (Options::useHandlerICInFTL()) {
                                 jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
                                 generator->propertyCache()->m_slowOperation = optimizationFunction;
                                 slowPathCall = callOperation(
@@ -16278,7 +16278,7 @@ IGNORE_CLANG_WARNINGS_END
                                     base, subscript, CCallHelpers::TrustedImmPtr(generator->propertyCache()), CCallHelpers::TrustedImmPtr(nullptr)).call();
                             }
                         } else {
-                            if (Options::useDataICInFTL()) {
+                            if (Options::useHandlerICInFTL()) {
                                 jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
                                 generator->propertyCache()->m_slowOperation = optimizationFunction;
                                 slowPathCall = callOperation(
@@ -16751,7 +16751,7 @@ IGNORE_CLANG_WARNINGS_END
         patchpoint->appendSomeRegister(prototype);
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
-        patchpoint->numGPScratchRegisters = Options::useDataICInFTL() ? 1 : 0;
+        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
         patchpoint->resultConstraints = { ValueRep::SomeEarlyRegister };
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
 
@@ -16767,7 +16767,7 @@ IGNORE_CLANG_WARNINGS_END
                 GPRReg resultGPR = params[0].gpr();
                 GPRReg valueGPR = params[1].gpr();
                 GPRReg prototypeGPR = params[2].gpr();
-                GPRReg propertyCacheGPR = Options::useDataICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
+                GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
 
                 CCallHelpers::Jump doneJump;
                 if (!valueIsCell) {
@@ -16793,7 +16793,7 @@ IGNORE_CLANG_WARNINGS_END
                     jit.codeBlock(), propertyCache, JITType::FTLJIT, semanticNodeOrigin, callSiteIndex,
                     params.unavailableRegisters(), resultGPR, valueGPR, prototypeGPR, propertyCacheGPR, prototypeIsObject);
                 generator->generateFastPath(jit);
-                if (!Options::useDataICInFTL())
+                if (!Options::useHandlerICInFTL())
                     slowCases.append(generator->slowPathJump());
                 CCallHelpers::Label done = jit.label();
 
@@ -16806,7 +16806,7 @@ IGNORE_CLANG_WARNINGS_END
                         slowCases.link(&jit);
                         CCallHelpers::Label slowPathBegin = jit.label();
                         CCallHelpers::Call slowPathCall;
-                        if (Options::useDataICInFTL()) {
+                        if (Options::useHandlerICInFTL()) {
                             jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
                             generator->propertyCache()->m_slowOperation = optimizationFunction;
                             slowPathCall = callOperation(
@@ -17611,7 +17611,7 @@ IGNORE_CLANG_WARNINGS_END
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = Options::useDataICInFTL() ? 1 : 0;
+        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 1 : 0;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -17635,7 +17635,7 @@ IGNORE_CLANG_WARNINGS_END
             GPRReg baseGPR = params[0].gpr();
             GPRReg propertyGPR = params[1].gpr();
             GPRReg valueGPR = params[2].gpr();
-            GPRReg propertyCacheGPR = Options::useDataICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
+            GPRReg propertyCacheGPR = Options::useHandlerICInFTL() ? params.gpScratch(0) : InvalidGPRReg;
 
             auto* propertyCache = state->addPropertyInlineCache();
             auto generator = Box<JITPutByValGenerator>::create(
@@ -17648,12 +17648,12 @@ IGNORE_CLANG_WARNINGS_END
             params.addLatePath([=] (CCallHelpers& jit) {
                 AllowMacroScratchRegisterUsage allowScratch(jit);
 
-                if (!Options::useDataICInFTL())
+                if (!Options::useHandlerICInFTL())
                     generator->slowPathJump().link(&jit);
                 CCallHelpers::Label slowPathBegin = jit.label();
                 CCallHelpers::Call slowPathCall;
                 auto operation = ecmaMode.isStrict() ? operationPutByValStrictOptimize : operationPutByValSloppyOptimize;
-                if (Options::useDataICInFTL()) {
+                if (Options::useHandlerICInFTL()) {
                     jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
                     generator->propertyCache()->m_slowOperation = operation;
                     slowPathCall = callOperation(
@@ -19126,7 +19126,7 @@ IGNORE_CLANG_WARNINGS_END
         patchpoint->appendSomeRegister(base);
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
-        patchpoint->numGPScratchRegisters = Options::useDataICInFTL() ? 2 : 0;
+        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 2 : 0;
 
         // FIXME: If this is a GetByIdFlush/GetByIdDirectFlush, we might get some performance boost if we claim that it
         // clobbers volatile registers late. It's not necessary for correctness, though, since the
@@ -19159,7 +19159,7 @@ IGNORE_CLANG_WARNINGS_END
 
                 GPRReg propertyCacheGPR = InvalidGPRReg;
                 GPRReg scratchGPR = InvalidGPRReg;
-                if (Options::useDataICInFTL()) {
+                if (Options::useHandlerICInFTL()) {
                     propertyCacheGPR = params.gpScratch(0);
                     scratchGPR = params.gpScratch(1);
                 }
@@ -19181,11 +19181,11 @@ IGNORE_CLANG_WARNINGS_END
 
                         auto optimizationFunction = appropriateGetByIdOptimizeFunction(type);
 
-                        if (!Options::useDataICInFTL())
+                        if (!Options::useHandlerICInFTL())
                             generator->slowPathJump().link(&jit);
                         CCallHelpers::Label slowPathBegin = jit.label();
                         CCallHelpers::Call slowPathCall;
-                        if (Options::useDataICInFTL()) {
+                        if (Options::useHandlerICInFTL()) {
                             jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
                             generator->propertyCache()->m_slowOperation = optimizationFunction;
                             slowPathCall = callOperation(
@@ -19223,7 +19223,7 @@ IGNORE_CLANG_WARNINGS_END
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = Options::useDataICInFTL() ? 2 : 0;
+        patchpoint->numGPScratchRegisters = Options::useHandlerICInFTL() ? 2 : 0;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle =
             preparePatchpointForExceptions(patchpoint);
@@ -19249,7 +19249,7 @@ IGNORE_CLANG_WARNINGS_END
 
                 GPRReg propertyCacheGPR = InvalidGPRReg;
                 GPRReg scratchGPR = InvalidGPRReg;
-                if (Options::useDataICInFTL()) {
+                if (Options::useHandlerICInFTL()) {
                     propertyCacheGPR = params.gpScratch(0);
                     scratchGPR = params.gpScratch(1);
                 }
@@ -19271,11 +19271,11 @@ IGNORE_CLANG_WARNINGS_END
 
                         auto optimizationFunction = operationGetByIdWithThisOptimize;
 
-                        if (!Options::useDataICInFTL())
+                        if (!Options::useHandlerICInFTL())
                             generator->slowPathJump().link(&jit);
                         CCallHelpers::Label slowPathBegin = jit.label();
                         CCallHelpers::Call slowPathCall;
-                        if (Options::useDataICInFTL()) {
+                        if (Options::useHandlerICInFTL()) {
                             jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
                             generator->propertyCache()->m_slowOperation = optimizationFunction;
                             slowPathCall = callOperation(

--- a/Source/JavaScriptCore/ftl/FTLState.cpp
+++ b/Source/JavaScriptCore/ftl/FTLState.cpp
@@ -171,7 +171,7 @@ PropertyInlineCache* State::addPropertyInlineCache()
 {
     ASSERT(!graph.m_plan.isUnlinked());
     auto* propertyCache = jitCode->common.m_propertyInlineCaches.add();
-    propertyCache->useDataIC = Options::useDataICInFTL();
+    propertyCache->useHandlerIC = Options::useHandlerICInFTL();
     return propertyCache;
 }
 

--- a/Source/JavaScriptCore/jit/JITInlineCacheGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITInlineCacheGenerator.cpp
@@ -63,7 +63,7 @@ void JITInlineCacheGenerator::finalize(
     LinkBuffer& fastPath, LinkBuffer& slowPath, CodeLocationLabel<JITStubRoutinePtrTag> start)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
     m_propertyCache->startLocation = start;
     m_propertyCache->doneLocation = fastPath.locationOf<JSInternalPtrTag>(m_done);
     m_propertyCache->m_slowPathCallLocation = slowPath.locationOf<JSInternalPtrTag>(m_slowPathCall);
@@ -73,13 +73,8 @@ void JITInlineCacheGenerator::finalize(
 void JITInlineCacheGenerator::generateDataICFastPath(CCallHelpers& jit, GPRReg propertyCacheGPR)
 {
     m_start = jit.label();
-    if (Options::useHandlerIC()) {
-        jit.loadPtr(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfHandler()), GPRInfo::handlerGPR);
-        jit.call(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfCallTarget()), JITStubRoutinePtrTag);
-    } else {
-        jit.loadPtr(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfHandler()), jit.scratchRegister());
-        jit.farJump(CCallHelpers::Address(jit.scratchRegister(), InlineCacheHandler::offsetOfCallTarget()), JITStubRoutinePtrTag);
-    }
+    jit.loadPtr(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfHandler()), GPRInfo::handlerGPR);
+    jit.call(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfCallTarget()), JITStubRoutinePtrTag);
     m_done = jit.label();
 }
 
@@ -96,12 +91,12 @@ void JITByIdGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 {
     ASSERT(m_propertyCache);
     JITInlineCacheGenerator::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
 }
 
 void JITByIdGenerator::generateFastCommon(CCallHelpers& jit, size_t inlineICSize)
 {
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
     jit.padBeforePatch(); // On ARMv7, this ensures that the patchable jump does not make the inline code too large.
     m_start = jit.label();
     size_t startSize = jit.m_assembler.buffer().codeSize();
@@ -165,20 +160,15 @@ static void generateGetByIdInlineAccessBaselineDataIC(CCallHelpers& jit, GPRReg 
     }
 
     slowCases.link(&jit);
-    if (Options::useHandlerIC()) {
-        jit.loadPtr(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfHandler()), GPRInfo::handlerGPR);
-        jit.call(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfCallTarget()), JITStubRoutinePtrTag);
-    } else {
-        jit.loadPtr(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfHandler()), jit.scratchRegister());
-        jit.farJump(CCallHelpers::Address(jit.scratchRegister(), InlineCacheHandler::offsetOfCallTarget()), JITStubRoutinePtrTag);
-    }
+    jit.loadPtr(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfHandler()), GPRInfo::handlerGPR);
+    jit.call(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfCallTarget()), JITStubRoutinePtrTag);
     doneCases.link(&jit);
 }
 
 void JITGetByIdGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
     generateFastCommon(jit, m_isLengthAccess ? InlineAccess::sizeForLengthAccess() : InlineAccess::sizeForPropertyAccess());
 }
 
@@ -210,7 +200,7 @@ JITGetByIdWithThisGenerator::JITGetByIdWithThisGenerator(
 void JITGetByIdWithThisGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
     generateFastCommon(jit, InlineAccess::sizeForPropertyAccess());
 }
 
@@ -248,13 +238,8 @@ static void generatePutByIdInlineAccessBaselineDataIC(CCallHelpers& jit, GPRReg 
     jit.storeProperty(valueJSR, baseJSR.payloadGPR(), scratch1GPR, scratch2GPR);
     auto done = jit.jump();
     doNotInlineAccess.link(&jit);
-    if (Options::useHandlerIC()) {
-        jit.loadPtr(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfHandler()), GPRInfo::handlerGPR);
-        jit.call(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfCallTarget()), JITStubRoutinePtrTag);
-    } else {
-        jit.loadPtr(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfHandler()), jit.scratchRegister());
-        jit.farJump(CCallHelpers::Address(jit.scratchRegister(), InlineCacheHandler::offsetOfCallTarget()), JITStubRoutinePtrTag);
-    }
+    jit.loadPtr(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfHandler()), GPRInfo::handlerGPR);
+    jit.call(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfCallTarget()), JITStubRoutinePtrTag);
     done.link(&jit);
 }
 
@@ -274,7 +259,7 @@ void JITPutByIdGenerator::generateDataICFastPath(CCallHelpers& jit)
 void JITPutByIdGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
     generateFastCommon(jit, InlineAccess::sizeForPropertyReplace());
 }
 
@@ -289,7 +274,7 @@ JITDelByValGenerator::JITDelByValGenerator(CodeBlock* codeBlock, CompileTimeProp
 void JITDelByValGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
     m_start = jit.label();
     m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
@@ -305,7 +290,7 @@ void JITDelByValGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 {
     ASSERT(m_propertyCache);
     Base::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
 }
 
 JITDelByIdGenerator::JITDelByIdGenerator(CodeBlock* codeBlock, CompileTimePropertyInlineCache propertyCache, JITType jitType, CodeOrigin codeOrigin, CallSiteIndex callSiteIndex, AccessType accessType, const RegisterSet& usedRegisters, CacheableIdentifier propertyName, JSValueRegs base, JSValueRegs result, GPRReg propertyCacheGPR)
@@ -319,7 +304,7 @@ JITDelByIdGenerator::JITDelByIdGenerator(CodeBlock* codeBlock, CompileTimeProper
 void JITDelByIdGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
     m_start = jit.label();
     m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
@@ -335,7 +320,7 @@ void JITDelByIdGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 {
     ASSERT(m_propertyCache);
     Base::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
 }
 
 JITInByValGenerator::JITInByValGenerator(CodeBlock* codeBlock, CompileTimePropertyInlineCache propertyCache, JITType jitType, CodeOrigin codeOrigin, CallSiteIndex callSiteIndex, AccessType accessType, const RegisterSet& usedRegisters, JSValueRegs base, JSValueRegs property, JSValueRegs result, GPRReg arrayProfileGPR, GPRReg propertyCacheGPR)
@@ -349,7 +334,7 @@ JITInByValGenerator::JITInByValGenerator(CodeBlock* codeBlock, CompileTimeProper
 void JITInByValGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
     m_start = jit.label();
     m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
@@ -367,7 +352,7 @@ void JITInByValGenerator::finalize(
     ASSERT(m_start.isSet());
     ASSERT(m_propertyCache);
     Base::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
 }
 
 JITInByIdGenerator::JITInByIdGenerator(
@@ -388,20 +373,15 @@ static void generateInByIdInlineAccessBaselineDataIC(CCallHelpers& jit, GPRReg p
     jit.boxBoolean(true, resultJSR);
     auto finished = jit.jump();
     skipInlineAccess.link(&jit);
-    if (Options::useHandlerIC()) {
-        jit.loadPtr(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfHandler()), GPRInfo::handlerGPR);
-        jit.call(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfCallTarget()), JITStubRoutinePtrTag);
-    } else {
-        jit.loadPtr(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfHandler()), jit.scratchRegister());
-        jit.farJump(CCallHelpers::Address(jit.scratchRegister(), InlineCacheHandler::offsetOfCallTarget()), JITStubRoutinePtrTag);
-    }
+    jit.loadPtr(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfHandler()), GPRInfo::handlerGPR);
+    jit.call(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfCallTarget()), JITStubRoutinePtrTag);
     finished.link(&jit);
 }
 
 void JITInByIdGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
     generateFastCommon(jit, InlineAccess::sizeForPropertyAccess());
 }
 
@@ -431,7 +411,7 @@ JITInstanceOfGenerator::JITInstanceOfGenerator(
 void JITInstanceOfGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
     m_start = jit.label();
     m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
@@ -447,7 +427,7 @@ void JITInstanceOfGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath
 {
     ASSERT(m_propertyCache);
     Base::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
 }
 
 JITGetByValGenerator::JITGetByValGenerator(CodeBlock* codeBlock, CompileTimePropertyInlineCache propertyCache, JITType jitType, CodeOrigin codeOrigin, CallSiteIndex callSiteIndex, AccessType accessType, const RegisterSet& usedRegisters, JSValueRegs base, JSValueRegs property, JSValueRegs result, GPRReg arrayProfileGPR, GPRReg propertyCacheGPR)
@@ -463,7 +443,7 @@ JITGetByValGenerator::JITGetByValGenerator(CodeBlock* codeBlock, CompileTimeProp
 void JITGetByValGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
     m_start = jit.label();
     m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
@@ -485,7 +465,7 @@ void JITGetByValGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 {
     ASSERT(m_propertyCache);
     Base::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
 }
 
 JITGetByValWithThisGenerator::JITGetByValWithThisGenerator(CodeBlock* codeBlock, CompileTimePropertyInlineCache propertyCache, JITType jitType, CodeOrigin codeOrigin, CallSiteIndex callSiteIndex, AccessType accessType, const RegisterSet& usedRegisters, JSValueRegs base, JSValueRegs property, JSValueRegs thisRegs, JSValueRegs result, GPRReg arrayProfileGPR, GPRReg propertyCacheGPR)
@@ -501,7 +481,7 @@ JITGetByValWithThisGenerator::JITGetByValWithThisGenerator(CodeBlock* codeBlock,
 void JITGetByValWithThisGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
     m_start = jit.label();
     m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
@@ -525,7 +505,7 @@ void JITGetByValWithThisGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& sl
 {
     ASSERT(m_propertyCache);
     Base::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
 }
 
 JITPutByValGenerator::JITPutByValGenerator(CodeBlock* codeBlock, CompileTimePropertyInlineCache propertyCache, JITType jitType, CodeOrigin codeOrigin, CallSiteIndex callSiteIndex, AccessType accessType, const RegisterSet& usedRegisters, JSValueRegs base, JSValueRegs property, JSValueRegs value, GPRReg arrayProfileGPR, GPRReg propertyCacheGPR)
@@ -541,7 +521,7 @@ JITPutByValGenerator::JITPutByValGenerator(CodeBlock* codeBlock, CompileTimeProp
 void JITPutByValGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
     m_start = jit.label();
     m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
@@ -557,7 +537,7 @@ void JITPutByValGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 {
     ASSERT(m_propertyCache);
     Base::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
 }
 
 JITPrivateBrandAccessGenerator::JITPrivateBrandAccessGenerator(CodeBlock* codeBlock, CompileTimePropertyInlineCache propertyCache, JITType jitType, CodeOrigin codeOrigin, CallSiteIndex callSiteIndex, AccessType accessType, const RegisterSet& usedRegisters, JSValueRegs base, JSValueRegs brand, GPRReg propertyCacheGPR)
@@ -572,7 +552,7 @@ JITPrivateBrandAccessGenerator::JITPrivateBrandAccessGenerator(CodeBlock* codeBl
 void JITPrivateBrandAccessGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
     m_start = jit.label();
     m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
@@ -588,7 +568,7 @@ void JITPrivateBrandAccessGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& 
 {
     ASSERT(m_propertyCache);
     Base::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useDataIC);
+    ASSERT(!m_propertyCache->useHandlerIC);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -811,7 +811,7 @@ void Options::notifyOptionsChanged()
     Options::useRandomizingExecutableIslandAllocation() = false;
 #endif
 
-    Options::useDataICInFTL() = false; // Currently, it is not completed. Disable forcefully.
+    Options::useHandlerICInFTL() = false; // Currently, it is not completed. Disable forcefully.
     Options::forceUnlinkedDFG() = false; // Currently, IC is rapidly changing. We disable this until we get the final form of Data IC.
 
     if (!Options::allowDoubleShape())
@@ -1521,15 +1521,6 @@ SUPPRESS_ASAN bool canUseJITCage()
 #else
 bool canUseJITCage() { return false; }
 #endif
-
-bool canUseHandlerIC()
-{
-#if USE(JSVALUE64)
-    return true;
-#else
-    return false;
-#endif
-}
 
 bool canUseWasm()
 {

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -41,7 +41,6 @@ namespace JSC {
 #define MAXIMUM_NUMBER_OF_FTL_COMPILER_THREADS 8
 
 JS_EXPORT_PRIVATE bool canUseJITCage();
-bool canUseHandlerIC();
 bool canUseWasm();
 bool hasCapacityToUseLargeGigacage();
 
@@ -623,8 +622,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maxNumericHotLoopSize, 225, Normal, nullptr) \
     v(Bool, printEachUnrolledLoop, false, Normal, nullptr) \
     v(Bool, verboseExecutablePoolAllocation, false, Normal, nullptr) \
-    v(Bool, useHandlerIC, canUseHandlerIC(), Normal, nullptr) \
-    v(Bool, useDataICInFTL, false, Normal, nullptr) \
+    v(Bool, useHandlerICInFTL, false, Normal, nullptr) \
     v(Bool, useLLIntICs, true, Normal, "Use property and call ICs in LLInt code."_s) \
     v(Bool, useBaselineJITCodeSharing, is64Bit(), Normal, nullptr) \
     v(Bool, libpasScavengeContinuously, false, Normal, nullptr) \

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -702,7 +702,7 @@ BASE_OPTIONS = ["--validateOptions=true", "--useFTLJIT=false", "--useFunctionDot
 EAGER_OPTIONS = ["--validateOptions=true", "--thresholdForJITAfterWarmUp=10", "--thresholdForJITSoon=10", "--thresholdForOptimizeAfterWarmUp=20", "--thresholdForOptimizeAfterLongWarmUp=20", "--thresholdForOptimizeSoon=20", "--thresholdForFTLOptimizeAfterWarmUp=20", "--thresholdForFTLOptimizeSoon=20", "--thresholdForOMGOptimizeAfterWarmUp=20", "--thresholdForOMGOptimizeSoon=20", "--maximumEvalCacheableSourceLength=150000", "--useEagerCodeBlockJettisonTiming=true", "--repatchBufferingCountdown=0"]
 # NOTE: Tests rely on this using scribbleFreeCells.
 NO_CJIT_OPTIONS = ["--validateOptions=true", "--useConcurrentJIT=false", "--thresholdForJITAfterWarmUp=100", "--scribbleFreeCells=true"]
-B3O1_OPTIONS = ["--defaultB3OptLevel=1", "--useDataICInFTL=1", "--forceUnlinkedDFG=1"]
+B3O1_OPTIONS = ["--defaultB3OptLevel=1", "--useHandlerICInFTL=1", "--forceUnlinkedDFG=1"]
 B3O0_OPTIONS = ["--maxDFGNodesInBasicBlockForPreciseAnalysis=100", "--defaultB3OptLevel=0"]
 FTL_OPTIONS = ["--validateOptions=true", "--useFTLJIT=true"]
 FORCE_LLINT_EXIT_OPTIONS = ["--forceOSRExitToLLInt=true"]
@@ -1175,7 +1175,7 @@ BASE_MODES = [
         "FTLNoCJIT",
         "misc-ftl-no-cjit",
         [
-            "--useDataICInFTL=true",
+            "--useHandlerICInFTL=true",
             "--allowNonSPTagging=false",
             "--libpasForcePGMWithRate=#{10 + rand(10)}",
         ] +
@@ -1204,7 +1204,7 @@ BASE_MODES = [
             "--useSamplingProfiler=true",
             "--airForceIRCAllocator=true",
             "--airUseGreedyRegAlloc=false", # FIXME: remove with rdar://144792585
-            "--useDataICInFTL=true",
+            "--useHandlerICInFTL=true",
             "--forceUnlinkedDFG=true",
             "--allowNonSPTagging=false",
         ] +
@@ -1267,7 +1267,7 @@ BASE_MODES = [
             "--airForceBriggsAllocator=true",
             "--useRandomizingExecutableIslandAllocation=true",
             "--forcePolyProto=true",
-            "--useDataICInFTL=true",
+            "--useHandlerICInFTL=true",
             "--allowNonSPTagging=false",
         ] +
         FTL_OPTIONS +


### PR DESCRIPTION
#### 365ecfc0a51121dc702cefd3135d58c7fe054085
<pre>
[JSC] Combine HandlerIC with DataIC in PropertyInlineCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=309395">https://bugs.webkit.org/show_bug.cgi?id=309395</a>
<a href="https://rdar.apple.com/171938929">rdar://171938929</a>

Reviewed by Yusuke Suzuki.

PropertyInlineCache had a DataIC mode and a HandlerIC mode however,
the non-handler DataIC has bitrotted and longer works on 64-bit. This
patch consolidates those to concepts into HandlerIC removing the option
and renaming the field in PropertyInlineCache.

Also, rename useDataICInFTL to useHandlerICInFTL to reflect this change.

No new tests, consolidating code, no behavior change.

Canonical link: <a href="https://commits.webkit.org/308910@main">https://commits.webkit.org/308910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ae45fb87fc1b315b587924f212b606b6bc3d613

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21374 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157346 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102091 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6819c10b-28c6-4708-ab33-b7e0df5e2950) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114597 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81599 "4 flakes 1 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4943723-c8c8-4e73-9c62-4b5bd10a88d2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16801 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133444 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95367 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9162bec-4fb5-49bf-8e52-f714e4a5850f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15917 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13756 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4781 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140628 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159681 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9448 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2821 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12886 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122663 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21176 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122887 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21184 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133158 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77313 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22923 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18190 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9920 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180089 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20786 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84588 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46119 "Found 1 new JSC stress test failure: Too many failures: 5682 jsc tests failed (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20518 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20664 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20574 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->