### PR TITLE
GlyphBufferMembers: Avoid passing const FloatSize by reference

### DIFF
--- a/Source/WebCore/platform/graphics/GlyphBufferMembers.h
+++ b/Source/WebCore/platform/graphics/GlyphBufferMembers.h
@@ -55,7 +55,7 @@ using GlyphBufferOrigin = FloatPoint;
 using GlyphBufferStringOffset = unsigned;
 #endif
 
-inline GlyphBufferAdvance makeGlyphBufferAdvance(const FloatSize&);
+inline GlyphBufferAdvance makeGlyphBufferAdvance(const FloatSize);
 inline GlyphBufferAdvance makeGlyphBufferAdvance(float = 0, float = 0);
 inline FloatSize size(const GlyphBufferAdvance&);
 inline void setWidth(GlyphBufferAdvance&, float);
@@ -72,7 +72,7 @@ inline float y(const GlyphBufferOrigin&);
 
 #if USE(CG)
 
-inline GlyphBufferAdvance makeGlyphBufferAdvance(const FloatSize& size)
+inline GlyphBufferAdvance makeGlyphBufferAdvance(const FloatSize size)
 {
     return CGSizeMake(size.width(), size.height());
 }
@@ -144,7 +144,7 @@ inline float y(const GlyphBufferOrigin& origin)
 
 #else
 
-inline GlyphBufferAdvance makeGlyphBufferAdvance(const FloatSize& size)
+inline GlyphBufferAdvance makeGlyphBufferAdvance(const FloatSize size)
 {
     return size;
 }


### PR DESCRIPTION
#### 6e8030e070135ff08ce099dee8a7c0b6b83596da
<pre>
GlyphBufferMembers: Avoid passing const FloatSize by reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=309403">https://bugs.webkit.org/show_bug.cgi?id=309403</a>
<a href="https://rdar.apple.com/171944298">rdar://171944298</a>

Reviewed by Sammy Gill.

FloatSize is small enough (2 floats, 8 bytes) to be passed by value
instead of reference and hopefully fit into registers.

* Source/WebCore/platform/graphics/GlyphBufferMembers.h:
(WebCore::makeGlyphBufferAdvance):

Canonical link: <a href="https://commits.webkit.org/308863@main">https://commits.webkit.org/308863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be4e03ae9e3fcd174e21729790e75d6d44cae01e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157327 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102072 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a32feadd-3e9a-475b-a4b0-3da5f65057fb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150515 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21233 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114587 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81589 "3 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f180de42-3239-4380-bbc3-06692bdc2d2b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16781 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133428 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95357 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/93fe656d-e7c3-4978-9e27-a9122e4966c9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15884 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13741 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4762 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159661 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2802 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12868 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122648 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122872 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33418 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21165 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133140 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77294 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18178 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9903 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20766 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84569 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20499 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20645 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20555 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->