### PR TITLE
[JSC] `Promise.resolve` with subclass constructor should not return base Promise

### DIFF
--- a/JSTests/stress/promise-resolve-subclass-should-not-return-base-promise.js
+++ b/JSTests/stress/promise-resolve-subclass-should-not-return-base-promise.js
@@ -1,0 +1,45 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+class DerivedPromise extends Promise { }
+
+{
+    let p = Promise.resolve(42);
+    let result = DerivedPromise.resolve(p);
+
+    shouldBe(result === p, false);
+    shouldBe(result instanceof DerivedPromise, true);
+    shouldBe(Object.getPrototypeOf(result), DerivedPromise.prototype);
+
+    let resolvedValue;
+    result.then((v) => { resolvedValue = v; });
+    drainMicrotasks();
+    shouldBe(resolvedValue, 42);
+}
+
+{
+    let dp = DerivedPromise.resolve(1);
+    shouldBe(DerivedPromise.resolve(dp) === dp, true);
+}
+
+{
+    let p = Promise.resolve(1);
+    shouldBe(Promise.resolve(p) === p, true);
+}
+
+{
+    let capturedResolve;
+    function MyThenable(executor) {
+        executor((v) => { capturedResolve = v; }, () => { });
+        this.then = () => { };
+    }
+
+    let p = Promise.resolve(99);
+    let result = Promise.resolve.call(MyThenable, p);
+
+    shouldBe(result === p, false);
+    shouldBe(result instanceof MyThenable, true);
+    shouldBe(capturedResolve, p);
+}

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -773,14 +773,16 @@ JSObject* JSPromise::promiseResolve(JSGlobalObject* globalObject, JSObject* cons
 
     if (argument.inherits<JSPromise>()) {
         auto* promise = jsCast<JSPromise*>(argument);
-        if (promiseSpeciesWatchpointIsValid(vm, promise)) [[likely]]
-            return promise;
+        if (promiseSpeciesWatchpointIsValid(vm, promise)) [[likely]] {
+            if (constructor == promise->globalObject()->promiseConstructor())
+                return promise;
+        } else {
+            auto property = promise->get(globalObject, vm.propertyNames->constructor);
+            RETURN_IF_EXCEPTION(scope, { });
 
-        auto property = promise->get(globalObject, vm.propertyNames->constructor);
-        RETURN_IF_EXCEPTION(scope, { });
-
-        if (property == constructor)
-            return promise;
+            if (property == constructor)
+                return promise;
+        }
     }
 
     if (constructor == globalObject->promiseConstructor()) [[likely]] {


### PR DESCRIPTION
#### 6309e93f81935cb0fc885f371879cb35fd2c00df
<pre>
[JSC] `Promise.resolve` with subclass constructor should not return base Promise
<a href="https://bugs.webkit.org/show_bug.cgi?id=309472">https://bugs.webkit.org/show_bug.cgi?id=309472</a>

Reviewed by Yusuke Suzuki.

The fast path in JSPromise::promiseResolve returned the argument
promise when the species watchpoint was valid, without checking that
the passed constructor C is the same as the argument&apos;s constructor.

This caused DerivedPromise.resolve(plainPromise) to return the plain
promise instead of creating a new DerivedPromise, violating
PromiseResolve step 1.b (SameValue(xConstructor, C))[1].

[1]: <a href="https://tc39.es/ecma262/#sec-promise-resolve">https://tc39.es/ecma262/#sec-promise-resolve</a>

Test: JSTests/stress/promise-resolve-subclass-should-not-return-base-promise.js

* JSTests/stress/promise-resolve-subclass-should-not-return-base-promise.js: Added.
(shouldBe):
(DerivedPromise):
(result.then):
(shouldBe.MyThenable):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::promiseResolve):

Canonical link: <a href="https://commits.webkit.org/308899@main">https://commits.webkit.org/308899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b81748bc024cb5cbdfd06b167790803765d211a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157471 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102216 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114700 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81690 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151746 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133556 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95472 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16018 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13863 "Found 1 new API test failure: TestWebKitAPI.WKWebsiteDataStore.FetchPersistentCredentials (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5235 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140753 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125618 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11476 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159808 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9574 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2946 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12998 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122764 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122990 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33441 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133270 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77496 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18294 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10032 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180214 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20911 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84713 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46131 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20643 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20790 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->