### PR TITLE
Drop default 'portrait' orientation from @page size serialization

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-page/page-rule-declarations-000.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-page/page-rule-declarations-000.html
@@ -8,6 +8,9 @@
 <script src="/resources/testharnessreport.js"></script>
 
 <style type="text/css">
+    :root {
+      print-color-adjust: exact;
+    }
 
     @page :visited { /* :visited is invalid for @page */
         color: red;
@@ -92,8 +95,8 @@
         "letter_page" : "size: letter;",
         "page_width_height" : "size: 10cm 15cm;",
         "page_size_orientation" : "size: ledger landscape;",
-        "page_orientation_size" : "size: a4 portrait;",
-        "page_jis_size_orientation" : "size: jis-b5 portrait;",
+        "page_orientation_size" : "size: a4;",
+        "page_jis_size_orientation" : "size: jis-b5;",
         "page_orientation_jis_size" : "size: jis-b4 landscape;",
         "err_empty_size" : "",
         "err_unknow_page_size" : "",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/size-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/size-valid-expected.txt
@@ -12,6 +12,6 @@ PASS size: b4
 PASS size: jis-b5
 PASS size: jis-b4
 PASS size: landscape
-FAIL size: letter assert_equals: for rule 12 expected "letter;" but got "letter portrait;"
+PASS size: letter
 PASS size: legal landscape
 

--- a/LayoutTests/printing/page-rule-css-text-expected.txt
+++ b/LayoutTests/printing/page-rule-css-text-expected.txt
@@ -10,7 +10,7 @@
 @page letter_page { size: letter; }
 @page page_widht_height { size: 10cm 15cm; }
 @page page_size_orientation { size: ledger landscape; }
-@page page_orientation_size { size: a4 portrait; }
+@page page_orientation_size { size: a4; }
 @page err_empty_size { }
 @page err_unknow_page_size { }
 @page err_length_and_page_size { }

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -62,6 +62,7 @@
 #include "CSSTokenizer.h"
 #include "CSSTransformListValue.h"
 #include "CSSURLValue.h"
+#include "CSSValuePair.h"
 #include "CSSVariableParser.h"
 #include "CSSVariableReferenceValue.h"
 #include "CSSWideKeyword.h"
@@ -805,6 +806,14 @@ bool consumePageDescriptor(CSSParserTokenRange& range, const CSSParserContext& c
     if (RefPtr parsedValue = CSSPropertyParsing::parsePageDescriptor(range, property, state)) {
         if (!range.atEnd())
             return false;
+
+        // Drop the default 'portrait' orientation from page size serialization.
+        if (property == CSSPropertySize) {
+            if (auto* pair = dynamicDowncast<CSSValuePair>(*parsedValue)) {
+                if (pair->second().valueID() == CSSValuePortrait)
+                    parsedValue = &pair->first();
+            }
+        }
 
         result.addProperty(state, property, CSSPropertyInvalid, WTF::move(parsedValue), IsImportant::No);
         return true;


### PR DESCRIPTION
#### 572055479070802c171adf120d7f7ed0db3b2f38
<pre>
Drop default &apos;portrait&apos; orientation from @page size serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=309432">https://bugs.webkit.org/show_bug.cgi?id=309432</a>
<a href="https://rdar.apple.com/172003889">rdar://172003889</a>

Reviewed by NOBODY (OOPS!).

This patches fixes serialization where the default &apos;portrait&apos; orientation keyword
would be omitted when serializing the @page &apos;size&apos; descriptor. When parsing returns
a CSSValuePair like &quot;letter portrait&quot;, we now strip the second value if it
is &apos;portrait&apos; since that is the default.

* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::consumePageDescriptor):
* LayoutTests/imported/w3c/web-platform-tests/css/css-page/parsing/size-valid-expected.txt: Progression
* LayoutTests/printing/page-rule-css-text-expected.txt:

&gt; Updated test as of <a href="https://github.com/web-platform-tests/wpt/commit/9c9679edcd05f5e75c5b93c0ad8d90f8359bb98b">https://github.com/web-platform-tests/wpt/commit/9c9679edcd05f5e75c5b93c0ad8d90f8359bb98b</a>
* LayoutTests/imported/w3c/web-platform-tests/css/css-page/page-rule-declarations-000.html: To match new behavior
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/572055479070802c171adf120d7f7ed0db3b2f38

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15005 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102153 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21314 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114649 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81642 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133502 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95419 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15961 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13808 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4843 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125560 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11422 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159743 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2883 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12944 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122714 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122938 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21246 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133216 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77399 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18236 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9978 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20848 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84650 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20580 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20727 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20636 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->