### PR TITLE
[JSC] Implement cached BigInt remainder

### DIFF
--- a/JSTests/stress/bigint-cached-mod.js
+++ b/JSTests/stress/bigint-cached-mod.js
@@ -1,0 +1,81 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+// Test 1: Repeated modulo with same divisor (triggers caching after 100 iterations).
+{
+    const p = 2n ** 255n - 19n; // ed25519 prime
+    let x = 12345678901234567890123456789n;
+    for (let i = 0; i < 200; i++)
+        x = (x * x) % p;
+    shouldBe(x, 36260996769751896565040950513605801167497797310772705034288993169759633740077n);
+}
+
+// Test 2: Various dividend sizes relative to divisor.
+{
+    const divisor = (1n << 256n) - 189n;
+    let results = [];
+    // Dividend close to divisor size (n digits)
+    let a = (1n << 255n) + 17n;
+    for (let i = 0; i < 150; i++) {
+        a = (a * 3n) % divisor;
+    }
+    results.push(a);
+
+    // Dividend close to 2*divisor size (2n digits)
+    let b = (1n << 500n) + 42n;
+    for (let i = 0; i < 150; i++) {
+        b = (b % divisor);
+        b = b * (1n << 250n) + 1n;
+    }
+    results.push(b % divisor);
+
+    // Verify all results are in range [0, divisor)
+    for (let r of results) {
+        if (r < 0n || r >= divisor)
+            throw new Error(`Result ${r} out of range`);
+    }
+}
+
+// Test 3: Divisor changes mid-loop (cache should invalidate).
+{
+    const p1 = 2n ** 255n - 19n;
+    const p2 = 2n ** 256n - 189n;
+    let x = 999999999999999999999999999999n;
+    for (let i = 0; i < 120; i++)
+        x = (x * x) % p1;
+    let y = x;
+    for (let i = 0; i < 120; i++)
+        y = (y * y) % p2;
+    // Just make sure it doesn't crash and produces a reasonable result.
+    shouldBe(y >= 0n && y < p2, true);
+}
+
+// Test 4: Small divisors that should NOT be cached (single-digit fast path).
+{
+    let x = 2n ** 300n;
+    for (let i = 0; i < 200; i++)
+        x = x % 7n;
+    shouldBe(x, (2n ** 300n) % 7n);
+}
+
+// Test 5: Sign handling with cached mod.
+{
+    const p = 2n ** 255n - 19n;
+    let x = -(2n ** 300n + 1n);
+    for (let i = 0; i < 150; i++)
+        x = x % p;
+    // Negative dividend: result should be negative or zero.
+    shouldBe(x <= 0n, true);
+    shouldBe(-x < p, true);
+}
+
+// Test 6: Exact multiple (result should be 0).
+{
+    const p = 2n ** 255n - 19n;
+    for (let i = 0; i < 150; i++) {
+        let x = p * BigInt(i + 1);
+        shouldBe(x % p, 0n);
+    }
+}

--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -790,9 +790,7 @@ std::span<JSBigInt::Digit> JSBigInt::multiplySingle(std::span<const Digit> multi
 // implementations.
 // This method is *highly* performance sensitive even for the advanced
 // algorithms, which use this as the base case of their recursive calls.
-std::span<JSBigInt::Digit> JSBigInt::multiplyTextbook(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result)
-{
-#define BODY(min, max) \
+#define MULTIPLY_BODY(min, max) \
     do { \
         for (uint32_t j = min; j <= max; j++) { \
             auto [low, high] = digitMul(x[j], y[i - j]); \
@@ -802,6 +800,8 @@ std::span<JSBigInt::Digit> JSBigInt::multiplyTextbook(std::span<const Digit> x, 
         result[i] = zi; \
     } while (0)
 
+std::span<JSBigInt::Digit> JSBigInt::multiplyTextbook(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result)
+{
     ASSERT(x.size() >= y.size());
     ASSERT(result.size() >= x.size() + y.size());
     ASSERT(x.size());
@@ -819,7 +819,7 @@ std::span<JSBigInt::Digit> JSBigInt::multiplyTextbook(std::span<const Digit> x, 
     if (i < y.size()) {
         Digit zi = next;
         next = 0;
-        BODY(0, 1);
+        MULTIPLY_BODY(0, 1);
         i++;
     }
 
@@ -830,7 +830,7 @@ std::span<JSBigInt::Digit> JSBigInt::multiplyTextbook(std::span<const Digit> x, 
         next = nextCarry + temp;
         carry = 0;
         nextCarry = 0;
-        BODY(0, i);
+        MULTIPLY_BODY(0, i);
     }
 
     // Last part: i exceeds y now, we have to be careful about bounds.
@@ -844,7 +844,7 @@ std::span<JSBigInt::Digit> JSBigInt::multiplyTextbook(std::span<const Digit> x, 
         next = nextCarry + temp;
         carry = 0;
         nextCarry = 0;
-        BODY(minXIndex, maxXIndex);
+        MULTIPLY_BODY(minXIndex, maxXIndex);
     }
 
     // Write the last digit.
@@ -853,6 +853,56 @@ std::span<JSBigInt::Digit> JSBigInt::multiplyTextbook(std::span<const Digit> x, 
     ASSERT(!temp);
     return result.first(i);
 }
+
+// For the needs of cachedMod, computes only the low result.size() digits of X * Y.
+void JSBigInt::multiplySpecialLow(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result)
+{
+    ASSERT(y.size() >= 1);
+    ASSERT(x.size() >= 2);
+    ASSERT(x.size() >= y.size() - 1);
+    ASSERT(result.size());
+
+    Digit next, nextCarry = 0, carry = 0;
+    // Unrolled first iteration: it's trivial.
+    {
+        auto [low, high] = digitMul(x[0], y[0]);
+        result[0] = low;
+        next = high;
+    }
+    size_t i = 1;
+    // Unrolled second iteration: a little less setup.
+    if (i < y.size()) {
+        Digit zi = next;
+        next = 0;
+        MULTIPLY_BODY(0, 1);
+        i++;
+    }
+    // Main part: no bounds checks in the loop.
+    size_t loopEnd = result.size() - 1;
+    size_t mainEnd = std::min({ x.size(), y.size(), loopEnd });
+    for (; i < mainEnd; i++) {
+        Digit temp = 0;
+        Digit zi = digitAdd(next, carry, temp);
+        next = nextCarry + temp;
+        carry = 0;
+        nextCarry = 0;
+        MULTIPLY_BODY(0, i);
+    }
+    // Last part: we have to be careful about bounds.
+    for (; i <= loopEnd; i++) {
+        size_t maxXIndex = std::min<size_t>(i, x.size() - 1);
+        size_t maxYIndex = std::min<size_t>(i, y.size() - 1);
+        size_t minXIndex = i - maxYIndex;
+        Digit temp = 0;
+        Digit zi = digitAdd(next, carry, temp);
+        next = nextCarry + temp;
+        carry = 0;
+        nextCarry = 0;
+        MULTIPLY_BODY(minXIndex, maxXIndex);
+    }
+}
+
+#undef MULTIPLY_BODY
 
 template <typename BigIntImpl1, typename BigIntImpl2>
 JSBigInt::ImplResult JSBigInt::multiplyImpl(JSGlobalObject* globalObject, BigIntImpl1 x, BigIntImpl2 y)
@@ -1052,6 +1102,16 @@ JSBigInt::Digit JSBigInt::inplaceAdd(std::span<Digit> z, std::span<const Digit> 
 JSBigInt::Digit JSBigInt::inplaceSub(std::span<Digit> z, std::span<const Digit> x)
 {
   return subtractAndReturnBorrow(z, z, x);
+}
+
+bool JSBigInt::greaterThanOrEqual(std::span<const Digit> a, std::span<const Digit> b)
+{
+    ASSERT(a.size() == b.size());
+    for (size_t i = a.size(); i-- > 0;) {
+        if (a[i] != b[i])
+            return a[i] > b[i];
+    }
+    return true;
 }
 
 static std::span<JSBigInt::Digit> spanCopy(std::span<JSBigInt::Digit> z, std::span<const JSBigInt::Digit> x)
@@ -1500,6 +1560,106 @@ JSValue JSBigInt::unaryMinus(JSGlobalObject* globalObject, JSBigInt* x)
     return tryConvertToBigInt32(unaryMinusImpl(globalObject, HeapBigIntImpl { x }));
 }
 
+// Compute the multiplicative inverse Inv ≈ floor(2^(2n*digitBits) / B) for cached modulo.
+// Given divisor B with n digits, the inverse has n+1 digits.
+// Uses V8's bit-negation trick to avoid a (2n+1)-digit dividend:
+//   A = ~(B << n) ≈ 2^(2n) - B*2^n - 1, then Inv = A/B + 2^n (undo the subtraction).
+void JSBigInt::cachedModMakeInverse(VM& vm, std::span<const Digit> b)
+{
+    size_t n = b.size();
+    ASSERT(n >= 2 && n <= maxCachedModDivisorSize);
+
+    size_t invLen = n + 1;
+    vm.m_bigIntCachedInverse.resize(invLen);
+
+    // Construct A (2n digits) using bit-negation trick:
+    // A[0..n-1] = ~0 (all 1-bits), A[n..2n-1] = ~B[i-n]
+    Vector<Digit, 64> a(2 * n);
+    size_t i = 0;
+    for (; i < n; i++)
+        a[i] = ~static_cast<Digit>(0);
+    for (; i < 2 * n; i++)
+        a[i] = ~b[i - n];
+
+    // Inv = A / B. Since A has 2n digits and B has n digits,
+    // quotient has at most n+1 digits (which is invLen).
+    auto inv = vm.m_bigIntCachedInverse.mutableSpan();
+    divideTextbook(inv, { }, a.span(), b);
+
+    // Undo the bit-negation: add 1 to the upper part (starting at digit n).
+    // This corresponds to adding back 2^n that was subtracted by the trick.
+    RELEASE_ASSERT(inv.size() == invLen);
+    {
+        Digit carry = 0;
+        inv[n] = digitAdd(inv[n], 1, carry);
+        ASSERT(!carry);
+    }
+
+    // Optionally add 1 to the whole inverse to improve convergence of the
+    // corrective loop in cachedMod. But don't do it when there's a risk of overflow.
+    if (inv[0] != ~static_cast<Digit>(0) || inv[invLen - 1] != ~static_cast<Digit>(0)) {
+        Digit carry = 0;
+        inv[0] = digitAdd(inv[0], 1, carry);
+        for (size_t j = 1; j < invLen && carry; j++) {
+            Digit c = 0;
+            inv[j] = digitAdd(inv[j], carry, c);
+            carry = c;
+        }
+    }
+}
+
+// Cached modulo: R = A mod B, using precomputed inverse Inv.
+// A must have between n and 2n digits (where n = B.size()).
+// Returns the normalized result span within r.
+std::span<const JSBigInt::Digit> JSBigInt::cachedMod(VM& vm, std::span<Digit> r, std::span<const Digit> a, std::span<const Digit> b)
+{
+    size_t n = b.size();
+    ASSERT(n >= 2 && n <= maxCachedModDivisorSize);
+    ASSERT(a.size() >= n && a.size() <= 2 * n);
+    ASSERT(r.size() >= n);
+
+    r = r.first(n);
+    auto inv = vm.m_bigIntCachedInverse.span().first(n + 1);
+
+    // Step 1: Compute full product A * Inv into scratch.
+    size_t scratchSpace = a.size() + inv.size();
+    Vector<Digit, 64> scratch(scratchSpace);
+    if (a.size() >= inv.size())
+        multiplyTextbook(a, inv, scratch.mutableSpan());
+    else
+        multiplyTextbook(inv, a, scratch.mutableSpan());
+
+    // Step 2: Extract estimated quotient Q from position 2n in the product.
+    auto qSpan = scratch.span().subspan(2 * n);
+
+    // Step 3: Compute product_low = B * Q (only low n+1 digits needed).
+    // Reuse the low part of scratch for product_low (overlapping the full product).
+    auto productLow = scratch.mutableSpan().first(n + 1);
+    multiplySpecialLow(b, qSpan, productLow);
+
+    // Step 4: R = A[0..n-1] - product_low[0..n-1].
+    Digit borrow = subtractAndReturnBorrow(r, a.first(n), productLow.first(n));
+
+    // Track the extra digit: r_high = A[n] - product_low[n] - borrow.
+    Digit an = a.size() > n ? a[n] : 0;
+    Digit rHigh = an - productLow[n] - borrow;
+
+    // Step 5: Corrective loop using sign bit of r_high.
+    constexpr Digit signBit = static_cast<Digit>(1) << (digitBits - 1);
+    if (rHigh & signBit) {
+        // Result is negative — add B back until r_high == 0.
+        do {
+            rHigh += inplaceAdd(r, b);
+        } while (rHigh);
+    } else {
+        // Result is non-negative but may be >= B — subtract B.
+        while (rHigh || greaterThanOrEqual(r, b))
+            rHigh -= inplaceSub(r, b);
+    }
+
+    return normalize(r);
+}
+
 template <typename BigIntImpl1, typename BigIntImpl2>
 JSBigInt::ImplResult JSBigInt::remainderImpl(JSGlobalObject* globalObject, BigIntImpl1 x, BigIntImpl2 y)
 {
@@ -1544,6 +1704,25 @@ JSBigInt::ImplResult JSBigInt::remainderImpl(JSGlobalObject* globalObject, BigIn
         remainder->setDigit(0, remainderDigit);
         remainder->setSign(x.sign());
         return remainder;
+    }
+
+    // Cached multiplicative inverse optimization for repeated modulo with the same divisor.
+    if constexpr (std::is_same_v<BigIntImpl2, HeapBigIntImpl>) {
+        if (vm.m_cachedBigIntDivisor.get() == y.toHeapBigInt(globalObject)) {
+            if (xSpan.size() <= 2 * ySpan.size()) {
+                Vector<Digit, 16> r(ySpan.size());
+                auto rSpan = cachedMod(vm, r.mutableSpan(), xSpan, ySpan);
+                RELEASE_AND_RETURN(scope, tryCreateFromImpl(globalObject, vm, x.sign(), rSpan));
+            }
+        } else if (vm.m_nextCachedBigIntDivisor.get() == y.toHeapBigInt(globalObject)) {
+            if (++vm.m_bigIntDivisorCount >= 100) {
+                vm.m_cachedBigIntDivisor.setWithoutWriteBarrier(y.toHeapBigInt(globalObject));
+                cachedModMakeInverse(vm, ySpan);
+            }
+        } else if (ySpan.size() >= 2 && ySpan.size() <= maxCachedModDivisorSize) {
+            vm.m_nextCachedBigIntDivisor.setWithoutWriteBarrier(y.toHeapBigInt(globalObject));
+            vm.m_bigIntDivisorCount = 1;
+        }
     }
 
     Vector<Digit, 16> r(ySpan.size());

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -529,6 +529,7 @@ private:
     static void multiplyAdd(std::span<const Digit> source, Digit factor, Digit summand, std::span<Digit> result);
     static std::span<Digit> multiplySingle(std::span<const Digit> multiplicand, Digit multiplier, std::span<Digit> result);
     static std::span<Digit> multiplyTextbook(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result);
+    static void multiplySpecialLow(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result);
     template<size_t N>
     static std::span<Digit, N * 2> multiplyComba(std::span<const Digit, N> x, std::span<const Digit, N> y, std::span<Digit, N * 2> result);
 
@@ -572,6 +573,12 @@ private:
 
     static Digit inplaceAdd(std::span<Digit> z, std::span<const Digit> x);
     static Digit inplaceSub(std::span<Digit> z, std::span<const Digit> x);
+
+    static constexpr unsigned maxCachedModDivisorSize = 32; // 2048-bit divisors on 64-bit
+    static void cachedModMakeInverse(VM&, std::span<const Digit> b);
+    static std::span<const Digit> cachedMod(VM&, std::span<Digit> r, std::span<const Digit>, std::span<const Digit>);
+    static bool greaterThanOrEqual(std::span<const Digit>, std::span<const Digit>);
+
     static std::span<Digit> rightShift(std::span<Digit> z, std::span<const Digit> x, unsigned);
     static std::span<Digit> leftShift(std::span<Digit> z, std::span<const Digit> x, unsigned);
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1901,6 +1901,8 @@ void VM::visitAggregateImpl(Visitor& visitor)
     visitor.append(m_slowCanConstructBoundExecutable);
     visitor.append(lastCachedString);
     visitor.append(heapBigIntConstantOne);
+    visitor.append(m_cachedBigIntDivisor);
+    visitor.append(m_nextCachedBigIntDivisor);
 
     visitor.append(m_promiseResolvingFunctionResolveExecutable);
     visitor.append(m_promiseResolvingFunctionRejectExecutable);

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -620,6 +620,12 @@ public:
 
     WriteBarrier<JSBigInt> heapBigIntConstantOne;
 
+    // Cached multiplicative inverse for BigInt modulo optimization.
+    WriteBarrier<JSBigInt> m_cachedBigIntDivisor;
+    WriteBarrier<JSBigInt> m_nextCachedBigIntDivisor;
+    Vector<UCPURegister> m_bigIntCachedInverse;
+    int m_bigIntDivisorCount { 0 };
+
     JSCell* orderedHashTableDeletedValue()
     {
         return m_orderedHashTableDeletedValue.get();


### PR DESCRIPTION
#### 559de0581a46a0432076447ba22305af8119dade
<pre>
[JSC] Implement cached BigInt remainder
<a href="https://bugs.webkit.org/show_bug.cgi?id=309479">https://bugs.webkit.org/show_bug.cgi?id=309479</a>
<a href="https://rdar.apple.com/172062278">rdar://172062278</a>

Reviewed by Yijia Huang.

This patch implements V8&apos;s optimization[1] for repeated remainder
computation with the same BigInt divisor. There are many cases which
repeatedly compute the modulo with the same divisor, this patch
accelerates it by caching the multiplicative inverse of the divisor.

[1]: <a href="https://chromium-review.googlesource.com/c/v8/v8/+/7607186">https://chromium-review.googlesource.com/c/v8/v8/+/7607186</a>

Test: JSTests/stress/bigint-cached-mod.js

* JSTests/stress/bigint-cached-mod.js: Added.
(shouldBe):
(throw.new.Error):
* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::JSBigInt::multiplyTextbook):
(JSC::JSBigInt::multiplySpecialLow):
(JSC::JSBigInt::greaterThanOrEqual):
(JSC::JSBigInt::cachedModMakeInverse):
(JSC::JSBigInt::cachedMod):
(JSC::JSBigInt::remainderImpl):
* Source/JavaScriptCore/runtime/JSBigInt.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::visitAggregateImpl):
* Source/JavaScriptCore/runtime/VM.h:

Canonical link: <a href="https://commits.webkit.org/308930@main">https://commits.webkit.org/308930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c0654ec7d6bd5c936652f8386ec4f9a442904bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148902 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21615 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/15184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157588 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/77025c6c-b976-4762-8163-30feab3eedb9) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/22068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21493 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/114787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4f820f3-e548-46a2-8b2a-7e916fae87b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151862 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/22068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/95548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/22068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/5437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140869 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/22068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/11568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160071 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9690 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3062 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/13090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/122845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17967 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/123074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/133362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22932 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/10124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180330 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/21027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84829 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->