### PR TITLE
[iOS/visionOS] WebKit should manage the appearance of `UIRefreshControl`s attached to WKScrollView

### DIFF
--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -139,6 +139,7 @@ enum class SDKAlignedBehavior {
     SuppressKeypressForModifierShortcuts,
     ScrollColorExtensionGrowsDuringRubberBanding,
     DocumentBackgroundColorFromCanvas,
+    ManagedRefreshControlAppearance,
 
     NumberOfBehaviors
 };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3241,8 +3241,12 @@ WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::FixedContai
     UNUSED_VARIABLE(isTopFixedEdgeChanging);
 #endif
 
-    if (isTopColorChanging)
+    if (isTopColorChanging) {
         [self didChangeValueForKey:RetainPtr { NSStringFromSelector(@selector(_sampledTopFixedPositionContentColor)) }.get()];
+#if ENABLE(MANAGED_UIREFRESHCONTROL_APPEARANCE)
+        [self _updateRefreshControlAppearance];
+#endif
+    }
 }
 
 #if ENABLE(PDF_PAGE_NUMBER_INDICATOR)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -660,6 +660,10 @@ struct PerWebProcessState {
 #endif
 #endif
 
+#if ENABLE(MANAGED_UIREFRESHCONTROL_APPEARANCE)
+- (void)_updateRefreshControlAppearance;
+#endif
+
 - (void)_updateFixedContainerEdges:(const WebCore::FixedContainerEdges&)edges;
 - (void)_updateScrollGeometryWithContentOffset:(CGPoint)contentOffset contentSize:(CGSize)contentSize;
 

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -93,6 +93,9 @@ void PageClientImplCocoa::underPageBackgroundColorDidChange()
 #if ENABLE(CONTENT_INSET_BACKGROUND_FILL)
     [webView _updateTopScrollPocketCaptureColor];
 #endif
+#if ENABLE(MANAGED_UIREFRESHCONTROL_APPEARANCE)
+    [webView _updateRefreshControlAppearance];
+#endif
 }
 
 void PageClientImplCocoa::sampledPageTopColorWillChange()

--- a/Source/WebKit/UIProcess/ios/WKScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKScrollView.mm
@@ -276,11 +276,16 @@ static BOOL shouldForwardScrollViewDelegateMethodToExternalDelegate(SEL selector
 
     super.backgroundColor = backgroundColor;
 
+    RetainPtr internalDelegate = _internalDelegate.get();
     if (!_backgroundColorSetByClient) {
-        RetainPtr internalDelegate = _internalDelegate.get();
         [internalDelegate _resetCachedScrollViewBackgroundColor];
         [internalDelegate _updateScrollViewBackground];
     }
+
+#if ENABLE(MANAGED_UIREFRESHCONTROL_APPEARANCE)
+    if (self.refreshControl)
+        [internalDelegate _updateRefreshControlAppearance];
+#endif
 }
 
 - (void)_setBackgroundColorInternal:(UIColor *)backgroundColor
@@ -290,7 +295,13 @@ static BOOL shouldForwardScrollViewDelegateMethodToExternalDelegate(SEL selector
 
     super.backgroundColor = backgroundColor;
 
-    [_internalDelegate.get() _resetCachedScrollViewBackgroundColor];
+    RetainPtr internalDelegate = _internalDelegate.get();
+    [internalDelegate _resetCachedScrollViewBackgroundColor];
+
+#if ENABLE(MANAGED_UIREFRESHCONTROL_APPEARANCE)
+    if (self.refreshControl)
+        [internalDelegate _updateRefreshControlAppearance];
+#endif
 }
 
 - (void)setIndicatorStyle:(UIScrollViewIndicatorStyle)indicatorStyle
@@ -420,6 +431,14 @@ static inline bool valuesAreWithinOnePixel(CGFloat a, CGFloat b)
         adjustedOffset.y = -edgeInsets.top + rubberbandAmount.height;
 
     [self setContentOffset:adjustedOffset];
+}
+
+- (void)setRefreshControl:(UIRefreshControl *)refreshControl
+{
+    [super setRefreshControl:refreshControl];
+#if ENABLE(MANAGED_UIREFRESHCONTROL_APPEARANCE)
+    [self.internalDelegate _updateRefreshControlAppearance];
+#endif
 }
 
 - (void)_setContentSizePreservingContentOffsetDuringRubberband:(CGSize)contentSize

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm
@@ -43,6 +43,10 @@
 #import "IOSMouseEventTestHarness.h"
 #endif
 
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/SampledPageTopColorAdditionsBefore.mm>
+#endif
+
 #define EXPECT_IN_RANGE(actual, min, max) \
     EXPECT_GE(actual, min); \
     EXPECT_LE(actual, max);
@@ -132,6 +136,10 @@ static String createHTMLGradientWithColorStops(String&& direction, Vector<String
     gradientBuilder.append(")\">Test"_s);
     return gradientBuilder.toString();
 }
+
+#if USE(APPLE_INTERNAL_SDK)
+#import <WebKitAdditions/SampledPageTopColorAdditionsAfter.mm>
+#endif
 
 TEST(SampledPageTopColor, ZeroMaxDifference)
 {


### PR DESCRIPTION
#### d9fcbdfe5170eef3c5b3b9e928519ba4820399fe
<pre>
[iOS/visionOS] WebKit should manage the appearance of `UIRefreshControl`s attached to WKScrollView
<a href="https://bugs.webkit.org/show_bug.cgi?id=309439">https://bugs.webkit.org/show_bug.cgi?id=309439</a>
<a href="https://rdar.apple.com/172010803">rdar://172010803</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

WebKit will now update the user interface style of any UIRefreshControl
attached to a WKScrollView. The determination of whether to use the light
or dark style is based upon the brightness of the color displayed underneath
the control (which will either be the sampled fixed position content color,
underPageBackgroundColor, or the background color of the scroll view).

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _updateFixedContainerEdges:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm:
(WebKit::PageClientImplCocoa::underPageBackgroundColorDidChange):
* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView setBackgroundColor:]):
(-[WKScrollView _setBackgroundColorInternal:]):
(-[WKScrollView setRefreshControl:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SampledPageTopColor.mm:

Canonical link: <a href="https://commits.webkit.org/309632@main">https://commits.webkit.org/309632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fd0f93aaac942dcccb1d36299779ea035b9d600

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150787 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159509 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104221 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23751 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116382 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82640 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/734df8a8-dd7b-4595-993e-c43deb2a9c03) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135274 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97110 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96ce0cc8-0bbf-4cec-8014-f9fe18a7af7d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17589 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15541 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7357 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142770 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127203 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161983 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11585 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5104 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14755 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124382 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124580 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134993 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79724 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23241 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19651 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11755 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182311 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22949 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86749 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46582 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22661 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22813 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22715 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->