### PR TITLE
[WPE][GStreamer] assertion GST_CLOCK_TIME_IS_VALID (timestamp) crashes test fast/speechsynthesis/speech-synthesis-real-client-version.html on ARM64

### DIFF
--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1314,8 +1314,6 @@ webkit.org/b/309360 [ arm64 ] imported/w3c/web-platform-tests/webcodecs/video-en
 webkit.org/b/309360 [ arm64 ] imported/w3c/web-platform-tests/webcodecs/video-encoder-rescaling.https.any.worker.html?h264_annexb [ Crash ]
 webkit.org/b/309360 [ arm64 ] imported/w3c/web-platform-tests/webcodecs/video-encoder-rescaling.https.any.worker.html?h264_avc [ Crash ]
 
-webkit.org/b/309361 [ arm64 ] fast/speechsynthesis/speech-synthesis-real-client-version.html [ Crash ]
-
 webkit.org/b/309369 [ arm64 ] svg/custom/image-with-transform-clip-filter.svg [ Failure ]
 webkit.org/b/309369 [ arm64 ] svg/custom/use-on-symbol-inside-pattern.svg [ Failure ]
 webkit.org/b/309369 [ arm64 ] svg/filters/feImage-preserveAspectRatio-all.svg [ Failure ]

--- a/Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp
+++ b/Source/WebCore/platform/gstreamer/WebKitFliteSourceGStreamer.cpp
@@ -114,9 +114,12 @@ static void webkitFliteSrcConstructed(GObject* object)
     WebKitFliteSrcPrivate* priv = src->priv;
 
     /* We operate in time */
-    gst_base_src_set_format(GST_BASE_SRC(src), GST_FORMAT_TIME);
-    gst_base_src_set_blocksize(GST_BASE_SRC(src), -1);
-    gst_base_src_set_automatic_eos(GST_BASE_SRC(src), FALSE);
+    auto baseSrc = GST_BASE_SRC_CAST(src);
+    gst_base_src_set_format(baseSrc, GST_FORMAT_TIME);
+    gst_base_src_set_blocksize(baseSrc, -1);
+    gst_base_src_set_automatic_eos(baseSrc, FALSE);
+    gst_base_src_set_do_timestamp(baseSrc, TRUE);
+    gst_base_src_set_live(baseSrc, TRUE);
 
     DataMutexLocker members { priv->dataMutex };
     members->adapter = adoptGRef(gst_adapter_new());


### PR DESCRIPTION
#### e7619d6d7c16312f6d8c25be508e250ea3b6c3c3
<pre>
[WPE][GStreamer] assertion GST_CLOCK_TIME_IS_VALID (timestamp) crashes test fast/speechsynthesis/speech-synthesis-real-client-version.html on ARM64
<a href="https://bugs.webkit.org/show_bug.cgi?id=309361">https://bugs.webkit.org/show_bug.cgi?id=309361</a>

Reviewed by Xabier Rodriguez-Calvar.

Configure the flite source element as a live source and enable automatic timestamping, the pitch
element used downstream expects valid timestamps.

Canonical link: <a href="https://commits.webkit.org/308900@main">https://commits.webkit.org/308900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eac06c14ef05a7c264a49b709bea20411a402eec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157435 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102180 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150623 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114675 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81665 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151710 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133528 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95445 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15987 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13834 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5203 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125587 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159772 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2910 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12970 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122739 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21265 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122964 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33444 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133242 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77439 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18262 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10004 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20875 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84677 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20607 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20754 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20663 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->