### PR TITLE
Add WKUserScript support for `//# sourceURL=`

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserScript.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserScript.mm
@@ -45,7 +45,18 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     if (!(self = [super init]))
         return nil;
 
-    API::Object::constructInWrapper<API::UserScript>(self, WebCore::UserScript { source, { }, { }, { }, API::toWebCoreUserScriptInjectionTime(injectionTime), forMainFrameOnly ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames }, Ref { *contentWorld->_contentWorld });
+    NSURL *associatedURL = nil;
+    NSString* sourceURLPrefix = @"//# sourceURL=";
+    if ([source hasPrefix:sourceURLPrefix]) {
+        NSRange firstLineRange = [source rangeOfCharacterFromSet:[NSCharacterSet newlineCharacterSet]];
+        if (firstLineRange.location == NSNotFound)
+            firstLineRange = NSMakeRange(0, source.length);
+        NSString* firstLine = [source substringToIndex:firstLineRange.location];
+        NSString* sourceURLString = [firstLine substringFromIndex:sourceURLPrefix.length];
+        associatedURL = [NSURL URLWithString:sourceURLString];
+    }
+
+    API::Object::constructInWrapper<API::UserScript>(self, WebCore::UserScript { source, associatedURL, { }, { }, API::toWebCoreUserScriptInjectionTime(injectionTime), forMainFrameOnly ? WebCore::UserContentInjectedFrames::InjectInTopFrameOnly : WebCore::UserContentInjectedFrames::InjectInAllFrames }, Ref { *contentWorld->_contentWorld });
 
     return self;
 }


### PR DESCRIPTION
#### a95498596f5f07826ab01329ab3004e6b2126446
<pre>
Add WKUserScript support for `//# sourceURL=`
<a href="https://bugs.webkit.org/show_bug.cgi?id=300607">https://bugs.webkit.org/show_bug.cgi?id=300607</a>

Reviewed by NOBODY (OOPS!).

WKUserScripts are difficult to debug because they are given automatically generated names of the format &quot;user-script:#&quot;, where # is dynamically generated at runtime. By providing a sourceURL comment, per <a href="https://tc39.es/ecma426/#sec-MatchSourceMapURL">https://tc39.es/ecma426/#sec-MatchSourceMapURL</a>, Safari inspector can show developers a more friendly name. Additionally, this is necessary in order to support any form of remote error debugging because the auto-generated names are meaningless and do not provide a means for symbolication.

To balance functionality with performance impact, the entire source string is not searched for the sourceURL comment, but only the first line.

No new tests (OOPS!).

* Source/WebKit/UIProcess/API/Cocoa/WKUserScript.mm:
(-[WKUserScript initWithSource:injectionTime:forMainFrameOnly:inContentWorld:]): Modified to parse a sourceURL comment from the first line of the given source.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a95498596f5f07826ab01329ab3004e6b2126446

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157341 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102086 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21247 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114593 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81595 "2 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133441 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95363 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15890 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13753 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4776 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125502 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159676 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2816 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122658 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122882 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133155 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77308 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18185 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9917 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20780 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84583 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20513 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20659 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20569 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->