### PR TITLE
Fixes for latest SDK

### DIFF
--- a/Source/WebKit/UIProcess/StdlibExtras.swift
+++ b/Source/WebKit/UIProcess/StdlibExtras.swift
@@ -63,11 +63,10 @@ extension WTF.String {
         // Safety - we are guaranteed to get a valid buffer from the Swift
         // string for the duration that we're using it to construct the WTF::String.
         // The WTF::String will take a copy.
-        let span = string.utf8CString.span
-        self = unsafe span.withUnsafeBufferPointer { ptr in
+        self = unsafe string.utf8CString.span.withUnsafeBufferPointer { ptr in
             // Warning here is rdar://163018821
             // swift-format-ignore: NeverForceUnwrap
-            let cppspan = unsafe SpanConstChar(ptr.baseAddress!, span.count)
+            let cppspan = unsafe SpanConstChar(ptr.baseAddress!, string.utf8CString.count)
             return unsafe WTF.String.fromUTF8(cppspan)
         }
     }

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -69,19 +69,6 @@ extension WebKit.WebBackForwardListItem {
     }
 }
 
-extension WebKit.WebBackForwardListFrameItem {
-    private borrowing func getFrameState() -> WebKit.FrameState {
-        // Safety: FrameState is a SWIFT_SHARED_REFERENCE so this will
-        // result in a reference count increment and no lifetime risk.
-        // FIXME(rdar://168057355): remove this.
-        unsafe __frameStateUnsafe()
-    }
-
-    var frameState: WebKit.FrameState {
-        getFrameState()
-    }
-}
-
 // Some of these utility functions would be better in WebBackForwardListSwiftUtilities.h
 // but can't be put there as we are unable to use swift::Array and swift::String
 // rdar://161270632
@@ -718,7 +705,7 @@ final class WebBackForwardList {
         guard let childFrameItem = parentFrameItem.childItemAtIndex(childFrameIndex) else {
             return nil
         }
-        return childFrameItem.frameState
+        return childFrameItem.frameState()
     }
 
     func loggingString() -> Swift.String {


### PR DESCRIPTION
#### e16e2b50c5ea6d56d0308948a20bad0c074bdfeb
<pre>
Fixes for latest SDK
<a href="https://bugs.webkit.org/show_bug.cgi?id=309444">https://bugs.webkit.org/show_bug.cgi?id=309444</a>
<a href="https://rdar.apple.com/172014821">rdar://172014821</a>

Reviewed by Richard Robinson.

Fix two incompatibilities between the latest Swift compiler and the Swift
WebBackForwardList. One of these is a new lifetime error, easily fixed; the
other is the replacement of the method __frameStateUnsafe with plain old
frameState which is a positive safety improvement.

Canonical link: <a href="https://commits.webkit.org/308903@main">https://commits.webkit.org/308903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea7ef0a83366ff697e8a1757771adba3f7378b32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148739 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157424 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102169 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6ace5ac-eead-4306-b6d5-f2cd815f37b1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21904 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21330 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114665 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81654 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01dd2037-1d9c-41fe-b9c1-1502168cf85b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151699 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133517 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95435 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/370fa535-1ca7-442c-8e3b-b7d8cc357709) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15976 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13823 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4859 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125575 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159760 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2899 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12959 "Found 1 new test failure: fast/attachment/mac/wide-attachment-image-controls-basic.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122730 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17832 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122954 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33443 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21262 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133231 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77425 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18251 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9993 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20864 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84666 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20596 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20743 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20652 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->