### PR TITLE
PlatformMediaDecodingType's enums are inappropriately named

### DIFF
--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
@@ -186,7 +186,7 @@ static void gatherDecodingInfo(Document& document, PlatformMediaDecodingConfigur
         configuration.pageIdentifier = page->identifier();
 
 #if ENABLE(WEB_RTC)
-    if (configuration.type == PlatformMediaDecodingType::WebRTC) {
+    if (configuration.type == PlatformMediaDecodingType::MediaStream) {
         if (page)
             page->webRTCProvider().createDecodingConfiguration(WTF::move(configuration), WTF::move(decodingCallback));
         return;

--- a/Source/WebCore/Modules/mediacapabilities/MediaDecodingType.h
+++ b/Source/WebCore/Modules/mediacapabilities/MediaDecodingType.h
@@ -38,9 +38,9 @@ enum class MediaDecodingType : uint8_t {
 inline PlatformMediaDecodingType toPlatform(MediaDecodingType value)
 {
     switch (value) {
-    case MediaDecodingType::File:           return PlatformMediaDecodingType::File;
+    case MediaDecodingType::File:           return PlatformMediaDecodingType::FileOrHLS;
     case MediaDecodingType::MediaSource:    return PlatformMediaDecodingType::MediaSource;
-    case MediaDecodingType::WebRTC:         return PlatformMediaDecodingType::WebRTC;
+    case MediaDecodingType::WebRTC:         return PlatformMediaDecodingType::MediaStream;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }
@@ -48,9 +48,9 @@ inline PlatformMediaDecodingType toPlatform(MediaDecodingType value)
 inline MediaDecodingType fromPlatform(PlatformMediaDecodingType value)
 {
     switch (value) {
-    case PlatformMediaDecodingType::File:           return MediaDecodingType::File;
+    case PlatformMediaDecodingType::FileOrHLS:      return MediaDecodingType::File;
     case PlatformMediaDecodingType::MediaSource:    return MediaDecodingType::MediaSource;
-    case PlatformMediaDecodingType::WebRTC:         return MediaDecodingType::WebRTC;
+    case PlatformMediaDecodingType::MediaStream:    return MediaDecodingType::WebRTC;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -5759,7 +5759,7 @@ URL HTMLMediaElement::selectNextSourceChild(ContentType* contentType, InvalidURL
                 INFO_LOG(LOGIDENTIFIER, "'type' is ", type);
             MediaEngineSupportParameters parameters {
 #if ENABLE(MEDIA_SOURCE)
-                .platformType = mediaURL.protocolIs(mediaSourceBlobProtocol) && MediaSource::lookup(mediaURL.string()) ? PlatformMediaDecodingType::MediaSource : PlatformMediaDecodingType::File,
+                .platformType = mediaURL.protocolIs(mediaSourceBlobProtocol) && MediaSource::lookup(mediaURL.string()) ? PlatformMediaDecodingType::MediaSource : PlatformMediaDecodingType::FileOrHLS,
 #endif
                 .type = ContentType(type),
                 .url = mediaURL,

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -430,7 +430,7 @@ const MediaPlayerFactory* MediaPlayer::mediaEngine(MediaPlayerEnums::MediaEngine
 
 static const MediaPlayerFactory* bestMediaEngineForSupportParameters(const MediaEngineSupportParameters& parameters, const WeakHashSet<const MediaPlayerFactory>& attemptedEngines = { }, const MediaPlayerFactory* current = nullptr)
 {
-    if (parameters.type.isEmpty() && parameters.platformType == PlatformMediaDecodingType::File)
+    if (parameters.type.isEmpty() && parameters.platformType == PlatformMediaDecodingType::FileOrHLS)
         return nullptr;
 
     // 4.8.10.3 MIME types - In the absence of a specification to the contrary, the MIME type "application/octet-stream"
@@ -595,9 +595,9 @@ CheckedPtr<const MediaPlayerFactory> MediaPlayer::nextBestMediaEngine(const Medi
 #endif
 #if ENABLE(MEDIA_STREAM)
             if (!!m_mediaStream)
-                return PlatformMediaDecodingType::WebRTC;
+                return PlatformMediaDecodingType::MediaStream;
 #endif
-            return PlatformMediaDecodingType::File;
+            return PlatformMediaDecodingType::FileOrHLS;
         }(),
         .type = m_loadOptions.contentType,
         .url = m_url,

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -112,7 +112,7 @@ struct HostingContext;
 struct VideoFrameMetadata;
 
 struct MediaEngineSupportParameters {
-    PlatformMediaDecodingType platformType { PlatformMediaDecodingType::File };
+    PlatformMediaDecodingType platformType { PlatformMediaDecodingType::FileOrHLS };
     ContentType type;
     URL url { };
     bool requiresRemotePlayback { false };

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -2064,7 +2064,7 @@ static bool keySystemIsSupported(const String& keySystem)
 
 MediaPlayer::SupportsType MediaPlayerPrivateAVFoundationObjC::supportsTypeAndCodecs(const MediaEngineSupportParameters& parameters)
 {
-    if (parameters.platformType != PlatformMediaDecodingType::File)
+    if (parameters.platformType != PlatformMediaDecodingType::FileOrHLS)
         return MediaPlayer::SupportsType::IsNotSupported;
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     if (parameters.playbackTargetType != MediaPlaybackTargetType::None && !playbackTargetTypes().contains(parameters.playbackTargetType))

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -238,7 +238,7 @@ MediaPlayer::SupportsType MediaPlayerPrivateMediaStreamAVFObjC::supportsType(con
         return MediaPlayer::SupportsType::IsNotSupported;
 #endif
 
-    return (parameters.platformType == PlatformMediaDecodingType::WebRTC && !parameters.requiresRemotePlayback) ? MediaPlayer::SupportsType::IsSupported : MediaPlayer::SupportsType::IsNotSupported;
+    return (parameters.platformType == PlatformMediaDecodingType::MediaStream && !parameters.requiresRemotePlayback) ? MediaPlayer::SupportsType::IsSupported : MediaPlayer::SupportsType::IsNotSupported;
 }
 
 #pragma mark -

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -149,7 +149,7 @@ void MediaPlayerPrivateWebM::getSupportedTypes(HashSet<String>& types)
 
 MediaPlayer::SupportsType MediaPlayerPrivateWebM::supportsType(const MediaEngineSupportParameters& parameters)
 {
-    if (parameters.platformType != PlatformMediaDecodingType::File || parameters.requiresRemotePlayback)
+    if (parameters.platformType != PlatformMediaDecodingType::FileOrHLS || parameters.requiresRemotePlayback)
         return MediaPlayer::SupportsType::IsNotSupported;
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)

--- a/Source/WebCore/platform/graphics/cocoa/PlatformMediaEngineConfigurationFactoryCocoa.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/PlatformMediaEngineConfigurationFactoryCocoa.cpp
@@ -66,7 +66,7 @@ static std::optional<PlatformMediaCapabilitiesInfo> computeMediaCapabilitiesInfo
     PlatformMediaCapabilitiesInfo info;
 
     if (configuration.video) {
-        if (configuration.type == PlatformMediaDecodingType::WebRTC) {
+        if (configuration.type == PlatformMediaDecodingType::MediaStream) {
             ASSERT_NOT_REACHED();
             return std::nullopt;
         }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -3286,7 +3286,7 @@ MediaPlayer::SupportsType MediaPlayerPrivateGStreamer::supportsType(const MediaE
         return result;
 #endif
 
-    if (parameters.platformType == PlatformMediaDecodingType::WebRTC) {
+    if (parameters.platformType == PlatformMediaDecodingType::MediaStream) {
 #if ENABLE(MEDIA_STREAM)
         return MediaPlayer::SupportsType::IsSupported;
 #else

--- a/Source/WebCore/platform/mediacapabilities/PlatformMediaCapabilitiesLogging.cpp
+++ b/Source/WebCore/platform/mediacapabilities/PlatformMediaCapabilitiesLogging.cpp
@@ -72,9 +72,9 @@ static String convertEnumerationToString(PlatformMediaCapabilitiesTransferFuncti
 static String convertEnumerationToString(PlatformMediaDecodingType value)
 {
     switch (value) {
-    case PlatformMediaDecodingType::File:           return "file"_s;
+    case PlatformMediaDecodingType::FileOrHLS:      return "file"_s;
     case PlatformMediaDecodingType::MediaSource:    return "media-source"_s;
-    case PlatformMediaDecodingType::WebRTC:         return "webrtc"_s;
+    case PlatformMediaDecodingType::MediaStream:    return "media-stream"_s;
     }
     RELEASE_ASSERT_NOT_REACHED();
 }

--- a/Source/WebCore/platform/mediacapabilities/PlatformMediaDecodingType.h
+++ b/Source/WebCore/platform/mediacapabilities/PlatformMediaDecodingType.h
@@ -28,9 +28,9 @@
 namespace WebCore {
 
 enum class PlatformMediaDecodingType : uint8_t {
-    File,
+    FileOrHLS,
     MediaSource,
-    WebRTC
+    MediaStream
 };
 
 }

--- a/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
@@ -331,7 +331,7 @@ static String contentTypeFromRTPVideoMimeType(const String& mimeType)
 
 void WebRTCProvider::createDecodingConfiguration(PlatformMediaDecodingConfiguration&& configuration, DecodingConfigurationCallback&& callback)
 {
-    ASSERT(configuration.type == PlatformMediaDecodingType::WebRTC);
+    ASSERT(configuration.type == PlatformMediaDecodingType::MediaStream);
 
     // FIXME: Validate additional parameters, in particular mime type parameters.
     PlatformMediaCapabilitiesDecodingInfo info { { }, WTF::move(configuration) };

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp
@@ -119,7 +119,7 @@ void GStreamerWebRTCProvider::initializeVideoDecodingCapabilities()
 std::optional<PlatformMediaCapabilitiesDecodingInfo> GStreamerWebRTCProvider::videoDecodingCapabilitiesOverride(const PlatformMediaCapabilitiesVideoConfiguration& configuration)
 {
     PlatformMediaCapabilitiesDecodingInfo info;
-    info.configuration.type = PlatformMediaDecodingType::WebRTC;
+    info.configuration.type = PlatformMediaDecodingType::MediaStream;
     ContentType contentType { configuration.contentType };
     auto containerType = contentType.containerType();
     if (equalLettersIgnoringASCIICase(containerType, "video/vp8"_s)) {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4452,9 +4452,9 @@ struct WebCore::MediaSelectionOption {
 };
 
 enum class WebCore::PlatformMediaDecodingType : uint8_t {
-    File,
+    FileOrHLS,
     MediaSource,
-    WebRTC
+    MediaStream
 };
 
 enum class WebCore::PlatformMediaEncodingType : bool;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -227,7 +227,7 @@ void RemoteMediaPlayerManager::getSupportedTypes(MediaPlayerEnums::MediaEngineId
 MediaPlayer::SupportsType RemoteMediaPlayerManager::supportsTypeAndCodecs(MediaPlayerEnums::MediaEngineIdentifier remoteEngineIdentifier, const MediaEngineSupportParameters& parameters)
 {
 #if ENABLE(MEDIA_STREAM)
-    if (parameters.platformType == PlatformMediaDecodingType::WebRTC)
+    if (parameters.platformType == PlatformMediaDecodingType::MediaStream)
         return MediaPlayer::SupportsType::IsNotSupported;
 #endif
 


### PR DESCRIPTION
#### 871e62af21afd3156116ef317499d61e8b795436
<pre>
PlatformMediaDecodingType&apos;s enums are inappropriately named
<a href="https://bugs.webkit.org/show_bug.cgi?id=309392">https://bugs.webkit.org/show_bug.cgi?id=309392</a>
<a href="https://rdar.apple.com/171936464">rdar://171936464</a>

Reviewed by Anne van Kesteren.

Rename enums so they reflect more the internal platform&apos;s MediaPlayer name (and constants)
* PlatformMediaDecodingType::File -&gt; PlatformMediaDecodingType::FileOrHLS
* PlatformMediaDecodingType::WebRTC -&gt; PlatformMediaDecodingType::MediaStream

No observable changes.

* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp:
(WebCore::gatherDecodingInfo):
* Source/WebCore/Modules/mediacapabilities/MediaDecodingType.h:
(WebCore::toPlatform):
(WebCore::fromPlatform):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::selectNextSourceChild):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::nextBestMediaEngine):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::supportsTypeAndCodecs):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::supportsType):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::supportsType):
* Source/WebCore/platform/graphics/cocoa/PlatformMediaEngineConfigurationFactoryCocoa.cpp:
(WebCore::computeMediaCapabilitiesInfo):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::supportsType):
* Source/WebCore/platform/mediacapabilities/PlatformMediaCapabilitiesLogging.cpp:
(WebCore::convertEnumerationToString):
* Source/WebCore/platform/mediacapabilities/PlatformMediaDecodingType.h:
* Source/WebCore/platform/mediastream/WebRTCProvider.cpp:
(WebCore::WebRTCProvider::createDecodingConfiguration):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp:
(WebCore::GStreamerWebRTCProvider::videoDecodingCapabilitiesOverride):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::supportsTypeAndCodecs):

Canonical link: <a href="https://commits.webkit.org/308848@main">https://commits.webkit.org/308848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adbdaa3718b66db1dc449596782e236639fae55c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157332 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11ca2807-f734-4b47-a7d7-ddc6a284da04) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21812 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114588 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e347ff7-945c-400b-99a3-90d66bf7ff21) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151607 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/16785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133433 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95358 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b81a560-48e0-44ac-9e9d-4b69a6ea820c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13746 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4767 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159666 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/2807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122653 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21162 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17745 "Found 1 new test failure: imported/w3c/web-platform-tests/encoding/encodeInto.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122877 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33412 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133145 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77299 "Built successfully") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9908 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/20771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20504 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->