### PR TITLE
Adopt queueTaskKeepingNodeAlive() in Document & Element for obvious cases

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2589,22 +2589,19 @@ void Document::unregisterForVisibilityStateChangedCallbacks(VisibilityChangeClie
 
 void Document::visibilityStateChanged()
 {
-    bool pageIsVisible = page() && page()->isVisible();
-
     // https://w3c.github.io/page-visibility/#reacting-to-visibilitychange-changes
-    if (!pageIsVisible)
+    if (bool pageIsVisible = page() && page()->isVisible(); !pageIsVisible)
         m_deferResizeEventForVisibilityChange = true;
 
-    eventLoop().queueTask(TaskSource::UserInteraction, [this, protectedDocument = Ref { *this }] {
-        dispatchEvent(Event::create(eventNames().visibilitychangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
+    queueTaskKeepingNodeAlive(*this, TaskSource::UserInteraction, [](auto& document) {
+        document.dispatchEvent(Event::create(eventNames().visibilitychangeEvent, Event::CanBubble::Yes, Event::IsCancelable::No));
 
-        bool pageIsVisible = page() && page()->isVisible();
-        if (!pageIsVisible)
+        if (bool pageIsVisible = document.page() && document.page()->isVisible(); !pageIsVisible)
             return;
 
-        m_deferResizeEventForVisibilityChange = false;
-        if (m_needsDOMWindowResizeEvent || m_needsVisualViewportResizeEvent)
-            scheduleRenderingUpdate(RenderingUpdateStep::Resize);
+        document.m_deferResizeEventForVisibilityChange = false;
+        if (document.m_needsDOMWindowResizeEvent || document.m_needsVisualViewportResizeEvent)
+            document.scheduleRenderingUpdate(RenderingUpdateStep::Resize);
     });
 
     m_visibilityStateCallbackClients.forEach([](auto& client) {
@@ -7031,8 +7028,8 @@ void Document::whenWindowLoadEventOrDestroyed(CompletionHandler<void()>&& comple
 
 void Document::queueTaskToDispatchEvent(TaskSource source, Ref<Event>&& event)
 {
-    eventLoop().queueTask(source, [document = Ref { *this }, event = WTF::move(event)] {
-        document->dispatchEvent(event);
+    queueTaskKeepingNodeAlive(*this, source, [event = WTF::move(event)](auto& document) {
+        document.dispatchEvent(event);
     });
 }
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -61,7 +61,6 @@
 #include "ElementTextDirection.h"
 #include "EventDispatcher.h"
 #include "EventHandler.h"
-#include "EventLoop.h"
 #include "EventNames.h"
 #include "FocusController.h"
 #include "FocusEvent.h"
@@ -4319,10 +4318,10 @@ void Element::dispatchBlurEvent(RefPtr<Element>&& newFocusedElement)
 
 void Element::enqueueFocusedElementDisconnectedEvent()
 {
-    document().eventLoop().queueTask(TaskSource::DOMManipulation, [element = GCReachableRef { *this }] {
-        Ref event = FocusEvent::create(eventNames().webkitfocusedelementdisconnectedEvent, Event::CanBubble::No, Event::IsCancelable::No, element->document().windowProxy(), 0, nullptr);
+    queueTaskKeepingNodeAlive(*this, TaskSource::DOMManipulation, [](auto& element) {
+        Ref event = FocusEvent::create(eventNames().webkitfocusedelementdisconnectedEvent, Event::CanBubble::No, Event::IsCancelable::No, element.document().windowProxy(), 0, nullptr);
         event->setIsAutofillEvent();
-        element->dispatchEvent(event);
+        element.dispatchEvent(event);
     });
 }
 
@@ -4354,11 +4353,11 @@ bool Element::dispatchMouseForceWillBegin()
 
 void Element::enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventInit&& eventInit)
 {
-    document().eventLoop().queueTask(TaskSource::DOMManipulation, [this, protectedThis = Ref { *this }, event = SecurityPolicyViolationEvent::create(eventNames().securitypolicyviolationEvent, WTF::move(eventInit), Event::IsTrusted::Yes)] {
-        if (!isConnected())
-            protect(document())->dispatchEvent(event);
+    queueTaskKeepingNodeAlive(*this, TaskSource::DOMManipulation, [event = SecurityPolicyViolationEvent::create(eventNames().securitypolicyviolationEvent, WTF::move(eventInit), Event::IsTrusted::Yes)](auto& element) {
+        if (!element.isConnected())
+            protect(element.document())->dispatchEvent(event);
         else
-            dispatchEvent(event);
+            element.dispatchEvent(event);
     });
 }
 

--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -278,6 +278,7 @@ inline void collectChildNodes(Node& node, NodeVector& children)
 template<typename T, typename Task>
 void Node::queueTaskKeepingNodeAlive(T& node, TaskSource source, Task&& task)
 {
+    static_assert(!std::is_base_of_v<ActiveDOMObject, T>, "Use ActiveDOMObject::queueTaskKeepingObjectAlive instead");
     protect(protect(node.document())->eventLoop())->queueTask(source, [protectedThis = GCReachableRef(node), task = std::forward<Task>(task)]() mutable {
         // Static analyzer does not know about GCReachableRef.
         SUPPRESS_UNCOUNTED_ARG task(protectedThis.get());


### PR DESCRIPTION
#### d96baae2fc0eace2d90af8fb65693ec776b03058
<pre>
Adopt queueTaskKeepingNodeAlive() in Document &amp; Element for obvious cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=309445">https://bugs.webkit.org/show_bug.cgi?id=309445</a>

Reviewed by Ryosuke Niwa.

Either we were already using GCReachableRef in which case it&apos;s
equivalent or an event is being dispatched in which case it&apos;s clear we
are supposed to prevent JS wrapper collection.

Document still has a number of other cases that are more involved that
are left for future cleanup.

We also add a static assert to queueTaskKeepingNodeAlive() to redirect
ActiveDOMObject objects to use queueTaskKeepingObjectAlive() instead.
(Relevant for HTMLScriptElement for instance.)

Canonical link: <a href="https://commits.webkit.org/308892@main">https://commits.webkit.org/308892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af4cd82cd6e92c97da36ca8d3f893ef4624958e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148740 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15022 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157425 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102170 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/62138f4a-d7b5-40bf-8716-cfc8073e8b1e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150613 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114666 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81655 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd717220-6c89-4fb9-b982-64562ecfc34e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133518 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95436 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c40df73-b023-4618-a7af-f06c016926e7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15977 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13824 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4860 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125576 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159761 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2900 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12960 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122731 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17833 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122955 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133232 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77424 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22919 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18252 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9994 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20865 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84667 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20597 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20744 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20653 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->