### PR TITLE
ResourceLoadStatisticsStore::hasStorageAccess drops completionHandler when domainID lookup fails.

### DIFF
--- a/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp
@@ -1675,8 +1675,10 @@ void ResourceLoadStatisticsStore::hasStorageAccess(SubFrameDomain&& subFrameDoma
     ASSERT(!RunLoop::isMain());
 
     auto result = ensureResourceStatisticsForRegistrableDomain(subFrameDomain, "hasStorageAccess"_s);
-    if (!result.second)
+    if (!result.second) {
+        completionHandler(false);
         return;
+    }
 
     switch (cookieAccess(subFrameDomain, topFrameDomain, canRequestStorageAccessWithoutUserInteraction)) {
     case CookieAccess::CannotRequest:
@@ -2511,7 +2513,7 @@ std::pair<ResourceLoadStatisticsStore::AddedRecord, std::optional<unsigned>> Res
         if (!scopedStatement
             || scopedStatement->bindText(1, domain.string()) != SQLITE_OK) {
             ITP_RELEASE_LOG_DATABASE_ERROR("ensureResourceStatisticsForRegistrableDomain: reason %" PUBLIC_LOG_STRING ", failed to bind parameter", reason.characters());
-            return { AddedRecord::No, 0 };
+            return { AddedRecord::No, std::nullopt };
         }
 
         if (scopedStatement->step() == SQLITE_ROW) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -2425,3 +2425,69 @@ TEST(ResourceLoadStatistics, StorageAccessGrantMultipleSubFrameDomains)
     EXPECT_FALSE(didSendSite2CookieHeader);
     didSendSite2CookieHeader = false;
 }
+
+// Verify that hasStorageAccess calls its completionHandler even when the ITP
+// database cannot be opened. Before the fix for rdar://171987676 the handler
+// was dropped, which caused the JS promise to never settle.
+TEST(ResourceLoadStatistics, HasStorageAccessWithDatabaseError)
+{
+    using namespace TestWebKitAPI;
+
+    // Create a temp directory where observations.db is itself a *directory*,
+    // which makes SQLiteDatabase::open() fail while the store object still
+    // gets created. This forces ensureResourceStatisticsForRegistrableDomain
+    // to return std::nullopt, exercising the error‐return path.
+    auto *defaultFileManager = [NSFileManager defaultManager];
+    NSURL *itpRootURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:@"HasStorageAccessWithDatabaseErrorTest"] isDirectory:YES];
+    [defaultFileManager removeItemAtPath:itpRootURL.path error:nil];
+    [defaultFileManager createDirectoryAtURL:[itpRootURL URLByAppendingPathComponent:@"observations.db"] withIntermediateDirectories:YES attributes:nil error:nil];
+
+    HTTPServer httpServer({
+        { "/"_s, { "<body></body>"_s } },
+        { "/has-access"_s, { "<body><script>document.hasStorageAccess().then((result) => alert(result ? 'true' : 'false'), (error) => alert('error'));</script></body>"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    storeConfiguration.get().httpsProxy = [NSURL URLWithString:[NSString stringWithFormat:@"https://127.0.0.1:%d/", httpServer.port()]];
+    storeConfiguration.get()._resourceLoadStatisticsDirectory = itpRootURL;
+
+    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    [dataStore _setResourceLoadStatisticsEnabled:YES];
+
+    // Wait for the ResourceLoadStatisticsStore to be created on the
+    // background queue. Without this synchronization point the store
+    // may still be null when hasStorageAccess is called, which would
+    // bypass the error path we want to exercise.
+    __block bool done = false;
+    [dataStore _clearResourceLoadStatistics:^(void) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setWebsiteDataStore:dataStore.get()];
+
+    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 100, 100) configuration:configuration.get()]);
+    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+    [webView setUIDelegate:uiDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://site1.example/"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    done = false;
+    [webView evaluateJavaScript:@"let iframe = document.createElement('iframe'); iframe.src = 'https://site2.example/has-access'; document.body.appendChild(iframe); true" completionHandler:^(id value, NSError *error) {
+        EXPECT_NULL(error);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    // Without the fix the completionHandler is dropped and this alert never
+    // arrives, causing the test to time out.
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], @"false");
+
+    [defaultFileManager removeItemAtPath:itpRootURL.path error:nil];
+}


### PR DESCRIPTION
#### 19e5a5c4f14d419285a898a62089a32546834b77
<pre>
ResourceLoadStatisticsStore::hasStorageAccess drops completionHandler when domainID lookup fails.
<a href="https://bugs.webkit.org/show_bug.cgi?id=309424">https://bugs.webkit.org/show_bug.cgi?id=309424</a>
<a href="https://rdar.apple.com/171987676">rdar://171987676</a>

Reviewed by Wenson Hsieh and Anne van Kesteren.

ResourceLoadStatisticsStore::hasStorageAccess() drops its completionHandler when
ensureResourceStatisticsForRegistrableDomain() returns std::nullopt, leaving the
document.hasStorageAccess() JS Promise permanently unresolved.

Fix two issues:

1. In hasStorageAccess(), call completionHandler(false) before the early return
   when ensureResourceStatisticsForRegistrableDomain() fails. This matches the
   pattern already used by requestStorageAccess() and grantStorageAccessInternal().

2. In ensureResourceStatisticsForRegistrableDomain(), the bind-failure error path
   returned { AddedRecord::No, 0 } instead of { AddedRecord::No, std::nullopt }.
   The implicit conversion from 0 to std::optional&lt;unsigned&gt;(0) masked the error
   — callers checking !result.second would see a &quot;valid&quot; domain ID of 0 rather
   than a failure. Change it to return std::nullopt for consistency with the other
   error paths in the same function.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
* Source/WebKit/NetworkProcess/Classifier/ResourceLoadStatisticsStore.cpp:
(WebKit::ResourceLoadStatisticsStore::hasStorageAccess):
(WebKit::ResourceLoadStatisticsStore::ensureResourceStatisticsForRegistrableDomain):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
(TEST(ResourceLoadStatistics, HasStorageAccessWithDatabaseError)):

Canonical link: <a href="https://commits.webkit.org/308880@main">https://commits.webkit.org/308880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d52066b8e67b859277093240357346ea2ca2a35c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14997 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157400 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102145 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a4f7058-3f85-411a-9c72-602afc402e7d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150588 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114643 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81633 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c350aa91-f12d-48fb-837b-d59ae5100c41) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133494 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95413 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6e382db-b6e6-490a-8623-16eb4bf93155) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15952 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13800 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4835 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125551 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159735 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2875 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122708 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122932 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33430 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21238 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133208 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77388 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18229 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9970 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20840 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84642 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20572 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20719 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20628 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->