### PR TITLE
Unreviewed. Update safer C++ expectations.

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations
@@ -8,6 +8,7 @@ Modules/mediastream/RTCPeerConnection.cpp
 Modules/mediastream/RTCRtpSender.cpp
 Modules/push-api/PushDatabase.cpp
 Modules/webaudio/OfflineAudioDestinationNode.cpp
+Modules/webauthn/AuthenticationExtensionsClientOutputs.cpp
 Modules/webcodecs/WebCodecsAudioDecoder.cpp
 Modules/webcodecs/WebCodecsAudioEncoder.cpp
 Modules/webcodecs/WebCodecsBase.cpp


### PR DESCRIPTION
#### 432c382ba8d242dba06dd80168876929fae6c713
<pre>
Unreviewed. Update safer C++ expectations.

* Source/WebCore/SaferCPPExpectations/UncountedLambdaCapturesCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/308847@main">https://commits.webkit.org/308847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/911f0492cc75dfc275e51c68d358e6f7428f7a0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21377 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/14946 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157349 "Failed to checkout and rebase branch from PR 60113") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150537 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/21829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21255 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/157349 "Failed to checkout and rebase branch from PR 60113") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151624 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/21829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/157349 "Failed to checkout and rebase branch from PR 60113") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/21829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4784 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/21829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/11370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159684 "Failed to checkout and rebase branch from PR 60113") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/2824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/12892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/159684 "Failed to checkout and rebase branch from PR 60113") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21179 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/17761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/159684 "Failed to checkout and rebase branch from PR 60113") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/133164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22902 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/9926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/20789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->