### PR TITLE
Find better homes for the remaining loose functions in RenderStyle.h

### DIFF
--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2854,6 +2854,7 @@ rendering/RenderGridLayoutState.cpp
 rendering/GridMasonryLayout.cpp
 rendering/GridTrackSizingAlgorithm.cpp
 rendering/HitTestLocation.cpp
+rendering/HitTestRequest.cpp
 rendering/HitTestResult.cpp
 rendering/HitTestingTransformState.cpp
 rendering/ImageQualityController.cpp

--- a/Source/WebCore/dom/PseudoElement.cpp
+++ b/Source/WebCore/dom/PseudoElement.cpp
@@ -31,6 +31,7 @@
 #include "DocumentPage.h"
 #include "InspectorInstrumentation.h"
 #include "KeyframeEffectStack.h"
+#include "PseudoElementUtilitiesInlines.h"
 #include "RenderElement.h"
 #include "RenderImage.h"
 #include "RenderQuote.h"
@@ -83,7 +84,7 @@ void PseudoElement::clearHostElement()
 
 bool PseudoElement::rendererIsNeeded(const RenderStyle& style)
 {
-    if (pseudoElementRendererIsNeeded(&style))
+    if (Style::pseudoElementRendererIsNeeded(style))
         return true;
 
     if (RefPtr element = m_hostElement.get()) {

--- a/Source/WebCore/rendering/HitTestRequest.cpp
+++ b/Source/WebCore/rendering/HitTestRequest.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "HitTestRequest.h"
+
+#include "RenderStyle+GettersInlines.h"
+
+namespace WebCore {
+
+bool HitTestRequest::isVisibleForStyle(const RenderStyle& style) const
+{
+    return (userTriggered() ? style.usedVisibility() : style.visibility()) == Visibility::Visible;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/HitTestRequest.h
+++ b/Source/WebCore/rendering/HitTestRequest.h
@@ -28,6 +28,8 @@
 
 namespace WebCore {
 
+class RenderStyle;
+
 class HitTestRequest {
 public:
     enum class Type {
@@ -109,6 +111,8 @@ public:
     bool touchRelease() const { return release() && touchEvent(); }
 
     OptionSet<Type> type() const { return m_type; }
+
+    bool isVisibleForStyle(const RenderStyle&) const;
 
 private:
     OptionSet<Type> m_type;

--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -812,34 +812,10 @@ constexpr bool RenderStyle::preserveNewline(WhiteSpaceCollapse mode)
     return mode == WhiteSpaceCollapse::Preserve || mode == WhiteSpaceCollapse::PreserveBreaks || mode == WhiteSpaceCollapse::BreakSpaces;
 }
 
-constexpr BorderStyle collapsedBorderStyle(BorderStyle style)
-{
-    if (style == BorderStyle::Outset)
-        return BorderStyle::Groove;
-    if (style == BorderStyle::Inset)
-        return BorderStyle::Ridge;
-    return style;
-}
-
 inline bool RenderStyle::isInterCharacterRubyPosition() const
 {
     auto rubyPosition = this->rubyPosition();
     return rubyPosition == RubyPosition::InterCharacter || rubyPosition == RubyPosition::LegacyInterCharacter;
-}
-
-inline bool isNonVisibleOverflow(Overflow overflow)
-{
-    return overflow == Overflow::Hidden || overflow == Overflow::Scroll || overflow == Overflow::Clip;
-}
-
-inline bool pseudoElementRendererIsNeeded(const RenderStyle* style)
-{
-    return style && style->display() != Style::DisplayType::None && style->content().isData();
-}
-
-inline bool isVisibleToHitTesting(const RenderStyle& style, const HitTestRequest& request)
-{
-    return (request.userTriggered() ? style.usedVisibility() : style.visibility()) == Visibility::Visible;
 }
 
 // MARK: has*() functions

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -504,11 +504,4 @@ private:
     const Style::SVGData& svgData() const LIFETIME_BOUND { return computedStyle().svgData(); }
 };
 
-constexpr BorderStyle collapsedBorderStyle(BorderStyle);
-
-inline bool pseudoElementRendererIsNeeded(const RenderStyle*);
-inline bool isNonVisibleOverflow(Overflow);
-
-inline bool isVisibleToHitTesting(const RenderStyle&, const HitTestRequest&);
-
 } // namespace WebCore

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -164,9 +164,18 @@ enum class BorderStyle : uint8_t {
     Double
 };
 
-inline bool isVisibleBorderStyle(BorderStyle value)
+constexpr bool isVisibleBorderStyle(BorderStyle value)
 {
     return value > BorderStyle::Hidden;
+}
+
+constexpr BorderStyle collapsedBorderStyle(BorderStyle style)
+{
+    if (style == BorderStyle::Outset)
+        return BorderStyle::Groove;
+    if (style == BorderStyle::Inset)
+        return BorderStyle::Ridge;
+    return style;
 }
 
 enum class BorderPrecedence : uint8_t {
@@ -240,6 +249,13 @@ enum class Overflow : uint8_t {
     PagedX,
     PagedY
 };
+
+constexpr bool isNonVisibleOverflow(Overflow overflow)
+{
+    return overflow == Overflow::Hidden
+        || overflow == Overflow::Scroll
+        || overflow == Overflow::Clip;
+}
 
 enum class Clear : uint8_t {
     None,

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -261,7 +261,7 @@ bool RenderSVGImage::nodeAtPoint(const HitTestRequest& request, HitTestResult& r
         return false;
 
     PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGImage, request, style().pointerEvents());
-    if (isVisibleToHitTesting(style(), request) || !hitRules.requireVisible) {
+    if (request.isVisibleForStyle(style()) || !hitRules.requireVisible) {
         if (hitRules.canHitFill) {
             if (m_objectBoundingBox.contains(localPoint)) {
                 updateHitTestResult(result, locationInContainer.point() - toLayoutSize(adjustedLocation));

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -306,7 +306,7 @@ bool RenderSVGShape::nodeAtPoint(const HitTestRequest& request, HitTestResult& r
         return false;
 
     PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGPath, request, usedPointerEvents());
-    if (isVisibleToHitTesting(style(), request) || !hitRules.requireVisible) {
+    if (request.isVisibleForStyle(style()) || !hitRules.requireVisible) {
         WindRule fillRule = style().fillRule();
         if (request.svgClipContent())
             fillRule = style().clipRule();

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -653,7 +653,7 @@ bool RenderSVGText::nodeAtFloatPoint(const HitTestRequest& request, HitTestResul
     ASSERT(!document().settings().layerBasedSVGEngineEnabled());
 
     PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGText, request, usedPointerEvents());
-    if (isVisibleToHitTesting(style(), request) || !hitRules.requireVisible) {
+    if (request.isVisibleForStyle(style()) || !hitRules.requireVisible) {
         if ((hitRules.canHitStroke && (!style().stroke().isNone() || !hitRules.requireStroke))
             || (hitRules.canHitFill && (!style().fill().isNone() || !hitRules.requireFill))) {
             static NeverDestroyed<SVGVisitedRendererTracking::VisitedSet> s_visitedSet;
@@ -684,7 +684,7 @@ bool RenderSVGText::nodeAtPoint(const HitTestRequest& request, HitTestResult& re
     auto adjustedLocation = accumulatedOffset + location();
 
     PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGText, request, style().pointerEvents());
-    if (isVisibleToHitTesting(style(), request) || !hitRules.requireVisible) {
+    if (request.isVisibleForStyle(style()) || !hitRules.requireVisible) {
         if ((hitRules.canHitStroke && (!style().stroke().isNone() || !hitRules.requireStroke))
         || (hitRules.canHitFill && (!style().fill().isNone() || !hitRules.requireFill))) {
             static NeverDestroyed<SVGVisitedRendererTracking::VisitedSet> s_visitedSet;
@@ -720,7 +720,7 @@ bool RenderSVGText::hitTestInlineChildren(const HitTestRequest& request, HitTest
             PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGText, request, usedPointerEvents());
 
             auto& renderer = textBox->renderer();
-            if (!isVisibleToHitTesting(renderer.style(), request) && hitRules.requireVisible)
+            if (!request.isVisibleForStyle(renderer.style()) && hitRules.requireVisible)
                 continue;
 
             bool hitsStroke = hitRules.canHitStroke && (!renderer.style().stroke().isNone() || !hitRules.requireStroke);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -249,7 +249,7 @@ bool LegacyRenderSVGImage::nodeAtFloatPoint(const HitTestRequest& request, HitTe
         return false;
 
     PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGImage, request, usedPointerEvents());
-    if (isVisibleToHitTesting(style(), request) || !hitRules.requireVisible) {
+    if (request.isVisibleForStyle(style()) || !hitRules.requireVisible) {
         static NeverDestroyed<SVGVisitedRendererTracking::VisitedSet> s_visitedSet;
 
         SVGVisitedRendererTracking recursionTracking(s_visitedSet);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -354,7 +354,7 @@ bool LegacyRenderSVGShape::nodeAtFloatPoint(const HitTestRequest& request, HitTe
     SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
 
     PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGPath, request, usedPointerEvents());
-    if (isVisibleToHitTesting(style(), request) || !hitRules.requireVisible) {
+    if (request.isVisibleForStyle(style()) || !hitRules.requireVisible) {
         WindRule fillRule = style().fillRule();
         if (request.svgClipContent())
             fillRule = style().clipRule();

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -32,6 +32,7 @@
 #include "InspectorInstrumentation.h"
 #include "KeyframeEffectStack.h"
 #include "PseudoElement.h"
+#include "PseudoElementUtilitiesInlines.h"
 #include "RenderCounter.h"
 #include "RenderDescendantIterator.h"
 #include "RenderElementInlines.h"
@@ -299,7 +300,7 @@ bool RenderTreeUpdater::GeneratedContent::needsPseudoElement(const RenderStyle* 
         return false;
     if (!m_updater.renderTreePosition().parent().canHaveGeneratedChildren())
         return false;
-    if (!pseudoElementRendererIsNeeded(style))
+    if (!Style::pseudoElementRendererIsNeeded(*style))
         return false;
     return true;
 }

--- a/Source/WebCore/style/PseudoElementUtilities.h
+++ b/Source/WebCore/style/PseudoElementUtilities.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2026 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +33,7 @@
 namespace WebCore {
 
 class Element;
+class RenderStyle;
 
 namespace Style {
 
@@ -41,6 +43,8 @@ struct ResolvedComputedPseudoElement {
 };
 
 ResolvedComputedPseudoElement resolveComputedPseudoElement(Element&, const String& pseudoElement);
+
+bool pseudoElementRendererIsNeeded(const RenderStyle&);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/PseudoElementUtilitiesInlines.h
+++ b/Source/WebCore/style/PseudoElementUtilitiesInlines.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "PseudoElementUtilities.h"
+#include "RenderStyle+GettersInlines.h"
+
+namespace WebCore::Style {
+
+inline bool pseudoElementRendererIsNeeded(const RenderStyle& style)
+{
+    return style.display() != DisplayType::None
+        && style.content().isData();
+}
+
+} // namespace WebCore::Style


### PR DESCRIPTION
#### 005fc76da761d8fc6a0db0ba2e83e73dc5e294fc
<pre>
Find better homes for the remaining loose functions in RenderStyle.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=309406">https://bugs.webkit.org/show_bug.cgi?id=309406</a>

Reviewed by Anne van Kesteren.

Moves the remaining global functions in RenderStyle.h to more appropriate files:

- collapsedBorderStyle() moves to RenderStyleConstants.h to be next to BorderStyle.
- isNonVisibleOverflow() moves to RenderStyleConstants.h to be next to Overflow.
- pseudoElementRendererIsNeeded() moves to PseudoElementUtilities.h
- isVisibleToHitTesting() moves to be a member function on HitTestRequest.

* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/PseudoElement.cpp:
* Source/WebCore/rendering/HitTestRequest.cpp: Added.
* Source/WebCore/rendering/HitTestRequest.h:
* Source/WebCore/rendering/style/RenderStyle+GettersInlines.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
* Source/WebCore/style/PseudoElementUtilities.h:
* Source/WebCore/style/PseudoElementUtilitiesInlines.h: Added.

Canonical link: <a href="https://commits.webkit.org/308872@main">https://commits.webkit.org/308872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a063f7636df8e2e3eb16eaef1035a2c6c992953b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157383 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102128 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150571 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114629 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95399 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15938 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13784 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4818 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125537 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11398 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159718 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2858 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122694 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21213 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122918 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33423 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21221 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133192 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77361 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18213 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9954 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20823 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84625 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20555 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20702 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20611 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->