### PR TITLE
[ Site-Isolation ] Create a temporary test to test new site-isolation EWS configuration

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge-expected.html
@@ -6,7 +6,7 @@
 
 <style>
 .target {
-  transform: rotate(330deg) translate3d(110px, 10px, 10px);
+  transform: rotate(330deg) translate3d(110px, 10px, 12px);
   border-radius: 0.375rem;
   width: 400px;
   height: 400px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge-ref.html
@@ -6,7 +6,7 @@
 
 <style>
 .target {
-  transform: rotate(330deg) translate3d(110px, 10px, 10px);
+  transform: rotate(330deg) translate3d(110px, 10px, 12px);
   border-radius: 0.375rem;
   width: 400px;
   height: 400px;


### PR DESCRIPTION
#### 5a4e5b8ccf4e016aaad0c0fd8858a4a04f34bcaf
<pre>
[ Site-Isolation ] Create a temporary test to test new site-isolation EWS configuration
<a href="https://rdar.apple.com/171940337">rdar://171940337</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309398">https://bugs.webkit.org/show_bug.cgi?id=309398</a>

This still not be landed. It is just a test.

* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge-ref.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a4e5b8ccf4e016aaad0c0fd8858a4a04f34bcaf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102064 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3fc22b1b-5d23-4feb-a8b5-25411112cd78) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114577 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81583 "3 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ccc5d5b-3fdd-4a49-aa64-4a9d531be8ee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16772 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95347 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a4998f3-d053-46f1-bd3c-d5c2465b2f9f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15875 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13734 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4754 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125487 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159653 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12862 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122636 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21149 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122860 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21157 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133134 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77286 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18169 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9897 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20758 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20491 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20637 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20547 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->