### PR TITLE
[WTF] Remove streaming interface of StringHasher to make changing algorithm easier

### DIFF
--- a/Source/JavaScriptCore/runtime/TemplateObjectDescriptor.h
+++ b/Source/JavaScriptCore/runtime/TemplateObjectDescriptor.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <limits>
+#include <wtf/HashFunctions.h>
 #include <wtf/Vector.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
@@ -91,14 +92,10 @@ inline TemplateObjectDescriptor::TemplateObjectDescriptor(EmptyValueTag)
 
 inline unsigned TemplateObjectDescriptor::calculateHash(const StringVector& rawStrings)
 {
-    SuperFastHash hasher;
-    for (const String& string : rawStrings) {
-        if (string.is8Bit())
-            hasher.addCharacters(string.span8());
-        else
-            hasher.addCharacters(string.span16());
-    }
-    return hasher.hash();
+    unsigned hash = WTF::stringHashingStartValue;
+    for (const String& string : rawStrings)
+        hash = pairIntHash(hash, string.hash());
+    return hash;
 }
 
 } // namespace JSC

--- a/Source/WTF/wtf/text/ASCIILiteral.h
+++ b/Source/WTF/wtf/text/ASCIILiteral.h
@@ -122,9 +122,7 @@ inline constexpr unsigned ASCIILiteral::hash() const
 {
     if (isNull())
         return 0;
-    SuperFastHash hasher;
-    hasher.addCharacters(characters(), length());
-    return hasher.hash();
+    return SuperFastHash::computeHash(span());
 }
 
 struct ASCIILiteralHash {

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -25,9 +25,10 @@
 #include <wtf/text/AtomStringImpl.h>
 
 #include <wtf/Threading.h>
+#include <wtf/text/ASCIIFastPath.h>
 #include <wtf/text/AtomStringTable.h>
 #include <wtf/text/StringHash.h>
-#include <wtf/unicode/UTF8Conversion.h>
+#include <wtf/text/WTFString.h>
 
 #if USE(WEB_THREAD)
 #include <wtf/Lock.h>
@@ -106,55 +107,6 @@ struct UTF16BufferTranslator {
         stringImpl->setHash(hash);
         stringImpl->setIsAtom(true);
         location = &stringImpl.leakRef();
-    }
-};
-
-struct HashedUTF8Characters {
-    std::span<const char8_t> characters;
-    Unicode::UTF16LengthWithHash length;
-};
-
-struct HashedUTF8CharactersTranslator {
-    static unsigned NODELETE hash(const HashedUTF8Characters& characters)
-    {
-        return characters.length.hash;
-    }
-
-    static bool equal(const AtomStringTable::StringEntry& passedString, const HashedUTF8Characters& characters)
-    {
-        // This is passed in to it is guaranteed to be valid. We want to extract the raw pointer
-        // here instead of repeatedly calling `PackedPtr::operator->()` which is not free.
-        SUPPRESS_UNCOUNTED_LOCAL auto* string = passedString.get();
-        if (characters.length.lengthUTF16 != string->length())
-            return false;
-
-        // If buffer contains only ASCII characters, UTF-8 and UTF16 lengths are the same.
-        if (characters.length.lengthUTF16 != characters.characters.size()) {
-            if (string->is8Bit())
-                return Unicode::equal(string->span8(), characters.characters);
-            return Unicode::equal(string->span16(), characters.characters);
-        }
-
-        auto charactersLatin1 = byteCast<Latin1Character>(characters.characters);
-        if (string->is8Bit())
-            return WTF::equal(string->span8().data(), charactersLatin1);
-        return WTF::equal(string->span16().data(), charactersLatin1);
-    }
-
-    static void translate(AtomStringTable::StringEntry& location, const HashedUTF8Characters& characters, unsigned hash)
-    {
-        std::span<char16_t> target;
-        auto newString = StringImpl::createUninitialized(characters.length.lengthUTF16, target);
-
-        auto result = Unicode::convert(characters.characters, target);
-        RELEASE_ASSERT(result.code == Unicode::ConversionResultCode::Success);
-
-        if (result.isAllASCII)
-            newString = StringImpl::create(byteCast<Latin1Character>(characters.characters));
-
-        newString->setHash(hash);
-        newString->setIsAtom(true);
-        location = &newString.leakRef();
     }
 };
 
@@ -476,10 +428,12 @@ RefPtr<AtomStringImpl> AtomStringImpl::lookUpSlowCase(StringImpl& string)
 
 RefPtr<AtomStringImpl> AtomStringImpl::add(std::span<const char8_t> characters)
 {
-    HashedUTF8Characters buffer { characters, computeUTF16LengthWithHash(characters) };
-    if (!buffer.length.hash)
+    if (charactersAreAllASCII(characters))
+        return add(byteCast<Latin1Character>(characters));
+    auto string = String::fromUTF8(characters);
+    if (string.isNull())
         return nullptr;
-    return addToStringTable<HashedUTF8Characters, HashedUTF8CharactersTranslator>(buffer);
+    return add(string.releaseImpl());
 }
 
 RefPtr<AtomStringImpl> AtomStringImpl::lookUp(std::span<const Latin1Character> characters)

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -145,10 +145,7 @@ unsigned CString::hash() const
 {
     if (isNull())
         return 0;
-    SuperFastHash hasher;
-    for (auto character : span())
-        hasher.addCharacter(character);
-    return hasher.hash();
+    return SuperFastHash::computeHash(span());
 }
 
 bool operator<(const CString& a, const CString& b)

--- a/Source/WTF/wtf/text/StringHasher.h
+++ b/Source/WTF/wtf/text/StringHasher.h
@@ -21,9 +21,7 @@
 
 #pragma once
 
-#include <array>
 #include <unicode/utypes.h>
-#include <wtf/FastMalloc.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/Latin1Character.h>
 
@@ -36,7 +34,6 @@ class SuperFastHash;
 class WYHash;
 
 class StringHasher {
-    WTF_DEPRECATED_MAKE_FAST_ALLOCATED(StringHasher);
 public:
     static constexpr unsigned flagCount = 8; // Save 8 bits for StringImpl to use as flags.
     static constexpr unsigned maskHash = (1U << (sizeof(unsigned) * 8 - flagCount)) - 1;
@@ -50,18 +47,11 @@ public:
         }
     };
 
-    StringHasher() = default;
-
     template<typename T, typename Converter = DefaultConverter>
     static unsigned computeHashAndMaskTop8Bits(std::span<const T> data);
 
     template<typename T, unsigned characterCount>
     static constexpr unsigned computeLiteralHashAndMaskTop8Bits(const T (&characters)[characterCount]);
-
-    void addCharacter(char16_t character);
-
-    // hashWithTop8BitsMasked will reset to initial status.
-    unsigned hashWithTop8BitsMasked();
 
 private:
     friend class SuperFastHash;
@@ -102,15 +92,6 @@ private:
             return hash;
         return 0x80000000 >> flagCount;
     }
-
-    bool m_pendingHashValue { false };
-    unsigned m_numberOfProcessedCharacters { 0 };
-    uint64_t m_seed { 0 };
-    uint64_t m_see1 { 0 };
-    uint64_t m_see2 { 0 };
-
-    unsigned m_bufferSize { 0 };
-    std::array<char16_t, numberOfCharactersInLargestBulkForWYHash * 2> m_buffer;
 };
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/StringHasherInlines.h
+++ b/Source/WTF/wtf/text/StringHasherInlines.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#include <wtf/Assertions.h>
 #include <wtf/text/StringHasher.h>
 #include <wtf/text/WYHash.h>
 
@@ -37,78 +36,6 @@ constexpr unsigned StringHasher::computeLiteralHashAndMaskTop8Bits(const T (&cha
 {
     constexpr unsigned characterCountWithoutNull = characterCount - 1;
     return WYHash::computeHashAndMaskTop8Bits<T>(unsafeMakeSpan(characters, characterCountWithoutNull));
-}
-
-inline void StringHasher::addCharacter(char16_t character)
-{
-    static constexpr unsigned bufferCapacity = numberOfCharactersInLargestBulkForWYHash * 2;
-    if (m_bufferSize == bufferCapacity) {
-        // This algorithm must stay in sync with WYHash::hash function.
-        if (!m_pendingHashValue) {
-            m_seed = WYHash::initSeed();
-            m_see1 = m_seed;
-            m_see2 = m_seed;
-            m_pendingHashValue = true;
-        }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        char16_t* p = m_buffer.data();
-        while (m_bufferSize >= 24) {
-            WYHash::consume24Characters(p, WYHash::Reader16Bit<char16_t>::wyr8, m_seed, m_see1, m_see2);
-            p += 24;
-            m_bufferSize -= 24;
-        }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-        ASSERT(!m_bufferSize);
-        m_numberOfProcessedCharacters += bufferCapacity;
-    }
-
-    ASSERT(m_bufferSize < bufferCapacity);
-    m_buffer[m_bufferSize++] = character;
-}
-
-inline unsigned StringHasher::hashWithTop8BitsMasked()
-{
-    static constexpr unsigned bufferCapacity = numberOfCharactersInLargestBulkForWYHash * 2;
-    unsigned hashValue;
-    if (!m_pendingHashValue) {
-        hashValue = WYHash::computeHashAndMaskTop8Bits<char16_t>(std::span { m_buffer }.first(m_bufferSize));
-    } else {
-        // This algorithm must stay in sync with WYHash::hash function.
-        auto wyr8 = WYHash::Reader16Bit<char16_t>::wyr8;
-        unsigned i = m_bufferSize;
-        if (i <= 24)
-            m_seed ^= m_see1 ^ m_see2;
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        char16_t* p = m_buffer.data();
-        WYHash::handleGreaterThan8CharactersCase(p, i, wyr8, m_seed, m_see1, m_see2);
-
-        uint64_t a = 0;
-        uint64_t b = 0;
-        if (m_bufferSize >= 8) {
-            a = wyr8(p + i - 8);
-            b = wyr8(p + i - 4);
-        } else {
-            char16_t tmp[8];
-            unsigned bufferIndex = bufferCapacity - (8 - i);
-            for (unsigned tmpIndex = 0; tmpIndex < 8; tmpIndex++) {
-                tmp[tmpIndex] = m_buffer[bufferIndex];
-                bufferIndex = (bufferIndex + 1) % bufferCapacity;
-            }
-
-            char16_t* tmpPtr = tmp;
-            a = wyr8(tmpPtr);
-            b = wyr8(tmpPtr + 4);
-        }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-
-        const uint64_t totalByteCount = (static_cast<uint64_t>(m_numberOfProcessedCharacters) + static_cast<uint64_t>(m_bufferSize)) << 1;
-        hashValue = StringHasher::avoidZero(WYHash::handleEndCase(a, b, m_seed, totalByteCount) & StringHasher::maskHash);
-
-        m_pendingHashValue = false;
-        m_numberOfProcessedCharacters = m_seed = m_see1 = m_see2 = 0;
-    }
-    m_bufferSize = 0;
-    return hashValue;
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/SuperFastHash.h
+++ b/Source/WTF/wtf/text/SuperFastHash.h
@@ -23,6 +23,7 @@
 
 #include <span>
 #include <wtf/Compiler.h>
+#include <wtf/FastMalloc.h>
 #include <wtf/text/StringHasher.h>
 
 namespace WTF {

--- a/Source/WTF/wtf/text/WYHash.h
+++ b/Source/WTF/wtf/text/WYHash.h
@@ -54,6 +54,7 @@
 
 #pragma once
 
+#include <wtf/FastMalloc.h>
 #include <wtf/Int128.h>
 #include <wtf/UnalignedAccess.h>
 #include <wtf/text/StringHasher.h>

--- a/Source/WTF/wtf/unicode/UTF8Conversion.cpp
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.cpp
@@ -30,7 +30,6 @@
 #include <unicode/uchar.h>
 #include <wtf/ASCIICType.h>
 #include <wtf/SIMDUTF.h>
-#include <wtf/text/StringHasherInlines.h>
 #include <wtf/text/icu/UnicodeExtras.h>
 #include <wtf/unicode/CharacterNames.h>
 
@@ -187,26 +186,6 @@ CheckedUTF8 checkUTF8(std::span<const char8_t> source)
         orAllData |= character;
     }
     return { source.first(sourceOffset), lengthUTF16, isASCII(orAllData) };
-}
-
-UTF16LengthWithHash computeUTF16LengthWithHash(std::span<const char8_t> source)
-{
-    StringHasher hasher;
-    size_t lengthUTF16 = 0;
-    for (size_t sourceOffset = 0; sourceOffset < source.size(); ) {
-        char32_t character = next(source, sourceOffset);
-        if (character == sentinelCodePoint)
-            return { };
-        if (U_IS_BMP(character)) {
-            hasher.addCharacter(character);
-            ++lengthUTF16;
-        } else {
-            hasher.addCharacter(U16_LEAD(character));
-            hasher.addCharacter(U16_TRAIL(character));
-            lengthUTF16 += 2;
-        }
-    }
-    return { lengthUTF16, hasher.hashWithTop8BitsMasked() };
 }
 
 template<typename CharacterTypeA, typename CharacterTypeB> bool equalInternal(std::span<CharacterTypeA> a, std::span<CharacterTypeB> b)

--- a/Source/WTF/wtf/unicode/UTF8Conversion.h
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.h
@@ -66,13 +66,5 @@ struct CheckedUTF8 {
 };
 WTF_EXPORT_PRIVATE CheckedUTF8 checkUTF8(std::span<const char8_t>);
 
-// The computeUTF16LengthWithHash function returns a length and hash of 0 if the
-// source is exhausted or invalid. The hash is of the computeHashAndMaskTop8Bits variety.
-struct UTF16LengthWithHash {
-    size_t lengthUTF16 { };
-    unsigned hash { };
-};
-WTF_EXPORT_PRIVATE UTF16LengthWithHash computeUTF16LengthWithHash(std::span<const char8_t>);
-
 } // namespace Unicode
 } // namespace WTF

--- a/Source/WebCore/contentextensions/DFAMinimizer.cpp
+++ b/Source/WebCore/contentextensions/DFAMinimizer.cpp
@@ -398,9 +398,9 @@ struct ActionKey {
         , actionsLength(actionsLength)
         , state(Valid)
     {
-        SuperFastHash hasher;
-        hasher.addCharactersAssumingAligned(reinterpret_cast<const char16_t*>(&dfa->actions[actionsStart]), actionsLength * sizeof(uint64_t) / sizeof(char16_t));
-        hash = hasher.hash();
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+        hash = SuperFastHash::computeHash(std::span { reinterpret_cast<const char16_t*>(&dfa->actions[actionsStart]), actionsLength * sizeof(uint64_t) / sizeof(char16_t) });
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     bool NODELETE isEmptyValue() const { return state == Empty; }

--- a/Source/WebCore/contentextensions/HashableActionList.h
+++ b/Source/WebCore/contentextensions/HashableActionList.h
@@ -46,9 +46,9 @@ struct HashableActionList {
         , state(Valid)
     {
         std::ranges::sort(actions);
-        SuperFastHash hasher;
-        hasher.addCharactersAssumingAligned(reinterpret_cast<const char16_t*>(actions.span().data()), actions.size() * sizeof(uint64_t) / sizeof(char16_t));
-        hash = hasher.hash();
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+        hash = SuperFastHash::computeHash(std::span { reinterpret_cast<const char16_t*>(actions.span().data()), actions.size() * sizeof(uint64_t) / sizeof(char16_t) });
+        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
     bool isEmptyValue() const { return state == Empty; }

--- a/Source/WebCore/platform/SharedStringHash.cpp
+++ b/Source/WebCore/platform/SharedStringHash.cpp
@@ -24,6 +24,7 @@
 #include "config.h"
 #include "SharedStringHash.h"
 
+#include <wtf/HashFunctions.h>
 #include <wtf/URL.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/StringHash.h>
@@ -243,10 +244,7 @@ static ALWAYS_INLINE SharedStringHash computeSharedStringHashInline(const URL& b
 
         // FIXME: This is incorrect for URLs that have a query or anchor; the "/" needs to go at the
         // end of the path, *before* the query or anchor.
-        SuperFastHash hasher;
-        hasher.addCharacters(characters);
-        hasher.addCharacter('/');
-        return AlreadyHashed::avoidDeletedValue(hasher.hash());
+        return AlreadyHashed::avoidDeletedValue(pairIntHash(SuperFastHash::computeHash(characters), static_cast<unsigned>('/')));
     }
 
     Vector<CharacterType, 512> buffer;

--- a/Tools/TestWebKitAPI/Tests/WTF/StringHasher.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringHasher.cpp
@@ -52,7 +52,6 @@ TEST(WTF, StringHasher)
         return array;
     };
 
-    StringHasher hash;
     unsigned max8Bit = std::numeric_limits<uint8_t>::max();
     for (size_t size = 0; size <= max8Bit; size++) {
         std::unique_ptr<const Latin1Character[]> arr1 = generateLatin1Array(size);
@@ -60,11 +59,6 @@ TEST(WTF, StringHasher)
         unsigned left = StringHasher::computeHashAndMaskTop8Bits(std::span { arr1.get(), size });
         unsigned right = StringHasher::computeHashAndMaskTop8Bits(std::span { arr2.get(), size });
         ASSERT_EQ(left, right);
-
-        for (size_t i = 0; i < size; i++)
-            hash.addCharacter(arr2.get()[i]);
-        unsigned result1 = hash.hashWithTop8BitsMasked();
-        ASSERT_EQ(right, result1);
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/UTF8Conversion.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/UTF8Conversion.cpp
@@ -99,19 +99,6 @@ static const char* serialize(WTF::Unicode::CheckedUTF8 result)
     return singleGlobalResult.c_str();
 }
 
-static const char* serialize(WTF::Unicode::UTF16LengthWithHash result)
-{
-    if (!result.lengthUTF16 && !result.hash)
-        return "source invalid";
-
-    std::ostringstream stream;
-    stream << result.lengthUTF16 << " UTF-16, " << std::hex << std::uppercase << std::setfill('0') << std::setw(6) << result.hash;
-
-    static std::string singleGlobalResult;
-    singleGlobalResult = stream.str();
-    return singleGlobalResult.c_str();
-}
-
 TEST(WTF_UTF8Conversion, UTF8ToUTF16)
 {
     using namespace WTF::Unicode;
@@ -511,40 +498,6 @@ TEST(WTF_UTF8Conversion, CheckUTF8)
 
     EXPECT_STREQ("1 UTF-8, 1 UTF-16", serialize(checkUTF8(char8Array(0x00, 0x80))));
     EXPECT_STREQ("2 UTF-8, 1 UTF-16", serialize(checkUTF8(char8Array(0xC2, 0x80, 0x80))));
-}
-
-TEST(WTF_UTF8Conversion, ComputeUTF16LengthWithHash)
-{
-    using namespace WTF::Unicode;
-
-    EXPECT_STREQ("0 UTF-16, BDE459", serialize(computeUTF16LengthWithHash(char8Array())));
-    EXPECT_STREQ("1 UTF-16, 267530", serialize(computeUTF16LengthWithHash(char8Array(0))));
-    EXPECT_STREQ("1 UTF-16, 92E0BF", serialize(computeUTF16LengthWithHash(char8Array('a'))));
-
-    EXPECT_STREQ("1 UTF-16, 28DD63", serialize(computeUTF16LengthWithHash(char8Array(0xED, 0x9F, 0xBF))));
-    EXPECT_STREQ("1 UTF-16, 1BD19D", serialize(computeUTF16LengthWithHash(char8Array(0xEE, 0x80, 0x80))));
-    EXPECT_STREQ("1 UTF-16, 879D89", serialize(computeUTF16LengthWithHash(char8Array(0xEF, 0xBF, 0xBD))));
-    EXPECT_STREQ("1 UTF-16, 59C8B7", serialize(computeUTF16LengthWithHash(char8Array(0xEF, 0xBF, 0xBE))));
-    EXPECT_STREQ("1 UTF-16, 52CCE0", serialize(computeUTF16LengthWithHash(char8Array(0xEF, 0xBF, 0xBF))));
-    EXPECT_STREQ("2 UTF-16, 921DEF", serialize(computeUTF16LengthWithHash(char8Array(0xF0, 0x90, 0x80, 0x80))));
-    EXPECT_STREQ("2 UTF-16, 4A9F3D", serialize(computeUTF16LengthWithHash(char8Array(0xF4, 0x8F, 0xBF, 0xBF))));
-
-    EXPECT_STREQ("2 UTF-16, 460955", serialize(computeUTF16LengthWithHash(char8Array(0, 0))));
-    EXPECT_STREQ("2 UTF-16, DA7C5E", serialize(computeUTF16LengthWithHash(char8Array('a', 0))));
-    EXPECT_STREQ("2 UTF-16, EF29F4", serialize(computeUTF16LengthWithHash(char8Array(0xED, 0x9F, 0xBF, 0))));
-
-    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0x80))));
-    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0xED, 0xA0, 0x80))));
-    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0xED, 0xAF, 0xBF))));
-    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0xED, 0xB0, 0x80))));
-    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0xED, 0xBF, 0xBF))));
-    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0x80, 0))));
-    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0xED, 0xA0, 0x80, 0))));
-    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0xF4, 0x90, 0x80, 0x80))));
-    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0xED, 0xA0, 0x80, 0xED, 0xBF, 0xBF))));
-
-    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0x00, 0x80))));
-    EXPECT_STREQ("source invalid", serialize(computeUTF16LengthWithHash(char8Array(0xC2, 0x80, 0x80))));
 }
 
 } // namespace


### PR DESCRIPTION
#### 756399f1473ca68f5cc78946026b865b22a4c81e
<pre>
[WTF] Remove streaming interface of StringHasher to make changing algorithm easier
<a href="https://bugs.webkit.org/show_bug.cgi?id=309471">https://bugs.webkit.org/show_bug.cgi?id=309471</a>
<a href="https://rdar.apple.com/172051660">rdar://172051660</a>

Reviewed by Yijia Huang.

This patch removes the streaming use of StringHasher. This is not so
much meaningfully used, and we would like to avoid having this for now
since we would like to replace the underlying algorithm easily. Only
offering one-shot algorithm makes replacing much easier.

* Source/JavaScriptCore/runtime/TemplateObjectDescriptor.h:
(JSC::TemplateObjectDescriptor::calculateHash):
* Source/WTF/wtf/text/ASCIILiteral.h:
(WTF::ASCIILiteral::hash const):
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::AtomStringImpl::add):
(WTF::HashedUTF8CharactersTranslator::hash): Deleted.
(WTF::HashedUTF8CharactersTranslator::equal): Deleted.
(WTF::HashedUTF8CharactersTranslator::translate): Deleted.
* Source/WTF/wtf/text/CString.cpp:
(WTF::CString::hash const):
* Source/WTF/wtf/text/StringHasher.h:
(WTF::StringHasher::avoidZero):
(): Deleted.
* Source/WTF/wtf/text/StringHasherInlines.h:
(WTF::StringHasher::addCharacter): Deleted.
(WTF::StringHasher::hashWithTop8BitsMasked): Deleted.
* Source/WTF/wtf/text/SuperFastHash.h:
* Source/WTF/wtf/text/WYHash.h:
* Source/WTF/wtf/unicode/UTF8Conversion.cpp:
(WTF::Unicode::computeUTF16LengthWithHash): Deleted.
* Source/WTF/wtf/unicode/UTF8Conversion.h:
* Source/WebCore/contentextensions/DFAMinimizer.cpp:
* Source/WebCore/contentextensions/HashableActionList.h:
(WebCore::ContentExtensions::HashableActionList::HashableActionList):
* Source/WebCore/platform/SharedStringHash.cpp:
(WebCore::computeSharedStringHashInline):

Canonical link: <a href="https://commits.webkit.org/308927@main">https://commits.webkit.org/308927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a954f9f53ab86cd93917ac11ef96f79f25616aef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15093 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157496 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102241 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/be534185-9607-4b83-b163-571a24e86cc1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150684 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114717 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81699 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6fbd7e12-f6ce-46f5-9ff1-2185f8e80516) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151771 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16925 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133577 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95486 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11496a3f-8c2c-4292-b896-a30b58e8ef3d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16036 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13879 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5261 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140778 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125637 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11497 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159834 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9599 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2971 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13019 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122782 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21326 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123007 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133291 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77522 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22929 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18307 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10053 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180239 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20936 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84738 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46137 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20668 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20815 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20724 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->