### PR TITLE
Respect zero intrinsic size for SVG in object/embed elements

### DIFF
--- a/LayoutTests/svg/custom/object-sizing-zero-intrinsic-width-height-expected.txt
+++ b/LayoutTests/svg/custom/object-sizing-zero-intrinsic-width-height-expected.txt
@@ -1,0 +1,8 @@
+
+
+PASS SVG in <object> with zero intrinsic size - 0x0
+PASS SVG in <object> with zero intrinsic size - 50x0
+PASS SVG in <object> with zero intrinsic size - 0x50
+PASS SVG in <object> with zero intrinsic size - 0x150
+PASS SVG in <object> with zero intrinsic size - 300x0
+

--- a/LayoutTests/svg/custom/object-sizing-zero-intrinsic-width-height.html
+++ b/LayoutTests/svg/custom/object-sizing-zero-intrinsic-width-height.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<title>SVG in &lt;object> with zero intrinsic size</title>
+<script src=../../resources/testharness.js></script>
+<script src=../../resources/testharnessreport.js></script>
+<object data-expected="0x0" data="data:image/svg+xml,
+    <svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='0' height='0'>
+        <rect width='50' height='50' fill='red'/>
+    </svg>"></object>
+<object data-expected="50x0" data="data:image/svg+xml,
+    <svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='50' height='0'>
+        <rect width='50' height='50' fill='red'/>
+    </svg>"></object>
+<object data-expected="0x50" data="data:image/svg+xml,
+    <svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='0' height='50'>
+        <rect width='50' height='50' fill='red'/>
+    </svg>"></object>
+<object data-expected="0x150" data="data:image/svg+xml,
+    <svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='0'>
+        <rect width='50' height='50' fill='red'/>
+    </svg>"></object>
+<object data-expected="300x0" data="data:image/svg+xml,
+    <svg xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' height='0'>
+        <rect width='50' height='50' fill='red'/>
+    </svg>"></object>
+<script>
+Array.prototype.forEach.call(document.querySelectorAll('object'), function(element) {
+    var t = async_test(document.title + " - " + element.dataset.expected);
+    element.onload = function() {
+        requestAnimationFrame(t.step_func(function() {
+            var clientRect = element.getBoundingClientRect();
+            assert_equals(clientRect.width + "x" + clientRect.height, element.dataset.expected);
+            t.done();
+        }));
+    }
+});
+</script>

--- a/Source/WebCore/rendering/RenderEmbeddedObject.cpp
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.cpp
@@ -39,8 +39,10 @@
 #include "HTMLParamElement.h"
 #include "HTMLPlugInElement.h"
 #include "HitTestResult.h"
+#include "LegacyRenderSVGRoot.h"
 #include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"
+#include "LocalFrameView.h"
 #include "LocalizedStrings.h"
 #include "MouseEvent.h"
 #include "Page.h"
@@ -50,9 +52,11 @@
 #include "RenderBoxInlines.h"
 #include "RenderLayoutState.h"
 #include "RenderObjectInlines.h"
+#include "RenderSVGRoot.h"
 #include "RenderTheme.h"
 #include "RenderView.h"
 #include "RenderWidgetInlines.h"
+#include "SVGSVGElement.h"
 #include "Settings.h"
 #include "SystemFontDatabase.h"
 #include "Text.h"
@@ -108,6 +112,35 @@ bool RenderEmbeddedObject::requiresAcceleratedCompositing() const
     if (!pluginViewBase)
         return false;
     return pluginViewBase->layerHostingStrategy() != PluginLayerHostingStrategy::None;
+}
+
+static RefPtr<SVGSVGElement> embeddedSVGElement(const RenderWidget& renderer)
+{
+    RefPtr frameView = dynamicDowncast<LocalFrameView>(renderer.widget());
+    if (!frameView)
+        return nullptr;
+    CheckedPtr contentBox = frameView->embeddedContentBox();
+    if (!contentBox)
+        return nullptr;
+    if (CheckedPtr svgRoot = dynamicDowncast<RenderSVGRoot>(contentBox.get()))
+        return &svgRoot->svgSVGElement();
+    if (CheckedPtr legacySvgRoot = dynamicDowncast<LegacyRenderSVGRoot>(contentBox.get()))
+        return &legacySvgRoot->svgSVGElement();
+    return nullptr;
+}
+
+bool RenderEmbeddedObject::shouldRespectZeroIntrinsicWidth() const
+{
+    if (RefPtr svgElement = embeddedSVGElement(*this))
+        return svgElement->hasIntrinsicWidth();
+    return false;
+}
+
+bool RenderEmbeddedObject::shouldRespectZeroIntrinsicHeight() const
+{
+    if (RefPtr svgElement = embeddedSVGElement(*this))
+        return svgElement->hasIntrinsicHeight();
+    return false;
 }
 
 ScrollableArea* RenderEmbeddedObject::scrollableArea() const

--- a/Source/WebCore/rendering/RenderEmbeddedObject.h
+++ b/Source/WebCore/rendering/RenderEmbeddedObject.h
@@ -78,6 +78,9 @@ private:
 
     ASCIILiteral renderName() const final { return "RenderEmbeddedObject"_s; }
 
+    bool shouldRespectZeroIntrinsicWidth() const final;
+    bool shouldRespectZeroIntrinsicHeight() const final;
+
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) final;
 
     bool scroll(ScrollDirection, ScrollGranularity, unsigned stepCount = 1, Element** stopElement = nullptr, RenderBox* startBox = nullptr, const IntPoint& wheelEventAbsolutePoint = IntPoint()) final;

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -110,6 +110,11 @@ bool RenderReplaced::shouldRespectZeroIntrinsicWidth() const
     return false;
 }
 
+bool RenderReplaced::shouldRespectZeroIntrinsicHeight() const
+{
+    return false;
+}
+
 void RenderReplaced::willBeDestroyed()
 {
     if (!renderTreeBeingDestroyed() && parent())
@@ -727,7 +732,7 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ShouldComputePreferred sh
     if (style.logicalWidth().isAuto()) {
         bool computedHeightIsAuto = style.logicalHeight().isAuto();
         bool hasIntrinsicWidth = constrainedSize.width() > 0 || (!constrainedSize.width() && shouldRespectZeroIntrinsicWidth()) || shouldApplySizeOrInlineSizeContainment();
-        bool hasIntrinsicHeight = constrainedSize.height() > 0 || shouldApplySizeContainment();
+        bool hasIntrinsicHeight = constrainedSize.height() > 0 || (!constrainedSize.height() && shouldRespectZeroIntrinsicHeight()) || shouldApplySizeContainment();
 
         // For flex or grid items where the logical height has been overriden then we should use that size to compute the replaced width as long as the flex or
         // grid item has an intrinsic size. It is possible (indeed, common) for an SVG graphic to have an intrinsic aspect ratio but not to have an intrinsic
@@ -820,7 +825,7 @@ LayoutUnit RenderReplaced::computeReplacedLogicalHeight(std::optional<LayoutUnit
 
     bool widthIsAuto = style().logicalWidth().isAuto();
     bool hasIntrinsicWidth = constrainedSize.width() > 0 || (!constrainedSize.width() && shouldRespectZeroIntrinsicWidth()) || shouldApplySizeOrInlineSizeContainment();
-    bool hasIntrinsicHeight = constrainedSize.height() > 0 || shouldApplySizeContainment();
+    bool hasIntrinsicHeight = constrainedSize.height() > 0 || (!constrainedSize.height() && shouldRespectZeroIntrinsicHeight()) || shouldApplySizeContainment();
 
     // See computeReplacedLogicalHeight() for a similar check for heights.
     if (auto overridinglogicalWidth = (!intrinsicRatio.isEmpty() && (isFlexItem() || isGridItem()) && hasIntrinsicSize(contentRenderer, hasIntrinsicWidth, hasIntrinsicHeight) ? overridingBorderBoxLogicalWidth() : std::nullopt))

--- a/Source/WebCore/rendering/RenderReplaced.h
+++ b/Source/WebCore/rendering/RenderReplaced.h
@@ -32,6 +32,7 @@ public:
     virtual ~RenderReplaced();
 
     virtual bool shouldRespectZeroIntrinsicWidth() const;
+    virtual bool shouldRespectZeroIntrinsicHeight() const;
 
     void computeReplacedOutOfFlowPositionedLogicalHeight(LogicalExtentComputedValues&) const;
     void computeReplacedOutOfFlowPositionedLogicalWidth(LogicalExtentComputedValues&) const;

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -67,9 +67,9 @@ RenderSVGRoot::RenderSVGRoot(SVGSVGElement& element, RenderStyle&& style)
 {
     ASSERT(isRenderSVGRoot());
     LayoutSize intrinsicSize(computeIntrinsicSize());
-    if (!intrinsicSize.width())
+    if (!intrinsicSize.width() && !svgSVGElement().hasIntrinsicWidth())
         intrinsicSize.setWidth(defaultWidth);
-    if (!intrinsicSize.height())
+    if (!intrinsicSize.height() && !svgSVGElement().hasIntrinsicHeight())
         intrinsicSize.setHeight(defaultHeight);
     setIntrinsicSize(intrinsicSize);
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -65,9 +65,9 @@ LegacyRenderSVGRoot::LegacyRenderSVGRoot(SVGSVGElement& element, RenderStyle&& s
 {
     ASSERT(isLegacyRenderSVGRoot());
     LayoutSize intrinsicSize(computeIntrinsicSize());
-    if (!intrinsicSize.width())
+    if (!intrinsicSize.width() && !svgSVGElement().hasIntrinsicWidth())
         intrinsicSize.setWidth(defaultWidth);
-    if (!intrinsicSize.height())
+    if (!intrinsicSize.height() && !svgSVGElement().hasIntrinsicHeight())
         intrinsicSize.setHeight(defaultHeight);
     setIntrinsicSize(intrinsicSize);
 }


### PR DESCRIPTION
#### 8ff8778cd19e2086b58adeef4f5385ab887c38d7
<pre>
Respect zero intrinsic size for SVG in object/embed elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=276569">https://bugs.webkit.org/show_bug.cgi?id=276569</a>
<a href="https://rdar.apple.com/132152736">rdar://132152736</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When an &lt;object&gt; or &lt;embed&gt; element loads an SVG with explicit zero
dimensions (e.g., width=&quot;0&quot; or height=&quot;0&quot;), WebKit incorrectly renders
the element at 300x150px. Other browsers correctly collapse it to zero.

The fix has two parts:

1. RenderSVGRoot/LegacyRenderSVGRoot constructors now only apply the
  300x150 default when the SVG lacks explicit width/height attributes
  (i.e., they default to &quot;100%&quot;), not when they are explicitly zero.

2. RenderEmbeddedObject now overrides shouldRespectZeroIntrinsicWidth()
  and the new shouldRespectZeroIntrinsicHeight() to check whether the
  embedded SVG has explicit dimensions via hasIntrinsicWidth/Height().
  This ensures RenderReplaced::computeReplacedLogicalWidth/Height()
  treats a zero intrinsic size as &quot;has intrinsic size of 0&quot; rather
  than &quot;no intrinsic size, fall back to 300x150&quot;.

Test: svg/custom/object-sizing-zero-intrinsic-width-height.html

Merge (Test): <a href="https://chromium.googlesource.com/chromium/src.git/+/da94afcf81b0564c60b759895245011b42662d7b">https://chromium.googlesource.com/chromium/src.git/+/da94afcf81b0564c60b759895245011b42662d7b</a>

* LayoutTests/svg/custom/object-sizing-zero-intrinsic-width-height-expected.txt: Added.
* LayoutTests/svg/custom/object-sizing-zero-intrinsic-width-height.html: Added.
* Source/WebCore/rendering/RenderEmbeddedObject.cpp:
(WebCore::embeddedSVGElement):
(WebCore::RenderEmbeddedObject::shouldRespectZeroIntrinsicWidth const):
(WebCore::RenderEmbeddedObject::shouldRespectZeroIntrinsicHeight const):
* Source/WebCore/rendering/RenderEmbeddedObject.h:
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::shouldRespectZeroIntrinsicHeight const):
(WebCore::RenderReplaced::computeReplacedLogicalWidth const):
(WebCore::RenderReplaced::computeReplacedLogicalHeight const):
* Source/WebCore/rendering/RenderReplaced.h:
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::RenderSVGRoot):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::LegacyRenderSVGRoot):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ff8778cd19e2086b58adeef4f5385ab887c38d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158913 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103634 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/acb09181-2f5d-47ad-b669-b2ea4143382b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23388 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115871 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82321 "4 flakes 1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/765e5086-9040-487a-861b-a702bf9cb688) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153160 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134744 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96603 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33f66e32-4258-49ed-aa89-70cd71b9046c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17086 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15032 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6759 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126701 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161386 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4519 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14220 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123873 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22760 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19079 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124077 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22747 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134463 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79061 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19203 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11220 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22360 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86160 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22074 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22226 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22128 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->