### PR TITLE
[Scroll anchoring] Fix anchoring in different writing modes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6319,16 +6319,8 @@ webkit.org/b/241104 fast/css/fill-available-with-percent-height-no-quirk.html [ 
 
 # scroll anchoring failures
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-inside-textarea.tentative.html [ Failure ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-updates-after-explicit-scroll.html [ Failure ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/clipped-scrollers-skipped.html [ Failure ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/device-pixel-adjustment.html [ Failure ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/history-restore-anchors.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/multicol-fragmented-anchor.html [ Failure ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/opt-out.html [ Failure ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic.html [ Failure ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html [ Pass Failure ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/start-edge-in-block-layout-direction.html [ Failure ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/nested-overflow-subtree-layout-vertical.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic.html [ Pass Failure ]
 fast/repaint/absolute-position-changed.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/307272 fast/events/no-scroll-on-input-text-selection.html [ Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-updates-after-explicit-scroll-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-updates-after-explicit-scroll-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Anchor node recomputed after an explicit scroll occurs. assert_equals: expected 200 but got 100
+PASS Anchor node recomputed after an explicit scroll occurs.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/clipped-scrollers-skipped-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/clipped-scrollers-skipped-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Anchor selection with nested scrollers. assert_equals: expected 300 but got 100
+PASS Anchor selection with nested scrollers.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/device-pixel-adjustment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/device-pixel-adjustment-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Test that scroll anchor adjustments can happen by a sub device-pixel amount. assert_equals: adjusting by 0.5px, 2 times, should be the same as adjusting by 1px, once. expected 11 but got 10
+PASS Test that scroll anchor adjustments can happen by a sub device-pixel amount.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/history-restore-anchors-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/history-restore-anchors-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Verify scroll anchoring interaction with history restoration assert_equals: expected 1100 but got 1000
+PASS Verify scroll anchoring interaction with history restoration
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/opt-out-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/opt-out-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Disabled on document, enabled on div. assert_equals: Scroll anchoring should apply to #scroller. expected 300 but got 100
-FAIL Enabled on document, disabled on div. assert_equals: Scroll anchoring should apply to the document scroller. expected 250 but got 100
+PASS Disabled on document, enabled on div.
+PASS Enabled on document, disabled on div.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/start-edge-in-block-layout-direction-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/start-edge-in-block-layout-direction-expected.txt
@@ -1,9 +1,13 @@
 
 
-FAIL Horizontal LTR. assert_equals: expected 150 but got 120
-FAIL Horizontal RTL. assert_equals: expected 130 but got 150
-FAIL Vertical-LR LTR. assert_equals: expected 120 but got 135
-FAIL Vertical-LR RTL. assert_equals: expected 120 but got 150
-FAIL Vertical-RL LTR. assert_equals: expected -120 but got -150
-FAIL Vertical-RL RTL. assert_equals: expected -120 but got -150
+PASS Horizontal LTR.
+PASS Horizontal RTL.
+PASS Vertical-LR LTR.
+PASS Vertical-LR RTL.
+PASS Vertical-RL LTR.
+PASS Vertical-RL RTL.
+PASS Sideways-LR LTR.
+PASS Sideways-LR RTL.
+PASS Sideways-RL LTR.
+PASS Sideways-RL RTL.
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7621,14 +7621,18 @@ imported/w3c/web-platform-tests/workers/SharedWorker_dataUrl.html [ Pass Failure
 # webkit.org/b/261919 NEW TEST(247465@main): [ macOS wk2 ] webanimations/frame-rate/animation-frame-rate-alignment-started-with-one-frame-separation.html is a flaky failure.
 webanimations/frame-rate/animation-frame-rate-alignment-started-with-one-frame-separation.html [ Pass Failure ]
 
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-containing-block-outside-scroller.html [ Pass Timeout ]
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/adjustments-in-scroll-event-handler.tentative.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-002.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/contenteditable-insert-line-at-top.tentative.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/dirty-contents-reselect-anchor.tentative.html [ Pass Failure ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/ignore-adjustments-while-scrolling-to-anchor.tentative.html [ Pass Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/history-restore-anchors.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html [ Failure ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/zero-scroll-offset-001.html [ Pass Failure ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/zero-scroll-offset-002.html [ Pass Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/zero-scroll-offset-001.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/zero-scroll-offset-002.html [ Failure ]
+
+webkit.org/b/309421 imported/w3c/web-platform-tests/css/css-scroll-anchoring/vertical-rl-viewport-size-change-000.html [ ImageOnlyFailure ]
+webkit.org/b/309421 imported/w3c/web-platform-tests/css/css-scroll-anchoring/vertical-rl-viewport-size-change-001.html [ ImageOnlyFailure ]
 
 # Requires user interaction.
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/fullscreen-crash.html [ Skip ]

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -62,6 +62,41 @@ ScrollAnchoringController::~ScrollAnchoringController()
     invalidate();
 }
 
+static bool hasScrolledFromOriginInBlockDirection(ScrollPosition scrollPosition, WritingMode writingMode)
+{
+    if (writingMode.isVertical())
+        return !!scrollPosition.x();
+
+    return !!scrollPosition.y();
+}
+
+static IntSize constrainedToBlockDirection(IntSize scrollDelta, WritingMode writingMode)
+{
+    if (writingMode.isVertical())
+        return { scrollDelta.width(), 0 };
+
+    return { 0, scrollDelta.height() };
+}
+
+static FloatPoint inlineAndBlockStartCorner(FloatRect box, WritingMode writingMode)
+{
+    switch (writingMode.blockDirection()) {
+    case FlowDirection::TopToBottom:
+        return writingMode.isInlineLeftToRight() ? box.location() : box.maxXMinYCorner();
+
+    case FlowDirection::BottomToTop:
+        return writingMode.isInlineLeftToRight() ? box.minXMaxYCorner() : box.maxXMaxYCorner();
+
+    case FlowDirection::LeftToRight:
+        return writingMode.isInlineTopToBottom() ? box.minXMinYCorner() : box.minXMaxYCorner();
+
+    case FlowDirection::RightToLeft:
+        return writingMode.isInlineTopToBottom() ? box.maxXMinYCorner() : box.maxXMaxYCorner();
+    }
+
+    return box.location();
+}
+
 bool ScrollAnchoringController::shouldMaintainScrollAnchor() const
 {
     CheckedPtr scrollerBox = scrollableAreaBox();
@@ -75,11 +110,7 @@ bool ScrollAnchoringController::shouldMaintainScrollAnchor() const
     if (scrollerBox->style().overflowAnchor() == OverflowAnchor::None)
         return false;
 
-    // FIXME: Writing modes: only check the block direction.
-    if (!m_owningScrollableArea->scrollOffset().y())
-        return false;
-
-    return true;
+    return hasScrolledFromOriginInBlockDirection(m_owningScrollableArea->scrollPosition(), scrollerBox->writingMode());
 }
 
 void ScrollAnchoringController::scrollPositionDidChange()
@@ -190,7 +221,6 @@ static FloatRect candidateLocalRectForAnchoring(RenderObject& renderer)
 
 auto ScrollAnchoringController::computeScrollerRelativeRects(RenderObject& candidate) const -> Rects
 {
-    // FIXME: This needs to handle writing modes and zooming.
     CheckedPtr scrollerBox = scrollableAreaBox();
     if (!scrollerBox)
         return { };
@@ -237,10 +267,17 @@ auto ScrollAnchoringController::computeScrollerRelativeRects(RenderObject& candi
     };
 }
 
-FloatPoint ScrollAnchoringController::computeOffsetFromOwningScroller(RenderObject& candidate) const
+// https://drafts.csswg.org/css-scroll-anchoring/#scroll-adjustment
+// ...of the block start edge of the anchor node’s scroll anchoring bounding rect,
+// relative to the block start edge of the scrolling content in the block flow direction of the scroller.
+FloatPoint ScrollAnchoringController::computeOffsetFromOwningScroller(RenderObject& candidate, RenderBox& scrollerBox) const
 {
     auto rects = computeScrollerRelativeRects(candidate);
-    return toFloatPoint(rects.boundsRelativeToScrolledContent.location() - rects.scrollerContentsVisibleRect.location());
+
+    auto candidateCorner = inlineAndBlockStartCorner(rects.boundsRelativeToScrolledContent, candidate.writingMode());
+    auto scrollerCorner = inlineAndBlockStartCorner(rects.scrollerContentsVisibleRect, scrollerBox.writingMode());
+
+    return toFloatPoint(candidateCorner - scrollerCorner);
 }
 
 void ScrollAnchoringController::notifyChildHadSuppressingStyleChange(RenderElement& renderer)
@@ -489,7 +526,7 @@ AnchorSearchStatus ScrollAnchoringController::findAnchorRecursive(RenderObject* 
 }
 
 // https://drafts.csswg.org/css-scroll-anchoring/#anchor-node-selection
-void ScrollAnchoringController::chooseAnchorElement(Document& document)
+void ScrollAnchoringController::chooseAnchorElement(Document& document, RenderBox& scrollerBox)
 {
     bool foundPriorityObject = findPriorityCandidate(document);
 
@@ -501,7 +538,7 @@ void ScrollAnchoringController::chooseAnchorElement(Document& document)
         return;
     }
 
-    m_lastAnchorOffset = computeOffsetFromOwningScroller(*m_anchorObject);
+    m_lastAnchorOffset = computeOffsetFromOwningScroller(*m_anchorObject, scrollerBox);
     LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::chooseAnchorElement() found anchor: " << *m_anchorObject << " offset: " << m_lastAnchorOffset);
 }
 
@@ -531,16 +568,15 @@ bool ScrollAnchoringController::anchoringSuppressedByStyleChange() const
 
 void ScrollAnchoringController::updateBeforeLayout()
 {
-    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this << " on " << *scrollableAreaBox() << " updateBeforeLayout() - scroll offset " << m_owningScrollableArea->scrollOffset() << " queued " << m_isQueuedForScrollPositionUpdate);
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this << " on " << *scrollableAreaBox() << " updateBeforeLayout() - scroll position " << m_owningScrollableArea->scrollPosition() << " queued " << m_isQueuedForScrollPositionUpdate);
 
     if (m_isQueuedForScrollPositionUpdate) {
         m_anchoringSuppressedByStyleChange |= anchoringSuppressedByStyleChange();
         return;
     }
 
-    auto scrollOffset = m_owningScrollableArea->scrollOffset();
-    // FIXME: Writing modes.
-    if (!scrollOffset.y()) {
+    CheckedPtr scrollerBox = scrollableAreaBox();
+    if (!hasScrolledFromOriginInBlockDirection(m_owningScrollableArea->scrollPosition(), scrollerBox->writingMode())) {
         clearAnchor();
         return;
     }
@@ -550,7 +586,7 @@ void ScrollAnchoringController::updateBeforeLayout()
         if (!document)
             return;
 
-        chooseAnchorElement(*document);
+        chooseAnchorElement(*document, *scrollerBox);
         if (!m_anchorObject) {
             LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this << " updateBeforeLayout() - did not find anchor");
             return;
@@ -589,14 +625,15 @@ void ScrollAnchoringController::adjustScrollPositionForAnchoring()
 
     SetForScope midUpdatingScrollPositionForAnchorElement(m_isUpdatingScrollPositionForAnchoring, true);
 
-    auto currentOffset = computeOffsetFromOwningScroller(*m_anchorObject);
+    CheckedPtr scrollerBox = scrollableAreaBox();
+
+    auto currentOffset = computeOffsetFromOwningScroller(*m_anchorObject, *scrollerBox);
     auto adjustment = currentOffset - m_lastAnchorOffset;
     if (adjustment.isZero())
         return;
 
     // FIXME: Handle content-visibility.
 
-    CheckedPtr scrollerBox = scrollableAreaBox();
     if (scrollerBox->isRenderView()) {
         auto pageScale = frameView().frame().frameScaleFactor();
         adjustment.scale(pageScale);
@@ -607,7 +644,7 @@ void ScrollAnchoringController::adjustScrollPositionForAnchoring()
         return;
 
     auto currentPosition = m_owningScrollableArea->scrollPosition();
-    auto newScrollPosition = currentPosition + roundedAdjustment;
+    auto newScrollPosition = currentPosition + constrainedToBlockDirection(roundedAdjustment, scrollerBox->writingMode());
     RELEASE_LOG(ScrollAnchoring, "ScrollAnchoringController::adjustScrollPositionForAnchoring() is main frame: %d, is main scroller: %d, adjusting from (%d, %d) to (%d, %d)",  frameView().frame().isMainFrame(), !m_owningScrollableArea->isRenderLayer(), currentPosition.x(), currentPosition.y(), newScrollPosition.x(), newScrollPosition.y());
     LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this << " adjustScrollPositionForAnchoring() for scroller element: " << ValueOrNull(scrollableAreaBox()) << " anchor: " << *m_anchorObject << " adjusting from " << currentPosition << " to " << newScrollPosition);
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -104,10 +104,10 @@ private:
 
     Rects computeScrollerRelativeRects(RenderObject&) const;
 
-    FloatPoint computeOffsetFromOwningScroller(RenderObject&) const;
+    FloatPoint computeOffsetFromOwningScroller(RenderObject&, RenderBox& scrollerBox) const;
 
     void invalidate();
-    void chooseAnchorElement(Document&);
+    void chooseAnchorElement(Document&, RenderBox& scrollerBox);
     bool anchoringSuppressedByStyleChange() const;
     void updateScrollableAreaRegistration();
 


### PR DESCRIPTION
#### 0155b492695bf89b082d19f991ebbe6e642c83f2
<pre>
[Scroll anchoring] Fix anchoring in different writing modes
<a href="https://bugs.webkit.org/show_bug.cgi?id=309422">https://bugs.webkit.org/show_bug.cgi?id=309422</a>
<a href="https://rdar.apple.com/171988494">rdar://171988494</a>

Reviewed by Alan Baradlay.

Scroll anchoring anchors in the block progression direction only, and anchors using the block start edge of the
anchor relative to the block start edge of the scrolled content. So fix
`ScrollAnchoringController::computeOffsetFromOwningScroller()` to compute using the appropriate corners.

We have to fix the &quot;has the scroller scrolled away from zero&quot; using scroll positions, and consulting the
appropriate axis, and ensure that we only adjust in the block progression axis.

This primarily fixes `css/css-scroll-anchoring/start-edge-in-block-layout-direction.html`. Clean up some
other expectations based on the current behavior.

[1] <a href="https://drafts.csswg.org/css-scroll-anchoring/#scroll-adjustment">https://drafts.csswg.org/css-scroll-anchoring/#scroll-adjustment</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-updates-after-explicit-scroll-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/clipped-scrollers-skipped-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/device-pixel-adjustment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/history-restore-anchors-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/opt-out-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/start-edge-in-block-layout-direction-expected.txt:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::hasScrolledFromOriginInBlockDirection):
(WebCore::constrainedToBlockDirection):
(WebCore::inlineAndBlockStartCorner):
(WebCore::ScrollAnchoringController::shouldMaintainScrollAnchor const):
(WebCore::ScrollAnchoringController::computeScrollerRelativeRects const):
(WebCore::ScrollAnchoringController::computeOffsetFromOwningScroller const):
(WebCore::ScrollAnchoringController::chooseAnchorElement):
(WebCore::ScrollAnchoringController::updateBeforeLayout):
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:

Canonical link: <a href="https://commits.webkit.org/308878@main">https://commits.webkit.org/308878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a7ae8ac35fb97fa58d124f27b041821425c9b38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148702 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157387 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102132 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/749d3f4f-03a7-4226-ad57-06068334f043) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21293 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114632 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81621 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f6f1712-0465-4d16-a166-841a453112de) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95402 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/09367480-cbfb-4f2b-9032-e0b60d481411) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15941 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13788 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4822 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159722 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2862 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122697 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21217 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17795 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122921 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33428 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21225 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133196 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77367 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18217 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9958 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20827 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84629 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20559 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20706 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20615 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->