### PR TITLE
Use correct limit for number of wasm tables

### DIFF
--- a/JSTests/wasm/references/multitable.js
+++ b/JSTests/wasm/references/multitable.js
@@ -428,10 +428,10 @@ if (!$vm.isMemoryLimited()) {
                   .GetLocal(0)
                   .TableSet(1)
                 .End()
-              .End().WebAssembly().get())), Error, "Table count of 1000000 is too big, maximum 1000000");
+              .End().WebAssembly().get())), Error, "Table count of 100000 is too big, maximum 100000");
 
     {
-        const largeNumber = 1000000;
+        const largeNumber = 100000;
         const $1 = new WebAssembly.Instance(new WebAssembly.Module(tableInsanity(largeNumber-2, (new Builder())
               .Type().End())
                     .Table({initial: 3, maximum: 3, element: "funcref"})

--- a/Source/JavaScriptCore/wasm/WasmLimits.h
+++ b/Source/JavaScriptCore/wasm/WasmLimits.h
@@ -61,7 +61,7 @@ constexpr size_t maxFunctionReturns = 1000;
 
 constexpr size_t maxTableEntries = 10000000;
 constexpr size_t maxTableInitializationEntries = 10000000;
-constexpr unsigned maxTables = 1000000;
+constexpr unsigned maxTables = 100000;
 
 // Limit of GC arrays in bytes. This is not included in the limits in the
 // JS API spec, but we set a limit to avoid complicated boundary conditions.


### PR DESCRIPTION
#### 0691f940a6f7f62509faf858df85d3416c107845
<pre>
Use correct limit for number of wasm tables
<a href="https://bugs.webkit.org/show_bug.cgi?id=308732">https://bugs.webkit.org/show_bug.cgi?id=308732</a>
<a href="https://rdar.apple.com/171801338">rdar://171801338</a>

Reviewed by Yusuke Suzuki.

JSC currently throws an error if a wasm module uses more than 1 million
tables. The JS embedding spec says the limit is 100,000:

<a href="https://webassembly.github.io/spec/js-api/index.html#limits">https://webassembly.github.io/spec/js-api/index.html#limits</a>

Corrected an existing test that assumed the limit was 1 million

* JSTests/wasm/references/multitable.js:
* Source/JavaScriptCore/wasm/WasmLimits.h:

Canonical link: <a href="https://commits.webkit.org/308922@main">https://commits.webkit.org/308922@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26bf33b4e928fc8fa07b7a0e128c7845d79c44dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157316 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102062 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21223 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114573 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81586 "4 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0d46200-de18-4509-b4bb-d7468870f7a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133419 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95343 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45eba1de-8fb0-4b2f-95ac-08b85a964def) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15895 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13732 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4752 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140599 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125506 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159651 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9419 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2792 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12859 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122639 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122863 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21155 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133131 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77284 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22925 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18176 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9894 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180060 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20756 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84559 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46086 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20489 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20635 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20545 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->