### PR TITLE
[iOS] Fix safer C++ warnings in Source/WebKit

### DIFF
--- a/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,1 +1,0 @@
-[ iOS ] WebProcess/WebPage/Cocoa/WebPageCocoa.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -1,7 +1,3 @@
-[ iOS ] UIProcess/API/Cocoa/WKContextMenuElementInfo.mm
-[ iOS ] UIProcess/API/Cocoa/WKWebViewConfiguration.mm
-[ iOS ] UIProcess/ios/ViewGestureControllerIOS.mm
-[ iOS ] WebProcess/WebPage/Cocoa/WebPageCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
 WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm

--- a/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -1,1 +1,0 @@
-[ iOS ] UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm

--- a/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -1,1 +1,0 @@
-[ iOS ] UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfo.mm
@@ -38,7 +38,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKContextMenuElementInfo.class, self))
         return;
-    _elementInfo->API::ContextMenuElementInfo::~ContextMenuElementInfo();
+    SUPPRESS_UNCOUNTED_ARG _elementInfo->API::ContextMenuElementInfo::~ContextMenuElementInfo();
     [super dealloc];
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -931,7 +931,7 @@ static NSString *defaultApplicationNameForUserAgent()
 
 - (void)_setClickInteractionDriverForTesting:(id<_UIClickInteractionDriving>)driver
 {
-    _pageConfiguration->setClickInteractionDriverForTesting((NSObject<_UIClickInteractionDriving> *)driver);
+    protect(_pageConfiguration.get())->setClickInteractionDriverForTesting((NSObject<_UIClickInteractionDriving> *)driver);
 }
 
 - (id <_UIClickInteractionDriving>)_clickInteractionDriverForTesting

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm
@@ -273,7 +273,7 @@ UIScrollView *findActingScrollParent(UIScrollView *scrollView, const RemoteLayer
             return nil;
         }
         if (RefPtr node = RemoteLayerTreeNode::forCALayer(view.layer)) {
-            if (auto* actingParent = host.nodeForID(node->actingScrollContainerID())) {
+            if (RefPtr actingParent = host.nodeForID(node->actingScrollContainerID())) {
                 if (auto scrollView = dynamic_objc_cast<UIScrollView>(actingParent->uiView()))
                     return scrollView;
             }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -504,10 +504,10 @@ void ScrollingTreeScrollingNodeDelegateIOS::currentSnapPointIndicesDidChange(std
 
 WKBaseScrollView *ScrollingTreeScrollingNodeDelegateIOS::scrollView() const
 {
-    if (auto* delegate = protect(scrollLayer()).get().delegate) {
-        auto scrollView = dynamic_objc_cast<WKBaseScrollView>(delegate);
-        ASSERT(scrollView);
-        return scrollView;
+    // FIXME: This is a static analyzer false positive.
+    SUPPRESS_UNRETAINED_LOCAL if (auto* delegate = protect(scrollLayer()).get().delegate) {
+        ASSERT(is<WKBaseScrollView>(delegate));
+        return dynamic_objc_cast<WKBaseScrollView>(delegate);
     }
     return nullptr;
 }

--- a/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
@@ -228,7 +228,7 @@ void ViewGestureController::beginSwipeGesture(_UINavigationInteractiveTransition
     // swiping forward will have the correct snapshot.
     if (m_webPageProxyForBackForwardListForCurrentSwipe != page.get()) {
         if (RefPtr currentViewHistoryItem = page->backForwardList().currentItem())
-            backForwardList.currentItem()->setSnapshot(currentViewHistoryItem->snapshot());
+            protect(backForwardList.currentItem())->setSnapshot(currentViewHistoryItem->snapshot());
     }
 
     RetainPtr liveSwipeView = m_liveSwipeView.get();

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2986,7 +2986,7 @@ Awaitable<std::optional<WebCore::FrameIdentifier>> WebPage::commitPotentialTap(s
             constexpr OptionSet hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowVisibleChildFrameContentOnly };
             auto roundedPoint = IntPoint { m_potentialTapLocation };
             auto result = localRootFrame->eventHandler().hitTestResultAtPoint(roundedPoint, hitType);
-            localRootFrame->eventHandler().setLastTouchedNode(result.innerNode());
+            localRootFrame->eventHandler().setLastTouchedNode(protect(result.innerNode()));
         }
 #endif
 


### PR DESCRIPTION
#### 4fb9d46f49fc18fcaaa02363ba7ff97dcf3b6d97
<pre>
[iOS] Fix safer C++ warnings in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=309417">https://bugs.webkit.org/show_bug.cgi?id=309417</a>

Reviewed by Anne van Kesteren.

Deployed more smart pointers in Source/WebKit to address safer C++ static analyzer warnings.

No new tests since there should be no behavioral changes.

* Source/WebKit/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebKit/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:
* Source/WebKit/UIProcess/API/Cocoa/WKContextMenuElementInfo.mm:
(-[WKContextMenuElementInfo dealloc]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration _setClickInteractionDriverForTesting:]):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeViews.mm:
(WebKit::findActingScrollParent):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::scrollView const):
* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(WebKit::ViewGestureController::beginSwipeGesture):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::commitPotentialTap):

Canonical link: <a href="https://commits.webkit.org/308865@main">https://commits.webkit.org/308865@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd5db563136f1e8854d979d3344c6a37ef5d39ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157380 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/550eb20b-0efc-4d05-860a-552d671951ad) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114626 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa123d75-d19f-4804-8af4-f222ee0e7d18) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16820 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95396 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ad0cf6a-45e8-487b-92cf-42fc59b4a1aa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15932 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13780 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4815 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125531 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159715 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2855 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12917 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122691 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122915 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133189 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77358 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22909 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18208 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9951 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84622 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20552 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20699 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20608 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->