### PR TITLE
[Dictation] Add DictationStreamingOpacity document marker for streaming partial results

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -62,7 +62,6 @@ platform/graphics/ca/TileController.cpp
 [ iOS ] platform/ios/DeviceMotionClientIOS.h
 [ iOS ] platform/ios/LegacyTileCache.h
 platform/mediastream/libwebrtc/LibWebRTCDav1dDecoder.cpp
-rendering/MarkedText.h
 rendering/RenderLayerBacking.cpp
 rendering/RenderLayerCompositor.cpp
 rendering/RenderTextLineBoxes.h

--- a/Source/WebCore/dom/DocumentMarker.h
+++ b/Source/WebCore/dom/DocumentMarker.h
@@ -99,6 +99,7 @@ enum class DocumentMarkerType : uint32_t {
     WritingToolsTextSuggestion = 1 << 16,
 #endif
     TransparentContent = 1 << 17,
+    DictationStreamingOpacity = 1 << 18,
 };
 
 // A range of a node within a document that is "marked", such as the range of a misspelled word.
@@ -142,6 +143,10 @@ public:
         WTF::UUID uuid;
     };
 
+    struct DictationStreamingOpacityData {
+        float opacity { 0 };
+    };
+
     using Data = Variant<
         String
         , DictationData // DictationAlternatives
@@ -157,6 +162,7 @@ public:
         , WritingToolsTextSuggestionData // WritingToolsTextSuggestion
 #endif
         , TransparentContentData // TransparentContent
+        , DictationStreamingOpacityData // DictationStreamingOpacity
     >;
 
     DocumentMarker(DocumentMarkerType, OffsetRange, Data&& = { });
@@ -211,6 +217,7 @@ constexpr auto DocumentMarker::allMarkers() -> OptionSet<DocumentMarkerType>
         DocumentMarkerType::WritingToolsTextSuggestion,
 #endif
         DocumentMarkerType::TransparentContent,
+        DocumentMarkerType::DictationStreamingOpacity,
     };
 }
 

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -133,6 +133,17 @@ void DocumentMarkerController::addTransparentContentMarker(const SimpleRange& ra
         addMarker(textPiece.node, { DocumentMarkerType::TransparentContent, textPiece.range, DocumentMarker::TransparentContentData { { textPiece.node.ptr() }, uuid } });
 }
 
+void DocumentMarkerController::addDictationStreamingOpacityMarker(const SimpleRange& range, float opacity)
+{
+    for (auto& textPiece : collectTextRanges(range))
+        addMarker(textPiece.node, { DocumentMarkerType::DictationStreamingOpacity, textPiece.range, DocumentMarker::DictationStreamingOpacityData { opacity } });
+}
+
+void DocumentMarkerController::removeAllDictationStreamingOpacityMarkers()
+{
+    removeMarkers({ DocumentMarkerType::DictationStreamingOpacity });
+}
+
 void DocumentMarkerController::removeMarkers(const SimpleRange& range, OptionSet<DocumentMarkerType> types, RemovePartiallyOverlappingMarker overlapRule)
 {
     filterMarkers(range, nullptr, types, overlapRule);

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -68,6 +68,8 @@ public:
     WEBCORE_EXPORT bool addMarker(Node&, DocumentMarker&&);
     void addDraggedContentMarker(const SimpleRange&);
     WEBCORE_EXPORT void addTransparentContentMarker(const SimpleRange&, WTF::UUID);
+    WEBCORE_EXPORT void addDictationStreamingOpacityMarker(const SimpleRange&, float opacity);
+    WEBCORE_EXPORT void removeAllDictationStreamingOpacityMarkers();
 
     void copyMarkers(Node& source, OffsetRange, Node& destination);
     bool hasMarkers() const;

--- a/Source/WebCore/rendering/MarkedText.cpp
+++ b/Source/WebCore/rendering/MarkedText.cpp
@@ -353,4 +353,27 @@ Vector<MarkedText> MarkedText::collectForDraggedAndTransparentContent(const Docu
     });
 }
 
+Vector<MarkedText> MarkedText::collectForDictationStreamingOpacity(const RenderText& renderer, const TextBoxSelectableRange& selectableRange)
+{
+    if (!renderer.textNode())
+        return { };
+
+    CheckedPtr markerController = renderer.document().markersIfExists();
+    if (!markerController)
+        return { };
+
+    auto markers = markerController->markersFor(*renderer.textNode(), DocumentMarkerType::DictationStreamingOpacity);
+    if (markers.isEmpty())
+        return { };
+
+    Vector<MarkedText> result;
+    result.reserveInitialCapacity(markers.size());
+    for (auto& marker : markers) {
+        auto [clampedStart, clampedEnd] = selectableRange.clamp(marker->startOffset(), marker->endOffset());
+        if (clampedStart < clampedEnd)
+            result.append({ clampedStart, clampedEnd, MarkedText::Type::DictationStreamingOpacity, marker.get() });
+    }
+    return result;
+}
+
 }

--- a/Source/WebCore/rendering/MarkedText.h
+++ b/Source/WebCore/rendering/MarkedText.h
@@ -67,6 +67,7 @@ struct MarkedText : public CanMakeCheckedPtr<MarkedText, WTF::DefaultedOperatorE
         Selection,
         DraggedContent,
         TransparentContent,
+        DictationStreamingOpacity,
     };
 
     enum class PaintPhase {
@@ -94,6 +95,7 @@ struct MarkedText : public CanMakeCheckedPtr<MarkedText, WTF::DefaultedOperatorE
     static Vector<MarkedText> collectForDocumentMarkers(const RenderText&, const TextBoxSelectableRange&, PaintPhase);
     static Vector<MarkedText> collectForHighlights(const RenderText&, const TextBoxSelectableRange&, PaintPhase);
     static Vector<MarkedText> collectForDraggedAndTransparentContent(const DocumentMarkerType, const RenderText& renderer, const TextBoxSelectableRange&);
+    static Vector<MarkedText> collectForDictationStreamingOpacity(const RenderText&, const TextBoxSelectableRange&);
 
     unsigned startOffset { 0 };
     unsigned endOffset { 0 };

--- a/Source/WebCore/rendering/StyledMarkedText.cpp
+++ b/Source/WebCore/rendering/StyledMarkedText.cpp
@@ -32,6 +32,7 @@
 #include "RenderStyle+GettersInlines.h"
 #include "RenderText.h"
 #include "RenderTheme.h"
+#include "RenderedDocumentMarker.h"
 
 namespace WebCore {
 
@@ -123,6 +124,10 @@ static StyledMarkedText resolveStyleForMarkedText(const MarkedText& markedText, 
         break;
     case MarkedText::Type::TransparentContent:
         style.alpha = 0.0;
+        break;
+    case MarkedText::Type::DictationStreamingOpacity:
+        if (auto* marker = markedText.marker)
+            style.alpha = std::get<DocumentMarker::DictationStreamingOpacityData>(marker->data()).opacity;
         break;
     case MarkedText::Type::Selection: {
         style.textStyles = computeTextSelectionPaintStyle(style.textStyles, renderer, lineStyle, paintInfo, style.textShadow);

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -439,6 +439,8 @@ void TextBoxPainter::paintForegroundAndDecorations()
             auto markedTextsForTransparentContent = MarkedText::collectForDraggedAndTransparentContent(DocumentMarkerType::TransparentContent, m_renderer, m_selectableRange);
             if (!markedTextsForTransparentContent.isEmpty())
                 markedTexts.appendVector(WTF::move(markedTextsForTransparentContent));
+
+            markedTexts.appendVector(MarkedText::collectForDictationStreamingOpacity(m_renderer, m_selectableRange));
         }
     }
     // The selection marked text acts as a placeholder when computing the marked texts for the gaps...
@@ -629,6 +631,19 @@ void TextBoxPainter::paintBackgroundFillForRange(unsigned startOffset, unsigned 
     context.fillRect(backgroundRect, color);
 }
 
+static bool isTransparent(const StyledMarkedText& markedText)
+{
+    switch (markedText.type) {
+    case MarkedText::Type::DraggedContent:
+    case MarkedText::Type::TransparentContent:
+    case MarkedText::Type::DictationStreamingOpacity:
+        return true;
+
+    default:
+        return false;
+    }
+}
+
 void TextBoxPainter::paintForeground(const StyledMarkedText& markedText)
 {
     if (markedText.startOffset >= markedText.endOffset)
@@ -655,7 +670,7 @@ void TextBoxPainter::paintForeground(const StyledMarkedText& markedText)
         m_isCombinedText ? &downcast<RenderCombineText>(m_renderer.get()) : nullptr
     };
 
-    bool isTransparentMarkedText = markedText.type == MarkedText::Type::DraggedContent || markedText.type == MarkedText::Type::TransparentContent;
+    bool isTransparentMarkedText = isTransparent(markedText);
     GraphicsContextStateSaver stateSaver(context, markedText.style.textStyles.strokeWidth > 0 || isTransparentMarkedText);
     if (isTransparentMarkedText)
         context.setAlpha(markedText.style.alpha);
@@ -717,7 +732,7 @@ TextDecorationPainter TextBoxPainter::createDecorationPainter(const StyledMarked
     // Note that if the text is truncated, we let the thing being painted in the truncation
     // draw its own decoration.
     GraphicsContextStateSaver stateSaver { context, false };
-    bool isTransparentContent = markedText.type == MarkedText::Type::DraggedContent || markedText.type == MarkedText::Type::TransparentContent;
+    bool isTransparentContent = isTransparent(markedText);
     if (isTransparentContent || !clipOutRect.isEmpty()) {
         stateSaver.save();
         if (isTransparentContent)
@@ -1241,6 +1256,7 @@ void TextBoxPainter::paintPlatformDocumentMarkers()
     // the other marked texts when being subdivided so that they do not get painted.
     Vector<MarkedText> allMarkedTexts;
     allMarkedTexts.appendVector(transparentContentMarkedTexts);
+    allMarkedTexts.appendVector(MarkedText::collectForDictationStreamingOpacity(m_renderer, m_selectableRange));
     allMarkedTexts.appendVector(markedTexts);
     if (textDecorationLineSpellingErrorAsMarkedText)
         allMarkedTexts.append(*textDecorationLineSpellingErrorAsMarkedText);
@@ -1251,6 +1267,7 @@ void TextBoxPainter::paintPlatformDocumentMarkers()
         switch (markedText.type) {
         case MarkedText::Type::DraggedContent:
         case MarkedText::Type::TransparentContent:
+        case MarkedText::Type::DictationStreamingOpacity:
             continue;
 
         default:

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -560,6 +560,8 @@ static bool markerTypeFrom(const String& markerType, DocumentMarkerType& result)
 #endif
     else if (equalLettersIgnoringASCIICase(markerType, "transparentcontent"_s))
         result = DocumentMarkerType::TransparentContent;
+    else if (equalLettersIgnoringASCIICase(markerType, "dictationstreamingopacity"_s))
+        result = DocumentMarkerType::DictationStreamingOpacity;
     else
         return false;
 
@@ -3037,6 +3039,11 @@ bool Internals::hasWritingToolsTextSuggestionMarker(int from, int length)
 bool Internals::hasTransparentContentMarker(int from, int length)
 {
     return hasMarkerFor(DocumentMarkerType::TransparentContent, from, length);
+}
+
+bool Internals::hasDictationStreamingOpacityMarker(int from, int length)
+{
+    return hasMarkerFor(DocumentMarkerType::DictationStreamingOpacity, from, length);
 }
 
 void Internals::setContinuousSpellCheckingEnabled(bool enabled)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -504,6 +504,7 @@ public:
     bool hasWritingToolsTextSuggestionMarker(int from, int length);
 #endif
     bool hasTransparentContentMarker(int from, int length);
+    bool hasDictationStreamingOpacityMarker(int from, int length);
     void setContinuousSpellCheckingEnabled(bool);
     void setAutomaticQuoteSubstitutionEnabled(bool);
     void setAutomaticLinkDetectionEnabled(bool);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -731,6 +731,7 @@ enum ContentsFormat {
     boolean hasWritingToolsTextSuggestionMarker(long from, long length);
 #endif
     boolean hasTransparentContentMarker(long from, long length);
+    boolean hasDictationStreamingOpacityMarker(long from, long length);
     undefined setContinuousSpellCheckingEnabled(boolean enabled);
     undefined setAutomaticQuoteSubstitutionEnabled(boolean enabled);
     undefined setAutomaticLinkDetectionEnabled(boolean enabled);

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -590,6 +590,22 @@ void WebPageProxy::clearDictationAlternatives(Vector<DictationContext>&& alterna
     protect(legacyMainFrameProcess())->send(Messages::WebPage::ClearDictationAlternatives(WTF::move(alternativesToClear)), webPageIDInMainFrameProcess());
 }
 
+void WebPageProxy::setDictationStreamingOpacity(const String& hypothesisText, WebCore::CharacterRange streamingRangeInHypothesis, float opacity)
+{
+    if (!hasRunningProcess())
+        return;
+
+    protect(legacyMainFrameProcess())->send(Messages::WebPage::SetDictationStreamingOpacity(hypothesisText, streamingRangeInHypothesis, opacity), webPageIDInMainFrameProcess());
+}
+
+void WebPageProxy::clearDictationStreamingOpacity()
+{
+    if (!hasRunningProcess())
+        return;
+
+    protect(legacyMainFrameProcess())->send(Messages::WebPage::ClearDictationStreamingOpacity(), webPageIDInMainFrameProcess());
+}
+
 ResourceError WebPageProxy::errorForUnpermittedAppBoundDomainNavigation(const URL& url)
 {
     return { WKErrorDomain, WKErrorNavigationAppBoundDomain, url, localizedDescriptionForErrorCode(WKErrorNavigationAppBoundDomain).get() };

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1383,6 +1383,8 @@ public:
     void addDictationAlternative(WebCore::TextAlternativeWithRange&&);
     void dictationAlternativesAtSelection(CompletionHandler<void(Vector<WebCore::DictationContext>&&)>&&);
     void clearDictationAlternatives(Vector<WebCore::DictationContext>&&);
+    void setDictationStreamingOpacity(const String& hypothesisText, WebCore::CharacterRange streamingRangeInHypothesis, float opacity);
+    void clearDictationStreamingOpacity();
 
     void hasMarkedText(CompletionHandler<void(bool)>&&);
     void getMarkedRangeAsync(CompletionHandler<void(const EditingRange&)>&&);

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -116,6 +116,7 @@
 #import <MobileCoreServices/UTCoreTypes.h>
 #import <UniformTypeIdentifiers/UTCoreTypes.h>
 #import <WebCore/AppHighlight.h>
+#import <WebCore/CharacterRange.h>
 #import <WebCore/ColorCocoa.h>
 #import <WebCore/ColorSerialization.h>
 #import <WebCore/CompositionHighlight.h>
@@ -6000,6 +6001,22 @@ static void logTextInteraction(const char* methodName, UIGestureRecognizer *loup
 
     _autocorrectionContextNeedsUpdate = YES;
     protect(_page)->replaceDictatedText(oldText, newText);
+}
+
+- (void)_setDictationStreamingOpacity:(CGFloat)opacity forHypothesisText:(NSString *)hypothesisText streamingRange:(NSRange)streamingRange
+{
+    if (!_page)
+        return;
+
+    protect(_page)->setDictationStreamingOpacity(hypothesisText, { streamingRange }, static_cast<float>(opacity));
+}
+
+- (void)_clearDictationStreamingOpacity
+{
+    if (!_page)
+        return;
+
+    protect(_page)->clearDictationStreamingOpacity();
 }
 
 // The completion handler should pass the rect of the correction text after replacing the input text, or nil if the replacement could not be performed.

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -139,6 +139,7 @@
 #import <WebCore/UTIRegistry.h>
 #import <WebCore/UTIUtilities.h>
 #import <WebCore/UserTypingGestureIndicator.h>
+#import <WebCore/VisibleUnits.h>
 #import <WebCore/WebAccessibilityObjectWrapperMac.h>
 #import <WebCore/markup.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
@@ -543,6 +544,57 @@ void WebPage::clearDictationAlternatives(Vector<DictationContext>&& contexts)
             return FilterMarkerResult::Keep;
         return setOfContextsToRemove.contains(std::get<WebCore::DocumentMarker::DictationData>(marker.data()).context) ? FilterMarkerResult::Remove : FilterMarkerResult::Keep;
     }, DocumentMarkerType::DictationAlternatives);
+}
+
+std::optional<SimpleRange> WebPage::findDictatedTextRangeBeforeCursor(LocalFrame& frame, const String& text)
+{
+    VisiblePosition position = frame.selection().selection().start();
+    for (auto i = numGraphemeClusters(text); i; --i)
+        position = position.previous();
+    if (position.isNull())
+        position = startOfDocument(protect(frame.document()));
+
+    auto range = makeSimpleRange(position, frame.selection().selection().start());
+    if (!range || plainTextForContext(*range) != text)
+        return std::nullopt;
+    return range;
+}
+
+void WebPage::setDictationStreamingOpacity(const String& hypothesisText, WebCore::CharacterRange streamingRangeInHypothesis, float opacity)
+{
+    RefPtr frame = m_page->focusController().focusedOrMainFrame();
+    if (!frame) {
+        WEBPAGE_RELEASE_LOG(ViewState, "setDictationStreamingOpacity - no focused frame");
+        return;
+    }
+
+    if (frame->selection().isNone() || !frame->selection().selection().isContentEditable()) {
+        WEBPAGE_RELEASE_LOG(ViewState, "setDictationStreamingOpacity - no editable selection");
+        return;
+    }
+
+    auto hypothesisRange = findDictatedTextRangeBeforeCursor(*frame, hypothesisText);
+    if (!hypothesisRange) {
+        WEBPAGE_RELEASE_LOG(ViewState, "setDictationStreamingOpacity - hypothesis text not found, expected length %u", hypothesisText.length());
+        return;
+    }
+
+    auto streamingRange = resolveCharacterRange(*hypothesisRange, streamingRangeInHypothesis);
+    if (streamingRange.collapsed()) {
+        WEBPAGE_RELEASE_LOG(ViewState, "setDictationStreamingOpacity - resolved streaming range is collapsed");
+        return;
+    }
+
+    protect(protect(frame->document())->markers())->addDictationStreamingOpacityMarker(streamingRange, opacity);
+}
+
+void WebPage::clearDictationStreamingOpacity()
+{
+    RefPtr frame = m_page->focusController().focusedOrMainFrame();
+    if (!frame || !frame->document())
+        return;
+
+    protect(protect(frame->document())->markers())->removeAllDictationStreamingOpacityMarkers();
 }
 
 void WebPage::accessibilityTransferRemoteToken(RetainPtr<NSData> remoteToken)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1350,6 +1350,8 @@ public:
     void addDictationAlternative(const String& text, WebCore::DictationContext, CompletionHandler<void(bool)>&&);
     void dictationAlternativesAtSelection(CompletionHandler<void(Vector<WebCore::DictationContext>&&)>&&);
     void clearDictationAlternatives(Vector<WebCore::DictationContext>&&);
+    void setDictationStreamingOpacity(const String& hypothesisText, WebCore::CharacterRange streamingRangeInHypothesis, float opacity);
+    void clearDictationStreamingOpacity();
 #endif // PLATFORM(COCOA)
 
 #if PLATFORM(MAC)
@@ -2753,6 +2755,8 @@ private:
 
 #if PLATFORM(COCOA)
     WebCore::BoxSideSet sidesRequiringFixedContainerEdges() const;
+
+    std::optional<WebCore::SimpleRange> findDictatedTextRangeBeforeCursor(WebCore::LocalFrame&, const String&);
 #endif
 
     void frameNameWasChangedInAnotherProcess(WebCore::FrameIdentifier, const String& frameName);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -585,6 +585,8 @@ messages -> WebPage WantsAsyncDispatchMessage {
     AddDictationAlternative(String text, WebCore::DictationContext context) -> (bool success) Async
     DictationAlternativesAtSelection() -> (Vector<WebCore::DictationContext> contexts) Async
     ClearDictationAlternatives(Vector<WebCore::DictationContext> contexts)
+    SetDictationStreamingOpacity(String hypothesisText, struct WebCore::CharacterRange streamingRangeInHypothesis, float opacity)
+    ClearDictationStreamingOpacity()
 
     HasMarkedText() -> (bool hasMarkedText)
     GetMarkedRangeAsync() -> (struct WebKit::EditingRange range)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2217,24 +2217,19 @@ void WebPage::replaceDictatedText(const String& oldText, const String& newText)
 
     if (frame->selection().isNone())
         return;
-    
+
     if (frame->selection().isRange()) {
         protect(frame->editor())->deleteSelectionWithSmartDelete(false);
         return;
     }
-    VisiblePosition position = frame->selection().selection().start();
-    for (auto i = numGraphemeClusters(oldText); i; --i)
-        position = position.previous();
-    if (position.isNull())
-        position = startOfDocument(protect(frame->document()));
-    auto range = makeSimpleRange(position, frame->selection().selection().start());
 
-    if (plainTextForContext(range) != oldText)
+    auto range = findDictatedTextRangeBeforeCursor(*frame, oldText);
+    if (!range)
         return;
 
     // We don't want to notify the client that the selection has changed until we are done inserting the new text.
     IgnoreSelectionChangeForScope ignoreSelectionChanges { *frame };
-    protect(frame->selection())->setSelectedRange(range, Affinity::Upstream, WebCore::FrameSelection::ShouldCloseTyping::Yes);
+    protect(frame->selection())->setSelectedRange(*range, Affinity::Upstream, WebCore::FrameSelection::ShouldCloseTyping::Yes);
     protect(frame->editor())->insertText(newText, 0);
 }
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		07EFC6202F576F610079E8EB /* AppKitGestures.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07EFC6182F576F560079E8EB /* AppKitGestures.mm */; };
 		07EFC6232F5771050079E8EB /* AppKitGesturesSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07EFC6222F5771010079E8EB /* AppKitGesturesSupport.swift */; };
 		07FAA74D2CE95E3200128360 /* WebPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07FAA74C2CE95E3200128360 /* WebPageTests.swift */; };
+		07FE67432F5BC233001DA439 /* DictationStreamingOpacity.mm in Sources */ = {isa = PBXBuildFile; fileRef = 07FE67422F5BC233001DA439 /* DictationStreamingOpacity.mm */; };
 		0DE559ED2A6B0AAF009AA320 /* WKWebViewResize.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0DE559E52A6B0AAF009AA320 /* WKWebViewResize.mm */; };
 		0E404A8C2166DE0A008271BA /* InjectedBundleNodeHandleIsSelectElement.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0E404A8A2166DDF8008271BA /* InjectedBundleNodeHandleIsSelectElement.mm */; };
 		0F139E771A423A5B00F590F5 /* WeakObjCPtr.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0F139E751A423A5300F590F5 /* WeakObjCPtr.mm */; };
@@ -2555,6 +2556,7 @@
 		07F7696C2CA8BAC500FF004B /* IOSMouseEventTestHarness.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IOSMouseEventTestHarness.h; sourceTree = "<group>"; };
 		07F7696D2CA8BAC500FF004B /* IOSMouseEventTestHarness.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = IOSMouseEventTestHarness.mm; sourceTree = "<group>"; };
 		07FAA74C2CE95E3200128360 /* WebPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPageTests.swift; sourceTree = "<group>"; };
+		07FE67422F5BC233001DA439 /* DictationStreamingOpacity.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DictationStreamingOpacity.mm; sourceTree = "<group>"; };
 		0BCD833414857CE400EA2003 /* HashMap.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HashMap.cpp; sourceTree = "<group>"; };
 		0BCD85691485C98B00EA2003 /* SetForScope.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SetForScope.cpp; sourceTree = "<group>"; };
 		0DE559E52A6B0AAF009AA320 /* WKWebViewResize.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewResize.mm; sourceTree = "<group>"; };
@@ -4959,6 +4961,7 @@
 				518EE51C20A78D3300E024F3 /* DecidePolicyForNavigationAction.mm */,
 				2D2D13B2229F408B005068AF /* DeviceManagementRestrictions.mm */,
 				46918EFB2237283500468DFE /* DeviceOrientation.mm */,
+				07FE67422F5BC233001DA439 /* DictationStreamingOpacity.mm */,
 				F4B0168225AE060F00E445C4 /* DisableSpellcheck.mm */,
 				F4B0167F25AE02D600E445C4 /* DisableSpellcheckPlugIn.mm */,
 				73BD731723A846500020F450 /* DisplayName.mm */,
@@ -7951,6 +7954,7 @@
 				7CCE7EBA1A411A7E00447C4C /* DeviceScaleFactorOnBack.mm in Sources */,
 				7C83E04D1D0A641800FEBCF3 /* DFACombiner.cpp in Sources */,
 				7C83E04E1D0A641800FEBCF3 /* DFAMinimizer.cpp in Sources */,
+				07FE67432F5BC233001DA439 /* DictationStreamingOpacity.mm in Sources */,
 				7CCE7EE91A411AE600447C4C /* DidAssociateFormControls.cpp in Sources */,
 				7CCE7EEA1A411AE600447C4C /* DidNotHandleKeyDown.cpp in Sources */,
 				AD57AC211DA7465B00FF1BDE /* DidRemoveFrameFromHiearchyInPageCache.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
@@ -72,6 +72,8 @@ std::ostream& operator<<(std::ostream& os, MarkedText::Type type)
 #endif
     case MarkedText::Type::TransparentContent:
         return os << "TransparentContent";
+    case MarkedText::Type::DictationStreamingOpacity:
+        return os << "DictationStreamingOpacity";
     case MarkedText::Type::Unmarked:
         return os << "Unmarked";
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DictationStreamingOpacity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DictationStreamingOpacity.mm
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "TestWKWebView.h"
+#import "UIKitSPIForTesting.h"
+#import "WKWebViewConfigurationExtras.h"
+#import <WebKit/WKWebViewPrivate.h>
+
+@interface UIView (DictationStreamingOpacityTesting)
+- (void)_setDictationStreamingOpacity:(CGFloat)opacity forHypothesisText:(NSString *)hypothesisText streamingRange:(NSRange)streamingRange;
+- (void)_clearDictationStreamingOpacity;
+@end
+
+@interface TestWKWebView (DictationStreamingOpacity)
+- (NSUInteger)dictationStreamingOpacityMarkerCount:(NSString *)nodeExpression;
+@end
+
+@implementation TestWKWebView (DictationStreamingOpacity)
+
+- (NSUInteger)dictationStreamingOpacityMarkerCount:(NSString *)nodeExpression
+{
+    RetainPtr script = [NSString stringWithFormat:@"internals.markerCountForNode((() => %@)(), 'dictationstreamingopacity')", nodeExpression];
+    return [[self objectByEvaluatingJavaScript:script.get()] unsignedIntegerValue];
+}
+
+@end
+
+namespace TestWebKitAPI {
+
+static RetainPtr<TestWKWebView> createWebViewForDictationStreamingOpacity()
+{
+    RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);
+    [webView _setEditable:YES];
+    return webView;
+}
+
+TEST(DictationStreamingOpacity, SetAndClearMarker)
+{
+    RetainPtr webView = createWebViewForDictationStreamingOpacity();
+    [webView synchronouslyLoadHTMLString:@"<body>hello world</body>"];
+    [webView stringByEvaluatingJavaScript:@"getSelection().setPosition(document.body, 1)"];
+
+    [[webView textInputContentView] _setDictationStreamingOpacity:0.5 forHypothesisText:@"hello world" streamingRange:NSMakeRange(0, 5)];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_EQ(1U, [webView dictationStreamingOpacityMarkerCount:@"document.body.childNodes[0]"]);
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"internals.hasDictationStreamingOpacityMarker(0, 5)"] boolValue]);
+
+    [[webView textInputContentView] _clearDictationStreamingOpacity];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_EQ(0U, [webView dictationStreamingOpacityMarkerCount:@"document.body.childNodes[0]"]);
+}
+
+TEST(DictationStreamingOpacity, MarkerAppliedToCorrectSubRange)
+{
+    RetainPtr webView = createWebViewForDictationStreamingOpacity();
+    [webView synchronouslyLoadHTMLString:@"<body>hello world</body>"];
+    [webView stringByEvaluatingJavaScript:@"getSelection().setPosition(document.body, 1)"];
+
+    [[webView textInputContentView] _setDictationStreamingOpacity:0.5 forHypothesisText:@"hello world" streamingRange:NSMakeRange(5, 6)];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"internals.hasDictationStreamingOpacityMarker(5, 6)"] boolValue]);
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"internals.hasDictationStreamingOpacityMarker(0, 5)"] boolValue]);
+}
+
+TEST(DictationStreamingOpacity, UpdateReplacesOldMarker)
+{
+    RetainPtr webView = createWebViewForDictationStreamingOpacity();
+    [webView synchronouslyLoadHTMLString:@"<body>hello world</body>"];
+    [webView stringByEvaluatingJavaScript:@"getSelection().setPosition(document.body, 1)"];
+
+    [[webView textInputContentView] _setDictationStreamingOpacity:0.5 forHypothesisText:@"hello world" streamingRange:NSMakeRange(0, 5)];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"internals.hasDictationStreamingOpacityMarker(0, 5)"] boolValue]);
+
+    [[webView textInputContentView] _setDictationStreamingOpacity:0.5 forHypothesisText:@"hello world" streamingRange:NSMakeRange(5, 6)];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"internals.hasDictationStreamingOpacityMarker(5, 6)"] boolValue]);
+    EXPECT_EQ(1U, [webView dictationStreamingOpacityMarkerCount:@"document.body.childNodes[0]"]);
+}
+
+TEST(DictationStreamingOpacity, HypothesisTextMismatch)
+{
+    RetainPtr webView = createWebViewForDictationStreamingOpacity();
+    [webView synchronouslyLoadHTMLString:@"<body>hello world</body>"];
+    [webView stringByEvaluatingJavaScript:@"getSelection().setPosition(document.body, 1)"];
+
+    [[webView textInputContentView] _setDictationStreamingOpacity:0.5 forHypothesisText:@"goodbye" streamingRange:NSMakeRange(0, 7)];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_EQ(0U, [webView dictationStreamingOpacityMarkerCount:@"document.body.childNodes[0]"]);
+}
+
+TEST(DictationStreamingOpacity, NonEditableContent)
+{
+    RetainPtr configuration = [WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES];
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration]);
+    [webView synchronouslyLoadHTMLString:@"<body>hello world</body>"];
+
+    [[webView textInputContentView] _setDictationStreamingOpacity:0.5 forHypothesisText:@"hello world" streamingRange:NSMakeRange(0, 5)];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_EQ(0U, [webView dictationStreamingOpacityMarkerCount:@"document.body.childNodes[0]"]);
+}
+
+TEST(DictationStreamingOpacity, EmptyHypothesisText)
+{
+    RetainPtr webView = createWebViewForDictationStreamingOpacity();
+    [webView synchronouslyLoadHTMLString:@"<body>hello world</body>"];
+    [webView stringByEvaluatingJavaScript:@"getSelection().setPosition(document.body, 1)"];
+
+    [[webView textInputContentView] _setDictationStreamingOpacity:0.5 forHypothesisText:@"" streamingRange:NSMakeRange(0, 0)];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_EQ(0U, [webView dictationStreamingOpacityMarkerCount:@"document.body.childNodes[0]"]);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### ab02bb4acf18afadbd1b3913a94686e7a47731d8
<pre>
[Dictation] Add DictationStreamingOpacity document marker for streaming partial results
<a href="https://bugs.webkit.org/show_bug.cgi?id=309109">https://bugs.webkit.org/show_bug.cgi?id=309109</a>
<a href="https://rdar.apple.com/169476197">rdar://169476197</a>

Reviewed by Aditya Keerthi.

Make it possible to set a specific opacity value on a range of streaming dictation text.

Tests: Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
       Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp
       Tools/TestWebKitAPI/Tests/WebKitCocoa/DictationStreamingOpacity.mm

* Source/WebCore/dom/DocumentMarker.h:
(WebCore::DocumentMarker::allMarkers):
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::DocumentMarkerController::addDictationStreamingOpacityMarker):
(WebCore::DocumentMarkerController::removeAllDictationStreamingOpacityMarkers):
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/rendering/MarkedText.cpp:
(WebCore::MarkedText::collectForDictationStreamingOpacity):
* Source/WebCore/rendering/MarkedText.h:
* Source/WebCore/rendering/StyledMarkedText.cpp:
(WebCore::resolveStyleForMarkedText):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter::paintForegroundAndDecorations):
(WebCore::TextBoxPainter::paintForeground):
(WebCore::TextBoxPainter::createDecorationPainter):
(WebCore::TextBoxPainter::paintPlatformDocumentMarkers):
* Source/WebCore/testing/Internals.cpp:
(WebCore::markerTypeFrom):
(WebCore::Internals::hasDictationStreamingOpacityMarker):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Add a new document marker type to be able to control the opacity of a particular piece of text.

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::setDictationStreamingOpacity):
(WebKit::WebPageProxy::clearDictationStreamingOpacity):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _setDictationStreamingOpacity:forHypothesisText:streamingRange:]):
(-[WKContentView _clearDictationStreamingOpacity]):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::findDictatedTextRangeBeforeCursor):
(WebKit::WebPage::setDictationStreamingOpacity):
(WebKit::WebPage::clearDictationStreamingOpacity):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::replaceDictatedText):

Add entry points to be able to set and clear dictation streaming opacity. This locates the hypothesis text by walking backward from the cursor and applying the marker to the streaming sub-range.

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/MarkedText.cpp:
(WebCore::operator&lt;&lt;):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DictationStreamingOpacity.mm: Added.
(-[TestWKWebView dictationStreamingOpacityMarkerCount:]):
(TestWebKitAPI::createWebViewForDictationStreamingOpacity):
(TestWebKitAPI::TEST(DictationStreamingOpacity, SetAndClearMarker)):
(TestWebKitAPI::TEST(DictationStreamingOpacity, MarkerAppliedToCorrectSubRange)):
(TestWebKitAPI::TEST(DictationStreamingOpacity, UpdateReplacesOldMarker)):
(TestWebKitAPI::TEST(DictationStreamingOpacity, HypothesisTextMismatch)):
(TestWebKitAPI::TEST(DictationStreamingOpacity, NonEditableContent)):
(TestWebKitAPI::TEST(DictationStreamingOpacity, EmptyHypothesisText)):

Add test infrastructure and tests.

Canonical link: <a href="https://commits.webkit.org/309001@main">https://commits.webkit.org/309001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3429ad6203fbbb410c89d9f5970fe49a1640e558

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21818 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/15388 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157793 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e96c10a-822b-4544-9c3d-027ad6400921) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150978 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/22272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21696 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/114949 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/135f5bc1-0362-4aca-a144-faa06f77c8ab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152065 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/22272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/95708 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/22272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14104 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5646 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/22272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/11741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160277 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3265 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/13263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/123000 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18133 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/123230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33501 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/133534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/10291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21230 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85032 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20962 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/21110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/21018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->