### PR TITLE
Fix the internal iOS build on versions of the SDK with NSTextTable_Private.h

### DIFF
--- a/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
+++ b/Tools/TestRunnerShared/spi/UIKitSPIForTesting.h
@@ -556,12 +556,14 @@ typedef NS_ENUM(NSUInteger, _UIClickInteractionShouldBeginResult) {
 - (UITextInputArrowKeyHistory *)_moveToStartOfParagraph:(BOOL)extending withHistory:(UITextInputArrowKeyHistory *)history;
 @end
 
-#if __has_include(<UIKit/NSTextTable.h>)
-#import <UIKit/NSTextTable.h>
-#import <UIKit/NSParagraphStyle.h>
+#if __has_include(<UIKit/NSTextTable_Private.h>)
+#import <UIKit/NSTextTable_Private.h>
 #elif __has_include(<UIFoundation/NSTextTable.h>)
 #import <UIFoundation/NSTextTable.h>
-#else
+#define __UIKIT_HAS_NS_TEXT_TABLE_API__ 1
+#endif
+
+#if !defined(__UIKIT_HAS_NS_TEXT_TABLE_API__)
 
 typedef NS_ENUM(NSInteger, NSTextBlockLayer) {
     NSTextBlockLayerPadding  = -1,
@@ -590,7 +592,7 @@ typedef NS_ENUM(NSInteger, NSTextBlockLayer) {
 - (NSArray<NSTextBlock *> *)textBlocks;
 @end
 
-#endif // !__has_include(<UIFoundation/NSTextTable.h>)
+#endif // !defined(__UIKIT_HAS_NS_TEXT_TABLE_API__)
 
 @interface UIResponder (Internal)
 - (void)_share:(id)sender;


### PR DESCRIPTION
#### 631a95192ae76405dcc91655c8b5eb4fd92a0d75
<pre>
Fix the internal iOS build on versions of the SDK with NSTextTable_Private.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=309428">https://bugs.webkit.org/show_bug.cgi?id=309428</a>
<a href="https://rdar.apple.com/171870586">rdar://171870586</a>

Reviewed by Jonathan Bedard.

Fix the iOS build by pulling these symbols from internal SDK headers when possible, with a fallback
to forward declarations. This will keep the build passing in the following 3 configurations:

• The internal iOS SDK after the changes in <a href="https://rdar.apple.com/162691202">rdar://162691202</a>
• The internal iOS SDK before the changes in <a href="https://rdar.apple.com/162691202">rdar://162691202</a>
• The latest iOS 26 SDK

* Tools/TestRunnerShared/spi/UIKitSPIForTesting.h:

Canonical link: <a href="https://commits.webkit.org/308877@main">https://commits.webkit.org/308877@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68f05f44179cda521ce82fd1cc66482033f55d4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21425 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157397 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102142 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/41b0e1cf-9e33-4d77-b406-a87f972b7b46) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21877 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114640 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81630 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/200b035f-2264-4c18-ae8c-495059eacadc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16838 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133491 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95410 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c5e91bc6-b050-4cb0-a5f4-4b9f1f45ff39) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15950 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13797 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4832 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11411 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159732 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12933 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122705 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122929 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33427 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133205 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77385 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18225 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9967 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20837 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20569 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20716 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20625 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->