### PR TITLE
Disable subpixel font quantization conditionally on accelerated drawing to prevent glyph clipping

### DIFF
--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -286,7 +286,9 @@ static void showGlyphsWithAdvances(const FloatPoint& point, const Font& font, CG
     }
 }
 
-static void setCGFontRenderingMode(GraphicsContext& context)
+static constexpr float minFontSizeForSubpixelQuantizationClipping = 16.f;
+
+static void setCGFontRenderingMode(GraphicsContext& context, const Font& font)
 {
     RetainPtr<CGContextRef> cgContext = context.platformContext();
     CGContextSetShouldAntialiasFonts(cgContext.get(), true);
@@ -295,6 +297,16 @@ static void setCGFontRenderingMode(GraphicsContext& context)
     bool isTranslationOrIntegralScale = WTF::isIntegral(contextTransform.a) && WTF::isIntegral(contextTransform.d) && contextTransform.b == 0.f && contextTransform.c == 0.f;
     bool isRotated = ((contextTransform.b || contextTransform.c) && (contextTransform.a || contextTransform.d));
     bool doSubpixelQuantization = isTranslationOrIntegralScale || (!isRotated && context.shouldSubpixelQuantizeFonts());
+
+    // Workaround for rdar://126148010: subpixel quantization on accelerated
+    // contexts can clip the left edge of fixed-pitch glyphs at certain font
+    // sizes when the device position is fractional.
+    float deviceX = contextTransform.tx;
+    bool isFractionalDevicePosition = deviceX != std::floor(deviceX);
+    doSubpixelQuantization &= !(context.renderingMode() == RenderingMode::Accelerated
+        && font.pitch() == FixedPitch
+        && font.platformData().size() >= minFontSizeForSubpixelQuantizationClipping
+        && isFractionalDevicePosition);
 
     CGContextSetShouldSubpixelPositionFonts(cgContext.get(), true);
     CGContextSetShouldSubpixelQuantizeFonts(cgContext.get(), doSubpixelQuantization);
@@ -349,7 +361,7 @@ void FontCascade::drawGlyphs(GraphicsContext& context, const Font& font, std::sp
     auto textMatrix = computeOverallTextMatrix(font);
     ScopedTextMatrix restorer(textMatrix, cgContext.get());
 
-    setCGFontRenderingMode(context);
+    setCGFontRenderingMode(context, font);
     CGContextSetFontSize(cgContext.get(), platformData.size());
 
     auto shadow = context.dropShadow();


### PR DESCRIPTION
#### be29b303ace864a3e329c4a234b53397f2362703
<pre>
Disable subpixel font quantization conditionally on accelerated drawing to prevent glyph clipping
<a href="https://rdar.apple.com/126148010">rdar://126148010</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
(WebCore::setCGFontRenderingMode):
(WebCore::FontCascade::drawGlyphs):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be29b303ace864a3e329c4a234b53397f2362703

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157355 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102100 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb035a44-3b26-4c5b-a55d-1be166d9197b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150543 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21261 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114604 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81601 "4 flakes 1 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bfb4fcaa-7800-4eaf-9b6b-11b0825d4c8d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151630 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16797 "Found 5 new test failures: fast/inline/decorating-box-style-with-anon-block-container.html fast/text/whitespace/text-wrap-balance-shape.html fast/text/whitespace/whitespace-with-zero-width-space-in-between.html imported/mozilla/svg/text/textpath-selection.svg imported/mozilla/svg/text/textpath.svg (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133457 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95374 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/704976e7-3176-4afd-9724-787c894a18e6) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15900 "") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4790 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125510 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159690 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2830 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12899 "Found 26 new test failures: fast/inline/decorating-box-style-with-anon-block-container.html fast/text/selection-with-text-decorations.html fast/text/whitespace/text-wrap-balance-shape.html fast/text/whitespace/whitespace-with-zero-width-space-in-between.html imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-087.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-088.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-089.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-090.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-091.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-092.xht ... (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122668 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21185 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17764 "Found 26 new test failures: fast/inline/decorating-box-style-with-anon-block-container.html fast/text/selection-with-text-decorations.html fast/text/whitespace/text-wrap-balance-shape.html fast/text/whitespace/whitespace-with-zero-width-space-in-between.html imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-087.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-088.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-089.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-090.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-091.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-092.xht ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122892 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21193 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133171 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77322 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18188 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9933 "Found 26 new test failures: fast/inline/decorating-box-style-with-anon-block-container.html fast/text/selection-with-text-decorations.html fast/text/whitespace/text-wrap-balance-shape.html fast/text/whitespace/whitespace-with-zero-width-space-in-between.html imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-087.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-088.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-089.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-090.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-091.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-092.xht ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20795 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84597 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20527 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20673 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20583 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->