### PR TITLE
AX: VoiceOver-right navigation loops with site isolation when encountering a remote frame

### DIFF
--- a/LayoutTests/http/tests/site-isolation/accessibility/client/search-past-remote-frame-immediate-descendants-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/search-past-remote-frame-immediate-descendants-expected.txt
@@ -1,0 +1,16 @@
+Tests that immediateDescendantsOnly AnyType search correctly finds elements after a cross-process iframe.
+VoiceOver obtains the iframe's FrameHost element via the remote element parent chain.
+Without the fix, the search loops back to the first element.
+
+PASS: frameHost.rawRoleForTesting.includes('FrameHost') === true
+
+Elements after FrameHost (immediateDescendantsOnly=true):
+  1: AXRole: AXButton
+
+PASS: foundButtonAfter === true
+PASS: First result after FrameHost is the button (no loop-back).
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+    Button After Iframe

--- a/LayoutTests/http/tests/site-isolation/accessibility/client/search-past-remote-frame-immediate-descendants.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/search-past-remote-frame-immediate-descendants.html
@@ -1,0 +1,86 @@
+<html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+<script src="/js-test-resources/accessibility-helper.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+
+<input id="text-before" type="text">
+
+<iframe id="iframe" src="http://localhost:8000/site-isolation/accessibility/resources/iframe-with-headings.html"></iframe>
+
+<button id="button-after">Button After Iframe</button>
+
+<script>
+var output = "Tests that immediateDescendantsOnly AnyType search correctly finds elements after a cross-process iframe.\n";
+output += "VoiceOver obtains the iframe's FrameHost element via the remote element parent chain.\n";
+output += "Without the fix, the search loops back to the first element.\n\n";
+
+window.jsTestIsAsync = true;
+accessibilityController.setClientAccessibilityMode(true);
+
+var frameHost, nextAfterFrameHost, foundButtonAfter;
+async function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    await waitForElements([
+        (element) => element.role.includes("Heading"),
+    ]);
+
+    var root = accessibilityController.rootElement;
+    var webArea = root.childAtIndex(0);
+
+    // Get the remote platform element (iframe) from WebArea's children, then get
+    // its parent. The remote token bridge maps the remote element's parent to the
+    // FrameHost (the ignored AccessibilityScrollView wrapping the iframe). This is
+    // how VoiceOver discovers the FrameHost element.
+    frameHost = webArea.childAtIndex(1).parentElement();
+    // We use rawRoleForTesting to verify we're getting an AccessibilityRole::FrameHost (it's platform
+    // role is group which is very generic). FrameHost is what VoiceOver used when
+    // triggering the actual bug, which is why we do this check.
+    output += expect("frameHost.rawRoleForTesting.includes('FrameHost')", "true");
+
+    // Now search forward from the FrameHost with immediateDescendantsOnly=true.
+    // This is the exact search VoiceOver performs. Without the fix, the search
+    // loops back to the first element.
+    nextAfterFrameHost = webArea.uiElementsForSearchPredicate(
+        frameHost, true, "AXAnyTypeSearchKey", "", false, true, 10
+    );
+
+    output += `\nElements after FrameHost (immediateDescendantsOnly=true):\n`;
+    if (nextAfterFrameHost) {
+        for (var i = 0; i < nextAfterFrameHost.length; i++)
+            output += `  ${i + 1}: ${nextAfterFrameHost[i].role}\n`;
+    }
+
+    // Verify the button after the iframe was found.
+    foundButtonAfter = false;
+    if (nextAfterFrameHost) {
+        for (var i = 0; i < nextAfterFrameHost.length; i++) {
+            if (nextAfterFrameHost[i].role && nextAfterFrameHost[i].role.includes("Button")) {
+                foundButtonAfter = true;
+                break;
+            }
+        }
+    }
+    output += "\n" + expect("foundButtonAfter", "true");
+
+    // The first result should be the button, not text-before (looping would return
+    // text-before as the first result since the search wraps around).
+    if (nextAfterFrameHost && nextAfterFrameHost.length > 0) {
+        var firstRole = nextAfterFrameHost[0].role || "";
+        if (firstRole.includes("Button"))
+            output += "PASS: First result after FrameHost is the button (no loop-back).\n";
+        else
+            output += `FAIL: First result after FrameHost is not the button; instead was this role, probably indicating a search-loop: ${firstRole}\n`;
+    }
+
+    debug(output);
+    finishJSTest();
+}
+
+document.getElementById("iframe").onload = runTest;
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -505,6 +505,62 @@ AXCoreObject* AXCoreObject::parentObjectIncludingCrossFrame() const
 #endif
 }
 
+AXCoreObject* AXCoreObject::nextSiblingUnignored() const
+{
+    RefPtr parent = parentObjectIncludingCrossFrame();
+    if (!parent)
+        return nullptr;
+
+    const auto& siblings = parent->children();
+    size_t index = siblings.findIf([this](const Ref<AXCoreObject>& child) {
+        return child.ptr() == this;
+    });
+    if (index == notFound)
+        return nullptr;
+
+    for (size_t i = index + 1; i < siblings.size(); ++i) {
+        auto& sibling = siblings[i];
+        if (sibling->isIgnored())
+            continue;
+        // Skip children that have been stitched into another object,
+        // as they don't appear in the exposed accessibility tree.
+        if (sibling->hasStitchableRole()) {
+            if (auto stitchedInto = sibling->stitchedIntoID(); stitchedInto && *stitchedInto != sibling->objectID())
+                continue;
+        }
+        return sibling.unsafePtr();
+    }
+    return nullptr;
+}
+
+AXCoreObject* AXCoreObject::previousSiblingUnignored() const
+{
+    RefPtr parent = parentObjectIncludingCrossFrame();
+    if (!parent)
+        return nullptr;
+
+    const auto& siblings = parent->children();
+    size_t index = siblings.findIf([this](const Ref<AXCoreObject>& child) {
+        return child.ptr() == this;
+    });
+    if (index == notFound || !index)
+        return nullptr;
+
+    for (size_t i = index; i > 0; --i) {
+        auto& sibling = siblings[i - 1];
+        if (sibling->isIgnored())
+            continue;
+        // Skip children that have been stitched into another object,
+        // as they don't appear in the exposed accessibility tree.
+        if (sibling->hasStitchableRole()) {
+            if (auto stitchedInto = sibling->stitchedIntoID(); stitchedInto && *stitchedInto != sibling->objectID())
+                continue;
+        }
+        return sibling.unsafePtr();
+    }
+    return nullptr;
+}
+
 #ifndef NDEBUG
 void AXCoreObject::verifyChildrenIndexInParent(const AccessibilityChildrenVector& children) const
 {

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -859,6 +859,11 @@ public:
     AXCoreObject* parentObjectIncludingCrossFrame() const;
     AXCoreObject* parentObjectUnignoredIncludingCrossFrame() const;
 
+    // Finds the next or previous sibling that is not ignored. Uses the parent's
+    // children() list, so it works for both live objects and isolated objects.
+    AXCoreObject* nextSiblingUnignored() const;
+    AXCoreObject* previousSiblingUnignored() const;
+
     // Finds objects within |this| object matching the given search criteria.
     virtual AccessibilityChildrenVector findMatchingObjectsWithin(AccessibilitySearchCriteria&&);
     virtual bool isDescendantOfRole(AccessibilityRole) const = 0;

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -224,6 +224,11 @@ static void appendChildrenToArray(AXCoreObject& object, bool isForward, RefPtr<A
     size_t startIndex = isForward ? childrenSize : 0;
     size_t endIndex = isForward ? 0 : childrenSize;
 
+    // Save the original startObject before the ignored-element handling may
+    // modify or nullify it. We need the original for the descendant-lookup
+    // fallback below.
+    RefPtr<AXCoreObject> originalStartObject = startObject;
+
     // If the startObject is ignored, we should use an accessible sibling as a start element instead.
     if (startObject && startObject->isIgnored() && startObject->crossFrameIsDescendantOfObject(object)) {
         RefPtr<AXCoreObject> parentObject = startObject->parentObjectIncludingCrossFrame();
@@ -235,16 +240,9 @@ static void appendChildrenToArray(AXCoreObject& object, bool isForward, RefPtr<A
             parentObject = parentObject->parentObjectIncludingCrossFrame();
         }
 
-        // We should only ever hit this case with a live object (not an isolated object), as it would require startObject to be ignored,
-        // and we should never have created an isolated object from an ignored live object.
-        // FIXME: This is not true for ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE), fix this before shipping it.
-        // FIXME: We hit this ASSERT on google.com. https://bugs.webkit.org/show_bug.cgi?id=293263
-        AX_BROKEN_ASSERT(is<AccessibilityObject>(startObject));
-        RefPtr newStartObject = dynamicDowncast<AccessibilityObject>(startObject);
         // Get the un-ignored sibling based on the search direction, and update the searchPosition.
-        if (newStartObject && newStartObject->isIgnored())
-            newStartObject = isForward ? newStartObject->previousSiblingUnignored() : newStartObject->nextSiblingUnignored();
-        startObject = newStartObject;
+        if (startObject->isIgnored())
+            startObject = isForward ? startObject->previousSiblingUnignored() : startObject->nextSiblingUnignored();
     }
 
     size_t searchPosition = notFound;
@@ -252,6 +250,22 @@ static void appendChildrenToArray(AXCoreObject& object, bool isForward, RefPtr<A
         searchPosition = searchChildren.findIf([&](const Ref<AXCoreObject>& object) {
             return startObject == object.ptr();
         });
+    }
+
+    // If startObject wasn't found directly in children, it may be an ignored
+    // ancestor of one of the children. For example, an iframe's FrameHost
+    // (AccessibilityScrollView) is ignored, but its child RemoteFrame appears
+    // directly in the parent's unignored children. Since crossFrameUnignoredChildren()
+    // replaces ignored parents with their children, we can find the right position
+    // by looking up the ignored element's direct children in searchChildren.
+    if (searchPosition == notFound && originalStartObject) {
+        for (const auto& child : originalStartObject->children()) {
+            searchPosition = searchChildren.findIf([&](const Ref<AXCoreObject>& searchChild) {
+                return searchChild.ptr() == child.ptr();
+            });
+            if (searchPosition != notFound)
+                break;
+        }
     }
 
     if (searchPosition != notFound) {

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -299,7 +299,7 @@ NSArray *makeNSArray(const WebCore::AXCoreObject::AccessibilityChildrenVector& c
 {
     AX_ASSERT(!isMainThread());
     // FIXME: Can hit this almost 100% of the time on google.com with ENABLE(ACCESSIBILITY_LOCAL_FRAME).
-    AX_BROKEN_ASSERT(!m_isolatedObject || m_isolatedObject->objectID() == newObject.objectID());
+    AX_ASSERT(!m_isolatedObject || m_isolatedObject->objectID() == newObject.objectID());
 
     m_isolatedObject = newObject;
     m_isolatedObjectInitialized = true;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -42,6 +42,7 @@
 #import "AXTextMarker.h"
 #import "AXTreeStore.h"
 #import "AXTreeStoreInlines.h"
+#import "AXUtilities.h"
 #import "AccessibilityObjectInlines.h"
 #import "AccessibilityProgressIndicator.h"
 #import "AccessibilityRenderObject.h"
@@ -2450,6 +2451,14 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 }
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
+static String debugDescriptionFrom(AXCoreObject* object)
+{
+    String objectDescription = "null backingObject"_s;
+    if (object)
+        objectDescription = object->debugDescription();
+    return makeString("PID: "_s, getpid(), ", "_s, objectDescription).createNSString().autorelease();
+}
+
 id attributeValueForTesting(const RefPtr<AXCoreObject>& backingObject, NSString *attributeName)
 {
     ASSERT_WITH_MESSAGE(AXObjectCache::clientIsInTestMode(), "Should be used for testing only, not for AT clients.");
@@ -2532,6 +2541,12 @@ id attributeValueForTesting(const RefPtr<AXCoreObject>& backingObject, NSString 
 
     if ([attributeName isEqualToString:NSAccessibilityPageRelativePositionAttribute])
         return [NSValue valueWithPoint:(CGPoint)backingObject->relativeFrame().location()];
+
+    if ([attributeName isEqualToString:@"_AXDebugDescription"])
+        return debugDescriptionFrom(backingObject.get()).createNSString().autorelease();
+
+    if ([attributeName isEqualToString:@"_AXRawRoleForTesting"])
+        return roleToString(backingObject->role()).createNSString().autorelease();
 
     return nil;
 }
@@ -4452,11 +4467,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSString *)debugDescription
 {
-    String backingObjectDescription = "null backingObject"_s;
     RefPtr<AXCoreObject> backingObject = self.updateObjectBackingStore;
-    if (backingObject)
-        backingObjectDescription = backingObject->debugDescription();
-    return makeString("PID: "_s, getpid(), ", "_s, backingObjectDescription).createNSString().autorelease();
+    return debugDescriptionFrom(backingObject.get()).createNSString().autorelease();
 }
 @end
 

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -141,6 +141,8 @@ public:
     virtual JSRetainPtr<JSStringRef> computedRoleString();
     virtual JSRetainPtr<JSStringRef> title();
     virtual JSRetainPtr<JSStringRef> description();
+    virtual JSRetainPtr<JSStringRef> debugDescription() { return nullptr; }
+    virtual JSRetainPtr<JSStringRef> rawRoleForTesting() { return nullptr; }
     virtual JSRetainPtr<JSStringRef> language();
     virtual JSRetainPtr<JSStringRef> stringValue();
     virtual JSRetainPtr<JSStringRef> dateValue();

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -51,6 +51,8 @@ interface AccessibilityUIElement {
     readonly attribute DOMString computedRoleString;
     readonly attribute DOMString title;
     readonly attribute DOMString description;
+    readonly attribute DOMString debugDescription;
+    readonly attribute DOMString rawRoleForTesting;
     readonly attribute DOMString language;
     readonly attribute DOMString helpText;
     readonly attribute DOMString valueDescription;

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.h
@@ -50,10 +50,14 @@ public:
     JSRetainPtr<JSStringRef> role() override;
     JSRetainPtr<JSStringRef> title() override;
     JSRetainPtr<JSStringRef> description() override;
+    JSRetainPtr<JSStringRef> debugDescription() final;
+    JSRetainPtr<JSStringRef> rawRoleForTesting() final;
     JSRetainPtr<JSStringRef> stringValue() override;
     JSRetainPtr<JSStringRef> domIdentifier() const override;
+    RefPtr<AccessibilityUIElement> parentElement() final;
     unsigned childrenCount() override;
     RefPtr<AccessibilityUIElement> childAtIndex(unsigned) override;
+    JSValueRef uiElementsForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly, unsigned resultsLimit) override;
     int hierarchicalLevel() const override;
     double minValue() override;
     double maxValue() override;

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.mm
@@ -32,6 +32,7 @@
 #import "InjectedBundle.h"
 #import <JavaScriptCore/JSRetainPtr.h>
 #import <JavaScriptCore/JSStringRef.h>
+#import <JavaScriptCore/JSValueRef.h>
 #import <JavaScriptCore/OpaqueJSString.h>
 #import <WebKit/WKBundle.h>
 #import <WebKit/WKBundlePrivate.h>
@@ -70,6 +71,25 @@ static WKRetainPtr<WKStringRef> axCopyAttributeValueAsString(uint64_t elementTok
         return nullptr;
 
     return adoptWK(static_cast<WKStringRef>(returnData));
+}
+
+static std::optional<uint64_t> axCopyAttributeValueAsElementToken(uint64_t elementToken, const char* attributeName)
+{
+    WKRetainPtr dictionary = adoptWK(WKMutableDictionaryCreate());
+    setValue(dictionary, "elementToken", elementToken);
+    setValue(dictionary, "attributeName", attributeName);
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    WKTypeRef returnData = nullptr;
+    WKBundlePostSynchronousMessage(InjectedBundle::singleton().bundle(), toWK("AXCopyAttributeValueAsElement").get(), dictionary.get(), &returnData);
+    ALLOW_DEPRECATED_DECLARATIONS_END
+
+    if (!returnData || WKGetTypeID(returnData) != WKUInt64GetTypeID())
+        return std::nullopt;
+
+    uint64_t token = WKUInt64GetValue(static_cast<WKUInt64Ref>(returnData));
+    WKRelease(returnData);
+    return token;
 }
 
 static WKRetainPtr<WKArrayRef> axCopyAttributeValueAsElementArray(uint64_t elementToken, const char* attributeName)
@@ -228,6 +248,16 @@ JSRetainPtr<JSStringRef> AccessibilityUIElementClientMac::description()
     return getStringAttribute("AXDescription");
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElementClientMac::debugDescription()
+{
+    return getStringAttribute("_AXDebugDescription");
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementClientMac::rawRoleForTesting()
+{
+    return getStringAttribute("_AXRawRoleForTesting");
+}
+
 JSRetainPtr<JSStringRef> AccessibilityUIElementClientMac::stringValue()
 {
     return getStringAttribute("AXValue");
@@ -332,6 +362,12 @@ Vector<RefPtr<AccessibilityUIElement>> AccessibilityUIElementClientMac::getChild
     return result;
 }
 
+RefPtr<AccessibilityUIElement> AccessibilityUIElementClientMac::parentElement()
+{
+    std::optional token = axCopyAttributeValueAsElementToken(m_elementToken, "AXParent");
+    return token ? create(*token).ptr() : nullptr;
+}
+
 unsigned AccessibilityUIElementClientMac::childrenCount()
 {
     return getChildren().size();
@@ -341,6 +377,59 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElementClientMac::childAtIndex(uns
 {
     Vector children = getChildrenInRange(index, 1);
     return children.size() == 1 ? children[0] : nullptr;
+}
+
+JSValueRef AccessibilityUIElementClientMac::uiElementsForSearchPredicate(JSContextRef context, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly, unsigned resultsLimit)
+{
+    if (!isValid())
+        return nullptr;
+
+    WKRetainPtr dictionary = adoptWK(WKMutableDictionaryCreate());
+    WTR::setValue(dictionary, "elementToken", m_elementToken);
+
+    uint64_t startElementToken = 0;
+    if (startElement) {
+        // In client mode, all elements are AccessibilityUIElementClientMac.
+        startElementToken = static_cast<AccessibilityUIElementClientMac*>(startElement)->m_elementToken;
+    }
+    WTR::setValue(dictionary, "startElementToken", startElementToken);
+
+    WTR::setValue(dictionary, "isDirectionNext", isDirectionNext);
+    WTR::setValue(dictionary, "resultsLimit", static_cast<uint64_t>(resultsLimit));
+    WTR::setValue(dictionary, "visibleOnly", visibleOnly);
+    WTR::setValue(dictionary, "immediateDescendantsOnly", immediateDescendantsOnly);
+
+    if (searchKey && JSValueIsString(context, searchKey)) {
+        JSRetainPtr<JSStringRef> jsStr(Adopt, JSValueToStringCopy(context, searchKey, nullptr));
+        WTR::setValue(dictionary, "searchKey", jsStr.get());
+    }
+
+    if (searchText && JSStringGetLength(searchText))
+        WTR::setValue(dictionary, "searchText", searchText);
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    WKTypeRef returnData = nullptr;
+    WKBundlePostSynchronousMessage(InjectedBundle::singleton().bundle(), toWK("AXSearchPredicate").get(), dictionary.get(), &returnData);
+    ALLOW_DEPRECATED_DECLARATIONS_END
+
+    if (!returnData || WKGetTypeID(returnData) != WKArrayGetTypeID())
+        return nullptr;
+
+    WKArrayRef resultArray = static_cast<WKArrayRef>(returnData);
+    size_t count = WKArrayGetSize(resultArray);
+
+    Vector<RefPtr<AccessibilityUIElement>> elements;
+    elements.reserveInitialCapacity(count);
+    for (size_t i = 0; i < count; i++) {
+        WKTypeRef item = WKArrayGetItemAtIndex(resultArray, i);
+        if (WKGetTypeID(item) == WKUInt64GetTypeID()) {
+            uint64_t childToken = WKUInt64GetValue(static_cast<WKUInt64Ref>(item));
+            elements.append(AccessibilityUIElementClientMac::create(childToken));
+        }
+    }
+
+    WKRelease(returnData);
+    return makeJSArray(context, elements);
 }
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h
@@ -115,6 +115,8 @@ public:
     JSRetainPtr<JSStringRef> computedRoleString() override;
     JSRetainPtr<JSStringRef> title() override;
     JSRetainPtr<JSStringRef> description() override;
+    JSRetainPtr<JSStringRef> debugDescription() override;
+    JSRetainPtr<JSStringRef> rawRoleForTesting() override;
     JSRetainPtr<JSStringRef> language() override;
     JSRetainPtr<JSStringRef> stringValue() override;
     JSRetainPtr<JSStringRef> dateValue() override;

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -1064,6 +1064,26 @@ JSRetainPtr<JSStringRef> AccessibilityUIElementMac::description()
     return nullptr;
 }
 
+JSRetainPtr<JSStringRef> AccessibilityUIElementMac::debugDescription()
+{
+    BEGIN_AX_OBJC_EXCEPTIONS
+    auto description = descriptionOfValue(attributeValue(@"_AXDebugDescription").get());
+    return concatenateAttributeAndValue(@"_AXDebugDescription", description.get());
+    END_AX_OBJC_EXCEPTIONS
+
+    return nullptr;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementMac::rawRoleForTesting()
+{
+    BEGIN_AX_OBJC_EXCEPTIONS
+    auto description = descriptionOfValue(attributeValue(@"_AXRawRoleForTesting").get());
+    return concatenateAttributeAndValue(@"_AXRawRoleForTesting", description.get());
+    END_AX_OBJC_EXCEPTIONS
+
+    return nullptr;
+}
+
 JSRetainPtr<JSStringRef> AccessibilityUIElementMac::brailleLabel() const
 {
     BEGIN_AX_OBJC_EXCEPTIONS

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -3429,6 +3429,9 @@ void TestController::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef 
 
     if (WKStringIsEqualToUTF8CString(messageName, "AXCopyAttributeValueAsSize"))
         return completionHandler(handleAXCopyAttributeValueAsSize(dictionaryValue(messageBody)).get());
+
+    if (WKStringIsEqualToUTF8CString(messageName, "AXSearchPredicate"))
+        return completionHandler(handleAXSearchPredicate(dictionaryValue(messageBody)).get());
 #endif
 
     completionHandler(protectedCurrentInvocation()->didReceiveSynchronousMessageFromInjectedBundle(messageName, messageBody).get());
@@ -5613,6 +5616,89 @@ WKRetainPtr<WKTypeRef> TestController::handleAXCopyAttributeValueAsSize(WKDictio
     setValue(dictionary, "width", size.width);
     setValue(dictionary, "height", size.height);
     return dictionary;
+}
+
+WKRetainPtr<WKTypeRef> TestController::handleAXSearchPredicate(WKDictionaryRef messageBody)
+{
+    uint64_t elementToken = uint64Value(messageBody, "elementToken");
+    uint64_t startElementToken = uint64Value(messageBody, "startElementToken");
+    bool isDirectionNext = booleanValue(messageBody, "isDirectionNext");
+    uint64_t resultsLimit = uint64Value(messageBody, "resultsLimit");
+    bool visibleOnly = booleanValue(messageBody, "visibleOnly");
+    bool immediateDescendantsOnly = booleanValue(messageBody, "immediateDescendantsOnly");
+    WKStringRef searchKey = stringValue(messageBody, "searchKey");
+    WKStringRef searchText = stringValue(messageBody, "searchText");
+
+    AXUIElementRef element = static_cast<AXUIElementRef>(getAXElement(elementToken));
+    if (!element)
+        return nullptr;
+
+    // Build the search predicate parameter dictionary using CF APIs.
+    RetainPtr paramDictionary = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
+
+    if (startElementToken) {
+        if (AXUIElementRef startElement = static_cast<AXUIElementRef>(getAXElement(startElementToken)))
+            CFDictionarySetValue(paramDictionary.get(), CFSTR("AXStartElement"), startElement);
+    }
+
+    CFDictionarySetValue(paramDictionary.get(), CFSTR("AXDirection"),
+        isDirectionNext ? CFSTR("AXDirectionNext") : CFSTR("AXDirectionPrevious"));
+
+    int resultsLimitInt = static_cast<int>(resultsLimit);
+    RetainPtr resultsLimitNum = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &resultsLimitInt));
+    CFDictionarySetValue(paramDictionary.get(), CFSTR("AXResultsLimit"), resultsLimitNum.get());
+
+    if (searchKey) {
+        RetainPtr searchKeyCF = adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, toSTD(searchKey).c_str(), kCFStringEncodingUTF8));
+        CFDictionarySetValue(paramDictionary.get(), CFSTR("AXSearchKey"), searchKeyCF.get());
+    }
+
+    if (searchText) {
+        auto searchTextStd = toSTD(searchText);
+        if (!searchTextStd.empty()) {
+            RetainPtr searchTextCF = adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, searchTextStd.c_str(), kCFStringEncodingUTF8));
+            CFDictionarySetValue(paramDictionary.get(), CFSTR("AXSearchText"), searchTextCF.get());
+        }
+    }
+
+    CFDictionarySetValue(paramDictionary.get(), CFSTR("AXVisibleOnly"), visibleOnly ? kCFBooleanTrue : kCFBooleanFalse);
+    CFDictionarySetValue(paramDictionary.get(), CFSTR("AXImmediateDescendantsOnly"), immediateDescendantsOnly ? kCFBooleanTrue : kCFBooleanFalse);
+
+    CFTypeRef resultValue = nullptr;
+    AXError error = AXUIElementCopyParameterizedAttributeValue(element, CFSTR("AXUIElementsForSearchPredicate"), paramDictionary.get(), &resultValue);
+
+    if (error != kAXErrorSuccess || !resultValue)
+        return nullptr;
+
+    RetainPtr result = adoptCF(resultValue);
+
+    if (CFGetTypeID(result.get()) != CFArrayGetTypeID())
+        return nullptr;
+
+    CFArrayRef resultArray = static_cast<CFArrayRef>(result.get());
+    CFIndex count = CFArrayGetCount(resultArray);
+
+    WKRetainPtr tokenArray = adoptWK(WKMutableArrayCreate());
+    for (CFIndex i = 0; i < count; i++) {
+        CFTypeRef item = CFArrayGetValueAtIndex(resultArray, i);
+
+        AXUIElementRef resultElement = nullptr;
+        if (CFGetTypeID(item) == AXUIElementGetTypeID())
+            resultElement = static_cast<AXUIElementRef>(const_cast<void*>(item));
+        else if (CFGetTypeID(item) == CFDictionaryGetTypeID()) {
+            CFTypeRef searchResultElement = CFDictionaryGetValue(static_cast<CFDictionaryRef>(item), CFSTR("AXSearchResultElement"));
+            if (searchResultElement && CFGetTypeID(searchResultElement) == AXUIElementGetTypeID())
+                resultElement = static_cast<AXUIElementRef>(const_cast<void*>(searchResultElement));
+        }
+
+        if (resultElement) {
+            uint64_t token = storeAXElement(resultElement);
+            WKRetainPtr tokenRef = adoptWK(WKUInt64Create(token));
+            WKArrayAppendItem(tokenArray.get(), tokenRef.get());
+        }
+    }
+
+    return tokenArray;
 }
 
 #endif // PLATFORM(MAC)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -586,6 +586,7 @@ private:
     WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsBoolean(WKDictionaryRef);
     WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsPoint(WKDictionaryRef);
     WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsSize(WKDictionaryRef);
+    WKRetainPtr<WKTypeRef> handleAXSearchPredicate(WKDictionaryRef);
 #endif
 
     // WKContextClient


### PR DESCRIPTION
#### 09f3ff7a8562c28661311594574adceee38e2eb4
<pre>
AX: VoiceOver-right navigation loops with site isolation when encountering a remote frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=309401">https://bugs.webkit.org/show_bug.cgi?id=309401</a>
<a href="https://rdar.apple.com/171944277">rdar://171944277</a>

Reviewed by Joshua Hoffman.

When VoiceOver navigates past a site-isolated iframe using immediateDescendantsOnly
search, it passes the iframe&apos;s FrameHost (an ignored AccessibilityScrollView) as the
start element. Since the FrameHost is ignored, it doesn&apos;t appear in the WebArea&apos;s
crossFrameUnignoredChildren() list, so appendChildrenToArray couldn&apos;t find it and
returned all children — causing the search to loop back to the first element.

Fix by adding a descendant-lookup fallback: when the start element isn&apos;t found in the
children list, check if any child is a direct child of the original start element.
This finds the RemoteFrame (the FrameHost&apos;s unignored child) and resumes the search
from the correct position.

Also fix the existing ignored-element sibling walk to use AXCoreObject methods
(nextSiblingUnignored / previousSiblingUnignored) instead of dynamicDowncast to
AccessibilityObject, which failed on the isolated tree where objects are
AXIsolatedObject.

The sibling methods filter out stitched-text children to avoid interfering with
text stitching.

* LayoutTests/http/tests/site-isolation/accessibility/search-past-remote-frame-immediate-descendants-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/accessibility/search-past-remote-frame-immediate-descendants.html: Added.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::nextSiblingUnignored const):
(WebCore::AXCoreObject::previousSiblingUnignored const):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::appendChildrenToArray):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm:
(-[WebAccessibilityObjectWrapperBase attachIsolatedObject:]):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(debugDescriptionFrom):
(attributeValueForTesting):
(-[WebAccessibilityObjectWrapper debugDescription]):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
(WTR::AccessibilityUIElement::debugDescription):
(WTR::AccessibilityUIElement::rawRoleForTesting):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.h:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.mm:
(WTR::axCopyAttributeValueAsElementToken):
(WTR::AccessibilityUIElementClientMac::debugDescription):
(WTR::AccessibilityUIElementClientMac::rawRoleForTesting):
(WTR::AccessibilityUIElementClientMac::parentElement):
(WTR::AccessibilityUIElementClientMac::uiElementsForSearchPredicate):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElementMac::debugDescription):
(WTR::AccessibilityUIElementMac::rawRoleForTesting):
* Tools/WebKitTestRunner/TestController.cpp:
* Tools/WebKitTestRunner/TestController.h:

Canonical link: <a href="https://commits.webkit.org/309056@main">https://commits.webkit.org/309056@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee3eb8c9ce0eff21b3132c9bb6705cb914c32a39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149108 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157796 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102539 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150981 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21699 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114952 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81829 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ae1cda32-a58e-4c07-8bc2-5345d36e3d0f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17133 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133828 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95710 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5620623-a792-490e-bee0-a5fd557e2374) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16230 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14105 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5649 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125836 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160280 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3268 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13278 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122999 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18135 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123229 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33535 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21631 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133549 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77832 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18485 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10304 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21233 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85035 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20965 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21113 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21021 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->