### PR TITLE
[JSC] `RegExp#@@matchAll` fast path should clamp lastIndex > 2^53-1 to 2^53-1

### DIFF
--- a/JSTests/stress/regexp-prototype-matchall-lastindex-tolength.js
+++ b/JSTests/stress/regexp-prototype-matchall-lastindex-tolength.js
@@ -1,0 +1,93 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`${msg}: expected ${expected} but got ${actual}`);
+}
+
+function testFastPath() {
+    {
+        let r = /a/g;
+        r.lastIndex = Number.MAX_SAFE_INTEGER + 1;
+        let results = [...r[Symbol.matchAll]("aaa")];
+        shouldBe(results.length, 0, "fast: MAX_SAFE_INTEGER + 1");
+    }
+
+    {
+        let r = /a/g;
+        r.lastIndex = Infinity;
+        let results = [...r[Symbol.matchAll]("aaa")];
+        shouldBe(results.length, 0, "fast: Infinity");
+    }
+
+    {
+        let r = /a/g;
+        r.lastIndex = 1e100;
+        let results = [...r[Symbol.matchAll]("aaa")];
+        shouldBe(results.length, 0, "fast: 1e100");
+    }
+
+    {
+        let r = /a/g;
+        r.lastIndex = 2.5;
+        let results = [...r[Symbol.matchAll]("aaa")];
+        shouldBe(results.length, 1, "fast: 2.5 -> 2");
+        shouldBe(results[0].index, 2, "fast: 2.5 index");
+    }
+
+    {
+        let r = /a/g;
+        r.lastIndex = NaN;
+        let results = [...r[Symbol.matchAll]("aaa")];
+        shouldBe(results.length, 3, "fast: NaN -> 0");
+    }
+
+    {
+        let r = /a/g;
+        r.lastIndex = -5;
+        let results = [...r[Symbol.matchAll]("aaa")];
+        shouldBe(results.length, 3, "fast: -5 -> 0");
+    }
+
+    {
+        let r = /a/g;
+        r.lastIndex = -Infinity;
+        let results = [...r[Symbol.matchAll]("aaa")];
+        shouldBe(results.length, 3, "fast: -Infinity -> 0");
+    }
+
+    {
+        let r = /a/g;
+        r.lastIndex = Number.MAX_SAFE_INTEGER;
+        let results = [...r[Symbol.matchAll]("aaa")];
+        shouldBe(results.length, 0, "fast: MAX_SAFE_INTEGER");
+    }
+}
+
+function testSlowPath() {
+    class MyRegExp extends RegExp {}
+
+    {
+        let r = new MyRegExp("a", "g");
+        r.lastIndex = Number.MAX_SAFE_INTEGER + 1;
+        let results = [...r[Symbol.matchAll]("aaa")];
+        shouldBe(results.length, 0, "slow: MAX_SAFE_INTEGER + 1");
+    }
+
+    {
+        let r = new MyRegExp("a", "g");
+        r.lastIndex = Infinity;
+        let results = [...r[Symbol.matchAll]("aaa")];
+        shouldBe(results.length, 0, "slow: Infinity");
+    }
+
+    {
+        let r = new MyRegExp("a", "g");
+        r.lastIndex = 2.5;
+        let results = [...r[Symbol.matchAll]("aaa")];
+        shouldBe(results.length, 1, "slow: 2.5 -> 2");
+    }
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    testFastPath();
+    testSlowPath();
+}

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -1216,7 +1216,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncMatchAll, (JSGlobalObject* globalObject,
         bool fullUnicode = regExp->eitherUnicode();
 
         double lastIndexDouble = regExpObject->getLastIndex().asNumber();
-        size_t lastIndex = (lastIndexDouble >= 0 && lastIndexDouble <= maxSafeInteger()) ? static_cast<size_t>(lastIndexDouble) : 0;
+        size_t lastIndex = lastIndexDouble > 0 ? static_cast<size_t>(std::min(lastIndexDouble, maxSafeInteger())) : 0;
 
         Structure* structure = globalObject->regExpStructure();
         RegExpObject* matcher = RegExpObject::create(vm, structure, regExp);


### PR DESCRIPTION
#### 8cfdd1d58057ff6fa49d2918b1d853368fdc7c25
<pre>
[JSC] `RegExp#@@matchAll` fast path should clamp lastIndex &gt; 2^53-1 to 2^53-1
<a href="https://bugs.webkit.org/show_bug.cgi?id=309470">https://bugs.webkit.org/show_bug.cgi?id=309470</a>

Reviewed by Yusuke Suzuki.

The fast path in regExpProtoFuncMatchAll incorrectly treated lastIndex values
exceeding Number.MAX_SAFE_INTEGER as 0. Per spec, ToLength clamps such values
to 2^53-1[1][2]. Regression from 4b4cd07889.

[1]: <a href="https://tc39.es/ecma262/#sec-string.prototype.matchall">https://tc39.es/ecma262/#sec-string.prototype.matchall</a>
[2]: <a href="https://tc39.es/ecma262/#sec-tolength">https://tc39.es/ecma262/#sec-tolength</a>

Test: JSTests/stress/regexp-prototype-matchall-lastindex-tolength.js

* JSTests/stress/regexp-prototype-matchall-lastindex-tolength.js: Added.
(shouldBe):
(testSlowPath.MyRegExp):
(testSlowPath):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/309129@main">https://commits.webkit.org/309129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c58e2d5589918294459b79917c902aed21adf4b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21498 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15067 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157470 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102215 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21950 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114699 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81689 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95471 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16015 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13862 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5234 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140752 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125615 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159807 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9573 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2945 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122763 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21300 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17872 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122989 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33583 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133269 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77495 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18290 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10031 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180213 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20910 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84712 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46130 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20642 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20789 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20698 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->