### PR TITLE
[iOS] Copied Image does not show content in Yahoo Mail (Browser Version)

### DIFF
--- a/LayoutTests/editing/pasteboard/data-transfer-get-data-on-pasting-html-uses-data-url-expected.txt
+++ b/LayoutTests/editing/pasteboard/data-transfer-get-data-on-pasting-html-uses-data-url-expected.txt
@@ -1,0 +1,25 @@
+This tests getData strips away secrets and dangerous code when copying inside a null origin document.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS typesInNullOrigin.includes("text/html") is true
+PASS htmlInNullOrigin.includes("secret") is false
+PASS htmlInNullOrigin.includes("dangerousCode") is false
+PASS parsedTree = (new DOMParser).parseFromString(htmlInNullOrigin, "text/html"); !!parsedTree.querySelector("b"); is true
+PASS parsedTree.querySelector("b").textContent is "16th President of the United States:"
+PASS (new URL(parsedTree.querySelector("img").src)).protocol is "data:"
+PASS parsedTree.querySelector("img").src.includes("resources/abe.png") is false
+PASS itemsInNullOrigin.some((item) => item.kind == "string" && item.type == "text/html") is true
+PASS typesInNullOrigin.includes("text/html") is true
+PASS htmlInSameDocument.includes("secret") is false
+PASS htmlInSameDocument.includes("dangerousCode") is false
+PASS parsedTree = (new DOMParser).parseFromString(htmlInNullOrigin, "text/html"); !!parsedTree.querySelector("b"); is true
+PASS parsedTree.querySelector("b").textContent is "16th President of the United States:"
+FAIL (new URL(parsedTree.querySelector("img").src)).protocol should be file:. Was data:.
+FAIL parsedTree.querySelector("img").src.includes("resources/abe.png") should be true. Was false.
+PASS itemsInSameDocument.some((item) => item.kind == "string" && item.type == "text/html") is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/pasteboard/data-transfer-get-data-on-pasting-html-uses-data-url.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-get-data-on-pasting-html-uses-data-url.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test-pre.js"></script>
+<div id="container">
+<button id="copy" onclick="runTest()">1. Copy</button>
+<div><br></div>
+<div id="source" oncopy="doCopy(event)" contenteditable>
+    <b>16th President of the United States:</b>
+    <!-- secret-->
+    <img src="../resources/abe.png" alt="Abraham Lincoln" onmouseover="dangerousCode()">
+    <script>function dangerousCode() { } dangerousCode();</script>
+</div>
+<div id="destination" onpaste="doPaste(event)" contenteditable>3. Paste here</div></div>
+<script>
+
+description('This tests getData strips away secrets and dangerous code when copying inside a null origin document.');
+jsTestIsAsync = true;
+
+if (window.internals)
+    internals.settings.setCustomPasteboardDataEnabled(true);
+
+function runTest() {
+    document.getElementById('source').focus();
+    document.execCommand('selectAll');
+    document.execCommand('copy');
+}
+
+const container = document.getElementById('container');
+function doCopy(event) {
+    const iframe = document.createElement('iframe');
+    container.insertBefore(iframe, container.lastChild);
+    iframe.src = `data:text/html;charset=utf-8,<!DOCTYPE html>
+    <div id="destination" onpaste="doPaste(event)" contenteditable>2. Paste here</div>
+    <script>
+
+    function doPaste(event) {
+        event.preventDefault();
+        parent.postMessage({
+            html: event.clipboardData.getData('text/html'),
+            types: event.clipboardData.types,
+            items: Array.from(event.clipboardData.items).map((item) => ({kind: item.kind, type: item.type})),
+        }, '*');
+    };
+
+    document.getElementById('destination').focus();
+    if (window.testRunner)
+        document.execCommand('paste');
+
+    </scri` + 'pt>';
+}
+
+onmessage = (event) => {
+    typesInNullOrigin = event.data.types;
+    shouldBeTrue('typesInNullOrigin.includes("text/html")');
+
+    htmlInNullOrigin = event.data.html;
+    shouldBeFalse('htmlInNullOrigin.includes("secret")');
+    shouldBeFalse('htmlInNullOrigin.includes("dangerousCode")');
+    shouldBeTrue('parsedTree = (new DOMParser).parseFromString(htmlInNullOrigin, "text/html"); !!parsedTree.querySelector("b");');
+    shouldBeEqualToString('parsedTree.querySelector("b").textContent', '16th President of the United States:');
+    shouldBeEqualToString('(new URL(parsedTree.querySelector("img").src)).protocol', 'data:');
+    shouldBeFalse('parsedTree.querySelector("img").src.includes("resources/abe.png")');
+
+    itemsInNullOrigin = event.data.items;
+    shouldBeTrue('itemsInNullOrigin.some((item) => item.kind == "string" && item.type == "text/html")');
+
+    document.getElementById('destination').focus();
+    if (window.testRunner)
+        document.execCommand('paste');
+}
+
+function doPaste(event) {
+    event.preventDefault();
+
+    typesInSameDocument = event.clipboardData.types;
+    shouldBeTrue('typesInNullOrigin.includes("text/html")');
+
+    htmlInSameDocument = event.clipboardData.getData('text/html');
+    shouldBeFalse('htmlInSameDocument.includes("secret")');
+    shouldBeFalse('htmlInSameDocument.includes("dangerousCode")');
+    shouldBeTrue('parsedTree = (new DOMParser).parseFromString(htmlInNullOrigin, "text/html"); !!parsedTree.querySelector("b");');
+    shouldBeEqualToString('parsedTree.querySelector("b").textContent', '16th President of the United States:');
+
+    // FIXME: These two test cases fail.
+    shouldBeEqualToString('(new URL(parsedTree.querySelector("img").src)).protocol', 'file:');
+    shouldBeTrue('parsedTree.querySelector("img").src.includes("resources/abe.png")');
+
+    itemsInSameDocument = Array.from(event.clipboardData.items);
+    shouldBeTrue('itemsInSameDocument.some((item) => item.kind == "string" && item.type == "text/html")');
+
+    container.remove();
+    finishJSTest();
+}
+
+if (window.testRunner)
+    window.onload = runTest;
+
+successfullyParsed = true;
+
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/editing/pasteboard/paste-image-as-data-url-expected.txt
+++ b/LayoutTests/editing/pasteboard/paste-image-as-data-url-expected.txt
@@ -1,0 +1,14 @@
+Tests that pasted images use data URLs with valid MIME types.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS pastedImages.length is 1
+PASS url.protocol is "data:"
+PASS img.src.startsWith('data:image/') is true
+PASS img.src.includes(';base64,') is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/editing/pasteboard/paste-image-as-data-url.html
+++ b/LayoutTests/editing/pasteboard/paste-image-as-data-url.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<div id="destination" contenteditable="true" style="width: 500px; height: 100px; border: solid red 1px"></div>
+<iframe id="iframe" src="../resources/abe.png" onload="selectInFrame()"></iframe>
+</body>
+<script>
+    description("Tests that pasted images use data URLs with valid MIME types.");
+    jsTestIsAsync = true;
+
+    function selectInFrame() {
+        if (window.internals)
+            window.internals.settings.setPreferMIMETypeForImages(true);
+        var iframe = document.getElementById("iframe");
+        var iframeDocument = iframe.contentDocument;
+        var destination = document.getElementById("destination");
+        iframeDocument.body.focus();
+        iframeDocument.execCommand("SelectAll");
+        iframeDocument.execCommand("Copy");
+        destination.focus();
+        document.execCommand("Paste");
+
+        pastedImages = destination.getElementsByTagName("img");
+        shouldBe("pastedImages.length", "1");
+        img = pastedImages[0];
+        url = new URL(img.src);
+        shouldBeEqualToString("url.protocol", "data:");
+        shouldBeTrue("img.src.startsWith('data:image/')");
+        shouldBeTrue("img.src.includes(';base64,')");
+
+        finishJSTest();
+    }
+</script>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3672,6 +3672,8 @@ fast/url/data-url-mediatype.html [ Skip ]
 
 # Needs Cocoa specific features
 editing/pasteboard/copy-paste-data-detected-links.html [ Skip ]
+editing/pasteboard/paste-image-as-data-url.html [ Skip ]
+editing/pasteboard/data-transfer-get-data-on-pasting-html-uses-data-url.html [ Skip ]
 
 # PDF as image source
 fast/hidpi/pdf-image-scaled.html [ Skip ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3117,6 +3117,7 @@ webkit.org/b/181838 js/slow-stress/Int32Array-alloc-huge-long-lived.html [ Slow 
 webkit.org/b/182592 webgl/webgl-texture-image-buffer-reuse.html [ Skip ]
 
 webkit.org/b/183219 editing/pasteboard/data-transfer-get-data-on-pasting-html-uses-blob-url.html [ Skip ]
+editing/pasteboard/paste-image-as-blob-url.html [ Skip ]
 
 [ Debug ] imported/w3c/web-platform-tests/hr-time/idlharness.any.html [ Slow ]
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -221,6 +221,8 @@ editing/mac/pasteboard/drag-selections-to-contenteditable.html
 editing/pasteboard/4947130.html
 editing/pasteboard/cleanup-on-move.html
 editing/pasteboard/copy-standalone-image-crash.html
+# webkit.org/b/309400 Times out due to web archive UTI issue on modern macOS
+editing/pasteboard/copy-standalone-image.html [ Skip ]
 editing/pasteboard/drag-drop-paragraph-crasher.html
 editing/pasteboard/emacs-cntl-y-001.html
 editing/pasteboard/emacs-ctrl-k-y-001.html

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2497,3 +2497,7 @@ imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-over-r
 tiled-drawing/mac/margin-tiles-with-banner-view-overlay.html [ Skip ]
 tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-x.html [ Skip ]
 tiled-drawing/mac/margin-tiles-with-banner-view-overlay-repeat-y.html [ Skip ]
+
+# Cocoa platforms use data URLs for pasted images; blob URL tests are for Glib ports
+editing/pasteboard/paste-image-as-blob-url.html [ Skip ]
+editing/pasteboard/data-transfer-get-data-on-pasting-html-uses-blob-url.html [ Skip ]

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -135,6 +135,7 @@ enum class SDKAlignedBehavior {
     CrashWhenMutatingProcessAssertionsFromBackgroundThread,
     NoFontFaceSetConstructor,
     NoHTMLEnhancedSelectParsingQuirk,
+    DataURLForPastedImages,
 
     NumberOfBehaviors
 };

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -74,6 +74,8 @@
 #import <wtf/FileSystem.h>
 #import <wtf/SoftLinking.h>
 #import <wtf/URLParser.h>
+#import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#import <wtf/text/Base64.h>
 
 #if PLATFORM(MAC)
 #import "LocalDefaultSystemAppearance.h"
@@ -90,6 +92,12 @@ SOFT_LINK(WebKitLegacy, _WebCreateFragment, void, (WebCore::Document& document, 
 #endif
 
 namespace WebCore {
+
+static String dataURLForImageData(std::span<const uint8_t> data, const String& type)
+{
+    auto mimeType = isDeclaredUTI(type) ? MIMETypeFromUTI(type) : type;
+    return makeString("data:"_s, mimeType, ";base64,"_s, base64Encoded(data));
+}
 
 #if PLATFORM(MACCATALYST)
 
@@ -546,15 +554,21 @@ static String sanitizeMarkupWithArchive(LocalFrame& frame, Document& destination
         return sanitizedMarkupForFragmentInDocument(WTF::move(fragment), *stagingDocument, msoListQuirks, markupAndArchive.markup);
     }
 
-    HashMap<AtomString, AtomString> blobURLMap;
+    HashMap<AtomString, AtomString> blobOrDataURLMap;
+    bool useDataURLs = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::DataURLForPastedImages);
     for (const Ref<ArchiveResource>& subresource : markupAndArchive.archive->subresources()) {
         auto& subresourceURL = subresource->url();
         if (!shouldReplaceSubresourceURLWithBlobDuringSanitization(subresourceURL))
             continue;
-        Ref data = subresource->data();
-        auto blob = Blob::create(&destinationDocument, data->copyData(), subresource->mimeType());
-        String blobURL = DOMURL::createObjectURL(destinationDocument, blob);
-        blobURLMap.set(AtomString { subresourceURL.string() }, AtomString { blobURL });
+        String replacementURL;
+        if (useDataURLs && MIMETypeRegistry::isSupportedImageMIMEType(subresource->mimeType()))
+            replacementURL = dataURLForImageData(subresource->data().makeContiguous()->span(), subresource->mimeType());
+        else {
+            Ref data = subresource->data();
+            auto blob = Blob::create(&destinationDocument, data->copyData(), subresource->mimeType());
+            replacementURL = DOMURL::createObjectURL(destinationDocument, blob);
+        }
+        blobOrDataURLMap.set(AtomString { subresourceURL.string() }, AtomString { replacementURL });
     }
 
     auto contentOrigin = SecurityOrigin::create(markupAndArchive.mainResource->url());
@@ -578,10 +592,10 @@ static String sanitizeMarkupWithArchive(LocalFrame& frame, Document& destination
         auto blob = Blob::create(&destinationDocument, Vector(byteCast<uint8_t>(subframeMarkup.utf8().span())), type);
 
         String subframeBlobURL = DOMURL::createObjectURL(destinationDocument, blob);
-        blobURLMap.set(AtomString { subframeURL.string() }, AtomString { subframeBlobURL });
+        blobOrDataURLMap.set(AtomString { subframeURL.string() }, AtomString { subframeBlobURL });
     }
 
-    replaceSubresourceURLs(fragment.get(), WTF::move(blobURLMap));
+    replaceSubresourceURLs(fragment.get(), WTF::move(blobOrDataURLMap));
 
     return sanitizedMarkupForFragmentInDocument(WTF::move(fragment), *stagingDocument, msoListQuirks, markupAndArchive.markup);
 }
@@ -780,8 +794,14 @@ bool WebContentReader::readImage(Ref<FragmentedSharedBuffer>&& buffer, const Str
     Ref document = *frame->document();
     if (shouldReplaceRichContentWithAttachments())
         addFragment(createFragmentForImageAttachment(frame, document, WTF::move(buffer), type, preferredPresentationSize));
-    else
-        addFragment(createFragmentForImageAndURL(document, DOMURL::createObjectURL(document, Blob::create(document.ptr(), buffer->extractData(), type)), preferredPresentationSize));
+    else {
+        String imageURL;
+        if (linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::DataURLForPastedImages))
+            imageURL = dataURLForImageData(buffer->makeContiguous()->span(), type);
+        else
+            imageURL = DOMURL::createObjectURL(document, Blob::create(document.ptr(), buffer->extractData(), type));
+        addFragment(createFragmentForImageAndURL(document, imageURL, preferredPresentationSize));
+    }
 
     return m_fragment;
 }

--- a/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm
@@ -431,7 +431,7 @@ TEST(DragAndDropTests, CanDragImageWhenNotFirstResponder)
     [simulator runFrom:CGPointMake(100, 50) to:CGPointMake(100, 250)];
 
     NSURL *droppedImageURL = [NSURL URLWithString:[webView stringByEvaluatingJavaScript:@"editor.querySelector('img').src"]];
-    EXPECT_WK_STREQ("blob", droppedImageURL.scheme);
+    EXPECT_WK_STREQ("data", droppedImageURL.scheme);
 }
 
 TEST(DragAndDropTests, ContentEditableMoveParagraphs)


### PR DESCRIPTION
#### 85451fa3d26cc098d7d727854a2d881eca6b5122
<pre>
[iOS] Copied Image does not show content in Yahoo Mail (Browser Version)
<a href="https://bugs.webkit.org/show_bug.cgi?id=309400">https://bugs.webkit.org/show_bug.cgi?id=309400</a>
<a href="https://rdar.apple.com/168711407">rdar://168711407</a>

Reviewed by Ryosuke Niwa and Brent Fulgham.

Strict HTML sanitizers reject blob URLs. This change generates inline
base64 data URLs instead,gated behind SDKAlignedBehaviour::DataURLForPastedImages
so Safari gets data URLs by default and older WebKit-embedding apps keep blob URLs.

The dataURLForImagesData helper converts UTI type identifiers to
MIME types so data URLs are valid on iOS where pasteboard types are UTIs.

* LayoutTests/editing/pasteboard/data-transfer-get-data-on-pasting-html-uses-data-url-expected.txt: Added.
* LayoutTests/editing/pasteboard/data-transfer-get-data-on-pasting-html-uses-data-url.html: Added.
* LayoutTests/editing/pasteboard/paste-image-as-data-url-expected.txt: Added.
* LayoutTests/editing/pasteboard/paste-image-as-data-url.html: Copied from LayoutTests/editing/pasteboard/paste-image-as-blob-url.html.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::dataURLForImageData):
(WebCore::sanitizeMarkupWithArchive):
(WebCore::WebContentReader::readImage):
* Tools/TestWebKitAPI/Tests/ios/DragAndDropTestsIOS.mm:
(TestWebKitAPI::TEST(DragAndDropTests, CanDragImageWhenNotFirstResponder)):

Canonical link: <a href="https://commits.webkit.org/309231@main">https://commits.webkit.org/309231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14959920274f0dedd3a36f516d1eefe5b707f9c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149944 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16247 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158651 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151817 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115660 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103378 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152904 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134543 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96398 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16895 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14824 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6497 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141921 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126510 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161128 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10738 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123674 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123877 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22472 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134267 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78713 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23070 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19041 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11020 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181374 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22073 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85893 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21803 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21955 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21860 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->