### PR TITLE
[JSC] Add SourceDump option to JITDump

### DIFF
--- a/Source/JavaScriptCore/assembler/LinkBuffer.cpp
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.cpp
@@ -48,6 +48,7 @@ size_t LinkBuffer::s_profileCummulativeLinkedSizes[LinkBuffer::numberOfProfiles]
 size_t LinkBuffer::s_profileCummulativeLinkedCounts[LinkBuffer::numberOfProfiles];
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IRDumpDebugInfo);
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SourceCodeDumpDebugInfo);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(LinkBuffer);
 
 static const char* profileName(LinkBuffer::Profile profile)
@@ -128,7 +129,7 @@ void LinkBuffer::logJITCodeForJITDump(CodeRef<LinkBufferPtrTag>& codeRef, ASCIIL
         GdbJIT::log(finalName, codeRef);
 
     if (Options::useJITDump()) [[unlikely]]
-        PerfLog::log(finalName, codeRef, WTF::move(m_irDumpDebugInfo));
+        PerfLog::log(finalName, codeRef, WTF::move(m_irDumpDebugInfo), WTF::move(m_sourceCodeDebugInfo));
 }
 
 LinkBuffer::CodeRef<LinkBufferPtrTag> LinkBuffer::finalizeCodeWithDisassemblyImpl(bool dumpDisassembly, ASCIILiteral simpleName, const char* format, ...)

--- a/Source/JavaScriptCore/assembler/LinkBuffer.h
+++ b/Source/JavaScriptCore/assembler/LinkBuffer.h
@@ -36,15 +36,20 @@
 #define CSS_CODE_ID reinterpret_cast<void*>(static_cast<intptr_t>(-2))
 
 #include <JavaScriptCore/JITCompilationEffort.h>
+#include <JavaScriptCore/LineColumn.h>
 #include <JavaScriptCore/MacroAssembler.h>
 #include <JavaScriptCore/MacroAssemblerCodeRef.h>
+#include <JavaScriptCore/SourceProvider.h>
 #include <wtf/DataLog.h>
+#include <wtf/Ref.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/CString.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
+
+class SourceProvider;
 
 class IRDumpDebugInfo {
     WTF_MAKE_TZONE_ALLOCATED(IRDumpDebugInfo);
@@ -70,6 +75,25 @@ public:
 
     CString functionName;
     Vector<IRLine> irLines;
+    Vector<CodeEntry> codeEntries;
+};
+
+class SourceCodeDumpDebugInfo {
+    WTF_MAKE_TZONE_ALLOCATED(SourceCodeDumpDebugInfo);
+    WTF_MAKE_NONCOPYABLE(SourceCodeDumpDebugInfo);
+public:
+    struct CodeEntry {
+        uint32_t codeOffset;
+        LineColumn lineColumn;
+        Ref<SourceProvider> sourceProvider;
+    };
+
+    SourceCodeDumpDebugInfo(CString&& name)
+        : functionName(WTF::move(name))
+    {
+    }
+
+    CString functionName;
     Vector<CodeEntry> codeEntries;
 };
 
@@ -358,6 +382,8 @@ ALLOW_NONLITERAL_FORMAT_END
 
     void setIRDumpDebugInfo(std::unique_ptr<IRDumpDebugInfo>&& info) { m_irDumpDebugInfo = WTF::move(info); }
 
+    void setSourceCodeDumpDebugInfo(std::unique_ptr<SourceCodeDumpDebugInfo>&& info) { m_sourceCodeDebugInfo = WTF::move(info); }
+
 private:
     JS_EXPORT_PRIVATE CodeRef<LinkBufferPtrTag> finalizeCodeWithoutDisassemblyImpl(ASCIILiteral);
     JS_EXPORT_PRIVATE CodeRef<LinkBufferPtrTag> finalizeCodeWithDisassemblyImpl(bool dumpDisassembly, ASCIILiteral, const char* format, ...) WTF_ATTRIBUTE_PRINTF(4, 5);
@@ -445,6 +471,7 @@ private:
     Vector<Ref<SharedTask<void(LinkBuffer&)>>> m_linkTasks;
     Vector<Ref<SharedTask<void(LinkBuffer&)>>> m_lateLinkTasks;
     std::unique_ptr<IRDumpDebugInfo> m_irDumpDebugInfo;
+    std::unique_ptr<SourceCodeDumpDebugInfo> m_sourceCodeDebugInfo;
 
     static size_t s_profileCummulativeLinkedSizes[numberOfProfiles];
     static size_t s_profileCummulativeLinkedCounts[numberOfProfiles];

--- a/Source/JavaScriptCore/assembler/PerfLog.cpp
+++ b/Source/JavaScriptCore/assembler/PerfLog.cpp
@@ -31,6 +31,7 @@
 
 #include "Options.h"
 #include "ProfilerSupport.h"
+#include "SourceProvider.h"
 #include <array>
 #include <fcntl.h>
 #include <mutex>
@@ -183,6 +184,9 @@ PerfLog::PerfLog()
         if (Options::useIRDump())
             m_irDumpDirectory = Options::irDumpDirectory();
 
+        if (Options::useSourceCodeDump())
+            m_sourceCodeDumpDirectory = Options::sourceCodeDumpDirectory();
+
 #if OS(LINUX)
         // Linux perf command records this mmap operation in perf.data as a metadata to the JIT perf annotations.
         // We do not use this mmap-ed memory region actually.
@@ -211,11 +215,11 @@ void PerfLog::flush(const AbstractLocker&)
     m_file.flush();
 }
 
-void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> code, std::unique_ptr<IRDumpDebugInfo>&& debugInfo)
+void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> code, std::unique_ptr<IRDumpDebugInfo>&& debugInfo, std::unique_ptr<SourceCodeDumpDebugInfo>&& sourceCodeDebugInfo)
 {
     auto timestamp = ProfilerSupport::generateTimestamp();
     auto tid = ProfilerSupport::getCurrentThreadID();
-    ProfilerSupport::singleton().queue().dispatch([name = name, code, tid, timestamp, debugInfo = WTF::move(debugInfo)] {
+    ProfilerSupport::singleton().queue().dispatch([name = name, code, tid, timestamp, debugInfo = WTF::move(debugInfo), sourceCodeDebugInfo = WTF::move(sourceCodeDebugInfo)] {
         PerfLog& logger = singleton();
         size_t size = code.size();
         auto* executableAddress = code.code().untaggedPtr<const uint8_t*>();
@@ -282,6 +286,45 @@ void PerfLog::log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag> c
                 debugEntry.discrim = 0;
                 logger.write(locker, unsafeMakeSpan(std::bit_cast<char*>(&debugEntry), sizeof(JITDump::DebugEntry)));
                 logger.write(locker, irFilePath.spanIncludingNullTerminator());
+            }
+        }
+
+        if (sourceCodeDebugInfo && !sourceCodeDebugInfo->codeEntries.isEmpty()) {
+            struct SourceEntry {
+                uint32_t codeOffset;
+                uint32_t line;
+                uint32_t column;
+                CString filePath;
+            };
+            Vector<SourceEntry> sourceEntries;
+            const CString& sourceCodeDumpDir = logger.m_sourceCodeDumpDirectory;
+            for (auto& entry : sourceCodeDebugInfo->codeEntries) {
+                CString filePath = protect(entry.sourceProvider)->sourceCodeDumpFilePath(sourceCodeDumpDir);
+                if (!filePath.isNull())
+                    sourceEntries.append({ entry.codeOffset, entry.lineColumn.line, entry.lineColumn.column, WTF::move(filePath) });
+            }
+
+            if (!sourceEntries.isEmpty()) {
+                JITDump::DebugInfoRecord debugRecord;
+                debugRecord.header.timestamp = timestamp;
+                debugRecord.codeAddress = std::bit_cast<uintptr_t>(executableAddress);
+                debugRecord.nrEntry = sourceEntries.size();
+
+                uint32_t totalSize = sizeof(JITDump::DebugInfoRecord);
+                for (auto& sourceEntry : sourceEntries)
+                    totalSize += sizeof(JITDump::DebugEntry) + (sourceEntry.filePath.length() + 1);
+                debugRecord.header.totalSize = totalSize;
+
+                logger.write(locker, unsafeMakeSpan(std::bit_cast<char*>(&debugRecord), sizeof(JITDump::DebugInfoRecord)));
+
+                for (auto& sourceEntry : sourceEntries) {
+                    JITDump::DebugEntry debugEntry;
+                    debugEntry.codeAddress = std::bit_cast<uintptr_t>(executableAddress) + sourceEntry.codeOffset;
+                    debugEntry.line = sourceEntry.line;
+                    debugEntry.discrim = sourceEntry.column;
+                    logger.write(locker, unsafeMakeSpan(std::bit_cast<char*>(&debugEntry), sizeof(JITDump::DebugEntry)));
+                    logger.write(locker, sourceEntry.filePath.spanIncludingNullTerminator());
+                }
             }
         }
 

--- a/Source/JavaScriptCore/assembler/PerfLog.h
+++ b/Source/JavaScriptCore/assembler/PerfLog.h
@@ -45,7 +45,7 @@ class PerfLog {
     WTF_MAKE_NONCOPYABLE(PerfLog);
     friend class LazyNeverDestroyed<PerfLog>;
 public:
-    static void log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag>, std::unique_ptr<IRDumpDebugInfo>&& = nullptr);
+    static void log(const CString& name, MacroAssemblerCodeRef<LinkBufferPtrTag>, std::unique_ptr<IRDumpDebugInfo>&& = nullptr, std::unique_ptr<SourceCodeDumpDebugInfo>&& = nullptr);
 
 private:
     PerfLog();
@@ -57,6 +57,7 @@ private:
 
     WTF::FileSystemImpl::FileHandle m_file { };
     CString m_irDumpDirectory;
+    CString m_sourceCodeDumpDirectory;
     uint64_t m_codeIndex { 0 };
     Lock m_lock;
 };

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -404,6 +404,44 @@ void JITCompiler::collectIRDumpDebugInfo(LinkBuffer& linkBuffer)
     linkBuffer.setIRDumpDebugInfo(WTF::move(debugInfo));
 }
 
+void JITCompiler::collectSourceCodeDumpDebugInfo(LinkBuffer& linkBuffer)
+{
+    if (!Options::useSourceCodeDump())
+        return;
+
+    if (m_irDumpLabels.isEmpty())
+        return;
+
+    auto debugInfo = makeUnique<SourceCodeDumpDebugInfo>(m_graph.m_codeBlock->inferredName());
+    void* codeStart = linkBuffer.entrypoint<DisassemblyPtrTag>().untaggedPtr();
+
+    for (auto& entry : m_irDumpLabels) {
+        CodeOrigin codeOrigin = entry.node->origin.semantic;
+        if (!codeOrigin.isSet())
+            continue;
+
+        InlineCallFrame* inlineCallFrame = codeOrigin.inlineCallFrame();
+        CodeBlock* codeBlock = inlineCallFrame ? inlineCallFrame->baselineCodeBlock.get() : m_graph.m_codeBlock;
+        if (!codeBlock)
+            continue;
+
+        BytecodeIndex bytecodeIndex = codeOrigin.bytecodeIndex();
+        if (bytecodeIndex.offset() >= codeBlock->instructionsSize())
+            continue;
+
+        LineColumn lineColumn = codeBlock->lineColumnForBytecodeIndex(bytecodeIndex);
+        RefPtr provider = codeBlock->ownerExecutable()->source().provider();
+        if (!provider)
+            continue;
+
+        auto location = linkBuffer.locationOf<DisassemblyPtrTag>(entry.label);
+        uint32_t codeOffset = static_cast<uint32_t>(location.dataLocation<uintptr_t>() - reinterpret_cast<uintptr_t>(codeStart));
+        debugInfo->codeEntries.append({ codeOffset, lineColumn, provider.releaseNonNull() });
+    }
+
+    linkBuffer.setSourceCodeDumpDebugInfo(WTF::move(debugInfo));
+}
+
 #if USE(JSVALUE32_64)
 void* JITCompiler::addressOfDoubleConstant(Node* node)
 {

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.h
@@ -115,7 +115,7 @@ public:
     
     void setForNode(Node* node)
     {
-        if (Options::useIRDump()) [[unlikely]]
+        if (Options::useIRDump() || Options::useSourceCodeDump()) [[unlikely]]
             m_irDumpLabels.append({ labelIgnoringWatchpoints(), node });
         if (!m_disassembler) [[likely]]
             return;
@@ -388,6 +388,7 @@ protected:
     void linkOSRExits();
     void disassemble(LinkBuffer&);
     void collectIRDumpDebugInfo(LinkBuffer&);
+    void collectSourceCodeDumpDebugInfo(LinkBuffer&);
 
     void makeCatchOSREntryBuffer();
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -183,6 +183,7 @@ void SpeculativeJIT::compile()
     linkOSREntries(linkBuffer);
 
     collectIRDumpDebugInfo(linkBuffer);
+    collectSourceCodeDumpDebugInfo(linkBuffer);
 
     disassemble(linkBuffer);
 
@@ -288,6 +289,7 @@ void SpeculativeJIT::compileFunction()
     linkOSREntries(linkBuffer);
 
     collectIRDumpDebugInfo(linkBuffer);
+    collectSourceCodeDumpDebugInfo(linkBuffer);
 
     disassemble(linkBuffer);
 

--- a/Source/JavaScriptCore/ftl/FTLCompile.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCompile.cpp
@@ -40,6 +40,7 @@
 #include "DFGGraphSafepoint.h"
 #include "DFGNode.h"
 #include "FTLJITCode.h"
+#include "InlineCallFrame.h"
 #include "JITThunks.h"
 #include "LLIntEntrypoint.h"
 #include "LLIntThunks.h"
@@ -55,6 +56,121 @@ namespace JSC { namespace FTL {
 const char* const tierName = "FTL ";
 
 using namespace DFG;
+
+static void collectIRDumpDebugInfo(State& state, DFG::Graph& graph, CodeBlock* codeBlock)
+{
+    if (!Options::useIRDump() || !state.proc->needsPCToOriginMap())
+        return;
+
+    auto debugInfo = makeUnique<IRDumpDebugInfo>(codeBlock->inferredName());
+    auto nodeToLineIndex = graph.collectIRDumpDebugInfo(*debugInfo);
+
+    auto& originMap = state.proc->pcToOriginMap();
+    void* codeStart = state.b3CodeLinkBuffer->entrypoint<DisassemblyPtrTag>().untaggedPtr();
+
+    DFG::Node* current = nullptr;
+    uint32_t currentLineIndex = 0;
+    std::optional<uint32_t> currentCodeOffset;
+    auto flush = [&] {
+        if (currentCodeOffset)
+            debugInfo->codeEntries.append({ currentCodeOffset.value(), currentLineIndex });
+        current = nullptr;
+        currentLineIndex = 0;
+        currentCodeOffset = std::nullopt;
+    };
+
+    auto append = [&](DFG::Node* node, uint32_t codeOffset, uint32_t lineIndex) {
+        if (current != node)
+            flush();
+        current = node;
+        currentLineIndex = lineIndex;
+        if (!currentCodeOffset)
+            currentCodeOffset = codeOffset;
+    };
+
+    for (auto& range : originMap.ranges()) {
+        auto origin = range.origin;
+        if (!origin || !origin.isDFGOrigin())
+            continue;
+        DFG::Node* node = origin.dfgOrigin();
+        if (!node)
+            continue;
+
+        auto it = nodeToLineIndex.find(node);
+        if (it == nodeToLineIndex.end())
+            continue;
+
+        auto location = state.b3CodeLinkBuffer->locationOf<DisassemblyPtrTag>(range.label);
+        uint32_t codeOffset = static_cast<uint32_t>(location.dataLocation<uintptr_t>() - reinterpret_cast<uintptr_t>(codeStart));
+        append(node, codeOffset, it->value);
+    }
+    flush();
+
+    state.b3CodeLinkBuffer->setIRDumpDebugInfo(WTF::move(debugInfo));
+}
+
+static void collectSourceCodeDumpDebugInfo(State& state, CodeBlock* codeBlock)
+{
+    if (!Options::useSourceCodeDump() || !state.proc->needsPCToOriginMap())
+        return;
+
+    auto debugInfo = makeUnique<SourceCodeDumpDebugInfo>(codeBlock->inferredName());
+
+    auto& originMap = state.proc->pcToOriginMap();
+    void* codeStart = state.b3CodeLinkBuffer->entrypoint<DisassemblyPtrTag>().untaggedPtr();
+
+    CodeOrigin currentOrigin;
+    std::optional<uint32_t> currentCodeOffset;
+    LineColumn currentLineColumn;
+    SourceProvider* currentProvider = nullptr;
+    auto flush = [&] {
+        if (currentCodeOffset && currentProvider)
+            debugInfo->codeEntries.append({ currentCodeOffset.value(), currentLineColumn, *currentProvider });
+        currentOrigin = CodeOrigin();
+        currentCodeOffset = std::nullopt;
+        currentLineColumn = { };
+        currentProvider = nullptr;
+    };
+
+    for (auto& range : originMap.ranges()) {
+        auto origin = range.origin;
+        if (!origin || !origin.isDFGOrigin())
+            continue;
+        DFG::Node* node = origin.dfgOrigin();
+        if (!node)
+            continue;
+
+        CodeOrigin codeOrigin = node->origin.semantic;
+        if (!codeOrigin.isSet())
+            continue;
+
+        if (currentOrigin == codeOrigin)
+            continue;
+
+        flush();
+
+        InlineCallFrame* inlineCallFrame = codeOrigin.inlineCallFrame();
+        CodeBlock* originCodeBlock = inlineCallFrame
+            ? inlineCallFrame->baselineCodeBlock.get()
+            : codeBlock;
+        if (!originCodeBlock)
+            continue;
+
+        BytecodeIndex bytecodeIndex = codeOrigin.bytecodeIndex();
+        if (bytecodeIndex.offset() >= originCodeBlock->instructionsSize())
+            continue;
+
+        currentOrigin = codeOrigin;
+        currentLineColumn = originCodeBlock->lineColumnForBytecodeIndex(bytecodeIndex);
+        currentProvider = originCodeBlock->ownerExecutable()->source().provider();
+
+        auto location = state.b3CodeLinkBuffer->locationOf<DisassemblyPtrTag>(range.label);
+        currentCodeOffset = static_cast<uint32_t>(location.dataLocation<uintptr_t>() - reinterpret_cast<uintptr_t>(codeStart));
+    }
+    flush();
+
+    state.b3CodeLinkBuffer->setSourceCodeDumpDebugInfo(WTF::move(debugInfo));
+}
 
 void compile(State& state, Safepoint::Result& safepointResult)
 {
@@ -206,53 +322,8 @@ void compile(State& state, Safepoint::Result& safepointResult)
         return;
     }
 
-    if (Options::useIRDump() && state.proc->needsPCToOriginMap()) {
-        auto debugInfo = makeUnique<IRDumpDebugInfo>(codeBlock->inferredName());
-        auto nodeToLineIndex = graph.collectIRDumpDebugInfo(*debugInfo);
-
-        auto& originMap = state.proc->pcToOriginMap();
-        void* codeStart = state.b3CodeLinkBuffer->entrypoint<DisassemblyPtrTag>().untaggedPtr();
-
-        DFG::Node* current = nullptr;
-        uint32_t currentLineIndex = 0;
-        std::optional<uint32_t> currentCodeOffset;
-        auto flush = [&] {
-            if (currentCodeOffset)
-                debugInfo->codeEntries.append({ currentCodeOffset.value(), currentLineIndex });
-            current = nullptr;
-            currentLineIndex = 0;
-            currentCodeOffset = std::nullopt;
-        };
-
-        auto append = [&](DFG::Node* node, uint32_t codeOffset, uint32_t lineIndex) {
-            if (current != node)
-                flush();
-            current = node;
-            currentLineIndex = lineIndex;
-            if (!currentCodeOffset)
-                currentCodeOffset = codeOffset;
-        };
-
-        for (auto& range : originMap.ranges()) {
-            auto origin = range.origin;
-            if (!origin || !origin.isDFGOrigin())
-                continue;
-            DFG::Node* node = origin.dfgOrigin();
-            if (!node)
-                continue;
-
-            auto it = nodeToLineIndex.find(node);
-            if (it == nodeToLineIndex.end())
-                continue;
-
-            auto location = state.b3CodeLinkBuffer->locationOf<DisassemblyPtrTag>(range.label);
-            uint32_t codeOffset = static_cast<uint32_t>(location.dataLocation<uintptr_t>() - reinterpret_cast<uintptr_t>(codeStart));
-            append(node, codeOffset, it->value);
-        }
-        flush();
-
-        state.b3CodeLinkBuffer->setIRDumpDebugInfo(WTF::move(debugInfo));
-    }
+    collectIRDumpDebugInfo(state, graph, codeBlock);
+    collectSourceCodeDumpDebugInfo(state, codeBlock);
 
     if (vm.shouldBuilderPCToCodeOriginMapping()) {
         B3::PCToOriginMap originMap = state.proc->releasePCToOriginMap();

--- a/Source/JavaScriptCore/ftl/FTLState.cpp
+++ b/Source/JavaScriptCore/ftl/FTLState.cpp
@@ -70,7 +70,7 @@ State::State(Graph& graph)
 
     proc = makeUniqueWithoutFastMallocCheck<Procedure>(/* usesSIMD = */ false);
 
-    if (graph.m_vm.shouldBuilderPCToCodeOriginMapping() || Options::useIRDump())
+    if (graph.m_vm.shouldBuilderPCToCodeOriginMapping() || Options::useIRDump() || Options::useSourceCodeDump())
         proc->setNeedsPCToOriginMap();
 
     proc->setOriginPrinter(

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -971,7 +971,26 @@ RefPtr<BaselineJITCode> JIT::link(LinkBuffer& patchBuffer)
     std::unique_ptr<PCToCodeOriginMap> pcToCodeOriginMap;
     if (m_pcToCodeOriginMapBuilder.didBuildMapping())
         pcToCodeOriginMap = makeUnique<PCToCodeOriginMap>(WTF::move(m_pcToCodeOriginMapBuilder), patchBuffer);
-    
+
+    if (Options::useSourceCodeDump() && m_profiledCodeBlock) [[unlikely]] {
+        auto debugInfo = makeUnique<SourceCodeDumpDebugInfo>(m_profiledCodeBlock->inferredName());
+        if (RefPtr provider = m_profiledCodeBlock->ownerExecutable()->source().provider()) {
+            void* codeStart = patchBuffer.entrypoint<DisassemblyPtrTag>().untaggedPtr();
+            for (unsigned bytecodeOffset = 0; bytecodeOffset < m_labels.size(); ++bytecodeOffset) {
+                if (!m_labels[bytecodeOffset].isSet())
+                    continue;
+                BytecodeIndex bytecodeIndex(bytecodeOffset);
+                if (bytecodeIndex.offset() >= m_profiledCodeBlock->instructionsSize())
+                    continue;
+                LineColumn lineColumn = m_profiledCodeBlock->lineColumnForBytecodeIndex(bytecodeIndex);
+                auto location = patchBuffer.locationOf<DisassemblyPtrTag>(m_labels[bytecodeOffset]);
+                uint32_t codeOffset = static_cast<uint32_t>(location.dataLocation<uintptr_t>() - reinterpret_cast<uintptr_t>(codeStart));
+                debugInfo->codeEntries.append({ codeOffset, lineColumn, provider.releaseNonNull() });
+            }
+            patchBuffer.setSourceCodeDumpDebugInfo(WTF::move(debugInfo));
+        }
+    }
+
     // FIXME: Make a version of CodeBlockWithJITType that knows about UnlinkedCodeBlock.
     CodeRef<JSEntryPtrTag> result = FINALIZE_BASELINE_CODE(
         patchBuffer, JSEntryPtrTag,

--- a/Source/JavaScriptCore/parser/SourceProvider.cpp
+++ b/Source/JavaScriptCore/parser/SourceProvider.cpp
@@ -26,6 +26,11 @@
 #include "config.h"
 #include "SourceProvider.h"
 
+#include <wtf/FileHandle.h>
+#include <wtf/FileSystem.h>
+#include <wtf/ProcessID.h>
+#include <wtf/text/MakeString.h>
+
 namespace JSC {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StringSourceProvider);
@@ -81,6 +86,55 @@ const String& SourceProvider::sourceURLStripped()
         return m_sourceURLStripped;
     m_sourceURLStripped = URL(m_sourceURL).strippedForUseAsReport();
     return m_sourceURLStripped;
+}
+
+CString SourceProvider::sourceCodeDumpFilePath(const CString& dumpDirectory)
+{
+    if (m_sourceCodeDumped.load(std::memory_order_acquire)) {
+        Locker locker { m_sourceCodeDumpLock };
+        return m_sourceCodeDumpFilePath;
+    }
+
+    Locker locker { m_sourceCodeDumpLock };
+    if (m_sourceCodeDumped.load(std::memory_order_relaxed))
+        return m_sourceCodeDumpFilePath;
+
+    auto tryExtractLocalPath = [](const String& urlString) -> String {
+        if (urlString.isNull())
+            return { };
+        if (urlString.startsWith('/'))
+            return urlString;
+        if (urlString.startsWith("file://"_s))
+            return URL(urlString).fileSystemPath();
+        return { };
+    };
+
+    String localPath = tryExtractLocalPath(sourceURL());
+
+    if (!localPath.isNull())
+        m_sourceCodeDumpFilePath = FileSystem::fileSystemRepresentation(localPath);
+    else {
+        auto baseName = makeString("source-"_s, asID(), '-', WTF::getCurrentProcessID());
+        String filePath;
+        FileSystem::FileHandle handle;
+        if (dumpDirectory.isNull()) {
+            auto result = FileSystem::openTemporaryFile(baseName, ".js"_s);
+            filePath = result.first;
+            handle = WTF::move(result.second);
+        } else {
+            filePath = makeString(String::fromUTF8(dumpDirectory.span()), FileSystem::pathSeparator, baseName, ".js"_s);
+            handle = FileSystem::openFile(filePath, FileSystem::FileOpenMode::Truncate);
+        }
+        if (handle) {
+            auto sourceText = source().utf8();
+            handle.write(WTF::asByteSpan(sourceText.span()));
+            handle.flush();
+            m_sourceCodeDumpFilePath = FileSystem::fileSystemRepresentation(filePath);
+        }
+    }
+
+    m_sourceCodeDumped.store(true, std::memory_order_release);
+    return m_sourceCodeDumpFilePath;
 }
 
 #if ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/parser/SourceProvider.h
+++ b/Source/JavaScriptCore/parser/SourceProvider.h
@@ -37,6 +37,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include <JavaScriptCore/CodeSpecializationKind.h>
 #include <JavaScriptCore/SourceOrigin.h>
 #include <JavaScriptCore/SourceTaintedOrigin.h>
+#include <wtf/Lock.h>
 #include <wtf/RefCounted.h>
 #include <wtf/text/TextPosition.h>
 #include <wtf/text/WTFString.h>
@@ -112,6 +113,8 @@ public:
 
     virtual bool isScriptBufferSourceProvider() const { return false; }
 
+    JS_EXPORT_PRIVATE CString sourceCodeDumpFilePath(const CString& dumpDirectory);
+
 private:
     JS_EXPORT_PRIVATE virtual void lockUnderlyingBufferImpl();
     JS_EXPORT_PRIVATE virtual void unlockUnderlyingBufferImpl();
@@ -129,6 +132,10 @@ private:
     TextPosition m_startPosition;
     SourceID m_id { 0 };
     SourceTaintedOrigin m_taintedness;
+
+    std::atomic<bool> m_sourceCodeDumped { false };
+    Lock m_sourceCodeDumpLock;
+    CString m_sourceCodeDumpFilePath WTF_GUARDED_BY_LOCK(m_sourceCodeDumpLock);
 };
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StringSourceProvider);

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -876,6 +876,11 @@ void Options::notifyOptionsChanged()
         if (Options::useIRDump() && !Options::useJITDump())
             Options::useIRDump() = false;
 
+        if (Options::useSourceCodeDump() && !Options::useJITDump())
+            Options::useSourceCodeDump() = false;
+        if (Options::useSourceCodeDump() && Options::useIRDump())
+            Options::useSourceCodeDump() = false;
+
         if (OptionsHelper::wasOverridden(jitPolicyScaleID))
             scaleJITPolicy();
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -150,6 +150,8 @@ bool hasCapacityToUseLargeGigacage();
     v(OptionString, jitDumpDirectory, nullptr, Normal, "Directory to place JITDump"_s) \
     v(Bool, useIRDump, false, Normal, "generates IR dump files and JIT_CODE_DEBUG_INFO in JITDump"_s) \
     v(OptionString, irDumpDirectory, nullptr, Normal, "Directory to place IR dump files"_s) \
+    v(Bool, useSourceCodeDump, false, Normal, "generates source code debug info in JITDump"_s) \
+    v(OptionString, sourceCodeDumpDirectory, nullptr, Normal, "Directory to place dumped source files"_s) \
     v(OptionString, textMarkersDirectory, nullptr, Normal, "Directory to place MarkerTxt") \
     v(OptionRange, bytecodeRangeToJITCompile, nullptr, Normal, "bytecode size range to allow compilation on, e.g. 1:100"_s) \
     v(OptionRange, bytecodeRangeToDFGCompile, nullptr, Normal, "bytecode size range to allow DFG compilation on, e.g. 1:100"_s) \


### PR DESCRIPTION
#### cd8340e8676091cea8211420a2e95c5dfde2fe46
<pre>
[JSC] Add SourceDump option to JITDump
<a href="https://bugs.webkit.org/show_bug.cgi?id=309409">https://bugs.webkit.org/show_bug.cgi?id=309409</a>
<a href="https://rdar.apple.com/171953162">rdar://171953162</a>

Reviewed by Yijia Huang.

Like IRDump mechanism, this patch implements useSourceDump mechanism,
which is additional option to JITDump. Once it is enabled, we attempt to
record original source URL content to the local disk (or using local
file path if possible). Then resolving Origin to bytecode offset, and
then line and column of source. And attaching these information to
JITDump&apos;s debug metadata. As a result, we can show the original JS
source code as a source, with samples attached to the right place of JS
source code.

The limitation is,

1. This is adding huge performance penalty. So you can enable it with
   your own risk.
2. This is generating significant amount of source to directory
   like /tmp.
3. Because it is using JIT dump, only works for JIT functions.
   Interpreter cannot work well.
4. Currently wasm is not supported.
5. Inlined functions in JS JIT cannot be represented as a nested frames
   with JITDump. This is large limitation since we cannot show which
   inlined function has how many samples well in the consistent view.
   This requires JITDump format&apos;s extension.

The idea and some mechanisms are contributed by Jeff Muizelaar.

* Source/JavaScriptCore/assembler/LinkBuffer.cpp:
(JSC::LinkBuffer::logJITCodeForJITDump):
* Source/JavaScriptCore/assembler/LinkBuffer.h:
(JSC::SourceCodeDumpDebugInfo::SourceCodeDumpDebugInfo):
(JSC::LinkBuffer::setSourceCodeDumpDebugInfo):
* Source/JavaScriptCore/assembler/PerfLog.cpp:
(JSC::PerfLog::PerfLog):
(JSC::PerfLog::log):
* Source/JavaScriptCore/assembler/PerfLog.h:
* Source/JavaScriptCore/dfg/DFGJITCompiler.cpp:
(JSC::DFG::JITCompiler::collectSourceCodeDumpDebugInfo):
* Source/JavaScriptCore/dfg/DFGJITCompiler.h:
(JSC::DFG::JITCompiler::setForNode):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compile):
(JSC::DFG::SpeculativeJIT::compileFunction):
* Source/JavaScriptCore/ftl/FTLCompile.cpp:
(JSC::FTL::collectIRDumpDebugInfo):
(JSC::FTL::collectSourceCodeDumpDebugInfo):
(JSC::FTL::compile):
* Source/JavaScriptCore/ftl/FTLState.cpp:
(JSC::FTL::State::State):
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::link):
* Source/JavaScriptCore/parser/SourceProvider.cpp:
(JSC::SourceProvider::sourceCodeDumpFilePath):
* Source/JavaScriptCore/parser/SourceProvider.h:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/runtime/OptionsList.h:

Canonical link: <a href="https://commits.webkit.org/308946@main">https://commits.webkit.org/308946@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dde4d2a580e55a56e00a6306075184bc239b394b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102133 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/24f92fbd-de5c-4836-9614-1e6bd41fbf2c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114633 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81623 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/39279b5f-d6f8-458b-aea5-edc7ef76839e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133483 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95403 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/711e7204-c9b3-414a-a7a8-b67bb234c5fb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15944 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13789 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4823 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140670 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125543 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159723 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9491 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2863 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122698 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122922 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133197 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77371 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22940 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18218 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9959 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180131 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20828 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84630 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46123 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20560 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20707 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20616 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->