### PR TITLE
Table layout incorrectly merges column tracks defined by COL elements with span

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/column-track-merging-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/column-track-merging-expected.txt
@@ -104,47 +104,8 @@ PASS main table 6
 PASS main table 7
 PASS main table 8
 PASS main table 9
-FAIL main table 10 assert_equals:
-<table id="col_fixed_130" style="table-layout:fixed; width: 130px" data-expected-width="340">
-<colgroup><col span="10">
-</colgroup><caption>fixed 130px</caption>
-<tbody><tr>
-  <td data-expected-width="50"></td>
-  <td></td>
-</tr>
-<tr>
-  <td></td>
-  <td></td>
-</tr>
-</tbody></table>
-width expected 340 but got 200
-FAIL main table 11 assert_equals:
-<table id="col_auto" data-expected-width="580">
-<caption>auto col 30px</caption>
-<colgroup><col span="10" style="width:30px">
-</colgroup><tbody><tr>
-  <td data-expected-width="50"></td>
-  <td></td>
-</tr>
-<tr>
-  <td></td>
-  <td></td>
-</tr>
-</tbody></table>
-width expected 580 but got 180
-FAIL main table 12 assert_equals:
-<table id="col_auto" data-expected-width="640">
-<caption>auto col 10%</caption>
-<colgroup><col span="5" style="width:10%">
-</colgroup><tbody><tr>
-  <td data-expected-width="100"></td>
-  <td></td>
-</tr>
-<tr>
-  <td></td>
-  <td></td>
-</tr>
-</tbody></table>
-width expected 640 but got 580
+PASS main table 10
+PASS main table 11
+PASS main table 12
 PASS main table 13
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/html5-table-formatting-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/html5-table-formatting-1-expected.txt
@@ -24,7 +24,7 @@ The table grid is 2x1, so the table is not empty and follows step 3A of the tabl
 PASS Empty tables can still get a lsyout
 PASS Empty tables do not take table-columns into account
 FAIL Empty tables do not take table-rows into account assert_equals: expected 50 but got 100
-FAIL Table-columns are taken into account after missing cells are generated (empty line) assert_equals: expected 200 but got 100
-FAIL Table-columns are taken into account after missing cells are generated (partially empty line) assert_equals: expected 200 but got 100
+PASS Table-columns are taken into account after missing cells are generated (empty line)
+PASS Table-columns are taken into account after missing cells are generated (partially empty line)
 PASS Table-columns are taken into account after missing cells are generated (non-empty line)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/html5-table-formatting-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/html5-table-formatting-2-expected.txt
@@ -43,9 +43,9 @@ The consecutive tracks are not merged together because they are all defined expl
 Three 25px border-spacing causes the addition of 75px
 
 
-FAIL Explicitely defined columns are not merged assert_equals: expected 100 but got 50
+PASS Explicitely defined columns are not merged
 PASS Explicitely defined rows are not merged
-FAIL Border-spacing is added between any two unmerged columns (1) assert_equals: expected 175 but got 100
+PASS Border-spacing is added between any two unmerged columns (1)
 PASS Border-spacing is added between any two unmerged rows (1)
 PASS Border-spacing is added between any two unmerged columns (2)
 PASS Border-spacing is added between any two unmerged rows (2)
@@ -53,6 +53,6 @@ PASS Border-spacing is added between any two unmerged columns (3)
 PASS Border-spacing is added between any two unmerged rows (3)
 PASS Border-spacing is added between any two unmerged columns (4)
 PASS Border-spacing is added between any two unmerged rows (4)
-FAIL Border-spacing is added between any two unmerged columns (5) assert_equals: expected 175 but got 100
+PASS Border-spacing is added between any two unmerged columns (5)
 PASS Border-spacing is added between any two unmerged rows (5)
 

--- a/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug47163-expected.txt
+++ b/LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug47163-expected.txt
@@ -13,8 +13,8 @@ layer at (0,0) size 800x84
         RenderTableSection {TBODY} at (0,0) size 784x68
           RenderTableRow {TR} at (0,0) size 784x68
             RenderTableCell {TD} at (0,34) size 26x0 [r=0 c=0 rs=1 cs=1]
-            RenderTableCell {TD} at (26,0) size 758x68 [r=0 c=1 rs=1 cs=2]
-              RenderBlock {P} at (0,16) size 758x36
+            RenderTableCell {TD} at (26,0) size 732x68 [r=0 c=1 rs=1 cs=2]
+              RenderBlock {P} at (0,16) size 732x36
                 RenderText {#text} at (0,0) size 715x36
                   text run at (0,0) width 715: "Nach der Pruefung der Daten, (Normalerweise benoetigen wir f\x{FC}r die Pruefung nur wenige Minuten, aber wenn"
                   text run at (0,18) width 447: "einmal besonders viel los ist, kann es auch ein wenig laenger dauern.)"

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -173,6 +173,7 @@ void AutoTableLayout::fullRecalc()
 
     Style::PreferredSize groupLogicalWidth = CSS::Keyword::Auto { };
     unsigned currentColumn = 0;
+    bool tableHasCells = m_table->topNonEmptySection() != nullptr;
     for (RenderTableCol* column = m_table->firstColumn(); column; column = column->nextColumn()) {
         if (column->isTableColumnGroupWithColumnChildren())
             groupLogicalWidth = column->style().logicalWidth();
@@ -186,9 +187,20 @@ void AutoTableLayout::fullRecalc()
             unsigned span = column->span();
 
             // Apply width to all columns covered by this col element.
+            // When a COL element with specified width has a span that exceeds
+            // existing effective columns, create individual columns for the extras.
+            // Only do this when the table has cells; empty tables should not
+            // take COL-defined columns into account per the spec.
             if (!colLogicalWidth.isAuto()) {
                 for (unsigned spanOffset = 0; spanOffset < span; ++spanOffset) {
                     unsigned effCol = m_table->colToEffCol(currentColumn + spanOffset);
+                    if (effCol >= nEffCols && tableHasCells) {
+                        m_table->appendColumn(1);
+                        nEffCols = m_table->numEffCols();
+                        m_layoutStruct.resizeToFit(nEffCols);
+                        m_layoutStruct[nEffCols - 1] = Layout();
+                        effCol = nEffCols - 1;
+                    }
                     if (effCol < nEffCols && m_table->spanOfEffCol(effCol) == 1) {
                         m_layoutStruct[effCol].usedZoom = column->style().usedZoom();
                         m_layoutStruct[effCol].logicalWidth = colLogicalWidth;
@@ -204,6 +216,9 @@ void AutoTableLayout::fullRecalc()
         if (column->isTableColumn() && !column->nextSibling())
             groupLogicalWidth = CSS::Keyword::Auto { };
     }
+
+    nEffCols = m_table->numEffCols();
+    m_layoutStruct.resizeToFit(nEffCols);
 
     for (unsigned i = 0; i < nEffCols; i++)
         recalcColumn(i);

--- a/Source/WebCore/rendering/FixedTableLayout.cpp
+++ b/Source/WebCore/rendering/FixedTableLayout.cpp
@@ -110,10 +110,11 @@ float FixedTableLayout::calcWidthArray()
         while (span) {
             unsigned spanInCurrentEffectiveColumn;
             if (currentEffectiveColumn >= nEffCols) {
-                m_table->appendColumn(span);
+                // Create individual columns for proper border spacing.
+                m_table->appendColumn(1);
                 nEffCols++;
                 m_width.append(CSS::Keyword::Auto { });
-                spanInCurrentEffectiveColumn = span;
+                spanInCurrentEffectiveColumn = 1;
             } else {
                 if (span < m_table->spanOfEffCol(currentEffectiveColumn)) {
                     m_table->splitColumn(currentEffectiveColumn, span);


### PR DESCRIPTION
#### 6a4981301ad3c71883f520f7ef5af523d351aea6
<pre>
Table layout incorrectly merges column tracks defined by COL elements with span
<a href="https://bugs.webkit.org/show_bug.cgi?id=309447">https://bugs.webkit.org/show_bug.cgi?id=309447</a>
<a href="https://rdar.apple.com/172018557">rdar://172018557</a>

Reviewed by NOBODY (OOPS!).

When a &lt;col span=N&gt; element defines columns beyond those established by
table cells, both fixed and auto table layout algorithms would create a
single effective column with span=N instead of N individual columns.

This merging is incorrect when the COL has a specified width because each
column track should be an independent column that contributes its own
border-spacing. Consider:

    &lt;table style=&quot;border-spacing:20px&quot;&gt;
      &lt;col span=10 style=&quot;width:30px&quot;&gt;
      &lt;tr&gt;&lt;td&gt;&lt;/td&gt;&lt;td&gt;&lt;/td&gt;&lt;/tr&gt;
    &lt;/table&gt;

    Before (wrong):
      ┌──────────────────────────────────────────┐
      │ effCol[0]  │ effCol[1]  │ effCol[2]      │
      │ span=1     │ span=1     │ span=8 (merged)│
      │ 2 border-spacings → narrower table       │
      └──────────────────────────────────────────┘

    After (correct):
      ┌──────────────────────────────────────────────────────┐
      │ effCol[0] │ effCol[1] │ effCol[2] │ ... │ effCol[9]  │
      │ span=1    │ span=1    │ span=1    │     │ span=1     │
      │ 9 border-spacings → wider table as expected          │
      └──────────────────────────────────────────────────────┘

The two cells in &lt;tr&gt; establish the first two effective columns (each
with span=1). The remaining 8 columns from &lt;col span=10&gt; were appended
as one merged effective column with span=8, causing only 2 border-
spacings instead of the correct 9.

Fixed layout fix: In FixedTableLayout::calcWidthArray(), when a COL
element&apos;s span exceeds existing effective columns, create one column at
a time via appendColumn(1) instead of appendColumn(remainingSpan). The
existing while loop already decrements the remaining span, so this
naturally produces individual columns.

Auto layout fix: In AutoTableLayout::fullRecalc(), when a COL element
with specified width references columns beyond those created by cells,
create individual effective columns for the excess. This is guarded by
checking that the table has cells (topNonEmptySection), since per spec
empty tables should not take COL-defined columns into account.

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/column-track-merging-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/html5-table-formatting-1-expected.txt: Ditto
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/html5-table-formatting-2-expected.txt: Ditto
* LayoutTests/platform/mac/tables/mozilla_expected_failures/bugs/bug47163-expected.txt: Rebaseline
* Source/WebCore/rendering/AutoTableLayout.cpp:
(WebCore::AutoTableLayout::fullRecalc):
* Source/WebCore/rendering/FixedTableLayout.cpp:
(WebCore::FixedTableLayout::calcWidthArray):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a4981301ad3c71883f520f7ef5af523d351aea6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157429 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102174 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/09be04d6-3967-4a1c-8c29-f1bf5f32043d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21335 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114669 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-tables/table_grid_size_col_colspan.html tables/mozilla_expected_failures/bugs/bug47163.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81658 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e0ca9b76-da01-4e06-a1fd-fe718558512b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151704 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16869 "Found 1 new test failure: tables/mozilla_expected_failures/bugs/bug47163.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133523 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95439 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/308f9953-f57f-4485-9352-bea571366b3a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15981 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13827 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4864 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125580 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159765 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2904 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12965 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-tables/table_grid_size_col_colspan.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122734 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-tables/table_grid_size_col_colspan.html tables/mozilla_expected_failures/bugs/bug47163.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21259 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17836 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-tables/table_grid_size_col_colspan.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122958 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21267 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133237 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77431 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18257 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9999 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-tables/table_grid_size_col_colspan.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20869 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84671 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20601 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20748 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20657 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->