### PR TITLE
Address concurrency warnings in USDModel.swift

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -879,9 +879,6 @@ final class USDModelLoader: _Proto_UsdStageSession_v1.Delegate {
     private let objcLoader: WKBridgeModelLoader
 
     @nonobjc
-    private let dispatchSerialQueue: DispatchSerialQueue
-
-    @nonobjc
     fileprivate var time: TimeInterval = 0
 
     @nonobjc
@@ -894,7 +891,6 @@ final class USDModelLoader: _Proto_UsdStageSession_v1.Delegate {
     init(objcInstance: WKBridgeModelLoader) {
         objcLoader = objcInstance
         usdLoader = _Proto_UsdStageSession_v1.noMetalSession(gpuFamily: MTLGPUFamily.apple7)
-        dispatchSerialQueue = DispatchSerialQueue(label: "USDModelWebProcess", qos: .userInteractive)
         usdLoader.delegate = self
     }
 
@@ -907,9 +903,7 @@ final class USDModelLoader: _Proto_UsdStageSession_v1.Delegate {
     }
 
     func meshUpdated(data: consuming sending _Proto_MeshDataUpdate_v1) {
-        self.dispatchSerialQueue.async {
-            self.objcLoader.updateMesh(webRequest: webUpdateMeshRequestFromUpdateMeshRequest(data))
-        }
+        self.objcLoader.updateMesh(webRequest: webUpdateMeshRequestFromUpdateMeshRequest(data))
     }
 
     func meshDestroyed(identifier: String) {
@@ -917,9 +911,7 @@ final class USDModelLoader: _Proto_UsdStageSession_v1.Delegate {
     }
 
     func materialUpdated(data: consuming sending _Proto_MaterialDataUpdate_v1) {
-        self.dispatchSerialQueue.async {
-            self.objcLoader.updateMaterial(webRequest: webUpdateMaterialRequestFromUpdateMaterialRequest(data))
-        }
+        self.objcLoader.updateMaterial(webRequest: webUpdateMaterialRequestFromUpdateMaterialRequest(data))
     }
 
     func materialDestroyed(identifier: String) {
@@ -927,9 +919,7 @@ final class USDModelLoader: _Proto_UsdStageSession_v1.Delegate {
     }
 
     func textureUpdated(data: consuming sending _Proto_TextureDataUpdate_v1) {
-        self.dispatchSerialQueue.async {
-            self.objcLoader.updateTexture(webRequest: webUpdateTextureRequestFromUpdateTextureRequest(data))
-        }
+        self.objcLoader.updateTexture(webRequest: webUpdateTextureRequestFromUpdateTextureRequest(data))
     }
 
     func textureDestroyed(identifier: String) {

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.h
@@ -135,6 +135,7 @@ private:
     PauseState m_pauseState { PauseState::None };
     std::optional<WebCore::LayoutPoint> m_currentPoint;
     std::optional<Ref<WebCore::SharedBuffer>> m_environmentMap;
+    dispatch_queue_t m_serialQueue;
     float m_yawAcceleration { 0.f };
     float m_pitchAcceleration { 0.f };
     float m_yaw { 0.f };

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -129,6 +129,7 @@ WebModelPlayer::WebModelPlayer(WebCore::Page& page, WebCore::ModelPlayerClient& 
 : m_client { client }
 , m_id { WebCore::ModelPlayerIdentifier::generate() }
 , m_page(page)
+, m_serialQueue(dispatch_queue_create("USDStageKit-Serial-Dispatcher", DISPATCH_QUEUE_SERIAL))
 {
 }
 
@@ -293,44 +294,50 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
     m_modelLoader = adoptNS([allocWKBridgeModelLoaderInstance() init]);
     Ref protectedThis = Ref { *this };
     [m_modelLoader setCallbacksWithModelUpdatedCallback:^(WKBridgeUpdateMesh *updateRequest) {
-        ensureOnMainThreadWithProtectedThis([updateRequest] (Ref<WebModelPlayer> protectedThis) {
-            RefPtr model = protectedThis->m_currentModel;
-            if (model) {
-                model->update(toCpp(updateRequest));
-                protectedThis->setStageMode(protectedThis->m_stageMode);
-            }
+        dispatch_async(m_serialQueue, ^{
+            ensureOnMainThreadWithProtectedThis([updateRequest] (Ref<WebModelPlayer> protectedThis) {
+                RefPtr model = protectedThis->m_currentModel;
+                if (model) {
+                    model->update(toCpp(updateRequest));
+                    protectedThis->setStageMode(protectedThis->m_stageMode);
+                }
 
-            [protectedThis->m_modelLoader requestCompleted:updateRequest];
+                [protectedThis->m_modelLoader requestCompleted:updateRequest];
 
-            if (RefPtr client = protectedThis->m_client.get(); client && !protectedThis->m_didFinishLoading) {
-                protectedThis->m_didFinishLoading = true;
-                client->didFinishLoading(protectedThis.get());
-                auto [simdCenter, simdExtents] = model->getCenterAndExtents();
-                client->didUpdateBoundingBox(protectedThis.get(), WebCore::FloatPoint3D(simdCenter.x, simdCenter.y, simdCenter.z), WebCore::FloatPoint3D(simdExtents.x, simdExtents.y, simdExtents.z));
-                protectedThis->notifyEntityTransformUpdated();
+                if (RefPtr client = protectedThis->m_client.get(); client && !protectedThis->m_didFinishLoading) {
+                    protectedThis->m_didFinishLoading = true;
+                    client->didFinishLoading(protectedThis.get());
+                    auto [simdCenter, simdExtents] = model->getCenterAndExtents();
+                    client->didUpdateBoundingBox(protectedThis.get(), WebCore::FloatPoint3D(simdCenter.x, simdCenter.y, simdCenter.z), WebCore::FloatPoint3D(simdExtents.x, simdExtents.y, simdExtents.z));
+                    protectedThis->notifyEntityTransformUpdated();
 
-                auto environmentMap = protectedThis->m_environmentMap;
-                if (model && environmentMap) {
-                    if (auto environmentMapImage = loadIBL(WTF::move(*environmentMap))) {
-                        model->setEnvironmentMap(*environmentMapImage);
-                        protectedThis->m_environmentMap = std::nullopt;
+                    auto environmentMap = protectedThis->m_environmentMap;
+                    if (model && environmentMap) {
+                        if (auto environmentMapImage = loadIBL(WTF::move(*environmentMap))) {
+                            model->setEnvironmentMap(*environmentMapImage);
+                            protectedThis->m_environmentMap = std::nullopt;
+                        }
                     }
                 }
-            }
+            });
         });
     } textureUpdatedCallback:^(WKBridgeUpdateTexture *updateTexture) {
-        ensureOnMainThreadWithProtectedThis([updateTexture] (Ref<WebModelPlayer> protectedThis) {
-            if (protectedThis->m_currentModel)
-                protectedThis->m_currentModel->updateTexture(toCpp(updateTexture));
+        dispatch_async(m_serialQueue, ^{
+            ensureOnMainThreadWithProtectedThis([updateTexture] (Ref<WebModelPlayer> protectedThis) {
+                if (protectedThis->m_currentModel)
+                    protectedThis->m_currentModel->updateTexture(toCpp(updateTexture));
 
-            [protectedThis->m_modelLoader requestCompleted:updateTexture];
+                [protectedThis->m_modelLoader requestCompleted:updateTexture];
+            });
         });
     } materialUpdatedCallback:^(WKBridgeUpdateMaterial *updateMaterial) {
-        ensureOnMainThreadWithProtectedThis([updateMaterial] (Ref<WebModelPlayer> protectedThis) {
-            if (protectedThis->m_currentModel)
-                protectedThis->m_currentModel->updateMaterial(toCpp(updateMaterial));
+        dispatch_async(m_serialQueue, ^{
+            ensureOnMainThreadWithProtectedThis([updateMaterial] (Ref<WebModelPlayer> protectedThis) {
+                if (protectedThis->m_currentModel)
+                    protectedThis->m_currentModel->updateMaterial(toCpp(updateMaterial));
 
-            [protectedThis->m_modelLoader requestCompleted:updateMaterial];
+                [protectedThis->m_modelLoader requestCompleted:updateMaterial];
+            });
         });
     }];
 


### PR DESCRIPTION
#### 5cc4004a6ecd32f0260e40c73dadecee76ff96b5
<pre>
Address concurrency warnings in USDModel.swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=309473">https://bugs.webkit.org/show_bug.cgi?id=309473</a>
<a href="https://rdar.apple.com/172053589">rdar://172053589</a>

Reviewed by NOBODY (OOPS!).

Address Swift sendability warnings by moving the dispatch async calls
from Swift to Objective-C++.

Functionally zero code change.

Why is this needed in general?

USDStageKit ensures the callbacks occur in a certain order but they
may originate from different threads, including the main thread, so
calling ensureOnMainThread may re-order the calls from USDStageKit
which is not desired. When already running on the main thread,
ensureOnMainThread invokes the callback synchronously which would
result in changing the order.

By funneling through a serial queue we can ensure ordering.

* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(USDModelLoader.meshUpdated(_:)):
(USDModelLoader.materialUpdated(_:)):
(USDModelLoader.textureUpdated(_:)):
* Source/WebKit/WebProcess/Model/WebModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::WebModelPlayer):
(WebKit::m_serialQueue):
(WebKit::WebModelPlayer::load):
(WebKit::m_page): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cc4004a6ecd32f0260e40c73dadecee76ff96b5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157479 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102224 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/398fe477-730b-4729-a7d0-5b6b8a941d15) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114703 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81692 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2cb8a56e-566b-43b5-907c-28db5eed19af) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16905 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133563 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95475 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a0d50eb6-8fbe-4966-ad5b-9308a246135a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16017 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13866 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5243 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125617 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159817 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2954 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13005 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122767 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17876 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122993 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133277 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77505 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18293 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10039 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20919 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84721 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20651 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20798 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20707 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->