### PR TITLE
WidthIterator::applyExtraSpacingAfterShaping: Extract applyTextAutospaceIfNeededAndGetCharacterClass

### DIFF
--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -645,6 +645,20 @@ static void applyHorizontalGlyphStretch(GlyphBuffer& glyphBuffer, unsigned glyph
     }
 }
 
+TextSpacing::CharacterClass WidthIterator::applyTextAutospaceIfNeededAndGetCharacterClass(GlyphBuffer& glyphBuffer, const TextAutospace& textAutospace, unsigned characterIndex, GlyphIndexRange glyphIndexRange, TextSpacing::CharacterClass previousCharacterClass)
+{
+    if (textAutospace.isNoAutospace())
+        return TextSpacing::CharacterClass::Undefined;
+
+    auto currentCharacterClass = TextSpacing::characterClass(m_run.get()[characterIndex]);
+    if (textAutospace.shouldApplySpacing(currentCharacterClass, previousCharacterClass)) {
+        auto textAutospaceSpacing = TextAutospace::textAutospaceSize(protect(glyphBuffer.fontAt(glyphIndexRange.leadingGlyphIndex)));
+        glyphBuffer.expandAdvanceToLogicalRight(glyphIndexRange.leadingGlyphIndex, textAutospaceSpacing);
+        m_runWidthSoFar += textAutospaceSpacing;
+    }
+    return currentCharacterClass;
+}
+
 void WidthIterator::applyExtraSpacingAfterShaping(GlyphBuffer& glyphBuffer, unsigned characterStartIndex, unsigned glyphBufferStartIndex, unsigned characterDestinationIndex, float startingRunWidth)
 {
     auto [characterIndexToGlyphIndexRange, advanceWidths] = buildCharacterToGlyphMapping(glyphBuffer, glyphBufferStartIndex, m_run->length());
@@ -661,17 +675,7 @@ void WidthIterator::applyExtraSpacingAfterShaping(GlyphBuffer& glyphBuffer, unsi
         auto width = calculateAdditionalWidth(glyphBuffer, characterIndex, glyphIndexRange->leadingGlyphIndex, glyphIndexRange->trailingGlyphIndex, position);
         applyAdditionalWidth(glyphBuffer, glyphIndexRange.value(), width.left, width.right, width.leftExpansion, width.rightExpansion);
 
-        auto textAutospaceSpacing = 0.f;
-        auto characterClass = TextSpacing::CharacterClass::Undefined;
-        if (!textAutospace.isNoAutospace()) {
-            characterClass = TextSpacing::characterClass(m_run.get()[characterIndex]);
-            if (textAutospace.shouldApplySpacing(characterClass, previousCharacterClass)) {
-                textAutospaceSpacing = TextAutospace::textAutospaceSize(protect(glyphBuffer.fontAt(glyphIndexRange->leadingGlyphIndex)));
-                glyphBuffer.expandAdvanceToLogicalRight(glyphIndexRange->leadingGlyphIndex, textAutospaceSpacing);
-                m_runWidthSoFar += textAutospaceSpacing;
-            }
-        }
-        previousCharacterClass = characterClass;
+        previousCharacterClass = applyTextAutospaceIfNeededAndGetCharacterClass(glyphBuffer, textAutospace, characterIndex, *glyphIndexRange, previousCharacterClass);
 
         m_isAfterExpansion = (ltr() && width.rightExpansion) || (rtl() && width.leftExpansion);
 

--- a/Source/WebCore/platform/graphics/WidthIterator.h
+++ b/Source/WebCore/platform/graphics/WidthIterator.h
@@ -34,12 +34,17 @@ namespace WebCore {
 class FontCascade;
 class FontCascadeDescription;
 class Font;
+class TextAutospace;
 class TextRun;
 struct GlyphData;
 struct GlyphIndexRange;
 struct OriginalAdvancesForCharacterTreatedAsSpace;
 struct AdvanceInternalState;
 struct SmallCapsState;
+
+namespace TextSpacing {
+enum class CharacterClass : uint8_t;
+}
 
 using CharactersTreatedAsSpace = Vector<OriginalAdvancesForCharacterTreatedAsSpace, 64>;
 
@@ -81,6 +86,7 @@ private:
 
     bool hasExtraSpacing() const;
     void applyExtraSpacingAfterShaping(GlyphBuffer&, unsigned characterStartIndex, unsigned glyphBufferStartIndex, unsigned characterDestinationIndex, float startingRunWidth);
+    TextSpacing::CharacterClass applyTextAutospaceIfNeededAndGetCharacterClass(GlyphBuffer&, const TextAutospace&, unsigned characterIndex, GlyphIndexRange, TextSpacing::CharacterClass previousCharacterClass);
     void applyCSSVisibilityRules(GlyphBuffer&, unsigned glyphBufferStartIndex);
 
     struct AdditionalWidth {


### PR DESCRIPTION
#### 8b67517931448d7ab76f246138f722ef693935d4
<pre>
WidthIterator::applyExtraSpacingAfterShaping: Extract applyTextAutospaceIfNeededAndGetCharacterClass
<a href="https://bugs.webkit.org/show_bug.cgi?id=309464">https://bugs.webkit.org/show_bug.cgi?id=309464</a>
<a href="https://rdar.apple.com/172040208">rdar://172040208</a>

Reviewed by Sammy Gill.

Extract the text-autospace logic from applyTextAutospaceIfNeededAndGetCharacterClass
into its own method for readability.

* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::applyTextAutospaceIfNeededAndGetCharacterClass):
(WebCore::WidthIterator::applyExtraSpacingAfterShaping):
* Source/WebCore/platform/graphics/WidthIterator.h:

Canonical link: <a href="https://commits.webkit.org/308953@main">https://commits.webkit.org/308953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c1e086cf378105baf4f094dd47eba50d8a78626

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157684 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114860 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/173c159c-1c06-4b76-9151-f3bd1f72f1ae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151956 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/17049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95618 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/5533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160166 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122915 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123142 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33472 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133446 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/10204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/21121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/21001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->