### PR TITLE
[AppKit Gestures] Start converting WKAppKitGestureController to Swift (part 1)

### DIFF
--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -363,6 +363,11 @@ module WebKit_Internal [system] {
         requires objc
     }
 
+    module WKAppKitGestureController {
+        header "../../UIProcess/mac/WKAppKitGestureController.h"
+        export *
+    }
+
     // FIXME: These parts of the module map needs work as discussed in https://github.com/WebKit/WebKit/pull/54322
 
     module WebKit_Internal_Cxx {

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
@@ -29,7 +29,7 @@
 
 #if HAVE(APPKIT_GESTURES_SUPPORT)
 
-#import <AppKit/NSGestureRecognizer.h>
+#import <AppKit/NSGestureRecognizer_Private.h>
 #import <wtf/Forward.h>
 #import <wtf/ObjectIdentifier.h>
 #import <wtf/Vector.h>
@@ -52,7 +52,12 @@ OBJC_CLASS NSPanGestureRecognizer;
 #import <WebKitAdditions/WKAppKitGestureControllerAdditionsBefore.mm>
 #endif
 
-@interface WKAppKitGestureController : NSObject <NSGestureRecognizerDelegate>
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+// MARK: WKAppKitGestureController
+
+NS_SWIFT_UI_ACTOR
+@interface WKAppKitGestureController : NSObject
 
 - (instancetype)initWithPage:(std::reference_wrapper<WebKit::WebPageProxy>)page viewImpl:(std::reference_wrapper<WebKit::WebViewImpl>)viewImpl;
 - (void)enableGesturesIfNeeded;
@@ -68,8 +73,34 @@ OBJC_CLASS NSPanGestureRecognizer;
 - (void)didHandleClickAsHover;
 - (void)didNotHandleClickAsClick:(const WebCore::IntPoint&)point;
 
-#endif
+#endif // ENABLE(TWO_PHASE_CLICKS)
 
 @end
+
+// MARK: WKAppKitGestureController + Internal
+
+@interface WKAppKitGestureController (Internal)
+
+@property (nonatomic, readonly) NSPanGestureRecognizer *_panGestureRecognizer;
+
+@property (nonatomic, readonly) NSPressGestureRecognizer *_singleClickGestureRecognizer;
+
+@property (nonatomic, readonly) NSClickGestureRecognizer *_doubleClickGestureRecognizer;
+
+@property (nonatomic, readonly) NSPressGestureRecognizer *_secondaryClickGestureRecognizer;
+
+@property (nonatomic, readonly, nullable) WebKit::WebViewImpl *_viewImpl;
+
+@property (nonatomic, readonly, nullable) WebKit::WebPageProxy *_page;
+
+@end
+
+// MARK: WKAppKitGestureController + NSGestureRecognizerDelegatePrivate
+
+@interface WKAppKitGestureController (NSGestureRecognizerDelegate) <NSGestureRecognizerDelegatePrivate>
+
+@end
+
+NS_HEADER_AUDIT_END(nullability, sendability)
 
 #endif // HAVE(APPKIT_GESTURES_SUPPORT)

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -150,9 +150,6 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     return -delta;
 }
 
-@interface WKAppKitGestureController () <NSGestureRecognizerDelegatePrivate>
-@end
-
 @implementation WKAppKitGestureController {
     WeakPtr<WebKit::WebPageProxy> _page;
     WeakPtr<WebKit::WebViewImpl> _viewImpl;
@@ -710,110 +707,38 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "Interrupted momentum scrolling");
 }
 
-#pragma mark - NSGestureRecognizerDelegate
+@end
 
-static BOOL isBuiltInScrollViewPanGestureRecognizer(NSGestureRecognizer *recognizer)
+@implementation WKAppKitGestureController (Internal)
+
+- (NSPanGestureRecognizer *)_panGestureRecognizer
 {
-    static Class scrollViewPanGestureClass = NSClassFromString(@"NSScrollViewPanGestureRecognizer");
-    return [recognizer isKindOfClass:scrollViewPanGestureClass];
+    return _panGestureRecognizer.get();
 }
 
-static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NSGestureRecognizer *x, NSGestureRecognizer *y)
+- (NSPressGestureRecognizer *)_singleClickGestureRecognizer
 {
-    return (a == x && b == y) || (b == x && a == y);
+    return _singleClickGestureRecognizer.get();
 }
 
-- (BOOL)gestureRecognizer:(NSGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(NSGestureRecognizer *)otherGestureRecognizer
+- (NSClickGestureRecognizer *)_doubleClickGestureRecognizer
 {
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Gesture: %@, Other gesture: %@", gestureRecognizer, otherGestureRecognizer);
-
-    if (isSamePair(gestureRecognizer, otherGestureRecognizer, _singleClickGestureRecognizer.get(), _panGestureRecognizer.get()))
-        return YES;
-
-    if (gestureRecognizer == _singleClickGestureRecognizer
-        && isBuiltInScrollViewPanGestureRecognizer(otherGestureRecognizer)
-        && [otherGestureRecognizer.view isKindOfClass:NSScrollView.class])
-        return YES;
-
-    CheckedPtr viewImpl = _viewImpl.get();
-    if (!viewImpl)
-        return NO;
-
-    RetainPtr webView = viewImpl->view();
-    if (!webView)
-        return NO;
-
-    // Allow the single click GR to be simultaneously recognized with any of those from the text selection manager.
-
-    for (NSGestureRecognizer *gestureForFailureRequirements in [[webView textSelectionManager] gesturesForFailureRequirements]) {
-        if ((gestureRecognizer == _singleClickGestureRecognizer && otherGestureRecognizer == gestureForFailureRequirements)
-            || (otherGestureRecognizer == _singleClickGestureRecognizer && gestureRecognizer == gestureForFailureRequirements))
-            return YES;
-    }
-
-    return NO;
+    return _doubleClickGestureRecognizer.get();
 }
 
-- (BOOL)gestureRecognizer:(NSGestureRecognizer *)gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:(NSGestureRecognizer *)otherGestureRecognizer
+- (NSPressGestureRecognizer *)_secondaryClickGestureRecognizer
 {
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Gesture: %@, Other gesture: %@", gestureRecognizer, otherGestureRecognizer);
-
-    CheckedPtr viewImpl = _viewImpl.get();
-    if (!viewImpl)
-        return NO;
-
-    RetainPtr webView = viewImpl->view();
-    if (!webView)
-        return NO;
-
-    // Fail any gestures from the text selection manager if the secondary click GR handles them.
-
-    for (NSGestureRecognizer *gestureForFailureRequirements in [[webView textSelectionManager] gesturesForFailureRequirements]) {
-        if (gestureRecognizer == _secondaryClickGestureRecognizer && otherGestureRecognizer == gestureForFailureRequirements)
-            return YES;
-    }
-
-    return NO;
+    return _secondaryClickGestureRecognizer.get();
 }
 
-- (BOOL)gestureRecognizer:(NSGestureRecognizer *)gestureRecognizer shouldRequireFailureOfGestureRecognizer:(NSGestureRecognizer *)otherGestureRecognizer
+- (WebKit::WebViewImpl *)_viewImpl
 {
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Gesture: %@, Other gesture: %@", gestureRecognizer, otherGestureRecognizer);
-
-    if (gestureRecognizer == _singleClickGestureRecognizer && otherGestureRecognizer == _doubleClickGestureRecognizer)
-        return YES;
-
-    return NO;
+    return _viewImpl.get();
 }
 
-- (BOOL)gestureRecognizerShouldBegin:(NSGestureRecognizer *)gestureRecognizer
+- (WebKit::WebPageProxy *)_page
 {
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Gesture: %@", gestureRecognizer);
-
-    if (gestureRecognizer == _doubleClickGestureRecognizer) {
-        CheckedPtr viewImpl = _viewImpl.get();
-        if (!viewImpl || !viewImpl->allowsMagnification())
-            return NO;
-    }
-
-    if (gestureRecognizer == _secondaryClickGestureRecognizer) {
-        // FIXME: Implement logic for determining if the clicked node is not text.
-        return NO;
-    }
-
-    return YES;
-}
-
-- (BOOL)_isScrollOrZoomGestureRecognizer:(NSGestureRecognizer *)gesture
-{
-    // FIXME: Should we account for any system pan gesture recognizers?
-    return gesture == _panGestureRecognizer || [gesture isKindOfClass:[NSMagnificationGestureRecognizer class]];
-}
-
-- (BOOL)_gestureRecognizer:(NSGestureRecognizer *)preventingGestureRecognizer canPreventGestureRecognizer:(NSGestureRecognizer *)preventedGestureRecognizer
-{
-    bool isOurClickGesture = preventingGestureRecognizer == _singleClickGestureRecognizer || preventingGestureRecognizer == _secondaryClickGestureRecognizer;
-    return !isOurClickGesture || ![self _isScrollOrZoomGestureRecognizer:preventedGestureRecognizer];
+    return _page.get();
 }
 
 @end

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureRecognizer.swift
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureRecognizer.swift
@@ -1,0 +1,176 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if HAVE_APPKIT_GESTURES_SUPPORT && compiler(>=6.2)
+
+import Foundation
+internal import WebKit_Internal
+
+@objc(NSGestureRecognizerDelegate)
+@implementation
+extension WKAppKitGestureController {
+    @objc(gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:)
+    func gestureRecognizer(
+        _ gestureRecognizer: NSGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: NSGestureRecognizer
+    ) -> Bool {
+        guard let page = _page else {
+            return false
+        }
+
+        Logger.viewGestures.log(
+            "[pageProxyID=\(page.logIdentifier())] \(#function) Gesture: \(String(reflecting: gestureRecognizer)), Other gesture: \(String(reflecting: otherGestureRecognizer))"
+        )
+
+        if Set([gestureRecognizer, otherGestureRecognizer]) == Set([_singleClickGestureRecognizer, _panGestureRecognizer]) {
+            return true
+        }
+
+        if gestureRecognizer === _singleClickGestureRecognizer
+            && otherGestureRecognizer.isBuiltInScrollViewPanGestureRecognizer
+            && otherGestureRecognizer.view is NSScrollView
+        {
+            return true
+        }
+
+        guard let webView = unsafe _viewImpl?.view() else {
+            return false
+        }
+
+        // Allow the single click GR to be simultaneously recognized with any of those from the text selection manager.
+
+        if let textSelectionManager = webView.textSelectionManager {
+            if textSelectionManager.gesturesForFailureRequirements.contains(where: {
+                Set([gestureRecognizer, otherGestureRecognizer]) == Set([_singleClickGestureRecognizer, $0])
+            }) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    @objc(gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:)
+    func gestureRecognizer(
+        _ gestureRecognizer: NSGestureRecognizer,
+        shouldBeRequiredToFailBy otherGestureRecognizer: NSGestureRecognizer
+    ) -> Bool {
+        guard let page = _page else {
+            return false
+        }
+
+        Logger.viewGestures.log(
+            "[pageProxyID=\(page.logIdentifier())] \(#function) Gesture: \(String(reflecting: gestureRecognizer)), Other gesture: \(String(reflecting: otherGestureRecognizer))"
+        )
+
+        guard let webView = unsafe _viewImpl?.view() else {
+            return false
+        }
+
+        // Fail any gestures from the text selection manager if the secondary click GR handles them.
+
+        if let textSelectionManager = webView.textSelectionManager {
+            if textSelectionManager.gesturesForFailureRequirements.contains(where: {
+                gestureRecognizer === _secondaryClickGestureRecognizer && otherGestureRecognizer === $0
+            }) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    @objc(gestureRecognizer:shouldRequireFailureOfGestureRecognizer:)
+    func gestureRecognizer(
+        _ gestureRecognizer: NSGestureRecognizer,
+        shouldRequireFailureOf otherGestureRecognizer: NSGestureRecognizer
+    ) -> Bool {
+        guard let page = _page else {
+            return false
+        }
+
+        Logger.viewGestures.log(
+            "[pageProxyID=\(page.logIdentifier())] \(#function) Gesture: \(String(reflecting: gestureRecognizer)), Other gesture: \(String(reflecting: otherGestureRecognizer))"
+        )
+
+        if gestureRecognizer === _singleClickGestureRecognizer && otherGestureRecognizer === _doubleClickGestureRecognizer {
+            return true
+        }
+
+        return false
+    }
+
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: NSGestureRecognizer) -> Bool {
+        guard let page = _page else {
+            return false
+        }
+
+        guard let viewImpl = unsafe _viewImpl else {
+            return false
+        }
+
+        Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) Gesture: \(String(reflecting: gestureRecognizer))")
+
+        if gestureRecognizer === _doubleClickGestureRecognizer {
+            if unsafe !viewImpl.allowsMagnification() {
+                return false
+            }
+        }
+
+        if gestureRecognizer === _secondaryClickGestureRecognizer {
+            // FIXME: Implement logic for determining if the clicked node is not text.
+            return false
+        }
+
+        return true
+    }
+
+    private func isScrollOrZoomGestureRecognizer(_ gestureRecognizer: NSGestureRecognizer) -> Bool {
+        // FIXME: Should we account for any system pan gesture recognizers?
+        gestureRecognizer === _panGestureRecognizer || gestureRecognizer is NSMagnificationGestureRecognizer
+    }
+
+    // swift-format-ignore: NoLeadingUnderscores
+    @objc(_gestureRecognizer:canPreventGestureRecognizer:)
+    func _gestureRecognizer(
+        _ preventingGestureRecognizer: NSGestureRecognizer!,
+        canPrevent preventedGestureRecognizer: NSGestureRecognizer!
+    ) -> Bool {
+        let isOurClickGesture =
+            preventingGestureRecognizer === _singleClickGestureRecognizer
+            || preventingGestureRecognizer === _secondaryClickGestureRecognizer
+
+        return !isOurClickGesture || !isScrollOrZoomGestureRecognizer(preventedGestureRecognizer)
+    }
+}
+
+extension NSGestureRecognizer {
+    fileprivate var isBuiltInScrollViewPanGestureRecognizer: Bool {
+        guard let scrollViewPanGestureClass: AnyClass = NSClassFromString("NSScrollViewPanGestureRecognizer") else {
+            return false
+        }
+        return isKind(of: scrollViewPanGestureClass)
+    }
+}
+
+#endif // HAVE_APPKIT_GESTURES_SUPPORT && compiler(>=6.2)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		07AF79E12D693DD7004E8D3A /* WKScrollGeometryAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07AF79E02D693DD7004E8D3A /* WKScrollGeometryAdapter.swift */; };
 		07AF79E92D695195004E8D3A /* WKUIDelegateInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 07AF79E82D695195004E8D3A /* WKUIDelegateInternal.h */; };
 		07BAEEA12ED056EE00251691 /* WebURLSchemeTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D124271E6D3F1F002B2820 /* WebURLSchemeTask.h */; };
+		07C7D2782F5E8B25007D69FB /* WKAppKitGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C7D2772F5E8B25007D69FB /* WKAppKitGestureRecognizer.swift */; };
 		07CB79962CE9435700199C49 /* WebPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07CB79952CE9435700199C49 /* WebPage.swift */; };
 		07CB79982CE943E400199C49 /* WKNavigationDelegateAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07CB79972CE943E400199C49 /* WKNavigationDelegateAdapter.swift */; };
 		07CF2D512C2147A50064DF23 /* PlatformWritingToolsUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 07CA7FE92C20FAAA00798167 /* PlatformWritingToolsUtilities.h */; };
@@ -3499,6 +3500,7 @@
 		07B93FF523AF0CB80036F8EA /* RemoteMediaPlayerConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaPlayerConfiguration.h; sourceTree = "<group>"; };
 		07BAF35623A2CC170044257E /* RemoteMediaPlayerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaPlayerProxy.h; sourceTree = "<group>"; };
 		07BAF35723A2CC190044257E /* RemoteMediaPlayerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaPlayerProxy.cpp; sourceTree = "<group>"; };
+		07C7D2772F5E8B25007D69FB /* WKAppKitGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKAppKitGestureRecognizer.swift; sourceTree = "<group>"; };
 		07CA7FE92C20FAAA00798167 /* PlatformWritingToolsUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlatformWritingToolsUtilities.h; sourceTree = "<group>"; };
 		07CA7FEA2C20FAAA00798167 /* PlatformWritingToolsUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PlatformWritingToolsUtilities.mm; sourceTree = "<group>"; };
 		07CB79952CE9435700199C49 /* WebPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPage.swift; sourceTree = "<group>"; };
@@ -16549,6 +16551,7 @@
 				868160CF187645370021E79D /* WindowServerConnection.mm */,
 				336E07462EBCC1C100B4D635 /* WKAppKitGestureController.h */,
 				336E07472EBCC1C100B4D635 /* WKAppKitGestureController.mm */,
+				07C7D2772F5E8B25007D69FB /* WKAppKitGestureRecognizer.swift */,
 				CDCA85C7132ABA4E00E961DF /* WKFullScreenWindowController.h */,
 				CDCA85C6132ABA4E00E961DF /* WKFullScreenWindowController.mm */,
 				9321D5851A38EE3C008052BE /* WKImmediateActionController.h */,
@@ -22168,6 +22171,7 @@
 				9356F2DF2152B72300E6D5DF /* WebSWOriginStore.cpp in Sources */,
 				9356F2E12152B76600E6D5DF /* WebSWServerConnection.cpp in Sources */,
 				9356F2E02152B75200E6D5DF /* WebSWServerToContextConnection.cpp in Sources */,
+				07C7D2782F5E8B25007D69FB /* WKAppKitGestureRecognizer.swift in Sources */,
 				A190E9422F3DB703009615AD /* WKAVContentSource.mm in Sources */,
 				C6A4CA0C2252899800169289 /* WKBundlePageMac.mm in Sources */,
 				2D931169212F61B200044BFE /* WKContentView.mm in Sources */,


### PR DESCRIPTION
#### e345e857d0531ff0f2b770f0f26be46bbbe7975e
<pre>
[AppKit Gestures] Start converting WKAppKitGestureController to Swift (part 1)
<a href="https://rdar.apple.com/172055446">rdar://172055446</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309475">https://bugs.webkit.org/show_bug.cgi?id=309475</a>

Reviewed by NOBODY (OOPS!).

Start converting WKAppKitGestureController piece-by-piece to Swift, starting off with the GR delegate

* Source/WebKit/Modules/Internal/module.modulemap:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.h:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController _panGestureRecognizer]):
(-[WKAppKitGestureController _singleClickGestureRecognizer]):
(-[WKAppKitGestureController _doubleClickGestureRecognizer]):
(-[WKAppKitGestureController _secondaryClickGestureRecognizer]):
(-[WKAppKitGestureController _viewImpl]):
(-[WKAppKitGestureController _page]):
(isBuiltInScrollViewPanGestureRecognizer): Deleted.
(isSamePair): Deleted.
(-[WKAppKitGestureController gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]): Deleted.
(-[WKAppKitGestureController gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:]): Deleted.
(-[WKAppKitGestureController gestureRecognizer:shouldRequireFailureOfGestureRecognizer:]): Deleted.
(-[WKAppKitGestureController gestureRecognizerShouldBegin:]): Deleted.
(-[WKAppKitGestureController _isScrollOrZoomGestureRecognizer:]): Deleted.
(-[WKAppKitGestureController _gestureRecognizer:canPreventGestureRecognizer:]): Deleted.
* Source/WebKit/UIProcess/mac/WKAppKitGestureRecognizer.swift: Added.
(WKAppKitGestureController.gestureRecognizerShouldBegin(_:)):
(WKAppKitGestureController.isScrollOrZoomGestureRecognizer(_:)):
(NSGestureRecognizer.isBuiltInScrollViewPanGestureRecognizer):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e345e857d0531ff0f2b770f0f26be46bbbe7975e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157497 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102242 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8bdeab85-7b5d-4ade-9c65-d11815cf8054) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21403 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114713 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81700 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8e69fad-de2d-4d66-97ea-5968f4319c9f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133570 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95482 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/42d60502-3885-4d00-90ec-ff3032ec1e08) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16028 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13880 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5262 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125629 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159835 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2972 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122776 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21327 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17891 "Found 1 new test failure: apple-visual-effects/apple-visual-effect-automatic-vibrancy.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123001 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21335 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133284 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77523 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18305 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10046 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20937 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84739 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20669 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20816 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20725 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->