### PR TITLE
WidthIterator::applyExtraSpacingAfterShaping: extract buildCharacterToGlyphMapping and applyHorizontalGlyphStretch

### DIFF
--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -599,52 +599,72 @@ void WidthIterator::applyAdditionalWidth(GlyphBuffer& glyphBuffer, GlyphIndexRan
     }
 }
 
-void WidthIterator::applyExtraSpacingAfterShaping(GlyphBuffer& glyphBuffer, unsigned characterStartIndex, unsigned glyphBufferStartIndex, unsigned characterDestinationIndex, float startingRunWidth)
+struct CharacterToGlyphMapping {
+    Vector<std::optional<GlyphIndexRange>> characterIndexToGlyphIndexRange;
+    Vector<float> advanceWidths;
+
+    CharacterToGlyphMapping(unsigned length)
+        : characterIndexToGlyphIndexRange(length, std::nullopt)
+        , advanceWidths(length, 0)
+    {
+    }
+};
+
+static CharacterToGlyphMapping buildCharacterToGlyphMapping(const GlyphBuffer& glyphBuffer, unsigned glyphBufferStartIndex, unsigned runLength)
 {
-    Vector<std::optional<GlyphIndexRange>> characterIndexToGlyphIndexRange(m_run->length(), std::nullopt);
-    Vector<float> advanceWidths(m_run->length(), 0);
-    for (unsigned i = glyphBufferStartIndex; i < glyphBuffer.size(); ++i) {
-        auto stringOffset = glyphBuffer.checkedStringOffsetAt(i, m_run->length());
+    CharacterToGlyphMapping mapping(runLength);
+    for (unsigned glyphIndex = glyphBufferStartIndex; glyphIndex < glyphBuffer.size(); ++glyphIndex) {
+        auto stringOffset = glyphBuffer.checkedStringOffsetAt(glyphIndex, runLength);
         if (!stringOffset)
             continue;
-        advanceWidths[stringOffset.value()] += width(glyphBuffer.advanceAt(i));
-        auto& glyphIndexRange = characterIndexToGlyphIndexRange[stringOffset.value()];
+        mapping.advanceWidths[stringOffset.value()] += width(glyphBuffer.advanceAt(glyphIndex));
+        auto& glyphIndexRange = mapping.characterIndexToGlyphIndexRange[stringOffset.value()];
         if (glyphIndexRange)
-            glyphIndexRange->trailingGlyphIndex = i;
+            glyphIndexRange->trailingGlyphIndex = glyphIndex;
         else
-            glyphIndexRange = {{i, i}};
+            glyphIndexRange = { { glyphIndex, glyphIndex } };
     }
+    return mapping;
+}
 
-    // SVG can stretch advances
-    if (m_run->horizontalGlyphStretch() != 1) {
-        for (unsigned i = glyphBufferStartIndex; i < glyphBuffer.size(); ++i) {
-            // All characters' advances get stretched, except apparently tab characters...
-            // This doesn't make much sense, because even tab characters get letter-spacing...
-            auto stringOffset = glyphBuffer.checkedStringOffsetAt(i, m_run->length());
-            if (stringOffset && m_run.get()[stringOffset.value()] == tabCharacter)
-                continue;
+static void applyHorizontalGlyphStretch(GlyphBuffer& glyphBuffer, unsigned glyphBufferStartIndex, const TextRun& run)
+{
+    if (run.horizontalGlyphStretch() == 1)
+        return;
 
-            auto currentAdvance = width(glyphBuffer.advanceAt(i));
-            auto newAdvance = currentAdvance * m_run->horizontalGlyphStretch();
-            glyphBuffer.expandAdvance(i, newAdvance - currentAdvance);
-        }
+    for (unsigned glyphIndex = glyphBufferStartIndex; glyphIndex < glyphBuffer.size(); ++glyphIndex) {
+        // All characters' advances get stretched, except apparently tab characters...
+        // This doesn't make much sense, because even tab characters get letter-spacing...
+        auto stringOffset = glyphBuffer.checkedStringOffsetAt(glyphIndex, run.length());
+        if (stringOffset && run[stringOffset.value()] == tabCharacter)
+            continue;
+
+        auto currentAdvance = width(glyphBuffer.advanceAt(glyphIndex));
+        auto newAdvance = currentAdvance * run.horizontalGlyphStretch();
+        glyphBuffer.expandAdvance(glyphIndex, newAdvance - currentAdvance);
     }
+}
+
+void WidthIterator::applyExtraSpacingAfterShaping(GlyphBuffer& glyphBuffer, unsigned characterStartIndex, unsigned glyphBufferStartIndex, unsigned characterDestinationIndex, float startingRunWidth)
+{
+    auto [characterIndexToGlyphIndexRange, advanceWidths] = buildCharacterToGlyphMapping(glyphBuffer, glyphBufferStartIndex, m_run->length());
+    applyHorizontalGlyphStretch(glyphBuffer, glyphBufferStartIndex, m_run);
 
     auto previousCharacterClass = m_run->textSpacingState().lastCharacterClassFromPreviousRun;
     float position = m_run->xPos() + startingRunWidth;
     auto textAutospace = m_fontCascade->textAutospace();
-    for (auto i = characterStartIndex; i < characterDestinationIndex; ++i) {
-        auto& glyphIndexRange = characterIndexToGlyphIndexRange[i];
+    for (auto characterIndex = characterStartIndex; characterIndex < characterDestinationIndex; ++characterIndex) {
+        auto& glyphIndexRange = characterIndexToGlyphIndexRange[characterIndex];
         if (!glyphIndexRange)
             continue;
 
-        auto width = calculateAdditionalWidth(glyphBuffer, i, glyphIndexRange->leadingGlyphIndex, glyphIndexRange->trailingGlyphIndex, position);
+        auto width = calculateAdditionalWidth(glyphBuffer, characterIndex, glyphIndexRange->leadingGlyphIndex, glyphIndexRange->trailingGlyphIndex, position);
         applyAdditionalWidth(glyphBuffer, glyphIndexRange.value(), width.left, width.right, width.leftExpansion, width.rightExpansion);
 
         auto textAutospaceSpacing = 0.f;
         auto characterClass = TextSpacing::CharacterClass::Undefined;
         if (!textAutospace.isNoAutospace()) {
-            characterClass = TextSpacing::characterClass(m_run.get()[i]);
+            characterClass = TextSpacing::characterClass(m_run.get()[characterIndex]);
             if (textAutospace.shouldApplySpacing(characterClass, previousCharacterClass)) {
                 textAutospaceSpacing = TextAutospace::textAutospaceSize(protect(glyphBuffer.fontAt(glyphIndexRange->leadingGlyphIndex)));
                 glyphBuffer.expandAdvanceToLogicalRight(glyphIndexRange->leadingGlyphIndex, textAutospaceSpacing);
@@ -667,7 +687,7 @@ void WidthIterator::applyExtraSpacingAfterShaping(GlyphBuffer& glyphBuffer, unsi
         // Also, even if we did the O(n^2) thing, there would still be cases that wouldn't be perfect
         // (because the fundamental concept of tabs isn't really compatible with complex text shaping),
         // so let's choose the fast-wrong approach here instead of the slow-wrong approach.
-        position += advanceWidths[i]
+        position += advanceWidths[characterIndex]
             + width.left
             + width.right
             + width.leftExpansion


### PR DESCRIPTION
#### 3575a7979008506c38cc0c629372147d09f62e92
<pre>
WidthIterator::applyExtraSpacingAfterShaping: extract buildCharacterToGlyphMapping and applyHorizontalGlyphStretch
<a href="https://bugs.webkit.org/show_bug.cgi?id=309431">https://bugs.webkit.org/show_bug.cgi?id=309431</a>
<a href="https://rdar.apple.com/172002254">rdar://172002254</a>

Reviewed by Sammy Gill.

This function is too long and hard to read. We can encapsulate parts of it
as it is doing different things at each phase. We can extract two of these
things into free functions:

- buildCharacterToGlyphMapping: builds the character-to-glyph index range
  mapping and per-character advance widths from the glyph buffer.
- applyHorizontalGlyphStretch: applies SVG horizontal glyph stretch to
  all non-tab glyph advances.

It should have no behavioral change, so no tests...

Since we are here we are also renaming indexes in these
functions that are called meaningness &apos;i&apos;.

Canonical link: <a href="https://commits.webkit.org/308945@main">https://commits.webkit.org/308945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a0ab962613d8cdfda025a0f8a0447d05020217e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157606 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/892a12da-63a5-4ea8-81db-727334a11b92) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21510 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114809 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3292bdb4-5d70-40e6-86b0-b730eb9cf46d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133661 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95560 "Found 1 new API test failure: WPE/TestWebKitWebContext:/webkit/WebKitWebContext/uri-scheme (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/344b124f-1db9-4ff8-93c0-645d9bb96c1c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16108 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13961 "Passed tests") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/5454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125710 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160088 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3079 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13104 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122855 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17976 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123084 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33466 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133376 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10138 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21044 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84846 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20776 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->