### PR TITLE
[GStreamer] media-elements/loading-the-media-resource/resource-selection-source-media-env-change.html is a flaky crash

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3531,8 +3531,6 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/t
 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/track/track-element/track-cues-sorted-before-dispatch.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/offsets-into-the-media-resource/currentTime-move-within-document.html [ Skip ]
 
-webkit.org/b/309434 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/loading-the-media-resource/resource-selection-source-media-env-change.html [ Pass Crash ]
-
 # PiP / presentation-mode is not supported yet
 webkit.org/b/202756 media/airplay-wirelessvideoplaybackdisabled.html [ Skip ]
 webkit.org/b/202756 http/tests/media/modern-media-controls/pip-support [ Skip ]

--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
@@ -50,32 +50,26 @@ static void ensureDebugCategoryInitialized()
 }
 
 AudioTrackPrivateGStreamer::AudioTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&& player, unsigned index, GRefPtr<GstPad>&& pad, bool shouldHandleStreamStartEvent)
-    : TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Audio, this, index, WTF::move(pad), shouldHandleStreamStartEvent)
-    , m_player(WTF::move(player))
+    : TrackPrivateBaseGStreamer(WTF::move(player), GStreamerTrackType::Audio, this, index, WTF::move(pad), shouldHandleStreamStartEvent)
 {
     ensureDebugCategoryInitialized();
-    installUpdateConfigurationHandlers();
 }
 
 AudioTrackPrivateGStreamer::AudioTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&& player, unsigned index, GRefPtr<GstPad>&& pad, TrackID trackId)
-    : TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Audio, this, index, WTF::move(pad), trackId)
-    , m_player(WTF::move(player))
+    : TrackPrivateBaseGStreamer(WTF::move(player), GStreamerTrackType::Audio, this, index, WTF::move(pad), trackId)
 {
     ensureDebugCategoryInitialized();
-    installUpdateConfigurationHandlers();
 }
 
 AudioTrackPrivateGStreamer::AudioTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&& player, unsigned index, GstStream* stream)
-    : TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Audio, this, index, stream)
-    , m_player(WTF::move(player))
+    : TrackPrivateBaseGStreamer(WTF::move(player), GStreamerTrackType::Audio, this, index, stream)
 {
     ensureDebugCategoryInitialized();
-    installUpdateConfigurationHandlers();
 
-    auto caps = adoptGRef(gst_stream_get_caps(m_stream.get()));
+    auto caps = adoptGRef(gst_stream_get_caps(m_data->m_stream.get()));
     updateConfigurationFromCaps(WTF::move(caps));
 
-    auto tags = adoptGRef(gst_stream_get_tags(m_stream.get()));
+    auto tags = adoptGRef(gst_stream_get_tags(m_data->m_stream.get()));
     updateConfigurationFromTags(WTF::move(tags));
 }
 
@@ -84,7 +78,7 @@ void AudioTrackPrivateGStreamer::capsChanged(TrackID streamId, GRefPtr<GstCaps>&
     ASSERT(isMainThread());
     updateConfigurationFromCaps(WTF::move(caps));
 
-    RefPtr player = m_player.get();
+    RefPtr player = m_data->m_player.get();
     if (!player)
         return;
 
@@ -92,7 +86,7 @@ void AudioTrackPrivateGStreamer::capsChanged(TrackID streamId, GRefPtr<GstCaps>&
     if (codec.isEmpty())
         return;
 
-    GST_DEBUG_OBJECT(objectForLogging(), "Setting codec to %s", codec.ascii().data());
+    GST_DEBUG_OBJECT(m_data->objectForLogging(), "Setting codec to %s", codec.ascii().data());
     auto configuration = this->configuration();
     configuration.codec = WTF::move(codec);
     setConfiguration(WTF::move(configuration));
@@ -101,13 +95,13 @@ void AudioTrackPrivateGStreamer::capsChanged(TrackID streamId, GRefPtr<GstCaps>&
 void AudioTrackPrivateGStreamer::updateConfigurationFromTags(GRefPtr<GstTagList>&& tags)
 {
     ASSERT(isMainThread());
-    GST_DEBUG_OBJECT(objectForLogging(), "Updating audio configuration from %" GST_PTR_FORMAT, tags.get());
     if (!tags)
         return;
 
-    if (updateTrackIDFromTags(tags)) {
-        GST_DEBUG_OBJECT(objectForLogging(), "Audio track ID set from container-specific-track-id tag %" G_GUINT64_FORMAT, *m_trackID);
-        notifyClients([trackID = *m_trackID](auto& client) {
+    GST_DEBUG_OBJECT(m_data->objectForLogging(), "Updating audio configuration from %" GST_PTR_FORMAT, tags.get());
+    if (m_data->updateTrackIDFromTags(tags)) {
+        GST_DEBUG_OBJECT(m_data->objectForLogging(), "Audio track ID set from container-specific-track-id tag %" G_GUINT64_FORMAT, *m_data->m_trackID);
+        notifyClients([trackID = *m_data->m_trackID](auto& client) {
             client.idChanged(trackID);
         });
     }
@@ -116,7 +110,7 @@ void AudioTrackPrivateGStreamer::updateConfigurationFromTags(GRefPtr<GstTagList>
     if (!gst_tag_list_get_uint(tags.get(), GST_TAG_BITRATE, &bitrate))
         return;
 
-    GST_DEBUG_OBJECT(objectForLogging(), "Setting bitrate to %u", bitrate);
+    GST_DEBUG_OBJECT(m_data->objectForLogging(), "Setting bitrate to %u", bitrate);
     auto configuration = this->configuration();
     configuration.bitrate = bitrate;
     setConfiguration(WTF::move(configuration));
@@ -128,7 +122,7 @@ void AudioTrackPrivateGStreamer::updateConfigurationFromCaps(GRefPtr<GstCaps>&& 
     if (!caps || !gst_caps_is_fixed(caps.get()))
         return;
 
-    GST_DEBUG_OBJECT(objectForLogging(), "Updating audio configuration from %" GST_PTR_FORMAT, caps.get());
+    GST_DEBUG_OBJECT(m_data->objectForLogging(), "Updating audio configuration from %" GST_PTR_FORMAT, caps.get());
     auto configuration = this->configuration();
     auto scopeExit = makeScopeExit([&] {
         setConfiguration(WTF::move(configuration));
@@ -158,23 +152,10 @@ void AudioTrackPrivateGStreamer::updateConfigurationFromCaps(GRefPtr<GstCaps>&& 
 
 AudioTrackPrivate::Kind AudioTrackPrivateGStreamer::kind() const
 {
-    if (m_stream && gst_stream_get_stream_flags(m_stream.get()) & GST_STREAM_FLAG_SELECT)
+    if (m_data->m_stream && gst_stream_get_stream_flags(m_data->m_stream.get()) & GST_STREAM_FLAG_SELECT)
         return AudioTrackPrivate::Kind::Main;
 
     return AudioTrackPrivate::kind();
-}
-
-void AudioTrackPrivateGStreamer::disconnect()
-{
-    m_taskQueue.startAborting();
-
-    if (m_stream)
-        g_signal_handlers_disconnect_matched(m_stream.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
-
-    m_player = nullptr;
-    TrackPrivateBaseGStreamer::disconnect();
-
-    m_taskQueue.finishAborting();
 }
 
 void AudioTrackPrivateGStreamer::setEnabled(bool enabled)
@@ -183,9 +164,38 @@ void AudioTrackPrivateGStreamer::setEnabled(bool enabled)
         return;
     AudioTrackPrivate::setEnabled(enabled);
 
-    RefPtr player = m_player.get();
+    RefPtr player = m_data->m_player.get();
     if (player)
         player->updateEnabledAudioTrack();
+}
+
+int AudioTrackPrivateGStreamer::trackIndex() const
+{
+    return m_data->m_index;
+}
+
+TrackID AudioTrackPrivateGStreamer::id() const
+{
+    return m_data->m_trackID.value_or(m_data->m_id);
+}
+
+std::optional<String> AudioTrackPrivateGStreamer::trackUID() const
+{
+    auto player = m_data->m_player.get();
+    if (!player || !player->isMediaStreamPlayer())
+        return std::nullopt;
+
+    return m_data->m_gstStreamId;
+}
+
+String AudioTrackPrivateGStreamer::label() const
+{
+    return m_data->m_label;
+}
+
+String AudioTrackPrivateGStreamer::language() const
+{
+    return m_data->m_language;
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h
@@ -55,30 +55,18 @@ public:
 
     Kind kind() const final;
 
-    void disconnect() final;
-
     void setEnabled(bool) final;
     void setActive(bool enabled) final { setEnabled(enabled); }
 
-    int trackIndex() const final { return m_index; }
+    int trackIndex() const final;
 
-    TrackID id() const final { return m_trackID.value_or(m_id); }
-    std::optional<String> trackUID() const final
-    {
-        auto player = m_player.get();
+    TrackID id() const final;
+    std::optional<String> trackUID() const final;
 
-        if (player && player->isMediaStreamPlayer())
-            return m_gstStreamId;
-
-        return std::nullopt;
-    }
-
-    String label() const final { return m_label; }
-    String language() const final { return m_language; }
+    String label() const final;
+    String language() const final;
 
     void updateConfigurationFromCaps(GRefPtr<GstCaps>&&) final;
-
-protected:
     void updateConfigurationFromTags(GRefPtr<GstTagList>&&) final;
 
     void tagsChanged(GRefPtr<GstTagList>&& tags) final { updateConfigurationFromTags(WTF::move(tags)); }
@@ -88,8 +76,6 @@ private:
     AudioTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&&, unsigned index, GRefPtr<GstPad>&&, bool shouldHandleStreamStartEvent);
     AudioTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&&, unsigned index, GRefPtr<GstPad>&&, TrackID);
     AudioTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&&, unsigned index, GstStream*);
-
-    ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer> m_player;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.cpp
@@ -47,33 +47,30 @@ static void ensureTextTrackDebugCategoryInitialized()
 
 InbandTextTrackPrivateGStreamer::InbandTextTrackPrivateGStreamer(unsigned index, GRefPtr<GstPad>&& pad, bool shouldHandleStreamStartEvent)
     : InbandTextTrackPrivate(CueFormat::WebVTT)
-    , TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Text, this, index, WTF::move(pad), shouldHandleStreamStartEvent)
+    , TrackPrivateBaseGStreamer(nullptr, GStreamerTrackType::Text, this, index, WTF::move(pad), shouldHandleStreamStartEvent)
     , m_kind(Kind::Subtitles)
 {
     ensureTextTrackDebugCategoryInitialized();
-    installUpdateConfigurationHandlers();
 }
 
 InbandTextTrackPrivateGStreamer::InbandTextTrackPrivateGStreamer(unsigned index, GRefPtr<GstPad>&& pad, TrackID trackId)
     : InbandTextTrackPrivate(CueFormat::WebVTT)
-    , TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Text, this, index, WTF::move(pad), trackId)
+    , TrackPrivateBaseGStreamer(nullptr, GStreamerTrackType::Text, this, index, WTF::move(pad), trackId)
     , m_kind(Kind::Subtitles)
 {
     ensureTextTrackDebugCategoryInitialized();
-    installUpdateConfigurationHandlers();
 }
 
 InbandTextTrackPrivateGStreamer::InbandTextTrackPrivateGStreamer(unsigned index, GstStream* stream)
     : InbandTextTrackPrivate(CueFormat::WebVTT)
-    , TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Text, this, index, stream)
+    , TrackPrivateBaseGStreamer(nullptr, GStreamerTrackType::Text, this, index, stream)
 {
     ensureTextTrackDebugCategoryInitialized();
-    installUpdateConfigurationHandlers();
 
-    GST_INFO("Track %" PRIu64 " got stream start. GStreamer stream-id: %s", m_id, m_gstStreamId.utf8().data());
+    GST_INFO("Track %" PRIu64 " got stream start. GStreamer stream-id: %s", m_data->m_id, m_data->m_gstStreamId.utf8().data());
 
-    GST_DEBUG("Stream %" GST_PTR_FORMAT, m_stream.get());
-    auto caps = adoptGRef(gst_stream_get_caps(m_stream.get()));
+    GST_DEBUG("Stream %" GST_PTR_FORMAT, m_data->m_stream.get());
+    auto caps = adoptGRef(gst_stream_get_caps(m_data->m_stream.get()));
     m_kind = doCapsHaveType(caps.get(), "closedcaption/"_s) ? Kind::Captions : Kind::Subtitles;
 }
 
@@ -83,11 +80,11 @@ void InbandTextTrackPrivateGStreamer::tagsChanged(GRefPtr<GstTagList>&& tags)
     if (!tags)
         return;
 
-    if (!updateTrackIDFromTags(tags))
+    if (!m_data->updateTrackIDFromTags(tags))
         return;
 
-    GST_DEBUG_OBJECT(objectForLogging(), "Text track ID set from container-specific-track-id tag %" G_GUINT64_FORMAT, *m_trackID);
-    notifyClients([trackID = *m_trackID](auto& client) {
+    GST_DEBUG_OBJECT(m_data->objectForLogging(), "Text track ID set from container-specific-track-id tag %" G_GUINT64_FORMAT, *m_data->m_trackID);
+    notifyClients([trackID = *m_data->m_trackID](auto& client) {
         client.idChanged(trackID);
     });
 }
@@ -100,7 +97,7 @@ void InbandTextTrackPrivateGStreamer::handleSample(GRefPtr<GstSample>&& sample)
     }
 
     RefPtr<InbandTextTrackPrivateGStreamer> protectedThis(this);
-    m_notifier->notify(MainThreadNotification::NewSample, [protectedThis] {
+    m_data->m_notifier->notify(TrackDataHolder::MainThreadNotification::NewSample, [protectedThis] {
         protectedThis->notifyTrackOfSample();
     });
 }
@@ -116,17 +113,17 @@ void InbandTextTrackPrivateGStreamer::notifyTrackOfSample()
     for (auto& sample : samples) {
         GstBuffer* buffer = gst_sample_get_buffer(sample.get());
         if (!buffer) {
-            GST_WARNING("Track %" PRIu64 " got sample with no buffer.", m_id);
+            GST_WARNING("Track %" PRIu64 " got sample with no buffer.", m_data->m_id);
             continue;
         }
         GstMappedBuffer mappedBuffer(buffer, GST_MAP_READ);
         ASSERT(mappedBuffer);
         if (!mappedBuffer) {
-            GST_WARNING("Track %" PRIu64 " unable to map buffer.", m_id);
+            GST_WARNING("Track %" PRIu64 " unable to map buffer.", m_data->m_id);
             continue;
         }
 
-        GST_INFO("Track %" PRIu64 " parsing sample: %.*s", m_id, static_cast<int>(mappedBuffer.size()),
+        GST_INFO("Track %" PRIu64 " parsing sample: %.*s", m_data->m_id, static_cast<int>(mappedBuffer.size()),
             reinterpret_cast<char*>(mappedBuffer.data()));
         ASSERT(isMainThread());
         ASSERT(!hasClients() || hasOneClient());
@@ -134,6 +131,26 @@ void InbandTextTrackPrivateGStreamer::notifyTrackOfSample()
             downcast<InbandTextTrackPrivateClient>(client).parseWebVTTCueData(mappedBuffer.span<uint8_t>());
         });
     }
+}
+
+TrackID InbandTextTrackPrivateGStreamer::id() const
+{
+    return m_data->m_trackID.value_or(m_data->m_id);
+}
+
+String InbandTextTrackPrivateGStreamer::label() const
+{
+    return m_data->m_label;
+}
+
+String InbandTextTrackPrivateGStreamer::language() const
+{
+    return m_data->m_language;
+}
+
+int InbandTextTrackPrivateGStreamer::trackIndex() const
+{
+    return m_data->m_index;
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/InbandTextTrackPrivateGStreamer.h
@@ -58,15 +58,14 @@ public:
     }
 
     Kind kind() const final { return m_kind; }
-    TrackID id() const final { return m_trackID.value_or(m_id); }
+    TrackID id() const final;
     std::optional<String> trackUID() const final { return std::nullopt; }
-    String label() const final { return m_label; }
-    String language() const final { return m_language; }
-    int trackIndex() const final { return m_index; }
+    String label() const final;
+    String language() const final;
+    int trackIndex() const final;
 
     void handleSample(GRefPtr<GstSample>&&);
 
-protected:
     void tagsChanged(GRefPtr<GstTagList>&&) final;
 
 private:

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "MediaPlayerPrivateGStreamer.h"
+#include "TrackPrivateBaseGStreamer.h"
 
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
@@ -1207,23 +1208,22 @@ void MediaPlayerPrivateGStreamer::notifyPlayerOfTrack()
 
     ASSERT(m_isLegacyPlaybin);
 
-    using TrackType = TrackPrivateBaseGStreamer::TrackType;
     Variant<TrackIDHashMap<Ref<AudioTrackPrivateGStreamer>>*, TrackIDHashMap<Ref<VideoTrackPrivateGStreamer>>*, TrackIDHashMap<Ref<InbandTextTrackPrivateGStreamer>>*> variantTracks = static_cast<TrackIDHashMap<Ref<TrackPrivateType>>*>(0);
-    auto type(static_cast<TrackType>(variantTracks.index()));
+    auto type(static_cast<GStreamerTrackType>(variantTracks.index()));
     ASCIILiteral typeName;
     bool* hasType;
     switch (type) {
-    case TrackType::Audio:
+    case GStreamerTrackType::Audio:
         typeName = "audio"_s;
         hasType = &m_hasAudio;
         variantTracks = &m_audioTracks;
         break;
-    case TrackType::Video:
+    case GStreamerTrackType::Video:
         typeName = "video"_s;
         hasType = &m_hasVideo;
         variantTracks = &m_videoTracks;
         break;
-    case TrackType::Text:
+    case GStreamerTrackType::Text:
         typeName = "text"_s;
         hasType = nullptr;
         variantTracks = &m_textTracks;
@@ -1234,7 +1234,7 @@ void MediaPlayerPrivateGStreamer::notifyPlayerOfTrack()
     auto& tracks = *std::get<TrackIDHashMap<Ref<TrackPrivateType>>*>(variantTracks);
 
     // Ignore notifications after a EOS. We don't want the tracks to disappear when the video is finished.
-    if (m_isEndReached && (type == TrackType::Audio || type == TrackType::Video))
+    if (m_isEndReached && (type == GStreamerTrackType::Audio || type == GStreamerTrackType::Video))
         return;
 
     unsigned numberOfTracks = 0;
@@ -1249,7 +1249,7 @@ void MediaPlayerPrivateGStreamer::notifyPlayerOfTrack()
         if (oldHasType != *hasType)
             player->characteristicChanged();
 
-        if (*hasType && type == TrackType::Video)
+        if (*hasType && type == GStreamerTrackType::Video)
             player->sizeChanged();
     }
 
@@ -1283,18 +1283,18 @@ void MediaPlayerPrivateGStreamer::notifyPlayerOfTrack()
 
         auto track = TrackPrivateType::create(*this, i, GRefPtr(pad));
         ASSERT(track->streamId() == streamId);
-        if (!track->trackIndex() && (type == TrackType::Audio || type == TrackType::Video))
+        if (!track->trackIndex() && (type == GStreamerTrackType::Audio || type == GStreamerTrackType::Video))
             track->setActive(true);
 
         Variant<AudioTrackPrivate*, VideoTrackPrivate*, InbandTextTrackPrivate*> variantTrack(&track.get());
         switch (variantTrack.index()) {
-        case TrackType::Audio:
+        case GStreamerTrackType::Audio:
             player->addAudioTrack(*std::get<AudioTrackPrivate*>(variantTrack));
             break;
-        case TrackType::Video:
+        case GStreamerTrackType::Video:
             player->addVideoTrack(*std::get<VideoTrackPrivate*>(variantTrack));
             break;
-        case TrackType::Text:
+        case GStreamerTrackType::Text:
             player->addTextTrack(*std::get<InbandTextTrackPrivate*>(variantTrack));
             break;
         }

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -42,6 +42,20 @@ GST_DEBUG_CATEGORY_EXTERN(webkit_media_player_debug);
 
 namespace WebCore {
 
+static GRefPtr<GstTagList> getAllTags(const GRefPtr<GstPad>& pad)
+{
+    auto allTags = adoptGRef(gst_tag_list_new_empty());
+    GstTagList* taglist = nullptr;
+    for (unsigned i = 0;; i++) {
+        GRefPtr<GstEvent> tagsEvent = adoptGRef(gst_pad_get_sticky_event(pad.get(), GST_EVENT_TAG, i));
+        if (!tagsEvent)
+            break;
+        gst_event_parse_tag(tagsEvent.get(), &taglist);
+        allTags = adoptGRef(gst_tag_list_merge(allTags.get(), taglist, GST_TAG_MERGE_APPEND));
+    }
+    return allTags;
+}
+
 static GRefPtr<GstPad> findBestUpstreamPad(GRefPtr<GstPad> pad)
 {
     if (!pad)
@@ -58,56 +72,96 @@ static GRefPtr<GstPad> findBestUpstreamPad(GRefPtr<GstPad> pad)
     return sinkPad;
 }
 
-TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer(TrackType type, TrackPrivateBase* owner, unsigned index, GRefPtr<GstPad>&& pad, bool shouldHandleStreamStartEvent)
-    : m_notifier(MainThreadNotifier<MainThreadNotification>::create())
-    , m_index(index)
-    , m_type(type)
-    , m_owner(owner)
-    , m_shouldHandleStreamStartEvent(shouldHandleStreamStartEvent)
+static std::optional<String> getTag(GstTagList* tags, ASCIILiteral tagName)
 {
-    setPad(WTF::move(pad));
-    ASSERT(m_pad);
+    GUniqueOutPtr<gchar> tagValue;
+    if (!gst_tag_list_get_string(tags, tagName.characters(), &tagValue.outPtr()))
+        return std::nullopt;
 
-    // We can't call notifyTrackOfTagsChanged() directly, because we need tagsChanged() to setup m_tags.
-    tagsChanged();
+    GST_DEBUG("Track got %s %s.", tagName.characters(), tagValue.get());
+    return String(byteCast<char8_t>(unsafeSpan(tagValue.get())));
 }
 
-TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer(TrackType type, TrackPrivateBase* owner, unsigned index, GRefPtr<GstPad>&& pad, TrackID trackId)
-    : m_notifier(MainThreadNotifier<MainThreadNotification>::create())
-    , m_index(index)
-    , m_id(trackId)
-    , m_type(type)
-    , m_owner(owner)
-    , m_shouldUsePadStreamId(false)
-    , m_shouldHandleStreamStartEvent(false)
+static std::optional<String> getLanguageCode(GstTagList* tags)
 {
-    setPad(WTF::move(pad));
-    ASSERT(m_pad);
+    auto language = getTag(tags, ASCIILiteral::fromLiteralUnsafe(GST_TAG_LANGUAGE_CODE));
+    if (!language)
+        return std::nullopt;
 
-    // We can't call notifyTrackOfTagsChanged() directly, because we need tagsChanged() to setup m_tags.
-    tagsChanged();
+    auto convertedLanguage = CStringView::unsafeFromUTF8(gst_tag_get_language_code_iso_639_1(language->utf8().data()));
+    GST_DEBUG("Converted track's language code to %s.", convertedLanguage.utf8());
+    return String(convertedLanguage.span());
 }
 
-TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer(TrackType type, TrackPrivateBase* owner, unsigned index, GstStream* stream)
+TrackDataHolder::TrackDataHolder(TrackPrivateBaseGStreamer& track)
     : m_notifier(MainThreadNotifier<MainThreadNotification>::create())
-    , m_index(index)
-    , m_gstStreamId(byteCast<Latin1Character>(unsafeSpan(gst_stream_get_stream_id(stream))))
-    , m_id(parseStreamId(m_gstStreamId).value_or(index))
-    , m_stream(stream)
-    , m_type(type)
-    , m_owner(owner)
+    , m_track(track)
 {
-    ASSERT(m_stream);
+}
 
-    g_signal_connect_swapped(m_stream.get(), "notify::tags", G_CALLBACK(+[](TrackPrivateBaseGStreamer* track) {
-        track->tagsChanged();
-    }), this);
+TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&& player, GStreamerTrackType type, TrackPrivateBase* owner, unsigned index, GRefPtr<GstPad>&& pad, bool shouldHandleStreamStartEvent)
+    : m_data(TrackDataHolder::create(*this))
+{
+    m_data->m_player = WTF::move(player);
+    m_data->m_index = index;
+    m_data->m_type = type;
+    m_data->m_owner = owner;
+    m_data->m_shouldHandleStreamStartEvent = shouldHandleStreamStartEvent;
+    ASSERT(pad);
+    m_data->setPad(WTF::move(pad));
 
     // We can't call notifyTrackOfTagsChanged() directly, because we need tagsChanged() to setup m_tags.
-    tagsChanged();
+    m_data->tagsChanged();
+
+    m_data->installUpdateConfigurationHandlers();
+}
+
+TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&& player, GStreamerTrackType type, TrackPrivateBase* owner, unsigned index, GRefPtr<GstPad>&& pad, TrackID trackId)
+    : m_data(TrackDataHolder::create(*this))
+{
+    m_data->m_player = WTF::move(player);
+    m_data->m_index = index;
+    m_data->m_id = trackId;
+    m_data->m_type = type;
+    m_data->m_owner = owner;
+    m_data->m_shouldUsePadStreamId = false;
+    m_data->m_shouldHandleStreamStartEvent = false;
+
+    ASSERT(pad);
+    m_data->setPad(WTF::move(pad));
+
+    // We can't call notifyTrackOfTagsChanged() directly, because we need tagsChanged() to setup m_tags.
+    m_data->tagsChanged();
+
+    m_data->installUpdateConfigurationHandlers();
+}
+
+TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&& player, GStreamerTrackType type, TrackPrivateBase* owner, unsigned index, GstStream* stream)
+    : m_data(TrackDataHolder::create(*this))
+{
+    ASSERT(stream);
+
+    m_data->m_player = WTF::move(player);
+    m_data->m_index = index;
+    m_data->m_gstStreamId = byteCast<Latin1Character>(unsafeSpan(gst_stream_get_stream_id(stream)));
+    m_data->m_id = parseStreamId(m_data->m_gstStreamId).value_or(index);
+    m_data->m_type = type;
+    m_data->m_owner = owner;
+
+    m_data->setStream(GRefPtr(stream));
+
+    // We can't call notifyTrackOfTagsChanged() directly, because we need tagsChanged() to setup m_tags.
+    m_data->tagsChanged();
+
+    m_data->installUpdateConfigurationHandlers();
 }
 
 void TrackPrivateBaseGStreamer::setPad(GRefPtr<GstPad>&& pad)
+{
+    m_data->setPad(WTF::move(pad));
+}
+
+void TrackDataHolder::setPad(GRefPtr<GstPad>&& pad)
 {
     ASSERT(isMainThread());
 
@@ -124,23 +178,31 @@ void TrackPrivateBaseGStreamer::setPad(GRefPtr<GstPad>&& pad)
     if (!m_bestUpstreamPad)
         return;
 
-    m_eventProbe = gst_pad_add_probe(m_bestUpstreamPad.get(), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, reinterpret_cast<GstPadProbeCallback>(+[](GstPad*, GstPadProbeInfo* info, TrackPrivateBaseGStreamer* track) -> GstPadProbeReturn {
-        auto* event = gst_pad_probe_info_get_event(info);
+    m_eventProbe = gst_pad_add_probe(m_bestUpstreamPad.get(), GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM, reinterpret_cast<GstPadProbeCallback>(+[](GstPad*, GstPadProbeInfo* info, gpointer userData) -> GstPadProbeReturn {
+        RefPtr holder = reinterpret_cast<ThreadSafeWeakPtr<TrackDataHolder>*>(userData)->get();
+        if (!holder)
+            return GST_PAD_PROBE_REMOVE;
+
+        auto event = gst_pad_probe_info_get_event(info);
         switch (GST_EVENT_TYPE(event)) {
         case GST_EVENT_TAG:
-            track->tagsChanged();
+            holder->tagsChanged();
             break;
         case GST_EVENT_STREAM_START:
-            if (track->m_shouldHandleStreamStartEvent)
-                track->streamChanged();
+            if (holder->m_shouldHandleStreamStartEvent)
+                holder->streamChanged();
             break;
         case GST_EVENT_CAPS: {
-            track->m_taskQueue.enqueueTask([track, event = GRefPtr<GstEvent>(event)]() {
+            holder->m_taskQueue.enqueueTask([weakHolder = ThreadSafeWeakPtr<TrackDataHolder> { holder.get() }, event = GRefPtr<GstEvent>(event)]() mutable {
+                RefPtr holder = weakHolder.get();
+                if (!holder)
+                    return;
+
                 GstCaps* caps;
                 gst_event_parse_caps(event.get(), &caps);
                 if (!caps)
                     return;
-                track->capsChanged(track->m_id, GRefPtr<GstCaps>(caps));
+                holder->m_track.capsChanged(holder->m_id, GRefPtr<GstCaps>(caps));
             });
             break;
         }
@@ -148,16 +210,39 @@ void TrackPrivateBaseGStreamer::setPad(GRefPtr<GstPad>&& pad)
             break;
         }
         return GST_PAD_PROBE_OK;
-    }), this, nullptr);
+    }), new ThreadSafeWeakPtr<TrackDataHolder> { this }, reinterpret_cast<GDestroyNotify>(+[](gpointer data) {
+        delete static_cast<ThreadSafeWeakPtr<TrackDataHolder>*>(data);
+    }));
 }
 
-TrackPrivateBaseGStreamer::~TrackPrivateBaseGStreamer()
+void TrackDataHolder::setStream(GRefPtr<GstStream>&& stream)
+{
+    if (m_streamTagsNotifyHandlerId) {
+        g_signal_handler_disconnect(m_stream.get(), m_streamTagsNotifyHandlerId);
+        m_streamTagsNotifyHandlerId = 0;
+    }
+    if (m_streamCapsNotifyHandlerId) {
+        g_signal_handler_disconnect(m_stream.get(), m_streamCapsNotifyHandlerId);
+        m_streamCapsNotifyHandlerId = 0;
+    }
+    m_stream = WTF::move(stream);
+    m_streamTagsNotifyHandlerId = g_signal_connect_data(m_stream.get(), "notify::tags", G_CALLBACK(+[](GstStream*, GParamSpec*, gpointer userData) {
+        RefPtr holder = reinterpret_cast<ThreadSafeWeakPtr<TrackDataHolder>*>(userData)->get();
+        if (!holder)
+            return;
+        holder->tagsChanged();
+    }), new ThreadSafeWeakPtr<TrackDataHolder> { this }, [](gpointer data, GClosure*) {
+        delete static_cast<ThreadSafeWeakPtr<TrackDataHolder>*>(data);
+    }, static_cast<GConnectFlags>(0));
+}
+
+TrackDataHolder::~TrackDataHolder()
 {
     disconnect();
     m_notifier->invalidate();
 }
 
-GstObject* TrackPrivateBaseGStreamer::objectForLogging() const
+GstObject* TrackDataHolder::objectForLogging() const
 {
     if (m_stream)
         return GST_OBJECT_CAST(m_stream.get());
@@ -166,10 +251,60 @@ GstObject* TrackPrivateBaseGStreamer::objectForLogging() const
     return GST_OBJECT_CAST(m_pad.get());
 }
 
+GRefPtr<GstPad> TrackPrivateBaseGStreamer::pad() const
+{
+    return m_data->m_pad;
+}
+
+unsigned TrackPrivateBaseGStreamer::index()
+{
+    return m_data->m_index;
+}
+
+void TrackPrivateBaseGStreamer::setIndex(unsigned index)
+{
+    m_data->m_index = index;
+}
+
+GRefPtr<GstStream> TrackPrivateBaseGStreamer::stream() const
+{
+    return m_data->m_stream;
+}
+
+void TrackPrivateBaseGStreamer::setInitialCaps(GRefPtr<GstCaps>&& caps)
+{
+    m_data->m_initialCaps = WTF::move(caps);
+}
+
+GRefPtr<GstCaps> TrackPrivateBaseGStreamer::initialCaps()
+{
+    return m_data->m_initialCaps;
+}
+
+TrackID TrackPrivateBaseGStreamer::streamId() const
+{
+    return m_data->m_id;
+}
+
+String TrackPrivateBaseGStreamer::gstStreamId() const
+{
+    return m_data->m_gstStreamId;
+}
+
 void TrackPrivateBaseGStreamer::disconnect()
 {
-    if (m_stream)
-        g_signal_handlers_disconnect_matched(m_stream.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
+    m_data->disconnect();
+}
+
+void TrackDataHolder::disconnect()
+{
+    m_taskQueue.startAborting();
+
+    if (m_stream) {
+        g_signal_handler_disconnect(m_stream.get(), m_streamTagsNotifyHandlerId);
+        g_signal_handler_disconnect(m_stream.get(), m_streamCapsNotifyHandlerId);
+        m_stream.clear();
+    }
 
     m_tags.clear();
 
@@ -182,18 +317,22 @@ void TrackPrivateBaseGStreamer::disconnect()
     }
 
     if (m_pad) {
-        g_signal_handlers_disconnect_matched(m_pad.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
+        g_signal_handler_disconnect(m_pad.get(), m_padTagsNotifyHandlerId);
+        g_signal_handler_disconnect(m_pad.get(), m_padCapsNotifyHandlerId);
         m_pad.clear();
     }
+
+    m_player = nullptr;
+    m_taskQueue.finishAborting();
 }
 
-void TrackPrivateBaseGStreamer::tagsChanged()
+void TrackDataHolder::tagsChanged()
 {
     // May be called by any thread, including the streaming thread.
     GRefPtr<GstTagList> tags;
     if (m_bestUpstreamPad) {
         GRefPtr<GstEvent> tagEvent;
-        guint i = 0;
+        unsigned i = 0;
         // Prefer the tag event having a language tag, if available.
         do {
             tagEvent = adoptGRef(gst_pad_get_sticky_event(m_bestUpstreamPad.get(), GST_EVENT_TAG, i));
@@ -224,28 +363,7 @@ void TrackPrivateBaseGStreamer::tagsChanged()
     });
 }
 
-std::optional<String> TrackPrivateBaseGStreamer::getLanguageCode(GstTagList* tags)
-{
-    auto language = getTag(tags, ASCIILiteral::fromLiteralUnsafe(GST_TAG_LANGUAGE_CODE));
-    if (language) {
-        auto convertedLanguage = CStringView::unsafeFromUTF8(gst_tag_get_language_code_iso_639_1(language->utf8().data()));
-        GST_DEBUG("Converted track %" PRIu64 "'s language code to %s.", m_id, convertedLanguage.utf8());
-        return String(convertedLanguage.span());
-    }
-    return std::nullopt;
-}
-
-std::optional<String> TrackPrivateBaseGStreamer::getTag(GstTagList* tags, ASCIILiteral tagName)
-{
-    GUniqueOutPtr<gchar> tagValue;
-    if (gst_tag_list_get_string(tags, tagName.characters(), &tagValue.outPtr())) {
-        GST_DEBUG("Track %" PRIu64 " got %s %s.", m_id, tagName.characters(), tagValue.get());
-        return String(byteCast<char8_t>(unsafeSpan(tagValue.get())));
-    }
-    return std::nullopt;
-}
-
-void TrackPrivateBaseGStreamer::notifyTrackOfTagsChanged()
+void TrackDataHolder::notifyTrackOfTagsChanged()
 {
     ASSERT(isMainThread());
     GRefPtr<GstTagList> tags;
@@ -257,12 +375,16 @@ void TrackPrivateBaseGStreamer::notifyTrackOfTagsChanged()
     if (!tags)
         return;
 
-    tagsChanged(GRefPtr<GstTagList>(tags));
+    m_track.tagsChanged(GRefPtr<GstTagList>(tags));
+
+    RefPtr owner = m_owner.get();
+    if (!owner)
+        return;
 
     auto label = getTag(tags.get(), ASCIILiteral::fromLiteralUnsafe(GST_TAG_TITLE));
     if (label) {
         m_label = *label;
-        m_owner->notifyMainThreadClient([&](auto& client) {
+        owner->notifyMainThreadClient([&](auto& client) {
             client.labelChanged(m_label);
         });
     }
@@ -275,12 +397,12 @@ void TrackPrivateBaseGStreamer::notifyTrackOfTagsChanged()
         return;
 
     m_language = *language;
-    m_owner->notifyMainThreadClient([&](auto& client) {
+    owner->notifyMainThreadClient([&](auto& client) {
         client.languageChanged(m_language);
     });
 }
 
-void TrackPrivateBaseGStreamer::notifyTrackOfStreamChanged()
+void TrackDataHolder::streamIdChanged()
 {
     if (!m_pad)
         return;
@@ -296,75 +418,93 @@ void TrackPrivateBaseGStreamer::notifyTrackOfStreamChanged()
     GST_INFO("Track %" PRIu64 " got stream start. GStreamer stream-id: %s", m_id, m_gstStreamId.utf8().data());
 }
 
-void TrackPrivateBaseGStreamer::streamChanged()
+void TrackDataHolder::streamChanged()
 {
     m_notifier->notify(MainThreadNotification::StreamChanged, [this] {
-        notifyTrackOfStreamChanged();
+        streamIdChanged();
     });
 }
 
-void TrackPrivateBaseGStreamer::installUpdateConfigurationHandlers()
+void TrackDataHolder::installUpdateConfigurationHandlers()
 {
     if (m_pad) {
-        g_signal_connect_swapped(m_pad.get(), "notify::caps", G_CALLBACK(+[](TrackPrivateBaseGStreamer* track) {
-            if (!track->m_pad)
+        m_padCapsNotifyHandlerId = g_signal_connect_data(m_pad.get(), "notify::caps", G_CALLBACK(+[](GstPad*, GParamSpec*, gpointer userData) {
+            RefPtr holder = reinterpret_cast<ThreadSafeWeakPtr<TrackDataHolder>*>(userData)->get();
+            if (!holder)
                 return;
-            auto caps = adoptGRef(gst_pad_get_current_caps(track->m_pad.get()));
+            if (!holder->m_pad)
+                return;
+            auto caps = adoptGRef(gst_pad_get_current_caps(holder->m_pad.get()));
             // We will receive a synchronous notification for caps being unset during pipeline teardown.
             if (!caps)
                 return;
 
-            track->m_taskQueue.enqueueTask([track, caps = WTF::move(caps)]() mutable {
-                track->capsChanged(getStreamIdFromPad(track->m_pad.get()).value_or(track->m_index), WTF::move(caps));
-            });
-        }), this);
-        g_signal_connect_swapped(m_pad.get(), "notify::tags", G_CALLBACK(+[](TrackPrivateBaseGStreamer* track) {
-            track->m_taskQueue.enqueueTask([track]() {
-                if (!track->m_pad)
+            holder->m_taskQueue.enqueueTask([weakHolder = ThreadSafeWeakPtr<TrackDataHolder> { holder.get() }, caps = WTF::move(caps)]() mutable {
+                auto holder = weakHolder.get();
+                if (!holder)
                     return;
-                track->updateConfigurationFromTags(getAllTags(track->m_pad));
+                holder->m_track.capsChanged(getStreamIdFromPad(holder->m_pad.get()).value_or(holder->m_index), WTF::move(caps));
             });
-        }), this);
+        }), new ThreadSafeWeakPtr<TrackDataHolder> { this }, [](gpointer data, GClosure*) {
+            delete static_cast<ThreadSafeWeakPtr<TrackDataHolder>*>(data);
+        }, static_cast<GConnectFlags>(0));
+        m_padTagsNotifyHandlerId = g_signal_connect_data(m_pad.get(), "notify::tags", G_CALLBACK(+[](GstPad*, GParamSpec*, gpointer userData) {
+            RefPtr holder = reinterpret_cast<ThreadSafeWeakPtr<TrackDataHolder>*>(userData)->get();
+            if (!holder)
+                return;
+            holder->m_taskQueue.enqueueTask([weakHolder = ThreadSafeWeakPtr<TrackDataHolder> { holder.get() }]() mutable {
+                auto holder = weakHolder.get();
+                if (!holder)
+                    return;
+                if (!holder->m_pad)
+                    return;
+                holder->m_track.updateConfigurationFromTags(getAllTags(holder->m_pad));
+            });
+        }), new ThreadSafeWeakPtr<TrackDataHolder> { this }, [](gpointer data, GClosure*) {
+            delete static_cast<ThreadSafeWeakPtr<TrackDataHolder>*>(data);
+        }, static_cast<GConnectFlags>(0));
     } else if (m_stream) {
-        g_signal_connect_swapped(m_stream.get(), "notify::caps", G_CALLBACK(+[](TrackPrivateBaseGStreamer* track) {
-            track->m_taskQueue.enqueueTask([track]() {
-                auto caps = adoptGRef(gst_stream_get_caps(track->m_stream.get()));
-                track->capsChanged(getStreamIdFromStream(track->m_stream.get()).value_or(track->m_index), WTF::move(caps));
+        m_streamCapsNotifyHandlerId = g_signal_connect_data(m_stream.get(), "notify::caps", G_CALLBACK(+[](GstStream*, GParamSpec*, gpointer userData) {
+            RefPtr holder = reinterpret_cast<ThreadSafeWeakPtr<TrackDataHolder>*>(userData)->get();
+            if (!holder)
+                return;
+            holder->m_taskQueue.enqueueTask([weakHolder = ThreadSafeWeakPtr<TrackDataHolder> { holder.get() }]() mutable {
+                auto holder = weakHolder.get();
+                if (!holder)
+                    return;
+                auto caps = adoptGRef(gst_stream_get_caps(holder->m_stream.get()));
+                holder->m_track.capsChanged(getStreamIdFromStream(holder->m_stream.get()).value_or(holder->m_index), WTF::move(caps));
             });
-        }), this);
+        }), new ThreadSafeWeakPtr<TrackDataHolder> { this }, [](gpointer data, GClosure*) {
+            delete static_cast<ThreadSafeWeakPtr<TrackDataHolder>*>(data);
+        }, static_cast<GConnectFlags>(0));
 
         // This signal can be triggered from the main thread
         // (CanvasCaptureMediaStreamTrack::Source::captureCanvas() triggering the mediastreamsrc
         // InternalSource::videoFrameAvailable() which can update the stream tags.)
-        g_signal_connect_swapped(m_stream.get(), "notify::tags", G_CALLBACK(+[](TrackPrivateBaseGStreamer* track) {
+        m_streamTagsNotifyHandlerId = g_signal_connect_data(m_stream.get(), "notify::tags", G_CALLBACK(+[](GstStream*, GParamSpec*, gpointer userData) {
+            RefPtr holder = reinterpret_cast<ThreadSafeWeakPtr<TrackDataHolder>*>(userData)->get();
+            if (!holder)
+                return;
             if (isMainThread()) {
-                auto tags = adoptGRef(gst_stream_get_tags(track->m_stream.get()));
-                track->updateConfigurationFromTags(WTF::move(tags));
+                auto tags = adoptGRef(gst_stream_get_tags(holder->m_stream.get()));
+                holder->m_track.updateConfigurationFromTags(WTF::move(tags));
                 return;
             }
-            track->m_taskQueue.enqueueTask([track]() {
-                auto tags = adoptGRef(gst_stream_get_tags(track->m_stream.get()));
-                track->updateConfigurationFromTags(WTF::move(tags));
+            holder->m_taskQueue.enqueueTask([weakHolder = ThreadSafeWeakPtr<TrackDataHolder> { holder.get() }]() mutable {
+                auto holder = weakHolder.get();
+                if (!holder)
+                    return;
+                auto tags = adoptGRef(gst_stream_get_tags(holder->m_stream.get()));
+                holder->m_track.updateConfigurationFromTags(WTF::move(tags));
             });
-        }), this);
+        }), new ThreadSafeWeakPtr<TrackDataHolder> { this }, [](gpointer data, GClosure*) {
+            delete static_cast<ThreadSafeWeakPtr<TrackDataHolder>*>(data);
+        }, static_cast<GConnectFlags>(0));
     }
 }
 
-GRefPtr<GstTagList> TrackPrivateBaseGStreamer::getAllTags(const GRefPtr<GstPad>& pad)
-{
-    auto allTags = adoptGRef(gst_tag_list_new_empty());
-    GstTagList* taglist = nullptr;
-    for (guint i = 0;; i++) {
-        GRefPtr<GstEvent> tagsEvent = adoptGRef(gst_pad_get_sticky_event(pad.get(), GST_EVENT_TAG, i));
-        if (!tagsEvent)
-            break;
-        gst_event_parse_tag(tagsEvent.get(), &taglist);
-        allTags = adoptGRef(gst_tag_list_merge(allTags.get(), taglist, GST_TAG_MERGE_APPEND));
-    }
-    return allTags;
-}
-
-bool TrackPrivateBaseGStreamer::updateTrackIDFromTags(const GRefPtr<GstTagList>& tags)
+bool TrackDataHolder::updateTrackIDFromTags(const GRefPtr<GstTagList>& tags)
 {
     ASSERT(isMainThread());
     GUniqueOutPtr<char> trackIDString;

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
@@ -30,64 +30,50 @@
 #include "AbortableTaskQueue.h"
 #include "GStreamerCommon.h"
 #include "MainThreadNotifier.h"
+#include "MediaPlayerPrivateGStreamer.h"
 #include <gst/gst.h>
 #include <wtf/Lock.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
 class TrackPrivateBase;
 using TrackID = uint64_t;
+enum GStreamerTrackType {
+    Audio,
+    Video,
+    Text,
+    Unknown
+};
 
-class TrackPrivateBaseGStreamer {
+class TrackPrivateBaseGStreamer;
+class TrackDataHolder : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<TrackDataHolder> {
+    WTF_MAKE_TZONE_ALLOCATED(TrackDataHolder);
+    WTF_MAKE_NONCOPYABLE(TrackDataHolder);
+
 public:
-    virtual ~TrackPrivateBaseGStreamer();
+    static Ref<TrackDataHolder> create(TrackPrivateBaseGStreamer& track)
+    {
+        return adoptRef(*new TrackDataHolder(track));
+    }
+    virtual ~TrackDataHolder();
 
-    enum TrackType {
-        Audio,
-        Video,
-        Text,
-        Unknown
-    };
-
-    GstPad* pad() const { return m_pad.get(); }
     void setPad(GRefPtr<GstPad>&&);
+    void setStream(GRefPtr<GstStream>&&);
 
-    virtual void disconnect();
+    void disconnect();
 
-    virtual void setActive(bool) { }
-
-    unsigned index() { return m_index; };
-    void setIndex(unsigned index) { m_index =  index; }
-
-    GstStream* stream() const { return m_stream.get(); }
-
-    // Used for MSE, where the initial caps of the pad are relevant for initializing the matching pad in the
-    // playback pipeline.
-    void setInitialCaps(GRefPtr<GstCaps>&& caps) { m_initialCaps = WTF::move(caps); }
-    const GRefPtr<GstCaps>& initialCaps() { return m_initialCaps; }
-
-    TrackID streamId() const { return m_id; }
-    const String& gstStreamId() const LIFETIME_BOUND { return m_gstStreamId; }
-
-    virtual void updateConfigurationFromCaps(GRefPtr<GstCaps>&&) { }
-
-protected:
-    TrackPrivateBaseGStreamer(TrackType, TrackPrivateBase*, unsigned index, GRefPtr<GstPad>&&, bool shouldHandleStreamStartEvent);
-    TrackPrivateBaseGStreamer(TrackType, TrackPrivateBase*, unsigned index, GRefPtr<GstPad>&&, TrackID);
-    TrackPrivateBaseGStreamer(TrackType, TrackPrivateBase*, unsigned index, GstStream*);
-
+    void tagsChanged();
     void notifyTrackOfTagsChanged();
-    void notifyTrackOfStreamChanged();
+
+    void streamIdChanged();
+    void streamChanged();
+    void installUpdateConfigurationHandlers();
+    bool updateTrackIDFromTags(const GRefPtr<GstTagList>&);
 
     GstObject* objectForLogging() const;
-
-    virtual void tagsChanged(GRefPtr<GstTagList>&&) { }
-    virtual void capsChanged(TrackID, GRefPtr<GstCaps>&&) { }
-    void installUpdateConfigurationHandlers();
-    virtual void updateConfigurationFromTags(GRefPtr<GstTagList>&&) { }
-
-    static GRefPtr<GstTagList> getAllTags(const GRefPtr<GstPad>&);
 
     enum MainThreadNotification {
         TagsChanged = 1 << 1,
@@ -96,7 +82,8 @@ protected:
     };
 
     Ref<MainThreadNotifier<MainThreadNotification>> m_notifier;
-    unsigned m_index;
+    // FIXME: this should be optional...
+    unsigned m_index { 0 };
     String m_label;
     String m_language;
     String m_gstStreamId;
@@ -111,23 +98,63 @@ protected:
 
     // Track ID inferred from container-specific-track-id tag.
     std::optional<TrackID> m_trackID;
-    bool updateTrackIDFromTags(const GRefPtr<GstTagList>&);
 
-private:
-    std::optional<String> getLanguageCode(GstTagList*);
-    static String generateUniquePlaybin2StreamID(TrackType, unsigned index);
-    static char prefixForType(TrackType);
-    std::optional<String> getTag(GstTagList* tags, ASCIILiteral tagName);
-
-    void streamChanged();
-    void tagsChanged();
-
-    TrackType m_type;
-    TrackPrivateBase* m_owner;
+    GStreamerTrackType m_type;
+    ThreadSafeWeakPtr<TrackPrivateBase> m_owner;
     Lock m_tagMutex;
-    GRefPtr<GstTagList> m_tags;
+    GRefPtr<GstTagList> m_tags WTF_GUARDED_BY_LOCK(m_tagMutex);
     bool m_shouldUsePadStreamId { true };
     bool m_shouldHandleStreamStartEvent { true };
+
+    ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer> m_player;
+
+    // The owning track, its lifetime is the same as its TrackDataHolder reference.
+    TrackPrivateBaseGStreamer& m_track;
+private:
+    TrackDataHolder(TrackPrivateBaseGStreamer&);
+
+    gulong m_streamTagsNotifyHandlerId { 0 };
+    gulong m_streamCapsNotifyHandlerId { 0 };
+    gulong m_padTagsNotifyHandlerId { 0 };
+    gulong m_padCapsNotifyHandlerId { 0 };
+};
+
+class TrackPrivateBaseGStreamer {
+public:
+    friend class AudioTrackPrivateGStreamer;
+    friend class InbandTextTrackPrivateGStreamer;
+    friend class VideoTrackPrivateGStreamer;
+
+    void disconnect();
+    void setPad(GRefPtr<GstPad>&&);
+    GRefPtr<GstPad> pad() const;
+
+    virtual void setActive(bool) { }
+
+    unsigned index();
+    void setIndex(unsigned);
+
+    GRefPtr<GstStream> stream() const;
+
+    // Used for MSE, where the initial caps of the pad are relevant for initializing the matching pad in the
+    // playback pipeline.
+    void setInitialCaps(GRefPtr<GstCaps>&&);
+    GRefPtr<GstCaps> initialCaps();
+
+    TrackID streamId() const;
+    String gstStreamId() const;
+
+    virtual void updateConfigurationFromCaps(GRefPtr<GstCaps>&&) { }
+    virtual void tagsChanged(GRefPtr<GstTagList>&&) { }
+    virtual void capsChanged(TrackID, GRefPtr<GstCaps>&&) { }
+    virtual void updateConfigurationFromTags(GRefPtr<GstTagList>&&) { }
+
+private:
+    TrackPrivateBaseGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&&, GStreamerTrackType, TrackPrivateBase*, unsigned index, GRefPtr<GstPad>&&, bool shouldHandleStreamStartEvent);
+    TrackPrivateBaseGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&&, GStreamerTrackType, TrackPrivateBase*, unsigned index, GRefPtr<GstPad>&&, TrackID);
+    TrackPrivateBaseGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&&, GStreamerTrackType, TrackPrivateBase*, unsigned index, GstStream*);
+
+    const Ref<TrackDataHolder> m_data;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp
@@ -51,32 +51,26 @@ static void ensureVideoTrackDebugCategoryInitialized()
 }
 
 VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&& player, unsigned index, GRefPtr<GstPad>&& pad, bool shouldHandleStreamStartEvent)
-    : TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Video, this, index, WTF::move(pad), shouldHandleStreamStartEvent)
-    , m_player(WTF::move(player))
+    : TrackPrivateBaseGStreamer(WTF::move(player), GStreamerTrackType::Video, this, index, WTF::move(pad), shouldHandleStreamStartEvent)
 {
     ensureVideoTrackDebugCategoryInitialized();
-    installUpdateConfigurationHandlers();
 }
 
 VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&& player, unsigned index, GRefPtr<GstPad>&& pad, TrackID trackId)
-    : TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Video, this, index, WTF::move(pad), trackId)
-    , m_player(WTF::move(player))
+    : TrackPrivateBaseGStreamer(WTF::move(player), GStreamerTrackType::Video, this, index, WTF::move(pad), trackId)
 {
     ensureVideoTrackDebugCategoryInitialized();
-    installUpdateConfigurationHandlers();
 }
 
 VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&& player, unsigned index, GstStream* stream)
-    : TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Video, this, index, stream)
-    , m_player(WTF::move(player))
+    : TrackPrivateBaseGStreamer(WTF::move(player), GStreamerTrackType::Video, this, index, stream)
 {
     ensureVideoTrackDebugCategoryInitialized();
-    installUpdateConfigurationHandlers();
 
-    auto caps = adoptGRef(gst_stream_get_caps(m_stream.get()));
+    auto caps = adoptGRef(gst_stream_get_caps(m_data->m_stream.get()));
     updateConfigurationFromCaps(WTF::move(caps));
 
-    auto tags = adoptGRef(gst_stream_get_tags(m_stream.get()));
+    auto tags = adoptGRef(gst_stream_get_tags(m_data->m_stream.get()));
     updateConfigurationFromTags(WTF::move(tags));
 }
 
@@ -85,7 +79,7 @@ void VideoTrackPrivateGStreamer::capsChanged(TrackID streamId, GRefPtr<GstCaps>&
     ASSERT(isMainThread());
     updateConfigurationFromCaps(WTF::move(caps));
 
-    RefPtr player = m_player.get();
+    RefPtr player = m_data->m_player.get();
     if (!player)
         return;
 
@@ -94,7 +88,7 @@ void VideoTrackPrivateGStreamer::capsChanged(TrackID streamId, GRefPtr<GstCaps>&
         return;
 
     auto configuration = this->configuration();
-    GST_DEBUG_OBJECT(objectForLogging(), "Setting codec to %s", codec.ascii().data());
+    GST_DEBUG_OBJECT(m_data->objectForLogging(), "Setting codec to %s", codec.ascii().data());
     configuration.codec = WTF::move(codec);
     setConfiguration(WTF::move(configuration));
 }
@@ -102,13 +96,13 @@ void VideoTrackPrivateGStreamer::capsChanged(TrackID streamId, GRefPtr<GstCaps>&
 void VideoTrackPrivateGStreamer::updateConfigurationFromTags(GRefPtr<GstTagList>&& tags)
 {
     ASSERT(isMainThread());
-    GST_DEBUG_OBJECT(objectForLogging(), "Updating video configuration from %" GST_PTR_FORMAT, tags.get());
     if (!tags)
         return;
 
-    if (updateTrackIDFromTags(tags)) {
-        GST_DEBUG_OBJECT(objectForLogging(), "Video track ID set from container-specific-track-id tag %" G_GUINT64_FORMAT, *m_trackID);
-        notifyClients([trackID = *m_trackID](auto& client) {
+    GST_DEBUG_OBJECT(m_data->objectForLogging(), "Updating video configuration from %" GST_PTR_FORMAT, tags.get());
+    if (m_data->updateTrackIDFromTags(tags)) {
+        GST_DEBUG_OBJECT(m_data->objectForLogging(), "Video track ID set from container-specific-track-id tag %" G_GUINT64_FORMAT, *m_data->m_trackID);
+        notifyClients([trackID = *m_data->m_trackID](auto& client) {
             client.idChanged(trackID);
         });
     }
@@ -117,7 +111,7 @@ void VideoTrackPrivateGStreamer::updateConfigurationFromTags(GRefPtr<GstTagList>
     if (!gst_tag_list_get_uint(tags.get(), GST_TAG_BITRATE, &bitrate))
         return;
 
-    GST_DEBUG_OBJECT(objectForLogging(), "Setting bitrate to %u", bitrate);
+    GST_DEBUG_OBJECT(m_data->objectForLogging(), "Setting bitrate to %u", bitrate);
     auto configuration = this->configuration();
     configuration.bitrate = bitrate;
     setConfiguration(WTF::move(configuration));
@@ -129,7 +123,7 @@ void VideoTrackPrivateGStreamer::updateConfigurationFromCaps(GRefPtr<GstCaps>&& 
     if (!caps || !gst_caps_is_fixed(caps.get()))
         return;
 
-    GST_DEBUG_OBJECT(objectForLogging(), "Updating video configuration from %" GST_PTR_FORMAT, caps.get());
+    GST_DEBUG_OBJECT(m_data->objectForLogging(), "Updating video configuration from %" GST_PTR_FORMAT, caps.get());
     auto configuration = this->configuration();
     auto scopeExit = makeScopeExit([&] {
         setConfiguration(WTF::move(configuration));
@@ -173,23 +167,10 @@ void VideoTrackPrivateGStreamer::updateConfigurationFromCaps(GRefPtr<GstCaps>&& 
 
 VideoTrackPrivate::Kind VideoTrackPrivateGStreamer::kind() const
 {
-    if (m_stream && gst_stream_get_stream_flags(m_stream.get()) & GST_STREAM_FLAG_SELECT)
+    if (m_data->m_stream && gst_stream_get_stream_flags(m_data->m_stream.get()) & GST_STREAM_FLAG_SELECT)
         return VideoTrackPrivate::Kind::Main;
 
     return VideoTrackPrivate::kind();
-}
-
-void VideoTrackPrivateGStreamer::disconnect()
-{
-    m_taskQueue.startAborting();
-
-    if (m_stream)
-        g_signal_handlers_disconnect_matched(m_stream.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
-
-    m_player = nullptr;
-    TrackPrivateBaseGStreamer::disconnect();
-
-    m_taskQueue.finishAborting();
 }
 
 void VideoTrackPrivateGStreamer::setSelected(bool selected)
@@ -198,14 +179,44 @@ void VideoTrackPrivateGStreamer::setSelected(bool selected)
         return;
     VideoTrackPrivate::setSelected(selected);
 
-    RefPtr player = m_player.get();
-    if (player) {
-        // On MSE, the player holds its own set of tracks, independent from the ones SourceBuffer
-        // reported to HTMLMediaElement. We need to synchronize the enabled status of the player
-        // mirror when the element one changed. Fortunately, both share the same trackId.
-        player->mirrorEnabledVideoTrackIfNeeded(*this);
-        player->updateEnabledVideoTrack();
-    }
+    RefPtr player = m_data->m_player.get();
+    if (!player)
+        return;
+
+    // On MSE, the player holds its own set of tracks, independent from the ones SourceBuffer
+    // reported to HTMLMediaElement. We need to synchronize the enabled status of the player
+    // mirror when the element one changed. Fortunately, both share the same trackId.
+    player->mirrorEnabledVideoTrackIfNeeded(*this);
+    player->updateEnabledVideoTrack();
+}
+
+int VideoTrackPrivateGStreamer::trackIndex() const
+{
+    return m_data->m_index;
+}
+
+TrackID VideoTrackPrivateGStreamer::id() const
+{
+    return m_data->m_trackID.value_or(m_data->m_id);
+}
+
+std::optional<String> VideoTrackPrivateGStreamer::trackUID() const
+{
+    auto player = m_data->m_player.get();
+    if (player && player->isMediaStreamPlayer())
+        return m_data->m_gstStreamId;
+
+    return std::nullopt;
+}
+
+String VideoTrackPrivateGStreamer::label() const
+{
+    return m_data->m_label;
+}
+
+String VideoTrackPrivateGStreamer::language() const
+{
+    return m_data->m_language;
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h
@@ -56,26 +56,16 @@ public:
 
     Kind kind() const final;
 
-    void disconnect() final;
-
     void setSelected(bool) final;
     void setActive(bool enabled) final { setSelected(enabled); }
 
-    int trackIndex() const final { return m_index; }
+    int trackIndex() const final;
 
-    TrackID id() const final { return m_trackID.value_or(m_id); }
-    std::optional<String> trackUID() const final
-    {
-        auto player = m_player.get();
+    TrackID id() const final;
+    std::optional<String> trackUID() const final;
 
-        if (player && player->isMediaStreamPlayer())
-            return m_gstStreamId;
-
-        return std::nullopt;
-    }
-
-    String label() const final { return m_label; }
-    String language() const final { return m_language; }
+    String label() const final;
+    String language() const final;
 
     void updateConfigurationFromCaps(GRefPtr<GstCaps>&&) final;
 
@@ -89,8 +79,6 @@ private:
     VideoTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&&, unsigned index, GRefPtr<GstPad>&&, bool shouldHandleStreamStartEvent);
     VideoTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&&, unsigned index, GRefPtr<GstPad>&&, TrackID);
     VideoTrackPrivateGStreamer(ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer>&&, unsigned index, GstStream*);
-
-    ThreadSafeWeakPtr<MediaPlayerPrivateGStreamer> m_player;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -574,7 +574,7 @@ void MediaPlayerPrivateGStreamerMSE::emitStreams(const Vector<RefPtr<MediaSource
         if (!uniqueTracks.containsIf([&track](const auto& current) { return track->id() == current->id(); })) {
             uniqueTracks.append(track);
 
-            if (track->type() != TrackPrivateBaseGStreamer::Text)
+            if (track->type() != GStreamerTrackType::Text)
                 playbackTracks.append(track);
             else
                 GST_DEBUG("Ignoring text track with id %" PRIu64, track->id());

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.h
@@ -74,7 +74,7 @@ public:
 
     void detach();
 
-    // Similar to TrackPrivateBaseGStreamer::TrackType, but with a new value (Invalid) for when the codec is
+    // Similar to WebCore::GStreamerTrackType, but with a new value (Invalid) for when the codec is
     // not supported on this system, which should result in ParsingFailed error being thrown in SourceBuffer.
     enum StreamType { Audio, Video, Text, Unknown, Invalid };
 

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.cpp
@@ -39,7 +39,7 @@ GST_DEBUG_CATEGORY_STATIC(webkit_mse_track_debug);
 
 namespace WebCore {
 
-MediaSourceTrackGStreamer::MediaSourceTrackGStreamer(TrackPrivateBaseGStreamer::TrackType type, TrackID trackId, GRefPtr<GstCaps>&& initialCaps)
+MediaSourceTrackGStreamer::MediaSourceTrackGStreamer(GStreamerTrackType type, TrackID trackId, GRefPtr<GstCaps>&& initialCaps)
     : m_type(type)
     , m_id(trackId)
     , m_initialCaps(WTF::move(initialCaps))
@@ -56,7 +56,7 @@ MediaSourceTrackGStreamer::~MediaSourceTrackGStreamer()
     ASSERT(m_isRemoved);
 }
 
-Ref<MediaSourceTrackGStreamer> MediaSourceTrackGStreamer::create(TrackPrivateBaseGStreamer::TrackType type, TrackID trackId, GRefPtr<GstCaps>&& initialCaps)
+Ref<MediaSourceTrackGStreamer> MediaSourceTrackGStreamer::create(GStreamerTrackType type, TrackID trackId, GRefPtr<GstCaps>&& initialCaps)
 {
     return adoptRef(*new MediaSourceTrackGStreamer(type, trackId, WTF::move(initialCaps)));
 }

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourceTrackGStreamer.h
@@ -41,10 +41,10 @@ namespace WebCore {
 
 class MediaSourceTrackGStreamer final: public ThreadSafeRefCounted<MediaSourceTrackGStreamer> {
 public:
-    static Ref<MediaSourceTrackGStreamer> create(TrackPrivateBaseGStreamer::TrackType, TrackID, GRefPtr<GstCaps>&& initialCaps);
+    static Ref<MediaSourceTrackGStreamer> create(GStreamerTrackType, TrackID, GRefPtr<GstCaps>&& initialCaps);
     ~MediaSourceTrackGStreamer();
 
-    TrackPrivateBaseGStreamer::TrackType type() const { return m_type; }
+    GStreamerTrackType type() const { return m_type; }
     TrackID id() const { return m_id; }
     GRefPtr<GstCaps>& initialCaps() { return m_initialCaps; }
     DataMutex<TrackQueue>& queueDataMutex() LIFETIME_BOUND { return m_queueDataMutex; }
@@ -64,9 +64,9 @@ public:
     void remove();
 
 private:
-    explicit MediaSourceTrackGStreamer(TrackPrivateBaseGStreamer::TrackType, TrackID, GRefPtr<GstCaps>&& initialCaps);
+    explicit MediaSourceTrackGStreamer(GStreamerTrackType, TrackID, GRefPtr<GstCaps>&& initialCaps);
 
-    TrackPrivateBaseGStreamer::TrackType m_type;
+    GStreamerTrackType m_type;
     TrackID m_id;
     GRefPtr<GstCaps> m_initialCaps;
     DataMutex<TrackQueue> m_queueDataMutex;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -188,7 +188,7 @@ void SourceBufferPrivateGStreamer::flush(TrackID trackId)
         return;
     }
 
-    if (track->type() == TrackPrivateBaseGStreamer::Text) {
+    if (track->type() == GStreamerTrackType::Text) {
         if (player)
             GST_DEBUG_OBJECT(player->pipeline(), "Track is a text stream, so we only need to clear the queue. trackId = '%" PRIu64 "'", track->id());
         track->clearQueue();
@@ -222,7 +222,7 @@ void SourceBufferPrivateGStreamer::enqueueSample(Ref<MediaSample>&& sample, Trac
     auto track = m_tracks[trackId];
 
 #ifndef GST_DISABLE_GST_DEBUG
-    if (player && track->type() == TrackPrivateBaseGStreamer::Text) {
+    if (player && track->type() == GStreamerTrackType::Text) {
         GstMappedBuffer mappedBuffer(gst_sample_get_buffer(gstSample.get()), GST_MAP_READ);
 
         if (mappedBuffer) [[likely]] {
@@ -277,21 +277,21 @@ bool SourceBufferPrivateGStreamer::precheckInitializationSegment(const Initializ
         GRefPtr<GstCaps> initialCaps = videoTrackInfo->initialCaps();
         ASSERT(initialCaps);
         if (!m_tracks.contains(videoTrackInfo->id()))
-            m_tracks.try_emplace(videoTrackInfo->id(), MediaSourceTrackGStreamer::create(TrackPrivateBaseGStreamer::TrackType::Video, videoTrackInfo->id(), WTF::move(initialCaps)));
+            m_tracks.try_emplace(videoTrackInfo->id(), MediaSourceTrackGStreamer::create(GStreamerTrackType::Video, videoTrackInfo->id(), WTF::move(initialCaps)));
     }
     for (auto& trackInfo : segment.audioTracks) {
         auto* audioTrackInfo = static_cast<AudioTrackPrivateGStreamer*>(trackInfo.track.get());
         GRefPtr<GstCaps> initialCaps = audioTrackInfo->initialCaps();
         ASSERT(initialCaps);
         if (!m_tracks.contains(audioTrackInfo->id()))
-            m_tracks.try_emplace(audioTrackInfo->id(), MediaSourceTrackGStreamer::create(TrackPrivateBaseGStreamer::TrackType::Audio, audioTrackInfo->id(), WTF::move(initialCaps)));
+            m_tracks.try_emplace(audioTrackInfo->id(), MediaSourceTrackGStreamer::create(GStreamerTrackType::Audio, audioTrackInfo->id(), WTF::move(initialCaps)));
     }
     for (auto& trackInfo : segment.textTracks) {
         auto* textTrackInfo = static_cast<InbandTextTrackPrivateGStreamer*>(trackInfo.track.get());
         GRefPtr<GstCaps> initialCaps = textTrackInfo->initialCaps();
         ASSERT(initialCaps);
         if (!m_tracks.contains(textTrackInfo->id()))
-            m_tracks.try_emplace(textTrackInfo->id(), MediaSourceTrackGStreamer::create(TrackPrivateBaseGStreamer::TrackType::Text, textTrackInfo->id(), WTF::move(initialCaps)));
+            m_tracks.try_emplace(textTrackInfo->id(), MediaSourceTrackGStreamer::create(GStreamerTrackType::Text, textTrackInfo->id(), WTF::move(initialCaps)));
     }
 
     return true;
@@ -409,13 +409,13 @@ size_t SourceBufferPrivateGStreamer::platformMaximumBufferSize() const
 
         for (auto& [_, track] : m_tracks) {
             switch (track->type()) {
-            case TrackPrivateBaseGStreamer::Video:
+            case GStreamerTrackType::Video:
                 hasVideo = true;
                 break;
-            case TrackPrivateBaseGStreamer::Audio:
+            case GStreamerTrackType::Audio:
                 hasAudio = true;
                 break;
-            case TrackPrivateBaseGStreamer::Text:
+            case GStreamerTrackType::Text:
                 hasText = true;
                 break;
             default:

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -203,14 +203,14 @@ static void dumpPipeline([[maybe_unused]] ASCIILiteral description, [[maybe_unus
 #endif
 }
 
-static GstStreamType gstStreamType(TrackPrivateBaseGStreamer::TrackType type)
+static GstStreamType gstStreamType(GStreamerTrackType type)
 {
     switch (type) {
-    case TrackPrivateBaseGStreamer::TrackType::Video:
+    case GStreamerTrackType::Video:
         return GST_STREAM_TYPE_VIDEO;
-    case TrackPrivateBaseGStreamer::TrackType::Audio:
+    case GStreamerTrackType::Audio:
         return GST_STREAM_TYPE_AUDIO;
-    case TrackPrivateBaseGStreamer::TrackType::Text:
+    case GStreamerTrackType::Text:
         return GST_STREAM_TYPE_TEXT;
     default:
         GST_ERROR("Received unexpected stream type");
@@ -219,17 +219,17 @@ static GstStreamType gstStreamType(TrackPrivateBaseGStreamer::TrackType type)
 }
 
 #ifndef GST_DISABLE_GST_DEBUG
-static ASCIILiteral streamTypeToString(TrackPrivateBaseGStreamer::TrackType type)
+static ASCIILiteral streamTypeToString(GStreamerTrackType type)
 {
     switch (type) {
-    case TrackPrivateBaseGStreamer::TrackType::Audio:
+    case GStreamerTrackType::Audio:
         return "Audio"_s;
-    case TrackPrivateBaseGStreamer::TrackType::Video:
+    case GStreamerTrackType::Video:
         return "Video"_s;
-    case TrackPrivateBaseGStreamer::TrackType::Text:
+    case GStreamerTrackType::Text:
         return "Text"_s;
     default:
-    case TrackPrivateBaseGStreamer::TrackType::Unknown:
+    case GStreamerTrackType::Unknown:
         return "Unknown"_s;
     }
 }
@@ -603,7 +603,7 @@ static void webKitMediaSrcLoop(void* userData)
         ASSERT(GST_BUFFER_PTS_IS_VALID(buffer.get()));
         GST_TRACE_OBJECT(pad, "Pushing buffer downstream: %" GST_PTR_FORMAT, buffer.get());
         GstFlowReturn result = gst_pad_push(pad, buffer.leakRef());
-        if (result == GST_FLOW_NOT_LINKED && stream->track->type() == TrackPrivateBaseGStreamer::TrackType::Video) {
+        if (result == GST_FLOW_NOT_LINKED && stream->track->type() == GStreamerTrackType::Video) {
             // We allow multiple video tracks and all of them except one may be unlinked. Just drop the buffer.
             GST_TRACE_OBJECT(pad, "Buffer not pushed because pad is not-linked, ignoring");
         } else if (result != GST_FLOW_OK && result != GST_FLOW_FLUSHING) {
@@ -773,7 +773,7 @@ static void webKitMediaSrcSeek(WebKitMediaSrc* source, uint64_t startTime, doubl
         webKitMediaSrcStreamFlush(stream.get(), true);
 }
 
-static int countStreamsOfType(WebKitMediaSrc* source, WebCore::TrackPrivateBaseGStreamer::TrackType type)
+static int countStreamsOfType(WebKitMediaSrc* source, WebCore::GStreamerTrackType type)
 {
     // Barring pipeline dumps someone may add during debugging, WebKit will only read these properties (n-video etc.) from the main thread.
     return std::count_if(source->priv->streams.begin(), source->priv->streams.end(), [type](auto item) {
@@ -787,13 +787,13 @@ static void webKitMediaSrcGetProperty(GObject* object, unsigned propId, GValue* 
 
     switch (propId) {
     case WEBKIT_MEDIA_SRC_PROP_N_AUDIO:
-        g_value_set_int(value, countStreamsOfType(source, WebCore::TrackPrivateBaseGStreamer::TrackType::Audio));
+        g_value_set_int(value, countStreamsOfType(source, WebCore::GStreamerTrackType::Audio));
         break;
     case WEBKIT_MEDIA_SRC_PROP_N_VIDEO:
-        g_value_set_int(value, countStreamsOfType(source, WebCore::TrackPrivateBaseGStreamer::TrackType::Video));
+        g_value_set_int(value, countStreamsOfType(source, WebCore::GStreamerTrackType::Video));
         break;
     case WEBKIT_MEDIA_SRC_PROP_N_TEXT:
-        g_value_set_int(value, countStreamsOfType(source, WebCore::TrackPrivateBaseGStreamer::TrackType::Text));
+        g_value_set_int(value, countStreamsOfType(source, WebCore::GStreamerTrackType::Text));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID(object, propId, pspec);


### PR DESCRIPTION
#### da7090ba5483bfeccd47bc50ca2df45ec907aa77
<pre>
[GStreamer] media-elements/loading-the-media-resource/resource-selection-source-media-env-change.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=309434">https://bugs.webkit.org/show_bug.cgi?id=309434</a>

Reviewed by Xabier Rodriguez-Calvar.

This patch refactors the TrackPrivateBaseGStreamer data in a new class that can be used as a weak
pointer for GObject signal handlers. TrackPrivateBaseGStreamer itself can&apos;t be made WeakPtr-able
because it is part of mixins inheriting from TrackPrivateBase which is a
ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr.

Canonical link: <a href="https://commits.webkit.org/308971@main">https://commits.webkit.org/308971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af64bb28a531327f23fa1406edbb78dc1a0ed2d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15330 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157735 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114904 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17090 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133767 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95664 "Failed to checkout and rebase branch from PR 60161") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14057 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5585 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160217 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3207 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13214 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122957 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21562 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123184 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33487 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133485 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77758 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18442 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10244 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21172 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84974 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20904 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21052 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->