### PR TITLE
[EvaluationTimeZoom] Convert transform properties to evaluation time zoom

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/perspective-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/perspective-expected.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.box {
+  padding: 10px;
+  width: 100px;
+  height: 100px;
+  background: red;
+  transform: rotateY(60deg);
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p> 
+<div class="group">
+  <div class="outer">
+    <div class="container" style="perspective: 100px;">
+      <div class="box"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="perspective: 100px;">
+      <div class="box"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="perspective: 100px;">
+      <div class="box"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="perspective: 100px;">
+      <div class="box"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/perspective.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/perspective.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to perspective</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/perspective-ref.html">
+<meta name="fuzzy" content="maxDifference=62; totalPixels=40">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.box {
+  padding: 10px;
+  width: 100px;
+  height: 100px;
+  background: red;
+  transform: rotateY(60deg);
+}
+.box-zoom {
+  padding: 5px;
+  width: 50px;
+  height: 50px;
+  background: red;
+  transform: rotateY(60deg);
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.container-zoom {
+  width: 100px;
+  height: 100px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="perspective: 100px; zoom: 1;">
+      <div class="box"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer" style="perspective: 100px;">
+    <div class="container" style="perspective: inherit; zoom: 1;">
+      <div class="box"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom" style="perspective: 50px; zoom: 2;">
+      <div class="box-zoom"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer" style="perspective: 50px;">
+    <div class="container-zoom" style="perspective: inherit; zoom: 2;">
+      <div class="box-zoom"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/perspective-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/perspective-ref.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.box {
+  padding: 10px;
+  width: 100px;
+  height: 100px;
+  background: red;
+  transform: rotateY(60deg);
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="perspective: 100px;">
+      <div class="box"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="perspective: 100px;">
+      <div class="box"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container" style="perspective: 100px;">
+      <div class="box"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container" style="perspective: 100px;">
+      <div class="box"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/transform-matrix-2d-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/transform-matrix-2d-ref.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.box {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="transform: matrix(1, 0, 0, 1, 20, 40);"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer" >
+    <div class="container">
+      <div class="box" style="transform: matrix(1, 0, 0, 1, 20, 40);"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box"  style="transform: matrix(1, 0, 0, 1, 30, 60);"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="transform: matrix(1, 0, 0, 1, 30, 60);"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/transform-matrix-3d-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/transform-matrix-3d-ref.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.box {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 20, 40, 0, 1);"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer" >
+    <div class="container">
+      <div class="box" style="transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 20, 40, 0, 1);"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box"  style="transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 30, 60, 0, 1);"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 30, 60, 0, 1);"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/transform-perspective-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/transform-perspective-ref.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.box {
+  padding: 10px;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each box below should match the corresponding box in references/transform-perspective-ref.html</p>
+<div class="outer">
+  <div class="container">
+    <div class="box" style="transform: perspective(100px) rotateY(60deg);"></div>
+  </div>
+</div>
+<div class="spacer"></div>
+<div class="outer" >
+  <div class="container" style="transform: perspective(100px) rotateY(60deg);">
+    <div class="box" style="transform: perspective(100px) rotateY(60deg);"></div>
+  </div>
+</div>
+<div class="spacer"></div>
+<div class="outer">
+  <div class="container">
+    <div class="box"  style="transform: perspective(100px) rotateY(60deg);"></div>
+  </div>
+</div>
+<div class="spacer"></div>
+<div class="outer">
+  <div class="container" style="transform: perspective(50px) rotateY(60deg);">
+    <div class="box" style="transform: perspective(100px) rotateY(60deg);"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/transform-translate-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/transform-translate-ref.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.box {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="transform: translate(20px, 40px);"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer" >
+    <div class="container">
+      <div class="box" style="transform: translate(20px, 40px);"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box"  style="transform: translate(30px, 60px);"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="transform: translate(30px, 60px);"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/translate-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/translate-ref.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.box {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="translate: 20px 40px;"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer" >
+    <div class="container">
+      <div class="box" style="translate: 20px 40px;"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box"  style="translate: 30px 60px;"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="translate: 30px 60px;"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-matrix-2d-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-matrix-2d-expected.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.box {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p> 
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="transform: matrix(1, 0, 0, 1, 20, 40);"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer" >
+    <div class="container">
+      <div class="box" style="transform: matrix(1, 0, 0, 1, 20, 40);"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box"  style="transform: matrix(1, 0, 0, 1, 30, 60);"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="transform: matrix(1, 0, 0, 1, 30, 60);"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-matrix-2d.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-matrix-2d.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to transform: matrix()</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/transform-matrix-2d-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.box {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+.box-zoom {
+  width: 50px;
+  height: 50px;
+  background: red;
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.container-zoom {
+  width: 100px;
+  height: 100px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="transform: matrix(1, 0, 0, 1, 20, 40); zoom: 1;"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer" >
+    <div class="container" style="transform: matrix(1, 0, 0, 1, 10, 20);">
+      <div class="box" style="transform: inherit; zoom: 1;"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom">
+      <div class="box-zoom"  style="transform: matrix(1, 0, 0, 1, 15, 30); zoom: 2;"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="transform: matrix(1, 0, 0, 1, 10, 20);">
+      <div class="box-zoom" style="transform: inherit; zoom: 2;"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-matrix-3d-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-matrix-3d-expected.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.box {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p> 
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 20, 40, 0, 1);"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer" >
+    <div class="container">
+      <div class="box" style="transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 20, 40, 0, 1);"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box"  style="transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 30, 60, 0, 1);"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 30, 60, 0, 1);"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-matrix-3d.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-matrix-3d.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to transform: matrix3d()</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/transform-matrix-3d-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.box {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+.box-zoom {
+  width: 50px;
+  height: 50px;
+  background: red;
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.container-zoom {
+  width: 100px;
+  height: 100px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 20, 40, 0, 1); zoom: 1;"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer" >
+    <div class="container" style="transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 20, 0, 1);">
+      <div class="box" style="transform: inherit; zoom: 1;"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom">
+      <div class="box-zoom"  style="transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 15, 30, 0, 1); zoom: 2;"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="transform: matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 20, 0, 1);">
+      <div class="box-zoom" style="transform: inherit; zoom: 2;"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-perspective-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-perspective-expected.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.box {
+  padding: 10px;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each box below should match the corresponding box in references/transform-perspective-ref.html</p> 
+<div class="outer">
+  <div class="container">
+    <div class="box" style="transform: perspective(100px) rotateY(60deg);"></div>
+  </div>
+</div>
+<div class="spacer"></div>
+<div class="outer" >
+  <div class="container" style="transform: perspective(100px) rotateY(60deg);">
+    <div class="box" style="transform: perspective(100px) rotateY(60deg);"></div>
+  </div>
+</div>
+<div class="spacer"></div>
+<div class="outer">
+  <div class="container">
+    <div class="box"  style="transform: perspective(100px) rotateY(60deg);"></div>
+  </div>
+</div>
+<div class="spacer"></div>
+<div class="outer">
+  <div class="container" style="transform: perspective(50px) rotateY(60deg);">
+    <div class="box" style="transform: perspective(100px) rotateY(60deg);"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-perspective.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-perspective.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to transform: perspective()</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/transform-perspective-ref.html">
+<meta name="fuzzy" content="maxDifference=62; totalPixels=40">
+<style>
+.box {
+  padding: 10px;
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+.box-zoom {
+  padding: 5px;
+  width: 50px;
+  height: 50px;
+  background: red;
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each box below should match the corresponding box in references/transform-perspective-ref.html</p>
+<div class="outer">
+  <div class="container">
+    <div class="box" style="transform: perspective(100px) rotateY(60deg); zoom: 1;"></div>
+  </div>
+</div>
+<div class="spacer"></div>
+<div class="outer" >
+  <div class="container" style="transform: perspective(100px) rotateY(60deg);">
+    <div class="box" style="transform: inherit; zoom: 1;"></div>
+  </div>
+</div>
+<div class="spacer"></div>
+<div class="outer">
+  <div class="container">
+    <div class="box-zoom"  style="transform: perspective(50px) rotateY(60deg); zoom: 2;"></div>
+  </div>
+</div>
+<div class="spacer"></div>
+<div class="outer">
+  <div class="container" style="transform: perspective(50px) rotateY(60deg);">
+    <div class="box-zoom" style="transform: inherit; zoom: 2;"></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-translate-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-translate-expected.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.box {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p> 
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="transform: translate(20px, 40px);"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer" >
+    <div class="container">
+      <div class="box" style="transform: translate(20px, 40px);"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box"  style="transform: translate(30px, 60px);"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="transform: translate(30px, 60px);"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-translate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-translate.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to transform: translate()</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/transform-translate-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.box {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+.box-zoom {
+  width: 50px;
+  height: 50px;
+  background: red;
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.container-zoom {
+  width: 100px;
+  height: 100px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="transform: translate(20px, 40px); zoom: 1;"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer" >
+    <div class="container" style="transform: translate(10px, 20px);">
+      <div class="box" style="transform: inherit; zoom: 1;"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom">
+      <div class="box-zoom"  style="transform: translate(15px, 30px); zoom: 2;"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="transform: translate(10px, 20px);">
+      <div class="box-zoom" style="transform: inherit; zoom: 2;"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/translate-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/translate-expected.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.box {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p> 
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="translate: 20px 40px;"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer" >
+    <div class="container">
+      <div class="box" style="translate: 20px 40px;"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box"  style="translate: 30px 60px;"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="translate: 30px 60px;"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/translate.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/translate.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSS Zoom applies to translate</title>
+<link rel="author" title="Sam Weinig" href="mailto:sam@webkit.org">
+<link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<link rel="match" href="reference/translate-ref.html">
+<style>
+.group {
+  border: solid black 1px;
+  padding: 20px;
+  margin: 10px;
+  width: max-content;
+}
+.box {
+  width: 100px;
+  height: 100px;
+  background: red;
+}
+.box-zoom {
+  width: 50px;
+  height: 50px;
+  background: red;
+}
+.outer {
+  border: solid black 1px;
+  display: inline-block;
+  width: 200px;
+  height: 200px;
+  overflow: clip;
+}
+.container {
+  width: 200px;
+  height: 200px;
+}
+.container-zoom {
+  width: 100px;
+  height: 100px;
+}
+.spacer {
+  display: inline-block;
+  width: 20px;
+}
+</style>
+</head>
+<body>
+<p>Each grouping below should have two matching boxes.</p>
+<div class="group">
+  <div class="outer">
+    <div class="container">
+      <div class="box" style="translate: 20px 40px; zoom: 1;"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer" >
+    <div class="container" style="translate: 10px 20px;">
+      <div class="box" style="translate: inherit; zoom: 1;"></div>
+    </div>
+  </div>
+</div>
+<div class="group">
+  <div class="outer">
+    <div class="container-zoom">
+      <div class="box-zoom"  style="translate: 15px 30px; zoom: 2;"></div>
+    </div>
+  </div>
+  <div class="spacer"></div>
+  <div class="outer">
+    <div class="container-zoom" style="translate: 10px 20px;">
+      <div class="box-zoom" style="translate: inherit; zoom: 2;"></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/css/DOMMatrix.cpp
+++ b/Source/WebCore/css/DOMMatrix.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "DOMMatrix.h"
 
-#include "ScriptExecutionContext.h"
+#include "Document.h"
 #include <JavaScriptCore/Float32Array.h>
 #include <cmath>
 #include <limits>
@@ -41,10 +41,11 @@ ExceptionOr<Ref<DOMMatrix>> DOMMatrix::create(ScriptExecutionContext& scriptExec
 
     return WTF::switchOn(init.value(),
         [&scriptExecutionContext](const String& init) -> ExceptionOr<Ref<DOMMatrix>> {
-            if (!scriptExecutionContext.isDocument())
+            RefPtr document = dynamicDowncast<Document>(scriptExecutionContext);
+            if (!document)
                 return Exception { ExceptionCode::TypeError };
 
-            auto parseResult = parseStringIntoAbstractMatrix(init);
+            auto parseResult = parseStringIntoAbstractMatrix(*document, init);
             if (parseResult.hasException())
                 return parseResult.releaseException();
             
@@ -244,9 +245,9 @@ Ref<DOMMatrix> DOMMatrix::invertSelf()
     return Ref<DOMMatrix> { *this };
 }
 
-ExceptionOr<Ref<DOMMatrix>> DOMMatrix::setMatrixValueForBindings(const String& string)
+ExceptionOr<Ref<DOMMatrix>> DOMMatrix::setMatrixValueForBindings(Document& document, const String& string)
 {
-    auto result = setMatrixValue(string);
+    auto result = setMatrixValue(document, string);
     if (result.hasException())
         return result.releaseException();
     return Ref<DOMMatrix> { *this };

--- a/Source/WebCore/css/DOMMatrix.h
+++ b/Source/WebCore/css/DOMMatrix.h
@@ -62,7 +62,7 @@ public:
     Ref<DOMMatrix> skewYSelf(double sy = 0); // Angle is in degrees.
     Ref<DOMMatrix> invertSelf();
 
-    ExceptionOr<Ref<DOMMatrix>> setMatrixValueForBindings(const String&);
+    ExceptionOr<Ref<DOMMatrix>> setMatrixValueForBindings(Document&, const String&);
 
     void setA(double f) { m_matrix.setA(f); }
     void setB(double f) { m_matrix.setB(f); }

--- a/Source/WebCore/css/DOMMatrix.idl
+++ b/Source/WebCore/css/DOMMatrix.idl
@@ -92,5 +92,5 @@
     DOMMatrix skewYSelf(optional unrestricted double sy = 0); // Angle is in degrees.
     DOMMatrix invertSelf();
 
-    [Exposed=Window, ImplementedAs=setMatrixValueForBindings] DOMMatrix setMatrixValue(DOMString transformList);
+    [Exposed=Window, CallWith=CurrentDocument, ImplementedAs=setMatrixValueForBindings] DOMMatrix setMatrixValue(DOMString transformList);
 };

--- a/Source/WebCore/css/DOMMatrixReadOnly.cpp
+++ b/Source/WebCore/css/DOMMatrixReadOnly.cpp
@@ -32,8 +32,8 @@
 #include "CSSToLengthConversionData.h"
 #include "DOMMatrix.h"
 #include "DOMPoint.h"
+#include "Document.h"
 #include "MutableStyleProperties.h"
-#include "ScriptExecutionContext.h"
 #include "ScriptWrappableInlines.h"
 #include "StyleProperties.h"
 #include "StyleTransform.h"
@@ -56,10 +56,11 @@ ExceptionOr<Ref<DOMMatrixReadOnly>> DOMMatrixReadOnly::create(ScriptExecutionCon
 
     return WTF::switchOn(init.value(),
         [&scriptExecutionContext](const String& init) -> ExceptionOr<Ref<DOMMatrixReadOnly>> {
-            if (!scriptExecutionContext.isDocument())
+            RefPtr document = dynamicDowncast<Document>(scriptExecutionContext);
+            if (!document)
                 return Exception { ExceptionCode::TypeError };
 
-            auto parseResult = parseStringIntoAbstractMatrix(init);
+            auto parseResult = parseStringIntoAbstractMatrix(*document, init);
             if (parseResult.hasException())
                 return parseResult.releaseException();
             
@@ -225,12 +226,12 @@ bool DOMMatrixReadOnly::isIdentity() const
     return m_matrix.isIdentity();
 }
 
-ExceptionOr<DOMMatrixReadOnly::AbstractMatrix> DOMMatrixReadOnly::parseStringIntoAbstractMatrix(const String& string)
+ExceptionOr<DOMMatrixReadOnly::AbstractMatrix> DOMMatrixReadOnly::parseStringIntoAbstractMatrix(Document& document, const String& string)
 {
     if (string.isEmpty())
         return AbstractMatrix { };
 
-    auto transform = CSSPropertyParserHelpers::parseTransformRaw(string, CSSParserContext(HTMLStandardMode));
+    auto transform = CSSPropertyParserHelpers::parseTransformRaw(string, CSSParserContext(HTMLStandardMode), document);
     if (!transform)
         return Exception { ExceptionCode::SyntaxError };
 
@@ -244,7 +245,7 @@ ExceptionOr<DOMMatrixReadOnly::AbstractMatrix> DOMMatrixReadOnly::parseStringInt
 
     AbstractMatrix matrix;
     for (auto& function : *transform) {
-        protect(function.function())->apply(matrix.matrix, { 0, 0 });
+        protect(function.function())->apply(matrix.matrix, { 0, 0 }, Style::ZoomFactor::none());
         if (function->is3DOperation())
             matrix.is2D = false;
     }
@@ -253,9 +254,9 @@ ExceptionOr<DOMMatrixReadOnly::AbstractMatrix> DOMMatrixReadOnly::parseStringInt
 }
 
 // https://drafts.fxtf.org/geometry/#dom-dommatrix-setmatrixvalue
-ExceptionOr<void> DOMMatrixReadOnly::setMatrixValue(const String& string)
+ExceptionOr<void> DOMMatrixReadOnly::setMatrixValue(Document& document, const String& string)
 {
-    auto parseResult = parseStringIntoAbstractMatrix(string);
+    auto parseResult = parseStringIntoAbstractMatrix(document, string);
     if (parseResult.hasException())
         return parseResult.releaseException();
 

--- a/Source/WebCore/css/DOMMatrixReadOnly.h
+++ b/Source/WebCore/css/DOMMatrixReadOnly.h
@@ -39,6 +39,7 @@ namespace WebCore {
 
 class DOMMatrix;
 class DOMPoint;
+class Document;
 class ScriptExecutionContext;
 struct DOMPointInit;
 
@@ -95,8 +96,7 @@ public:
     bool is2D() const { return m_is2D; }
     bool NODELETE isIdentity() const;
 
-    ExceptionOr<void> setMatrixValue(const String&);
-    ExceptionOr<void> setMatrixValue(const Vector<double>&);
+    ExceptionOr<void> setMatrixValue(Document&, const String&);
 
     Ref<DOMMatrix> NODELETE translate(double tx = 0, double ty = 0, double tz = 0);
     ExceptionOr<Ref<DOMMatrix>> multiply(DOMMatrixInit&& other) const;
@@ -133,7 +133,7 @@ protected:
         bool is2D { true };
     };
 
-    static ExceptionOr<AbstractMatrix> parseStringIntoAbstractMatrix(const String&);
+    static ExceptionOr<AbstractMatrix> parseStringIntoAbstractMatrix(Document&, const String&);
 
     template <typename T>
     static ExceptionOr<Ref<T>> fromMatrixHelper(DOMMatrixInit&&);

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp
@@ -116,13 +116,13 @@ RefPtr<CSSValue> consumeTranslateFunction(CSSParserTokenRange& range, CSS::Prope
     auto consumeParameters = [](auto& args, auto& state) -> std::optional<CSSValueListBuilder> {
         CSSValueListBuilder arguments;
 
-        auto firstValue = CSSPrimitiveValueResolver<CSS::LengthPercentage<>>::consumeAndResolve(args, state);
+        auto firstValue = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::AllUnzoomed>>::consumeAndResolve(args, state);
         if (!firstValue)
             return { };
         arguments.append(firstValue.releaseNonNull());
 
         if (consumeCommaIncludingWhitespace(args)) {
-            auto secondValue = CSSPrimitiveValueResolver<CSS::LengthPercentage<>>::consumeAndResolve(args, state);
+            auto secondValue = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::AllUnzoomed>>::consumeAndResolve(args, state);
             if (!secondValue)
                 return { };
             // A second value of `0` is the same as no second argument, so there is no need to store one if we know it is `0`.
@@ -156,21 +156,21 @@ RefPtr<CSSValue> consumeTranslate3dFunction(CSSParserTokenRange& range, CSS::Pro
     // translate3d() = translate3d( <length-percentage> , <length-percentage> , <length> )
 
     auto consumeParameters = [](auto& args, auto& state) -> std::optional<CSSValueListBuilder> {
-        auto firstValue = CSSPrimitiveValueResolver<CSS::LengthPercentage<>>::consumeAndResolve(args, state);
+        auto firstValue = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::AllUnzoomed>>::consumeAndResolve(args, state);
         if (!firstValue)
             return { };
 
         if (!consumeCommaIncludingWhitespace(args))
             return { };
 
-        auto secondValue = CSSPrimitiveValueResolver<CSS::LengthPercentage<>>::consumeAndResolve(args, state);
+        auto secondValue = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::AllUnzoomed>>::consumeAndResolve(args, state);
         if (!secondValue)
             return { };
 
         if (!consumeCommaIncludingWhitespace(args))
             return { };
 
-        auto thirdValue = CSSPrimitiveValueResolver<CSS::Length<>>::consumeAndResolve(args, state);
+        auto thirdValue = CSSPrimitiveValueResolver<CSS::Length<CSS::AllUnzoomed>>::consumeAndResolve(args, state);
         if (!thirdValue)
             return { };
 
@@ -213,7 +213,7 @@ RefPtr<CSSValue> consumeTranslate(CSSParserTokenRange& range, CSS::PropertyParse
     // value is missing, it defaults to 0px. If three values are given, this specifies a 3d translation, equivalent to the
     // translate3d() function.
 
-    auto x = CSSPrimitiveValueResolver<CSS::LengthPercentage<>>::consumeAndResolve(range, state);
+    auto x = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::AllUnzoomed>>::consumeAndResolve(range, state);
     if (!x)
         return nullptr;
 
@@ -222,7 +222,7 @@ RefPtr<CSSValue> consumeTranslate(CSSParserTokenRange& range, CSS::PropertyParse
     if (range.atEnd())
         return CSSValueList::createSpaceSeparated(x.releaseNonNull());
 
-    auto y = CSSPrimitiveValueResolver<CSS::LengthPercentage<>>::consumeAndResolve(range, state);
+    auto y = CSSPrimitiveValueResolver<CSS::LengthPercentage<CSS::AllUnzoomed>>::consumeAndResolve(range, state);
     if (!y)
         return nullptr;
 
@@ -239,7 +239,7 @@ RefPtr<CSSValue> consumeTranslate(CSSParserTokenRange& range, CSS::PropertyParse
         return CSSValueList::createSpaceSeparated(x.releaseNonNull(), y.releaseNonNull());
     }
 
-    auto z = CSSPrimitiveValueResolver<CSS::Length<>>::consumeAndResolve(range, state);
+    auto z = CSSPrimitiveValueResolver<CSS::Length<CSS::AllUnzoomed>>::consumeAndResolve(range, state);
     if (!z)
         return nullptr;
 
@@ -410,7 +410,7 @@ RefPtr<CSSValue> consumeScale(CSSParserTokenRange& range, CSS::PropertyParserSta
     return CSSValueList::createSpaceSeparated(x.releaseNonNull());
 }
 
-std::optional<Style::Transform> parseTransformRaw(const String& string, const CSSParserContext& context)
+std::optional<Style::Transform> parseTransformRaw(const String& string, const CSSParserContext& context, const Document& document)
 {
     auto tokenizer = CSSTokenizer(string);
     auto range = tokenizer.tokenRange();
@@ -430,7 +430,7 @@ std::optional<Style::Transform> parseTransformRaw(const String& string, const CS
         return { };
 
     auto dummyStyle = Style::ComputedStyle::create();
-    auto dummyState = Style::BuilderState::create(dummyStyle);
+    auto dummyState = Style::BuilderState::create(dummyStyle, Style::BuilderContext { document });
 
     ASSERT(parsedValue->canResolveDependenciesWithConversionData(dummyState->cssToLengthConversionData()));
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.h
@@ -33,6 +33,7 @@ namespace WebCore {
 class CSSParserTokenRange;
 class CSSToLengthConversionData;
 class CSSValue;
+class Document;
 struct CSSParserContext;
 
 namespace CSS {
@@ -60,7 +61,7 @@ RefPtr<CSSValue> consumeScale(CSSParserTokenRange&, CSS::PropertyParserState&);
 RefPtr<CSSValue> consumeRotate(CSSParserTokenRange&, CSS::PropertyParserState&);
 
 // MARK: <'transform'> parsing (raw)
-std::optional<Style::Transform> parseTransformRaw(const String&, const CSSParserContext&);
+std::optional<Style::Transform> parseTransformRaw(const String&, const CSSParserContext&, const Document&);
 
 } // namespace CSSPropertyParserHelpers
 } // namespace WebCore

--- a/Source/WebCore/css/values/non-standard/CSSWebkitBoxReflect.h
+++ b/Source/WebCore/css/values/non-standard/CSSWebkitBoxReflect.h
@@ -33,7 +33,7 @@ namespace CSS {
 
 struct WebkitBoxReflection {
     using Direction = Variant<Keyword::Above, Keyword::Below, Keyword::Left, Keyword::Right>;
-    using Offset = LengthPercentage<CSS::All, float>;
+    using Offset = LengthPercentage<CSS::AllUnzoomed, float>;
     using Mask = MaskBorder;
 
     Direction direction;

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -975,6 +975,11 @@ void ViewTransition::copyElementBaseProperties(RenderLayerModelObject& renderer,
         transform.translate(output.size.width() / 2, output.size.height() / 2);
         transform.translateRight(-output.size.width() / 2, -output.size.height() / 2);
 
+        // Factor out the zoom from the nearest common ancestor of the captured element and the view transition
+        // pseudo tree (the document element), so that it doesn't get applied a second time when rendering the
+        // snapshots.
+        transform.unzoom(documentElementRenderer->style().usedZoom());
+
         Ref transformListValue = CSSTransformListValue::create(Style::createCSSValue(CSSValuePool::singleton(), documentElementRenderer->style(), transform));
         protect(output.properties)->setProperty(CSSPropertyTransform, WTF::move(transformListValue));
     }

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -119,10 +119,10 @@ AcceleratedEffectValues::AcceleratedEffectValues(const Style::ComputedStyle& sty
 
     opacity = Style::evaluate<AcceleratedEffectOpacity>(style.opacity());
     transformBox = toAcceleratedEffectTransformBox(style.transformBox());
-    transform = Style::toPlatform(style.transform(), borderBoxSize);
-    translate = Style::toPlatform(style.translate(), borderBoxSize);
-    scale = Style::toPlatform(style.scale(), borderBoxSize);
-    rotate = Style::toPlatform(style.rotate(), borderBoxSize);
+    transform = Style::toPlatform(style.transform(), borderBoxSize, zoom);
+    translate = Style::toPlatform(style.translate(), borderBoxSize, zoom);
+    scale = Style::toPlatform(style.scale(), borderBoxSize, zoom);
+    rotate = Style::toPlatform(style.rotate(), borderBoxSize, zoom);
 
     if (transformOperationData && transformOperationData->motionPathData && !style.offsetPath().isNone()) {
         auto evaluatedOffsetPath = Style::evaluate<AcceleratedEffectOffsetPath>(style.offsetPath(), *transformOperationData, zoom);

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp
@@ -1282,6 +1282,17 @@ TransformationMatrix& TransformationMatrix::zoom(double zoomFactor)
     return *this;
 }
 
+TransformationMatrix& TransformationMatrix::unzoom(double zoomFactor)
+{
+    m_matrix[0][3] *= zoomFactor;
+    m_matrix[1][3] *= zoomFactor;
+    m_matrix[2][3] *= zoomFactor;
+    m_matrix[3][0] /= zoomFactor;
+    m_matrix[3][1] /= zoomFactor;
+    m_matrix[3][2] /= zoomFactor;
+    return *this;
+}
+
 // this = mat * this.
 TransformationMatrix& TransformationMatrix::multiply(const TransformationMatrix& mat)
 {

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -312,6 +312,7 @@ public:
     //     new_mat * (scale3d(z, z, z) * x) == scale3d(z, z, z) * (mat * x)
     //
     TransformationMatrix& NODELETE zoom(double zoomFactor);
+    TransformationMatrix& NODELETE unzoom(double zoomFactor);
 
     WEBCORE_EXPORT bool NODELETE isInvertible() const;
     WEBCORE_EXPORT std::optional<TransformationMatrix> inverse() const;

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1020,8 +1020,8 @@ int RenderBox::reflectionOffset() const
     if (!reflection)
         return 0;
     if (reflection->direction == ReflectionDirection::Left || reflection->direction == ReflectionDirection::Right)
-        return Style::evaluate<int>(reflection->offset, borderBoxWidth(), Style::ZoomNeeded { });
-    return Style::evaluate<int>(reflection->offset, borderBoxHeight(), Style::ZoomNeeded { });
+        return Style::evaluate<int>(reflection->offset, borderBoxWidth(), style().usedZoomForLength());
+    return Style::evaluate<int>(reflection->offset, borderBoxHeight(), style().usedZoomForLength());
 }
 
 LayoutRect RenderBox::reflectedRect(const LayoutRect& r) const

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4804,33 +4804,34 @@ bool RenderLayerBacking::startAnimation(double timeOffset, const GraphicsLayerAn
 
     for (auto& currentKeyframe : keyframes) {
         const Style::ComputedStyle* keyframeStyle = currentKeyframe.style();
-        double offset = currentKeyframe.offset();
-
         if (!keyframeStyle)
             continue;
 
-        RefPtr tf = currentKeyframe.timingFunction();
+        auto zoom = keyframeStyle->usedZoomForLength();
+
+        double offset = currentKeyframe.offset();
+        RefPtr timingFunction = currentKeyframe.timingFunction();
 
         if (currentKeyframe.animatesProperty(CSSPropertyRotate))
-            rotateVector.insert(makeUnique<GraphicsLayerTransformAnimationValue>(offset, Style::toPlatform(keyframeStyle->rotate(), referenceBoxRect.size()).get(), tf));
+            rotateVector.insert(makeUnique<GraphicsLayerTransformAnimationValue>(offset, Style::toPlatform(keyframeStyle->rotate(), referenceBoxRect.size(), zoom).get(), timingFunction));
 
         if (currentKeyframe.animatesProperty(CSSPropertyScale))
-            scaleVector.insert(makeUnique<GraphicsLayerTransformAnimationValue>(offset, Style::toPlatform(keyframeStyle->scale(), referenceBoxRect.size()).get(), tf));
+            scaleVector.insert(makeUnique<GraphicsLayerTransformAnimationValue>(offset, Style::toPlatform(keyframeStyle->scale(), referenceBoxRect.size(), zoom).get(), timingFunction));
 
         if (currentKeyframe.animatesProperty(CSSPropertyTranslate))
-            translateVector.insert(makeUnique<GraphicsLayerTransformAnimationValue>(offset, Style::toPlatform(keyframeStyle->translate(), referenceBoxRect.size()).get(), tf));
+            translateVector.insert(makeUnique<GraphicsLayerTransformAnimationValue>(offset, Style::toPlatform(keyframeStyle->translate(), referenceBoxRect.size(), zoom).get(), timingFunction));
 
         if (currentKeyframe.animatesProperty(CSSPropertyTransform))
-            transformVector.insert(makeUnique<GraphicsLayerTransformAnimationValue>(offset, Style::toPlatform(keyframeStyle->transform(), referenceBoxRect.size()), tf));
+            transformVector.insert(makeUnique<GraphicsLayerTransformAnimationValue>(offset, Style::toPlatform(keyframeStyle->transform(), referenceBoxRect.size(), zoom), timingFunction));
 
         if (currentKeyframe.animatesProperty(CSSPropertyOpacity))
-            opacityVector.insert(makeUnique<GraphicsLayerFloatAnimationValue>(offset, Style::evaluate<float>(keyframeStyle->opacity()), tf));
+            opacityVector.insert(makeUnique<GraphicsLayerFloatAnimationValue>(offset, Style::evaluate<float>(keyframeStyle->opacity()), timingFunction));
 
         if (currentKeyframe.animatesProperty(CSSPropertyFilter))
-            filterVector.insert(makeUnique<GraphicsLayerFilterAnimationValue>(offset, Style::toPlatform(keyframeStyle->filter(), renderer().style()), tf));
+            filterVector.insert(makeUnique<GraphicsLayerFilterAnimationValue>(offset, Style::toPlatform(keyframeStyle->filter(), renderer().style()), timingFunction));
 
         if (currentKeyframe.animatesProperty(CSSPropertyWebkitBackdropFilter) || currentKeyframe.animatesProperty(CSSPropertyBackdropFilter))
-            backdropFilterVector.insert(makeUnique<GraphicsLayerFilterAnimationValue>(offset, Style::toPlatform(keyframeStyle->backdropFilter(), renderer().style()), tf));
+            backdropFilterVector.insert(makeUnique<GraphicsLayerFilterAnimationValue>(offset, Style::toPlatform(keyframeStyle->backdropFilter(), renderer().style()), timingFunction));
     }
 
     bool didAnimate = false;
@@ -5257,7 +5258,7 @@ TransformationMatrix RenderLayerBacking::transformMatrixForProperty(AnimatedProp
     TransformationMatrix matrix;
 
     auto applyTransformOperation = [&](const auto& operation) {
-        operation.apply(matrix, snappedIntRect(m_owningLayer.rendererBorderBoxRect()).size());
+        operation.apply(matrix, snappedIntRect(m_owningLayer.rendererBorderBoxRect()).size(), renderer().style().usedZoomForLength());
     };
 
     if (property == AnimatedProperty::Translate)

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1550,19 +1550,23 @@ void RenderObject::getTransformFromContainer(const LayoutSize& offsetInContainer
     }
 
     CheckedPtr perspectiveObject = parent();
+    if (!perspectiveObject || !perspectiveObject->hasLayer())
+        return;
 
-    if (perspectiveObject && perspectiveObject->hasLayer() && !perspectiveObject->style().perspective().isNone()) {
-        // Perspective on the container affects us, so we have to factor it in here.
-        ASSERT(perspectiveObject->hasLayer());
-        FloatPoint perspectiveOrigin = downcast<RenderLayerModelObject>(*perspectiveObject).layer()->perspectiveOrigin();
+    CheckedRef style = perspectiveObject->style();
+    if (style->perspective().isNone())
+        return;
 
-        TransformationMatrix perspectiveMatrix;
-        perspectiveMatrix.applyPerspective(perspectiveObject->style().usedPerspective());
-        
-        transform.translateRight3d(-perspectiveOrigin.x(), -perspectiveOrigin.y(), 0);
-        transform = perspectiveMatrix * transform;
-        transform.translateRight3d(perspectiveOrigin.x(), perspectiveOrigin.y(), 0);
-    }
+    // Perspective on the container affects us, so we have to factor it in here.
+    ASSERT(perspectiveObject->hasLayer());
+    FloatPoint perspectiveOrigin = downcast<RenderLayerModelObject>(*perspectiveObject).layer()->perspectiveOrigin();
+
+    TransformationMatrix perspectiveMatrix;
+    perspectiveMatrix.applyPerspective(Style::evaluate<float>(style->perspective(), style->usedZoomForLength()));
+
+    transform.translateRight3d(-perspectiveOrigin.x(), -perspectiveOrigin.y(), 0);
+    transform = perspectiveMatrix * transform;
+    transform.translateRight3d(perspectiveOrigin.x(), perspectiveOrigin.y(), 0);
 }
 
 void RenderObject::pushOntoTransformState(TransformState& transformState, OptionSet<MapCoordinatesMode> mode, const RenderLayerModelObject* repaintContainer, const RenderElement* container, const LayoutSize& offsetInContainer, bool containerSkipped) const

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -83,12 +83,7 @@ namespace Style {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BuilderState);
 
-BuilderState::BuilderState(Style::ComputedStyle& style)
-    : m_style(style)
-{
-}
-
-BuilderState::BuilderState(Style::ComputedStyle& style, BuilderContext&& context)
+BuilderState::BuilderState(ComputedStyle& style, BuilderContext&& context)
     : m_style(style)
     , m_context(WTF::move(context))
     , m_cssToLengthConversionData(style, *this)

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -93,7 +93,7 @@ struct RegisteredSubstitutionAttribute {
 };
 
 struct BuilderContext {
-    const RefPtr<const Document> document { };
+    const Ref<const Document> document;
     const Style::ComputedStyle* parentStyle { };
     const Style::ComputedStyle* rootElementStyle { };
     RefPtr<const Element> element { };
@@ -112,14 +112,9 @@ class BuilderState : public CanMakeCheckedPtr<BuilderState> {
 public:
     template<typename T, class... Args> friend WTF::UniqueRef<T> WTF::makeUniqueRefWithoutFastMallocCheck(Args&&...);
 
-    static UniqueRef<BuilderState> create(Style::ComputedStyle& renderStyle)
+    static UniqueRef<BuilderState> create(ComputedStyle& style, BuilderContext&& builderContext)
     {
-        return makeUniqueRefWithoutRefCountedCheck<BuilderState>(renderStyle);
-    }
-
-    static UniqueRef<BuilderState> create(Style::ComputedStyle& renderStyle, BuilderContext&& builderContext)
-    {
-        return makeUniqueRefWithoutRefCountedCheck<BuilderState>(renderStyle, WTF::move(builderContext));
+        return makeUniqueRefWithoutRefCountedCheck<BuilderState>(style, WTF::move(builderContext));
     }
 
     ComputedStyle& style() { return m_style; }
@@ -136,7 +131,7 @@ public:
     const ComputedStyle* rootElementStyle() const { return m_context.rootElementStyle; }
     const Style::ComputedStyle* rootElementRenderStyle() const LIFETIME_BOUND { return m_context.rootElementStyle; }
 
-    const Document& document() const { return *m_context.document; }
+    const Document& document() const { return m_context.document; }
     const Element* element() const { return m_context.element.get(); }
 
     const CSSRegisteredCustomProperty* registeredProperty(const AtomString&) const;
@@ -254,8 +249,7 @@ private:
     friend class Builder;
     friend class SubstitutionResolver;
 
-    BuilderState(Style::ComputedStyle&);
-    BuilderState(Style::ComputedStyle&, BuilderContext&&);
+    BuilderState(ComputedStyle&, BuilderContext&&);
 
     void NODELETE adjustStyleForInterCharacterRuby();
 

--- a/Source/WebCore/style/StyleCustomPropertyRegistry.cpp
+++ b/Source/WebCore/style/StyleCustomPropertyRegistry.cpp
@@ -198,7 +198,7 @@ auto CustomPropertyRegistry::parseInitialValue(const Document& document, const A
 
     // We don't need to provide a real context style since only computationally independent values are allowed (no 'em' etc).
     auto placeholderStyle = Style::ComputedStyle::create();
-    auto dummyState = Style::BuilderState::create(placeholderStyle, { &document });
+    auto dummyState = Style::BuilderState::create(placeholderStyle, { document });
 
     auto initialValue = CSSPropertyParser::parseTypedCustomPropertyInitialValue(propertyName, syntax, tokenRange, dummyState, { document });
     if (!initialValue)

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -2289,8 +2289,12 @@ inline Ref<CSSValue> ExtractorCustom::extractTransform(ExtractorState& state)
     if (state.style.transform().isNone() && state.style.offsetPath().isNone())
         return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
-    if (state.renderer)
-        return CSSTransformListValue::create(createCSSValue(state.pool, state.style, TransformResolver::computeTransform(state.style, TransformOperationData(state.renderer->transformReferenceBoxRect(state.style), state.renderer), { })));
+    if (state.renderer) {
+        auto transform = TransformResolver::computeTransform(state.style, TransformOperationData(state.renderer->transformReferenceBoxRect(state.style), state.renderer), { });
+        transform.unzoom(state.style.usedZoomForLength().value);
+
+        return CSSTransformListValue::create(createCSSValue(state.pool, state.style, transform));
+    }
 
     // https://w3c.github.io/csswg-drafts/css-transforms-1/#serialization-of-the-computed-value
     // If we don't have a renderer, then the value should be "none" if we're asking for the
@@ -2309,7 +2313,10 @@ inline void ExtractorCustom::extractTransformSerialization(ExtractorState& state
     }
 
     if (state.renderer) {
-        serializationForCSS(builder, context, state.style, TransformResolver::computeTransform(state.style, TransformOperationData(state.renderer->transformReferenceBoxRect(state.style), state.renderer), { }));
+        auto transform = TransformResolver::computeTransform(state.style, TransformOperationData(state.renderer->transformReferenceBoxRect(state.style), state.renderer), { });
+        transform.unzoom(state.style.usedZoomForLength().value);
+
+        serializationForCSS(builder, context, state.style, transform);
         return;
     }
 

--- a/Source/WebCore/style/StyleTransformResolver.cpp
+++ b/Source/WebCore/style/StyleTransformResolver.cpp
@@ -92,7 +92,7 @@ void TransformResolver::applyPerspective(const FloatPoint& originTranslate)
     m_transform.translate(originTranslate.x(), originTranslate.y());
 
     // 3. Multiply by the matrix that would be obtained from the perspective() transform function, where the length is provided by the value of the perspective property
-    m_transform.applyPerspective(m_style->perspective().usedPerspective());
+    m_transform.applyPerspective(Style::evaluate<float>(m_style->perspective(), m_style->usedZoomForLength()));
 
     // 4. Translate by the negated computed X and Y values of perspective-origin
     m_transform.translate(-originTranslate.x(), -originTranslate.y());
@@ -119,25 +119,26 @@ void TransformResolver::applyCSSTransform(const TransformOperationData& transfor
     // 2. Translate by the computed X, Y, and Z values of transform-origin.
     // (implemented in applyTransformOrigin)
     auto& boundingBox = transformData.boundingBox;
+    auto zoom = m_style->usedZoomForLength();
 
     // 3. Translate by the computed X, Y, and Z values of translate.
     if (options.contains(Option::Translate))
-        m_style->translate().apply(m_transform, boundingBox.size());
+        m_style->translate().apply(m_transform, boundingBox.size(), zoom);
 
     // 4. Rotate by the computed <angle> about the specified axis of rotate.
     if (options.contains(Option::Rotate))
-        m_style->rotate().apply(m_transform, boundingBox.size());
+        m_style->rotate().apply(m_transform, boundingBox.size(), zoom);
 
     // 5. Scale by the computed X, Y, and Z values of scale.
     if (options.contains(Option::Scale))
-        m_style->scale().apply(m_transform, boundingBox.size());
+        m_style->scale().apply(m_transform, boundingBox.size(), zoom);
 
     // 6. Translate and rotate by the transform specified by offset.
     if (options.contains(Option::Offset))
-        applyMotionPathTransform(transformData, m_style->usedZoomForLength());
+        applyMotionPathTransform(transformData, zoom);
 
     // 7. Multiply by each of the transform functions in transform from left to right.
-    m_style->transform().apply(m_transform, boundingBox.size());
+    m_style->transform().apply(m_transform, boundingBox.size(), zoom);
 
     // 8. Translate by the negated computed X, Y and Z values of transform-origin.
     // (implemented in unapplyTransformOrigin)

--- a/Source/WebCore/style/computed/StyleComputedStyle+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle+GettersInlines.h
@@ -137,11 +137,6 @@ inline TransformStyle3D ComputedStyle::usedTransformStyle3D() const
     return transformStyleForcedToFlat() ? TransformStyle3D::Flat : transformStyle3D();
 }
 
-inline float ComputedStyle::usedPerspective() const
-{
-    return perspective().usedPerspective();
-}
-
 inline Visibility ComputedStyle::usedVisibility() const
 {
     if (isForceHidden()) [[unlikely]]

--- a/Source/WebCore/style/computed/StyleComputedStyle.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle.h
@@ -159,7 +159,6 @@ public:
     WEBCORE_EXPORT UserSelect NODELETE usedUserSelect() const;
     Style::Contain usedContain() const;
     inline TransformStyle3D usedTransformStyle3D() const;
-    inline float usedPerspective() const;
     WebCore::Color usedScrollbarThumbColor() const;
     WebCore::Color usedScrollbarTrackColor() const;
     WebCore::Color usedAccentColor(OptionSet<StyleColorOptions>) const;

--- a/Source/WebCore/style/values/non-standard/StyleWebKitBoxReflect.h
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitBoxReflect.h
@@ -39,7 +39,7 @@ namespace Style {
 
 struct WebkitBoxReflection {
     using Direction = ReflectionDirection;
-    using Offset = LengthPercentage<>;
+    using Offset = LengthPercentage<CSS::AllUnzoomed>;
     using Mask = MaskBorder;
 
     Direction direction { Direction::Below };

--- a/Source/WebCore/style/values/transforms/StylePerspective.cpp
+++ b/Source/WebCore/style/values/transforms/StylePerspective.cpp
@@ -55,8 +55,11 @@ auto CSSValueConversion<Perspective>::operator()(BuilderState& state, const CSSV
     if (primitiveValue->isLength())
         return toStyleFromCSSValue<Perspective::Length>(state, *primitiveValue);
 
-    if (primitiveValue->isNumber())
-        return Perspective::Length { toStyleFromCSSValue<Number<CSS::Nonnegative, float>>(state, *primitiveValue).value * state.cssToLengthConversionData().zoom() };
+    if (primitiveValue->isNumber()) {
+        if (!state.cssToLengthConversionData().evaluationTimeZoomEnabled())
+            return Perspective::Length { toStyleFromCSSValue<Number<CSS::Nonnegative, float>>(state, *primitiveValue).value * state.cssToLengthConversionData().zoom() };
+        return Perspective::Length { toStyleFromCSSValue<Number<CSS::Nonnegative, float>>(state, *primitiveValue).value };
+    }
 
     state.setCurrentPropertyInvalidAtComputedValueTime();
     return CSS::Keyword::None { };

--- a/Source/WebCore/style/values/transforms/StylePerspective.h
+++ b/Source/WebCore/style/values/transforms/StylePerspective.h
@@ -30,11 +30,9 @@ namespace WebCore::Style {
 
 // <'perspective'> = none | <length [0,∞]>
 // https://drafts.csswg.org/css-transforms-2/#propdef-perspective
-struct Perspective : ValueOrKeyword<Length<CSS::Nonnegative, float>, CSS::Keyword::None> {
+struct Perspective : ValueOrKeyword<Length<CSS::NonnegativeUnzoomed, float>, CSS::Keyword::None> {
     using Base::Base;
     using Length = typename Base::Value;
-
-    float usedPerspective() const { return std::max(1.0f, tryValue().value_or(1.0f).resolveZoom(Style::ZoomNeeded { })); }
 
     bool isNone() const { return isKeyword(); }
     bool isLength() const { return isValue(); }
@@ -44,6 +42,15 @@ static_assert(sizeof(Perspective) == sizeof(float));
 // MARK: - Conversion
 
 template<> struct CSSValueConversion<Perspective> { auto operator()(BuilderState&, const CSSValue&) -> Perspective; };
+
+// MARK: - Evaluation
+
+template<typename Result> struct Evaluation<Perspective, Result> {
+    constexpr auto operator()(const Perspective& perspective, ZoomFactor zoom) -> Result
+    {
+        return Result(std::max(1.0f, perspective.tryValue().value_or(1.0f).resolveZoom(zoom)));
+    }
+};
 
 } // namespace WebCore::Style
 

--- a/Source/WebCore/style/values/transforms/StyleRotate.cpp
+++ b/Source/WebCore/style/values/transforms/StyleRotate.cpp
@@ -36,10 +36,10 @@ namespace Style {
 
 using namespace CSS::Literals;
 
-void Rotate::apply(TransformationMatrix& transform, const FloatSize& size) const
+void Rotate::apply(TransformationMatrix& transform, const FloatSize& size, ZoomFactor zoom) const
 {
     if (RefPtr protectedValue = value)
-        protectedValue->apply(transform, size);
+        protectedValue->apply(transform, size, zoom);
 }
 
 // MARK: - Conversion
@@ -138,10 +138,10 @@ auto Blending<Rotate>::blend(const Rotate& from, const Rotate& to, const Blendin
 
 // MARK: - Platform
 
-auto ToPlatform<Rotate>::operator()(const Rotate& value, const FloatSize& size) -> RefPtr<TransformOperation>
+auto ToPlatform<Rotate>::operator()(const Rotate& value, const FloatSize& size, ZoomFactor zoom) -> RefPtr<TransformOperation>
 {
     if (RefPtr function = value.value)
-        return function->toPlatform(size);
+        return function->toPlatform(size, zoom);
     return nullptr;
 }
 

--- a/Source/WebCore/style/values/transforms/StyleRotate.h
+++ b/Source/WebCore/style/values/transforms/StyleRotate.h
@@ -47,7 +47,7 @@ struct Rotate {
     bool isRepresentableIn2D() const { return !value || value->isRepresentableIn2D(); }
     bool is3DOperation() const { return value && value->is3DOperation(); }
 
-    void apply(TransformationMatrix&, const FloatSize&) const;
+    void apply(TransformationMatrix&, const FloatSize&, ZoomFactor) const;
 
     bool isNone() const { return !value; }
     bool isFunction() const { return !!value; }
@@ -119,7 +119,7 @@ template<> struct Blending<Rotate> {
 
 // MARK: - Platform
 
-template<> struct ToPlatform<Rotate> { auto operator()(const Rotate&, const FloatSize&) -> RefPtr<TransformOperation>; };
+template<> struct ToPlatform<Rotate> { auto operator()(const Rotate&, const FloatSize&, ZoomFactor) -> RefPtr<TransformOperation>; };
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/transforms/StyleScale.cpp
+++ b/Source/WebCore/style/values/transforms/StyleScale.cpp
@@ -36,10 +36,10 @@ namespace Style {
 
 using namespace CSS::Literals;
 
-void Scale::apply(TransformationMatrix& transform, const FloatSize& size) const
+void Scale::apply(TransformationMatrix& transform, const FloatSize& size, ZoomFactor zoom) const
 {
     if (RefPtr protectedValue = value)
-        protectedValue->apply(transform, size);
+        protectedValue->apply(transform, size, zoom);
 }
 
 // MARK: - Conversion
@@ -109,10 +109,10 @@ auto Blending<Scale>::blend(const Scale& from, const Scale& to, const BlendingCo
 
 // MARK: - Platform
 
-auto ToPlatform<Scale>::operator()(const Scale& value, const FloatSize& size) -> RefPtr<TransformOperation>
+auto ToPlatform<Scale>::operator()(const Scale& value, const FloatSize& size, ZoomFactor zoom) -> RefPtr<TransformOperation>
 {
     if (RefPtr function = value.value)
-        return function->toPlatform(size);
+        return function->toPlatform(size, zoom);
     return nullptr;
 }
 

--- a/Source/WebCore/style/values/transforms/StyleScale.h
+++ b/Source/WebCore/style/values/transforms/StyleScale.h
@@ -47,7 +47,7 @@ struct Scale {
     bool isRepresentableIn2D() const { return !value || value->isRepresentableIn2D(); }
     bool is3DOperation() const { return value && value->is3DOperation(); }
 
-    void apply(TransformationMatrix&, const FloatSize&) const;
+    void apply(TransformationMatrix&, const FloatSize&, ZoomFactor) const;
 
     bool isNone() const { return !value; }
     bool isFunction() const { return !!value; }
@@ -110,7 +110,7 @@ template<> struct Blending<Scale> {
 
 // MARK: - Platform
 
-template<> struct ToPlatform<Scale> { auto operator()(const Scale&, const FloatSize&) -> RefPtr<TransformOperation>; };
+template<> struct ToPlatform<Scale> { auto operator()(const Scale&, const FloatSize&, ZoomFactor) -> RefPtr<TransformOperation>; };
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/transforms/StyleTransform.cpp
+++ b/Source/WebCore/style/values/transforms/StyleTransform.cpp
@@ -93,10 +93,10 @@ auto Blending<Transform>::blend(const Transform& from, const Transform& to, cons
 
 // MARK: - Platform
 
-auto ToPlatform<Transform>::operator()(const Transform& value, const FloatSize& size) -> TransformOperations
+auto ToPlatform<Transform>::operator()(const Transform& value, const FloatSize& size, ZoomFactor zoom) -> TransformOperations
 {
     return TransformOperations { WTF::map(value, [&](auto& transformFunction) {
-        return Style::toPlatform(transformFunction, size);
+        return Style::toPlatform(transformFunction, size, zoom);
     }) };
 }
 

--- a/Source/WebCore/style/values/transforms/StyleTransform.h
+++ b/Source/WebCore/style/values/transforms/StyleTransform.h
@@ -26,6 +26,7 @@
 
 #include <WebCore/StyleTransformList.h>
 #include <WebCore/StyleValueTypes.h>
+#include <WebCore/StyleZoomPrimitives.h>
 
 namespace WebCore {
 
@@ -47,7 +48,7 @@ struct Transform : ListOrNone<TransformList> {
     template<TransformFunctionType operationType>
     bool hasTransformOfType() const;
 
-    void apply(TransformationMatrix&, const FloatSize&, unsigned start = 0) const;
+    void apply(TransformationMatrix&, const FloatSize&, ZoomFactor, unsigned start = 0) const;
 
     // Return true if any of the operation types are 3D operation types (even if the
     // values describe affine transforms)
@@ -75,9 +76,9 @@ bool Transform::hasTransformOfType() const
     return m_value.hasTransformOfType<operationType>();
 }
 
-inline void Transform::apply(TransformationMatrix& matrix, const FloatSize& size, unsigned start) const
+inline void Transform::apply(TransformationMatrix& matrix, const FloatSize& size, ZoomFactor zoom, unsigned start) const
 {
-    m_value.apply(matrix, size, start);
+    m_value.apply(matrix, size, zoom, start);
 }
 
 inline bool Transform::has3DOperation() const
@@ -120,7 +121,7 @@ template<> struct Blending<Transform> {
 
 // MARK: - Platform
 
-template<> struct ToPlatform<Transform> { auto operator()(const Transform&, const FloatSize&) -> TransformOperations; };
+template<> struct ToPlatform<Transform> { auto operator()(const Transform&, const FloatSize&, ZoomFactor) -> TransformOperations; };
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/transforms/StyleTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/StyleTransformFunction.cpp
@@ -38,7 +38,6 @@
 #include "CSSTransformListValue.h"
 #include "CSSValueList.h"
 #include "DeprecatedCSSOMValue.h"
-#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StyleBuilderChecking.h"
 #include "StyleComputedStyle+GettersInlines.h"
 #include "StyleInterpolationContext.h"
@@ -47,6 +46,7 @@
 #include "StyleMatrixTransformFunction.h"
 #include "StylePerspectiveTransformFunction.h"
 #include "StylePrimitiveNumericTypes+Blending.h"
+#include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+CSSValueCreation.h"
 #include "StylePrimitiveNumericTypes+Serialization.h"
 #include "StyleRotateTransformFunction.h"
@@ -69,14 +69,25 @@ static RefPtr<const TransformFunctionBase> createMatrixTransformFunction(const C
     if (!function)
         return { };
 
-    auto zoom = state.cssToLengthConversionData().zoom();
+    if (auto conversionData = state.cssToLengthConversionData(); !conversionData.evaluationTimeZoomEnabled()) {
+        auto zoom = conversionData.zoom();
+        return MatrixTransformFunction::create(
+            toStyleFromCSSValue<Number<>>(state, protect(function->item(0))).value,
+            toStyleFromCSSValue<Number<>>(state, protect(function->item(1))).value,
+            toStyleFromCSSValue<Number<>>(state, protect(function->item(2))).value,
+            toStyleFromCSSValue<Number<>>(state, protect(function->item(3))).value,
+            toStyleFromCSSValue<Number<>>(state, protect(function->item(4))).value * zoom,
+            toStyleFromCSSValue<Number<>>(state, protect(function->item(5))).value * zoom
+        );
+    }
+
     return MatrixTransformFunction::create(
         toStyleFromCSSValue<Number<>>(state, protect(function->item(0))).value,
         toStyleFromCSSValue<Number<>>(state, protect(function->item(1))).value,
         toStyleFromCSSValue<Number<>>(state, protect(function->item(2))).value,
         toStyleFromCSSValue<Number<>>(state, protect(function->item(3))).value,
-        toStyleFromCSSValue<Number<>>(state, protect(function->item(4))).value * zoom,
-        toStyleFromCSSValue<Number<>>(state, protect(function->item(5))).value * zoom
+        toStyleFromCSSValue<Number<>>(state, protect(function->item(4))).value,
+        toStyleFromCSSValue<Number<>>(state, protect(function->item(5))).value
     );
 }
 
@@ -107,7 +118,9 @@ static RefPtr<const TransformFunctionBase> createMatrix3dTransformFunction(const
         toStyleFromCSSValue<Number<>>(state, protect(function->item(14))).value,
         toStyleFromCSSValue<Number<>>(state, protect(function->item(15))).value
     );
-    matrix.zoom(state.cssToLengthConversionData().zoom());
+
+    if (auto conversionData = state.cssToLengthConversionData(); !conversionData.evaluationTimeZoomEnabled())
+        matrix.zoom(conversionData.zoom());
 
     return Matrix3DTransformFunction::create(WTF::move(matrix));
 }
@@ -341,8 +354,8 @@ static RefPtr<const TransformFunctionBase> createTranslateTransformFunction(cons
     if (!function)
         return { };
 
-    auto tx = toStyleFromCSSValue<TranslateTransformFunction::LengthPercentage>(state, protect(function->item(0)));
-    auto ty = function->size() > 1 ? toStyleFromCSSValue<TranslateTransformFunction::LengthPercentage>(state, protect(function->item(1))) : TranslateTransformFunction::LengthPercentage { 0_css_px };
+    auto tx = toStyleFromCSSValue<TranslateTransformFunction::X>(state, protect(function->item(0)));
+    auto ty = function->size() > 1 ? toStyleFromCSSValue<TranslateTransformFunction::Y>(state, protect(function->item(1))) : TranslateTransformFunction::Y { 0_css_px };
     auto tz = 0_css_px;
 
     return TranslateTransformFunction::create(WTF::move(tx), WTF::move(ty), WTF::move(tz), TransformFunctionType::Translate);
@@ -357,9 +370,9 @@ static RefPtr<const TransformFunctionBase> createTranslate3dTransformFunction(co
     if (!function)
         return { };
 
-    auto tx = toStyleFromCSSValue<TranslateTransformFunction::LengthPercentage>(state, protect(function->item(0)));
-    auto ty = toStyleFromCSSValue<TranslateTransformFunction::LengthPercentage>(state, protect(function->item(1)));
-    auto tz = toStyleFromCSSValue<TranslateTransformFunction::Length>(state, protect(function->item(2)));
+    auto tx = toStyleFromCSSValue<TranslateTransformFunction::X>(state, protect(function->item(0)));
+    auto ty = toStyleFromCSSValue<TranslateTransformFunction::Y>(state, protect(function->item(1)));
+    auto tz = toStyleFromCSSValue<TranslateTransformFunction::Z>(state, protect(function->item(2)));
 
     return TranslateTransformFunction::create(WTF::move(tx), WTF::move(ty), WTF::move(tz), TransformFunctionType::Translate3D);
 }
@@ -373,7 +386,7 @@ static RefPtr<const TransformFunctionBase> createTranslateXTransformFunction(con
     if (!function)
         return { };
 
-    auto tx = toStyleFromCSSValue<TranslateTransformFunction::LengthPercentage>(state, protect(function->item(0)));
+    auto tx = toStyleFromCSSValue<TranslateTransformFunction::X>(state, protect(function->item(0)));
     auto ty = 0_css_px;
     auto tz = 0_css_px;
 
@@ -390,7 +403,7 @@ static RefPtr<const TransformFunctionBase> createTranslateYTransformFunction(con
         return { };
 
     auto tx = 0_css_px;
-    auto ty = toStyleFromCSSValue<TranslateTransformFunction::LengthPercentage>(state, protect(function->item(0)));
+    auto ty = toStyleFromCSSValue<TranslateTransformFunction::Y>(state, protect(function->item(0)));
     auto tz = 0_css_px;
 
     return TranslateTransformFunction::create(WTF::move(tx), WTF::move(ty), WTF::move(tz), TransformFunctionType::TranslateY);
@@ -407,7 +420,7 @@ static RefPtr<const TransformFunctionBase> createTranslateZTransformFunction(con
 
     auto tx = 0_css_px;
     auto ty = 0_css_px;
-    auto tz = toStyleFromCSSValue<TranslateTransformFunction::Length>(state, protect(function->item(0)));
+    auto tz = toStyleFromCSSValue<TranslateTransformFunction::Z>(state, protect(function->item(0)));
 
     return TranslateTransformFunction::create(WTF::move(tx), WTF::move(ty), WTF::move(tz), TransformFunctionType::TranslateZ);
 }
@@ -439,14 +452,12 @@ static RefPtr<const TransformFunctionBase> createPerspectiveTransformFunction(co
         return { };
 
     if (primitiveValue->isLength())
-        return PerspectiveTransformFunction::create(toStyleFromCSSValue<Length<CSS::Nonnegative>>(state, *primitiveValue));
+        return PerspectiveTransformFunction::create(toStyleFromCSSValue<Length<CSS::NonnegativeUnzoomed>>(state, *primitiveValue));
 
     // FIXME: Support for <number> parameters for `perspective` is a quirk that should go away when 3d transforms are finalized.
-    return PerspectiveTransformFunction::create(
-        Length<CSS::Nonnegative> {
-            static_cast<float>(toStyleFromCSSValue<Number<CSS::Nonnegative>>(state, *primitiveValue).value)
-        }
-    );
+    if (auto conversionData = state.cssToLengthConversionData(); !conversionData.evaluationTimeZoomEnabled())
+        return PerspectiveTransformFunction::create(Length<CSS::NonnegativeUnzoomed> { toStyleFromCSSValue<Number<CSS::Nonnegative, float>>(state, *primitiveValue).value * conversionData.zoom() });
+    return PerspectiveTransformFunction::create(Length<CSS::NonnegativeUnzoomed> { toStyleFromCSSValue<Number<CSS::Nonnegative, float>>(state, *primitiveValue).value });
 }
 
 // MARK: - Conversion
@@ -615,7 +626,7 @@ auto CSSValueCreation<TransformFunction>::operator()(CSSValuePool& pool, const S
     case TransformFunctionType::Matrix:
     case TransformFunctionType::Matrix3D: {
         TransformationMatrix transform;
-        function->apply(transform, { });
+        function->apply(transform, { }, ZoomFactor::none());
         return createCSSValue(pool, style, transform);
     }
     }
@@ -626,21 +637,40 @@ auto CSSValueCreation<TransformFunction>::operator()(CSSValuePool& pool, const S
 
 auto CSSValueCreation<TransformationMatrix>::operator()(CSSValuePool&, const Style::ComputedStyle& style, const TransformationMatrix& transform) -> Ref<CSSValue>
 {
-    auto zoom = style.usedZoom();
     if (transform.isAffine()) {
-        double values[] = { transform.a(), transform.b(), transform.c(), transform.d(), transform.e() / zoom, transform.f() / zoom };
+        auto values = [&] -> std::array<double, 6> {
+            if (!style.evaluationTimeZoomEnabled()) {
+                auto zoom = style.usedZoom();
+                return { transform.a(), transform.b(), transform.c(), transform.d(), transform.e() / zoom, transform.f() / zoom };
+            }
+            return { transform.a(), transform.b(), transform.c(), transform.d(), transform.e(), transform.f() };
+        }();
+
         CSSValueListBuilder arguments;
         for (auto value : values)
             arguments.append(CSSPrimitiveValue::create(value));
         return CSSFunctionValue::create(CSSValueMatrix, WTF::move(arguments));
     }
 
-    double values[] = {
-        transform.m11(), transform.m12(), transform.m13(), transform.m14() * zoom,
-        transform.m21(), transform.m22(), transform.m23(), transform.m24() * zoom,
-        transform.m31(), transform.m32(), transform.m33(), transform.m34() * zoom,
-        transform.m41() / zoom, transform.m42() / zoom, transform.m43() / zoom, transform.m44()
-    };
+    auto values = [&] -> std::array<double, 16> {
+        if (!style.evaluationTimeZoomEnabled()) {
+            auto zoom = style.usedZoom();
+            return {
+                transform.m11(), transform.m12(), transform.m13(), transform.m14() * zoom,
+                transform.m21(), transform.m22(), transform.m23(), transform.m24() * zoom,
+                transform.m31(), transform.m32(), transform.m33(), transform.m34() * zoom,
+                transform.m41() / zoom, transform.m42() / zoom, transform.m43() / zoom, transform.m44(),
+            };
+        }
+
+        return {
+            transform.m11(), transform.m12(), transform.m13(), transform.m14(),
+            transform.m21(), transform.m22(), transform.m23(), transform.m24(),
+            transform.m31(), transform.m32(), transform.m33(), transform.m34(),
+            transform.m41(), transform.m42(), transform.m43(), transform.m44(),
+        };
+    }();
+
     CSSValueListBuilder arguments;
     for (auto value : values)
         arguments.append(CSSPrimitiveValue::create(value));
@@ -817,7 +847,7 @@ void Serialize<TransformFunction>::operator()(StringBuilder& builder, const CSS:
     case TransformFunctionType::Matrix:
     case TransformFunctionType::Matrix3D: {
         TransformationMatrix transform;
-        function->apply(transform, { });
+        function->apply(transform, { }, ZoomFactor::none());
         serializationForCSS(builder, context, style, transform);
         return;
     }
@@ -828,21 +858,38 @@ void Serialize<TransformFunction>::operator()(StringBuilder& builder, const CSS:
 
 void Serialize<TransformationMatrix>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const Style::ComputedStyle& style, const TransformationMatrix& transform)
 {
-    auto zoom = style.usedZoom();
     if (transform.isAffine()) {
-        std::array values { transform.a(), transform.b(), transform.c(), transform.d(), transform.e() / zoom, transform.f() / zoom };
+        auto values = [&] -> std::array<double, 6> {
+            if (!style.evaluationTimeZoomEnabled()) {
+                auto zoom = style.usedZoom();
+                return { transform.a(), transform.b(), transform.c(), transform.d(), transform.e() / zoom, transform.f() / zoom };
+            }
+            return { transform.a(), transform.b(), transform.c(), transform.d(), transform.e(), transform.f() };
+        }();
         builder.append(nameLiteral(CSSValueMatrix), '(', interleave(values, [&](auto& builder, auto& value) {
             CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { value });
         }, ", "_s), ')');
         return;
     }
 
-    std::array values {
-        transform.m11(), transform.m12(), transform.m13(), transform.m14() * zoom,
-        transform.m21(), transform.m22(), transform.m23(), transform.m24() * zoom,
-        transform.m31(), transform.m32(), transform.m33(), transform.m34() * zoom,
-        transform.m41() / zoom, transform.m42() / zoom, transform.m43() / zoom, transform.m44()
-    };
+    auto values = [&] -> std::array<double, 16> {
+        if (!style.evaluationTimeZoomEnabled()) {
+            auto zoom = style.usedZoom();
+            return {
+                transform.m11(), transform.m12(), transform.m13(), transform.m14() * zoom,
+                transform.m21(), transform.m22(), transform.m23(), transform.m24() * zoom,
+                transform.m31(), transform.m32(), transform.m33(), transform.m34() * zoom,
+                transform.m41() / zoom, transform.m42() / zoom, transform.m43() / zoom, transform.m44(),
+            };
+        }
+
+        return {
+            transform.m11(), transform.m12(), transform.m13(), transform.m14(),
+            transform.m21(), transform.m22(), transform.m23(), transform.m24(),
+            transform.m31(), transform.m32(), transform.m33(), transform.m34(),
+            transform.m41(), transform.m42(), transform.m43(), transform.m44(),
+        };
+    }();
     builder.append(nameLiteral(CSSValueMatrix3d), '(', interleave(values, [&](auto& builder, auto& value) {
         CSS::serializationForCSS(builder, context, CSS::NumberRaw<> { value });
     }, ", "_s), ')');
@@ -857,9 +904,9 @@ auto Blending<TransformFunction>::blend(const TransformFunction& from, const Tra
 
 // MARK: - Platform
 
-auto ToPlatform<TransformFunction>::operator()(const TransformFunction& value, const FloatSize& size) -> Ref<TransformOperation>
+auto ToPlatform<TransformFunction>::operator()(const TransformFunction& value, const FloatSize& size, ZoomFactor zoom) -> Ref<TransformOperation>
 {
-    return protect(value.value)->toPlatform(size);
+    return protect(value.value)->toPlatform(size, zoom);
 }
 
 // MARK: - Logging

--- a/Source/WebCore/style/values/transforms/StyleTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/StyleTransformFunction.h
@@ -64,7 +64,7 @@ template<> struct Blending<TransformFunction> {
 
 // MARK: - Platform
 
-template<> struct ToPlatform<TransformFunction> { auto operator()(const TransformFunction&, const FloatSize&) -> Ref<TransformOperation>; };
+template<> struct ToPlatform<TransformFunction> { auto operator()(const TransformFunction&, const FloatSize&, ZoomFactor) -> Ref<TransformOperation>; };
 
 // MARK: - Logging
 

--- a/Source/WebCore/style/values/transforms/StyleTransformList.cpp
+++ b/Source/WebCore/style/values/transforms/StyleTransformList.cpp
@@ -35,10 +35,10 @@
 namespace WebCore {
 namespace Style {
 
-void TransformList::apply(TransformationMatrix& matrix, const FloatSize& size, unsigned start) const
+void TransformList::apply(TransformationMatrix& matrix, const FloatSize& size, ZoomFactor zoom, unsigned start) const
 {
     for (unsigned i = start; i < m_value.size(); ++i)
-        m_value[i]->apply(matrix, size);
+        m_value[i]->apply(matrix, size, zoom);
 }
 
 bool TransformList::has3DOperation() const
@@ -59,7 +59,7 @@ bool TransformList::affectedByTransformOrigin() const
 bool TransformList::isInvertible(const LayoutSize& size) const
 {
     TransformationMatrix transform;
-    apply(transform, size);
+    apply(transform, size, ZoomFactor::none());
     return transform.isInvertible();
 }
 
@@ -118,10 +118,10 @@ auto Blending<TransformList>::blend(const TransformList& from, const TransformLi
 
     auto createBlendedMatrixFunctionFromOperationsSuffix = [&](unsigned i) -> TransformFunction {
         TransformationMatrix fromTransform;
-        from.apply(fromTransform, boxSize, i);
+        from.apply(fromTransform, boxSize, ZoomFactor::none(), i);
 
         TransformationMatrix toTransform;
-        to.apply(toTransform, boxSize, i);
+        to.apply(toTransform, boxSize, ZoomFactor::none(), i);
 
         auto progress = context.progress;
         auto compositeOperation = context.compositeOperation;

--- a/Source/WebCore/style/values/transforms/StyleTransformList.h
+++ b/Source/WebCore/style/values/transforms/StyleTransformList.h
@@ -77,7 +77,7 @@ struct TransformList {
     template<TransformFunctionType>
     bool hasTransformOfType() const;
 
-    void apply(TransformationMatrix&, const FloatSize&, unsigned start = 0) const;
+    void apply(TransformationMatrix&, const FloatSize&, ZoomFactor, unsigned start = 0) const;
 
     // Return true if any of the operation types are 3D operation types (even if the
     // values describe affine transforms)

--- a/Source/WebCore/style/values/transforms/StyleTranslate.cpp
+++ b/Source/WebCore/style/values/transforms/StyleTranslate.cpp
@@ -43,10 +43,10 @@ TransformFunctionSizeDependencies Translate::computeSizeDependencies() const
     return { };
 }
 
-void Translate::apply(TransformationMatrix& transform, const FloatSize& size) const
+void Translate::apply(TransformationMatrix& transform, const FloatSize& size, ZoomFactor zoom) const
 {
     if (RefPtr protectedValue = value)
-        protectedValue->apply(transform, size);
+        protectedValue->apply(transform, size, zoom);
 }
 
 // MARK: - Conversion
@@ -71,9 +71,9 @@ auto CSSValueConversion<Translate>::operator()(BuilderState& state, const CSSVal
         return CSS::Keyword::None { };
 
     auto type = list->size() > 2 ? TransformFunctionType::Translate3D : TransformFunctionType::Translate;
-    auto tx = toStyleFromCSSValue<TranslateTransformFunction::LengthPercentage>(state, protect(list->item(0)));
-    auto ty = list->size() > 1 ? toStyleFromCSSValue<TranslateTransformFunction::LengthPercentage>(state, protect(list->item(1))) : TranslateTransformFunction::LengthPercentage { 0_css_px };
-    auto tz = list->size() > 2 ? toStyleFromCSSValue<TranslateTransformFunction::Length>(state, protect(list->item(2))) : TranslateTransformFunction::Length { 0_css_px };
+    auto tx = toStyleFromCSSValue<TranslateTransformFunction::X>(state, protect(list->item(0)));
+    auto ty = list->size() > 1 ? toStyleFromCSSValue<TranslateTransformFunction::Y>(state, protect(list->item(1))) : TranslateTransformFunction::Y { 0_css_px };
+    auto tz = list->size() > 2 ? toStyleFromCSSValue<TranslateTransformFunction::Z>(state, protect(list->item(2))) : TranslateTransformFunction::Z { 0_css_px };
 
     return TranslateTransformFunction::create(WTF::move(tx), WTF::move(ty), WTF::move(tz), type);
 }
@@ -117,10 +117,10 @@ auto Blending<Translate>::blend(const Translate& from, const Translate& to, cons
 
 // MARK: - Platform
 
-auto ToPlatform<Translate>::operator()(const Translate& value, const FloatSize& size) -> RefPtr<TransformOperation>
+auto ToPlatform<Translate>::operator()(const Translate& value, const FloatSize& size, ZoomFactor zoom) -> RefPtr<TransformOperation>
 {
     if (RefPtr function = value.value)
-        return function->toPlatform(size);
+        return function->toPlatform(size, zoom);
     return nullptr;
 }
 

--- a/Source/WebCore/style/values/transforms/StyleTranslate.h
+++ b/Source/WebCore/style/values/transforms/StyleTranslate.h
@@ -48,7 +48,7 @@ struct Translate {
 
     TransformFunctionSizeDependencies computeSizeDependencies() const;
 
-    void apply(TransformationMatrix&, const FloatSize&) const;
+    void apply(TransformationMatrix&, const FloatSize&, ZoomFactor) const;
 
     bool isNone() const { return !value; }
     bool isFunction() const { return !!value; }
@@ -111,7 +111,7 @@ template<> struct Blending<Translate> {
 
 // MARK: - Platform
 
-template<> struct ToPlatform<Translate> { auto operator()(const Translate&, const FloatSize&) -> RefPtr<TransformOperation>; };
+template<> struct ToPlatform<Translate> { auto operator()(const Translate&, const FloatSize&, ZoomFactor) -> RefPtr<TransformOperation>; };
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/values/transforms/functions/StyleMatrix3DTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/functions/StyleMatrix3DTransformFunction.cpp
@@ -52,9 +52,10 @@ Ref<const TransformFunctionBase> Matrix3DTransformFunction::clone() const
     return adoptRef(*new Matrix3DTransformFunction(m_matrix));
 }
 
-Ref<TransformOperation> Matrix3DTransformFunction::toPlatform(const FloatSize&) const
+Ref<TransformOperation> Matrix3DTransformFunction::toPlatform(const FloatSize&, ZoomFactor zoom) const
 {
-    return Matrix3DTransformOperation::create(m_matrix);
+    auto copy = m_matrix;
+    return Matrix3DTransformOperation::create(copy.zoom(zoom.value));
 }
 
 bool Matrix3DTransformFunction::operator==(const TransformFunctionBase& other) const
@@ -66,9 +67,10 @@ bool Matrix3DTransformFunction::operator==(const TransformFunctionBase& other) c
     return m_matrix == otherMatrix3D.m_matrix;
 }
 
-void Matrix3DTransformFunction::apply(TransformationMatrix& transform, const FloatSize&) const
+void Matrix3DTransformFunction::apply(TransformationMatrix& transform, const FloatSize&, ZoomFactor zoom) const
 {
-    transform.multiply(m_matrix);
+    auto copy = m_matrix;
+    transform.multiply(copy.zoom(zoom.value));
 }
 
 Ref<const TransformFunctionBase> Matrix3DTransformFunction::blend(const TransformFunctionBase* from, const BlendingContext& context, bool blendToIdentity) const

--- a/Source/WebCore/style/values/transforms/functions/StyleMatrix3DTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleMatrix3DTransformFunction.h
@@ -41,9 +41,7 @@ public:
     static Ref<const Matrix3DTransformFunction> create(const TransformationMatrix&);
 
     Ref<const TransformFunctionBase> clone() const override;
-    Ref<TransformOperation> toPlatform(const FloatSize&) const override;
-
-    TransformationMatrix matrix() const { return m_matrix; }
+    Ref<TransformOperation> toPlatform(const FloatSize&, ZoomFactor) const override;
 
     bool isIdentity() const override { return m_matrix.isIdentity(); }
     bool isAffectedByTransformOrigin() const override { return !isIdentity(); }
@@ -52,7 +50,7 @@ public:
     bool operator==(const Matrix3DTransformFunction& other) const { return operator==(static_cast<const TransformFunctionBase&>(other)); }
     bool operator==(const TransformFunctionBase&) const override;
 
-    void apply(TransformationMatrix&, const FloatSize& borderBoxSize) const override;
+    void apply(TransformationMatrix&, const FloatSize& borderBoxSize, ZoomFactor) const override;
 
     Ref<const TransformFunctionBase> blend(const TransformFunctionBase* from, const BlendingContext&, bool blendToIdentity = false) const override;
 
@@ -60,6 +58,8 @@ public:
 
 private:
     Matrix3DTransformFunction(const TransformationMatrix&);
+
+    TransformationMatrix matrix() const { return m_matrix; }
 
     TransformationMatrix m_matrix;
 };

--- a/Source/WebCore/style/values/transforms/functions/StyleMatrixTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/functions/StyleMatrixTransformFunction.cpp
@@ -68,9 +68,16 @@ Ref<const TransformFunctionBase> MatrixTransformFunction::clone() const
     return adoptRef(*new MatrixTransformFunction(m_a, m_b, m_c, m_d, m_e, m_f));
 }
 
-Ref<TransformOperation> MatrixTransformFunction::toPlatform(const FloatSize&) const
+Ref<TransformOperation> MatrixTransformFunction::toPlatform(const FloatSize&, ZoomFactor zoom) const
 {
-    return MatrixTransformOperation::create(m_a.value, m_b.value, m_c.value, m_d.value, m_e.value, m_f.value);
+    return MatrixTransformOperation::create(
+        m_a.value,
+        m_b.value,
+        m_c.value,
+        m_d.value,
+        m_e.value * zoom.value,
+        m_f.value * zoom.value
+    );
 }
 
 bool MatrixTransformFunction::operator==(const TransformFunctionBase& other) const
@@ -87,14 +94,23 @@ bool MatrixTransformFunction::operator==(const TransformFunctionBase& other) con
         && m_f == otherMatrix.m_f;
 }
 
-void MatrixTransformFunction::apply(TransformationMatrix& transform, const FloatSize&) const
+void MatrixTransformFunction::apply(TransformationMatrix& transform, const FloatSize&, ZoomFactor zoom) const
 {
-    transform.multiply(matrix());
+    transform.multiply(
+        TransformationMatrix(
+            m_a.value,
+            m_b.value,
+            m_c.value,
+            m_d.value,
+            m_e.value * zoom.value,
+            m_f.value * zoom.value
+        )
+    );
 }
 
 Ref<const TransformFunctionBase> MatrixTransformFunction::blend(const TransformFunctionBase* from, const BlendingContext& context, bool blendToIdentity) const
 {
-    auto createOperation = [] (TransformationMatrix& to, TransformationMatrix& from, const BlendingContext& context) {
+    auto createOperation = [](TransformationMatrix& to, TransformationMatrix& from, const BlendingContext& context) {
         to.blend(from, context.progress, context.compositeOperation);
         return MatrixTransformFunction::create(to);
     };

--- a/Source/WebCore/style/values/transforms/functions/StyleMatrixTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleMatrixTransformFunction.h
@@ -41,9 +41,7 @@ public:
     static Ref<const MatrixTransformFunction> create(const TransformationMatrix&);
 
     Ref<const TransformFunctionBase> clone() const override;
-    Ref<TransformOperation> toPlatform(const FloatSize&) const override;
-
-    TransformationMatrix matrix() const { return TransformationMatrix(m_a.value, m_b.value, m_c.value, m_d.value, m_e.value, m_f.value); }
+    Ref<TransformOperation> toPlatform(const FloatSize&, ZoomFactor) const override;
 
     bool isIdentity() const override { return m_a == 1 && m_b == 0 && m_c == 0 && m_d == 1 && m_e == 0 && m_f == 0; }
     bool isAffectedByTransformOrigin() const override { return !isIdentity(); }
@@ -51,7 +49,7 @@ public:
     bool operator==(const MatrixTransformFunction& other) const { return operator==(static_cast<const TransformFunctionBase&>(other)); }
     bool operator==(const TransformFunctionBase&) const override;
 
-    void apply(TransformationMatrix&, const FloatSize& borderBoxSize) const override;
+    void apply(TransformationMatrix&, const FloatSize& borderBoxSize, ZoomFactor) const override;
 
     Ref<const TransformFunctionBase> blend(const TransformFunctionBase* from, const BlendingContext&, bool blendToIdentity = false) const override;
 
@@ -60,6 +58,8 @@ public:
 private:
     MatrixTransformFunction(Number<>, Number<>, Number<>, Number<>, Number<>, Number<>);
     MatrixTransformFunction(const TransformationMatrix&);
+
+    TransformationMatrix matrix() const { return TransformationMatrix(m_a.value, m_b.value, m_c.value, m_d.value, m_e.value, m_f.value); }
 
     Number<> m_a;
     Number<> m_b;

--- a/Source/WebCore/style/values/transforms/functions/StylePerspectiveTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/functions/StylePerspectiveTransformFunction.cpp
@@ -53,14 +53,14 @@ Ref<const TransformFunctionBase> PerspectiveTransformFunction::clone() const
     return adoptRef(*new PerspectiveTransformFunction(m_p));
 }
 
-Ref<TransformOperation> PerspectiveTransformFunction::toPlatform(const FloatSize&) const
+Ref<TransformOperation> PerspectiveTransformFunction::toPlatform(const FloatSize&, ZoomFactor zoom) const
 {
     return WTF::switchOn(m_p,
         [](const CSS::Keyword::None&) -> Ref<TransformOperation> {
             return PerspectiveTransformOperation::create(std::nullopt);
         },
-        [](const Perspective::Length& value) -> Ref<TransformOperation> {
-            return PerspectiveTransformOperation::create(evaluate<float>(value, ZoomNeeded { }));
+        [&](const Perspective::Length& value) -> Ref<TransformOperation> {
+            return PerspectiveTransformOperation::create(evaluate<float>(value, zoom));
         }
     );
 }
@@ -73,10 +73,10 @@ bool PerspectiveTransformFunction::operator==(const TransformFunctionBase& other
     return m_p == otherPerspective.m_p;
 }
 
-void PerspectiveTransformFunction::apply(TransformationMatrix& transform, const FloatSize&) const
+void PerspectiveTransformFunction::apply(TransformationMatrix& transform, const FloatSize&, ZoomFactor zoom) const
 {
     if (auto value = m_p.tryValue())
-        transform.applyPerspective(std::max(1.0f, evaluate<float>(*value, ZoomNeeded { })));
+        transform.applyPerspective(std::max(1.0f, evaluate<float>(*value, zoom)));
 }
 
 std::optional<float> PerspectiveTransformFunction::unresolvedFloatValue() const

--- a/Source/WebCore/style/values/transforms/functions/StylePerspectiveTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StylePerspectiveTransformFunction.h
@@ -41,7 +41,7 @@ public:
     static Ref<const PerspectiveTransformFunction> create(Perspective);
 
     Ref<const TransformFunctionBase> clone() const override;
-    Ref<TransformOperation> toPlatform(const FloatSize&) const override;
+    Ref<TransformOperation> toPlatform(const FloatSize&, ZoomFactor) const override;
 
     Perspective perspective() const { return m_p; }
 
@@ -52,7 +52,7 @@ public:
     bool operator==(const PerspectiveTransformFunction& other) const { return operator==(static_cast<const TransformFunctionBase&>(other)); }
     bool operator==(const TransformFunctionBase&) const override;
 
-    void apply(TransformationMatrix&, const FloatSize& borderBoxSize) const override;
+    void apply(TransformationMatrix&, const FloatSize& borderBoxSize, ZoomFactor) const override;
 
     Ref<const TransformFunctionBase> blend(const TransformFunctionBase* from, const BlendingContext&, bool blendToIdentity = false) const override;
 

--- a/Source/WebCore/style/values/transforms/functions/StyleRotateTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/functions/StyleRotateTransformFunction.cpp
@@ -59,7 +59,7 @@ Ref<const TransformFunctionBase> RotateTransformFunction::clone() const
     return adoptRef(*new RotateTransformFunction(m_x, m_y, m_z, m_angle, type()));
 }
 
-Ref<TransformOperation> RotateTransformFunction::toPlatform(const FloatSize&) const
+Ref<TransformOperation> RotateTransformFunction::toPlatform(const FloatSize&, ZoomFactor) const
 {
     return RotateTransformOperation::create(m_x.value, m_y.value, m_z.value, m_angle.value, Style::toPlatform(type()));
 }
@@ -73,7 +73,7 @@ bool RotateTransformFunction::operator==(const TransformFunctionBase& other) con
     return m_angle == otherRotate.m_angle && m_x == otherRotate.m_x && m_y == otherRotate.m_y && m_z == otherRotate.m_z;
 }
 
-void RotateTransformFunction::apply(TransformationMatrix& transform, const FloatSize&) const
+void RotateTransformFunction::apply(TransformationMatrix& transform, const FloatSize&, ZoomFactor) const
 {
     if (type() == TransformFunctionBase::Type::Rotate)
         transform.rotate(m_angle.value);

--- a/Source/WebCore/style/values/transforms/functions/StyleRotateTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleRotateTransformFunction.h
@@ -48,7 +48,7 @@ public:
     static Ref<const RotateTransformFunction> create(Number<>, Number<>, Number<>, Angle<>, TransformFunctionBase::Type);
 
     Ref<const TransformFunctionBase> clone() const override;
-    Ref<TransformOperation> toPlatform(const FloatSize&) const override;
+    Ref<TransformOperation> toPlatform(const FloatSize&, ZoomFactor) const override;
 
     Number<> x() const { return m_x; }
     Number<> y() const { return m_y; }
@@ -64,7 +64,7 @@ public:
     bool isRepresentableIn2D() const override { return (m_x.isZero() && m_y.isZero()) || m_angle.isZero(); }
     bool isAffectedByTransformOrigin() const override { return !isIdentity(); }
 
-    void apply(TransformationMatrix&, const FloatSize& borderBoxSize) const override;
+    void apply(TransformationMatrix&, const FloatSize& borderBoxSize, ZoomFactor) const override;
 
     Ref<const TransformFunctionBase> blend(const TransformFunctionBase* from, const BlendingContext&, bool blendToIdentity = false) const override;
 

--- a/Source/WebCore/style/values/transforms/functions/StyleScaleTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/functions/StyleScaleTransformFunction.cpp
@@ -56,7 +56,7 @@ Ref<const TransformFunctionBase> ScaleTransformFunction::clone() const
     return adoptRef(*new ScaleTransformFunction(m_x, m_y, m_z, type()));
 }
 
-Ref<TransformOperation> ScaleTransformFunction::toPlatform(const FloatSize&) const
+Ref<TransformOperation> ScaleTransformFunction::toPlatform(const FloatSize&, ZoomFactor) const
 {
     return ScaleTransformOperation::create(m_x.value.value, m_y.value.value, m_z.value.value, Style::toPlatform(type()));
 }
@@ -70,7 +70,7 @@ bool ScaleTransformFunction::operator==(const TransformFunctionBase& other) cons
     return m_x == otherScale.m_x && m_y == otherScale.m_y && m_z == otherScale.m_z;
 }
 
-void ScaleTransformFunction::apply(TransformationMatrix& transform, const FloatSize&) const
+void ScaleTransformFunction::apply(TransformationMatrix& transform, const FloatSize&, ZoomFactor) const
 {
     transform.scale3d(m_x.value.value, m_y.value.value, m_z.value.value);
 }

--- a/Source/WebCore/style/values/transforms/functions/StyleScaleTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleScaleTransformFunction.h
@@ -46,7 +46,7 @@ public:
     static Ref<const ScaleTransformFunction> create(NumberOrPercentageResolvedToNumber<>, NumberOrPercentageResolvedToNumber<>, NumberOrPercentageResolvedToNumber<>, TransformFunctionBase::Type);
 
     Ref<const TransformFunctionBase> clone() const override;
-    Ref<TransformOperation> toPlatform(const FloatSize&) const override;
+    Ref<TransformOperation> toPlatform(const FloatSize&, ZoomFactor) const override;
 
     TransformFunctionBase::Type primitiveType() const override { return (type() == Type::ScaleZ || type() == Type::Scale3D) ? Type::Scale3D : Type::Scale; }
 
@@ -61,7 +61,7 @@ public:
     bool operator==(const ScaleTransformFunction& other) const { return operator==(static_cast<const TransformFunctionBase&>(other)); }
     bool operator==(const TransformFunctionBase&) const override;
 
-    void apply(TransformationMatrix&, const FloatSize& borderBoxSize) const override;
+    void apply(TransformationMatrix&, const FloatSize& borderBoxSize, ZoomFactor) const override;
 
     Ref<const TransformFunctionBase> blend(const TransformFunctionBase* from, const BlendingContext&, bool blendToIdentity = false) const override;
 

--- a/Source/WebCore/style/values/transforms/functions/StyleSkewTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/functions/StyleSkewTransformFunction.cpp
@@ -50,7 +50,7 @@ Ref<const TransformFunctionBase> SkewTransformFunction::clone() const
     return adoptRef(*new SkewTransformFunction(m_angleX, m_angleY, type()));
 }
 
-Ref<TransformOperation> SkewTransformFunction::toPlatform(const FloatSize&) const
+Ref<TransformOperation> SkewTransformFunction::toPlatform(const FloatSize&, ZoomFactor) const
 {
     return SkewTransformOperation::create(m_angleX.value, m_angleY.value, Style::toPlatform(type()));
 }
@@ -64,7 +64,7 @@ bool SkewTransformFunction::operator==(const TransformFunctionBase& other) const
     return m_angleX == otherSkew.m_angleX && m_angleY == otherSkew.m_angleY;
 }
 
-void SkewTransformFunction::apply(TransformationMatrix& transform, const FloatSize&) const
+void SkewTransformFunction::apply(TransformationMatrix& transform, const FloatSize&, ZoomFactor) const
 {
     transform.skew(m_angleX.value, m_angleY.value);
 }

--- a/Source/WebCore/style/values/transforms/functions/StyleSkewTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleSkewTransformFunction.h
@@ -43,7 +43,7 @@ public:
     static Ref<const SkewTransformFunction> create(Angle<>, Angle<>, TransformFunctionBase::Type);
 
     Ref<const TransformFunctionBase> clone() const override;
-    Ref<TransformOperation> toPlatform(const FloatSize&) const override;
+    Ref<TransformOperation> toPlatform(const FloatSize&, ZoomFactor) const override;
 
     Angle<> angleX() const { return m_angleX; }
     Angle<> angleY() const { return m_angleY; }
@@ -54,7 +54,7 @@ public:
     bool operator==(const SkewTransformFunction& other) const { return operator==(static_cast<const TransformFunctionBase&>(other)); }
     bool operator==(const TransformFunctionBase&) const override;
 
-    void apply(TransformationMatrix&, const FloatSize& borderBoxSize) const override;
+    void apply(TransformationMatrix&, const FloatSize& borderBoxSize, ZoomFactor) const override;
 
     Ref<const TransformFunctionBase> blend(const TransformFunctionBase* from, const BlendingContext&, bool blendToIdentity = false) const override;
 

--- a/Source/WebCore/style/values/transforms/functions/StyleTransformFunctionBase.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleTransformFunctionBase.h
@@ -34,10 +34,9 @@
 #include <wtf/TypeCasts.h>
 
 namespace WebCore {
-
-struct BlendingContext;
-
 namespace Style {
+
+struct ZoomFactor;
 
 enum class TransformFunctionType : uint8_t {
     ScaleX,
@@ -81,11 +80,11 @@ public:
 
     virtual Ref<const TransformFunctionBase> clone() const = 0;
 
-    virtual Ref<TransformOperation> toPlatform(const FloatSize& borderBoxSize) const = 0;
+    virtual Ref<TransformOperation> toPlatform(const FloatSize& borderBoxSize, ZoomFactor) const = 0;
 
     virtual bool operator==(const TransformFunctionBase&) const = 0;
 
-    virtual void apply(TransformationMatrix&, const FloatSize& borderBoxSize) const = 0;
+    virtual void apply(TransformationMatrix&, const FloatSize& borderBoxSize, ZoomFactor) const = 0;
 
     virtual Ref<const TransformFunctionBase> blend(const TransformFunctionBase* from, const BlendingContext&, bool blendToIdentity = false) const = 0;
 

--- a/Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.cpp
@@ -36,7 +36,7 @@ namespace Style {
 
 using namespace CSS::Literals;
 
-TranslateTransformFunction::TranslateTransformFunction(const LengthPercentage& x, const LengthPercentage& y, const Length& z, TransformFunctionBase::Type type)
+TranslateTransformFunction::TranslateTransformFunction(const X& x, const Y& y, const Z& z, TransformFunctionBase::Type type)
     : TransformFunctionBase(type)
     , m_x(x)
     , m_y(y)
@@ -45,12 +45,12 @@ TranslateTransformFunction::TranslateTransformFunction(const LengthPercentage& x
     RELEASE_ASSERT(isTranslateTransformFunctionType(type));
 }
 
-Ref<const TranslateTransformFunction> TranslateTransformFunction::create(const LengthPercentage& x, const LengthPercentage& y, TransformFunctionBase::Type type)
+Ref<const TranslateTransformFunction> TranslateTransformFunction::create(const X& x, const Y& y, TransformFunctionBase::Type type)
 {
     return adoptRef(*new TranslateTransformFunction(x, y, 0_css_px, type));
 }
 
-Ref<const TranslateTransformFunction> TranslateTransformFunction::create(const LengthPercentage& x, const LengthPercentage& y, const Length& z, TransformFunctionBase::Type type)
+Ref<const TranslateTransformFunction> TranslateTransformFunction::create(const X& x, const Y& y, const Z& z, TransformFunctionBase::Type type)
 {
     return adoptRef(*new TranslateTransformFunction(x, y, z, type));
 }
@@ -60,12 +60,12 @@ Ref<const TransformFunctionBase> TranslateTransformFunction::clone() const
     return adoptRef(*new TranslateTransformFunction(m_x, m_y, m_z, type()));
 }
 
-Ref<TransformOperation> TranslateTransformFunction::toPlatform(const FloatSize& borderBoxSize) const
+Ref<TransformOperation> TranslateTransformFunction::toPlatform(const FloatSize& borderBoxSize, ZoomFactor zoom) const
 {
     return TranslateTransformOperation::create(
-        evaluate<float>(m_x, borderBoxSize.width(), ZoomNeeded { }),
-        evaluate<float>(m_y, borderBoxSize.height(), ZoomNeeded { }),
-        evaluate<float>(m_z, ZoomNeeded { }),
+        evaluate<float>(m_x, borderBoxSize.width(), zoom),
+        evaluate<float>(m_y, borderBoxSize.height(), zoom),
+        evaluate<float>(m_z, zoom),
         Style::toPlatform(type())
     );
 }
@@ -87,12 +87,12 @@ bool TranslateTransformFunction::operator==(const TransformFunctionBase& other) 
     return m_x == otherTranslate.m_x && m_y == otherTranslate.m_y && m_z == otherTranslate.m_z;
 }
 
-void TranslateTransformFunction::apply(TransformationMatrix& transform, const FloatSize& borderBoxSize) const
+void TranslateTransformFunction::apply(TransformationMatrix& transform, const FloatSize& borderBoxSize, ZoomFactor zoom) const
 {
     transform.translate3d(
-        evaluate<float>(m_x, borderBoxSize.width(), ZoomNeeded { }),
-        evaluate<float>(m_y, borderBoxSize.height(), ZoomNeeded { }),
-        evaluate<float>(m_z, ZoomNeeded { })
+        evaluate<float>(m_x, borderBoxSize.width(), zoom),
+        evaluate<float>(m_y, borderBoxSize.height(), zoom),
+        evaluate<float>(m_z, zoom)
     );
 }
 
@@ -100,9 +100,9 @@ Ref<const TransformFunctionBase> TranslateTransformFunction::blend(const Transfo
 {
     if (blendToIdentity) {
         return TranslateTransformFunction::create(
-            Style::blend(m_x, LengthPercentage { 0_css_px }, context),
-            Style::blend(m_y, LengthPercentage { 0_css_px }, context),
-            Style::blend(m_z, Length { 0_css_px }, context),
+            Style::blend(m_x, X { 0_css_px }, context),
+            Style::blend(m_y, Y { 0_css_px }, context),
+            Style::blend(m_z, Z { 0_css_px }, context),
             type()
         );
     }
@@ -112,9 +112,9 @@ Ref<const TransformFunctionBase> TranslateTransformFunction::blend(const Transfo
         return *this;
 
     RefPtr fromOp = downcast<TranslateTransformFunction>(from);
-    auto fromX = fromOp ? fromOp->m_x : LengthPercentage { 0_css_px };
-    auto fromY = fromOp ? fromOp->m_y : LengthPercentage { 0_css_px };
-    auto fromZ = fromOp ? fromOp->m_z : Length { 0_css_px };
+    auto fromX = fromOp ? fromOp->m_x : X { 0_css_px };
+    auto fromY = fromOp ? fromOp->m_y : Y { 0_css_px };
+    auto fromZ = fromOp ? fromOp->m_z : Z { 0_css_px };
 
     return TranslateTransformFunction::create(
         Style::blend(fromX, x(), context),

--- a/Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.h
+++ b/Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.h
@@ -44,20 +44,21 @@ namespace Style {
 
 class TranslateTransformFunction final : public TransformFunctionBase {
 public:
-    using LengthPercentage = Style::LengthPercentage<>;
-    using Length = Style::Length<>;
+    using X = Style::LengthPercentage<CSS::AllUnzoomed>;
+    using Y = Style::LengthPercentage<CSS::AllUnzoomed>;
+    using Z = Style::Length<CSS::AllUnzoomed>;
 
-    static Ref<const TranslateTransformFunction> create(const LengthPercentage&, const LengthPercentage&, TransformFunctionBase::Type);
-    static Ref<const TranslateTransformFunction> create(const LengthPercentage&, const LengthPercentage&, const Length&, TransformFunctionBase::Type);
+    static Ref<const TranslateTransformFunction> create(const X&, const Y&, TransformFunctionBase::Type);
+    static Ref<const TranslateTransformFunction> create(const X&, const Y&, const Z&, TransformFunctionBase::Type);
 
     Ref<const TransformFunctionBase> clone() const override;
-    Ref<TransformOperation> toPlatform(const FloatSize&) const override;
+    Ref<TransformOperation> toPlatform(const FloatSize&, ZoomFactor) const override;
 
     TransformFunctionBase::Type primitiveType() const override { return isRepresentableIn2D() ? Type::Translate : Type::Translate3D; }
 
-    const LengthPercentage& x() const LIFETIME_BOUND { return m_x; }
-    const LengthPercentage& y() const LIFETIME_BOUND { return m_y; }
-    Length z() const { return m_z; }
+    const X& x() const LIFETIME_BOUND { return m_x; }
+    const Y& y() const LIFETIME_BOUND { return m_y; }
+    Z z() const { return m_z; }
 
     bool isIdentity() const override { return m_x.isKnownZero() && m_y.isKnownZero() && m_z.isZero(); }
     bool isRepresentableIn2D() const override { return m_z.isZero(); }
@@ -67,18 +68,18 @@ public:
     bool operator==(const TranslateTransformFunction& other) const { return operator==(static_cast<const TransformFunctionBase&>(other)); }
     bool operator==(const TransformFunctionBase&) const override;
 
-    void apply(TransformationMatrix&, const FloatSize& borderBoxSize) const override;
+    void apply(TransformationMatrix&, const FloatSize& borderBoxSize, ZoomFactor) const override;
 
     Ref<const TransformFunctionBase> blend(const TransformFunctionBase* from, const BlendingContext&, bool blendToIdentity = false) const override;
 
     void dump(WTF::TextStream&) const override;
 
 private:
-    TranslateTransformFunction(const LengthPercentage&, const LengthPercentage&, const Length&, TransformFunctionBase::Type);
+    TranslateTransformFunction(const X&, const Y&, const Z&, TransformFunctionBase::Type);
 
-    LengthPercentage m_x;
-    LengthPercentage m_y;
-    Length m_z;
+    X m_x;
+    Y m_y;
+    Z m_z;
 };
 
 } // namespace Style


### PR DESCRIPTION
#### 60695446c0bfd30ba8ee2d5bd86121f49fb1bf5e
<pre>
[EvaluationTimeZoom] Convert transform properties to evaluation time zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=309420">https://bugs.webkit.org/show_bug.cgi?id=309420</a>

Reviewed by Darin Adler and Antti Koivisto.

Converts the transform properties that handle lengths, `transform`, `translate`,
and `perspective`, including all `transform` functions, to evaluation time zoom.

To keep box reflection consistent, the reflection offset was also converted.

Tests: imported/w3c/web-platform-tests/css/css-viewport/zoom/perspective.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/perspective-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/transform-matrix-2d-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/transform-matrix-3d-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/transform-perspective-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/transform-translate-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/translate-ref.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-matrix-2d.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-matrix-3d.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-perspective.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-translate.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/translate.html
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/perspective-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/perspective.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/perspective-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/transform-matrix-2d-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/transform-matrix-3d-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/transform-perspective-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/transform-translate-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/translate-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-matrix-2d-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-matrix-2d.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-matrix-3d-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-matrix-3d.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-perspective-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-perspective.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-translate-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/transform-translate.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/translate-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/translate.html: Added.
* Source/WebCore/css/DOMMatrix.cpp:
* Source/WebCore/css/DOMMatrix.h:
* Source/WebCore/css/DOMMatrix.idl:
* Source/WebCore/css/DOMMatrixReadOnly.cpp:
* Source/WebCore/css/DOMMatrixReadOnly.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Transform.h:
* Source/WebCore/css/values/non-standard/CSSWebkitBoxReflect.h:
* Source/WebCore/dom/ViewTransition.cpp:
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.cpp:
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.h:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/style/StyleBuilderState.cpp:
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleCustomPropertyRegistry.cpp:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleTransformResolver.cpp:
* Source/WebCore/style/computed/StyleComputedStyle+GettersInlines.h:
* Source/WebCore/style/computed/StyleComputedStyle.h:
* Source/WebCore/style/values/non-standard/StyleWebKitBoxReflect.h:
* Source/WebCore/style/values/transforms/StylePerspective.cpp:
* Source/WebCore/style/values/transforms/StylePerspective.h:
* Source/WebCore/style/values/transforms/StyleRotate.cpp:
* Source/WebCore/style/values/transforms/StyleRotate.h:
* Source/WebCore/style/values/transforms/StyleScale.cpp:
* Source/WebCore/style/values/transforms/StyleScale.h:
* Source/WebCore/style/values/transforms/StyleTransform.cpp:
* Source/WebCore/style/values/transforms/StyleTransform.h:
* Source/WebCore/style/values/transforms/StyleTransformFunction.cpp:
* Source/WebCore/style/values/transforms/StyleTransformFunction.h:
* Source/WebCore/style/values/transforms/StyleTransformList.cpp:
* Source/WebCore/style/values/transforms/StyleTransformList.h:
* Source/WebCore/style/values/transforms/StyleTranslate.cpp:
* Source/WebCore/style/values/transforms/StyleTranslate.h:
* Source/WebCore/style/values/transforms/functions/StyleMatrix3DTransformFunction.cpp:
* Source/WebCore/style/values/transforms/functions/StyleMatrix3DTransformFunction.h:
* Source/WebCore/style/values/transforms/functions/StyleMatrixTransformFunction.cpp:
* Source/WebCore/style/values/transforms/functions/StyleMatrixTransformFunction.h:
* Source/WebCore/style/values/transforms/functions/StylePerspectiveTransformFunction.cpp:
* Source/WebCore/style/values/transforms/functions/StylePerspectiveTransformFunction.h:
* Source/WebCore/style/values/transforms/functions/StyleRotateTransformFunction.cpp:
* Source/WebCore/style/values/transforms/functions/StyleRotateTransformFunction.h:
* Source/WebCore/style/values/transforms/functions/StyleScaleTransformFunction.cpp:
* Source/WebCore/style/values/transforms/functions/StyleScaleTransformFunction.h:
* Source/WebCore/style/values/transforms/functions/StyleSkewTransformFunction.cpp:
* Source/WebCore/style/values/transforms/functions/StyleSkewTransformFunction.h:
* Source/WebCore/style/values/transforms/functions/StyleTransformFunctionBase.h:
* Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.cpp:
* Source/WebCore/style/values/transforms/functions/StyleTranslateTransformFunction.h:

Canonical link: <a href="https://commits.webkit.org/316631@main">https://commits.webkit.org/316631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36896ba67f5269f2ca0784fb0fef416625ca367a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172810 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/40193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/182268 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/130366 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/46404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134402 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94872 "22 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37796 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154962 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114873 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36443 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34758 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30867 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146860 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184801 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/37532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38960 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143198 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/46400 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143075 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38666 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47078 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/31298 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/held.https.any.sharedworker.html (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/112071 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38071 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118839 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45595 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/9409 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44995 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45227 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45054 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->