### PR TITLE
Use regular ref-counting for CachedResource

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -486,7 +486,7 @@ static void imageBytesForSource(WebGPU::Queue& backing, const GPUImageCopyExtern
         },
         [&]([[maybe_unused]] const Ref<HTMLImageElement>& imageElement) -> ResultType {
 #if PLATFORM(COCOA)
-            auto* cachedImage = imageElement->cachedImage();
+            RefPtr cachedImage = imageElement->cachedImage();
             if (!cachedImage)
                 return callback({ }, 0, 0);
             RefPtr image = dynamicDowncast<BitmapImage>(cachedImage->image());

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -50,7 +50,7 @@ NavigatorBeacon::NavigatorBeacon(Navigator& navigator)
 NavigatorBeacon::~NavigatorBeacon()
 {
     for (auto& beacon : m_inflightBeacons)
-        beacon->removeClient(*this);
+        RefPtr { beacon }->removeClient(*this);
 }
 
 void NavigatorBeacon::ref() const
@@ -160,15 +160,15 @@ ExceptionOr<bool> NavigatorBeacon::sendBeacon(Document& document, const String& 
         }
     }
 
-    auto cachedResource = protect(document.cachedResourceLoader())->requestBeaconResource({ WTF::move(request), options });
-    if (!cachedResource) {
-        logError(cachedResource.error());
+    auto cachedResourceOrError = protect(document.cachedResourceLoader())->requestBeaconResource({ WTF::move(request), options });
+    if (!cachedResourceOrError) {
+        logError(cachedResourceOrError.error());
         return false;
     }
-
-    ASSERT(!m_inflightBeacons.contains(cachedResource.value().get()));
-    m_inflightBeacons.append(cachedResource.value().get());
-    cachedResource.value()->addClient(*this);
+    Ref cachedResource = WTF::move(cachedResourceOrError.value());
+    ASSERT(!m_inflightBeacons.contains(cachedResource.ptr()));
+    m_inflightBeacons.append(cachedResource.copyRef());
+    cachedResource->addClient(*this);
     return true;
 }
 

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -140,10 +140,8 @@ HTMLModelElement::HTMLModelElement(const QualifiedName& tagName, Document& docum
 
 HTMLModelElement::~HTMLModelElement()
 {
-    if (m_resource) {
-        m_resource->removeClient(*this);
-        m_resource = nullptr;
-    }
+    if (RefPtr resource = std::exchange(m_resource, nullptr))
+        resource->removeClient(*this);
 
 #if ENABLE(MODEL_ELEMENT_ENVIRONMENT_MAP)
     if (m_environmentMapResource) {
@@ -253,10 +251,8 @@ void HTMLModelElement::setSourceURL(const URL& url)
     m_dataComplete = false;
     m_model = nullptr;
 
-    if (m_resource) {
-        m_resource->removeClient(*this);
-        m_resource = nullptr;
-    }
+    if (RefPtr resource = std::exchange(m_resource, nullptr))
+        resource->removeClient(*this);
 
     deleteModelPlayer();
 
@@ -1288,14 +1284,15 @@ bool HTMLModelElement::shouldDeferLoading() const
 void HTMLModelElement::modelResourceFinished()
 {
     auto invalidateResourceHandleAndUpdateRenderer = [&] {
-        m_resource->removeClient(*this);
+        protect(m_resource)->removeClient(*this);
         m_resource = nullptr;
 
         if (CheckedPtr renderer = this->renderer())
             renderer->updateFromElement();
     };
 
-    if (m_resource->loadFailedOrCanceled()) {
+    RefPtr resource = m_resource;
+    if (resource->loadFailedOrCanceled()) {
         m_data.reset();
 
         ActiveDOMObject::queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));
@@ -1310,7 +1307,7 @@ void HTMLModelElement::modelResourceFinished()
 
     m_dataComplete = true;
     m_dataMemoryCost.store(m_data.size(), std::memory_order_relaxed);
-    m_model = Model::create(m_data.takeBufferAsContiguous().get(), m_resource->mimeType(), m_resource->url());
+    m_model = Model::create(m_data.takeBufferAsContiguous().get(), resource->mimeType(), resource->url());
 
     ActiveDOMObject::queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
 
@@ -1789,7 +1786,7 @@ void HTMLModelElement::sourceRequestResource()
     m_data.empty();
 
     m_resource = resource.value();
-    m_resource->addClient(*this);
+    protect(m_resource)->addClient(*this);
 }
 
 void HTMLModelElement::viewportIntersectionChanged(bool isIntersecting)

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -47,7 +47,6 @@ layout/formattingContexts/inline/InlineFormattingContext.h
 layout/formattingContexts/inline/InlineItemsBuilder.cpp
 layout/formattingContexts/inline/InlineLine.h
 layout/integration/inline/LayoutIntegrationLineLayout.h
-layout/layouttree/LayoutElementBox.h
 [ iOS ] page/cocoa/ContentChangeObserver.h
 [ Mac ] page/mac/ImageOverlayControllerMac.mm
 [ Mac ] page/mac/ServicesOverlayController.mm

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2728,7 +2728,7 @@ AccessibilitySVGObject* AccessibilityRenderObject::remoteSVGRootElement(CreateIf
     if (!renderImage)
         return nullptr;
 
-    auto* cachedImage = renderImage->cachedImage();
+    RefPtr cachedImage = renderImage->cachedImage();
     if (!cachedImage)
         return nullptr;
 

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
@@ -46,7 +46,7 @@ CachedResourceHandle<CachedScript> CachedScriptFetcher::requestModuleScript(Docu
     return requestScriptWithCache(document, sourceURL, destination, String { }, WTF::move(integrity), { }, serviceWorkersMode);
 }
 
-CachedResourceHandle<CachedScript> CachedScriptFetcher::requestScriptWithCache(Document& document, const URL& sourceURL, FetchOptionsDestination destination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority> resourceLoadPriority, std::optional<ServiceWorkersMode> serviceWorkersMode) const
+RefPtr<CachedScript> CachedScriptFetcher::requestScriptWithCache(Document& document, const URL& sourceURL, FetchOptionsDestination destination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority> resourceLoadPriority, std::optional<ServiceWorkersMode> serviceWorkersMode) const
 {
     if (!document.settings().isScriptEnabled())
         return nullptr;
@@ -71,7 +71,8 @@ CachedResourceHandle<CachedScript> CachedScriptFetcher::requestScriptWithCache(D
     if (!m_initiatorType.isNull())
         request.setInitiatorType(m_initiatorType);
 
-    return protect(document.cachedResourceLoader())->requestScript(WTF::move(request)).value_or(nullptr);
+    auto result = protect(document.cachedResourceLoader())->requestScript(WTF::move(request));
+    return result ? RefPtr { WTF::move(result.value()) } : nullptr;
 }
 
 }

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.h
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.h
@@ -62,7 +62,7 @@ protected:
     {
     }
 
-    CachedResourceHandle<CachedScript> requestScriptWithCache(Document&, const URL& sourceURL, FetchOptionsDestination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority>, std::optional<ServiceWorkersMode>) const;
+    RefPtr<CachedScript> requestScriptWithCache(Document&, const URL& sourceURL, FetchOptionsDestination, const String& crossOriginMode, String&& integrity, std::optional<ResourceLoadPriority>, std::optional<ServiceWorkersMode>) const;
 
 private:
     bool isCachedScriptFetcher() const final { return true; }

--- a/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/CachedScriptSourceProvider.h
@@ -40,7 +40,7 @@ public:
 
     virtual ~CachedScriptSourceProvider()
     {
-        m_cachedScript->removeClient(*this);
+        protect(m_cachedScript)->removeClient(*this);
     }
 
     // CachedResourceClient.
@@ -52,7 +52,7 @@ public:
 
     JSC::CodeBlockHash codeBlockHashConcurrently(int startOffset, int endOffset, JSC::CodeSpecializationKind kind) override
     {
-        return m_cachedScript->codeBlockHashConcurrently(startOffset, endOffset, kind, isModuleType() ? CachedScript::ShouldDecodeAsUTF8Only::Yes : CachedScript::ShouldDecodeAsUTF8Only::No);
+        return protect(m_cachedScript)->codeBlockHashConcurrently(startOffset, endOffset, kind, isModuleType() ? CachedScript::ShouldDecodeAsUTF8Only::Yes : CachedScript::ShouldDecodeAsUTF8Only::No);
     }
 
 private:
@@ -60,7 +60,7 @@ private:
         : SourceProvider(JSC::SourceOrigin { cachedScript->response().url(), WTF::move(scriptFetcher) }, String(cachedScript->response().url().string()), cachedScript->response().isRedirected() ? String(cachedScript->url().string()) : String(), cachedScript->requiresPrivacyProtections() ? JSC::SourceTaintedOrigin::KnownTainted : JSC::SourceTaintedOrigin::Untainted, TextPosition(), sourceType)
         , m_cachedScript(cachedScript)
     {
-        m_cachedScript->addClient(*this);
+        cachedScript->addClient(*this);
     }
 
     CachedResourceHandle<CachedScript> m_cachedScript;
@@ -70,14 +70,14 @@ inline unsigned CachedScriptSourceProvider::hash() const
 {
     // Modules should always be decoded as UTF-8.
     // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
-    return m_cachedScript->scriptHash(isModuleType() ? CachedScript::ShouldDecodeAsUTF8Only::Yes : CachedScript::ShouldDecodeAsUTF8Only::No);
+    return protect(m_cachedScript)->scriptHash(isModuleType() ? CachedScript::ShouldDecodeAsUTF8Only::Yes : CachedScript::ShouldDecodeAsUTF8Only::No);
 }
 
 inline StringView CachedScriptSourceProvider::source() const
 {
     // Modules should always be decoded as UTF-8.
     // https://html.spec.whatwg.org/multipage/webappapis.html#fetch-a-single-module-script
-    return m_cachedScript->script(isModuleType() ? CachedScript::ShouldDecodeAsUTF8Only::Yes : CachedScript::ShouldDecodeAsUTF8Only::No);
+    return protect(m_cachedScript)->script(isModuleType() ? CachedScript::ShouldDecodeAsUTF8Only::Yes : CachedScript::ShouldDecodeAsUTF8Only::No);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
+++ b/Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h
@@ -48,15 +48,15 @@ public:
 
     virtual ~WebAssemblyCachedScriptSourceProvider()
     {
-        m_cachedScript->removeClient(*this);
+        protect(m_cachedScript)->removeClient(*this);
     }
 
     // CachedResourceClient.
     void ref() const final { JSC::BaseWebAssemblySourceProvider::ref(); }
     void deref() const final { JSC::BaseWebAssemblySourceProvider::deref(); }
 
-    unsigned hash() const final { return m_cachedScript->scriptHash(); }
-    StringView source() const final { return m_cachedScript->script(); }
+    unsigned hash() const final { return protect(m_cachedScript)->scriptHash(); }
+    StringView source() const final { return protect(m_cachedScript)->script(); }
     size_t size() const final { return m_buffer ? m_buffer->size() : 0; }
 
     const uint8_t* data() final
@@ -86,9 +86,8 @@ private:
     WebAssemblyCachedScriptSourceProvider(CachedScript* cachedScript, const JSC::SourceOrigin& sourceOrigin, String sourceURL)
         : BaseWebAssemblySourceProvider(sourceOrigin, WTF::move(sourceURL))
         , m_cachedScript(cachedScript)
-        , m_buffer(nullptr)
     {
-        m_cachedScript->addClient(*this);
+        protect(m_cachedScript)->addClient(*this);
     }
 
     CachedResourceHandle<CachedScript> m_cachedScript;

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -89,8 +89,8 @@ Ref<CSSFontFaceSrcResourceValue> CSSFontFaceSrcResourceValue::create(CSS::URL lo
 
 RefPtr<FontLoadRequest> CSSFontFaceSrcResourceValue::fontLoadRequest(ScriptExecutionContext& context, bool isInitiatingElementInUserAgentShadowTree)
 {
-    if (m_cachedFont)
-        return CachedFontLoadRequest::create(*m_cachedFont, context);
+    if (RefPtr cachedFont = m_cachedFont)
+        return CachedFontLoadRequest::create(*cachedFont, context);
 
     bool isFormatSVG;
     if (m_format.isEmpty()) {
@@ -121,7 +121,8 @@ RefPtr<FontLoadRequest> CSSFontFaceSrcResourceValue::fontLoadRequest(ScriptExecu
 
 bool CSSFontFaceSrcResourceValue::customTraverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>& handler) const
 {
-    return m_cachedFont && handler(*m_cachedFont);
+    RefPtr cachedFont = m_cachedFont;
+    return cachedFont && handler(*cachedFont);
 }
 
 bool CSSFontFaceSrcResourceValue::customMayDependOnBaseURL() const

--- a/Source/WebCore/css/CSSImageValue.cpp
+++ b/Source/WebCore/css/CSSImageValue.cpp
@@ -143,7 +143,10 @@ CachedImage* CSSImageValue::loadImage(CachedResourceLoader& loader, const Resour
 
 bool CSSImageValue::customTraverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>& handler) const
 {
-    return m_cachedImage && *m_cachedImage && handler(**m_cachedImage);
+    if (!m_cachedImage)
+        return false;
+    RefPtr cachedImage = m_cachedImage->get();
+    return cachedImage && handler(*cachedImage);
 }
 
 bool CSSImageValue::customMayDependOnBaseURL() const
@@ -172,7 +175,10 @@ Ref<DeprecatedCSSOMValue> CSSImageValue::createDeprecatedCSSOMWrapper(CSSStyleDe
 
 bool CSSImageValue::knownToBeOpaque(const RenderElement& renderer) const
 {
-    return m_cachedImage.value_or(nullptr) && (**m_cachedImage).currentFrameKnownToBeOpaque(&renderer);
+    if (!m_cachedImage)
+        return false;
+    RefPtr cacheImage = m_cachedImage->get();
+    return cacheImage && cacheImage->currentFrameKnownToBeOpaque(&renderer);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -124,7 +124,7 @@ CSSStyleSheet* CSSImportRule::styleSheet() const
         return nullptr;
 
     std::optional<bool> isOriginClean;
-    if (const auto* cachedSheet = m_importRule->cachedCSSStyleSheet())
+    if (RefPtr cachedSheet = m_importRule->cachedCSSStyleSheet())
         isOriginClean = cachedSheet->isCORSSameOrigin();
 
     if (!m_styleSheetCSSOMWrapper)

--- a/Source/WebCore/css/StyleRuleImport.cpp
+++ b/Source/WebCore/css/StyleRuleImport.cpp
@@ -161,7 +161,10 @@ void StyleRuleImport::requestStyleSheet()
         auto options = request.options();
         options.loadedFromOpaqueSource = m_parentStyleSheet->loadedFromOpaqueSource();
         request.setOptions(WTF::move(options));
-        m_cachedSheet = protect(document->cachedResourceLoader())->requestCSSStyleSheet(WTF::move(request)).value_or(nullptr);
+        if (auto result = protect(document->cachedResourceLoader())->requestCSSStyleSheet(WTF::move(request)))
+            m_cachedSheet = WTF::move(result.value());
+        else
+            m_cachedSheet = nullptr;
     }
     if (m_cachedSheet) {
         // if the import rule is issued dynamically, the sheet may be

--- a/Source/WebCore/css/StyleSheetContents.cpp
+++ b/Source/WebCore/css/StyleSheetContents.cpp
@@ -565,7 +565,7 @@ bool StyleSheetContents::traverseSubresources(NOESCAPE const Function<bool(const
         case StyleRuleType::FontFace:
             return uncheckedDowncast<StyleRuleFontFace>(rule).properties().traverseSubresources(handler);
         case StyleRuleType::Import:
-            if (auto* cachedResource = uncheckedDowncast<StyleRuleImport>(rule).cachedCSSStyleSheet())
+            if (RefPtr cachedResource = uncheckedDowncast<StyleRuleImport>(rule).cachedCSSStyleSheet())
                 return handler(*cachedResource);
             return false;
         case StyleRuleType::CounterStyle:

--- a/Source/WebCore/dom/DataTransferMac.mm
+++ b/Source/WebCore/dom/DataTransferMac.mm
@@ -54,8 +54,8 @@ DragImageRef DataTransfer::createDragImage(const Document*, IntPoint& location) 
             location.setX(elementRect.x() - imageRect.x() + m_dragLocation.x());
             location.setY(imageRect.height() - (elementRect.y() - imageRect.y() + m_dragLocation.y()));
         }
-    } else if (m_dragImage) {
-        result = protect(m_dragImage->image())->adapter().snapshotNSImage();
+    } else if (RefPtr dragImage = m_dragImage) {
+        result = protect(dragImage->image())->adapter().snapshotNSImage();
         
         location = m_dragLocation;
         location.setY([result size].height - location.y());

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4125,7 +4125,7 @@ void Document::implicitOpen()
 
 RefPtr<FontLoadRequest> Document::fontLoadRequest(const String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource loadedFromOpaqueSource)
 {
-    CachedResourceHandle cachedFont = protect(fontLoader())->cachedFont(completeURL(url), isSVG, isInitiatingElementInUserAgentShadowTree, loadedFromOpaqueSource);
+    RefPtr cachedFont = protect(fontLoader())->cachedFont(completeURL(url), isSVG, isInitiatingElementInUserAgentShadowTree, loadedFromOpaqueSource);
     if (!cachedFont)
         return nullptr;
     return CachedFontLoadRequest::create(*cachedFont, *this);
@@ -4133,7 +4133,7 @@ RefPtr<FontLoadRequest> Document::fontLoadRequest(const String& url, bool isSVG,
 
 void Document::beginLoadingFontSoon(FontLoadRequest& request)
 {
-    CachedResourceHandle font = downcast<CachedFontLoadRequest>(request).cachedFont();
+    RefPtr font = downcast<CachedFontLoadRequest>(request).cachedFont();
     protect(fontLoader())->beginLoadingFontSoon(*font);
 }
 

--- a/Source/WebCore/dom/DocumentFontLoader.cpp
+++ b/Source/WebCore/dom/DocumentFontLoader.cpp
@@ -63,7 +63,7 @@ void DocumentFontLoader::deref() const
     m_document->deref();
 }
 
-CachedFont* DocumentFontLoader::cachedFont(URL&& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource loadedFromOpaqueSource)
+RefPtr<CachedFont> DocumentFontLoader::cachedFont(URL&& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource loadedFromOpaqueSource)
 {
     ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
     options.contentSecurityPolicyImposition = isInitiatingElementInUserAgentShadowTree ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
@@ -72,7 +72,8 @@ CachedFont* DocumentFontLoader::cachedFont(URL&& url, bool isSVG, bool isInitiat
 
     CachedResourceRequest request(ResourceRequest(WTF::move(url)), options);
     request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
-    return protect(protect(m_document)->cachedResourceLoader())->requestFont(WTF::move(request), isSVG).value_or(nullptr).get();
+    auto result = protect(protect(m_document)->cachedResourceLoader())->requestFont(WTF::move(request), isSVG);
+    return result ? RefPtr { WTF::move(result.value()) } : nullptr;
 }
 
 void DocumentFontLoader::beginLoadingFontSoon(CachedFont& font)
@@ -95,14 +96,16 @@ void DocumentFontLoader::loadPendingFonts()
     if (m_isFontLoadingSuspended)
         return;
 
-    Vector<CachedResourceHandle<CachedFont>> fontsToBeginLoading;
-    fontsToBeginLoading.swap(m_fontsToBeginLoading);
+    Vector<Ref<CachedFont>> fontsToBeginLoading = WTF::map(m_fontsToBeginLoading, [](auto& font) {
+        return Ref { *font };
+    });
+    m_fontsToBeginLoading.clear();
 
     Ref cachedResourceLoader = protect(m_document)->cachedResourceLoader();
     for (auto& fontHandle : fontsToBeginLoading) {
         fontHandle->beginLoadIfNeeded(cachedResourceLoader);
         // Balances incrementRequestCount() in beginLoadingFontSoon().
-        cachedResourceLoader->decrementRequestCount(*fontHandle);
+        cachedResourceLoader->decrementRequestCount(fontHandle);
     }
 }
 

--- a/Source/WebCore/dom/DocumentFontLoader.h
+++ b/Source/WebCore/dom/DocumentFontLoader.h
@@ -47,7 +47,7 @@ public:
     void NODELETE ref() const;
     void deref() const;
 
-    CachedFont* cachedFont(URL&&, bool, bool, LoadedFromOpaqueSource);
+    RefPtr<CachedFont> cachedFont(URL&&, bool, bool, LoadedFromOpaqueSource);
     void beginLoadingFontSoon(CachedFont&);
 
     void loadPendingFonts();

--- a/Source/WebCore/dom/LoadableClassicScript.cpp
+++ b/Source/WebCore/dom/LoadableClassicScript.cpp
@@ -48,7 +48,7 @@ LoadableNonModuleScriptBase::LoadableNonModuleScriptBase(const AtomString& nonce
 
 LoadableNonModuleScriptBase::~LoadableNonModuleScriptBase()
 {
-    if (CachedResourceHandle cachedScript = m_cachedScript)
+    if (RefPtr cachedScript = m_cachedScript)
         cachedScript->removeClient(*this);
 }
 
@@ -82,7 +82,7 @@ std::optional<LoadableScript::Error> LoadableNonModuleScriptBase::takeError()
 bool LoadableNonModuleScriptBase::wasCanceled() const
 {
     ASSERT(m_cachedScript);
-    return m_cachedScript->wasCanceled();
+    return protect(m_cachedScript)->wasCanceled();
 }
 
 void LoadableNonModuleScriptBase::notifyFinished(CachedResource& resource, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess)
@@ -101,7 +101,7 @@ void LoadableNonModuleScriptBase::notifyFinished(CachedResource& resource, const
         };
     }
 
-    CachedResourceHandle cachedScript = m_cachedScript;
+    RefPtr cachedScript = m_cachedScript;
     if (!m_error && !isScriptAllowedByNosniff(cachedScript->response())) {
         m_error = Error {
             ErrorType::Nosniff,
@@ -149,11 +149,10 @@ bool LoadableNonModuleScriptBase::load(Document& document, const URL& sourceURL)
     };
 
     m_weakDocument = document;
-    CachedResourceHandle cachedScript = requestScriptWithCache(document, sourceURL, FetchOptionsDestination::Script, crossOriginMode(), String { integrity() }, priority(), { });
-    m_cachedScript = cachedScript;
-    if (!cachedScript)
+    m_cachedScript = requestScriptWithCache(document, sourceURL, FetchOptionsDestination::Script, crossOriginMode(), String { integrity() }, priority(), { });
+    if (!m_cachedScript)
         return false;
-    cachedScript->addClient(*this);
+    protect(m_cachedScript)->addClient(*this);
     return true;
 }
 
@@ -170,7 +169,7 @@ LoadableClassicScript::LoadableClassicScript(const AtomString& nonce, const Atom
 void LoadableClassicScript::execute(ScriptElement& scriptElement)
 {
     ASSERT(!m_error);
-    scriptElement.executeClassicScript(ScriptSourceCode(protect(cachedScript()).get(), JSC::SourceProviderSourceType::Program, *this));
+    scriptElement.executeClassicScript(ScriptSourceCode(protect(cachedScript()).ptr(), JSC::SourceProviderSourceType::Program, *this));
 }
 
 }

--- a/Source/WebCore/dom/LoadableClassicScript.h
+++ b/Source/WebCore/dom/LoadableClassicScript.h
@@ -38,7 +38,7 @@ namespace WebCore {
 
 class WeakPtrImplWithEventTargetData;
 
-// A CachedResourceHandle alone does not prevent the underlying CachedResource
+// A RefPtr alone does not prevent the underlying CachedResource
 // from purging its data buffer. This class holds a client until this class is
 // destroyed in order to guarantee that the data buffer will not be purged.
 class LoadableNonModuleScriptBase : public LoadableScript, protected CachedResourceClient {

--- a/Source/WebCore/dom/LoadableSpeculationRules.cpp
+++ b/Source/WebCore/dom/LoadableSpeculationRules.cpp
@@ -57,11 +57,11 @@ LoadableSpeculationRules::LoadableSpeculationRules(Document& document, const URL
 
 LoadableSpeculationRules::~LoadableSpeculationRules()
 {
-    if (m_cachedScript)
-        m_cachedScript->removeClient(*this);
+    if (RefPtr cachedScript = m_cachedScript)
+        cachedScript->removeClient(*this);
 }
 
-CachedResourceHandle<CachedScript> LoadableSpeculationRules::requestSpeculationRules(Document& document, const URL& sourceURL)
+RefPtr<CachedScript> LoadableSpeculationRules::requestSpeculationRules(Document& document, const URL& sourceURL)
 {
     // https://html.spec.whatwg.org/C#the-speculation-rules-header
     // 3.4.2.2.1. Let request be a new request whose URL is url, destination is "speculationrules", and mode is "cors".
@@ -81,7 +81,8 @@ CachedResourceHandle<CachedScript> LoadableSpeculationRules::requestSpeculationR
     request.upgradeInsecureRequestIfNeeded(document);
     request.setPriority(ResourceLoadPriority::Low);
 
-    return protect(document.cachedResourceLoader())->requestScript(WTF::move(request)).value_or(nullptr);
+    auto result = protect(document.cachedResourceLoader())->requestScript(WTF::move(request));
+    return result ? RefPtr { WTF::move(result.value()) } : nullptr;
 }
 
 bool LoadableSpeculationRules::load(Document& document, const URL& url)
@@ -91,11 +92,10 @@ bool LoadableSpeculationRules::load(Document& document, const URL& url)
     if (!url.isValid())
         return false;
 
-    CachedResourceHandle cachedScript = requestSpeculationRules(document, m_url);
-    m_cachedScript = cachedScript;
-    if (!cachedScript)
+    m_cachedScript = requestSpeculationRules(document, m_url);
+    if (!m_cachedScript)
         return false;
-    cachedScript->addClient(*this);
+    protect(m_cachedScript)->addClient(*this);
 
     return true;
 }
@@ -106,13 +106,14 @@ void LoadableSpeculationRules::notifyFinished(CachedResource& resource, const Ne
 {
     ASSERT(&resource == m_cachedScript.get());
 
-    RefPtr document = m_document.get();
+    RefPtr document = m_document;
     if (!document)
         return;
 
     // 1. If bodyBytes is null or failure, then abort these steps.
     // 2. If response's status is not an ok status, then abort these steps.
-    if (m_cachedScript->errorOccurred()) {
+    RefPtr cachedScript = m_cachedScript;
+    if (cachedScript->errorOccurred()) {
         document->addConsoleMessage(MessageSource::Other, MessageLevel::Error, makeString("Failed to load speculation rules from "_s, m_url.string()));
         return;
     }
@@ -124,7 +125,7 @@ void LoadableSpeculationRules::notifyFinished(CachedResource& resource, const Ne
     }
 
     // 4. Let bodyText be the result of UTF-8 decoding bodyBytes.
-    String speculationRulesText = m_cachedScript->script(CachedScript::ShouldDecodeAsUTF8Only::Yes).toString();
+    String speculationRulesText = cachedScript->script(CachedScript::ShouldDecodeAsUTF8Only::Yes).toString();
     if (speculationRulesText.isEmpty())
         return;
 

--- a/Source/WebCore/dom/LoadableSpeculationRules.h
+++ b/Source/WebCore/dom/LoadableSpeculationRules.h
@@ -58,7 +58,7 @@ public:
 private:
     LoadableSpeculationRules(Document&, const URL&);
 
-    CachedResourceHandle<CachedScript> requestSpeculationRules(Document&, const URL& sourceURL);
+    RefPtr<CachedScript> requestSpeculationRules(Document&, const URL& sourceURL);
 
     CachedResourceHandle<CachedScript> m_cachedScript;
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -66,7 +66,7 @@ ProcessingInstruction::~ProcessingInstruction()
     if (RefPtr sheet = m_sheet)
         sheet->clearOwnerNode();
 
-    if (CachedResourceHandle cachedSheet = m_cachedSheet)
+    if (RefPtr cachedSheet = m_cachedSheet)
         cachedSheet->removeClient(*this);
 
     if (isConnected())
@@ -134,9 +134,9 @@ void ProcessingInstruction::checkStyleSheet()
             }
 #endif
         } else {
-            if (CachedResourceHandle cachedSheet = std::exchange(m_cachedSheet, nullptr))
+            if (RefPtr cachedSheet = std::exchange(m_cachedSheet, nullptr))
                 cachedSheet->removeClient(*this);
-            
+
             if (!m_loading) {
                 m_loading = true;
                 document->styleScope().addPendingSheet(*this);
@@ -148,16 +148,22 @@ void ProcessingInstruction::checkStyleSheet()
             if (m_isXSL) {
                 auto options = CachedResourceLoader::defaultCachedResourceOptions();
                 options.mode = FetchOptions::Mode::SameOrigin;
-                m_cachedSheet = protect(document->cachedResourceLoader())->requestXSLStyleSheet({ ResourceRequest(document->completeURL(href)), options }).value_or(nullptr);
+                if (auto result = protect(document->cachedResourceLoader())->requestXSLStyleSheet({ ResourceRequest(document->completeURL(href)), options }))
+                    m_cachedSheet = WTF::move(result.value());
+                else
+                    m_cachedSheet = nullptr;
             } else
 #endif
             {
                 String charset = attributes->get<HashTranslatorASCIILiteral>("charset"_s);
                 CachedResourceRequest request(document->completeURL(href), CachedResourceLoader::defaultCachedResourceOptions(), std::nullopt, charset.isEmpty() ? String::fromLatin1(document->charset()) : WTF::move(charset));
 
-                m_cachedSheet = protect(document->cachedResourceLoader())->requestCSSStyleSheet(WTF::move(request)).value_or(nullptr);
+                if (auto result = protect(document->cachedResourceLoader())->requestCSSStyleSheet(WTF::move(request)))
+                    m_cachedSheet = WTF::move(result.value());
+                else
+                    m_cachedSheet = nullptr;
             }
-            if (CachedResourceHandle cachedSheet = m_cachedSheet)
+            if (RefPtr cachedSheet = m_cachedSheet)
                 cachedSheet->addClient(*this);
             else {
                 // The request may have been denied if (for example) the stylesheet is local and the document is remote.
@@ -240,7 +246,7 @@ void ProcessingInstruction::parseStyleSheet(const String& sheet)
         downcast<XSLStyleSheet>(styleSheet.get()).parseString(sheet);
 #endif
 
-    if (CachedResourceHandle cachedSheet = std::exchange(m_cachedSheet, nullptr))
+    if (RefPtr cachedSheet = std::exchange(m_cachedSheet, nullptr))
         cachedSheet->removeClient(*this);
 
     m_loading = false;

--- a/Source/WebCore/dom/mac/ImageControlsMac.cpp
+++ b/Source/WebCore/dom/mac/ImageControlsMac.cpp
@@ -134,7 +134,7 @@ static Image* imageFromImageElementNode(Node& node)
     CheckedPtr renderer = dynamicDowncast<RenderImage>(node.renderer());
     if (!renderer)
         return nullptr;
-    CachedResourceHandle image = renderer->cachedImage();
+    RefPtr image = renderer->cachedImage();
     if (!image || image->errorOccurred())
         return nullptr;
     return image->imageForRenderer(renderer.get());

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -1222,7 +1222,7 @@ HashSet<Ref<HTMLImageElement>> visibleImageElementsInRangeWithNonLoadedImages(co
         if (!imageElement)
             continue;
 
-        auto* cachedImage = imageElement->cachedImage();
+        RefPtr cachedImage = imageElement->cachedImage();
         if (cachedImage && cachedImage->isLoading())
             result.add(imageElement.releaseNonNull());
     }

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4812,7 +4812,7 @@ void Editor::registerAttachmentIdentifier(const String& identifier, const Attach
         if (!renderer)
             return std::nullopt;
 
-        auto* cachedImage = renderer->cachedImage();
+        RefPtr cachedImage = renderer->cachedImage();
         if (!cachedImage || cachedImage->errorOccurred())
             return std::nullopt;
 

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
@@ -132,7 +132,7 @@ static String preferredFilenameForElement(const HTMLImageElement& element)
 
 static RetainPtr<NSFileWrapper> fileWrapperForElement(const HTMLImageElement& element)
 {
-    if (CachedImage* cachedImage = element.cachedImage()) {
+    if (RefPtr cachedImage = element.cachedImage()) {
         if (RefPtr sharedBuffer = cachedImage->resourceBuffer()) {
             RetainPtr wrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:sharedBuffer->makeContiguous()->createNSData().get()]);
             [wrapper setPreferredFilename:preferredFilenameForElement(element).createNSString().get()];
@@ -142,7 +142,7 @@ static RetainPtr<NSFileWrapper> fileWrapperForElement(const HTMLImageElement& el
 
     CheckedPtr renderer = element.renderer();
     if (CheckedPtr renderImage = dynamicDowncast<RenderImage>(renderer)) {
-        CachedResourceHandle image = renderImage->cachedImage();
+        RefPtr image = renderImage->cachedImage();
         if (image && !image->errorOccurred()) {
             RetainPtr<NSFileWrapper> wrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:(__bridge NSData *)image->imageForRenderer(renderer)->adapter().tiffRepresentation()]);
             [wrapper setPreferredFilename:@"image.tiff"];

--- a/Source/WebCore/editing/ios/EditorIOS.mm
+++ b/Source/WebCore/editing/ios/EditorIOS.mm
@@ -87,7 +87,7 @@ static void getImage(Element& imageElement, RefPtr<Image>& image, CachedImage*& 
     if (!renderImage)
         return;
 
-    CachedResourceHandle tentativeCachedImage = renderImage->cachedImage();
+    RefPtr tentativeCachedImage = renderImage->cachedImage();
     if (!tentativeCachedImage || tentativeCachedImage->errorOccurred())
         return;
 

--- a/Source/WebCore/editing/mac/EditorMac.mm
+++ b/Source/WebCore/editing/mac/EditorMac.mm
@@ -204,7 +204,7 @@ static void getImage(Element& imageElement, RefPtr<Image>& image, CachedImage*& 
     if (!renderImage)
         return;
 
-    CachedResourceHandle tentativeCachedImage = renderImage->cachedImage();
+    RefPtr tentativeCachedImage = renderImage->cachedImage();
     if (!tentativeCachedImage || tentativeCachedImage->errorOccurred())
         return;
 

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -593,8 +593,8 @@ unsigned HTMLImageElement::width()
             return optionalWidth.value();
 
         // if the image is available, use its width
-        if (m_imageLoader->image())
-            return m_imageLoader->image()->imageSizeForRenderer(nullptr, 1.0f).width().toUnsigned();
+        if (RefPtr image = m_imageLoader->image())
+            return image->imageSizeForRenderer(nullptr, 1.0f).width().toUnsigned();
     }
 
     CheckedPtr box = renderBox();
@@ -616,8 +616,8 @@ unsigned HTMLImageElement::height()
             return optionalHeight.value();
 
         // if the image is available, use its height
-        if (m_imageLoader->image())
-            return m_imageLoader->image()->imageSizeForRenderer(nullptr, 1.0f).height().toUnsigned();
+        if (RefPtr image = m_imageLoader->image())
+            return image->imageSizeForRenderer(nullptr, 1.0f).height().toUnsigned();
     }
 
     CheckedPtr box = renderBox();
@@ -629,10 +629,11 @@ unsigned HTMLImageElement::height()
 
 float HTMLImageElement::effectiveImageDevicePixelRatio() const
 {
-    if (!m_imageLoader->image())
+    RefPtr cachedImage = m_imageLoader->image();
+    if (!cachedImage)
         return 1.0f;
 
-    RefPtr image = m_imageLoader->image()->image();
+    RefPtr image = cachedImage->image();
     if (image && image->drawsSVGImage())
         return 1.0f;
 
@@ -641,18 +642,14 @@ float HTMLImageElement::effectiveImageDevicePixelRatio() const
 
 unsigned HTMLImageElement::naturalWidth() const
 {
-    if (!m_imageLoader->image())
-        return 0;
-
-    return m_imageLoader->image()->unclampedImageSizeForRenderer(protect(renderer()).get(), effectiveImageDevicePixelRatio()).width().toUnsigned();
+    RefPtr image = m_imageLoader->image();
+    return image ? image->unclampedImageSizeForRenderer(protect(renderer()).get(), effectiveImageDevicePixelRatio()).width().toUnsigned() : 0;
 }
 
 unsigned HTMLImageElement::naturalHeight() const
 {
-    if (!m_imageLoader->image())
-        return 0;
-
-    return m_imageLoader->image()->unclampedImageSizeForRenderer(protect(renderer()).get(), effectiveImageDevicePixelRatio()).height().toUnsigned();
+    RefPtr image = m_imageLoader->image();
+    return image ? image->unclampedImageSizeForRenderer(protect(renderer()).get(), effectiveImageDevicePixelRatio()).height().toUnsigned() : 0;
 }
 
 bool HTMLImageElement::isURLAttribute(const Attribute& attribute) const
@@ -849,7 +846,7 @@ bool HTMLImageElement::allowsOrientationOverride() const
 
 Image* HTMLImageElement::image() const
 {
-    if (auto* cachedImage = this->cachedImage())
+    if (RefPtr cachedImage = this->cachedImage())
         return cachedImage->image();
     return nullptr;
 }
@@ -1054,7 +1051,7 @@ bool HTMLImageElement::originClean(const SecurityOrigin& origin) const
 {
     UNUSED_PARAM(origin);
 
-    auto* cachedImage = this->cachedImage();
+    RefPtr cachedImage = this->cachedImage();
     if (!cachedImage)
         return true;
 

--- a/Source/WebCore/html/HTMLImageLoader.cpp
+++ b/Source/WebCore/html/HTMLImageLoader.cpp
@@ -68,8 +68,9 @@ void HTMLImageLoader::dispatchLoadEvent()
     }
 #endif
 
-    bool errorOccurred = image()->errorOccurred();
-    if (!errorOccurred && image()->response().httpStatusCode() >= 400)
+    RefPtr image = this->image();
+    bool errorOccurred = image->errorOccurred();
+    if (!errorOccurred && image->response().httpStatusCode() >= 400)
         errorOccurred = is<HTMLObjectElement>(element()); // An <object> considers a 404 to be an error and should fire onerror.
     protect(element())->dispatchEvent(Event::create(errorOccurred ? eventNames().errorEvent : eventNames().loadEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
@@ -77,19 +78,19 @@ void HTMLImageLoader::dispatchLoadEvent()
 void HTMLImageLoader::notifyFinished(CachedResource&, const NetworkLoadMetrics& metrics, LoadWillContinueInAnotherProcess loadWillContinueInAnotherProcess)
 {
     ASSERT(image());
-    CachedImage& cachedImage = *image();
+    Ref cachedImage = *image();
 
     Ref<Element> protect(element());
     ImageLoader::notifyFinished(cachedImage, metrics, loadWillContinueInAnotherProcess);
 
-    bool loadError = cachedImage.errorOccurred() || cachedImage.response().httpStatusCode() >= 400;
+    bool loadError = cachedImage->errorOccurred() || cachedImage->response().httpStatusCode() >= 400;
     if (!loadError) {
         if (!element().isConnected()) {
             JSC::VM& vm = commonVM();
             JSC::JSLockHolder lock(vm);
             // FIXME: Adopt reportExtraMemoryVisited, and switch to reportExtraMemoryAllocated.
             // https://bugs.webkit.org/show_bug.cgi?id=142595
-            vm.heap.deprecatedReportExtraMemory(cachedImage.encodedSize());
+            vm.heap.deprecatedReportExtraMemory(cachedImage->encodedSize());
         }
     }
 

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -351,7 +351,7 @@ void HTMLLinkElement::process()
         if (!PAL::TextEncoding { charset }.isValid())
             charset = document->charset();
 
-        if (CachedResourceHandle cachedSheet = std::exchange(m_cachedSheet, nullptr)) {
+        if (RefPtr cachedSheet = std::exchange(m_cachedSheet, nullptr)) {
             removePendingSheet();
             cachedSheet->removeClient(*this);
         }
@@ -398,9 +398,11 @@ void HTMLLinkElement::process()
         request.setInitiator(*this);
 
         ASSERT_WITH_SECURITY_IMPLICATION(!m_cachedSheet);
-        m_cachedSheet = protect(document->cachedResourceLoader())->requestCSSStyleSheet(WTF::move(request)).value_or(nullptr);
-
-        if (CachedResourceHandle cachedSheet = m_cachedSheet)
+        if (auto result = protect(document->cachedResourceLoader())->requestCSSStyleSheet(WTF::move(request)))
+            m_cachedSheet = WTF::move(result.value());
+        else
+            m_cachedSheet = nullptr;
+        if (RefPtr cachedSheet = m_cachedSheet)
             cachedSheet->addClient(*this);
         else {
             // The request may have been denied if (for example) the stylesheet is local and the document is remote.

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -297,7 +297,7 @@ void HTMLObjectElement::renderFallbackContent()
     // Before we give up and use fallback content, check to see if this is a MIME type issue.
     RefPtr loader = imageLoader();
     if (loader && loader->image() && loader->image()->status() != CachedResource::LoadError) {
-        m_serviceType = loader->image()->response().mimeType();
+        m_serviceType = protect(loader->image())->response().mimeType();
         if (!isImageType()) {
             // If we don't think we have an image type anymore, then clear the image from the loader.
             loader->clearImage();

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -138,10 +138,10 @@ HTMLImageElement* ImageDocument::imageElement() const
 
 LayoutSize ImageDocument::imageSize()
 {
-    RefPtr imageElement = m_imageElement.get();
+    RefPtr imageElement = m_imageElement;
     ASSERT(imageElement);
     updateStyleIfNeeded();
-    CachedResourceHandle cachedImage = imageElement->cachedImage();
+    RefPtr cachedImage = imageElement->cachedImage();
     if (!cachedImage)
         return { };
     return cachedImage->imageSizeForRenderer(protect(imageElement->renderer()).get(), frame() ? frame()->pageZoomFactor() : 1);
@@ -159,7 +159,7 @@ void ImageDocument::updateDuringParsing()
         return;
 
     if (RefPtr buffer = protect(loader())->mainResourceData()) {
-        if (CachedResourceHandle cachedImage = m_imageElement->cachedImage())
+        if (RefPtr cachedImage = m_imageElement->cachedImage())
             cachedImage->updateBuffer(*buffer);
     }
 
@@ -173,8 +173,8 @@ void ImageDocument::finishedParsing()
         return;
     }
 
-    if (RefPtr imageElement = m_imageElement.get(); imageElement && imageElement->cachedImage()) {
-        CachedResourceHandle cachedImage = *imageElement->cachedImage();
+    if (RefPtr imageElement = m_imageElement; imageElement && imageElement->cachedImage()) {
+        RefPtr cachedImage = *imageElement->cachedImage();
         Ref loader = *this->loader();
         RefPtr data = loader->mainResourceData();
 
@@ -267,7 +267,7 @@ void ImageDocument::createDocumentStructure()
         imageElement->setAttribute(styleAttr, "-webkit-user-select:none; display:block; padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);"_s);
     imageElement->setLoadManually(true);
     imageElement->setAttributeWithoutSynchronization(srcAttr, AtomString { url().string() });
-    if (CachedResourceHandle cachedImage = imageElement->cachedImage(); documentLoader && cachedImage)
+    if (RefPtr cachedImage = imageElement->cachedImage(); documentLoader && cachedImage)
         cachedImage->setResponse(ResourceResponse { documentLoader->response() });
     body->appendChild(imageElement);
     imageElement->setLoadManually(false);
@@ -334,7 +334,7 @@ float ImageDocument::scale()
 
 void ImageDocument::resizeImageToFit()
 {
-    RefPtr imageElement = m_imageElement.get();
+    RefPtr imageElement = m_imageElement;
     if (!imageElement)
         return;
 
@@ -352,7 +352,7 @@ void ImageDocument::restoreImageSize()
     if (!m_imageSizeIsKnown)
         return;
 
-    RefPtr imageElement = m_imageElement.get();
+    RefPtr imageElement = m_imageElement;
     if (!imageElement)
         return;
 
@@ -387,7 +387,7 @@ void ImageDocument::didChangeViewSize()
     if (!m_imageSizeIsKnown)
         return;
 
-    RefPtr imageElement = m_imageElement.get();
+    RefPtr imageElement = m_imageElement;
     if (!imageElement)
         return;
 
@@ -450,7 +450,7 @@ void ImageDocument::imageClicked(int x, int y)
 
 void ImageEventListener::handleEvent(ScriptExecutionContext&, Event& event)
 {
-    RefPtr document = m_document.get();
+    RefPtr document = m_document;
     if (auto* mouseEvent = dynamicDowncast<MouseEvent>(event); mouseEvent && isAnyClick(event) && document)
         document->imageClicked(mouseEvent->offsetX(), mouseEvent->offsetY());
 }
@@ -466,16 +466,14 @@ bool ImageEventListener::operator==(const EventListener& other) const
 
 ImageDocumentElement::~ImageDocumentElement()
 {
-    if (RefPtr imageDocument = m_imageDocument.get())
+    if (RefPtr imageDocument = m_imageDocument)
         imageDocument->disconnectImageElement();
 }
 
 void ImageDocumentElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
 {
-    if (RefPtr imageDocument = m_imageDocument.get()) {
+    if (RefPtr imageDocument = std::exchange(m_imageDocument, nullptr))
         imageDocument->disconnectImageElement();
-        m_imageDocument = nullptr;
-    }
     HTMLImageElement::didMoveToNewDocument(oldDocument, newDocument);
 }
 

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -188,7 +188,7 @@ unsigned ImageInputType::height() const
     // If the image is available, use its height.
     RefPtr imageLoader = element->imageLoader();
     if (imageLoader && imageLoader->image())
-        return imageLoader->image()->imageSizeForRenderer(renderer.get(), 1).height().toUnsigned();
+        return protect(imageLoader->image())->imageSizeForRenderer(renderer.get(), 1).height().toUnsigned();
 
     return 0;
 }
@@ -211,7 +211,7 @@ unsigned ImageInputType::width() const
     // If the image is available, use its width.
     RefPtr imageLoader = element->imageLoader();
     if (imageLoader && imageLoader->image())
-        return imageLoader->image()->imageSizeForRenderer(renderer.get(), 1).width().toUnsigned();
+        return protect(imageLoader->image())->imageSizeForRenderer(renderer.get(), 1).width().toUnsigned();
 
     return 0;
 }

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2232,7 +2232,7 @@ ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(C
 
 ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(HTMLImageElement& imageElement, bool repeatX, bool repeatY)
 {
-    CachedResourceHandle cachedImage = imageElement.cachedImage();
+    RefPtr cachedImage = imageElement.cachedImage();
     
     // If the image loading hasn't started or the image is not complete, it is not fully decodable.
     if (!cachedImage || !imageElement.complete())
@@ -2257,7 +2257,7 @@ ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(H
 
 ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(SVGImageElement& imageElement, bool repeatX, bool repeatY)
 {
-    CachedResourceHandle cachedImage = imageElement.cachedImage();
+    RefPtr cachedImage = imageElement.cachedImage();
 
     // The image loading hasn't started.
     if (!cachedImage)

--- a/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
+++ b/Source/WebCore/inspector/InspectorAuditResourcesObject.cpp
@@ -61,7 +61,7 @@ InspectorAuditResourcesObject::InspectorAuditResourcesObject(InspectorAuditAgent
 
 InspectorAuditResourcesObject::~InspectorAuditResourcesObject()
 {
-    for (auto* cachedResource : m_resources.values())
+    for (RefPtr cachedResource : m_resources.values())
         cachedResource->removeClient(clientForResource(*cachedResource));
 }
 
@@ -75,7 +75,7 @@ ExceptionOr<Vector<InspectorAuditResourcesObject::Resource>> InspectorAuditResou
     if (!frame)
         return Exception { ExceptionCode::NotAllowedError, "Cannot be called with a detached document"_s };
 
-    for (auto* cachedResource : ResourceUtilities::cachedResourcesForFrame(frame)) {
+    for (RefPtr cachedResource : ResourceUtilities::cachedResourcesForFrame(frame)) {
         Resource resource;
         resource.url = cachedResource->url().string();
         resource.mimeType = cachedResource->mimeType();
@@ -109,7 +109,7 @@ ExceptionOr<InspectorAuditResourcesObject::ResourceContent> InspectorAuditResour
     if (!frame)
         return Exception { ExceptionCode::NotAllowedError, "Cannot be called with a detached document"_s };
 
-    auto* cachedResource = m_resources.get(id);
+    RefPtr cachedResource = m_resources.get(id);
     if (!cachedResource)
         return Exception { ExceptionCode::NotFoundError, makeString("Unknown identifier "_s, id) };
 

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -545,7 +545,7 @@ int InspectorCanvas::indexForData(DuplicateDataVariant data)
         [&](const Ref<HTMLImageElement>& imageElement) {
             String dataURL = "data:,"_s;
 
-            if (CachedImage* cachedImage = imageElement->cachedImage()) {
+            if (RefPtr cachedImage = imageElement->cachedImage()) {
                 RefPtr<Image> image = cachedImage->image();
                 if (image && image != &Image::nullImage()) {
                     dataURL = encodeDataURL(image->currentNativeImage(), "image/png"_s);
@@ -616,7 +616,7 @@ int InspectorCanvas::indexForData(DuplicateDataVariant data)
         [&](const Ref<CSSStyleImageValue>& cssImageValue) {
             String dataURL = "data:,"_s;
 
-            if (auto* cachedImage = cssImageValue->image()) {
+            if (RefPtr cachedImage = cssImageValue->image()) {
                 RefPtr image = cachedImage->image();
                 if (image && image != &Image::nullImage())
                     dataURL = encodeDataURL(image->currentNativeImage(), "image/png"_s);

--- a/Source/WebCore/inspector/InspectorResourceUtilities.cpp
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.cpp
@@ -112,7 +112,7 @@ Vector<CachedResource*> cachedResourcesForFrame(LocalFrame* frame)
     Vector<CachedResource*> result;
 
     for (auto& cachedResourceHandle : frame->document()->cachedResourceLoader().allCachedResources().values()) {
-        auto* cachedResource = cachedResourceHandle.get();
+        RefPtr cachedResource = cachedResourceHandle;
         if (cachedResource->resourceRequest().hiddenFromInspector())
             continue;
 
@@ -158,7 +158,7 @@ void resourceContent(Inspector::Protocol::ErrorString& errorString, LocalFrame* 
     }
 
     if (!success) {
-        if (auto* resource = cachedResource(frame, url))
+        if (RefPtr resource = cachedResource(frame, url))
             success = cachedResourceContent(*resource, result, base64Encoded);
     }
 
@@ -191,12 +191,12 @@ String sourceMapURLForResource(CachedResource* cachedResource)
     return String();
 }
 
-CachedResource* cachedResource(const LocalFrame* frame, const URL& url)
+RefPtr<CachedResource> cachedResource(const LocalFrame* frame, const URL& url)
 {
     if (url.isNull())
         return nullptr;
 
-    CachedResource* cachedResource = frame->document()->cachedResourceLoader().cachedResource(MemoryCache::removeFragmentIdentifierIfNeeded(url));
+    RefPtr cachedResource = frame->document()->cachedResourceLoader().cachedResource(MemoryCache::removeFragmentIdentifierIfNeeded(url));
     if (!cachedResource) {
         ResourceRequest request(URL { url });
         request.setDomainForCachePartition(frame->document()->domainForCachePartition());

--- a/Source/WebCore/inspector/InspectorResourceUtilities.h
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.h
@@ -50,7 +50,7 @@ void resourceContent(Inspector::Protocol::ErrorString&, WebCore::LocalFrame*, co
 bool mainResourceContent(WebCore::LocalFrame*, bool withBase64Encode, String* result);
 
 String sourceMapURLForResource(WebCore::CachedResource*);
-WebCore::CachedResource* cachedResource(const WebCore::LocalFrame*, const URL&);
+RefPtr<WebCore::CachedResource> cachedResource(const WebCore::LocalFrame*, const URL&);
 Inspector::ResourceType NODELETE inspectorResourceType(WebCore::CachedResource::Type);
 Inspector::ResourceType inspectorResourceType(const WebCore::CachedResource&);
 

--- a/Source/WebCore/inspector/NetworkResourcesData.h
+++ b/Source/WebCore/inspector/NetworkResourcesData.h
@@ -123,7 +123,7 @@ public:
         SharedBufferBuilder m_dataBuffer;
         RefPtr<FragmentedSharedBuffer> m_buffer;
         std::optional<CertificateInfo> m_certificateInfo;
-        CachedResource* m_cachedResource { nullptr };
+        WeakPtr<CachedResource> m_cachedResource;
         Inspector::ResourceType m_type { Inspector::ResourceType::Other };
         int m_httpStatusCode { 0 };
         String m_httpStatusText;

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -465,9 +465,12 @@ void InspectorNetworkAgent::willSendRequest(ResourceLoaderIdentifier identifier,
         }
     }
     if (type == ResourceType::Other) {
+        RefPtr<const CachedResource> updatedCachedResource;
         if (!cachedResource && loader)
-            cachedResource = ResourceUtilities::cachedResource(loader->frame(), request.url());
-        type = resourceTypeForCachedResource(cachedResource);
+            updatedCachedResource = ResourceUtilities::cachedResource(loader->frame(), request.url());
+        else
+            updatedCachedResource = cachedResource;
+        type = resourceTypeForCachedResource(updatedCachedResource);
     }
     willSendRequest(identifier, loader, request, redirectResponse, type, resourceLoader);
 }
@@ -499,7 +502,7 @@ void InspectorNetworkAgent::didReceiveResponse(ResourceLoaderIdentifier identifi
 
     bool isNotModified = response.httpStatusCode() == 304;
 
-    CachedResource* cachedResource = nullptr;
+    RefPtr<CachedResource> cachedResource;
     if (auto* subresourceLoader = dynamicDowncast<SubresourceLoader>(resourceLoader); subresourceLoader && !isNotModified)
         cachedResource = subresourceLoader->cachedResource();
     if (!cachedResource && loader)

--- a/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorPageAgent.cpp
@@ -595,7 +595,7 @@ Inspector::Protocol::ErrorStringOr<Ref<JSON::ArrayOf<Inspector::Protocol::Generi
         success = ResourceUtilities::mainResourceContent(frame, false, &content);
 
     if (!success) {
-        if (auto* resource = ResourceUtilities::cachedResource(frame, kurl)) {
+        if (RefPtr resource = ResourceUtilities::cachedResource(frame, kurl)) {
             if (auto textContent = ResourceUtilities::textContentForCachedResource(*resource)) {
                 content = *textContent;
                 success = true;

--- a/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp
@@ -105,7 +105,7 @@ String PageDebuggerAgent::sourceMapURLForScript(const JSC::Debugger::Script& scr
         if (!localMainFrame)
             return String();
 
-        CachedResource* resource = ResourceUtilities::cachedResource(localMainFrame.get(), URL({ }, script.url));
+        RefPtr resource = ResourceUtilities::cachedResource(localMainFrame.get(), URL({ }, script.url));
         if (resource) {
             String sourceMapHeader = resource->response().httpHeaderField(StringView { sourceMapHTTPHeader });
             if (!sourceMapHeader.isEmpty())

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.h
@@ -25,13 +25,13 @@
 
 #pragma once
 
+#include <WebCore/CachedImage.h>
 #include <WebCore/LayoutBox.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
 
 namespace WebCore {
 
-class CachedImage;
 class RenderElement;
 class RenderStyle;
 
@@ -52,7 +52,7 @@ public:
     struct ReplacedAttributes {
         LayoutSize intrinsicSize;
         std::optional<LayoutUnit> intrinsicRatio { };
-        CachedImage* cachedImage { };
+        WeakPtr<CachedImage> cachedImage { };
     };
     ElementBox(ElementAttributes&&, ReplacedAttributes&&, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle = nullptr);
 
@@ -115,7 +115,7 @@ private:
 
         std::optional<LayoutSize> intrinsicSize;
         std::optional<LayoutUnit> intrinsicRatio;
-        CachedImage* cachedImage { nullptr };
+        WeakPtr<CachedImage> cachedImage;
     };
 
     std::unique_ptr<Box> m_firstChild;

--- a/Source/WebCore/loader/ApplicationManifestLoader.cpp
+++ b/Source/WebCore/loader/ApplicationManifestLoader.cpp
@@ -92,8 +92,11 @@ bool ApplicationManifestLoader::startLoading()
     CachedResourceRequest request(WTF::move(resourceRequest), options);
 
     auto cachedResource = protect(frame->document()->cachedResourceLoader())->requestApplicationManifest(WTF::move(request));
-    m_resource = cachedResource.value_or(nullptr);
-    if (CachedResourceHandle resource = m_resource)
+    if (cachedResource)
+        m_resource = WTF::move(cachedResource.value());
+    else
+        m_resource = nullptr;
+    if (RefPtr resource = m_resource)
         resource->addClient(*this);
     else {
         LOG_ERROR("Failed to start load for application manifest at url %s (error: %s)", resourceRequestURL.string().ascii().data(), cachedResource.error().localizedDescription().utf8().data());
@@ -105,14 +108,14 @@ bool ApplicationManifestLoader::startLoading()
 
 void ApplicationManifestLoader::stopLoading()
 {
-    if (CachedResourceHandle resource = std::exchange(m_resource, nullptr))
+    if (RefPtr resource = std::exchange(m_resource, nullptr))
         resource->removeClient(*this);
 }
 
 std::optional<ApplicationManifest>& ApplicationManifestLoader::processManifest()
 {
     if (!m_processedManifest) {
-        if (CachedResourceHandle resource = m_resource) {
+        if (RefPtr resource = m_resource) {
             auto manifestURL = m_url;
             auto documentURL = m_documentLoader->url();
             RefPtr frame = m_documentLoader->frame();

--- a/Source/WebCore/loader/ContentFilter.cpp
+++ b/Source/WebCore/loader/ContentFilter.cpp
@@ -383,8 +383,8 @@ void ContentFilter::deliverResourceData(const SharedBuffer& buffer)
 
 URL ContentFilter::url()
 {
-    if (m_mainResource)
-        return m_mainResource->url();
+    if (RefPtr mainResource = m_mainResource)
+        return mainResource->url();
     return m_mainResourceURL;
 }
 

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
@@ -64,7 +64,7 @@ CrossOriginPreflightChecker::CrossOriginPreflightChecker(DocumentThreadableLoade
 
 CrossOriginPreflightChecker::~CrossOriginPreflightChecker()
 {
-    if (CachedResourceHandle resource = m_resource)
+    if (RefPtr resource = m_resource)
         resource->removeClient(*this);
 }
 
@@ -144,8 +144,11 @@ void CrossOriginPreflightChecker::startPreflight()
     preflightRequest.setInitiatorType(AtomString { loader->options().initiatorType });
 
     ASSERT(!m_resource);
-    m_resource = protect(loader->document().cachedResourceLoader())->requestRawResource(WTF::move(preflightRequest)).value_or(nullptr);
-    if (CachedResourceHandle resource = m_resource)
+    if (auto result = protect(loader->document().cachedResourceLoader())->requestRawResource(WTF::move(preflightRequest)))
+        m_resource = WTF::move(result.value());
+    else
+        m_resource = nullptr;
+    if (RefPtr resource = m_resource)
         resource->addClient(*this);
 }
 
@@ -190,7 +193,7 @@ void CrossOriginPreflightChecker::doPreflight(DocumentThreadableLoader& loader, 
 
 void CrossOriginPreflightChecker::setDefersLoading(bool value)
 {
-    if (CachedResourceHandle resource = m_resource)
+    if (RefPtr resource = m_resource)
         resource->setDefersLoading(value);
 }
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -1779,7 +1779,7 @@ RefPtr<ArchiveResource> DocumentLoader::subresource(const URL& url) const
     if (!isCommitted())
         return nullptr;
     
-    auto* resource = m_cachedResourceLoader->cachedResource(url);
+    RefPtr resource = m_cachedResourceLoader->cachedResource(url);
     if (!resource || !resource->isLoaded())
         return archiveResourceForURL(url);
 
@@ -1995,7 +1995,7 @@ void DocumentLoader::stopLoadingPlugIns()
 void DocumentLoader::stopLoadingSubresources()
 {
     for (auto& loader : copyToVector(m_subresourceLoaders)) {
-        if (CachedResourceHandle cachedResource = loader->cachedResource()) {
+        if (RefPtr cachedResource = loader->cachedResource()) {
             // Don't cancel loaders for prefetch resources, as they need to survive navigation.
             if (cachedResource->options().cachingPolicy == CachingPolicy::AllowCachingMainResourcePrefetch) {
                 m_subresourceLoaders.remove(loader);

--- a/Source/WebCore/loader/DocumentPrefetcher.cpp
+++ b/Source/WebCore/loader/DocumentPrefetcher.cpp
@@ -47,7 +47,14 @@ DocumentPrefetcher::DocumentPrefetcher(FrameLoader& frameLoader)
 {
 }
 
-DocumentPrefetcher::~DocumentPrefetcher() = default;
+DocumentPrefetcher::~DocumentPrefetcher()
+{
+    for (auto& [url, data] : m_prefetchedData) {
+        RefPtr resource = data.resource;
+        if (resource && resource->hasClient(*this))
+            resource->removeClient(*this);
+    }
+}
 
 static bool isPassingSecurityChecks(const URL& url, Document& document)
 {
@@ -146,11 +153,9 @@ void DocumentPrefetcher::prefetch(const URL& url, const Vector<String>& tags, st
 
     if (!resourceErrorOr)
         return;
-    auto prefetchedResource = resourceErrorOr.value();
-    if (prefetchedResource) {
-        m_prefetchedData.set(url, PrefetchedResourceData { prefetchedResource, { } });
-        prefetchedResource->addClient(*this);
-    }
+    auto& prefetchedResource = resourceErrorOr.value();
+    m_prefetchedData.set(url, PrefetchedResourceData { CachedResourceHandle { prefetchedResource.get() }, { } });
+    prefetchedResource->addClient(*this);
 }
 
 void DocumentPrefetcher::responseReceived(const CachedResource&, const ResourceResponse&, CompletionHandler<void()>&& completionHandler)
@@ -167,12 +172,14 @@ void DocumentPrefetcher::notifyFinished(CachedResource& resource, const NetworkL
         it->value.metrics = Box<NetworkLoadMetrics>::create(metrics);
 
     if (!resource.response().isSuccessful()) {
+        if (resource.hasClient(*this))
+            resource.removeClient(*this);
         m_prefetchedData.remove(resourceURL);
         MemoryCache::singleton().remove(resource);
     }
-
-    if (resource.hasClient(*this))
-        resource.removeClient(*this);
+    // For successful responses, keep the client registration so the resource
+    // stays "live" in the memory cache and is not prematurely evicted. The
+    // client is removed later when the prefetch is consumed or cancelled.
 }
 
 void DocumentPrefetcher::removePrefetch(const URL& url)
@@ -181,7 +188,8 @@ void DocumentPrefetcher::removePrefetch(const URL& url)
     if (it == m_prefetchedData.end())
         return;
 
-    if (auto& resource = it->value.resource) {
+    if (CachedResourceHandle<CachedRawResource>& resourceHandle = it->value.resource) {
+        RefPtr resource = resourceHandle;
         if (resource->hasClient(*this))
             resource->removeClient(*this);
         MemoryCache::singleton().remove(*resource);
@@ -199,8 +207,12 @@ Box<NetworkLoadMetrics> DocumentPrefetcher::takePrefetchedResourceMetrics(const 
     auto it = m_prefetchedData.find(url);
     if (it != m_prefetchedData.end() && it->value.metrics) {
         auto metrics = WTF::move(it->value.metrics);
-        if (it->value.resource)
-            MemoryCache::singleton().remove(*it->value.resource);
+        if (CachedResourceHandle<CachedRawResource>& resourceHandle = it->value.resource) {
+            RefPtr resource = resourceHandle;
+            if (resource->hasClient(*this))
+                resource->removeClient(*this);
+            MemoryCache::singleton().remove(*resource);
+        }
         m_prefetchedData.remove(it);
         return metrics;
     }
@@ -209,10 +221,14 @@ Box<NetworkLoadMetrics> DocumentPrefetcher::takePrefetchedResourceMetrics(const 
 
 void DocumentPrefetcher::clearPrefetchedResourcesExcept(const URL& url)
 {
-    m_prefetchedData.removeIf([&url](auto& entry) {
+    m_prefetchedData.removeIf([&](auto& entry) {
         if (entry.key != url) {
-            if (entry.value.resource)
-                MemoryCache::singleton().remove(*entry.value.resource);
+            if (CachedResourceHandle<CachedRawResource>& resourceHandle = entry.value.resource) {
+                RefPtr resource = resourceHandle;
+                if (resource->hasClient(*this))
+                    resource->removeClient(*this);
+                MemoryCache::singleton().remove(*resource);
+            }
             return true;
         }
         return false;
@@ -222,11 +238,15 @@ void DocumentPrefetcher::clearPrefetchedResourcesExcept(const URL& url)
 // https://wicg.github.io/nav-speculation/prefetch.html#clear-prefetch-cache
 void DocumentPrefetcher::clearPrefetchedResourcesForOrigin(const SecurityOrigin& origin)
 {
-    m_prefetchedData.removeIf([&origin](auto& entry) {
+    m_prefetchedData.removeIf([&](auto& entry) {
         Ref urlOrigin = SecurityOrigin::create(entry.key);
         if (origin.isSameOriginAs(urlOrigin)) {
-            if (entry.value.resource)
-                MemoryCache::singleton().remove(*entry.value.resource);
+            if (CachedResourceHandle<CachedRawResource>& resourceHandle = entry.value.resource) {
+                RefPtr resource = resourceHandle;
+                if (resource->hasClient(*this))
+                    resource->removeClient(*this);
+                MemoryCache::singleton().remove(*resource);
+            }
             return true;
         }
         return false;

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -248,7 +248,7 @@ void DocumentThreadableLoader::makeCrossOriginAccessRequestWithPreflight(Resourc
 
 DocumentThreadableLoader::~DocumentThreadableLoader()
 {
-    if (CachedResourceHandle resource = m_resource)
+    if (RefPtr resource = m_resource)
         resource->removeClient(*this);
 }
 
@@ -259,7 +259,7 @@ void DocumentThreadableLoader::cancel()
     // Cancel can re-enter and m_resource might be null here as a result.
     if (RefPtr client = m_client.get(); client && m_resource) {
         // FIXME: This error is sent to the client in didFail(), so it should not be an internal one. Use LocalFrameLoaderClient::cancelledError() instead.
-        ResourceError error(errorDomainWebKitInternal, 0, m_resource->url(), "Load cancelled"_s, ResourceError::Type::Cancellation);
+        ResourceError error(errorDomainWebKitInternal, 0, protect(m_resource)->url(), "Load cancelled"_s, ResourceError::Type::Cancellation);
         client->didFail(m_document->identifier(), error); // May destroy the client.
     }
     clearResource();
@@ -274,7 +274,7 @@ void DocumentThreadableLoader::computeIsDone()
         return;
     }
     platformStrategies()->loaderStrategy()->isResourceLoadFinished(*protect(m_resource), [weakThis = WeakPtr { *this }](bool isDone) {
-        RefPtr protectedThis = weakThis.get();
+        RefPtr protectedThis = weakThis;
         if (!protectedThis)
             return;
         if (RefPtr client = protectedThis->m_client.get())
@@ -284,7 +284,7 @@ void DocumentThreadableLoader::computeIsDone()
 
 void DocumentThreadableLoader::setDefersLoading(bool value)
 {
-    if (CachedResourceHandle resource = m_resource)
+    if (RefPtr resource = m_resource)
         resource->setDefersLoading(value);
     if (RefPtr preflightChecker = m_preflightChecker)
         preflightChecker->setDefersLoading(value);
@@ -296,10 +296,8 @@ void DocumentThreadableLoader::clearResource()
     // which could lead to calling CachedResource::removeClient() multiple times for
     // this DocumentThreadableLoader. Save off a copy of m_resource and clear it to
     // prevent the reentrancy.
-    if (CachedResourceHandle resource = m_resource) {
-        m_resource = nullptr;
+    if (RefPtr resource = std::exchange(m_resource, nullptr))
         resource->removeClient(*this);
-    }
     m_preflightChecker = nullptr;
 }
 
@@ -410,7 +408,7 @@ void DocumentThreadableLoader::didReceiveResponse(ResourceLoaderIdentifier ident
     ASSERT(response.type() != ResourceResponse::Type::Error);
 
     // https://fetch.spec.whatwg.org/commit-snapshots/6257e220d70f560a037e46f1b4206325400db8dc/#main-fetch step 17.
-    if (response.source() == ResourceResponse::Source::ServiceWorker && response.url() != m_resource->url()) {
+    if (response.source() == ResourceResponse::Source::ServiceWorker && response.url() != protect(m_resource)->url()) {
         if (!isResponseAllowedByContentSecurityPolicy(response)) {
             reportContentSecurityPolicyError(response.url());
             return;
@@ -478,15 +476,16 @@ void DocumentThreadableLoader::notifyFinished(CachedResource& resource, const Ne
     ASSERT(m_client);
     ASSERT_UNUSED(resource, &resource == m_resource);
 
-    if (m_resource->errorOccurred())
-        didFail(m_resource->resourceLoaderIdentifier(), m_resource->resourceError());
+    RefPtr rawResource = m_resource;
+    if (rawResource->errorOccurred())
+        didFail(rawResource->resourceLoaderIdentifier(), rawResource->resourceError());
     else
-        didFinishLoading(m_resource->resourceLoaderIdentifier(), metrics);
+        didFinishLoading(rawResource->resourceLoaderIdentifier(), metrics);
 }
 
 void DocumentThreadableLoader::didFinishLoading(std::optional<ResourceLoaderIdentifier> identifier, const NetworkLoadMetrics& metrics)
 {
-    RefPtr document = m_document.get();
+    RefPtr document = m_document;
     if (!document)
         return;
 
@@ -494,7 +493,7 @@ void DocumentThreadableLoader::didFinishLoading(std::optional<ResourceLoaderIden
     ASSERT(client);
 
     if (m_delayCallbacksForIntegrityCheck) {
-        CachedResourceHandle resource = m_resource;
+        RefPtr resource = m_resource;
         if (!matchIntegrityMetadata(*resource, m_options.integrity)) {
             reportIntegrityMetadataError(*resource, m_options.integrity);
             return;
@@ -535,7 +534,7 @@ void DocumentThreadableLoader::didFail(std::optional<ResourceLoaderIdentifier>, 
     if (m_shouldLogError == ShouldLogError::Yes)
         logError(protect(*m_document), error, m_options.initiatorType);
 
-    RefPtr document = m_document.get();
+    RefPtr document = m_document;
     if (!document)
         return;
     if (RefPtr client = m_client.get())
@@ -598,12 +597,15 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
         newRequest.setOrigin(protect(securityOrigin()));
 
         ASSERT(!m_resource);
-        if (CachedResourceHandle resource = std::exchange(m_resource, nullptr))
+        if (RefPtr resource = std::exchange(m_resource, nullptr))
             resource->removeClient(*this);
 
         auto cachedResource = protect(protect(*m_document)->cachedResourceLoader())->requestRawResource(WTF::move(newRequest));
-        m_resource = cachedResource.value_or(nullptr);
-        if (CachedResourceHandle resource = m_resource)
+        if (cachedResource)
+            m_resource = WTF::move(cachedResource.value());
+        else
+            m_resource = nullptr;
+        if (RefPtr resource = m_resource)
             resource->addClient(*this);
         else
             logErrorAndFail(cachedResource.error());

--- a/Source/WebCore/loader/FontLoadRequest.h
+++ b/Source/WebCore/loader/FontLoadRequest.h
@@ -51,7 +51,7 @@ class FontLoadRequest : public AbstractRefCounted {
 public:
     virtual ~FontLoadRequest() = default;
 
-    virtual const URL& url() const = 0;
+    virtual URL url() const = 0;
     virtual bool isPending() const = 0;
     virtual bool isLoading() const = 0;
     virtual bool errorOccurred() const = 0;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4827,7 +4827,7 @@ void FrameLoader::tellClientAboutPastMemoryCacheLoads()
     documentLoader->takeMemoryCacheLoadsForClientNotification(pastLoads);
 
     for (auto& pastLoad : pastLoads) {
-        CachedResourceHandle resource = MemoryCache::singleton().resourceForRequest(pastLoad, page->sessionID());
+        RefPtr resource = MemoryCache::singleton().resourceForRequest(pastLoad, page->sessionID());
 
         // FIXME: These loads, loaded from cache, but now gone from the cache by the time
         // Page::setMemoryCacheClientCallsEnabled(true) is called, will not be seen by the client.

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -129,7 +129,7 @@ static inline bool NODELETE pageIsBeingDismissed(Document& document)
 // https://html.spec.whatwg.org/multipage/images.html#updating-the-image-data:list-of-available-images
 static bool canReuseFromListOfAvailableImages(const CachedResourceRequest& request, Document& document)
 {
-    CachedResourceHandle resource = MemoryCache::singleton().resourceForRequest(request.resourceRequest(), document.page()->sessionID());
+    RefPtr resource = MemoryCache::singleton().resourceForRequest(request.resourceRequest(), document.page()->sessionID());
     if (!resource || resource->stillNeedsLoad() || resource->isPreloaded())
         return false;
 
@@ -156,7 +156,7 @@ ImageLoader::ImageLoader(Element& element)
 
 ImageLoader::~ImageLoader()
 {
-    if (CachedResourceHandle image = m_image)
+    if (RefPtr image = m_image)
         image->removeClient(*this);
 
     ASSERT(m_hasPendingLoadEvent || m_hasPendingErrorEvent || !loadEventSender().hasPendingEvents(*this));
@@ -188,8 +188,7 @@ void ImageLoader::clearImageWithoutConsideringPendingLoadEvent()
     LOG_WITH_STREAM(LazyLoading, stream << "ImageLoader " << this << " clearImageWithoutConsideringPendingLoadEvent");
 
     ASSERT(m_failedLoadURL.isEmpty());
-    if (CachedResourceHandle oldImage = m_image) {
-        m_image = nullptr;
+    if (RefPtr oldImage = std::exchange(m_image, nullptr)) {
         m_hasPendingBeforeLoadEvent = false;
         if (m_hasPendingLoadEvent || m_hasPendingErrorEvent) {
             loadEventSender().cancelEvent(*this);
@@ -222,7 +221,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
     if (!m_failedLoadURL.isEmpty() && attr == m_failedLoadURL)
         return;
 
-    CachedResourceHandle<CachedImage> newImage;
+    RefPtr<CachedImage> newImage;
 
     // Do not load any image if the 'src' attribute is missing.
     if (attr.isNull()) {
@@ -259,8 +258,8 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
 
     // Use URL from original request for same URL loads in order to preserve the original base URL.
     URL imageURL;
-    if (m_image && attr == m_pendingURL)
-        imageURL = m_image->url();
+    if (RefPtr image = m_image; image && attr == m_pendingURL)
+        imageURL = image->url();
     else {
         if (imageElement) {
             // It is possible that attributes are bulk-set via Element::parserSetAttributes. In that case, it is possible that attribute vectors are already configured,
@@ -288,10 +287,10 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
         cachedResourceLoader->setAutoLoadImages(false);
         RefPtr page = m_element->document().page();
         // FIXME: We shouldn't do an explicit `new` here.
-        newImage = new CachedImage(WTF::move(request), page->sessionID(), &page->cookieJar());
+        newImage = adoptRef(*new CachedImage(WTF::move(request), page->sessionID(), &page->cookieJar()));
         newImage->setStatus(CachedResource::Pending);
         newImage->setLoading(true);
-        cachedResourceLoader->m_documentResources.set(newImage->url().string(), newImage.get());
+        cachedResourceLoader->m_documentResources.set(newImage->url().string(), *newImage);
         cachedResourceLoader->setAutoLoadImages(autoLoadOtherImages);
     } else {
 #if !LOG_DISABLED
@@ -343,13 +342,13 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
     didUpdateCachedImage(relevantMutation, WTF::move(newImage));
 }
 
-void ImageLoader::didUpdateCachedImage(RelevantMutation relevantMutation, CachedResourceHandle<CachedImage>&& newImage)
+void ImageLoader::didUpdateCachedImage(RelevantMutation relevantMutation, RefPtr<CachedImage>&& newImage)
 {
     LOG_WITH_STREAM(LazyLoading, stream << "ImageLoader " << this << " didUpdateCachedImage " << newImage.get());
 
     Ref document = element().document();
 
-    CachedResourceHandle oldImage = m_image;
+    RefPtr oldImage = m_image;
     if (newImage != oldImage || relevantMutation == RelevantMutation::Yes) {
         LOG_WITH_STREAM(LazyLoading, stream << " switching from old image " << oldImage.get() << " to image " << newImage.get() << " " << (newImage ? newImage->url() : URL()));
 
@@ -467,10 +466,11 @@ void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetr
         return;
     }
 
-    if (m_image->resourceError().isAccessControl()) {
+    RefPtr image = m_image;
+    if (image->resourceError().isAccessControl()) {
         setImageCompleteAndMaybeUpdateRenderer();
 
-        auto imageURL = m_image->url();
+        auto imageURL = image->url();
         clearImageWithoutConsideringPendingLoadEvent();
 
         m_hasPendingErrorEvent = true;
@@ -490,7 +490,7 @@ void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetr
         return;
     }
 
-    if (m_image->wasCanceled()) {
+    if (image->wasCanceled()) {
         setImageCompleteAndMaybeUpdateRenderer();
 
         if (hasPendingDecodePromises())
@@ -502,7 +502,7 @@ void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetr
         return;
     }
 
-    protect(m_image->image())->subresourcesAreFinished(protect(document()).ptr(), [this, protectedThis = Ref { *this }]() mutable {
+    protect(image->image())->subresourcesAreFinished(protect(document()).ptr(), [this, protectedThis = Ref { *this }]() mutable {
         // It is technically possible state changed underneath us.
         if (!m_hasPendingLoadEvent)
             return;
@@ -560,7 +560,7 @@ void ImageLoader::updateRenderer()
     // Only update the renderer if it doesn't have an image or if what we have
     // is a complete image. This prevents flickering in the case where a dynamic
     // change is happening between two images.
-    CachedImage* cachedImage = imageResource->cachedImage();
+    RefPtr cachedImage = imageResource->cachedImage();
     if (m_image != cachedImage && (m_imageComplete || !cachedImage))
         imageResource->setCachedImage(protect(m_image));
 }
@@ -622,12 +622,13 @@ void ImageLoader::decode()
         return;
     }
 
-    if (!m_image || !m_image->image() || m_image->errorOccurred()) {
+    RefPtr image = m_image;
+    if (!image || !image->image() || image->errorOccurred()) {
         rejectDecodePromises("Loading error."_s);
         return;
     }
 
-    RefPtr bitmapImage = dynamicDowncast<BitmapImage>(m_image->image());
+    RefPtr bitmapImage = dynamicDowncast<BitmapImage>(image->image());
     if (!bitmapImage) {
         resolveDecodePromises();
         return;
@@ -651,7 +652,9 @@ bool ImageLoader::hasPendingActivity() const
 {
     // Because of lazy image loading, an image's load may be deferred indefinitely. To avoid leaking the element, we only
     // protect it once the load has actually started.
-    bool imageWillBeLoadedLater = m_image && !m_image->isLoading() && m_image->stillNeedsLoad();
+    // We are using SUPPRESS_UNCOUNTED_ARG and not ref'ing m_image here because this function
+    // may get called on the GC thread, and it would trip threading assertion in RefCounted.
+    SUPPRESS_UNCOUNTED_ARG bool imageWillBeLoadedLater = m_image && !m_image->isLoading() && m_image->stillNeedsLoad();
     return (m_hasPendingLoadEvent && !imageWillBeLoadedLater) || m_hasPendingErrorEvent;
 }
 

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -108,7 +108,7 @@ private:
     virtual void dispatchLoadEvent() = 0;
 
     void updatedHasPendingEvent();
-    void didUpdateCachedImage(RelevantMutation, CachedResourceHandle<CachedImage>&&);
+    void didUpdateCachedImage(RelevantMutation, RefPtr<CachedImage>&&);
 
     void dispatchPendingBeforeLoadEvent();
     void dispatchPendingLoadEvent();

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -83,7 +83,7 @@ LinkLoader::LinkLoader(LinkLoaderClient& client)
 
 LinkLoader::~LinkLoader()
 {
-    if (CachedResourceHandle cachedLinkResource = m_cachedLinkResource)
+    if (RefPtr cachedLinkResource = m_cachedLinkResource)
         cachedLinkResource->removeClient(*this);
     if (RefPtr client = m_preloadResourceClient)
         client->clear();
@@ -111,7 +111,7 @@ void LinkLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetri
 {
     ASSERT_UNUSED(resource, m_cachedLinkResource.get() == &resource);
 
-    CachedResourceHandle cachedLinkResource = m_cachedLinkResource;
+    RefPtr cachedLinkResource = m_cachedLinkResource;
     triggerEvents(*cachedLinkResource);
 
     cachedLinkResource->removeClient(*this);
@@ -401,7 +401,9 @@ RefPtr<LinkPreloadResourceClient> LinkLoader::preloadIfNeeded(const LinkLoadPara
     linkRequest.setIgnoreForRequestCount(true);
     linkRequest.setIsLinkPreload();
 
-    auto cachedLinkResource = protect(document.cachedResourceLoader())->preload(type.value(), WTF::move(linkRequest)).value_or(nullptr);
+    RefPtr<CachedResource> cachedLinkResource;
+    if (auto result = protect(document.cachedResourceLoader())->preload(type.value(), WTF::move(linkRequest)))
+        cachedLinkResource = WTF::move(result.value());
 
     if (cachedLinkResource && cachedLinkResource->type() != *type)
         return nullptr;
@@ -423,10 +425,9 @@ void LinkLoader::prefetchIfNeeded(const LinkLoadParameters& params, Document& do
     std::optional<ResourceLoadPriority> priority;
     CachedResource::Type type = CachedResource::Type::LinkPrefetch;
 
-    if (m_cachedLinkResource) {
-        m_cachedLinkResource->removeClient(*this);
-        m_cachedLinkResource = nullptr;
-    }
+    if (RefPtr resource = std::exchange(m_cachedLinkResource, nullptr))
+        resource->removeClient(*this);
+
     // FIXME: Add further prefetch restrictions/limitations:
     // - third-party iframes cannot trigger prefetches
     // - Number of prefetches of a given page is limited (to 1 maybe?)
@@ -440,8 +441,11 @@ void LinkLoader::prefetchIfNeeded(const LinkLoadParameters& params, Document& do
     options.cachingPolicy = CachingPolicy::DisallowCaching;
     options.referrerPolicy = params.referrerPolicy;
     options.nonce = params.nonce;
-    m_cachedLinkResource = protect(document.cachedResourceLoader())->requestLinkResource(type, CachedResourceRequest(ResourceRequest { document.completeURL(params.href.string()) }, options, priority)).value_or(nullptr);
-    if (CachedResourceHandle cachedLinkResource = m_cachedLinkResource)
+    if (auto result = protect(document.cachedResourceLoader())->requestLinkResource(type, CachedResourceRequest(ResourceRequest { document.completeURL(params.href.string()) }, options, priority)))
+        m_cachedLinkResource = WTF::move(result.value());
+    else
+        m_cachedLinkResource = nullptr;
+    if (RefPtr cachedLinkResource = m_cachedLinkResource)
         cachedLinkResource->addClient(*this);
 }
 

--- a/Source/WebCore/loader/LinkPreloadResourceClients.h
+++ b/Source/WebCore/loader/LinkPreloadResourceClients.h
@@ -58,7 +58,7 @@ protected:
 
     void addResource(CachedResourceClient& client)
     {
-        m_resource->addClient(client);
+        protect(m_resource)->addClient(client);
     }
 
     void clearResource(CachedResourceClient& client)
@@ -66,7 +66,7 @@ protected:
         if (!m_resource)
             return;
 
-        m_resource->removeClient(client);
+        protect(m_resource)->removeClient(client);
         m_resource = nullptr;
     }
 

--- a/Source/WebCore/loader/MediaResourceLoader.cpp
+++ b/Source/WebCore/loader/MediaResourceLoader.cpp
@@ -159,7 +159,9 @@ RefPtr<PlatformMediaResource> MediaResourceLoader::requestResource(ResourceReque
     if (RefPtr element = m_element.get())
         cachedRequest.setInitiator(*element);
 
-    auto resource = protect(document->cachedResourceLoader())->requestMedia(WTF::move(cachedRequest)).value_or(nullptr);
+    RefPtr<CachedRawResource> resource;
+    if (auto result = protect(document->cachedResourceLoader())->requestMedia(WTF::move(cachedRequest)))
+        resource = WTF::move(result.value());
     if (!resource)
         return nullptr;
 
@@ -300,7 +302,7 @@ void MediaResource::shutdown()
 
     setClient(nullptr);
 
-    if (CachedResourceHandle resource = std::exchange(m_resource, nullptr))
+    if (RefPtr resource = std::exchange(m_resource, nullptr))
         resource->removeClient(*this);
 }
 

--- a/Source/WebCore/loader/ResourceTimingInformation.cpp
+++ b/Source/WebCore/loader/ResourceTimingInformation.cpp
@@ -86,20 +86,18 @@ void ResourceTimingInformation::removeResourceTiming(CachedResource& resource)
     m_initiatorMap.remove(resource);
 }
 
-void ResourceTimingInformation::storeResourceTimingInitiatorInformation(const CachedResourceHandle<CachedResource>& resource, const AtomString& initiatorType, LocalFrame* frame)
+void ResourceTimingInformation::storeResourceTimingInitiatorInformation(CachedResource& resource, const AtomString& initiatorType, LocalFrame* frame)
 {
-    ASSERT(resource.get());
-
-    if (resource->type() == CachedResource::Type::MainResource) {
+    if (resource.type() == CachedResource::Type::MainResource) {
         // <iframe>s should report the initial navigation requested by the parent document, but not subsequent navigations.
         ASSERT(frame);
         if (frame->ownerElement()) {
             InitiatorInfo info = { frame->ownerElement()->localName(), NotYetAdded };
-            m_initiatorMap.add(*resource, info);
+            m_initiatorMap.add(resource, info);
         }
     } else {
         InitiatorInfo info = { initiatorType, NotYetAdded };
-        m_initiatorMap.add(*resource, info);
+        m_initiatorMap.add(resource, info);
     }
 }
 

--- a/Source/WebCore/loader/ResourceTimingInformation.h
+++ b/Source/WebCore/loader/ResourceTimingInformation.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <WebCore/CachedResourceHandle.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/text/WTFString.h>
 
@@ -42,7 +41,7 @@ public:
 
     void addResourceTiming(CachedResource&, Document&, ResourceTiming&&);
     void removeResourceTiming(CachedResource&);
-    void storeResourceTimingInitiatorInformation(const CachedResourceHandle<CachedResource>&, const AtomString&, LocalFrame*);
+    void storeResourceTimingInitiatorInformation(CachedResource&, const AtomString&, LocalFrame*);
 
 private:
     enum AlreadyAdded { NotYetAdded, Added };

--- a/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/Source/WebCore/loader/SubresourceLoader.cpp
@@ -107,8 +107,8 @@ auto SubresourceLoader::RequestCountTracker::operator=(RequestCountTracker&& oth
 
 SubresourceLoader::RequestCountTracker::~RequestCountTracker()
 {
-    RefPtr cachedResourceLoader = m_cachedResourceLoader.get();
-    CachedResourceHandle resource = m_resource.get();
+    RefPtr cachedResourceLoader = m_cachedResourceLoader;
+    RefPtr resource = m_resource;
     if (cachedResourceLoader && resource)
         cachedResourceLoader->decrementRequestCount(*resource);
 }
@@ -246,12 +246,12 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
 
     ASSERT(!newRequest.isNull());
     if (!redirectResponse.isNull()) {
-        CachedResourceHandle resource = m_resource.get();
+        RefPtr resource = m_resource;
         if (options().redirect != FetchOptions::Redirect::Follow) {
             if (options().redirect == FetchOptions::Redirect::Error) {
                 ResourceError error { errorDomainWebKitInternal, 0, request().url(), makeString("Not allowed to follow a redirection while loading "_s, request().url().string()), ResourceError::Type::AccessControl };
 
-                if (RefPtr frame = m_frame.get(); frame && frame->document())
+                if (RefPtr frame = m_frame; frame && frame->document())
                     protect(frame->document())->addConsoleMessage(MessageSource::Security, MessageLevel::Error, error.localizedDescription());
 
                 SUBRESOURCELOADER_RELEASE_LOG(SUBRESOURCELOADER_WILLSENDREQUESTINTERNAL_RESOURCELOAD_CANCELLED_REDIRECT_NOT_ALLOWED);
@@ -284,8 +284,8 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
         // Requesting the same original URL a second time can redirect to a unique second resource.
         // Therefore, if a redirect to a different destination URL occurs, we should no longer consider this a revalidation of the first resource.
         // Doing so would have us reusing the resource from the first request if the second request's revalidation succeeds.
-        RefPtr frame = m_frame.get();
-        if (newRequest.isConditional() && resource->resourceToRevalidate() && newRequest.url() != resource->resourceToRevalidate()->response().url()) {
+        RefPtr frame = m_frame;
+        if (newRequest.isConditional() && resource->resourceToRevalidate() && newRequest.url() != protect(resource->resourceToRevalidate())->response().url()) {
             newRequest.makeUnconditional();
             MemoryCache::singleton().revalidationFailed(*resource);
             if (frame && frame->page())
@@ -305,7 +305,7 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
 
         if (!isPortAllowed(newRequest.url())) {
             SUBRESOURCELOADER_RELEASE_LOG(SUBRESOURCELOADER_WILLSENDREQUESTINTERNAL_RESOURCE_LOAD_CANCELLED_AFTER_USING_BLOCKED_PORT);
-            if (RefPtr frame = m_frame.get())
+            if (RefPtr frame = m_frame)
                 FrameLoader::reportBlockedLoadFailed(*frame, newRequest.url());
             if (frameLoader())
                 cancel(frameLoader()->blockedError(newRequest));
@@ -315,7 +315,7 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
         auto accessControlCheckResult = checkRedirectionCrossOriginAccessControl(request(), redirectResponse, newRequest);
         if (!accessControlCheckResult) {
             auto errorMessage = makeString("Cross-origin redirection to "_s, newRequest.url().string(), " denied by Cross-Origin Resource Sharing policy: "_s, accessControlCheckResult.error());
-            if (RefPtr frame = m_frame.get(); frame && frame->document())
+            if (RefPtr frame = m_frame; frame && frame->document())
                 protect(frame->document())->addConsoleMessage(MessageSource::Security, MessageLevel::Error, errorMessage);
             SUBRESOURCELOADER_RELEASE_LOG(SUBRESOURCELOADER_WILLSENDREQUESTINTERNAL_RESOURCE_LOAD_CANCELLED_AFTER_REDIRECT_DENIED_BY_CORS_POLICY);
             cancel(ResourceError(String(), 0, request().url(), errorMessage, ResourceError::Type::AccessControl));
@@ -423,13 +423,13 @@ void SubresourceLoader::didReceiveResponse(ResourceResponse&& response, Completi
     if (shouldIncludeCertificateInfo())
         response.includeCertificateInfo();
 
-    CachedResourceHandle resource = m_resource.get();
+    RefPtr resource = m_resource;
     if (!resource) {
         ASSERT_NOT_REACHED();
         RELEASE_LOG_FAULT(Loading, "Resource was unexpectedly null in SubresourceLoader::didReceiveResponse");
     }
 
-    RefPtr frame = m_frame.get();
+    RefPtr frame = m_frame;
     if (resource && resource->resourceToRevalidate()) {
         if (response.httpStatusCode() == httpStatus304NotModified) {
             // Existing resource is ok, just use it updating the expiration time.
@@ -515,7 +515,7 @@ void SubresourceLoader::didReceiveResponse(ResourceResponse&& response, Completi
         if (reachedTerminalState())
             return;
 
-        CachedResourceHandle resource = m_resource.get();
+        RefPtr resource = m_resource;
         // FIXME: Main resources have a different set of rules for multipart than images do.
         // Hopefully we can merge those 2 paths.
         if (isResponseMultipart && resource && resource->type() != CachedResource::Type::MainResource) {
@@ -560,7 +560,7 @@ void SubresourceLoader::didReceiveBuffer(const FragmentedSharedBuffer& buffer, l
         return;
 #endif
 
-    CachedResourceHandle resource = m_resource.get();
+    RefPtr resource = m_resource;
     ASSERT(resource);
 
     if (resource->response().httpStatusCode() >= httpStatus400BadRequest && !resource->shouldIgnoreHTTPStatusCodeErrors())
@@ -584,7 +584,7 @@ void SubresourceLoader::didReceiveBuffer(const FragmentedSharedBuffer& buffer, l
 
 bool SubresourceLoader::responseHasHTTPStatusCodeError() const
 {
-    CachedResourceHandle resource = m_resource.get();
+    RefPtr resource = m_resource;
     if (resource->response().httpStatusCode() < httpStatus400BadRequest || resource->shouldIgnoreHTTPStatusCodeErrors())
         return false;
     return true;
@@ -745,7 +745,7 @@ void SubresourceLoader::didFinishLoading(const NetworkLoadMetrics& networkLoadMe
     Ref protectedThis { *this };
 
     ASSERT(!reachedTerminalState());
-    CachedResourceHandle resource = m_resource.get();
+    RefPtr resource = m_resource;
     if (!resource)
         return;
 
@@ -805,10 +805,10 @@ void SubresourceLoader::didFail(const ResourceError& error)
         return;
 
     ASSERT(!reachedTerminalState());
-    CachedResourceHandle resource = m_resource.get();
+    RefPtr resource = m_resource;
     LOG(ResourceLoading, "Failed to load '%s'.\n", resource->url().string().latin1().data());
 
-    RefPtr frame = m_frame.get();
+    RefPtr frame = m_frame;
     if (frame && frame->document() && error.isAccessControl() && error.domain() != InspectorNetworkAgent::errorDomain() && resource->type() != CachedResource::Type::Ping)
         protect(frame->document())->addConsoleMessage(MessageSource::Security, MessageLevel::Error, error.localizedDescription());
 
@@ -848,7 +848,7 @@ void SubresourceLoader::willCancel(const ResourceError& error)
     ASSERT(!reachedTerminalState());
 
     Ref protectedThis { *this };
-    CachedResourceHandle resource = m_resource.get();
+    RefPtr resource = m_resource;
     LOG(ResourceLoading, "Cancelled load of '%s'.\n", resource->url().string().latin1().data());
 
 #if PLATFORM(IOS_FAMILY)
@@ -868,7 +868,7 @@ void SubresourceLoader::didCancel(LoadWillContinueInAnotherProcess loadWillConti
     if (m_state == Uninitialized || reachedTerminalState())
         return;
 
-    CachedResourceHandle resource = m_resource.get();
+    RefPtr resource = m_resource;
     ASSERT(resource);
 
     if (resource->type() != CachedResource::Type::MainResource)
@@ -918,7 +918,7 @@ void SubresourceLoader::releaseResources()
 
 void SubresourceLoader::reportResourceTiming(const NetworkLoadMetrics& networkLoadMetrics)
 {
-    CachedResourceHandle resource = m_resource.get();
+    RefPtr resource = m_resource;
     ASSERT(resource);
     if (!resource || !ResourceTimingInformation::shouldAddResourceTiming(*resource))
         return;
@@ -941,7 +941,7 @@ void SubresourceLoader::reportResourceTiming(const NetworkLoadMetrics& networkLo
     }
 
     ASSERT(options().initiatorContext == InitiatorContext::Document);
-    documentLoader->cachedResourceLoader().resourceTimingInformation().addResourceTiming(*cachedResource(), *document, WTF::move(resourceTiming));
+    documentLoader->cachedResourceLoader().resourceTimingInformation().addResourceTiming(*protect(cachedResource()), *document, WTF::move(resourceTiming));
 }
 
 const HTTPHeaderMap* SubresourceLoader::originalHeaders() const

--- a/Source/WebCore/loader/SubresourceLoader.h
+++ b/Source/WebCore/loader/SubresourceLoader.h
@@ -33,7 +33,6 @@
 #include <WebCore/ResourceLoader.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Platform.h>
-#include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
  
 namespace WebCore {
@@ -134,7 +133,9 @@ private:
 #if PLATFORM(IOS_FAMILY)
     ResourceRequest m_iOSOriginalRequest;
 #endif
-    WeakPtr<CachedResource> m_resource;
+    // CachedResource has a RefPtr back to this SubresourceLoader via m_loader,
+    // forming a ref-cycle that is broken in releaseResources().
+    RefPtr<CachedResource> m_resource;
     SubresourceLoaderState m_state;
     std::optional<RequestCountTracker> m_requestCountTracker;
     RefPtr<SecurityOrigin> m_origin;

--- a/Source/WebCore/loader/TextTrackLoader.cpp
+++ b/Source/WebCore/loader/TextTrackLoader.cpp
@@ -59,7 +59,7 @@ TextTrackLoader::TextTrackLoader(TextTrackLoaderClient& client, Document& docume
 
 TextTrackLoader::~TextTrackLoader()
 {
-    if (CachedResourceHandle resource = m_resource)
+    if (RefPtr resource = m_resource)
         resource->removeClient(*this);
 }
 
@@ -79,7 +79,7 @@ void TextTrackLoader::cueLoadTimerFired()
 
 void TextTrackLoader::cancelLoad()
 {
-    if (CachedResourceHandle resource = std::exchange(m_resource, nullptr))
+    if (RefPtr resource = std::exchange(m_resource, nullptr))
         resource->removeClient(*this);
 }
 
@@ -95,7 +95,7 @@ void TextTrackLoader::processNewCueData(CachedResource& resource)
         return;
 
     if (!m_cueParser) {
-        RefPtr document = m_document.get();
+        RefPtr document = m_document;
         if (!document)
             return;
         m_cueParser = makeUnique<WebVTTParser>(static_cast<WebVTTParserClient&>(*this), *document);
@@ -122,7 +122,7 @@ void TextTrackLoader::deprecatedDidReceiveCachedResource(CachedResource& resourc
 void TextTrackLoader::corsPolicyPreventedLoad()
 {
     static NeverDestroyed<String> consoleMessage(MAKE_STATIC_STRING_IMPL("Cross-origin text track load denied by Cross-Origin Resource Sharing policy."));
-    if (RefPtr document = m_document.get())
+    if (RefPtr document = m_document)
         document->addConsoleMessage(MessageSource::Security, MessageLevel::Error, consoleMessage);
     m_state = Failed;
 }
@@ -131,19 +131,19 @@ void TextTrackLoader::notifyFinished(CachedResource& resource, const NetworkLoad
 {
     ASSERT_UNUSED(resource, m_resource == &resource);
 
-    if (m_resource->resourceError().isAccessControl())
+    RefPtr textTrackResource = m_resource;
+    if (textTrackResource->resourceError().isAccessControl())
         corsPolicyPreventedLoad();
 
-    if (!m_resource->resourceBuffer())
+    if (!textTrackResource->resourceBuffer())
         m_state = Failed;
 
     if (m_state != Failed) {
-        CachedResourceHandle resource = m_resource;
-        processNewCueData(*resource);
+        processNewCueData(resource);
         if (m_cueParser)
             m_cueParser->fileFinished();
         if (m_state != Failed)
-            m_state = resource->errorOccurred() ? Failed : Finished;
+            m_state = resource.errorOccurred() ? Failed : Finished;
     }
 
     if (m_state == Finished && m_cueParser)
@@ -162,7 +162,7 @@ bool TextTrackLoader::load(const URL& url, HTMLTrackElement& element)
     ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
     options.contentSecurityPolicyImposition = element.isInUserAgentShadowTree() ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
 
-    RefPtr document = m_document.get();
+    RefPtr document = m_document;
     if (!document)
         return false;
 
@@ -173,8 +173,11 @@ bool TextTrackLoader::load(const URL& url, HTMLTrackElement& element)
         resourceRequest.setInspectorInitiatorNodeIdentifier(InspectorInstrumentation::identifierForNode(*mediaElement));
 
     auto cueRequest = createPotentialAccessControlRequest(WTF::move(resourceRequest), WTF::move(options), *document, element.mediaElementCrossOriginAttribute());
-    m_resource = protect(document->cachedResourceLoader())->requestTextTrack(WTF::move(cueRequest)).value_or(nullptr);
-    if (CachedResourceHandle resource = m_resource) {
+    if (auto result = protect(document->cachedResourceLoader())->requestTextTrack(WTF::move(cueRequest)))
+        m_resource = WTF::move(result.value());
+    else
+        m_resource = nullptr;
+    if (RefPtr resource = m_resource) {
         resource->addClient(*this);
         return true;
     }
@@ -220,7 +223,7 @@ Vector<Ref<VTTCue>> TextTrackLoader::getNewCues()
     if (!m_cueParser)
         return { };
 
-    RefPtr document = m_document.get();
+    RefPtr document = m_document;
     if (!document)
         return { };
 

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -773,7 +773,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::createInternal(const String& markupSt
                 if (!resource) {
                     ResourceRequest request(URL { subresourceURL });
                     request.setDomainForCachePartition(frame.document()->domainForCachePartition());
-                    if (auto* cachedResource = MemoryCache::singleton().resourceForRequest(request, frame.page()->sessionID()))
+                    if (RefPtr cachedResource = MemoryCache::singleton().resourceForRequest(request, frame.page()->sessionID()))
                         resource = ArchiveResource::create(cachedResource->resourceBuffer(), subresourceURL, cachedResource->response());
                 }
 

--- a/Source/WebCore/loader/cache/CachedFont.cpp
+++ b/Source/WebCore/loader/cache/CachedFont.cpp
@@ -108,7 +108,7 @@ void CachedFont::finishLoading(const FragmentedSharedBuffer* data, const Network
 
 void CachedFont::setErrorAndDeleteData()
 {
-    CachedResourceHandle protectedThis { *this };
+    RefPtr protectedThis { *this };
     setEncodedSize(0);
     error(Status::DecodeError);
     if (inCache())

--- a/Source/WebCore/loader/cache/CachedFontLoadRequest.h
+++ b/Source/WebCore/loader/cache/CachedFontLoadRequest.h
@@ -66,17 +66,18 @@ private:
     {
     }
 
-    const URL& url() const final { return m_font->url(); }
+    URL url() const final { return protect(m_font)->url(); }
     bool isPending() const final { return m_font->status() == CachedResource::Status::Pending; }
     bool isLoading() const final { return m_font->isLoading(); }
     bool errorOccurred() const final { return m_font->errorOccurred(); }
 
     bool ensureCustomFontData() final
     {
-        bool result = m_font->ensureCustomFontData();
-        if (!result && m_font->didRefuseToParseCustomFontWithSafeFontParser()) {
+        RefPtr font = m_font;
+        bool result = font->ensureCustomFontData();
+        if (!result && font->didRefuseToParseCustomFontWithSafeFontParser()) {
             if (RefPtr context = m_context.get()) {
-                auto message = makeString("[Lockdown Mode] This font wasn't parsed: "_s, m_font->url().string());
+                auto message = makeString("[Lockdown Mode] This font wasn't parsed: "_s, font->url().string());
                 context->addConsoleMessage(MessageSource::Security, MessageLevel::Info, message);
             }
         }

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -217,7 +217,7 @@ void CachedImage::switchClientsToRevalidatedResource()
         for (auto& request : m_pendingContainerContextRequests)
             switchContainerContextRequests.set(request.key, request.value);
         CachedResource::switchClientsToRevalidatedResource();
-        CachedResourceHandle revalidatedCachedImage = downcast<CachedImage>(*resourceToRevalidate());
+        RefPtr revalidatedCachedImage = downcast<CachedImage>(*resourceToRevalidate());
         for (auto& request : switchContainerContextRequests)
             revalidatedCachedImage->setContainerContextForClient(request.key, request.value.containerSize, request.value.containerZoom, request.value.imageURL);
         return;
@@ -418,25 +418,25 @@ CachedImage::CachedImageObserver::CachedImageObserver(CachedImage& image)
 
 void CachedImage::CachedImageObserver::encodedDataStatusChanged(const Image& image, EncodedDataStatus status)
 {
-    for (CachedResourceHandle cachedImage : m_cachedImages)
+    for (RefPtr cachedImage : m_cachedImages)
         cachedImage->encodedDataStatusChanged(image, status);
 }
 
 void CachedImage::CachedImageObserver::decodedSizeChanged(const Image& image, long long delta)
 {
-    for (CachedResourceHandle cachedImage : m_cachedImages)
+    for (RefPtr cachedImage : m_cachedImages)
         cachedImage->decodedSizeChanged(image, delta);
 }
 
 void CachedImage::CachedImageObserver::didDraw(const Image& image)
 {
-    for (CachedResourceHandle cachedImage : m_cachedImages)
+    for (RefPtr cachedImage : m_cachedImages)
         cachedImage->didDraw(image);
 }
 
 bool CachedImage::CachedImageObserver::canDestroyDecodedData(const Image& image) const
 {
-    for (CachedResourceHandle cachedImage : m_cachedImages) {
+    for (RefPtr cachedImage : m_cachedImages) {
         if (&image != cachedImage->image())
             continue;
         if (!cachedImage->canDestroyDecodedData(image))
@@ -447,25 +447,25 @@ bool CachedImage::CachedImageObserver::canDestroyDecodedData(const Image& image)
 
 void CachedImage::CachedImageObserver::imageFrameAvailable(const Image& image, ImageAnimatingState animatingState, const IntRect* changeRect, DecodingStatus decodingStatus)
 {
-    for (CachedResourceHandle cachedImage : m_cachedImages)
+    for (RefPtr cachedImage : m_cachedImages)
         cachedImage->imageFrameAvailable(image, animatingState, changeRect, decodingStatus);
 }
 
 void CachedImage::CachedImageObserver::changedInRect(const Image& image, const IntRect* rect)
 {
-    for (CachedResourceHandle cachedImage : m_cachedImages)
+    for (RefPtr cachedImage : m_cachedImages)
         cachedImage->changedInRect(image, rect);
 }
 
 void CachedImage::CachedImageObserver::imageContentChanged(const Image& image)
 {
-    for (CachedResourceHandle cachedImage : m_cachedImages)
+    for (RefPtr cachedImage : m_cachedImages)
         cachedImage->imageContentChanged(image);
 }
 
 void CachedImage::CachedImageObserver::scheduleRenderingUpdate(const Image& image)
 {
-    for (CachedResourceHandle cachedImage : m_cachedImages)
+    for (RefPtr cachedImage : m_cachedImages)
         cachedImage->scheduleRenderingUpdate(image);
 }
 
@@ -476,7 +476,7 @@ bool CachedImage::CachedImageObserver::allowsAnimation(const Image& image) const
     if (!Image::systemAllowsAnimationControls())
         return true;
 
-    for (CachedResourceHandle cachedImage : m_cachedImages) {
+    for (RefPtr cachedImage : m_cachedImages) {
         if (cachedImage->allowsAnimation(image))
             return true;
     }
@@ -505,7 +505,7 @@ inline void CachedImage::clearImage()
 
 void CachedImage::updateBufferInternal(const FragmentedSharedBuffer& data)
 {
-    CachedResourceHandle protectedThis { *this };
+    RefPtr protectedThis { *this };
     m_data = const_cast<FragmentedSharedBuffer*>(&data);
     setEncodedSize(m_data->size());
     createImage();

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -30,16 +30,6 @@
 #include <WebCore/SVGImageCache.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
-#include <wtf/WeakRef.h>
-
-namespace WebCore {
-class CachedImage;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CachedImage> : std::true_type { };
-}
 
 namespace WebCore {
 

--- a/Source/WebCore/loader/cache/CachedRawResource.cpp
+++ b/Source/WebCore/loader/cache/CachedRawResource.cpp
@@ -64,7 +64,7 @@ void CachedRawResource::updateBuffer(const FragmentedSharedBuffer& data)
 
     // We need to keep a strong reference to both the SharedBuffer and the current CachedRawResource instance
     // as notifyClientsDataWasReceived call may delete both.
-    CachedResourceHandle protectedThis(this);
+    RefPtr protectedThis(this);
     Ref protectedData { data };
 
     ASSERT(dataBufferingPolicy() == DataBufferingPolicy::BufferData);
@@ -110,7 +110,7 @@ void CachedRawResource::finishLoading(const FragmentedSharedBuffer* data, const 
         m_delayedFinishLoading = std::make_optional(DelayedFinishLoading { data });
         return;
     };
-    CachedResourceHandle protectedThis { this };
+    RefPtr protectedThis { this };
     DataBufferingPolicy dataBufferingPolicy = this->dataBufferingPolicy();
     if (dataBufferingPolicy == DataBufferingPolicy::BufferData) {
         m_data = const_cast<FragmentedSharedBuffer*>(data);
@@ -139,23 +139,23 @@ void CachedRawResource::notifyClientsDataWasReceived(const SharedBuffer& buffer)
     if (buffer.isEmpty())
         return;
 
-    CachedResourceHandle protectedThis { this };
+    RefPtr protectedThis { this };
     CachedResourceClientWalker<CachedRawResourceClient> walker(*this);
     while (RefPtr client = walker.next())
         client->dataReceived(*this, buffer);
 }
 
-static void iterateRedirects(CachedResourceHandle<CachedRawResource>&& handle, CachedRawResourceClient& client, Vector<std::pair<ResourceRequest, ResourceResponse>>&& redirectsInReverseOrder, CompletionHandler<void(ResourceRequest&&)>&& completionHandler)
+static void iterateRedirects(CachedRawResource& handle, CachedRawResourceClient& client, Vector<std::pair<ResourceRequest, ResourceResponse>>&& redirectsInReverseOrder, CompletionHandler<void(ResourceRequest&&)>&& completionHandler)
 {
-    if (!handle->hasClient(client) || redirectsInReverseOrder.isEmpty())
+    if (!handle.hasClient(client) || redirectsInReverseOrder.isEmpty())
         return completionHandler({ });
     auto redirectPair = redirectsInReverseOrder.takeLast();
-    client.redirectReceived(*handle, WTF::move(redirectPair.first), WTF::move(redirectPair.second), [handle = WTF::move(handle), client = WeakPtr { client }, redirectsInReverseOrder = WTF::move(redirectsInReverseOrder), completionHandler = WTF::move(completionHandler)] (ResourceRequest&&) mutable {
+    client.redirectReceived(handle, WTF::move(redirectPair.first), WTF::move(redirectPair.second), [handle = Ref { handle }, client = WeakPtr { client }, redirectsInReverseOrder = WTF::move(redirectsInReverseOrder), completionHandler = WTF::move(completionHandler)] (ResourceRequest&&) mutable {
         // Ignore the new request because we can't do anything with it.
         // We're just replying a redirect chain that has already happened.
         if (!client)
             return completionHandler({ });
-        iterateRedirects(WTF::move(handle), *client, WTF::move(redirectsInReverseOrder), WTF::move(completionHandler));
+        iterateRedirects(handle, *client, WTF::move(redirectsInReverseOrder), WTF::move(completionHandler));
     });
 }
 
@@ -168,7 +168,7 @@ void CachedRawResource::didAddClient(CachedResourceClient& c)
         return std::pair<ResourceRequest, ResourceResponse> { pair.m_request, pair.m_redirectResponse };
     });
 
-    iterateRedirects(protect(this), client, WTF::move(redirectsInReverseOrder), [this, protectedThis = CachedResourceHandle { this }, client = WeakPtr { client }] (ResourceRequest&&) mutable {
+    iterateRedirects(*this, client, WTF::move(redirectsInReverseOrder), [this, protectedThis = RefPtr { this }, client = WeakPtr { client }] (ResourceRequest&&) mutable {
         if (!client || !hasClient(*client))
             return;
         auto responseProcessedHandler = [this, protectedThis = WTF::move(protectedThis), client] {
@@ -205,13 +205,13 @@ void CachedRawResource::allClientsRemoved()
         loader->cancelIfNotFinishing();
 }
 
-static void iterateClients(CachedResourceClientWalker<CachedRawResourceClient>&& walker, CachedResourceHandle<CachedRawResource>&& handle, ResourceRequest&& request, std::unique_ptr<ResourceResponse>&& response, CompletionHandler<void(ResourceRequest&&)>&& completionHandler)
+static void iterateClients(CachedResourceClientWalker<CachedRawResourceClient>&& walker, Ref<CachedRawResource>&& handle, ResourceRequest&& request, std::unique_ptr<ResourceResponse>&& response, CompletionHandler<void(ResourceRequest&&)>&& completionHandler)
 {
     RefPtr client = walker.next();
     if (!client)
         return completionHandler(WTF::move(request));
     const ResourceResponse& responseReference = *response;
-    client->redirectReceived(*handle, WTF::move(request), responseReference, [walker = WTF::move(walker), handle = WTF::move(handle), response = WTF::move(response), completionHandler = WTF::move(completionHandler)] (ResourceRequest&& request) mutable {
+    client->redirectReceived(handle, WTF::move(request), responseReference, [walker = WTF::move(walker), handle, response = WTF::move(response), completionHandler = WTF::move(completionHandler)] (ResourceRequest&& request) mutable {
         iterateClients(WTF::move(walker), WTF::move(handle), WTF::move(request), WTF::move(response), WTF::move(completionHandler));
     });
 }
@@ -223,7 +223,7 @@ void CachedRawResource::redirectReceived(ResourceRequest&& request, const Resour
         CachedResource::redirectReceived(WTF::move(request), response, WTF::move(completionHandler));
     else {
         m_redirectChain.append(RedirectPair(request, response));
-        iterateClients(CachedResourceClientWalker<CachedRawResourceClient>(*this), protect(this), WTF::move(request), makeUnique<ResourceResponse>(response), [this, protectedThis = CachedResourceHandle { this }, completionHandler = WTF::move(completionHandler), response] (ResourceRequest&& request) mutable {
+        iterateClients(CachedResourceClientWalker<CachedRawResourceClient>(*this), protect(*this), WTF::move(request), makeUnique<ResourceResponse>(response), [this, protectedThis = RefPtr { this }, completionHandler = WTF::move(completionHandler), response] (ResourceRequest&& request) mutable {
             CachedResource::redirectReceived(WTF::move(request), response, WTF::move(completionHandler));
         });
     }
@@ -231,7 +231,7 @@ void CachedRawResource::redirectReceived(ResourceRequest&& request, const Resour
 
 void CachedRawResource::responseReceived(ResourceResponse&& newResponse)
 {
-    CachedResourceHandle protectedThis { this };
+    RefPtr protectedThis { this };
     if (!m_resourceLoaderIdentifier)
         m_resourceLoaderIdentifier = m_loader->identifier();
     CachedResource::responseReceived(WTF::move(newResponse));
@@ -360,7 +360,7 @@ void CachedRawResource::clear()
 #if USE(QUICK_LOOK)
 void CachedRawResource::previewResponseReceived(ResourceResponse&& newResponse)
 {
-    CachedResourceHandle protectedThis { this };
+    RefPtr protectedThis { this };
     CachedResource::previewResponseReceived(WTF::move(newResponse));
     CachedResourceClientWalker<CachedRawResourceClient> walker(*this);
     while (CachedRawResourceClient* c = walker.next())

--- a/Source/WebCore/loader/cache/CachedResource.cpp
+++ b/Source/WebCore/loader/cache/CachedResource.cpp
@@ -70,7 +70,6 @@
 
 namespace WebCore {
 
-DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CachedResource);
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CachedResourceResponseData);
 
 static Seconds deadDecodedDataDeletionIntervalForResourceType(CachedResource::Type type)
@@ -125,19 +124,22 @@ CachedResource::CachedResource(const URL& url, Type type, PAL::SessionID session
 
 CachedResource::~CachedResource()
 {
-    ASSERT(!m_resourceToRevalidate); // Should be true because canDelete() checks this.
-    ASSERT(canDelete());
+    ASSERT(!m_resourceToRevalidate);
     ASSERT(!inCache());
-    ASSERT(!m_deleted);
     ASSERT(url().isNull() || !allowsCaching() || MemoryCache::singleton().resourceForRequest(resourceRequest(), sessionID()) != this);
-
-#if ASSERT_ENABLED
-    m_deleted = true;
-#endif
 
     auto callbacks = std::exchange(m_loadedCallbacks, { });
     for (auto& callback : callbacks)
         callback();
+}
+
+void CachedResource::deref() const
+{
+    // Invoke the inspector notification while the object is still fully intact
+    // (i.e. before derived class destructors have run).
+    if (hasOneRef())
+        InspectorInstrumentation::willDestroyCachedResource(const_cast<CachedResource&>(*this));
+    RefCountedAndCanMakeWeakPtr::deref();
 }
 
 void CachedResource::failBeforeStarting()
@@ -201,7 +203,7 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
     m_loading = true;
 
     if (isCacheValidator()) {
-        CachedResourceHandle resourceToRevalidate = m_resourceToRevalidate.get();
+        RefPtr resourceToRevalidate = m_resourceToRevalidate;
         ASSERT(resourceToRevalidate->canUseCacheValidator());
         ASSERT(resourceToRevalidate->isLoaded());
         const String& lastModified = resourceToRevalidate->response().httpHeaderField(HTTPHeaderName::LastModified);
@@ -247,12 +249,12 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
     // FIXME: Deprecate that code path.
     if (m_options.keepAlive && shouldUsePingLoad(type()) && platformStrategies()->loaderStrategy()->usePingLoad()) {
         ASSERT(m_originalRequest);
-        CachedResourceHandle protectedThis { *this };
+        RefPtr protectedThis { *this };
 
         auto identifier = ResourceLoaderIdentifier::generate();
         InspectorInstrumentation::willSendRequestOfType(frame.ptr(), identifier, protect(frameLoader->activeDocumentLoader()).get(), request, InspectorInstrumentation::LoadType::Beacon);
 
-        platformStrategies()->loaderStrategy()->startPingLoad(frame, request, m_originalRequest->httpHeaderFields(), m_options, m_options.contentSecurityPolicyImposition, [this, protectedThis = WTF::move(protectedThis), frame = Ref { frame }, identifier] (const ResourceError& error, const ResourceResponse& response) {
+        platformStrategies()->loaderStrategy()->startPingLoad(frame, request, m_originalRequest->httpHeaderFields(), m_options, m_options.contentSecurityPolicyImposition, [this, protectedThis = Ref { *this }, frame = Ref { frame }, identifier] (const ResourceError& error, const ResourceResponse& response) {
             if (!response.isNull())
                 InspectorInstrumentation::didReceiveResourceResponse(frame, identifier, protect(frame->loader().activeDocumentLoader()), response, nullptr);
             if (!error.isNull()) {
@@ -268,7 +270,7 @@ void CachedResource::load(CachedResourceLoader& cachedResourceLoader)
         return;
     }
 
-    platformStrategies()->loaderStrategy()->loadResource(frame, *this, WTF::move(request), m_options, [this, protectedThis = CachedResourceHandle { *this }, frameRef = Ref { frame }] (RefPtr<SubresourceLoader>&& loader) {
+    platformStrategies()->loaderStrategy()->loadResource(frame, *this, WTF::move(request), m_options, [this, protectedThis = RefPtr { *this }, frameRef = Ref { frame }] (RefPtr<SubresourceLoader>&& loader) {
         m_loader = WTF::move(loader);
         if (!m_loader) {
             RELEASE_LOG(Network, "%p - [pageID=%" PRIu64 ", frameID=%" PRIu64 "] CachedResource::load: Unable to create SubresourceLoader", this, PAGE_ID(frameRef.get()), FRAME_ID(frameRef.get()));
@@ -462,7 +464,7 @@ Seconds CachedResource::freshnessLifetime(const ResourceResponse& response) cons
 
 void CachedResource::redirectReceived(ResourceRequest&& request, const ResourceResponse& response, CompletionHandler<void(ResourceRequest&&)>&& completionHandler)
 {
-    CachedResourceHandle protectedThis { *this };
+    RefPtr protectedThis { *this };
     CACHEDRESOURCE_RELEASE_LOG("redirectReceived:");
 
     // Remove redirect urls from the memory cache if they contain a fragment.
@@ -516,7 +518,6 @@ void CachedResource::clearLoader()
     else
         ASSERT_NOT_REACHED();
     m_loader = nullptr;
-    deleteIfPossible();
 }
 
 void CachedResource::addClient(CachedResourceClient& client)
@@ -597,14 +598,18 @@ void CachedResource::removeClient(CachedResourceClient& client)
         memoryCache->removeFromLiveDecodedResourcesList(*this);
     }
 
-    if (deleteIfPossible()) {
-        // `this` object is dead here.
-        return;
-    }
-
     if (!m_switchingClientsToRevalidatedResource)
         allClientsRemoved();
     destroyDecodedDataIfNeeded();
+
+    if (inCache() && !isPreloaded()) {
+        if (response().cacheControlContainsNoStore() || (isExpired() && !canUseCacheValidator())) {
+            memoryCache->remove(*this);
+            return;
+        }
+        if (RefPtr data = m_data)
+            data->hintMemoryNotNeededSoon();
+    }
 
     if (!allowsCaching())
         return;
@@ -632,51 +637,6 @@ void CachedResource::destroyDecodedDataIfNeeded()
 void CachedResource::decodedDataDeletionTimerFired()
 {
     destroyDecodedData();
-}
-
-bool CachedResource::deleteIfPossible()
-{
-    if (!canDelete()) {
-        LOG(ResourceLoading, "CachedResource %p deleteIfPossible - can't delete (hasClients %d loader %p preloadCount %u handleCount %u resourceToRevalidate %p proxyResource %p)", this, hasClients(), m_loader.get(), m_preloadCount, m_handleCount, m_resourceToRevalidate.get(), m_proxyResource.get());
-        return false;
-    }
-
-    LOG(ResourceLoading, "CachedResource %p deleteIfPossible - can delete, in cache %d", this, inCache());
-
-    if (!inCache()) {
-        deleteThis();
-        return true;
-    }
-
-    auto shouldRemoveFromCache = [&] {
-        // We may still keeps some of these cases in disk cache for history navigation.
-        if (response().cacheControlContainsNoStore())
-            return true;
-        if (isExpired() && !canUseCacheValidator())
-            return true;
-        return false;
-    }();
-
-    if (shouldRemoveFromCache) {
-        // Deletes this.
-        MemoryCache::singleton().remove(*this);
-        return true;
-    }
-
-    if (RefPtr data = m_data)
-        data->hintMemoryNotNeededSoon();
-
-    return false;
-}
-
-void CachedResource::deleteThis()
-{
-    RELEASE_ASSERT(canDelete());
-    RELEASE_ASSERT(!inCache());
-
-    InspectorInstrumentation::willDestroyCachedResource(*this);
-
-    delete this;
 }
 
 void CachedResource::setDecodedSize(unsigned size)
@@ -763,7 +723,7 @@ void CachedResource::setResourceToRevalidate(CachedResource* resource)
     m_resourceToRevalidate = resource;
 }
 
-void CachedResource::clearResourceToRevalidate() 
+void CachedResource::clearResourceToRevalidate()
 {
     ASSERT(m_resourceToRevalidate);
     ASSERT(m_resourceToRevalidate->m_proxyResource == this);
@@ -772,11 +732,9 @@ void CachedResource::clearResourceToRevalidate()
         return;
 
     m_resourceToRevalidate->m_proxyResource = nullptr;
-    m_resourceToRevalidate->deleteIfPossible();
 
     m_handlesToRevalidate.clear();
     m_resourceToRevalidate = nullptr;
-    deleteIfPossible();
 }
     
 void CachedResource::switchClientsToRevalidatedResource()
@@ -791,9 +749,7 @@ void CachedResource::switchClientsToRevalidatedResource()
     for (auto& handle : m_handlesToRevalidate) {
         handle->m_resource = m_resourceToRevalidate.get();
         protect(m_resourceToRevalidate)->registerHandle(handle);
-        --m_handleCount;
     }
-    ASSERT(!m_handleCount);
     m_handlesToRevalidate.clear();
 
     Vector<SingleThreadWeakPtr<CachedResourceClient>> clientsToMove;
@@ -836,21 +792,14 @@ void CachedResource::updateResponseAfterRevalidation(const ResourceResponse& val
 
 void CachedResource::registerHandle(CachedResourceHandleBase* h)
 {
-    ++m_handleCount;
     if (m_resourceToRevalidate)
         m_handlesToRevalidate.add(h);
 }
 
 void CachedResource::unregisterHandle(CachedResourceHandleBase* h)
 {
-    ASSERT(m_handleCount > 0);
-    --m_handleCount;
-
     if (m_resourceToRevalidate)
          m_handlesToRevalidate.remove(h);
-
-    if (!m_handleCount)
-        deleteIfPossible();
 }
 
 bool CachedResource::canUseCacheValidator() const
@@ -1005,7 +954,7 @@ unsigned CachedResource::decodedSize() const
 }
 
 inline CachedResourceCallback::CachedResourceCallback(CachedResource& resource, CachedResourceClient& client)
-    : m_timer([resource = CachedResourceHandle { resource }, client = WeakPtr { client }] {
+    : m_timer([resource = RefPtr { resource }, client = WeakPtr { client }] {
         if (client)
             resource->didAddClient(*client);
     })

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -39,6 +39,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/HashSet.h>
+#include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TypeCasts.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashCountedSet.h>
@@ -46,17 +47,8 @@
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
-class CachedResource;
+
 class CachedResourceCallback;
-}
-
-namespace WTF {
-template<typename T> struct IsDeprecatedWeakRefSmartPointerException;
-template<> struct IsDeprecatedWeakRefSmartPointerException<WebCore::CachedResource> : std::true_type { };
-}
-
-namespace WebCore {
-
 class CachedResourceClient;
 class CachedResourceHandleBase;
 class CachedResourceLoader;
@@ -76,11 +68,9 @@ enum class CachePolicy : uint8_t;
 // A resource that is held in the cache. Classes who want to use this object should derive
 // from CachedResourceClient, to get the function calls in case the requested data has arrived.
 // This class also does the actual communication with the loader to obtain the resource from the network.
-DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CachedResource);
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(CachedResourceResponseData);
-class CachedResource : public CanMakeWeakPtr<CachedResource> {
+class CachedResource : public RefCountedAndCanMakeWeakPtr<CachedResource> {
     WTF_MAKE_NONCOPYABLE(CachedResource);
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CachedResource, CachedResource);
     friend class MemoryCache;
 
 public:
@@ -128,7 +118,9 @@ public:
     static_assert(static_cast<unsigned>(DecodeError) <= ((1ULL << bitWidthOfStatus) - 1));
 
     CachedResource(CachedResourceRequest&&, Type, PAL::SessionID, const CookieJar*);
-    virtual ~CachedResource();
+    WEBCORE_EXPORT virtual ~CachedResource();
+
+    WEBCORE_EXPORT void deref() const;
 
     virtual void load(CachedResourceLoader&);
 
@@ -163,8 +155,6 @@ public:
     WEBCORE_EXPORT void removeClient(CachedResourceClient&);
     bool hasClients() const { return !m_clients.isEmptyIgnoringNullReferences() || !m_clientsAwaitingCallback.isEmptyIgnoringNullReferences(); }
     bool hasClient(const CachedResourceClient& client) { return m_clients.contains(client) || m_clientsAwaitingCallback.contains(client); }
-    bool deleteIfPossible();
-
     enum class PreloadResult : uint8_t {
         PreloadNotReferenced,
         PreloadReferenced,
@@ -258,9 +248,6 @@ public:
     SecurityOrigin* origin() { return m_origin.get(); }
     AtomString initiatorType() const { return m_initiatorType; }
 
-    bool canDelete() const { return !hasClients() && !m_loader && !m_preloadCount && !m_handleCount && !m_resourceToRevalidate && !m_proxyResource; }
-    bool hasOneHandle() const { return m_handleCount == 1; }
-
     bool isExpired() const;
 
     void cancelLoad(LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No);
@@ -276,9 +263,8 @@ public:
 
     virtual void destroyDecodedData() { }
 
-    bool isPreloaded() const { return m_preloadCount; }
-    void increasePreloadCount() { ++m_preloadCount; }
-    void decreasePreloadCount() { ASSERT(m_preloadCount); --m_preloadCount; }
+    bool isPreloaded() const { return m_isPreloaded; }
+    void setIsPreloaded(bool isPreloaded) { m_isPreloaded = isPreloaded; }
     bool isLinkPreload() const { return m_isLinkPreload; }
     void setLinkPreload() { m_isLinkPreload = true; }
     bool hasUnknownEncoding() { return m_hasUnknownEncoding; }
@@ -300,7 +286,7 @@ public:
     CachedResource* resourceToRevalidate() const { return m_resourceToRevalidate.get(); }
 
     // HTTP revalidation support methods for CachedResourceLoader.
-    void NODELETE setResourceToRevalidate(CachedResource*);
+    void setResourceToRevalidate(CachedResource*);
     virtual void switchClientsToRevalidatedResource();
     void clearResourceToRevalidate();
     void updateResponseAfterRevalidation(const ResourceResponse& validatingResponse);
@@ -344,8 +330,6 @@ protected:
 private:
     using Callback = CachedResourceCallback;
     template<typename T> friend class CachedResourceClientWalker;
-
-    void deleteThis();
 
     bool addClientToSet(CachedResourceClient&);
 
@@ -411,7 +395,7 @@ private:
     // using HTTP If-Modified-Since/If-None-Match headers. If the response is 304 all clients of this resource are moved
     // to to be clients of m_resourceToRevalidate and the resource is deleted. If not, the field is zeroed and this
     // resources becomes normal resource load.
-    WeakPtr<CachedResource> m_resourceToRevalidate;
+    RefPtr<CachedResource> m_resourceToRevalidate;
 
     // If this field is non-null, the resource has a proxy for checking whether it is still up to date (see m_resourceToRevalidate).
     WeakPtr<CachedResource> m_proxyResource;
@@ -424,8 +408,6 @@ private:
     RedirectChainCacheStatus m_redirectChainCacheStatus;
 
     unsigned m_accessCount { 0 };
-    unsigned m_handleCount { 0 };
-    unsigned m_preloadCount { 0 };
 
     Type m_type : bitWidthOfType;
 
@@ -442,9 +424,9 @@ private:
     bool m_switchingClientsToRevalidatedResource : 1 { false };
     bool m_ignoreForRequestCount : 1;
     bool m_isHashReportingNeeded : 1 { false };
+    bool m_isPreloaded : 1 { false };
 
 #if ASSERT_ENABLED
-    bool m_deleted { false };
     unsigned m_lruIndex { 0 };
 #endif
 

--- a/Source/WebCore/loader/cache/CachedResourceHandle.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceHandle.cpp
@@ -30,35 +30,32 @@
 
 namespace WebCore {
 
-CachedResourceHandleBase::CachedResourceHandleBase()
-    : m_resource(nullptr)
+CachedResourceHandleBase::CachedResourceHandleBase() = default;
+
+CachedResourceHandleBase::CachedResourceHandleBase(Ref<CachedResource>&& resource)
+    : m_resource(WTF::move(resource))
 {
+    protect(m_resource)->registerHandle(this);
 }
 
-CachedResourceHandleBase::CachedResourceHandleBase(CachedResource& resource)
-    : m_resource(&resource)
+CachedResourceHandleBase::CachedResourceHandleBase(RefPtr<CachedResource>&& resource)
+    : m_resource(WTF::move(resource))
 {
-    m_resource->registerHandle(this);
-}
-
-CachedResourceHandleBase::CachedResourceHandleBase(CachedResource* resource)
-    : m_resource(resource)
-{
-    if (m_resource)
-        m_resource->registerHandle(this);
+    if (RefPtr resource = m_resource)
+        resource->registerHandle(this);
 }
 
 CachedResourceHandleBase::CachedResourceHandleBase(const CachedResourceHandleBase& other)
     : m_resource(other.m_resource)
 {
-    if (m_resource)
-        m_resource->registerHandle(this);
+    if (RefPtr resource = m_resource)
+        resource->registerHandle(this);
 }
 
 CachedResourceHandleBase::~CachedResourceHandleBase()
 {
-    if (m_resource)
-        m_resource->unregisterHandle(this);
+    if (RefPtr resource = m_resource)
+        resource->unregisterHandle(this);
 }
 
 CachedResource* CachedResourceHandleBase::get() const
@@ -66,15 +63,15 @@ CachedResource* CachedResourceHandleBase::get() const
     return m_resource.get();
 }
 
-void CachedResourceHandleBase::setResource(CachedResource* resource)
+void CachedResourceHandleBase::setResource(RefPtr<CachedResource>&& resource)
 {
     if (resource == m_resource)
         return;
-    if (m_resource)
-        m_resource->unregisterHandle(this);
-    m_resource = resource;
-    if (m_resource)
-        m_resource->registerHandle(this);
+    if (RefPtr resource = m_resource)
+        resource->unregisterHandle(this);
+    m_resource = WTF::move(resource);
+    if (RefPtr resource = m_resource)
+        resource->registerHandle(this);
 }
 
 }

--- a/Source/WebCore/loader/cache/CachedResourceHandle.h
+++ b/Source/WebCore/loader/cache/CachedResourceHandle.h
@@ -27,7 +27,7 @@
 
 #include <WebCore/CachedResource.h>
 #include <wtf/Forward.h>
-#include <wtf/WeakPtr.h>
+#include <wtf/RefPtr.h>
 
 namespace WebCore {
 
@@ -42,25 +42,31 @@ public:
 
 protected:
     WEBCORE_EXPORT CachedResourceHandleBase();
-    WEBCORE_EXPORT explicit CachedResourceHandleBase(CachedResource*);
-    WEBCORE_EXPORT explicit CachedResourceHandleBase(CachedResource&);
+    WEBCORE_EXPORT explicit CachedResourceHandleBase(RefPtr<CachedResource>&&);
+    WEBCORE_EXPORT explicit CachedResourceHandleBase(Ref<CachedResource>&&);
     WEBCORE_EXPORT CachedResourceHandleBase(const CachedResourceHandleBase&);
 
-    WEBCORE_EXPORT void setResource(CachedResource*);
+    WEBCORE_EXPORT void setResource(RefPtr<CachedResource>&&);
     
 private:
     CachedResourceHandleBase& operator=(const CachedResourceHandleBase&) { return *this; } 
     
     friend class CachedResource;
 
-    WeakPtr<CachedResource> m_resource;
+    RefPtr<CachedResource> m_resource;
 };
     
 template <class R> class CachedResourceHandle : public CachedResourceHandleBase {
 public: 
     CachedResourceHandle() = default;
-    CachedResourceHandle(R& res) : CachedResourceHandleBase(res) { }
-    CachedResourceHandle(R* res) : CachedResourceHandleBase(res) { }
+    CachedResourceHandle(std::nullptr_t) { }
+    CachedResourceHandle(Ref<R>&& res) : CachedResourceHandleBase(Ref<CachedResource> { WTF::move(res) }) { }
+    template<typename U> requires (std::is_base_of_v<R, U> && !std::is_same_v<R, U>)
+    CachedResourceHandle(Ref<U>&& res) : CachedResourceHandleBase(Ref<CachedResource> { WTF::move(res) }) { }
+    CachedResourceHandle(R& res) : CachedResourceHandleBase(Ref<CachedResource> { res }) { }
+    CachedResourceHandle(RefPtr<R>&& res) : CachedResourceHandleBase(WTF::move(res)) { }
+    template<typename U> requires (std::is_base_of_v<R, U> && !std::is_same_v<R, U>)
+    CachedResourceHandle(RefPtr<U>&& res) : CachedResourceHandleBase(RefPtr<CachedResource> { WTF::move(res) }) { }
     CachedResourceHandle(const CachedResourceHandle<R>& o) : CachedResourceHandleBase(o) { }
     template<typename U> CachedResourceHandle(const CachedResourceHandle<U>& o) : CachedResourceHandleBase(o.get()) { }
 
@@ -73,10 +79,17 @@ public:
     }
     R* operator->() const { return get(); }
     R& operator*() const { ASSERT(get()); return *get(); }
+    operator RefPtr<R>() const { return get(); }
 
-    CachedResourceHandle& operator=(R* res) { setResource(res); return *this; } 
-    CachedResourceHandle& operator=(const CachedResourceHandle& o) { setResource(o.get()); return *this; }
-    template<typename U> CachedResourceHandle& operator=(const CachedResourceHandle<U>& o) { setResource(o.get()); return *this; }
+    CachedResourceHandle& operator=(std::nullptr_t) { setResource(nullptr); return *this; }
+    CachedResourceHandle& operator=(R& res) { setResource(Ref<CachedResource> { res }); return *this; }
+    CachedResourceHandle& operator=(Ref<R>&& res) { setResource(Ref<CachedResource> { WTF::move(res) }); return *this; }
+    template<typename U> requires (std::is_base_of_v<R, U> && !std::is_same_v<R, U>)
+    CachedResourceHandle& operator=(Ref<U>&& res) { setResource(Ref<CachedResource> { WTF::move(res) }); return *this; }
+    CachedResourceHandle& operator=(const RefPtr<R>& res) { setResource(RefPtr<CachedResource> { res.get() }); return *this; }
+    CachedResourceHandle& operator=(RefPtr<R>&& res) { setResource(WTF::move(res)); return *this; }
+    CachedResourceHandle& operator=(const CachedResourceHandle& o) { setResource(RefPtr<CachedResource> { o.get() }); return *this; }
+    template<typename U> CachedResourceHandle& operator=(const CachedResourceHandle<U>& o) { setResource(RefPtr<CachedResource> { o.get() }); return *this; }
 
     bool operator==(const CachedResourceHandle& o) const { return operator==(static_cast<const CachedResourceHandleBase&>(o)); }
     bool operator==(const CachedResourceHandleBase& o) const { return get() == o.get(); }
@@ -87,40 +100,22 @@ template <class R, class RR> bool operator==(const CachedResourceHandle<R>& h, c
     return h.get() == res;
 }
 
+template <class R, class RR> bool operator==(const CachedResourceHandle<R>& h, const RefPtr<RR>& ptr)
+{
+    return h.get() == ptr.get();
+}
+
 } // namespace WebCore
 
 namespace WTF {
 
-template<typename T> requires (requires { sizeof(T); } && std::derived_from<T, WebCore::CachedResource>)
-WebCore::CachedResourceHandle<T> protect(T* resource)
-{
-    return WebCore::CachedResourceHandle<T> { resource };
-}
-
-template<typename T> requires (requires { sizeof(T); } && std::derived_from<T, WebCore::CachedResource>)
-WebCore::CachedResourceHandle<T> protect(T& resource)
-{
-    return WebCore::CachedResourceHandle<T> { resource };
-}
-
-template<typename T, typename WeakPtrImpl, typename PtrTraits>
-    requires (requires { sizeof(T); } && std::derived_from<T, WebCore::CachedResource>)
-ALWAYS_INLINE CLANG_POINTER_CONVERSION WebCore::CachedResourceHandle<T> protect(const WeakPtr<T, WeakPtrImpl, PtrTraits>& resource)
-{
-    return WebCore::CachedResourceHandle<T> { resource.get() };
-}
-
-template<typename T, typename WeakPtrImpl>
-    requires (requires { sizeof(T); } && std::derived_from<T, WebCore::CachedResource>)
-ALWAYS_INLINE CLANG_POINTER_CONVERSION WebCore::CachedResourceHandle<T> protect(const WeakRef<T, WeakPtrImpl>& resource)
-{
-    return WebCore::CachedResourceHandle<T> { resource.get() };
-}
+template<typename R> RefPtr(const WebCore::CachedResourceHandle<R>&) -> RefPtr<R, RawPtrTraits<R>, DefaultRefDerefTraits<R>>;
+template<typename R> RefPtr(WebCore::CachedResourceHandle<R>&) -> RefPtr<R, RawPtrTraits<R>, DefaultRefDerefTraits<R>>;
 
 template<typename T>
-WebCore::CachedResourceHandle<T> protect(const WebCore::CachedResourceHandle<T>& handle)
+RefPtr<T> protect(const WebCore::CachedResourceHandle<T>& handle)
 {
-    return handle;
+    return handle.get();
 }
 
 } // namespace WTF

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -117,11 +117,11 @@ namespace WebCore {
 // Timeout for link preloads to be used after window.onload
 static const Seconds unusedPreloadTimeout { 3_s };
 
-template <typename T, typename U>
-static inline ResourceErrorOr<CachedResourceHandle<T>> castCachedResourceTo(ResourceErrorOr<CachedResourceHandle<U>>&& cachedResource)
+template<typename T>
+static inline ResourceErrorOr<Ref<T>> castCachedResourceTo(ResourceErrorOr<Ref<CachedResource>>&& cachedResource)
 {
     if (cachedResource)
-        return CachedResourceHandle<T> { downcast<T>(cachedResource.value().get()) };
+        return downcast<T>(WTF::move(cachedResource.value()));
     return makeUnexpected(cachedResource.error());
 }
 
@@ -137,22 +137,22 @@ static ScriptTrackingPrivacyProtectionsEnabled requiresScriptTrackingPrivacyProt
     return page->requiresScriptTrackingPrivacyProtections(request.url()) ? ScriptTrackingPrivacyProtectionsEnabled::Yes : ScriptTrackingPrivacyProtectionsEnabled::No;
 }
 
-static CachedResourceHandle<CachedResource> createResource(CachedResource::Type type, CachedResourceRequest&& request, PAL::SessionID sessionID, const CookieJar* cookieJar, const Settings& settings, const Document* document)
+static Ref<CachedResource> createResource(CachedResource::Type type, CachedResourceRequest&& request, PAL::SessionID sessionID, const CookieJar* cookieJar, const Settings& settings, const Document* document)
 {
     switch (type) {
     case CachedResource::Type::ImageResource:
-        return new CachedImage(WTF::move(request), sessionID, cookieJar);
+        return adoptRef(*new CachedImage(WTF::move(request), sessionID, cookieJar));
     case CachedResource::Type::CSSStyleSheet:
-        return new CachedCSSStyleSheet(WTF::move(request), sessionID, cookieJar);
+        return adoptRef(*new CachedCSSStyleSheet(WTF::move(request), sessionID, cookieJar));
     case CachedResource::Type::JSON:
     case CachedResource::Type::Script:
-        return new CachedScript(WTF::move(request), sessionID, cookieJar, requiresScriptTrackingPrivacyProtections(document, request.resourceRequest()));
+        return adoptRef(*new CachedScript(WTF::move(request), sessionID, cookieJar, requiresScriptTrackingPrivacyProtections(document, request.resourceRequest())));
     case CachedResource::Type::SVGDocumentResource:
-        return new CachedSVGDocument(WTF::move(request), sessionID, cookieJar, settings);
+        return adoptRef(*new CachedSVGDocument(WTF::move(request), sessionID, cookieJar, settings));
     case CachedResource::Type::SVGFontResource:
-        return new CachedSVGFont(WTF::move(request), sessionID, cookieJar, settings);
+        return adoptRef(*new CachedSVGFont(WTF::move(request), sessionID, cookieJar, settings));
     case CachedResource::Type::FontResource:
-        return new CachedFont(WTF::move(request), sessionID, cookieJar);
+        return adoptRef(*new CachedFont(WTF::move(request), sessionID, cookieJar));
     case CachedResource::Type::Beacon:
     case CachedResource::Type::Ping:
     case CachedResource::Type::MediaResource:
@@ -163,42 +163,41 @@ static CachedResourceHandle<CachedResource> createResource(CachedResource::Type 
     case CachedResource::Type::RawResource:
     case CachedResource::Type::Icon:
     case CachedResource::Type::MainResource:
-        return new CachedRawResource(WTF::move(request), type, sessionID, cookieJar);
+        return adoptRef(*new CachedRawResource(WTF::move(request), type, sessionID, cookieJar));
 #if ENABLE(XSLT)
     case CachedResource::Type::XSLStyleSheet:
-        return new CachedXSLStyleSheet(WTF::move(request), sessionID, cookieJar);
+        return adoptRef(*new CachedXSLStyleSheet(WTF::move(request), sessionID, cookieJar));
 #endif
     case CachedResource::Type::LinkPrefetch:
-        return new CachedResource(WTF::move(request), CachedResource::Type::LinkPrefetch, sessionID, cookieJar);
+        return adoptRef(*new CachedResource(WTF::move(request), CachedResource::Type::LinkPrefetch, sessionID, cookieJar));
 #if ENABLE(VIDEO)
     case CachedResource::Type::TextTrackResource:
-        return new CachedTextTrack(WTF::move(request), sessionID, cookieJar);
+        return adoptRef(*new CachedTextTrack(WTF::move(request), sessionID, cookieJar));
 #endif
 #if ENABLE(APPLICATION_MANIFEST)
     case CachedResource::Type::ApplicationManifest:
-        return new CachedApplicationManifest(WTF::move(request), sessionID, cookieJar);
+        return adoptRef(*new CachedApplicationManifest(WTF::move(request), sessionID, cookieJar));
 #endif
     }
-    ASSERT_NOT_REACHED();
-    return nullptr;
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
-static CachedResourceHandle<CachedResource> createResource(CachedResourceRequest&& request, CachedResource& resource, const Document* document)
+static Ref<CachedResource> createResource(CachedResourceRequest&& request, CachedResource& resource, const Document* document)
 {
     switch (resource.type()) {
     case CachedResource::Type::ImageResource:
-        return new CachedImage(WTF::move(request), resource.sessionID(), resource.cookieJar());
+        return adoptRef(*new CachedImage(WTF::move(request), resource.sessionID(), resource.cookieJar()));
     case CachedResource::Type::CSSStyleSheet:
-        return new CachedCSSStyleSheet(WTF::move(request), resource.sessionID(), resource.cookieJar());
+        return adoptRef(*new CachedCSSStyleSheet(WTF::move(request), resource.sessionID(), resource.cookieJar()));
     case CachedResource::Type::JSON:
     case CachedResource::Type::Script:
-        return new CachedScript(WTF::move(request), resource.sessionID(), resource.cookieJar(), requiresScriptTrackingPrivacyProtections(document, request.resourceRequest()));
+        return adoptRef(*new CachedScript(WTF::move(request), resource.sessionID(), resource.cookieJar(), requiresScriptTrackingPrivacyProtections(document, request.resourceRequest())));
     case CachedResource::Type::SVGDocumentResource:
-        return new CachedSVGDocument(WTF::move(request), downcast<CachedSVGDocument>(resource));
+        return adoptRef(*new CachedSVGDocument(WTF::move(request), downcast<CachedSVGDocument>(resource)));
     case CachedResource::Type::SVGFontResource:
-        return new CachedSVGFont(WTF::move(request), downcast<CachedSVGFont>(resource));
+        return adoptRef(*new CachedSVGFont(WTF::move(request), downcast<CachedSVGFont>(resource)));
     case CachedResource::Type::FontResource:
-        return new CachedFont(WTF::move(request), resource.sessionID(), resource.cookieJar());
+        return adoptRef(*new CachedFont(WTF::move(request), resource.sessionID(), resource.cookieJar()));
     case CachedResource::Type::Beacon:
     case CachedResource::Type::Ping:
     case CachedResource::Type::MediaResource:
@@ -209,24 +208,23 @@ static CachedResourceHandle<CachedResource> createResource(CachedResourceRequest
     case CachedResource::Type::EnvironmentMapResource:
     case CachedResource::Type::ModelResource:
 #endif
-        return new CachedRawResource(WTF::move(request), resource.type(), resource.sessionID(), resource.cookieJar());
+        return adoptRef(*new CachedRawResource(WTF::move(request), resource.type(), resource.sessionID(), resource.cookieJar()));
 #if ENABLE(XSLT)
     case CachedResource::Type::XSLStyleSheet:
-        return new CachedXSLStyleSheet(WTF::move(request), resource.sessionID(), resource.cookieJar());
+        return adoptRef(*new CachedXSLStyleSheet(WTF::move(request), resource.sessionID(), resource.cookieJar()));
 #endif
     case CachedResource::Type::LinkPrefetch:
-        return new CachedResource(WTF::move(request), CachedResource::Type::LinkPrefetch, resource.sessionID(), resource.cookieJar());
+        return adoptRef(*new CachedResource(WTF::move(request), CachedResource::Type::LinkPrefetch, resource.sessionID(), resource.cookieJar()));
 #if ENABLE(VIDEO)
     case CachedResource::Type::TextTrackResource:
-        return new CachedTextTrack(WTF::move(request), resource.sessionID(), resource.cookieJar());
+        return adoptRef(*new CachedTextTrack(WTF::move(request), resource.sessionID(), resource.cookieJar()));
 #endif
 #if ENABLE(APPLICATION_MANIFEST)
     case CachedResource::Type::ApplicationManifest:
-        return new CachedApplicationManifest(WTF::move(request), resource.sessionID(), resource.cookieJar());
+        return adoptRef(*new CachedApplicationManifest(WTF::move(request), resource.sessionID(), resource.cookieJar()));
 #endif
     }
-    ASSERT_NOT_REACHED();
-    return nullptr;
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 CachedResourceLoader::CachedResourceLoader(DocumentLoader* documentLoader)
@@ -252,7 +250,7 @@ CachedResourceLoader::~CachedResourceLoader()
 CachedResource* CachedResourceLoader::cachedResource(const String& resourceURL) const
 {
     ASSERT(!resourceURL.isNull());
-    RefPtr document = m_document.get();
+    RefPtr document = m_document;
     ASSERT(document);
     return document ? cachedResource(MemoryCache::removeFragmentIdentifierIfNeeded(document->completeURL(resourceURL))) : nullptr;
 }
@@ -268,7 +266,7 @@ LocalFrame* NODELETE CachedResourceLoader::frame() const
     return m_documentLoader ? m_documentLoader->frame() : nullptr;
 }
 
-ResourceErrorOr<CachedResourceHandle<CachedImage>> CachedResourceLoader::requestImage(CachedResourceRequest&& request, ImageLoading imageLoading)
+ResourceErrorOr<RefPtr<CachedImage>> CachedResourceLoader::requestImage(CachedResourceRequest&& request, ImageLoading imageLoading)
 {
     if (RefPtr frame = this->frame()) {
         if (frame->loader().pageDismissalEventBeingDispatched() != FrameLoader::PageDismissalType::None) {
@@ -280,16 +278,19 @@ ResourceErrorOr<CachedResourceHandle<CachedImage>> CachedResourceLoader::request
             URL requestURL = request.resourceRequest().url();
             if (requestURL.isValid() && canRequest(CachedResource::Type::ImageResource, requestURL, request.options(), ForPreload::No, isRequestUpgradable ? MixedContentChecker::IsUpgradable::Yes : MixedContentChecker::IsUpgradable::No, request.isLinkPreload()))
                 PingLoader::loadImage(*frame, WTF::move(requestURL));
-            return CachedResourceHandle<CachedImage> { };
+            return { nullptr };
         }
     }
 
     if (imageLoading == ImageLoading::Immediate)
         imageLoading = clientDefersImage(request.resourceRequest().url());
-    return castCachedResourceTo<CachedImage>(requestResource(CachedResource::Type::ImageResource, WTF::move(request), ForPreload::No, imageLoading));
+    auto result = castCachedResourceTo<CachedImage>(requestResource(CachedResource::Type::ImageResource, WTF::move(request), ForPreload::No, imageLoading));
+    if (!result)
+        return makeUnexpected(result.error());
+    return RefPtr { WTF::move(result.value()) };
 }
 
-ResourceErrorOr<CachedResourceHandle<CachedFont>> CachedResourceLoader::requestFont(CachedResourceRequest&& request, bool isSVG)
+ResourceErrorOr<Ref<CachedFont>> CachedResourceLoader::requestFont(CachedResourceRequest&& request, bool isSVG)
 {
     if (isSVG)
         return castCachedResourceTo<CachedFont>(requestResource(CachedResource::Type::SVGFontResource, WTF::move(request)));
@@ -297,13 +298,13 @@ ResourceErrorOr<CachedResourceHandle<CachedFont>> CachedResourceLoader::requestF
 }
 
 #if ENABLE(VIDEO)
-ResourceErrorOr<CachedResourceHandle<CachedTextTrack>> CachedResourceLoader::requestTextTrack(CachedResourceRequest&& request)
+ResourceErrorOr<Ref<CachedTextTrack>> CachedResourceLoader::requestTextTrack(CachedResourceRequest&& request)
 {
     return castCachedResourceTo<CachedTextTrack>(requestResource(CachedResource::Type::TextTrackResource, WTF::move(request)));
 }
 #endif
 
-ResourceErrorOr<CachedResourceHandle<CachedCSSStyleSheet>> CachedResourceLoader::requestCSSStyleSheet(CachedResourceRequest&& request)
+ResourceErrorOr<Ref<CachedCSSStyleSheet>> CachedResourceLoader::requestCSSStyleSheet(CachedResourceRequest&& request)
 {
     return castCachedResourceTo<CachedCSSStyleSheet>(requestResource(CachedResource::Type::CSSStyleSheet, WTF::move(request)));
 }
@@ -318,16 +319,16 @@ CachedResourceHandle<CachedCSSStyleSheet> CachedResourceLoader::requestUserCSSSt
 
     Ref memoryCache = MemoryCache::singleton();
     if (request.allowsCaching()) {
-        if (CachedResourceHandle existing = memoryCache->resourceForRequest(request.resourceRequest(), page.sessionID())) {
+        if (RefPtr existing = memoryCache->resourceForRequest(request.resourceRequest(), page.sessionID())) {
             if (auto* cssStyleSheet = dynamicDowncast<CachedCSSStyleSheet>(*existing))
-                return cssStyleSheet;
+                return *cssStyleSheet;
             memoryCache->remove(*existing);
         }
     }
 
     request.removeFragmentIdentifierIfNeeded();
 
-    CachedResourceHandle userSheet = new CachedCSSStyleSheet(WTF::move(request), page.sessionID(), protect(page.cookieJar()).ptr());
+    RefPtr userSheet = adoptRef(*new CachedCSSStyleSheet(WTF::move(request), page.sessionID(), protect(page.cookieJar()).ptr()));
 
     if (userSheet->allowsCaching())
         memoryCache->add(*userSheet);
@@ -336,32 +337,32 @@ CachedResourceHandle<CachedCSSStyleSheet> CachedResourceLoader::requestUserCSSSt
     return userSheet;
 }
 
-ResourceErrorOr<CachedResourceHandle<CachedScript>> CachedResourceLoader::requestScript(CachedResourceRequest&& request)
+ResourceErrorOr<Ref<CachedScript>> CachedResourceLoader::requestScript(CachedResourceRequest&& request)
 {
     return castCachedResourceTo<CachedScript>(requestResource(
         request.options().destination == FetchOptionsDestination::Json ? CachedResource::Type::JSON : CachedResource::Type::Script, WTF::move(request)));
 }
 
 #if ENABLE(XSLT)
-ResourceErrorOr<CachedResourceHandle<CachedXSLStyleSheet>> CachedResourceLoader::requestXSLStyleSheet(CachedResourceRequest&& request)
+ResourceErrorOr<Ref<CachedXSLStyleSheet>> CachedResourceLoader::requestXSLStyleSheet(CachedResourceRequest&& request)
 {
     return castCachedResourceTo<CachedXSLStyleSheet>(requestResource(CachedResource::Type::XSLStyleSheet, WTF::move(request)));
 }
 #endif
 
-ResourceErrorOr<CachedResourceHandle<CachedSVGDocument>> CachedResourceLoader::requestSVGDocument(CachedResourceRequest&& request)
+ResourceErrorOr<Ref<CachedSVGDocument>> CachedResourceLoader::requestSVGDocument(CachedResourceRequest&& request)
 {
     return castCachedResourceTo<CachedSVGDocument>(requestResource(CachedResource::Type::SVGDocumentResource, WTF::move(request)));
 }
 
-ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requestLinkResource(CachedResource::Type type, CachedResourceRequest&& request)
+ResourceErrorOr<Ref<CachedResource>> CachedResourceLoader::requestLinkResource(CachedResource::Type type, CachedResourceRequest&& request)
 {
     ASSERT(frame());
     ASSERT(type == CachedResource::Type::LinkPrefetch);
     return requestResource(type, WTF::move(request));
 }
 
-ResourceErrorOr<CachedResourceHandle<CachedRawResource>> CachedResourceLoader::requestMedia(CachedResourceRequest&& request)
+ResourceErrorOr<Ref<CachedRawResource>> CachedResourceLoader::requestMedia(CachedResourceRequest&& request)
 {
     auto resourceType = CachedResource::Type::MediaResource;
     switch (request.options().destination) {
@@ -385,47 +386,47 @@ ResourceErrorOr<CachedResourceHandle<CachedRawResource>> CachedResourceLoader::r
     return castCachedResourceTo<CachedRawResource>(requestResource(resourceType, WTF::move(request)));
 }
 
-ResourceErrorOr<CachedResourceHandle<CachedRawResource>> CachedResourceLoader::requestIcon(CachedResourceRequest&& request)
+ResourceErrorOr<Ref<CachedRawResource>> CachedResourceLoader::requestIcon(CachedResourceRequest&& request)
 {
     return castCachedResourceTo<CachedRawResource>(requestResource(CachedResource::Type::Icon, WTF::move(request)));
 }
 
-ResourceErrorOr<CachedResourceHandle<CachedRawResource>> CachedResourceLoader::requestRawResource(CachedResourceRequest&& request)
+ResourceErrorOr<Ref<CachedRawResource>> CachedResourceLoader::requestRawResource(CachedResourceRequest&& request)
 {
     return castCachedResourceTo<CachedRawResource>(requestResource(CachedResource::Type::RawResource, WTF::move(request)));
 }
 
-ResourceErrorOr<CachedResourceHandle<CachedRawResource>> CachedResourceLoader::requestBeaconResource(CachedResourceRequest&& request)
+ResourceErrorOr<Ref<CachedRawResource>> CachedResourceLoader::requestBeaconResource(CachedResourceRequest&& request)
 {
     ASSERT(request.options().destination == FetchOptions::Destination::EmptyString);
     return castCachedResourceTo<CachedRawResource>(requestResource(CachedResource::Type::Beacon, WTF::move(request)));
 }
 
-ResourceErrorOr<CachedResourceHandle<CachedRawResource>> CachedResourceLoader::requestPingResource(CachedResourceRequest&& request)
+ResourceErrorOr<Ref<CachedRawResource>> CachedResourceLoader::requestPingResource(CachedResourceRequest&& request)
 {
     ASSERT(request.options().destination == FetchOptions::Destination::EmptyString || request.options().destination == FetchOptions::Destination::Report);
     return castCachedResourceTo<CachedRawResource>(requestResource(CachedResource::Type::Ping, WTF::move(request)));
 }
 
-ResourceErrorOr<CachedResourceHandle<CachedRawResource>> CachedResourceLoader::requestMainResource(CachedResourceRequest&& request)
+ResourceErrorOr<Ref<CachedRawResource>> CachedResourceLoader::requestMainResource(CachedResourceRequest&& request)
 {
     return castCachedResourceTo<CachedRawResource>(requestResource(CachedResource::Type::MainResource, WTF::move(request)));
 }
 
 #if ENABLE(APPLICATION_MANIFEST)
-ResourceErrorOr<CachedResourceHandle<CachedApplicationManifest>> CachedResourceLoader::requestApplicationManifest(CachedResourceRequest&& request)
+ResourceErrorOr<Ref<CachedApplicationManifest>> CachedResourceLoader::requestApplicationManifest(CachedResourceRequest&& request)
 {
     return castCachedResourceTo<CachedApplicationManifest>(requestResource(CachedResource::Type::ApplicationManifest, WTF::move(request)));
 }
 #endif // ENABLE(APPLICATION_MANIFEST)
 
 #if ENABLE(MODEL_ELEMENT)
-ResourceErrorOr<CachedResourceHandle<CachedRawResource>> CachedResourceLoader::requestEnvironmentMapResource(CachedResourceRequest&& request)
+ResourceErrorOr<Ref<CachedRawResource>> CachedResourceLoader::requestEnvironmentMapResource(CachedResourceRequest&& request)
 {
     return castCachedResourceTo<CachedRawResource>(requestResource(CachedResource::Type::EnvironmentMapResource, WTF::move(request)));
 }
 
-ResourceErrorOr<CachedResourceHandle<CachedRawResource>> CachedResourceLoader::requestModelResource(CachedResourceRequest&& request)
+ResourceErrorOr<Ref<CachedRawResource>> CachedResourceLoader::requestModelResource(CachedResourceRequest&& request)
 {
     return castCachedResourceTo<CachedRawResource>(requestResource(CachedResource::Type::ModelResource, WTF::move(request)));
 }
@@ -497,7 +498,7 @@ bool CachedResourceLoader::allowedByContentSecurityPolicy(CachedResource::Type t
     if (options.contentSecurityPolicyImposition == ContentSecurityPolicyImposition::SkipPolicyCheck)
         return true;
 
-    RefPtr document = m_document.get();
+    RefPtr document = m_document;
     ASSERT(document);
     if (!document)
         return true;
@@ -583,7 +584,7 @@ static inline bool isSameOriginDataURL(const URL& url, const ResourceLoaderOptio
 // Security checks defined in https://fetch.spec.whatwg.org/#main-fetch.
 bool CachedResourceLoader::canRequest(CachedResource::Type type, const URL& url, const ResourceLoaderOptions& options, ForPreload forPreload, MixedContentChecker::IsUpgradable isRequestUpgradable, bool isLinkPreload)
 {
-    if (RefPtr document = m_document.get()) {
+    if (RefPtr document = m_document) {
         if (!protect(document->securityOrigin())->canDisplay(url, OriginAccessPatternsForWebProcess::singleton())) {
             if (forPreload == ForPreload::No)
                 FrameLoader::reportLocalLoadFailed(protect(frame()).get(), url.stringCenterEllipsizedToLength());
@@ -634,7 +635,7 @@ bool CachedResourceLoader::canRequest(CachedResource::Type type, const URL& url,
 // FIXME: Should we find a way to know whether the redirection is for a preload request like we do for CachedResourceLoader::canRequest?
 bool CachedResourceLoader::canRequestAfterRedirection(CachedResource::Type type, const URL& url, const ResourceLoaderOptions& options, const URL& preRedirectURL) const
 {
-    if (RefPtr document = m_document.get()) {
+    if (RefPtr document = m_document) {
         if (!protect(document->securityOrigin())->canDisplay(url, OriginAccessPatternsForWebProcess::singleton())) {
             FrameLoader::reportLocalLoadFailed(protect(frame()).get(), url.stringCenterEllipsizedToLength());
             LOG(ResourceLoading, "CachedResourceLoader::canRequestAfterRedirection URL was not allowed by SecurityOrigin::canDisplay");
@@ -932,7 +933,7 @@ static inline bool NODELETE isResourceSuitableForDirectReuse(const CachedResourc
     return true;
 }
 
-CachedResourceHandle<CachedResource> CachedResourceLoader::updateCachedResourceWithCurrentRequest(const CachedResource& resource, CachedResourceRequest&& request, PAL::SessionID sessionID, const CookieJar& cookieJar, const Settings& settings)
+Ref<CachedResource> CachedResourceLoader::updateCachedResourceWithCurrentRequest(const CachedResource& resource, CachedResourceRequest&& request, PAL::SessionID sessionID, const CookieJar& cookieJar, const Settings& settings)
 {
     if (!isResourceSuitableForDirectReuse(resource, request)) {
         request.setCachingPolicy(CachingPolicy::DisallowCaching);
@@ -942,7 +943,7 @@ CachedResourceHandle<CachedResource> CachedResourceLoader::updateCachedResourceW
     // TODO: we're using the caching policy as a flag to signal that this is a prefetch match. We'd be better off with an explicit prefetch match flag.
     if (resource.options().cachingPolicy == CachingPolicy::AllowCachingMainResourcePrefetch)
         request.setCachingPolicy(CachingPolicy::AllowCachingMainResourcePrefetch);
-    CachedResourceHandle resourceHandle = createResource(resource.type(), WTF::move(request), sessionID, &cookieJar, settings, protect(document()).get());
+    Ref resourceHandle = createResource(resource.type(), WTF::move(request), sessionID, &cookieJar, settings, protect(document()).get());
     resourceHandle->loadFrom(resource);
     return resourceHandle;
 }
@@ -1051,7 +1052,7 @@ static bool NODELETE computeMayAddToMemoryCache(const CachedResourceRequest& new
     return !existingResource || !existingResource->isPreloaded() || newRequest.options().serviceWorkersMode != ServiceWorkersMode::None || existingResource->options().serviceWorkersMode == ServiceWorkersMode::None;
 }
 
-ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requestResource(CachedResource::Type type, CachedResourceRequest&& request, ForPreload forPreload, ImageLoading imageLoading)
+ResourceErrorOr<Ref<CachedResource>> CachedResourceLoader::requestResource(CachedResource::Type type, CachedResourceRequest&& request, ForPreload forPreload, ImageLoading imageLoading)
 {
     URL url = request.resourceRequest().url();
     RefPtr framePtr = this->frame();
@@ -1094,7 +1095,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
     }
 
     bool isRequestUpgradable { false };
-    RefPtr document = m_document.get();
+    RefPtr document = m_document;
     if (document) {
         isRequestUpgradable = MixedContentChecker::shouldUpgradeInsecureContent(frame, isUpgradableTypeFromResourceType(type), url, request.options().destination, request.options().initiator);
         request.upgradeInsecureRequestIfNeeded(*document, isRequestUpgradable ? ContentSecurityPolicy::AlwaysUpgradeRequest::Yes : ContentSecurityPolicy::AlwaysUpgradeRequest::No);
@@ -1102,7 +1103,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
     }
 
     URL committedDocumentURL { frame->document() ? frame->document()->url() : URL { } };
-    if (RefPtr documentLoader = m_documentLoader.get()) {
+    if (RefPtr documentLoader = m_documentLoader) {
         if (shouldPerformHTTPSUpgrade(committedDocumentURL, request.resourceRequest().url(), frame, type, page->settings().httpsByDefault(), documentLoader->advancedPrivacyProtections(), documentLoader->httpsByDefaultMode())) {
             auto portsForUpgradingInsecureScheme = page->portsForUpgradingInsecureSchemeForTesting();
             auto upgradePort = (portsForUpgradingInsecureScheme && request.resourceRequest().url().port() == portsForUpgradingInsecureScheme->first) ? std::optional { portsForUpgradingInsecureScheme->second } : std::nullopt;
@@ -1135,7 +1136,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
     if (InspectorInstrumentation::willIntercept(frame.ptr(), request.resourceRequest()))
         request.setCachingPolicy(CachingPolicy::DisallowCaching);
 
-    if (RefPtr documentLoader = m_documentLoader.get()) {
+    if (RefPtr documentLoader = m_documentLoader) {
         bool madeHTTPS { request.resourceRequest().wasSchemeOptimisticallyUpgraded() };
 #if ENABLE(CONTENT_EXTENSIONS)
         const auto& resourceRequest = request.resourceRequest();
@@ -1154,10 +1155,9 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
                 CACHEDRESOURCELOADER_RELEASE_LOG_WITH_FRAME("requestResource: Resource blocked by content blocker", frame.get());
                 if (type == CachedResource::Type::MainResource) {
                     auto resource = createResource(type, WTF::move(request), page->sessionID(), protect(page->cookieJar()).ptr(), page->settings(), document.get());
-                    ASSERT(resource);
                     resource->error(CachedResource::Status::LoadError);
                     resource->setResourceError(ResourceError(ContentExtensions::WebKitContentBlockerDomain, 0, resourceRequest.url(), WEB_UI_STRING("The URL was blocked by a content blocker", "WebKitErrorBlockedByContentBlocker description")));
-                    return resource;
+                    return WTF::move(resource);
                 }
                 if (document && consoleMessage)
                     document->addConsoleMessage(MessageSource::ContentBlocker, MessageLevel::Info, WTF::move(*consoleMessage));
@@ -1222,7 +1222,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
         m_documentResources.remove(url.string());
 
     // See if we can use an existing resource from the cache.
-    CachedResourceHandle<CachedResource> resource;
+    RefPtr<CachedResource> resource;
     CheckedPtr<ContentSecurityPolicy> contentSecurityPolicy;
     if (document) {
         request.setDomainForCachePartition(*document);
@@ -1302,7 +1302,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
                     downcast<CachedRawResource>(resource.get())->finishedTimingForWorkerLoad(WTF::move(resourceTiming));
                 else {
                     ASSERT(initiatorContext == InitiatorContext::Document);
-                    m_resourceTimingInfo.storeResourceTimingInitiatorInformation(resource, request.initiatorType(), frame.ptr());
+                    m_resourceTimingInfo.storeResourceTimingInitiatorInformation(*resource, request.initiatorType(), frame.ptr());
                     m_resourceTimingInfo.addResourceTiming(*resource.get(), *document, WTF::move(resourceTiming));
                 }
             }
@@ -1345,7 +1345,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
     } else if (policy == Use && !ignoreForRequestCount && resource->isLoading() && resource->loader()) {
         ++m_requestCount;
         resource->whenLoaded([weakThis = WeakPtr { *this }] {
-            RefPtr protectedThis = weakThis.get();
+            RefPtr protectedThis = weakThis;
             if (!protectedThis)
                 return;
             if (--protectedThis->m_requestCount)
@@ -1359,9 +1359,9 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
         m_validatedURLs.add(resource->resourceRequest().url());
 
     ASSERT(resource->url() == url.string());
-    m_documentResources.set(resource->url().string(), resource);
+    m_documentResources.set(resource->url().string(), CachedResourceHandle { *resource });
     frame->loader().client().didLoadFromRegistrableDomain(RegistrableDomain(resource->resourceRequest().url()));
-    return resource;
+    return resource.releaseNonNull();
 }
 
 void CachedResourceLoader::documentDidFinishLoadEvent()
@@ -1370,7 +1370,7 @@ void CachedResourceLoader::documentDidFinishLoadEvent()
 
     // If m_preloads is not empty here, it's full of link preloads,
     // as speculative preloads were cleared at DCL.
-    if (m_preloads && !m_preloads->isEmptyIgnoringNullReferences() && !m_unusedPreloadsTimer.isActive())
+    if (m_preloads && !m_preloads->isEmpty() && !m_unusedPreloadsTimer.isActive())
         m_unusedPreloadsTimer.startOneShot(unusedPreloadTimeout);
 }
 
@@ -1379,7 +1379,7 @@ void CachedResourceLoader::stopUnusedPreloadsTimer()
     m_unusedPreloadsTimer.stop();
 }
 
-CachedResourceHandle<CachedResource> CachedResourceLoader::revalidateResource(CachedResourceRequest&& request, CachedResource& resource)
+Ref<CachedResource> CachedResourceLoader::revalidateResource(CachedResourceRequest&& request, CachedResource& resource)
 {
     ASSERT(resource.inCache());
     Ref memoryCache = MemoryCache::singleton();
@@ -1388,20 +1388,20 @@ CachedResourceHandle<CachedResource> CachedResourceLoader::revalidateResource(Ca
     ASSERT(!resource.resourceToRevalidate());
     ASSERT(resource.allowsCaching());
 
-    CachedResourceHandle newResource = createResource(WTF::move(request), resource, protect(document()).get());
+    auto newResource = createResource(WTF::move(request), resource, protect(document()).get());
 
-    LOG(ResourceLoading, "Resource %p created to revalidate %p", newResource.get(), &resource);
+    LOG(ResourceLoading, "Resource %p created to revalidate %p", newResource.ptr(), &resource);
     newResource->setResourceToRevalidate(&resource);
 
     memoryCache->remove(resource);
-    memoryCache->add(*newResource);
+    memoryCache->add(newResource);
 
     m_resourceTimingInfo.storeResourceTimingInitiatorInformation(newResource, newResource->initiatorType(), protect(frame()).get());
 
     return newResource;
 }
 
-CachedResourceHandle<CachedResource> CachedResourceLoader::loadResource(CachedResource::Type type, PAL::SessionID sessionID, CachedResourceRequest&& request, const CookieJar& cookieJar, const Settings& settings, MayAddToMemoryCache mayAddToMemoryCache)
+Ref<CachedResource> CachedResourceLoader::loadResource(CachedResource::Type type, PAL::SessionID sessionID, CachedResourceRequest&& request, const CookieJar& cookieJar, const Settings& settings, MayAddToMemoryCache mayAddToMemoryCache)
 {
     Ref memoryCache = MemoryCache::singleton();
     ASSERT(!request.allowsCaching() || mayAddToMemoryCache == MayAddToMemoryCache::No || !memoryCache->resourceForRequest(request.resourceRequest(), sessionID)
@@ -1409,10 +1409,10 @@ CachedResourceHandle<CachedResource> CachedResourceLoader::loadResource(CachedRe
 
     LOG(ResourceLoading, "Loading CachedResource for '%s'.", request.resourceRequest().url().stringCenterEllipsizedToLength().latin1().data());
 
-    CachedResourceHandle resource = createResource(type, WTF::move(request), sessionID, &cookieJar, settings, protect(document()).get());
+    auto resource = createResource(type, WTF::move(request), sessionID, &cookieJar, settings, protect(document()).get());
 
     if (resource->allowsCaching() && mayAddToMemoryCache == MayAddToMemoryCache::Yes)
-        memoryCache->add(*resource);
+        memoryCache->add(resource);
 
     m_resourceTimingInfo.storeResourceTimingInitiatorInformation(resource, resource->initiatorType(), protect(frame()).get());
 
@@ -1504,7 +1504,7 @@ CachedResourceLoader::RevalidationPolicy CachedResourceLoader::determineRevalida
         return Use;
     ASSERT(!existingResource->validationInProgress());
 
-    if (CachedResourceHandle cachedImage = dynamicDowncast<CachedImage>(*existingResource); cachedImage && cachedImage->canSkipRevalidation(*this, cachedResourceRequest))
+    if (RefPtr cachedImage = dynamicDowncast<CachedImage>(*existingResource); cachedImage && cachedImage->canSkipRevalidation(*this, cachedResourceRequest))
         return Use;
 
     auto cachePolicy = this->cachePolicy(type, request.url());
@@ -1609,7 +1609,7 @@ void CachedResourceLoader::printAccessDeniedMessage(const URL& url) const
         return;
 
     String message;
-    RefPtr document = m_document.get();
+    RefPtr document = m_document;
     if (!document || document->url().isNull())
         message = makeString("Unsafe attempt to load URL "_s, url.stringCenterEllipsizedToLength(), '.');
     else
@@ -1663,7 +1663,7 @@ bool CachedResourceLoader::shouldDeferImageLoad(const URL& url) const
 void CachedResourceLoader::reloadImagesIfNotDeferred()
 {
     for (auto& resource : m_documentResources.values()) {
-        CachedResourceHandle image = dynamicDowncast<CachedImage>(*resource);
+        RefPtr image = dynamicDowncast<CachedImage>(*resource);
         if (image && resource->stillNeedsLoad() && clientDefersImage(resource->url()) == ImageLoading::Immediate)
             image->load(*this);
     }
@@ -1731,9 +1731,12 @@ void CachedResourceLoader::garbageCollectDocumentResources()
     StringVector resourcesToDelete;
 
     for (auto& resourceEntry : m_documentResources) {
-        auto& resource = *resourceEntry.value;
+        Ref resource = *resourceEntry.value;
 
-        if (resource.hasOneHandle() && !resource.loader() && !resource.isPreloaded()) {
+        // A refcount of 2 is guaranteed by the m_documentResources ref and `resource` variable ref.
+        // If the resource is in the memory cache then the cache is also holding a ref, making the ref-count 3.
+        bool resourceHasExternalUsers = resource->refCount() > (resource->inCache() ? 3u : 2u);
+        if (!resourceHasExternalUsers && !resource->loader() && !resource->isPreloaded()) {
             resourcesToDelete.append(resourceEntry.key);
             m_resourceTimingInfo.removeResourceTiming(resource);
         }
@@ -1778,7 +1781,7 @@ Vector<Ref<SVGImage>> CachedResourceLoader::allCachedSVGImages() const
     Vector<Ref<SVGImage>> allCachedSVGImages;
 
     for (auto& cachedSVGImageURL : m_cachedSVGImagesURLs) {
-        CachedResourceHandle resource = cachedResource(cachedSVGImageURL);
+        RefPtr resource = cachedResource(cachedSVGImageURL);
         if (RefPtr image = cachedResourceSVGImage(resource.get()))
             allCachedSVGImages.append(image.releaseNonNull());
     }
@@ -1786,27 +1789,27 @@ Vector<Ref<SVGImage>> CachedResourceLoader::allCachedSVGImages() const
     return allCachedSVGImages;
 }
 
-ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::preload(CachedResource::Type type, CachedResourceRequest&& request)
+ResourceErrorOr<Ref<CachedResource>> CachedResourceLoader::preload(CachedResource::Type type, CachedResourceRequest&& request)
 {
     if (InspectorInstrumentation::willIntercept(protect(frame()).get(), request.resourceRequest()))
         return makeUnexpected(ResourceError { errorDomainWebKitInternal, 0, request.resourceRequest().url(), "Inspector intercept"_s });
 
-    RefPtr document = m_document.get();
+    RefPtr document = m_document;
     ASSERT(document);
     if (request.charset().isEmpty() && document && (type == CachedResource::Type::Script || type == CachedResource::Type::JSON || type == CachedResource::Type::CSSStyleSheet))
         request.setCharset(document->charset());
 
     auto resource = requestResource(type, WTF::move(request), ForPreload::Yes);
-    if (resource && (!m_preloads || !m_preloads->contains(*resource.value().get()))) {
-        CachedResourceHandle resourceValue = resource.value();
+    if (resource && (!m_preloads || !m_preloads->contains(resource.value().ptr()))) {
+        auto& resourceValue = resource.value();
         // Fonts need special treatment since just creating the resource doesn't trigger a load.
-        if (CachedResourceHandle cachedFont = dynamicDowncast<CachedFont>(resourceValue.get()))
+        if (RefPtr cachedFont = dynamicDowncast<CachedFont>(resourceValue.get()))
             cachedFont->beginLoadIfNeeded(*this);
-        resourceValue->increasePreloadCount();
+        resourceValue->setIsPreloaded(true);
 
         if (!m_preloads)
-            m_preloads = makeUnique<WeakListHashSet<CachedResource>>();
-        m_preloads->add(*resourceValue.get());
+            m_preloads = makeUnique<ListHashSet<RefPtr<CachedResource>>>();
+        m_preloads->add(resourceValue.ptr());
     }
     return resource;
 }
@@ -1821,9 +1824,9 @@ void CachedResourceLoader::warnUnusedPreloads()
         return;
 
     for (const auto& resource : *m_preloads) {
-        if (resource.isLinkPreload() && resource.preloadResult() == CachedResource::PreloadResult::PreloadNotReferenced) {
+        if (resource->isLinkPreload() && resource->preloadResult() == CachedResource::PreloadResult::PreloadNotReferenced) {
             document->addConsoleMessage(MessageSource::Other, MessageLevel::Warning,
-                makeString("The resource "_s, resource.url().string(),
+                makeString("The resource "_s, resource->url().string(),
                 " was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it wasn't preloaded for nothing."_s));
         }
     }
@@ -1831,7 +1834,7 @@ void CachedResourceLoader::warnUnusedPreloads()
 
 bool CachedResourceLoader::isPreloaded(const String& urlString) const
 {
-    RefPtr document = m_document.get();
+    RefPtr document = m_document;
     ASSERT(document);
     if (!document)
         return false;
@@ -1842,7 +1845,7 @@ bool CachedResourceLoader::isPreloaded(const String& urlString) const
         return false;
 
     for (auto& resource : *m_preloads) {
-        if (resource.url() == url)
+        if (resource->url() == url)
             return true;
     }
     return false;
@@ -1853,18 +1856,17 @@ void CachedResourceLoader::clearPreloads(ClearPreloadsMode mode)
     if (!m_preloads)
         return;
 
-    std::unique_ptr<WeakListHashSet<CachedResource>> remainingLinkPreloads;
+    std::unique_ptr<ListHashSet<RefPtr<CachedResource>>> remainingLinkPreloads;
     for (auto& resource : *m_preloads) {
-        if (mode == ClearPreloadsMode::ClearSpeculativePreloads && resource.isLinkPreload()) {
+        if (mode == ClearPreloadsMode::ClearSpeculativePreloads && resource->isLinkPreload()) {
             if (!remainingLinkPreloads)
-                remainingLinkPreloads = makeUnique<WeakListHashSet<CachedResource>>();
+                remainingLinkPreloads = makeUnique<ListHashSet<RefPtr<CachedResource>>>();
             remainingLinkPreloads->add(resource);
             continue;
         }
-        resource.decreasePreloadCount();
-        bool deleted = resource.deleteIfPossible();
-        if (!deleted && resource.preloadResult() == CachedResource::PreloadResult::PreloadNotReferenced)
-            MemoryCache::singleton().remove(resource);
+        resource->setIsPreloaded(false);
+        if (resource->preloadResult() == CachedResource::PreloadResult::PreloadNotReferenced)
+            MemoryCache::singleton().remove(*resource);
     }
     m_preloads = WTF::move(remainingLinkPreloads);
 }
@@ -1877,7 +1879,7 @@ Vector<CachedResourceHandle<CachedResource>> CachedResourceLoader::visibleResour
     Vector<CachedResourceHandle<CachedResource>> toPrioritize;
 
     for (auto& resource : m_documentResources.values()) {
-        CachedResourceHandle cachedImage = dynamicDowncast<CachedImage>(*resource);
+        RefPtr cachedImage = dynamicDowncast<CachedImage>(*resource);
         if (!cachedImage)
             continue;
         if (!cachedImage->isLoading())

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/CachedRawResource.h>
 #include <WebCore/CachedResource.h>
 #include <WebCore/CachedResourceHandle.h>
 #include <WebCore/CachedResourceRequest.h>
@@ -37,9 +38,9 @@
 #include <wtf/CheckedPtr.h>
 #include <wtf/Expected.h>
 #include <wtf/HashMap.h>
+#include <wtf/ListHashSet.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RobinHoodHashSet.h>
-#include <wtf/WeakListHashSet.h>
 #include <wtf/text/StringHash.h>
 
 namespace WebCore {
@@ -91,35 +92,35 @@ public:
     static Ref<CachedResourceLoader> create(DocumentLoader* documentLoader) { return adoptRef(*new CachedResourceLoader(documentLoader)); }
     ~CachedResourceLoader();
 
-    ResourceErrorOr<CachedResourceHandle<CachedImage>> requestImage(CachedResourceRequest&&, ImageLoading = ImageLoading::Immediate);
-    ResourceErrorOr<CachedResourceHandle<CachedCSSStyleSheet>> requestCSSStyleSheet(CachedResourceRequest&&);
+    ResourceErrorOr<RefPtr<CachedImage>> requestImage(CachedResourceRequest&&, ImageLoading = ImageLoading::Immediate);
+    ResourceErrorOr<Ref<CachedCSSStyleSheet>> requestCSSStyleSheet(CachedResourceRequest&&);
     CachedResourceHandle<CachedCSSStyleSheet> requestUserCSSStyleSheet(Page&, CachedResourceRequest&&);
-    ResourceErrorOr<CachedResourceHandle<CachedScript>> requestScript(CachedResourceRequest&&);
-    ResourceErrorOr<CachedResourceHandle<CachedFont>> requestFont(CachedResourceRequest&&, bool isSVG);
-    ResourceErrorOr<CachedResourceHandle<CachedRawResource>> requestMedia(CachedResourceRequest&&);
-    ResourceErrorOr<CachedResourceHandle<CachedRawResource>> requestIcon(CachedResourceRequest&&);
-    ResourceErrorOr<CachedResourceHandle<CachedRawResource>> requestBeaconResource(CachedResourceRequest&&);
-    ResourceErrorOr<CachedResourceHandle<CachedRawResource>> requestPingResource(CachedResourceRequest&&);
-    ResourceErrorOr<CachedResourceHandle<CachedRawResource>> requestMainResource(CachedResourceRequest&&);
-    ResourceErrorOr<CachedResourceHandle<CachedSVGDocument>> requestSVGDocument(CachedResourceRequest&&);
+    ResourceErrorOr<Ref<CachedScript>> requestScript(CachedResourceRequest&&);
+    ResourceErrorOr<Ref<CachedFont>> requestFont(CachedResourceRequest&&, bool isSVG);
+    ResourceErrorOr<Ref<CachedRawResource>> requestMedia(CachedResourceRequest&&);
+    ResourceErrorOr<Ref<CachedRawResource>> requestIcon(CachedResourceRequest&&);
+    ResourceErrorOr<Ref<CachedRawResource>> requestBeaconResource(CachedResourceRequest&&);
+    ResourceErrorOr<Ref<CachedRawResource>> requestPingResource(CachedResourceRequest&&);
+    ResourceErrorOr<Ref<CachedRawResource>> requestMainResource(CachedResourceRequest&&);
+    ResourceErrorOr<Ref<CachedSVGDocument>> requestSVGDocument(CachedResourceRequest&&);
 #if ENABLE(XSLT)
-    ResourceErrorOr<CachedResourceHandle<CachedXSLStyleSheet>> requestXSLStyleSheet(CachedResourceRequest&&);
+    ResourceErrorOr<Ref<CachedXSLStyleSheet>> requestXSLStyleSheet(CachedResourceRequest&&);
 #endif
-    ResourceErrorOr<CachedResourceHandle<CachedResource>> requestLinkResource(CachedResource::Type, CachedResourceRequest&&);
+    ResourceErrorOr<Ref<CachedResource>> requestLinkResource(CachedResource::Type, CachedResourceRequest&&);
 #if ENABLE(VIDEO)
-    ResourceErrorOr<CachedResourceHandle<CachedTextTrack>> requestTextTrack(CachedResourceRequest&&);
+    ResourceErrorOr<Ref<CachedTextTrack>> requestTextTrack(CachedResourceRequest&&);
 #endif
 #if ENABLE(APPLICATION_MANIFEST)
-    ResourceErrorOr<CachedResourceHandle<CachedApplicationManifest>> requestApplicationManifest(CachedResourceRequest&&);
+    ResourceErrorOr<Ref<CachedApplicationManifest>> requestApplicationManifest(CachedResourceRequest&&);
 #endif
 #if ENABLE(MODEL_ELEMENT)
-    ResourceErrorOr<CachedResourceHandle<CachedRawResource>> requestEnvironmentMapResource(CachedResourceRequest&&);
-    ResourceErrorOr<CachedResourceHandle<CachedRawResource>> requestModelResource(CachedResourceRequest&&);
+    ResourceErrorOr<Ref<CachedRawResource>> requestEnvironmentMapResource(CachedResourceRequest&&);
+    ResourceErrorOr<Ref<CachedRawResource>> requestModelResource(CachedResourceRequest&&);
 #endif
 
     // Called to load Web Worker main script, Service Worker main script, importScripts(), XHR,
     // EventSource, Fetch, and App Cache.
-    ResourceErrorOr<CachedResourceHandle<CachedRawResource>> requestRawResource(CachedResourceRequest&&);
+    ResourceErrorOr<Ref<CachedRawResource>> requestRawResource(CachedResourceRequest&&);
 
     // Logs an access denied message to the console for the specified URL.
     void printAccessDeniedMessage(const URL& url) const;
@@ -159,7 +160,7 @@ public:
     WEBCORE_EXPORT bool isPreloaded(const String& urlString) const;
     enum class ClearPreloadsMode { ClearSpeculativePreloads, ClearAllPreloads };
     void clearPreloads(ClearPreloadsMode);
-    ResourceErrorOr<CachedResourceHandle<CachedResource>> preload(CachedResource::Type, CachedResourceRequest&&);
+    ResourceErrorOr<Ref<CachedResource>> preload(CachedResource::Type, CachedResourceRequest&&);
     void printPreloadStats();
     void warnUnusedPreloads();
     void stopUnusedPreloadsTimer();
@@ -185,11 +186,11 @@ private:
 
     enum class ForPreload : bool { No, Yes };
 
-    ResourceErrorOr<CachedResourceHandle<CachedResource>> requestResource(CachedResource::Type, CachedResourceRequest&&, ForPreload = ForPreload::No, ImageLoading = ImageLoading::Immediate);
-    CachedResourceHandle<CachedResource> revalidateResource(CachedResourceRequest&&, CachedResource&);
+    ResourceErrorOr<Ref<CachedResource>> requestResource(CachedResource::Type, CachedResourceRequest&&, ForPreload = ForPreload::No, ImageLoading = ImageLoading::Immediate);
+    Ref<CachedResource> revalidateResource(CachedResourceRequest&&, CachedResource&);
 
     enum class MayAddToMemoryCache : bool { No, Yes };
-    CachedResourceHandle<CachedResource> loadResource(CachedResource::Type, PAL::SessionID, CachedResourceRequest&&, const CookieJar&, const Settings&, MayAddToMemoryCache);
+    Ref<CachedResource> loadResource(CachedResource::Type, PAL::SessionID, CachedResourceRequest&&, const CookieJar&, const Settings&, MayAddToMemoryCache);
 
     void prepareFetch(CachedResource::Type, CachedResourceRequest&);
     void updateHTTPRequestHeaders(FrameLoader&, CachedResource::Type, CachedResourceRequest&);
@@ -200,7 +201,7 @@ private:
     RevalidationPolicy determineRevalidationPolicy(CachedResource::Type, CachedResourceRequest&, CachedResource* existingResource, ForPreload, ImageLoading) const;
 
     bool shouldUpdateCachedResourceWithCurrentRequest(const CachedResource&, const CachedResourceRequest&);
-    CachedResourceHandle<CachedResource> updateCachedResourceWithCurrentRequest(const CachedResource&, CachedResourceRequest&&, PAL::SessionID, const CookieJar&, const Settings&);
+    Ref<CachedResource> updateCachedResourceWithCurrentRequest(const CachedResource&, CachedResourceRequest&&, PAL::SessionID, const CookieJar&, const Settings&);
 
     bool shouldContinueAfterNotifyingLoadedFromMemoryCache(const CachedResourceRequest&, CachedResource&, ResourceError&);
     bool checkInsecureContent(CachedResource::Type, const URL&, MixedContentChecker::IsUpgradable) const;
@@ -221,7 +222,7 @@ private:
 
     int m_requestCount { 0 };
 
-    std::unique_ptr<WeakListHashSet<CachedResource>> m_preloads;
+    std::unique_ptr<ListHashSet<RefPtr<CachedResource>>> m_preloads;
     Timer m_unusedPreloadsTimer;
 
     Timer m_garbageCollectDocumentResourcesTimer;

--- a/Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp
+++ b/Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp
@@ -47,7 +47,7 @@ CachedSVGDocumentReference::CachedSVGDocumentReference(const Style::URL& locatio
 
 CachedSVGDocumentReference::~CachedSVGDocumentReference()
 {
-    if (CachedResourceHandle document = m_document)
+    if (RefPtr document = m_document)
         document->removeClient(*this);
 }
 
@@ -60,8 +60,11 @@ void CachedSVGDocumentReference::load(CachedResourceLoader& loader, const Resour
     fetchOptions.mode = FetchOptions::Mode::SameOrigin;
     CachedResourceRequest request(ResourceRequest(URL { m_location.resolved }), fetchOptions);
     request.setInitiatorType(cachedResourceRequestInitiatorTypes().css);
-    m_document = loader.requestSVGDocument(WTF::move(request)).value_or(nullptr);
-    if (CachedResourceHandle document = m_document)
+    if (auto result = loader.requestSVGDocument(WTF::move(request)))
+        m_document = WTF::move(result.value());
+    else
+        m_document = nullptr;
+    if (RefPtr document = m_document)
         document->addClient(*this);
 
     m_loadRequested = true;

--- a/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
+++ b/Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp
@@ -37,7 +37,10 @@ Ref<KeepaliveRequestTracker> KeepaliveRequestTracker::create()
 
 KeepaliveRequestTracker::~KeepaliveRequestTracker()
 {
-    auto inflightRequests = WTF::move(m_inflightKeepaliveRequests);
+    auto inflightRequests = WTF::map(m_inflightKeepaliveRequests, [](auto& request) {
+        return RefPtr { request.get() };
+    });
+    m_inflightKeepaliveRequests.clear();
     for (auto& resource : inflightRequests)
         resource->removeClient(*this);
 }

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -145,15 +145,10 @@ void MemoryCache::revalidationSucceeded(CachedResource& revalidatingResource, co
     RELEASE_ASSERT(isMainThread());
     ASSERT(response.source() == ResourceResponse::Source::MemoryCacheAfterValidation);
     ASSERT(revalidatingResource.resourceToRevalidate());
-    CachedResourceHandle protectedRevalidatingResource { revalidatingResource };
-    CachedResourceHandle resource = *revalidatingResource.resourceToRevalidate();
+    RefPtr protectedRevalidatingResource { revalidatingResource };
+    RefPtr resource = *revalidatingResource.resourceToRevalidate();
     ASSERT(!resource->inCache());
     ASSERT(resource->isLoaded());
-
-    // Calling remove() can potentially delete revalidatingResource, which we use
-    // below. This mustn't be the case since revalidation means it is loaded
-    // and so canDelete() is false.
-    ASSERT(!revalidatingResource.canDelete());
 
     remove(revalidatingResource);
 
@@ -162,7 +157,7 @@ void MemoryCache::revalidationSucceeded(CachedResource& revalidatingResource, co
     // one.
     std::pair key { resource->url(), resource->cachePartition() };
     if (auto* existingResources = sessionResourceMap(resource->sessionID())) {
-        if (CachedResourceHandle existingResource = existingResources->get(key))
+        if (RefPtr existingResource = existingResources->get(key))
             remove(*existingResource);
     }
 
@@ -181,7 +176,6 @@ void MemoryCache::revalidationSucceeded(CachedResource& revalidatingResource, co
         adjustSize(resource->hasClients(), delta);
 
     revalidatingResource.switchClientsToRevalidatedResource();
-    ASSERT(!revalidatingResource.m_deleted);
     // This deletes the revalidating resource.
     revalidatingResource.clearResourceToRevalidate();
 }
@@ -242,13 +236,13 @@ void MemoryCache::pruneLiveResources(bool shouldDestroyDecodedDataForAllLiveReso
 void MemoryCache::forEachResource(NOESCAPE const Function<void(CachedResource&)>& function)
 {
     RELEASE_ASSERT(isMainThread());
-    Vector<WeakPtr<CachedResource>> allResources;
+    Vector<CachedResourceHandle<CachedResource>> allResources;
     for (auto& lruList : m_allResources) {
         allResources.reserveCapacity(allResources.size() + lruList->computeSize());
         allResources.appendRange(lruList->begin(), lruList->end());
     }
     for (auto& resource : allResources) {
-        if (CachedResourceHandle resourceHandle = resource.get())
+        if (RefPtr resourceHandle = resource)
             function(*resourceHandle);
     }
 }
@@ -262,7 +256,7 @@ void MemoryCache::forEachSessionResource(PAL::SessionID sessionID, NOESCAPE cons
         return;
 
     for (auto& weakResource : copyToVector(it->value->values())) {
-        if (CachedResourceHandle resource = weakResource.get())
+        if (RefPtr resource = weakResource)
             function(*resource);
     }
 }
@@ -302,7 +296,7 @@ void MemoryCache::pruneLiveResourcesToSize(unsigned targetSize, bool shouldDestr
     // For more details see: https://bugs.webkit.org/show_bug.cgi?id=30209
     auto it = m_liveDecodedResources.begin();
     while (it != m_liveDecodedResources.end()) {
-        CachedResourceHandle current = *it;
+        RefPtr current = *it;
 
         LOG(ResourceLoading, " live resource %p %.255s - loaded %d, decodedSize %u", current.get(), current->url().string().utf8().data(), current->isLoaded(), current->decodedSize());
 
@@ -370,7 +364,7 @@ void MemoryCache::pruneDeadResourcesToSize(unsigned targetSize)
         // First flush all the decoded data in this queue.
         // Remove from the head, since this is the least frequently accessed of the objects.
         for (auto& weakResource : lruList) {
-            CachedResourceHandle resource = weakResource.get();
+            RefPtr resource = weakResource;
             if (!resource)
                 continue;
 
@@ -379,8 +373,8 @@ void MemoryCache::pruneDeadResourcesToSize(unsigned targetSize)
                 continue;
 
             if (!resource->hasClients() && !resource->isPreloaded() && resource->isLoaded()) {
-                // Destroy our decoded data. This will remove us from 
-                // m_liveDecodedResources, and possibly move us to a different 
+                // Destroy our decoded data. This will remove us from
+                // m_liveDecodedResources, and possibly move us to a different
                 // LRU list in m_allResources.
 
                 LOG(ResourceLoading, " lru resource %p destroyDecodedData", resource.get());
@@ -397,7 +391,7 @@ void MemoryCache::pruneDeadResourcesToSize(unsigned targetSize)
         // Now evict objects from this list.
         // Remove from the head, since this is the least frequently accessed of the objects.
         for (auto& weakResource : lruList) {
-            CachedResourceHandle resource = weakResource.get();
+            RefPtr resource = weakResource;
             if (!resource)
                 continue;
 
@@ -434,7 +428,7 @@ void MemoryCache::setCapacities(unsigned minDeadBytes, unsigned maxDeadBytes, un
 void MemoryCache::remove(CachedResource& resource)
 {
     RELEASE_ASSERT(isMainThread());
-    CachedResourceHandle protectedResource { resource };
+    RefPtr protectedResource { resource };
 
     LOG(ResourceLoading, "Evicting resource %p for '%.255s' from cache", &resource, resource.url().string().latin1().data());
     // The resource may have already been removed by someone other than our caller,
@@ -544,20 +538,20 @@ void MemoryCache::removeResourcesWithOrigin(const SecurityOrigin& origin, const 
     Vector<WeakPtr<CachedResource>> resourcesWithOrigin;
     for (auto& resources : m_sessionResources.values()) {
         for (auto& keyValue : *resources) {
-            auto& resource = *keyValue.value;
+            Ref resource = *keyValue.value;
             auto& partitionName = keyValue.key.second;
             if (partitionName == cachePartition) {
                 resourcesWithOrigin.append(resource);
                 continue;
             }
-            auto resourceOrigin = SecurityOrigin::create(resource.url());
+            auto resourceOrigin = SecurityOrigin::create(resource->url());
             if (resourceOrigin->equal(origin))
                 resourcesWithOrigin.append(resource);
         }
     }
 
     for (auto& weakResource : resourcesWithOrigin) {
-        if (CachedResourceHandle resource = weakResource.get())
+        if (RefPtr resource = weakResource)
             remove(*resource);
     }
 }
@@ -590,18 +584,18 @@ void MemoryCache::removeResourcesWithOrigins(PAL::SessionID sessionID, const Has
 
     Vector<WeakPtr<CachedResource>> resourcesToRemove;
     for (auto& keyValuePair : *resourceMap) {
-        auto& resource = *keyValuePair.value;
+        Ref resource = *keyValuePair.value;
         auto& partitionName = keyValuePair.key.second;
         if (originPartitions.contains(partitionName)) {
             resourcesToRemove.append(resource);
             continue;
         }
-        if (origins.contains(SecurityOrigin::create(resource.url()).ptr()))
+        if (origins.contains(SecurityOrigin::create(resource->url()).ptr()))
             resourcesToRemove.append(resource);
     }
 
     for (auto& weakResource : resourcesToRemove) {
-        if (CachedResourceHandle resource = weakResource.get())
+        if (RefPtr resource = weakResource)
             remove(*resource);
     }
 }
@@ -611,12 +605,12 @@ void MemoryCache::getOriginsWithCache(SecurityOriginSet& origins)
     RELEASE_ASSERT(isMainThread());
     for (auto& resources : m_sessionResources.values()) {
         for (auto& keyValue : *resources) {
-            auto& resource = *keyValue.value;
+            Ref resource = *keyValue.value;
             auto& partitionName = keyValue.key.second;
             if (!partitionName.isEmpty())
                 origins.add(SecurityOrigin::create("http"_s, partitionName, 0));
             else
-                origins.add(SecurityOrigin::create(resource.url()));
+                origins.add(SecurityOrigin::create(resource->url()));
         }
     }
 }
@@ -630,12 +624,12 @@ HashSet<Ref<SecurityOrigin>> MemoryCache::originsWithCache(PAL::SessionID sessio
     auto it = m_sessionResources.find(sessionID);
     if (it != m_sessionResources.end()) {
         for (auto& keyValue : *it->value) {
-            auto& resource = *keyValue.value;
+            Ref resource = *keyValue.value;
             auto& partitionName = keyValue.key.second;
             if (!partitionName.isEmpty())
                 origins.add(SecurityOrigin::create("http"_s, partitionName, 0));
             else
-                origins.add(SecurityOrigin::create(resource.url()));
+                origins.add(SecurityOrigin::create(resource->url()));
         }
     }
 
@@ -702,7 +696,7 @@ void MemoryCache::removeRequestFromSessionCaches(ScriptExecutionContext& context
 
     Ref memoryCache = MemoryCache::singleton();
     for (auto& resources : memoryCache->m_sessionResources) {
-        if (CachedResourceHandle resource = memoryCache->resourceForRequestImpl(request, *resources.value))
+        if (RefPtr resource = memoryCache->resourceForRequestImpl(request, *resources.value))
             memoryCache->remove(*resource);
     }
 }
@@ -759,7 +753,7 @@ void MemoryCache::setDisabled(bool disabled)
     while (!m_sessionResources.isEmpty()) {
         auto& resources = *m_sessionResources.begin()->value;
         ASSERT(!resources.isEmpty());
-        CachedResourceHandle resource = *resources.begin()->value;
+        RefPtr resource = *resources.begin()->value;
         remove(*resource);
     }
 }
@@ -846,9 +840,9 @@ void MemoryCache::dumpLRULists(bool includeLive) const
     int size = m_allResources.size();
     for (int i = size - 1; i >= 0; i--) {
         WTFLogAlways("\nList %d:\n", i);
-        for (auto& resource : *m_allResources[i]) {
-            if (includeLive || !resource.hasClients())
-                WTFLogAlways("  %p %.255s %.1fK, %.1fK, accesses: %u, clients: %d\n", &resource, resource.url().string().utf8().data(), resource.decodedSize() / 1024.0f, (resource.encodedSize() + resource.overheadSize()) / 1024.0f, resource.accessCount(), resource.numberOfClients());
+        for (Ref resource : *m_allResources[i]) {
+            if (includeLive || !resource->hasClients())
+                WTFLogAlways("  %p %.255s %.1fK, %.1fK, accesses: %u, clients: %d\n", resource.ptr(), resource->url().string().utf8().data(), resource->decodedSize() / 1024.0f, (resource->encodedSize() + resource->overheadSize()) / 1024.0f, resource->accessCount(), resource->numberOfClients());
         }
     }
 }

--- a/Source/WebCore/loader/cache/MemoryCache.h
+++ b/Source/WebCore/loader/cache/MemoryCache.h
@@ -178,7 +178,7 @@ public:
     WEBCORE_EXPORT void pruneLiveResourcesToSize(unsigned targetSize, bool shouldDestroyDecodedDataForAllLiveResources = false);
 
 private:
-    using CachedResourceMap = HashMap<std::pair<URL, String /* partitionName */>, WeakPtr<CachedResource>>;
+    using CachedResourceMap = HashMap<std::pair<URL, String /* partitionName */>, RefPtr<CachedResource>>;
     using LRUList = WeakListHashSet<CachedResource>;
 
     MemoryCache();

--- a/Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.mm
+++ b/Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.mm
@@ -116,7 +116,7 @@ DiskCacheMonitor::DiskCacheMonitor(const ResourceRequest& request, PAL::SessionI
 
 void DiskCacheMonitor::resourceBecameFileBacked(SharedBuffer& fileBackedBuffer)
 {
-    CachedResourceHandle resource = MemoryCache::singleton().resourceForRequest(m_resourceRequest, m_sessionID);
+    RefPtr resource = MemoryCache::singleton().resourceForRequest(m_resourceRequest, m_sessionID);
     if (!resource)
         return;
 

--- a/Source/WebCore/loader/cocoa/SubresourceLoaderCocoa.mm
+++ b/Source/WebCore/loader/cocoa/SubresourceLoaderCocoa.mm
@@ -37,8 +37,9 @@ namespace WebCore {
 
 void SubresourceLoader::willCacheResponseAsync(ResourceHandle* handle, NSCachedURLResponse* response, CompletionHandler<void(NSCachedURLResponse *)>&& completionHandler)
 {
-    DiskCacheMonitor::monitorFileBackingStoreCreation(request(), m_resource->sessionID(), [response _CFCachedURLResponse]);
-    if (!m_resource->shouldCacheResponse(response.response))
+    RefPtr resource = m_resource;
+    DiskCacheMonitor::monitorFileBackingStoreCreation(request(), resource->sessionID(), [response _CFCachedURLResponse]);
+    if (!resource->shouldCacheResponse(response.response))
         return completionHandler(nullptr);
     ResourceLoader::willCacheResponseAsync(handle, response, WTF::move(completionHandler));
 }

--- a/Source/WebCore/loader/icon/IconLoader.cpp
+++ b/Source/WebCore/loader/icon/IconLoader.cpp
@@ -93,8 +93,11 @@ void IconLoader::startLoading()
     request.setInitiatorType(cachedResourceRequestInitiatorTypes().icon);
 
     auto cachedResource = protect(protect(frame->document())->cachedResourceLoader())->requestIcon(WTF::move(request));
-    m_resource = cachedResource.value_or(nullptr);
-    if (CachedResourceHandle resource = m_resource)
+    if (cachedResource)
+        m_resource = WTF::move(cachedResource.value());
+    else
+        m_resource = nullptr;
+    if (RefPtr resource = m_resource)
         resource->addClient(*this);
     else
         LOG_ERROR("Failed to start load for icon at url %s (error: %s)", resourceRequestURL.string().ascii().data(), cachedResource.error().localizedDescription().utf8().data());
@@ -102,7 +105,7 @@ void IconLoader::startLoading()
 
 void IconLoader::stopLoading()
 {
-    if (CachedResourceHandle resource = std::exchange(m_resource, nullptr))
+    if (RefPtr resource = std::exchange(m_resource, nullptr))
         resource->removeClient(*this);
 }
 
@@ -112,18 +115,18 @@ void IconLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetri
 
     // If we got a status code indicating an invalid response, then lets
     // ignore the data and not try to decode the error page as an icon.
-    RefPtr data = m_resource->resourceBuffer();
-    int status = m_resource->response().httpStatusCode();
+    RefPtr data = resource.resourceBuffer();
+    int status = resource.response().httpStatusCode();
     if (status && (status < 200 || status > 299))
         data = nullptr;
 
     constexpr std::array<uint8_t, 4> pdfMagicNumber { '%', 'P', 'D', 'F' };
     if (data && data->startsWith(pdfMagicNumber)) {
-        LOG(IconDatabase, "IconLoader::finishLoading() - Ignoring icon at %s because it appears to be a PDF", m_resource->url().string().ascii().data());
+        LOG(IconDatabase, "IconLoader::finishLoading() - Ignoring icon at %s because it appears to be a PDF", resource.url().string().ascii().data());
         data = nullptr;
     }
 
-    LOG(IconDatabase, "IconLoader::finishLoading() - Committing iconURL %s to database", m_resource->url().string().ascii().data());
+    LOG(IconDatabase, "IconLoader::finishLoading() - Committing iconURL %s to database", resource.url().string().ascii().data());
 
     // DocumentLoader::finishedLoadingIcon destroys this IconLoader as it finishes. This will automatically
     // trigger IconLoader::stopLoading() during destruction, so we should just return here.

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -781,7 +781,7 @@ static bool imageElementIsDraggable(const HTMLImageElement& image, const LocalFr
     if (!renderImage)
         return false;
 
-    CachedResourceHandle cachedImage = renderImage->cachedImage();
+    RefPtr cachedImage = renderImage->cachedImage();
     return cachedImage && !cachedImage->errorOccurred() && cachedImage->imageForRenderer(renderImage.get());
 }
 
@@ -888,7 +888,7 @@ static CachedImage* getCachedImage(Element& element)
 
 static Image* getImage(Element& element)
 {
-    CachedResourceHandle cachedImage = getCachedImage(element);
+    RefPtr cachedImage = getCachedImage(element);
     // Don't use cachedImage->imageForRenderer() here as that may return BitmapImages for cached SVG Images.
     // Users of getImage() want access to the SVGImage, in order to figure out the filename extensions,
     // which would be empty when asking the cached BitmapImages.
@@ -1347,7 +1347,7 @@ void DragController::doImageDrag(Element& element, const IntPoint& dragOrigin, c
         float dy = scale * (originY - mouseDownPoint.y());
         scaledOrigin = IntPoint((int)(dx + 0.5), (int)(dy + 0.5));
     } else {
-        if (CachedResourceHandle cachedImage = getCachedImage(element)) {
+        if (RefPtr cachedImage = getCachedImage(element)) {
             dragImage = DragImage { createDragImageIconForCachedImageFilename(cachedImage->response().suggestedFilename()) };
             if (dragImage) {
                 dragImage = DragImage { platformAdjustDragImageForDeviceScaleFactor(dragImage.get(), m_page->deviceScaleFactor()) };

--- a/Source/WebCore/page/FrameConsoleClient.cpp
+++ b/Source/WebCore/page/FrameConsoleClient.cpp
@@ -368,7 +368,7 @@ void FrameConsoleClient::screenshot(JSC::JSGlobalObject* lexicalGlobalObject, Re
                 // Only try to do something special for subclasses of Node if they're detached from the DOM tree.
                 if (!node->document().contains(*node)) {
                     auto snapshotImageElement = [&snapshot] (HTMLImageElement& imageElement) {
-                        if (auto* cachedImage = imageElement.cachedImage()) {
+                        if (RefPtr cachedImage = imageElement.cachedImage()) {
                             if (RefPtr image = cachedImage->image(); image && image != &Image::nullImage()) {
                                 snapshot = ImageBuffer::create(image->size(), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, /* scale */ 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
                                 snapshot->context().drawImage(*image, FloatPoint(0, 0));

--- a/Source/WebCore/page/ImageAnalysisQueue.cpp
+++ b/Source/WebCore/page/ImageAnalysisQueue.cpp
@@ -71,7 +71,7 @@ void ImageAnalysisQueue::enqueueIfNeeded(HTMLImageElement& element)
     if (!renderer)
         return;
 
-    CachedResourceHandle cachedImage = renderer->cachedImage();
+    RefPtr cachedImage = renderer->cachedImage();
     if (!cachedImage || cachedImage->errorOccurred())
         return;
 
@@ -166,7 +166,7 @@ void ImageAnalysisQueue::resumeProcessing()
         Ref page = *m_page;
         page->resetTextRecognitionResult(*element);
 
-        if (auto* image = element->cachedImage(); image && !image->errorOccurred())
+        if (RefPtr image = element->cachedImage(); image && !image->errorOccurred())
             m_queuedElements.set(*element, image->url());
 
         auto allowSnapshots = m_languageIdentifiers.target.isEmpty() ? TextRecognitionOptions::AllowSnapshots::Yes : TextRecognitionOptions::AllowSnapshots::No;

--- a/Source/WebCore/page/LargestContentfulPaintData.cpp
+++ b/Source/WebCore/page/LargestContentfulPaintData.cpp
@@ -225,7 +225,8 @@ RefPtr<LargestContentfulPaint> LargestContentfulPaintData::generateLargestConten
         auto& lcpData = element->ensureLargestContentfulPaintData();
 
         // FIXME: This is doing multiple localToAbsolute on the same element, but multiple images per element is rare.
-        for (auto image : imageList) {
+        for (auto weakImage : imageList) {
+            RefPtr image = weakImage;
             if (!image)
                 continue;
             auto findIndex = lcpData.imageData.findIf([&](auto& value) {

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -216,7 +216,7 @@ void PageSerializer::serializeFrame(LocalFrame* frame)
 
         if (RefPtr imageElement = dynamicDowncast<HTMLImageElement>(*element)) {
             auto url = document->completeURL(imageElement->attributeWithoutSynchronization(HTMLNames::srcAttr));
-            auto* cachedImage = imageElement->cachedImage();
+            RefPtr cachedImage = imageElement->cachedImage();
             addImageToResources(cachedImage, imageElement->renderer(), url);
         } else if (RefPtr linkElement = dynamicDowncast<HTMLLinkElement>(*element)) {
             if (RefPtr sheet = linkElement->sheet()) {
@@ -311,7 +311,7 @@ void PageSerializer::retrieveResourcesForProperties(const StyleProperties* style
         if (!cssValue)
             continue;
 
-        auto* image = cssValue->cachedImage();
+        RefPtr image = cssValue->cachedImage();
         if (!image)
             continue;
 

--- a/Source/WebCore/platform/graphics/avfoundation/cf/WebCoreAVCFResourceLoader.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/cf/WebCoreAVCFResourceLoader.cpp
@@ -87,7 +87,11 @@ void WebCoreAVCFResourceLoader::startLoading()
         CachingPolicy::DisallowCaching));
 
     CachedResourceLoader* loader = m_parent->player()->cachedResourceLoader();
-    m_resource = loader ? loader->requestRawResource(WTF::move(request)).value_or(nullptr) : nullptr;
+    m_resource = nullptr;
+    if (loader) {
+        if (auto result = loader->requestRawResource(WTF::move(request)))
+            m_resource = WTF::move(result.value());
+    }
     if (m_resource)
         m_resource->addClient(*this);
     else {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm
@@ -104,7 +104,9 @@ RefPtr<CachedResourceMediaLoader> CachedResourceMediaLoader::create(WebCoreAVFRe
     loaderOptions.destination = FetchOptions::Destination::Video;
     CachedResourceRequest request(WTF::move(resourceRequest), loaderOptions);
 
-    auto resource = loader.requestMedia(WTF::move(request)).value_or(nullptr);
+    RefPtr<CachedRawResource> resource;
+    if (auto result = loader.requestMedia(WTF::move(request)))
+        resource = WTF::move(result.value());
     if (!resource)
         return nullptr;
     return adoptRef(*new CachedResourceMediaLoader { parent, WTF::move(resource) });

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -555,7 +555,7 @@ template<typename Layer> void BackgroundPainter::paintFillLayerImpl(const Color&
                 if (m_renderer.element())
                     m_renderer.element()->setHasEverPaintedImages(true);
 
-                if (auto* image = bgImage->cachedImage(); image && image->currentFrameIsComplete(&m_renderer)) {
+                if (RefPtr image = bgImage->cachedImage(); image && image->currentFrameIsComplete(&m_renderer)) {
                     if (auto styleable = Styleable::fromRenderer(m_renderer))
                         document().didPaintImage(styleable->element, image, geometry.destinationRect);
                 }

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -341,7 +341,7 @@ void RenderImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
     if (CheckedPtr cache = document().existingAXObjectCache())
         cache->deferRecomputeIsIgnoredIfNeeded(element());
 
-    if (auto* image = cachedImage(); image && image->currentFrameIsComplete(this)) {
+    if (RefPtr image = cachedImage(); image && image->currentFrameIsComplete(this)) {
         if (auto styleable = Styleable::fromRenderer(*this))
             protect(document())->didLoadImage(protect(styleable->element).get(), image);
     }
@@ -455,7 +455,7 @@ bool RenderImage::isShowingAltText() const
 
 bool RenderImage::isDimensionlessSVG() const
 {
-    auto* cachedImage = this->cachedImage();
+    RefPtr cachedImage = this->cachedImage();
     if (!cachedImage)
         return false;
     RefPtr svgImage = dynamicDowncast<SVGImage>(cachedImage->image());
@@ -476,7 +476,7 @@ bool RenderImage::shouldDisplayBrokenImageIcon() const
 // See: https://github.com/w3c/csswg-drafts/issues/11236#issuecomment-2718502765
 bool RenderImage::shouldRespectZeroIntrinsicWidth() const
 {
-    auto* cachedImage = this->cachedImage();
+    RefPtr cachedImage = this->cachedImage();
     if (!cachedImage)
         return false;
     if (RefPtr svgImage = dynamicDowncast<SVGImage>(cachedImage->image())) {
@@ -970,7 +970,7 @@ bool RenderImage::shouldInvalidatePreferredWidths() const
 
 RenderBox* RenderImage::embeddedContentBox() const
 {
-    if (auto* cachedImage = this->cachedImage()) {
+    if (RefPtr cachedImage = this->cachedImage()) {
         if (RefPtr image = dynamicDowncast<SVGImage>(cachedImage->image()))
             return image->embeddedContentBox();
     }

--- a/Source/WebCore/rendering/RenderImageResource.cpp
+++ b/Source/WebCore/rendering/RenderImageResource.cpp
@@ -78,9 +78,9 @@ void RenderImageResource::clearCachedImage()
     m_styleImage = nullptr;
 }
 
-void RenderImageResource::setCachedImage(CachedResourceHandle<CachedImage>&& newImage)
+void RenderImageResource::setCachedImage(CachedImage* newImage)
 {
-    auto existingCachedImage = this->cachedImage();
+    RefPtr existingCachedImage = this->cachedImage();
     if (existingCachedImage == newImage)
         return;
 

--- a/Source/WebCore/rendering/RenderImageResource.h
+++ b/Source/WebCore/rendering/RenderImageResource.h
@@ -50,7 +50,7 @@ public:
     void willBeDestroyed();
 
     void clearCachedImage();
-    void setCachedImage(CachedResourceHandle<CachedImage>&&);
+    void setCachedImage(CachedImage*);
     CachedImage* cachedImage() const { return m_styleImage ? m_styleImage->cachedImage() : nullptr; }
 
     void resetAnimation();

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -881,7 +881,7 @@ void RenderInline::imageChanged(WrappedImagePtr image, const IntRect*)
     RefPtr styleImage = Style::findLayerUsedImage(style().backgroundLayers(), image, isNonEmpty);
     if (styleImage && isNonEmpty) {
         if (auto styleable = Styleable::fromRenderer(*this))
-            protect(document())->didLoadImage(protect(styleable->element).get(), styleImage->cachedImage());
+            protect(document())->didLoadImage(protect(styleable->element).get(), protect(styleImage->cachedImage()));
     }
 
     // FIXME: We can do better.

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3396,7 +3396,7 @@ bool RenderLayerBacking::isDirectlyCompositedImage() const
         return false;
 #endif
 
-    if (auto* cachedImage = imageRenderer->cachedImage()) {
+    if (RefPtr cachedImage = imageRenderer->cachedImage()) {
         if (!cachedImage->hasImage())
             return false;
 
@@ -3441,7 +3441,7 @@ bool RenderLayerBacking::isUnscaledBitmapOnly() const
         return false;
 
     if (CheckedPtr imageRenderer = dynamicDowncast<RenderImage>(renderer())) {
-        if (auto* cachedImage = imageRenderer->cachedImage()) {
+        if (RefPtr cachedImage = imageRenderer->cachedImage()) {
             if (!cachedImage->hasImage())
                 return false;
 
@@ -3537,7 +3537,7 @@ void RenderLayerBacking::updateImageContents(PaintedContentsInfo& contentsInfo)
     } else {
         auto& imageRenderer = downcast<RenderImage>(renderer());
 
-        auto* cachedImage = imageRenderer.cachedImage();
+        RefPtr cachedImage = imageRenderer.cachedImage();
         if (!cachedImage)
             return;
 

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -100,10 +100,10 @@ void RenderLayerFilters::updateReferenceFilterClients(const Style::Filter& filte
         WTF::switchOn(value,
             [&](const Style::FilterReference& filterReference) {
                 RefPtr documentReference = filterReference.cachedSVGDocumentReference;
-                if (auto* cachedSVGDocument = documentReference ? documentReference->document() : nullptr) {
+                if (RefPtr cachedSVGDocument = documentReference ? documentReference->document() : nullptr) {
                     // Reference is external; wait for notifyFinished().
                     cachedSVGDocument->addClient(*this);
-                    m_externalSVGReferences.append(cachedSVGDocument);
+                    m_externalSVGReferences.append(cachedSVGDocument.releaseNonNull());
                 } else {
                     // Reference is internal; add layer as a client so we can trigger filter repaint on SVG attribute change.
                     CheckedPtr layer = m_layer.get();

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -261,7 +261,7 @@ void RenderVideo::paintReplaced(PaintInfo& paintInfo, const LayoutPoint& paintOf
     if (paintInfo.phase == PaintPhase::Foreground) {
         page->addRelevantRepaintedObject(*this, rect);
         if (displayingPoster && !context.paintingDisabled())
-            protect(document())->didPaintImage(videoElement.get(), cachedImage(), videoBoxRect);
+            protect(document())->didPaintImage(videoElement.get(), protect(cachedImage()), videoBoxRect);
     }
 
     LayoutRect contentRect = contentBoxRect();

--- a/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
+++ b/Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp
@@ -323,11 +323,11 @@ static inline bool checkShapeImageOrigin(Document& document, const Style::Image&
         return true;
 
     ASSERT(styleImage.cachedImage());
-    CachedImage& cachedImage = *(styleImage.cachedImage());
-    if (cachedImage.isOriginClean(&document.securityOrigin()))
+    Ref cachedImage = *(styleImage.cachedImage());
+    if (cachedImage->isOriginClean(&document.securityOrigin()))
         return true;
 
-    const URL& url = cachedImage.url();
+    const URL& url = cachedImage->url();
     String urlString = url.isNull() ? "''"_s : url.stringCenterEllipsizedToLength();
     document.addConsoleMessage(MessageSource::Security, MessageLevel::Error, makeString("Unsafe attempt to load URL "_s, urlString, '.'));
 

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -76,7 +76,7 @@ SVGImageElement& RenderSVGImage::imageElement() const
 FloatRect RenderSVGImage::calculateObjectBoundingBox() const
 {
     LayoutSize intrinsicSize;
-    if (CachedImage* cachedImage = imageResource().cachedImage())
+    if (RefPtr cachedImage = imageResource().cachedImage())
         intrinsicSize = cachedImage->imageSizeForRenderer(nullptr, style().usedZoom());
 
     Ref imageElement = this->imageElement();
@@ -292,7 +292,7 @@ bool RenderSVGImage::updateImageViewport()
     // by setting the image's container size to its intrinsic size.
     // See: http://www.w3.org/TR/SVG/single-page.html, 7.8 The ‘preserveAspectRatio’ attribute.
     if (imageElement->preserveAspectRatio().align() == SVGPreserveAspectRatioValue::SVG_PRESERVEASPECTRATIO_NONE) {
-        if (CachedImage* cachedImage = imageResource().cachedImage()) {
+        if (RefPtr cachedImage = imageResource().cachedImage()) {
             LayoutSize intrinsicSize = cachedImage->imageSizeForRenderer(nullptr, style().usedZoom());
             if (intrinsicSize != imageResource().imageSize(style().usedZoom())) {
                 imageResource().setContainerContext(roundedIntSize(intrinsicSize), imageSourceURL);
@@ -369,7 +369,7 @@ void RenderSVGImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
     if (CheckedPtr cache = document().existingAXObjectCache())
         cache->deferRecomputeIsIgnoredIfNeeded(protect(imageElement()).ptr());
 
-    if (auto* image = imageResource().cachedImage(); image && image->currentFrameIsComplete(this)) {
+    if (RefPtr image = imageResource().cachedImage(); image && image->currentFrameIsComplete(this)) {
         if (auto styleable = Styleable::fromRenderer(*this))
             protect(document())->didLoadImage(protect(styleable->element).get(), image);
     }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -86,7 +86,7 @@ SVGImageElement& LegacyRenderSVGImage::imageElement() const
 FloatRect LegacyRenderSVGImage::calculateObjectBoundingBox() const
 {
     LayoutSize intrinsicSize;
-    if (CachedImage* cachedImage = imageResource().cachedImage())
+    if (RefPtr cachedImage = imageResource().cachedImage())
         intrinsicSize = cachedImage->imageSizeForRenderer(nullptr, style().usedZoom());
 
     Ref imageElement = this->imageElement();
@@ -128,7 +128,7 @@ bool LegacyRenderSVGImage::updateImageViewport()
     // by setting the image's container size to its intrinsic size.
     // See: http://www.w3.org/TR/SVG/single-page.html, 7.8 The ‘preserveAspectRatio’ attribute.
     if (imageElement().preserveAspectRatio().align() == SVGPreserveAspectRatioValue::SVG_PRESERVEASPECTRATIO_NONE) {
-        if (CachedImage* cachedImage = imageResource().cachedImage()) {
+        if (RefPtr cachedImage = imageResource().cachedImage()) {
             LayoutSize intrinsicSize = cachedImage->imageSizeForRenderer(nullptr, style().usedZoom());
             if (intrinsicSize != imageResource().imageSize(style().usedZoom())) {
                 imageResource().setContainerContext(roundedIntSize(intrinsicSize), imageSourceURL);
@@ -240,7 +240,7 @@ void LegacyRenderSVGImage::paintForeground(PaintInfo& paintInfo)
     auto& context = paintInfo.context();
     context.drawImage(*image, destRect, srcRect, options);
 
-    auto* cachedImage = imageResource().cachedImage();
+    RefPtr cachedImage = imageResource().cachedImage();
     if (cachedImage && !context.paintingDisabled())
         protect(document())->didPaintImage(imageElement(), cachedImage, destRect);
 }
@@ -304,7 +304,7 @@ void LegacyRenderSVGImage::imageChanged(WrappedImagePtr, const IntRect*)
 
     repaint();
 
-    if (auto* image = imageResource().cachedImage(); image && image->currentFrameIsComplete(this)) {
+    if (RefPtr image = imageResource().cachedImage(); image && image->currentFrameIsComplete(this)) {
         if (auto styleable = Styleable::fromRenderer(*this))
             protect(document())->didLoadImage(protect(styleable->element).get(), image);
     }

--- a/Source/WebCore/style/values/images/kinds/StyleFilterImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleFilterImage.cpp
@@ -56,8 +56,8 @@ FilterImage::FilterImage(RefPtr<Image>&& image, Filter&& filter)
 
 FilterImage::~FilterImage()
 {
-    if (m_cachedImage)
-        m_cachedImage->removeClient(*this);
+    if (RefPtr cachedImage = m_cachedImage)
+        cachedImage->removeClient(*this);
 }
 
 bool FilterImage::operator==(const Image& other) const
@@ -93,7 +93,7 @@ bool FilterImage::isPending() const
 
 void FilterImage::load(CachedResourceLoader& cachedResourceLoader, const ResourceLoaderOptions& options)
 {
-    CachedResourceHandle<WebCore::CachedImage> oldCachedImage = m_cachedImage;
+    RefPtr oldCachedImage = m_cachedImage;
 
     if (RefPtr image = m_image) {
         image->load(cachedResourceLoader, options);
@@ -104,8 +104,8 @@ void FilterImage::load(CachedResourceLoader& cachedResourceLoader, const Resourc
     if (m_cachedImage != oldCachedImage) {
         if (oldCachedImage)
             oldCachedImage->removeClient(*this);
-        if (m_cachedImage)
-            m_cachedImage->addClient(*this);
+        if (RefPtr cachedImage = m_cachedImage)
+            cachedImage->addClient(*this);
     }
 
     for (auto& value : m_filter) {

--- a/Source/WebCore/style/values/shapes/StyleShapeOutside.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeOutside.cpp
@@ -40,7 +40,7 @@ bool ShapeOutside::Image::isValid() const
 {
     Ref styleImage = image.value;
     if (styleImage->hasCachedImage()) {
-        auto* cachedImage = styleImage->cachedImage();
+        RefPtr cachedImage = styleImage->cachedImage();
         return cachedImage && cachedImage->hasImage();
     }
     return styleImage->isGeneratedImage();

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -77,7 +77,7 @@ bool SVGFEImageElement::renderingTaintsOrigin() const
 
 void SVGFEImageElement::clearResourceReferences()
 {
-    if (CachedResourceHandle cachedImage = std::exchange(m_cachedImage, nullptr))
+    if (RefPtr cachedImage = std::exchange(m_cachedImage, nullptr))
         cachedImage->removeClient(*this);
 
     removeElementReference();
@@ -92,7 +92,7 @@ void SVGFEImageElement::requestImageResource()
     request.setInitiator(*this);
     m_cachedImage = protect(document().cachedResourceLoader())->requestImage(WTF::move(request)).value_or(nullptr);
 
-    if (CachedResourceHandle cachedImage = m_cachedImage)
+    if (RefPtr cachedImage = m_cachedImage)
         cachedImage->addClient(*this);
 }
 
@@ -219,7 +219,7 @@ std::tuple<RefPtr<ImageBuffer>, FloatRect> SVGFEImageElement::imageBufferForEffe
 
 RefPtr<FilterEffect> SVGFEImageElement::createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const
 {
-    if (CachedResourceHandle cachedImage = m_cachedImage) {
+    if (RefPtr cachedImage = m_cachedImage) {
         RefPtr image = cachedImage->imageForRenderer(renderer());
         if (!image || image->isNull())
             return nullptr;

--- a/Source/WebCore/svg/SVGFontFaceUriElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.cpp
@@ -53,7 +53,7 @@ Ref<SVGFontFaceUriElement> SVGFontFaceUriElement::create(const QualifiedName& ta
 
 SVGFontFaceUriElement::~SVGFontFaceUriElement()
 {
-    if (CachedResourceHandle cachedFont = m_cachedFont)
+    if (RefPtr cachedFont = m_cachedFont)
         cachedFont->removeClient(*this);
 }
 
@@ -97,7 +97,7 @@ static bool isSVGFontTarget(const SVGFontFaceUriElement& element)
 
 void SVGFontFaceUriElement::loadFont()
 {
-    if (CachedResourceHandle cachedFont = m_cachedFont)
+    if (RefPtr cachedFont = m_cachedFont)
         cachedFont->removeClient(*this);
 
     const AtomString& href = getAttribute(SVGNames::hrefAttr, XLinkNames::hrefAttr);
@@ -108,8 +108,11 @@ void SVGFontFaceUriElement::loadFont()
         Ref cachedResourceLoader = document().cachedResourceLoader();
         CachedResourceRequest request(ResourceRequest(document().completeURL(href)), options);
         request.setInitiator(*this);
-        m_cachedFont = cachedResourceLoader->requestFont(WTF::move(request), isSVGFontTarget(*this)).value_or(nullptr);
-        if (CachedResourceHandle cachedFont = m_cachedFont) {
+        if (auto result = cachedResourceLoader->requestFont(WTF::move(request), isSVGFontTarget(*this)))
+            m_cachedFont = WTF::move(result.value());
+        else
+            m_cachedFont = nullptr;
+        if (RefPtr cachedFont = m_cachedFont) {
             cachedFont->addClient(*this);
             cachedFont->beginLoadIfNeeded(cachedResourceLoader);
         }

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -75,7 +75,7 @@ CachedImage* SVGImageElement::cachedImage() const
 
 bool SVGImageElement::renderingTaintsOrigin() const
 {
-    CachedResourceHandle cachedImage = this->cachedImage();
+    RefPtr cachedImage = this->cachedImage();
     if (!cachedImage)
         return false;
 

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -83,7 +83,7 @@ Ref<SVGUseElement> SVGUseElement::create(const QualifiedName& tagName, Document&
 
 SVGUseElement::~SVGUseElement()
 {
-    if (CachedResourceHandle externalDocument = m_externalDocument)
+    if (RefPtr externalDocument = m_externalDocument)
         externalDocument->removeClient(*this);
 }
 
@@ -673,7 +673,7 @@ void SVGUseElement::updateExternalDocument()
     if (externalDocumentURL == (m_externalDocument ? m_externalDocument->url() : URL()))
         return;
 
-    if (CachedResourceHandle externalDocument = m_externalDocument)
+    if (RefPtr externalDocument = m_externalDocument)
         externalDocument->removeClient(*this);
 
     if (externalDocumentURL.isNull())
@@ -686,8 +686,11 @@ void SVGUseElement::updateExternalDocument()
         options.sniffContent = ContentSniffingPolicy::DoNotSniffContent;
         CachedResourceRequest request { ResourceRequest { WTF::move(externalDocumentURL) }, options };
         request.setInitiator(*this);
-        m_externalDocument = protect(document->cachedResourceLoader())->requestSVGDocument(WTF::move(request)).value_or(nullptr);
-        if (CachedResourceHandle externalDocument = m_externalDocument)
+        if (auto result = protect(document->cachedResourceLoader())->requestSVGDocument(WTF::move(request)))
+            m_externalDocument = WTF::move(result.value());
+        else
+            m_externalDocument = nullptr;
+        if (RefPtr externalDocument = m_externalDocument)
             externalDocument->addClient(*this);
     }
 

--- a/Source/WebCore/workers/WorkerFontLoadRequest.h
+++ b/Source/WebCore/workers/WorkerFontLoadRequest.h
@@ -56,7 +56,7 @@ public:
 private:
     WorkerFontLoadRequest(URL&&, LoadedFromOpaqueSource);
 
-    const URL& url() const LIFETIME_BOUND final { return m_url; }
+    URL url() const LIFETIME_BOUND final { return m_url; }
     bool isPending() const final { return !m_isLoading && !m_errorOccurred && !m_data; }
     bool isLoading() const final { return m_isLoading; }
     bool errorOccurred() const final { return m_errorOccurred; }

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
@@ -264,7 +264,7 @@ void WorkerOrWorkletScriptController::evaluate(const ScriptSourceCode& sourceCod
     }
 
     if (returnedException) {
-        if (globalScope->canIncludeErrorDetails(sourceCode.cachedScript(), sourceCode.url().string())) {
+        if (globalScope->canIncludeErrorDetails(protect(sourceCode.cachedScript()), sourceCode.url().string())) {
             // FIXME: It's not great that this can run arbitrary code to string-ify the value of the exception.
             // Do we need to do anything to handle that properly, if it, say, raises another exception?
             if (returnedExceptionMessage)
@@ -459,7 +459,7 @@ void WorkerOrWorkletScriptController::linkAndEvaluateModule(WorkerScriptFetcher&
     }
 
     if (returnedException) {
-        if (protect(globalScope())->canIncludeErrorDetails(sourceCode.cachedScript(), sourceCode.url().string())) {
+        if (protect(globalScope())->canIncludeErrorDetails(protect(sourceCode.cachedScript()), sourceCode.url().string())) {
             // FIXME: It's not great that this can run arbitrary code to string-ify the value of the exception.
             // Do we need to do anything to handle that properly, if it, say, raises another exception?
             if (returnedExceptionMessage)

--- a/Source/WebCore/xml/XSLImportRule.cpp
+++ b/Source/WebCore/xml/XSLImportRule.cpp
@@ -101,7 +101,10 @@ void XSLImportRule::loadSheet()
 
     auto options = CachedResourceLoader::defaultCachedResourceOptions();
     options.mode = FetchOptions::Mode::SameOrigin;
-    m_cachedSheet = cachedResourceLoader->requestXSLStyleSheet({ ResourceRequest(protect(cachedResourceLoader->document())->completeURL(absHref)), options }).value_or(nullptr);
+    if (auto result = cachedResourceLoader->requestXSLStyleSheet({ ResourceRequest(protect(cachedResourceLoader->document())->completeURL(absHref)), options }))
+        m_cachedSheet = WTF::move(result.value());
+    else
+        m_cachedSheet = nullptr;
 
     if (m_cachedSheet) {
         m_cachedSheet->addClient(*this);

--- a/Source/WebKit/Shared/WebHitTestResultData.cpp
+++ b/Source/WebKit/Shared/WebHitTestResultData.cpp
@@ -125,7 +125,7 @@ WebHitTestResultData::WebHitTestResultData(const HitTestResult& hitTestResult, c
     if (RefPtr target = hitTestResult.innerNonSharedNode()) {
         if (CheckedPtr renderer = dynamicDowncast<RenderImage>(target->renderer())) {
             imageBitmap = createShareableBitmap(*renderer);
-            if (auto* cachedImage = renderer->cachedImage()) {
+            if (RefPtr cachedImage = renderer->cachedImage()) {
                 if (RefPtr image = cachedImage->image())
                     sourceImageMIMEType = image->mimeType();
             }

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -300,7 +300,7 @@ void NetworkProcessConnection::updateCachedCookiesEnabled()
 #if ENABLE(SHAREABLE_RESOURCE)
 void NetworkProcessConnection::didCacheResource(const ResourceRequest& request, ShareableResource::Handle&& handle)
 {
-    auto* resource = MemoryCache::singleton().resourceForRequest(request, WebProcess::singleton().sessionID());
+    RefPtr resource = MemoryCache::singleton().resourceForRequest(request, WebProcess::singleton().sessionID());
     if (!resource)
         return;
     

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -149,9 +149,9 @@ void WebLoaderStrategy::loadResource(LocalFrame& frame, CachedResource& resource
         }
     }
 
-    SubresourceLoader::create(frame, resource, WTF::move(request), options, [this, protectedThis = Ref { *this }, referrerPolicy = options.referrerPolicy, completionHandler = WTF::move(completionHandler), resource = CachedResourceHandle<CachedResource>(&resource), frame = Ref { frame }] (RefPtr<SubresourceLoader>&& loader) mutable {
+    SubresourceLoader::create(frame, resource, WTF::move(request), options, [this, protectedThis = Ref { *this }, referrerPolicy = options.referrerPolicy, completionHandler = WTF::move(completionHandler), resource = Ref { resource }, frame = Ref { frame }] (RefPtr<SubresourceLoader>&& loader) mutable {
         if (loader)
-            scheduleLoad(*loader, resource.get(), referrerPolicy == ReferrerPolicy::NoReferrerWhenDowngrade);
+            scheduleLoad(*loader, resource.ptr(), referrerPolicy == ReferrerPolicy::NoReferrerWhenDowngrade);
         else
             RELEASE_LOG(Network, "%p - [webPageID=%" PRIu64 ", frameID=%" PRIu64 "] WebLoaderStrategy::loadResource: Unable to create SubresourceLoader", this, frame->pageID() ? frame->pageID()->toUInt64() : 0, frame->frameID().toUInt64());
         completionHandler(WTF::move(loader));
@@ -294,7 +294,7 @@ void WebLoaderStrategy::scheduleLoad(ResourceLoader& resourceLoader, CachedResou
     }
 
     if (InspectorInstrumentationWebKit::shouldInterceptRequest(resourceLoader)) {
-        InspectorInstrumentationWebKit::interceptRequest(resourceLoader, [this, protectedThis = Ref { *this }, protectedResourceLoader = Ref { resourceLoader }, trackingParameters, shouldClearReferrerOnHTTPSToHTTPRedirect, resource](const ResourceRequest& request) {
+        InspectorInstrumentationWebKit::interceptRequest(resourceLoader, [this, protectedThis = Ref { *this }, protectedResourceLoader = Ref { resourceLoader }, trackingParameters, shouldClearReferrerOnHTTPSToHTTPRedirect, resource = RefPtr { resource }](const ResourceRequest& request) {
             auto& resourceLoader = protectedResourceLoader.get();
             WEBLOADERSTRATEGY_RELEASE_LOG("scheduleLoad: intercepted URL will be scheduled with the NetworkProcess");
             scheduleLoadFromNetworkProcess(resourceLoader, request, *trackingParameters, shouldClearReferrerOnHTTPSToHTTPRedirect, maximumBufferingTime(resource));
@@ -618,7 +618,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
     if (RefPtr frameLoader = resourceLoader.frameLoader())
         loadParameters.requiredCookiesVersion = frameLoader->requiredCookiesVersion();
 
-    if (CachedResourceHandle handle = resourceLoader.cachedResource())
+    if (RefPtr handle = resourceLoader.cachedResource())
         loadParameters.isInitiatorPrefetch = handle->type() == CachedResource::Type::LinkPrefetch;
 
     std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume;

--- a/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
@@ -81,7 +81,7 @@ RefPtr<ShareableBitmap> createShareableBitmap(RenderImage& renderImage, CreateSh
         return protect(renderVideo->videoElement())->bitmapImageForCurrentTimeSync();
 #endif // ENABLE(VIDEO)
 
-    auto* cachedImage = renderImage.cachedImage();
+    RefPtr cachedImage = renderImage.cachedImage();
     if (!cachedImage || cachedImage->errorOccurred())
         return { };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
@@ -118,12 +118,12 @@ void WebDragClient::didConcludeEditDrag()
 
 #if USE(APPKIT)
 
-static WebCore::CachedImage* cachedImage(Element& element)
+static RefPtr<WebCore::CachedImage> cachedImage(Element& element)
 {
     CheckedPtr renderImage = dynamicDowncast<WebCore::RenderImage>(element.renderer());
     if (!renderImage)
         return nullptr;
-    auto* image = renderImage->cachedImage();
+    RefPtr image = renderImage->cachedImage();
     if (!image || image->errorOccurred()) 
         return nullptr;
     return image;
@@ -133,7 +133,7 @@ void WebDragClient::declareAndWriteDragImage(const String& pasteboardName, Eleme
 {
     ASSERT(pasteboardName == String(NSPasteboardNameDrag));
 
-    WebCore::CachedImage* image = cachedImage(element);
+    RefPtr image = cachedImage(element);
 
     String extension;
     if (image) {

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
@@ -194,7 +194,7 @@ static std::optional<std::pair<WebCore::RenderImage&, WebCore::Image&>> imageRen
     if (!renderImage->cachedImage() || renderImage->cachedImage()->errorOccurred())
         return std::nullopt;
 
-    RefPtr image = renderImage->cachedImage()->imageForRenderer(renderImage);
+    RefPtr image = protect(renderImage->cachedImage())->imageForRenderer(renderImage);
     if (!image || image->width() <= 1 || image->height() <= 1)
         return std::nullopt;
 
@@ -242,7 +242,7 @@ static void imagePositionInformation(WebPage& page, WebCore::Element& element, c
 
     auto& [renderImage, image] = *rendererAndImage;
     info.isImage = true;
-    info.imageURL = page.applyLinkDecorationFiltering(protect(element.document())->completeURL(renderImage.cachedImage()->url().string()), WebCore::LinkDecorationFilteringTrigger::Unspecified);
+    info.imageURL = page.applyLinkDecorationFiltering(protect(element.document())->completeURL(protect(renderImage.cachedImage())->url().string()), WebCore::LinkDecorationFilteringTrigger::Unspecified);
     info.imageMIMEType = image.mimeType();
     info.isAnimatedImage = image.isAnimated();
     info.isAnimating = image.isAnimating();
@@ -321,7 +321,7 @@ static void elementPositionInformation(WebPage& page, WebCore::Element& element,
             if (request.includeImageData) {
                 if (auto rendererAndImage = imageRendererAndImage(element)) {
                     auto& [renderImage, image] = *rendererAndImage;
-                    info.imageURL = page.applyLinkDecorationFiltering(document->completeURL(renderImage.cachedImage()->url().string()), WebCore::LinkDecorationFilteringTrigger::Unspecified);
+                    info.imageURL = page.applyLinkDecorationFiltering(document->completeURL(protect(renderImage.cachedImage())->url().string()), WebCore::LinkDecorationFilteringTrigger::Unspecified);
                     info.imageMIMEType = image.mimeType();
                     info.image = createShareableBitmap(renderImage, { WebCore::screenSize() * page.corePage()->deviceScaleFactor(), AllowAnimatedImages::Yes, UseSnapshotForTransparentImages::Yes });
                 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9224,7 +9224,7 @@ void WebPage::requestTextRecognition(Element& element, TextRecognitionOptions&& 
         if (!protectedThis)
             return;
 
-        auto cachedImage = renderImage->cachedImage();
+        RefPtr cachedImage = renderImage->cachedImage();
         auto imageURL = cachedImage ? protect(weakElement->document())->completeURL(cachedImage->url().string()) : URL { };
         protectedThis->sendWithAsyncReply(Messages::WebPageProxy::RequestTextRecognition(WTF::move(imageURL), WTF::move(*bitmapHandle), options.sourceLanguageIdentifier, options.targetLanguageIdentifier), [weakThis, weakElement, resolveAndRemoveHandlerFollowingError = WTF::move(resolveAndRemoveHandlerFollowingError)] (auto&& result) mutable {
             RefPtr protectedThis = weakThis.get();
@@ -9334,7 +9334,7 @@ void WebPage::requestImageBitmap(const ElementContext& context, CompletionHandle
     }
 
     String mimeType;
-    if (auto* cachedImage = renderImage->cachedImage()) {
+    if (RefPtr cachedImage = renderImage->cachedImage()) {
         if (RefPtr image = cachedImage->image())
             mimeType = image->mimeType();
     }

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2585,7 +2585,7 @@ void WebPage::performActionOnElement(uint32_t action, const String& authorizatio
         CheckedPtr renderImage = dynamicDowncast<RenderImage>(*element->renderer());
         if (!renderImage)
             return;
-        auto* cachedImage = renderImage->cachedImage();
+        RefPtr cachedImage = renderImage->cachedImage();
         if (!cachedImage)
             return;
         RefPtr<FragmentedSharedBuffer> buffer = cachedImage->resourceBuffer();

--- a/Source/WebKitLegacy/mac/Misc/WebCache.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCache.mm
@@ -161,15 +161,11 @@ class DefaultStorageSessionProvider : public WebCore::StorageSessionProvider {
         return nullptr;
     
     WebCore::ResourceRequest request(url);
-    WebCore::CachedResource* cachedResource = WebCore::MemoryCache::singleton().resourceForRequest(request, PAL::SessionID::defaultSessionID());
-    if (!is<WebCore::CachedImage>(cachedResource))
-        return nullptr;
-
-    auto& cachedImage = downcast<WebCore::CachedImage>(*cachedResource);
-    if (!cachedImage.hasImage())
+    RefPtr cachedImage = dynamicDowncast<WebCore::CachedImage>(WebCore::MemoryCache::singleton().resourceForRequest(request, PAL::SessionID::defaultSessionID()));
+    if (!cachedImage || !cachedImage->hasImage())
         return nullptr;
     
-    auto nativeImage = cachedImage.image()->nativeImage();
+    auto nativeImage = cachedImage->image()->nativeImage();
     if (!nativeImage)
         return nullptr;
 


### PR DESCRIPTION
#### 51576a8fd07eaf9d8ebcf46af771cfb3ca76121e
<pre>
Use regular ref-counting for CachedResource
<a href="https://bugs.webkit.org/show_bug.cgi?id=309448">https://bugs.webkit.org/show_bug.cgi?id=309448</a>

Reviewed by Darin Adler.

CachedResource previously used a manual ref-counting scheme with
m_handleCount, m_preloadCount, deleteIfPossible(), and canDelete() to
manage its lifetime.

This patch replaces that with standard RefCountedAndCanMakeWeakPtr,
allowing CachedResource to use normal Ref/RefPtr semantics.
CachedResourceHandle now holds a RefPtr&lt;CachedResource&gt; instead of a raw
pointer with manual register/unregister calls. The MemoryCache stores
Ref&lt;CachedResource&gt; entries, and the preload count is replaced with a
simple m_isPreloaded boolean flag. This simplifies lifetime management
and removes the IsDeprecatedWeakRefSmartPointerException workaround.

This helps get CachedResource types covered by safer CPP and identified
a lot of unsafe patterns which I&apos;m addressing in this PR as well.

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::imageBytesForSource):
* Source/WebCore/Modules/beacon/NavigatorBeacon.cpp:
(WebCore::NavigatorBeacon::~NavigatorBeacon):
(WebCore::NavigatorBeacon::sendBeacon):
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::~HTMLModelElement):
(WebCore::HTMLModelElement::setSourceURL):
(WebCore::HTMLModelElement::modelResourceFinished):
(WebCore::HTMLModelElement::sourceRequestResource):
* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::remoteSVGRootElement const):
* Source/WebCore/bindings/js/CachedScriptFetcher.cpp:
(WebCore::CachedScriptFetcher::requestScriptWithCache const):
* Source/WebCore/bindings/js/CachedScriptFetcher.h:
* Source/WebCore/bindings/js/CachedScriptSourceProvider.h:
(WebCore::CachedScriptSourceProvider::hash const):
(WebCore::CachedScriptSourceProvider::source const):
* Source/WebCore/bindings/js/WebAssemblyCachedScriptSourceProvider.h:
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcResourceValue::fontLoadRequest):
(WebCore::CSSFontFaceSrcResourceValue::customTraverseSubresources const):
* Source/WebCore/css/CSSImageValue.cpp:
(WebCore::CSSImageValue::customTraverseSubresources const):
(WebCore::CSSImageValue::knownToBeOpaque const):
* Source/WebCore/css/CSSImportRule.cpp:
(WebCore::CSSImportRule::styleSheet const):
* Source/WebCore/css/StyleRuleImport.cpp:
(WebCore::StyleRuleImport::requestStyleSheet):
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::traverseSubresources const):
* Source/WebCore/dom/DataTransferMac.mm:
(WebCore::DataTransfer::createDragImage const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::fontLoadRequest):
(WebCore::Document::beginLoadingFontSoon):
* Source/WebCore/dom/DocumentFontLoader.cpp:
(WebCore::DocumentFontLoader::cachedFont):
(WebCore::DocumentFontLoader::loadPendingFonts):
* Source/WebCore/dom/DocumentFontLoader.h:
* Source/WebCore/dom/LoadableClassicScript.cpp:
(WebCore::LoadableNonModuleScriptBase::~LoadableNonModuleScriptBase):
(WebCore::LoadableNonModuleScriptBase::wasCanceled const):
(WebCore::LoadableNonModuleScriptBase::notifyFinished):
(WebCore::LoadableNonModuleScriptBase::load):
(WebCore::LoadableClassicScript::execute):
* Source/WebCore/dom/LoadableClassicScript.h:
* Source/WebCore/dom/LoadableSpeculationRules.cpp:
(WebCore::LoadableSpeculationRules::~LoadableSpeculationRules):
(WebCore::LoadableSpeculationRules::requestSpeculationRules):
(WebCore::LoadableSpeculationRules::load):
(WebCore::LoadableSpeculationRules::notifyFinished):
* Source/WebCore/dom/LoadableSpeculationRules.h:
* Source/WebCore/dom/ProcessingInstruction.cpp:
(WebCore::ProcessingInstruction::~ProcessingInstruction):
(WebCore::ProcessingInstruction::checkStyleSheet):
(WebCore::ProcessingInstruction::parseStyleSheet):
* Source/WebCore/dom/mac/ImageControlsMac.cpp:
(WebCore::ImageControlsMac::imageFromImageElementNode):
* Source/WebCore/editing/Editing.cpp:
(WebCore::visibleImageElementsInRangeWithNonLoadedImages):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::registerAttachmentIdentifier):
* Source/WebCore/editing/cocoa/EditingHTMLConverter.mm:
(WebCore::fileWrapperForElement):
* Source/WebCore/editing/ios/EditorIOS.mm:
(WebCore::getImage):
* Source/WebCore/editing/mac/EditorMac.mm:
(WebCore::getImage):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::width):
(WebCore::HTMLImageElement::height):
(WebCore::HTMLImageElement::effectiveImageDevicePixelRatio const):
(WebCore::HTMLImageElement::naturalWidth const):
(WebCore::HTMLImageElement::naturalHeight const):
(WebCore::HTMLImageElement::image const):
(WebCore::HTMLImageElement::originClean const):
* Source/WebCore/html/HTMLImageLoader.cpp:
(WebCore::HTMLImageLoader::dispatchLoadEvent):
(WebCore::HTMLImageLoader::notifyFinished):
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::process):
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::renderFallbackContent):
* Source/WebCore/html/ImageDocument.cpp:
(WebCore::ImageDocument::imageSize):
(WebCore::ImageDocument::updateDuringParsing):
(WebCore::ImageDocument::finishedParsing):
(WebCore::ImageDocument::createDocumentStructure):
(WebCore::ImageDocument::resizeImageToFit):
(WebCore::ImageDocument::restoreImageSize):
(WebCore::ImageDocument::didChangeViewSize):
(WebCore::ImageEventListener::handleEvent):
(WebCore::ImageDocumentElement::~ImageDocumentElement):
(WebCore::ImageDocumentElement::didMoveToNewDocument):
* Source/WebCore/html/ImageInputType.cpp:
(WebCore::ImageInputType::height const):
(WebCore::ImageInputType::width const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::createPattern):
* Source/WebCore/inspector/InspectorAuditResourcesObject.cpp:
(WebCore::InspectorAuditResourcesObject::~InspectorAuditResourcesObject):
(WebCore::InspectorAuditResourcesObject::getResources):
(WebCore::InspectorAuditResourcesObject::getResourceContent):
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::indexForData):
* Source/WebCore/inspector/InspectorResourceUtilities.cpp:
(Inspector::ResourceUtilities::resourceContent):
(Inspector::ResourceUtilities::cachedResource):
* Source/WebCore/inspector/InspectorResourceUtilities.h:
* Source/WebCore/inspector/NetworkResourcesData.h:
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::willSendRequest):
(WebCore::InspectorNetworkAgent::didReceiveResponse):
* Source/WebCore/inspector/agents/InspectorPageAgent.cpp:
(WebCore::InspectorPageAgent::searchInResource):
* Source/WebCore/inspector/agents/page/PageDebuggerAgent.cpp:
(WebCore::PageDebuggerAgent::sourceMapURLForScript):
* Source/WebCore/layout/layouttree/LayoutElementBox.h:
* Source/WebCore/loader/ApplicationManifestLoader.cpp:
(WebCore::ApplicationManifestLoader::startLoading):
(WebCore::ApplicationManifestLoader::stopLoading):
(WebCore::ApplicationManifestLoader::processManifest):
* Source/WebCore/loader/ContentFilter.cpp:
(WebCore::ContentFilter::url):
* Source/WebCore/loader/CrossOriginPreflightChecker.cpp:
(WebCore::CrossOriginPreflightChecker::~CrossOriginPreflightChecker):
(WebCore::CrossOriginPreflightChecker::startPreflight):
(WebCore::CrossOriginPreflightChecker::setDefersLoading):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::subresource const):
(WebCore::DocumentLoader::stopLoadingSubresources):
* Source/WebCore/loader/DocumentPrefetcher.cpp:
(WebCore::DocumentPrefetcher::~DocumentPrefetcher):
(WebCore::DocumentPrefetcher::prefetch):
(WebCore::DocumentPrefetcher::notifyFinished):
(WebCore::DocumentPrefetcher::removePrefetch):
(WebCore::DocumentPrefetcher::takePrefetchedResourceMetrics):
(WebCore::DocumentPrefetcher::clearPrefetchedResourcesExcept):
(WebCore::DocumentPrefetcher::clearPrefetchedResourcesForOrigin):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::~DocumentThreadableLoader):
(WebCore::DocumentThreadableLoader::cancel):
(WebCore::DocumentThreadableLoader::computeIsDone):
(WebCore::DocumentThreadableLoader::setDefersLoading):
(WebCore::DocumentThreadableLoader::clearResource):
(WebCore::DocumentThreadableLoader::didReceiveResponse):
(WebCore::DocumentThreadableLoader::notifyFinished):
(WebCore::DocumentThreadableLoader::didFinishLoading):
(WebCore::DocumentThreadableLoader::didFail):
(WebCore::DocumentThreadableLoader::loadRequest):
* Source/WebCore/loader/FontLoadRequest.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::tellClientAboutPastMemoryCacheLoads):
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::canReuseFromListOfAvailableImages):
(WebCore::ImageLoader::~ImageLoader):
(WebCore::ImageLoader::clearImageWithoutConsideringPendingLoadEvent):
(WebCore::ImageLoader::updateFromElement):
(WebCore::ImageLoader::didUpdateCachedImage):
(WebCore::ImageLoader::notifyFinished):
(WebCore::ImageLoader::updateRenderer):
(WebCore::ImageLoader::decode):
(WebCore::ImageLoader::hasPendingActivity const):
* Source/WebCore/loader/ImageLoader.h:
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::~LinkLoader):
(WebCore::LinkLoader::notifyFinished):
(WebCore::LinkLoader::preloadIfNeeded):
(WebCore::LinkLoader::prefetchIfNeeded):
* Source/WebCore/loader/LinkPreloadResourceClients.h:
(WebCore::LinkPreloadResourceClient::addResource):
(WebCore::LinkPreloadResourceClient::clearResource):
* Source/WebCore/loader/MediaResourceLoader.cpp:
(WebCore::MediaResourceLoader::requestResource):
(WebCore::MediaResource::shutdown):
* Source/WebCore/loader/ResourceTimingInformation.cpp:
(WebCore::ResourceTimingInformation::storeResourceTimingInitiatorInformation):
* Source/WebCore/loader/ResourceTimingInformation.h:
* Source/WebCore/loader/SubresourceLoader.cpp:
(WebCore::SubresourceLoader::RequestCountTracker::~RequestCountTracker):
(WebCore::SubresourceLoader::willSendRequestInternal):
(WebCore::SubresourceLoader::didReceiveResponse):
(WebCore::SubresourceLoader::didReceiveBuffer):
(WebCore::SubresourceLoader::responseHasHTTPStatusCodeError const):
(WebCore::SubresourceLoader::didFinishLoading):
(WebCore::SubresourceLoader::didFail):
(WebCore::SubresourceLoader::willCancel):
(WebCore::SubresourceLoader::didCancel):
(WebCore::SubresourceLoader::reportResourceTiming):
* Source/WebCore/loader/SubresourceLoader.h:
* Source/WebCore/loader/TextTrackLoader.cpp:
(WebCore::TextTrackLoader::~TextTrackLoader):
(WebCore::TextTrackLoader::cancelLoad):
(WebCore::TextTrackLoader::processNewCueData):
(WebCore::TextTrackLoader::corsPolicyPreventedLoad):
(WebCore::TextTrackLoader::notifyFinished):
(WebCore::TextTrackLoader::load):
(WebCore::TextTrackLoader::getNewCues):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::createInternal):
* Source/WebCore/loader/cache/CachedFont.cpp:
(WebCore::CachedFont::setErrorAndDeleteData):
* Source/WebCore/loader/cache/CachedFontLoadRequest.h:
* Source/WebCore/loader/cache/CachedImage.cpp:
(WebCore::CachedImage::switchClientsToRevalidatedResource):
(WebCore::CachedImage::CachedImageObserver::encodedDataStatusChanged):
(WebCore::CachedImage::CachedImageObserver::decodedSizeChanged):
(WebCore::CachedImage::CachedImageObserver::didDraw):
(WebCore::CachedImage::CachedImageObserver::canDestroyDecodedData const):
(WebCore::CachedImage::CachedImageObserver::imageFrameAvailable):
(WebCore::CachedImage::CachedImageObserver::changedInRect):
(WebCore::CachedImage::CachedImageObserver::imageContentChanged):
(WebCore::CachedImage::CachedImageObserver::scheduleRenderingUpdate):
(WebCore::CachedImage::CachedImageObserver::allowsAnimation const):
(WebCore::CachedImage::updateBufferInternal):
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/loader/cache/CachedRawResource.cpp:
(WebCore::CachedRawResource::updateBuffer):
(WebCore::CachedRawResource::finishLoading):
(WebCore::CachedRawResource::notifyClientsDataWasReceived):
(WebCore::iterateRedirects):
(WebCore::CachedRawResource::didAddClient):
(WebCore::iterateClients):
(WebCore::CachedRawResource::redirectReceived):
(WebCore::CachedRawResource::responseReceived):
(WebCore::CachedRawResource::previewResponseReceived):
* Source/WebCore/loader/cache/CachedResource.cpp:
(WebCore::CachedResource::~CachedResource):
(WebCore::CachedResource::deref const):
(WebCore::CachedResource::load):
(WebCore::CachedResource::redirectReceived):
(WebCore::CachedResource::clearLoader):
(WebCore::CachedResource::removeClient):
(WebCore::CachedResource::clearResourceToRevalidate):
(WebCore::CachedResource::switchClientsToRevalidatedResource):
(WebCore::CachedResource::registerHandle):
(WebCore::CachedResource::unregisterHandle):
(WebCore::CachedResourceCallback::CachedResourceCallback):
(WebCore::CachedResource::deleteIfPossible): Deleted.
(WebCore::CachedResource::deleteThis): Deleted.
* Source/WebCore/loader/cache/CachedResource.h:
(WebCore::CachedResource::hasClient):
(WebCore::CachedResource::isPreloaded const):
(WebCore::CachedResource::setIsPreloaded):
(WebCore::CachedResource::canDelete const): Deleted.
(WebCore::CachedResource::hasOneHandle const): Deleted.
(WebCore::CachedResource::increasePreloadCount): Deleted.
(WebCore::CachedResource::decreasePreloadCount): Deleted.
* Source/WebCore/loader/cache/CachedResourceHandle.cpp:
(WebCore::CachedResourceHandleBase::CachedResourceHandleBase):
(WebCore::CachedResourceHandleBase::~CachedResourceHandleBase):
(WebCore::CachedResourceHandleBase::setResource):
* Source/WebCore/loader/cache/CachedResourceHandle.h:
(WebCore::CachedResourceHandle::CachedResourceHandle):
(WebCore::CachedResourceHandle::operator RefPtr&lt;R&gt; const):
(WebCore::CachedResourceHandle::operator=):
(WebCore::operator==):
(WTF::protect):
(WTF::requires): Deleted.
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::castCachedResourceTo):
(WebCore::createResource):
(WebCore::CachedResourceLoader::cachedResource const):
(WebCore::CachedResourceLoader::requestImage):
(WebCore::CachedResourceLoader::requestFont):
(WebCore::CachedResourceLoader::requestTextTrack):
(WebCore::CachedResourceLoader::requestCSSStyleSheet):
(WebCore::CachedResourceLoader::requestUserCSSStyleSheet):
(WebCore::CachedResourceLoader::requestScript):
(WebCore::CachedResourceLoader::requestXSLStyleSheet):
(WebCore::CachedResourceLoader::requestSVGDocument):
(WebCore::CachedResourceLoader::requestLinkResource):
(WebCore::CachedResourceLoader::requestMedia):
(WebCore::CachedResourceLoader::requestIcon):
(WebCore::CachedResourceLoader::requestRawResource):
(WebCore::CachedResourceLoader::requestBeaconResource):
(WebCore::CachedResourceLoader::requestPingResource):
(WebCore::CachedResourceLoader::requestMainResource):
(WebCore::CachedResourceLoader::requestApplicationManifest):
(WebCore::CachedResourceLoader::requestEnvironmentMapResource):
(WebCore::CachedResourceLoader::requestModelResource):
(WebCore::CachedResourceLoader::allowedByContentSecurityPolicy const):
(WebCore::CachedResourceLoader::canRequest):
(WebCore::CachedResourceLoader::canRequestAfterRedirection const):
(WebCore::CachedResourceLoader::updateCachedResourceWithCurrentRequest):
(WebCore::CachedResourceLoader::requestResource):
(WebCore::CachedResourceLoader::documentDidFinishLoadEvent):
(WebCore::CachedResourceLoader::revalidateResource):
(WebCore::CachedResourceLoader::loadResource):
(WebCore::CachedResourceLoader::determineRevalidationPolicy const):
(WebCore::CachedResourceLoader::printAccessDeniedMessage const):
(WebCore::CachedResourceLoader::reloadImagesIfNotDeferred):
(WebCore::CachedResourceLoader::garbageCollectDocumentResources):
(WebCore::CachedResourceLoader::allCachedSVGImages const):
(WebCore::CachedResourceLoader::preload):
(WebCore::CachedResourceLoader::warnUnusedPreloads):
(WebCore::CachedResourceLoader::isPreloaded const):
(WebCore::CachedResourceLoader::clearPreloads):
(WebCore::CachedResourceLoader::visibleResourcesToPrioritize):
* Source/WebCore/loader/cache/CachedResourceLoader.h:
* Source/WebCore/loader/cache/CachedSVGDocumentReference.cpp:
(WebCore::CachedSVGDocumentReference::~CachedSVGDocumentReference):
(WebCore::CachedSVGDocumentReference::load):
* Source/WebCore/loader/cache/KeepaliveRequestTracker.cpp:
(WebCore::KeepaliveRequestTracker::~KeepaliveRequestTracker):
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::revalidationSucceeded):
(WebCore::MemoryCache::forEachResource):
(WebCore::MemoryCache::forEachSessionResource):
(WebCore::MemoryCache::pruneLiveResourcesToSize):
(WebCore::MemoryCache::pruneDeadResourcesToSize):
(WebCore::MemoryCache::remove):
(WebCore::MemoryCache::removeResourcesWithOrigin):
(WebCore::MemoryCache::removeResourcesWithOrigins):
(WebCore::MemoryCache::getOriginsWithCache):
(WebCore::MemoryCache::originsWithCache const):
(WebCore::MemoryCache::removeRequestFromSessionCaches):
(WebCore::MemoryCache::setDisabled):
(WebCore::MemoryCache::dumpLRULists const):
* Source/WebCore/loader/cache/MemoryCache.h:
* Source/WebCore/loader/cocoa/DiskCacheMonitorCocoa.mm:
(WebCore::DiskCacheMonitor::resourceBecameFileBacked):
* Source/WebCore/loader/cocoa/SubresourceLoaderCocoa.mm:
(WebCore::SubresourceLoader::willCacheResponseAsync):
* Source/WebCore/loader/icon/IconLoader.cpp:
(WebCore::IconLoader::startLoading):
(WebCore::IconLoader::stopLoading):
(WebCore::IconLoader::notifyFinished):
* Source/WebCore/page/DragController.cpp:
(WebCore::imageElementIsDraggable):
(WebCore::getImage):
(WebCore::DragController::doImageDrag):
* Source/WebCore/page/FrameConsoleClient.cpp:
(WebCore::FrameConsoleClient::screenshot):
* Source/WebCore/page/ImageAnalysisQueue.cpp:
(WebCore::ImageAnalysisQueue::enqueueIfNeeded):
(WebCore::ImageAnalysisQueue::resumeProcessing):
* Source/WebCore/page/LargestContentfulPaintData.cpp:
(WebCore::LargestContentfulPaintData::generateLargestContentfulPaintEntry):
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::PageSerializer::serializeFrame):
(WebCore::PageSerializer::retrieveResourcesForProperties):
* Source/WebCore/platform/graphics/avfoundation/cf/WebCoreAVCFResourceLoader.cpp:
(WebCore::WebCoreAVCFResourceLoader::startLoading):
* Source/WebCore/platform/graphics/avfoundation/objc/WebCoreAVFResourceLoader.mm:
(WebCore::CachedResourceMediaLoader::create):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayerImpl const):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::imageChanged):
(WebCore::RenderImage::isDimensionlessSVG const):
(WebCore::RenderImage::shouldRespectZeroIntrinsicWidth const):
(WebCore::RenderImage::embeddedContentBox const):
* Source/WebCore/rendering/RenderImageResource.cpp:
(WebCore::RenderImageResource::setCachedImage):
* Source/WebCore/rendering/RenderImageResource.h:
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::imageChanged):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::isDirectlyCompositedImage const):
(WebCore::RenderLayerBacking::isUnscaledBitmapOnly const):
(WebCore::RenderLayerBacking::updateImageContents):
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::updateReferenceFilterClients):
* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::paintReplaced):
* Source/WebCore/rendering/shapes/ShapeOutsideInfo.cpp:
(WebCore::checkShapeImageOrigin):
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::calculateObjectBoundingBox const):
(WebCore::RenderSVGImage::updateImageViewport):
(WebCore::RenderSVGImage::imageChanged):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::calculateObjectBoundingBox const):
(WebCore::LegacyRenderSVGImage::updateImageViewport):
(WebCore::LegacyRenderSVGImage::paintForeground):
(WebCore::LegacyRenderSVGImage::imageChanged):
* Source/WebCore/style/values/images/kinds/StyleFilterImage.cpp:
(WebCore::Style::FilterImage::~FilterImage):
(WebCore::Style::FilterImage::load):
* Source/WebCore/style/values/shapes/StyleShapeOutside.cpp:
(WebCore::Style::ShapeOutside::Image::isValid const):
* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::clearResourceReferences):
(WebCore::SVGFEImageElement::requestImageResource):
(WebCore::SVGFEImageElement::createFilterEffect const):
* Source/WebCore/svg/SVGFontFaceUriElement.cpp:
(WebCore::SVGFontFaceUriElement::~SVGFontFaceUriElement):
(WebCore::SVGFontFaceUriElement::loadFont):
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::renderingTaintsOrigin const):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::~SVGUseElement):
(WebCore::SVGUseElement::updateExternalDocument):
* Source/WebCore/workers/WorkerFontLoadRequest.h:
* Source/WebCore/workers/WorkerOrWorkletScriptController.cpp:
(WebCore::WorkerOrWorkletScriptController::evaluate):
(WebCore::WorkerOrWorkletScriptController::linkAndEvaluateModule):
* Source/WebCore/xml/XSLImportRule.cpp:
(WebCore::XSLImportRule::loadSheet):
* Source/WebKit/Shared/WebHitTestResultData.cpp:
(WebKit::WebHitTestResultData::WebHitTestResultData):
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::didCacheResource):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::loadResource):
(WebKit::WebLoaderStrategy::scheduleLoad):
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
* Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp:
(WebKit::createShareableBitmap):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm:
(WebKit::cachedImage):
(WebKit::WebDragClient::declareAndWriteDragImage):
* Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm:
(WebKit::imageRendererAndImage):
(WebKit::imagePositionInformation):
(WebKit::elementPositionInformation):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::requestTextRecognition):
(WebKit::WebPage::requestImageBitmap):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::performActionOnElement):
* Source/WebKitLegacy/mac/Misc/WebCache.mm:
(+[WebCache imageForURL:]):

Canonical link: <a href="https://commits.webkit.org/309205@main">https://commits.webkit.org/309205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b293310ebd9ea3d9a6599bc0e087a91bd15b63ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149876 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158582 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9b5220f-d2ab-4b7e-8842-827780b42ba8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151749 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115614 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fbdb7ceb-8a0b-4a6f-8bd3-e90cb83d2d92) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152836 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17738 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134494 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96353 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3336c8b4-e999-4437-94c3-c1d350304e03) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6429 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126442 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12425 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161058 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123630 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123834 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33629 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22404 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134218 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78629 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18994 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10970 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22005 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85825 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21735 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21887 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21792 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->