### PR TITLE
Adopt LIFETIME_BOUND in more places in JavaScriptCore

### DIFF
--- a/Source/JavaScriptCore/API/JSWeakObjectMapRefInternal.h
+++ b/Source/JavaScriptCore/API/JSWeakObjectMapRefInternal.h
@@ -50,7 +50,7 @@ public:
         return adoptRef(*new OpaqueJSWeakObjectMap(vm, data, callback));
     }
 
-    WeakMapType& map() { return m_map; }
+    WeakMapType& map() LIFETIME_BOUND { return m_map; }
     
     ~OpaqueJSWeakObjectMap()
     {

--- a/Source/JavaScriptCore/API/ObjCCallbackFunction.h
+++ b/Source/JavaScriptCore/API/ObjCCallbackFunction.h
@@ -71,7 +71,7 @@ public:
 
     DECLARE_EXPORT_INFO;
 
-    ObjCCallbackFunctionImpl* impl() const { return m_impl.get(); }
+    ObjCCallbackFunctionImpl* impl() const LIFETIME_BOUND { return m_impl.get(); }
 
 protected:
     ObjCCallbackFunction(VM&, Structure*, JSObjectCallAsFunctionCallback, JSObjectCallAsConstructorCallback, std::unique_ptr<ObjCCallbackFunctionImpl>);

--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -266,7 +266,7 @@ public:
     {
     }
     
-    AssemblerBuffer& buffer() { return m_buffer; }
+    AssemblerBuffer& buffer() LIFETIME_BOUND { return m_buffer; }
 
     // (HS, LO, HI, LS) -> (AE, B, A, BE)
     // (VS, VC) -> (O, NO)

--- a/Source/JavaScriptCore/assembler/ARMv7Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARMv7Assembler.h
@@ -495,7 +495,7 @@ public:
     {
     }
 
-    AssemblerBuffer& buffer() { return m_formatter.m_buffer; }
+    AssemblerBuffer& buffer() LIFETIME_BOUND { return m_formatter.m_buffer; }
 
 private:
 

--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -854,7 +854,7 @@ public:
             m_jumps.shrink(size);
         }
 
-        const JumpVector& jumps() const { return m_jumps; }
+        const JumpVector& jumps() const LIFETIME_BOUND { return m_jumps; }
 
     private:
         JumpVector m_jumps;

--- a/Source/JavaScriptCore/assembler/AssemblerBuffer.h
+++ b/Source/JavaScriptCore/assembler/AssemblerBuffer.h
@@ -460,11 +460,11 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif // !CPU(ARM64)
 
 #if !CPU(ARM64) // If we were to define this on arm64e, we'd need a way to update the hash as we write directly into the buffer.
-        void* data() const { return m_storage.buffer(); }
+        void* data() const LIFETIME_BOUND { return m_storage.buffer(); }
 #endif
 
 #if ENABLE(JIT_SIGN_ASSEMBLER_BUFFER)
-        ARM64EHash<ShouldSign::Yes>& arm64eHash() { return m_hash; }
+        ARM64EHash<ShouldSign::Yes>& arm64eHash() LIFETIME_BOUND { return m_hash; }
 #endif
 
     protected:

--- a/Source/JavaScriptCore/assembler/AssemblyComments.h
+++ b/Source/JavaScriptCore/assembler/AssemblyComments.h
@@ -43,7 +43,7 @@ public:
     static AssemblyCommentRegistry& singleton();
     static void initialize();
 
-    Lock& getLock() WTF_RETURNS_LOCK(m_lock) { return m_lock; }
+    Lock& getLock() LIFETIME_BOUND WTF_RETURNS_LOCK(m_lock) { return m_lock; }
 
     using CommentMap = UncheckedKeyHashMap<uintptr_t, String>;
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -94,7 +94,7 @@ public:
     static constexpr Assembler::Condition DefaultCondition = Assembler::ConditionInvalid;
     static constexpr Assembler::JumpType DefaultJump = Assembler::JumpNoConditionFixedSize;
 
-    Vector<LinkRecord, 0, UnsafeVectorOverflow>& jumpsToLink() { return m_assembler.jumpsToLink(); }
+    Vector<LinkRecord, 0, UnsafeVectorOverflow>& jumpsToLink() LIFETIME_BOUND { return m_assembler.jumpsToLink(); }
     static bool canCompact(JumpType jumpType) { return Assembler::canCompact(jumpType); }
     static JumpLinkType computeJumpType(LinkRecord& record, const uint8_t* from, const uint8_t* to) { return Assembler::computeJumpType(record, from, to); }
     static int jumpSizeDelta(JumpType jumpType, JumpLinkType jumpLinkType) { return Assembler::jumpSizeDelta(jumpType, jumpLinkType); }

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -115,7 +115,7 @@ public:
         return value >= -255 && value <= 255;
     }
 
-    Vector<LinkRecord, 0, UnsafeVectorOverflow>& jumpsToLink() { return m_assembler.jumpsToLink(); }
+    Vector<LinkRecord, 0, UnsafeVectorOverflow>& jumpsToLink() LIFETIME_BOUND { return m_assembler.jumpsToLink(); }
     static bool canCompact(JumpType jumpType) { return ARMv7Assembler::canCompact(jumpType); }
     static JumpLinkType computeJumpType(LinkRecord& record, const uint8_t* from, const uint8_t* to) { return ARMv7Assembler::computeJumpType(record, from, to); }
     static int jumpSizeDelta(JumpType jumpType, JumpLinkType jumpLinkType) { return ARMv7Assembler::jumpSizeDelta(jumpType, jumpLinkType); }

--- a/Source/JavaScriptCore/assembler/RISCV64Assembler.h
+++ b/Source/JavaScriptCore/assembler/RISCV64Assembler.h
@@ -1528,7 +1528,7 @@ public:
 
     RISCV64Assembler() { }
 
-    AssemblerBuffer& buffer() { return m_buffer; }
+    AssemblerBuffer& buffer() LIFETIME_BOUND { return m_buffer; }
 
     static void* getRelocatedAddress(void* code, AssemblerLabel label)
     {

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -553,7 +553,7 @@ public:
     {
     }
     
-    AssemblerBuffer& buffer() { return m_formatter.m_buffer; }
+    AssemblerBuffer& buffer() LIFETIME_BOUND { return m_formatter.m_buffer; }
 
     // Stack operations:
 
@@ -7440,7 +7440,7 @@ private:
         size_t codeSize() const { return m_buffer.codeSize(); }
         AssemblerLabel label() const { return m_buffer.label(); }
         bool isAligned(int alignment) const { return m_buffer.isAligned(alignment); }
-        void* data() const { return m_buffer.data(); }
+        void* data() const LIFETIME_BOUND { return m_buffer.data(); }
 
         unsigned debugOffset() { return m_buffer.debugOffset(); }
 

--- a/Source/JavaScriptCore/b3/B3AbstractHeap.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeap.h
@@ -128,7 +128,7 @@ public:
     IndexedAbstractHeap(AbstractHeap* parent, const char* heapName, ptrdiff_t offset, size_t elementSize);
     ~IndexedAbstractHeap();
 
-    AbstractHeap& atAnyIndex() { return m_heapForAnyIndex; }
+    AbstractHeap& atAnyIndex() LIFETIME_BOUND { return m_heapForAnyIndex; }
 
     const AbstractHeap& at(ptrdiff_t index)
     {
@@ -181,9 +181,9 @@ public:
     NumberedAbstractHeap(AbstractHeap* parent, const char* heapName);
     ~NumberedAbstractHeap();
 
-    AbstractHeap& atAnyNumber() { return m_indexedHeap.atAnyIndex(); }
+    AbstractHeap& atAnyNumber() LIFETIME_BOUND { return m_indexedHeap.atAnyIndex(); }
 
-    const AbstractHeap& at(ptrdiff_t number) { return m_indexedHeap.at(number); }
+    const AbstractHeap& at(ptrdiff_t number) LIFETIME_BOUND { return m_indexedHeap.at(number); }
     const AbstractHeap& operator[](ptrdiff_t number) { return at(number); }
 
     void dump(PrintStream&);
@@ -199,7 +199,7 @@ public:
     AbsoluteAbstractHeap(AbstractHeap* parent, const char* heapName);
     ~AbsoluteAbstractHeap();
 
-    const AbstractHeap& atAnyAddress() { return m_indexedHeap.atAnyIndex(); }
+    const AbstractHeap& atAnyAddress() LIFETIME_BOUND { return m_indexedHeap.atAnyIndex(); }
 
     const AbstractHeap& at(const void* address)
     {

--- a/Source/JavaScriptCore/b3/B3BasicBlock.h
+++ b/Source/JavaScriptCore/b3/B3BasicBlock.h
@@ -103,8 +103,8 @@ public:
     unsigned numSuccessors() const { return m_successors.size(); }
     const FrequentedBlock& successor(unsigned index) const { return m_successors[index]; }
     FrequentedBlock& successor(unsigned index) { return m_successors[index]; }
-    const SuccessorList& successors() const { return m_successors; }
-    SuccessorList& successors() { return m_successors; }
+    const SuccessorList& successors() const LIFETIME_BOUND { return m_successors; }
+    SuccessorList& successors() LIFETIME_BOUND { return m_successors; }
     
     void clearSuccessors();
     JS_EXPORT_PRIVATE void appendSuccessor(FrequentedBlock);
@@ -137,8 +137,8 @@ public:
     unsigned numPredecessors() const { return m_predecessors.size(); }
     BasicBlock* predecessor(unsigned index) const { return m_predecessors[index]; }
     BasicBlock*& predecessor(unsigned index) { return m_predecessors[index]; }
-    const PredecessorList& predecessors() const { return m_predecessors; }
-    PredecessorList& predecessors() { return m_predecessors; }
+    const PredecessorList& predecessors() const LIFETIME_BOUND { return m_predecessors; }
+    PredecessorList& predecessors() LIFETIME_BOUND { return m_predecessors; }
     bool containsPredecessor(BasicBlock* block) { return m_predecessors.contains(block); }
 
     bool addPredecessor(BasicBlock*);

--- a/Source/JavaScriptCore/b3/B3ConstrainedValue.h
+++ b/Source/JavaScriptCore/b3/B3ConstrainedValue.h
@@ -90,7 +90,7 @@ public:
     explicit operator bool() const { return m_value || m_rep; }
 
     Value* value() const { return m_value; }
-    const ValueRep& rep() const { return m_rep; }
+    const ValueRep& rep() const LIFETIME_BOUND { return m_rep; }
 
     void dump(PrintStream& out) const;
 

--- a/Source/JavaScriptCore/b3/B3GenericFrequentedBlock.h
+++ b/Source/JavaScriptCore/b3/B3GenericFrequentedBlock.h
@@ -55,7 +55,7 @@ public:
     BasicBlock* block() const { return m_block; }
     BasicBlock*& block() { return m_block; }
     FrequencyClass frequency() const { return m_frequency; }
-    FrequencyClass& frequency() { return m_frequency; }
+    FrequencyClass& frequency() LIFETIME_BOUND { return m_frequency; }
 
     bool isRare() const { return frequency() == FrequencyClass::Rare; }
 

--- a/Source/JavaScriptCore/b3/B3PCToOriginMap.h
+++ b/Source/JavaScriptCore/b3/B3PCToOriginMap.h
@@ -61,7 +61,7 @@ public:
         m_ranges.append(OriginRange{label, origin});
     }
 
-    const Vector<OriginRange>& ranges() const  { return m_ranges; }
+    const Vector<OriginRange>& ranges() const LIFETIME_BOUND { return m_ranges; }
 
 private:
     Vector<OriginRange, 0> m_ranges;

--- a/Source/JavaScriptCore/b3/B3PhiChildren.h
+++ b/Source/JavaScriptCore/b3/B3PhiChildren.h
@@ -163,7 +163,7 @@ public:
     UpsilonCollection at(Value* value) { return UpsilonCollection(this, value, &m_upsilons[value]); }
     UpsilonCollection operator[](Value* value) { return at(value); }
 
-    const Vector<Value*, 8>& phis() const { return m_phis; }
+    const Vector<Value*, 8>& phis() const LIFETIME_BOUND { return m_phis; }
 
 private:
     IndexMap<Value*, Vector<UpsilonValue*>> m_upsilons;

--- a/Source/JavaScriptCore/b3/B3Procedure.h
+++ b/Source/JavaScriptCore/b3/B3Procedure.h
@@ -173,14 +173,14 @@ public:
     SparseCollection<Air::StackSlot>& stackSlots();
     const SparseCollection<Air::StackSlot>& stackSlots() const;
 
-    SparseCollection<Variable>& variables() { return m_variables; }
-    const SparseCollection<Variable>& variables() const { return m_variables; }
+    SparseCollection<Variable>& variables() LIFETIME_BOUND { return m_variables; }
+    const SparseCollection<Variable>& variables() const LIFETIME_BOUND { return m_variables; }
 
     // Short for variables().remove(). It's better to call this method since it's out of line.
     void deleteVariable(Variable*);
 
-    SparseCollection<Value>& values() { return m_values; }
-    const SparseCollection<Value>& values() const { return m_values; }
+    SparseCollection<Value>& values() LIFETIME_BOUND { return m_values; }
+    const SparseCollection<Value>& values() const LIFETIME_BOUND { return m_values; }
 
     // Short for values().remove(). It's better to call this method since it's out of line.
     void deleteValue(Value*);
@@ -262,7 +262,7 @@ public:
     JS_EXPORT_PRIVATE unsigned frameSize() const;
     JS_EXPORT_PRIVATE RegisterAtOffsetList calleeSaveRegisterAtOffsetList() const;
 
-    PCToOriginMap& pcToOriginMap() { return m_pcToOriginMap; }
+    PCToOriginMap& pcToOriginMap() LIFETIME_BOUND { return m_pcToOriginMap; }
     PCToOriginMap releasePCToOriginMap()
     {
         RELEASE_ASSERT(needsPCToOriginMap());

--- a/Source/JavaScriptCore/b3/B3StackmapValue.h
+++ b/Source/JavaScriptCore/b3/B3StackmapValue.h
@@ -104,7 +104,7 @@ public:
     void appendSomeRegister(Value*);
     void appendSomeRegisterWithClobber(Value*);
     
-    const Vector<ValueRep>& reps() const { return m_reps; }
+    const Vector<ValueRep>& reps() const LIFETIME_BOUND { return m_reps; }
 
     // Stackmaps allow you to specify that the operation may clobber some registers. Clobbering a register
     // means that the operation appears to store a value into the register, but the compiler doesn't
@@ -195,10 +195,10 @@ public:
         clobberLate(set);
     }
 
-    RegisterSet& earlyClobbered() { return m_earlyClobbered; }
-    RegisterSet& lateClobbered() { return m_lateClobbered; }
-    const RegisterSet& earlyClobbered() const { return m_earlyClobbered; }
-    const RegisterSet& lateClobbered() const { return m_lateClobbered; }
+    RegisterSet& earlyClobbered() LIFETIME_BOUND { return m_earlyClobbered; }
+    RegisterSet& lateClobbered() LIFETIME_BOUND { return m_lateClobbered; }
+    const RegisterSet& earlyClobbered() const LIFETIME_BOUND { return m_earlyClobbered; }
+    const RegisterSet& lateClobbered() const LIFETIME_BOUND { return m_lateClobbered; }
 
     void setGenerator(RefPtr<StackmapGenerator> generator)
     {

--- a/Source/JavaScriptCore/b3/B3SwitchCase.h
+++ b/Source/JavaScriptCore/b3/B3SwitchCase.h
@@ -49,7 +49,7 @@ public:
 
     int64_t caseValue() const { return m_caseValue; }
     FrequentedBlock target() const { return m_target; }
-    BasicBlock* targetBlock() const { return m_target.block(); }
+    BasicBlock* targetBlock() const LIFETIME_BOUND { return m_target.block(); }
 
     void dump(PrintStream& out) const;
 

--- a/Source/JavaScriptCore/b3/B3SwitchValue.h
+++ b/Source/JavaScriptCore/b3/B3SwitchValue.h
@@ -47,7 +47,7 @@ public:
     // The successor for this case value is at the same index.
     int64_t caseValue(unsigned index) const { return m_values[index]; }
     
-    const Vector<int64_t>& caseValues() const { return m_values; }
+    const Vector<int64_t>& caseValues() const LIFETIME_BOUND { return m_values; }
 
     CaseCollection cases(const BasicBlock* owner) const { return CaseCollection(this, owner); }
     CaseCollection cases() const { return cases(owner); }

--- a/Source/JavaScriptCore/b3/air/AirBasicBlock.h
+++ b/Source/JavaScriptCore/b3/air/AirBasicBlock.h
@@ -81,8 +81,8 @@ public:
 
     void resize(unsigned size) { m_insts.resize(size); }
 
-    const InstList& insts() const { return m_insts; }
-    InstList& insts() { return m_insts; }
+    const InstList& insts() const LIFETIME_BOUND { return m_insts; }
+    InstList& insts() LIFETIME_BOUND { return m_insts; }
 
     template<typename Inst>
     Inst& appendInst(Inst&& inst)
@@ -103,8 +103,8 @@ public:
     unsigned numSuccessors() const { return m_successors.size(); }
     FrequentedBlock successor(unsigned index) const { return m_successors[index]; }
     FrequentedBlock& successor(unsigned index) { return m_successors[index]; }
-    const SuccessorList& successors() const { return m_successors; }
-    SuccessorList& successors() { return m_successors; }
+    const SuccessorList& successors() const LIFETIME_BOUND { return m_successors; }
+    SuccessorList& successors() LIFETIME_BOUND { return m_successors; }
 
     JS_EXPORT_PRIVATE void setSuccessors(FrequentedBlock);
     JS_EXPORT_PRIVATE void setSuccessors(FrequentedBlock, FrequentedBlock);
@@ -123,8 +123,8 @@ public:
     unsigned numPredecessors() const { return m_predecessors.size(); }
     BasicBlock* predecessor(unsigned index) const { return m_predecessors[index]; }
     BasicBlock*& predecessor(unsigned index) { return m_predecessors[index]; }
-    const PredecessorList& predecessors() const { return m_predecessors; }
-    PredecessorList& predecessors() { return m_predecessors; }
+    const PredecessorList& predecessors() const LIFETIME_BOUND { return m_predecessors; }
+    PredecessorList& predecessors() LIFETIME_BOUND { return m_predecessors; }
 
     bool addPredecessor(BasicBlock*);
     bool removePredecessor(BasicBlock*);

--- a/Source/JavaScriptCore/b3/air/AirCode.h
+++ b/Source/JavaScriptCore/b3/air/AirCode.h
@@ -189,7 +189,7 @@ public:
     // Note that this is not the same thing as proc().numEntrypoints(). This value here may be zero
     // until we lower EntrySwitch.
     unsigned numEntrypoints() const { return m_entrypoints.size(); }
-    const Vector<FrequentedBlock>& entrypoints() const { return m_entrypoints; }
+    const Vector<FrequentedBlock>& entrypoints() const LIFETIME_BOUND { return m_entrypoints; }
     const FrequentedBlock& entrypoint(unsigned index) const { return m_entrypoints[index]; }
     bool isEntrypoint(BasicBlock*) const;
     // Note: It is only valid to call this function after LowerEntrySwitch.
@@ -256,7 +256,7 @@ public:
 
     // This is used by phases that optimize the block list. You shouldn't use this unless you really know
     // what you're doing.
-    Vector<std::unique_ptr<BasicBlock>>& blockList() { return m_blocks; }
+    Vector<std::unique_ptr<BasicBlock>>& blockList() LIFETIME_BOUND { return m_blocks; }
 
     // Finds the smallest index' such that at(index') != null and index' >= index.
     JS_EXPORT_PRIVATE unsigned findFirstBlockIndex(unsigned index) const;
@@ -304,11 +304,11 @@ public:
     iterator begin() const LIFETIME_BOUND { return iterator(*this, 0); }
     iterator end() const LIFETIME_BOUND { return iterator(*this, size()); }
 
-    const SparseCollection<StackSlot>& stackSlots() const { return m_stackSlots; }
-    SparseCollection<StackSlot>& stackSlots() { return m_stackSlots; }
+    const SparseCollection<StackSlot>& stackSlots() const LIFETIME_BOUND { return m_stackSlots; }
+    SparseCollection<StackSlot>& stackSlots() LIFETIME_BOUND { return m_stackSlots; }
 
-    const SparseCollection<Special>& specials() const { return m_specials; }
-    SparseCollection<Special>& specials() { return m_specials; }
+    const SparseCollection<Special>& specials() const LIFETIME_BOUND { return m_specials; }
+    SparseCollection<Special>& specials() LIFETIME_BOUND { return m_specials; }
 
     void addFastTmp(Tmp);
 
@@ -352,7 +352,7 @@ public:
         m_disassembler = WTF::move(disassembler);
         forcePreservationOfB3Origins();
     }
-    Disassembler* disassembler() { return m_disassembler.get(); }
+    Disassembler* disassembler() LIFETIME_BOUND { return m_disassembler.get(); }
 
     RegisterSet mutableGPRs();
     ScalarRegisterSet pinnedRegisters() const { return m_pinnedRegs; }

--- a/Source/JavaScriptCore/b3/air/AirEmitShuffle.h
+++ b/Source/JavaScriptCore/b3/air/AirEmitShuffle.h
@@ -68,8 +68,8 @@ public:
     {
     }
 
-    const Arg& src() const { return m_src; }
-    const Arg& dst() const { return m_dst; }
+    const Arg& src() const LIFETIME_BOUND { return m_src; }
+    const Arg& dst() const LIFETIME_BOUND { return m_dst; }
 
     // The width determines the kind of move we do. You can only choose Width32 or Width64 right now.
     // For GP, it picks between Move32 and Move. For FP, it picks between MoveFloat and MoveDouble.

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -237,7 +237,7 @@ public:
         return m_structureID.value();
     }
 
-    const ObjectPropertyConditionSet& conditionSet() const { return m_conditionSet; }
+    const ObjectPropertyConditionSet& conditionSet() const LIFETIME_BOUND { return m_conditionSet; }
 
     JSObject* tryGetAlternateBase() const;
 

--- a/Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.h
+++ b/Source/JavaScriptCore/bytecode/AdaptiveInferredPropertyValueWatchpointBase.h
@@ -42,7 +42,7 @@ public:
     AdaptiveInferredPropertyValueWatchpointBase(const ObjectPropertyCondition&);
     AdaptiveInferredPropertyValueWatchpointBase() = default;
 
-    const ObjectPropertyCondition& key() const { return m_key; }
+    const ObjectPropertyCondition& key() const LIFETIME_BOUND { return m_key; }
 
     void initialize(const ObjectPropertyCondition&);
     void install(VM&);

--- a/Source/JavaScriptCore/bytecode/ArithProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArithProfile.h
@@ -144,7 +144,7 @@ public:
         m_bits |= ObservedResults::NonNumeric;
     }
 
-    const void* addressOfBits() const { return &m_bits; }
+    const void* addressOfBits() const LIFETIME_BOUND { return &m_bits; }
 
 #if ENABLE(JIT)
     // Sets (Int32Overflow | Int52Overflow | NonNegZeroDouble | NegZeroDouble) if it sees a

--- a/Source/JavaScriptCore/bytecode/ArrayProfile.h
+++ b/Source/JavaScriptCore/bytecode/ArrayProfile.h
@@ -231,8 +231,8 @@ public:
 
     bool mayBeResizableOrGrowableSharedTypedArray(const ConcurrentJSLocker&) const { return m_arrayProfileFlags.contains(ArrayProfileFlag::MayBeResizableOrGrowableSharedTypedArray); }
 
-    StructureID* addressOfSpeculationFailureStructureID() { return &m_speculationFailureStructureID; }
-    ArrayModes* addressOfArrayModes() { return &m_observedArrayModes; }
+    StructureID* addressOfSpeculationFailureStructureID() LIFETIME_BOUND { return &m_speculationFailureStructureID; }
+    ArrayModes* addressOfArrayModes() LIFETIME_BOUND { return &m_observedArrayModes; }
 
     static constexpr ptrdiff_t offsetOfLastSeenStructureID() { return OBJECT_OFFSETOF(ArrayProfile, m_lastSeenStructureID); }
     static constexpr ptrdiff_t offsetOfSpeculationFailureStructureID() { return OBJECT_OFFSETOF(ArrayProfile, m_speculationFailureStructureID); }

--- a/Source/JavaScriptCore/bytecode/BytecodeBasicBlock.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeBasicBlock.h
@@ -64,11 +64,11 @@ public:
     unsigned leaderOffset() const { return m_leaderOffset; }
     unsigned totalLength() const { return m_totalLength; }
 
-    const Vector<uint8_t>& delta() const { return m_delta; }
-    const Vector<unsigned>& successors() const { return m_successors; }
+    const Vector<uint8_t>& delta() const LIFETIME_BOUND { return m_delta; }
+    const Vector<unsigned>& successors() const LIFETIME_BOUND { return m_successors; }
 
-    FastBitVector& in() { return m_in; }
-    FastBitVector& out() { return m_out; }
+    FastBitVector& in() LIFETIME_BOUND { return m_in; }
+    FastBitVector& out() LIFETIME_BOUND { return m_out; }
 
     unsigned index() const { return m_index; }
 

--- a/Source/JavaScriptCore/bytecode/BytecodeLivenessAnalysis.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeLivenessAnalysis.h
@@ -87,7 +87,7 @@ public:
     
     std::unique_ptr<FullBytecodeLiveness> computeFullLiveness(CodeBlock*);
 
-    BytecodeGraph& graph() { return m_graph; }
+    BytecodeGraph& graph() LIFETIME_BOUND { return m_graph; }
 
 private:
     void dumpResults(CodeBlock*);

--- a/Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.h
+++ b/Source/JavaScriptCore/bytecode/CheckPrivateBrandStatus.h
@@ -75,7 +75,7 @@ public:
     bool operator!() const { return !isSet(); }
     bool observedSlowPath() const { return m_state == ObservedTakesSlowPath; }
     bool isSimple() const { return m_state == Simple; }
-    const Vector<CheckPrivateBrandVariant, 1>& variants() { return m_variants; }
+    const Vector<CheckPrivateBrandVariant, 1>& variants() LIFETIME_BOUND { return m_variants; }
     CacheableIdentifier singleIdentifier() const;
 
     CheckPrivateBrandStatus slowVersion() const;

--- a/Source/JavaScriptCore/bytecode/CheckPrivateBrandVariant.h
+++ b/Source/JavaScriptCore/bytecode/CheckPrivateBrandVariant.h
@@ -42,8 +42,8 @@ public:
 
     ~CheckPrivateBrandVariant();
 
-    const StructureSet& structureSet() const { return m_structureSet; }
-    StructureSet& structureSet() { return m_structureSet; }
+    const StructureSet& structureSet() const LIFETIME_BOUND { return m_structureSet; }
+    StructureSet& structureSet() LIFETIME_BOUND { return m_structureSet; }
 
     bool attemptToMerge(const CheckPrivateBrandVariant& other);
 

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -197,7 +197,7 @@ private:
 public:
     JS_EXPORT_PRIVATE ~CodeBlock();
 
-    UnlinkedCodeBlock* unlinkedCodeBlock() const { return m_unlinkedCode.get(); }
+    UnlinkedCodeBlock* unlinkedCodeBlock() const LIFETIME_BOUND { return m_unlinkedCode.get(); }
 
     CString inferredName() const;
     String inferredNameWithHash() const;
@@ -354,7 +354,7 @@ public:
         return BytecodeIndex(bytecodeOffset(returnAddress));
     }
 
-    const JSInstructionStream& instructions() const { return m_unlinkedCode->instructions(); }
+    const JSInstructionStream& instructions() const LIFETIME_BOUND { return m_unlinkedCode->instructions(); }
     const JSInstruction* instructionAt(BytecodeIndex index) const { return instructions().at(index).ptr(); }
 
     size_t predictedMachineCodeSize();
@@ -407,7 +407,7 @@ public:
 
     void jettison(Profiler::JettisonReason, ReoptimizationMode = DontCountReoptimization, const FireDetail* = nullptr);
     
-    ScriptExecutable* ownerExecutable() const { return m_ownerExecutable.get(); }
+    ScriptExecutable* ownerExecutable() const LIFETIME_BOUND { return m_ownerExecutable.get(); }
     
     VM& vm() const { return *m_vm; }
 
@@ -431,7 +431,7 @@ public:
         return PutPropertySlot::PutById;
     }
 
-    const SourceCode& source() const { return m_ownerExecutable->source(); }
+    const SourceCode& source() const LIFETIME_BOUND { return m_ownerExecutable->source(); }
     unsigned sourceOffset() const { return m_ownerExecutable->source().startOffset(); }
     unsigned firstLineColumnOffset() const { return m_ownerExecutable->startColumn(); }
 
@@ -454,7 +454,7 @@ public:
         return m_argumentValueProfiles[argumentIndex];
     }
 
-    FixedVector<ArgumentValueProfile>& argumentValueProfiles() { return m_argumentValueProfiles; }
+    FixedVector<ArgumentValueProfile>& argumentValueProfiles() LIFETIME_BOUND { return m_argumentValueProfiles; }
 
     ValueProfile& valueProfileForOffset(unsigned profileOffset) { return m_metadata->valueProfileForOffset(profileOffset); }
 
@@ -524,7 +524,7 @@ public:
     bool wasDestructed();
 #endif
 
-    Vector<WriteBarrier<Unknown>>& constants() { return m_constantRegisters; }
+    Vector<WriteBarrier<Unknown>>& constants() LIFETIME_BOUND { return m_constantRegisters; }
     unsigned addConstant(const ConcurrentJSLocker&, JSValue v)
     {
         unsigned result = m_constantRegisters.size();
@@ -540,7 +540,7 @@ public:
         return result;
     }
 
-    const Vector<WriteBarrier<Unknown>>& constantRegisters() { return m_constantRegisters; }
+    const Vector<WriteBarrier<Unknown>>& constantRegisters() LIFETIME_BOUND { return m_constantRegisters; }
     WriteBarrier<Unknown>& constantRegister(VirtualRegister reg) { return m_constantRegisters[reg.toConstantIndex()]; }
     ALWAYS_INLINE JSValue getConstant(VirtualRegister reg) const { return m_constantRegisters[reg.toConstantIndex()].get(); }
     bool isConstantOwnedByUnlinkedCodeBlock(VirtualRegister) const;
@@ -554,10 +554,10 @@ public:
     FunctionExecutable* functionExpr(int index) { return m_functionExprs[index].get(); }
     std::span<const WriteBarrier<FunctionExecutable>> functionExprs() { return m_functionExprs.span(); }
     
-    const BitVector& bitVector(size_t i) { return m_unlinkedCode->bitVector(i); }
+    const BitVector& bitVector(size_t i) LIFETIME_BOUND { return m_unlinkedCode->bitVector(i); }
 
-    JSC::Heap* heap() const { return &m_vm->heap; }
-    JSGlobalObject* globalObject() { return m_globalObject.get(); }
+    JSC::Heap* heap() const LIFETIME_BOUND { return &m_vm->heap; }
+    JSGlobalObject* globalObject() LIFETIME_BOUND { return m_globalObject.get(); }
 
     static constexpr ptrdiff_t offsetOfGlobalObject() { return OBJECT_OFFSETOF(CodeBlock, m_globalObject); }
 
@@ -601,7 +601,7 @@ public:
 #endif
 #endif
     size_t numberOfUnlinkedSwitchJumpTables() const { return m_unlinkedCode->numberOfUnlinkedSwitchJumpTables(); }
-    const UnlinkedSimpleJumpTable& unlinkedSwitchJumpTable(int tableIndex) { return m_unlinkedCode->unlinkedSwitchJumpTable(tableIndex); }
+    const UnlinkedSimpleJumpTable& unlinkedSwitchJumpTable(int tableIndex) LIFETIME_BOUND { return m_unlinkedCode->unlinkedSwitchJumpTable(tableIndex); }
 
 #if ENABLE(DFG_JIT)
     StringJumpTable& dfgStringSwitchJumpTable(int tableIndex);
@@ -609,7 +609,7 @@ public:
 #endif
 
     size_t numberOfUnlinkedStringSwitchJumpTables() const { return m_unlinkedCode->numberOfUnlinkedStringSwitchJumpTables(); }
-    const UnlinkedStringJumpTable& unlinkedStringSwitchJumpTable(int tableIndex) { return m_unlinkedCode->unlinkedStringSwitchJumpTable(tableIndex); }
+    const UnlinkedStringJumpTable& unlinkedStringSwitchJumpTable(int tableIndex) LIFETIME_BOUND { return m_unlinkedCode->unlinkedStringSwitchJumpTable(tableIndex); }
 
     DirectEvalCodeCache& directEvalCodeCache() { createRareDataIfNecessary(); return m_rareData->m_directEvalCodeCache; }
 
@@ -646,7 +646,7 @@ public:
     }
 
     typedef UncheckedKeyHashMap<std::tuple<StructureID, BytecodeIndex>, FixedVector<LLIntPrototypeLoadAdaptiveStructureWatchpoint>> StructureWatchpointMap;
-    StructureWatchpointMap& llintGetByIdWatchpointMap() { return m_llintGetByIdWatchpointMap; }
+    StructureWatchpointMap& llintGetByIdWatchpointMap() LIFETIME_BOUND { return m_llintGetByIdWatchpointMap; }
 
     // Functions for controlling when tiered compilation kicks in. This
     // controls both when the optimizing compiler is invoked and when OSR
@@ -836,7 +836,7 @@ public:
     // 64bit environment does not need a lock for ValueProfile operations.
     NoLockingNecessaryTag valueProfileLock() { return NoLockingNecessary; }
 #else
-    ConcurrentJSLock& valueProfileLock() { return m_lock; }
+    ConcurrentJSLock& valueProfileLock() LIFETIME_BOUND { return m_lock; }
 #endif
 
     static constexpr ptrdiff_t offsetOfShouldAlwaysBeInlined() { return OBJECT_OFFSETOF(CodeBlock, m_shouldAlwaysBeInlined); }

--- a/Source/JavaScriptCore/bytecode/ComplexGetStatus.h
+++ b/Source/JavaScriptCore/bytecode/ComplexGetStatus.h
@@ -98,7 +98,7 @@ public:
     
     Kind kind() const { return m_kind; }
     PropertyOffset offset() const { return m_offset; }
-    const ObjectPropertyConditionSet& conditionSet() const { return m_conditionSet; }
+    const ObjectPropertyConditionSet& conditionSet() const LIFETIME_BOUND { return m_conditionSet; }
     
 private:
     Kind m_kind;

--- a/Source/JavaScriptCore/bytecode/DeleteByStatus.h
+++ b/Source/JavaScriptCore/bytecode/DeleteByStatus.h
@@ -74,7 +74,7 @@ public:
     bool operator!() const { return !isSet(); }
     bool observedSlowPath() const { return m_state == ObservedTakesSlowPath; }
     bool isSimple() const { return m_state == Simple; }
-    const Vector<DeleteByVariant, 1>& variants() { return m_variants; }
+    const Vector<DeleteByVariant, 1>& variants() LIFETIME_BOUND { return m_variants; }
     CacheableIdentifier singleIdentifier() const;
 
     DeleteByStatus slowVersion() const;

--- a/Source/JavaScriptCore/bytecode/GetByStatus.h
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.h
@@ -110,7 +110,7 @@ public:
     bool isProxyObject() const { return m_state == ProxyObject; }
 
     size_t numVariants() const { return m_variants.size(); }
-    const Vector<GetByVariant, 1>& variants() const { return m_variants; }
+    const Vector<GetByVariant, 1>& variants() const LIFETIME_BOUND { return m_variants; }
     const GetByVariant& at(size_t index) const { return m_variants[index]; }
     const GetByVariant& operator[](size_t index) const { return at(index); }
 
@@ -129,8 +129,8 @@ public:
     void filter(const StructureSet&);
     void filterById(UniquedStringImpl*);
 
-    JSModuleNamespaceObject* moduleNamespaceObject() const { return m_moduleNamespaceData->m_moduleNamespaceObject; }
-    JSModuleEnvironment* moduleEnvironment() const { return m_moduleNamespaceData->m_moduleEnvironment; }
+    JSModuleNamespaceObject* moduleNamespaceObject() const LIFETIME_BOUND { return m_moduleNamespaceData->m_moduleNamespaceObject; }
+    JSModuleEnvironment* moduleEnvironment() const LIFETIME_BOUND { return m_moduleNamespaceData->m_moduleEnvironment; }
     ScopeOffset scopeOffset() const { return m_moduleNamespaceData->m_scopeOffset; }
     
     DECLARE_VISIT_AGGREGATE;

--- a/Source/JavaScriptCore/bytecode/GetByVariant.h
+++ b/Source/JavaScriptCore/bytecode/GetByVariant.h
@@ -62,18 +62,18 @@ public:
     
     bool isSet() const { return !!m_structureSet.size(); }
     explicit operator bool() const { return isSet(); }
-    const StructureSet& structureSet() const { return m_structureSet; }
-    StructureSet& structureSet() { return m_structureSet; }
+    const StructureSet& structureSet() const LIFETIME_BOUND { return m_structureSet; }
+    StructureSet& structureSet() LIFETIME_BOUND { return m_structureSet; }
 
     // A non-empty condition set means that this is a prototype load.
-    const ObjectPropertyConditionSet& conditionSet() const { return m_conditionSet; }
+    const ObjectPropertyConditionSet& conditionSet() const LIFETIME_BOUND { return m_conditionSet; }
     
     PropertyOffset offset() const { return m_offset; }
-    CallLinkStatus* callLinkStatus() const { return m_callLinkStatus.get(); }
+    CallLinkStatus* callLinkStatus() const LIFETIME_BOUND { return m_callLinkStatus.get(); }
     JSFunction* intrinsicFunction() const { return m_intrinsicFunction; }
     Intrinsic intrinsic() const { return m_intrinsicFunction ? m_intrinsicFunction->intrinsic() : NoIntrinsic; }
     CodePtr<CustomAccessorPtrTag> customAccessorGetter() const { return m_customAccessorGetter; }
-    DOMAttributeAnnotation* domAttribute() const { return m_domAttribute.get(); }
+    DOMAttributeAnnotation* domAttribute() const LIFETIME_BOUND { return m_domAttribute.get(); }
 
     bool isPropertyUnset() const { return offset() == invalidOffset; }
 

--- a/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/GetterSetterAccessCase.h
@@ -38,7 +38,7 @@ public:
     friend class AccessCase;
     friend class InlineCacheCompiler;
 
-    JSObject* customSlotBase() const { return m_customSlotBase.get(); }
+    JSObject* customSlotBase() const LIFETIME_BOUND { return m_customSlotBase.get(); }
     std::optional<DOMAttributeAnnotation> domAttribute() const { return m_domAttribute; }
 
     static Ref<AccessCase> create(

--- a/Source/JavaScriptCore/bytecode/InByStatus.h
+++ b/Source/JavaScriptCore/bytecode/InByStatus.h
@@ -96,7 +96,7 @@ public:
     bool isProxyObject() const { return m_state == ProxyObject; }
 
     size_t numVariants() const { return m_variants.size(); }
-    const Vector<InByVariant, 1>& variants() const { return m_variants; }
+    const Vector<InByVariant, 1>& variants() const LIFETIME_BOUND { return m_variants; }
     const InByVariant& at(size_t index) const { return m_variants[index]; }
     const InByVariant& operator[](size_t index) const { return at(index); }
 

--- a/Source/JavaScriptCore/bytecode/InByVariant.h
+++ b/Source/JavaScriptCore/bytecode/InByVariant.h
@@ -53,14 +53,14 @@ public:
 
     bool isSet() const { return !!m_structureSet.size(); }
     explicit operator bool() const { return isSet(); }
-    const StructureSet& structureSet() const { return m_structureSet; }
-    StructureSet& structureSet() { return m_structureSet; }
+    const StructureSet& structureSet() const LIFETIME_BOUND { return m_structureSet; }
+    StructureSet& structureSet() LIFETIME_BOUND { return m_structureSet; }
 
     // A non-empty condition set means that this is a prototype in-hit/in-miss.
-    const ObjectPropertyConditionSet& conditionSet() const { return m_conditionSet; }
+    const ObjectPropertyConditionSet& conditionSet() const LIFETIME_BOUND { return m_conditionSet; }
 
     PropertyOffset offset() const { return m_offset; }
-    CallLinkStatus* callLinkStatus() const { return m_callLinkStatus.get(); }
+    CallLinkStatus* callLinkStatus() const LIFETIME_BOUND { return m_callLinkStatus.get(); }
 
     bool isHit() const { return offset() != invalidOffset; }
 

--- a/Source/JavaScriptCore/bytecode/InstanceOfAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/InstanceOfAccessCase.h
@@ -41,7 +41,7 @@ public:
         VM&, JSCell*, AccessType, Structure*, const ObjectPropertyConditionSet&,
         JSObject* prototype);
     
-    JSObject* prototype() const { return m_prototype.get(); }
+    JSObject* prototype() const LIFETIME_BOUND { return m_prototype.get(); }
     
 private:
     InstanceOfAccessCase(

--- a/Source/JavaScriptCore/bytecode/InstanceOfStatus.h
+++ b/Source/JavaScriptCore/bytecode/InstanceOfStatus.h
@@ -105,7 +105,7 @@ public:
     JSObject* commonPrototype() const;
     
     size_t numVariants() const { return m_variants.size(); }
-    const Vector<InstanceOfVariant, 2>& variants() const { return m_variants; }
+    const Vector<InstanceOfVariant, 2>& variants() const LIFETIME_BOUND { return m_variants; }
     const InstanceOfVariant& at(size_t index) const { return m_variants[index]; }
     const InstanceOfVariant& operator[](size_t index) const { return at(index); }
 

--- a/Source/JavaScriptCore/bytecode/InstanceOfVariant.h
+++ b/Source/JavaScriptCore/bytecode/InstanceOfVariant.h
@@ -41,10 +41,10 @@ public:
     
     explicit operator bool() const { return !!m_structureSet.size(); }
     
-    const StructureSet& structureSet() const { return m_structureSet; }
-    StructureSet& structureSet() { return m_structureSet; }
+    const StructureSet& structureSet() const LIFETIME_BOUND { return m_structureSet; }
+    StructureSet& structureSet() LIFETIME_BOUND { return m_structureSet; }
     
-    const ObjectPropertyConditionSet& conditionSet() const { return m_conditionSet; }
+    const ObjectPropertyConditionSet& conditionSet() const LIFETIME_BOUND { return m_conditionSet; }
     
     JSObject* prototype() const { return m_prototype; }
     

--- a/Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/IntrinsicGetterAccessCase.h
@@ -37,7 +37,7 @@ public:
     friend class AccessCase;
     friend class InlineCacheCompiler;
 
-    JSFunction* intrinsicFunction() const { return m_intrinsicFunction.get(); }
+    JSFunction* intrinsicFunction() const LIFETIME_BOUND { return m_intrinsicFunction.get(); }
     Intrinsic intrinsic() const { return m_intrinsicFunction->intrinsic(); }
 
     static Ref<AccessCase> create(VM&, JSCell*, CacheableIdentifier, PropertyOffset, Structure*, const ObjectPropertyConditionSet&, JSFunction* intrinsicFunction, RefPtr<PolyProtoAccessChain>&&);

--- a/Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/LLIntPrototypeLoadAdaptiveStructureWatchpoint.h
@@ -46,7 +46,7 @@ public:
 
     static void clearLLIntGetByIdCache(GetByIdModeMetadata&);
 
-    const ObjectPropertyCondition& key() const { return m_key; }
+    const ObjectPropertyCondition& key() const LIFETIME_BOUND { return m_key; }
 
     void fireInternal(VM&, const FireDetail&);
 

--- a/Source/JavaScriptCore/bytecode/ModuleNamespaceAccessCase.h
+++ b/Source/JavaScriptCore/bytecode/ModuleNamespaceAccessCase.h
@@ -41,8 +41,8 @@ public:
     friend class AccessCase;
     friend class InlineCacheCompiler;
 
-    JSModuleNamespaceObject* moduleNamespaceObject() const { return m_moduleNamespaceObject.get(); }
-    JSModuleEnvironment* moduleEnvironment() const { return m_moduleEnvironment.get(); }
+    JSModuleNamespaceObject* moduleNamespaceObject() const LIFETIME_BOUND { return m_moduleNamespaceObject.get(); }
+    JSModuleEnvironment* moduleEnvironment() const LIFETIME_BOUND { return m_moduleEnvironment.get(); }
     ScopeOffset scopeOffset() const { return m_scopeOffset; }
 
     static Ref<AccessCase> create(VM&, JSCell* owner, CacheableIdentifier, JSModuleNamespaceObject*, JSModuleEnvironment*, ScopeOffset);

--- a/Source/JavaScriptCore/bytecode/PolyProtoAccessChain.h
+++ b/Source/JavaScriptCore/bytecode/PolyProtoAccessChain.h
@@ -45,7 +45,7 @@ public:
     static RefPtr<PolyProtoAccessChain> tryCreate(JSGlobalObject*, JSCell* base, CacheableIdentifier, const PropertySlot&);
     static RefPtr<PolyProtoAccessChain> tryCreate(JSGlobalObject*, JSCell* base, CacheableIdentifier, JSObject* target);
 
-    const FixedVector<StructureID>& chain() const { return m_chain; }
+    const FixedVector<StructureID>& chain() const LIFETIME_BOUND { return m_chain; }
 
     void dump(Structure* baseStructure, PrintStream& out) const;
 

--- a/Source/JavaScriptCore/bytecode/PutByStatus.h
+++ b/Source/JavaScriptCore/bytecode/PutByStatus.h
@@ -135,7 +135,7 @@ public:
     bool observedPropertyInlineCacheSlowPath() const { return m_state == ObservedTakesSlowPath || m_state == ObservedSlowPathAndMakesCalls; }
     
     size_t numVariants() const { return m_variants.size(); }
-    const Vector<PutByVariant, 1>& variants() const { return m_variants; }
+    const Vector<PutByVariant, 1>& variants() const LIFETIME_BOUND { return m_variants; }
     const PutByVariant& at(size_t index) const { return m_variants[index]; }
     const PutByVariant& operator[](size_t index) const { return at(index); }
     CacheableIdentifier singleIdentifier() const;

--- a/Source/JavaScriptCore/bytecode/PutByVariant.h
+++ b/Source/JavaScriptCore/bytecode/PutByVariant.h
@@ -114,7 +114,7 @@ public:
     bool reallocatesStorage() const;
     bool makesCalls() const;
     
-    const ObjectPropertyConditionSet& conditionSet() const { return m_conditionSet; }
+    const ObjectPropertyConditionSet& conditionSet() const LIFETIME_BOUND { return m_conditionSet; }
     
     // We don't support intrinsics for Setters (it would be sweet if we did) but we need this for templated helpers.
     Intrinsic intrinsic() const { return NoIntrinsic; }
@@ -161,7 +161,7 @@ public:
     bool viaGlobalProxy() const { return m_viaGlobalProxy; }
 
     CodePtr<CustomAccessorPtrTag> customAccessorSetter() const { return m_customAccessorSetter; }
-    DOMAttributeAnnotation* domAttribute() const { return m_domAttribute.get(); }
+    DOMAttributeAnnotation* domAttribute() const LIFETIME_BOUND { return m_domAttribute.get(); }
 
 private:
     bool attemptToMergeTransitionWithReplace(const PutByVariant& replace);

--- a/Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.h
+++ b/Source/JavaScriptCore/bytecode/SetPrivateBrandStatus.h
@@ -76,7 +76,7 @@ public:
     bool operator!() const { return !isSet(); }
     bool observedSlowPath() const { return m_state == ObservedTakesSlowPath; }
     bool isSimple() const { return m_state == Simple; }
-    const Vector<SetPrivateBrandVariant, 1>& variants() { return m_variants; }
+    const Vector<SetPrivateBrandVariant, 1>& variants() LIFETIME_BOUND { return m_variants; }
     CacheableIdentifier singleIdentifier() const;
 
     SetPrivateBrandStatus slowVersion() const;

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -197,15 +197,15 @@ public:
 
     size_t numberOfIdentifiers() const { return m_identifiers.size(); }
     const Identifier& identifier(int index) const { return m_identifiers[index]; }
-    const FixedVector<Identifier>& identifiers() const { return m_identifiers; }
+    const FixedVector<Identifier>& identifiers() const LIFETIME_BOUND { return m_identifiers; }
 
     BitVector& bitVector(size_t i) { ASSERT(m_rareData); return m_rareData->m_bitVectors[i]; }
 
-    const FixedVector<WriteBarrier<Unknown>>& constantRegisters() { return m_constantRegisters; }
+    const FixedVector<WriteBarrier<Unknown>>& constantRegisters() LIFETIME_BOUND { return m_constantRegisters; }
     const WriteBarrier<Unknown>& constantRegister(VirtualRegister reg) const { return m_constantRegisters[reg.toConstantIndex()]; }
     WriteBarrier<Unknown>& constantRegister(VirtualRegister reg) { return m_constantRegisters[reg.toConstantIndex()]; }
     ALWAYS_INLINE JSValue getConstant(VirtualRegister reg) const { return m_constantRegisters[reg.toConstantIndex()].get(); }
-    const FixedVector<SourceCodeRepresentation>& constantsSourceCodeRepresentation() { return m_constantsSourceCodeRepresentation; }
+    const FixedVector<SourceCodeRepresentation>& constantsSourceCodeRepresentation() LIFETIME_BOUND { return m_constantsSourceCodeRepresentation; }
 
     SourceCodeRepresentation constantSourceCodeRepresentation(VirtualRegister reg) const
     {
@@ -362,7 +362,7 @@ public:
         return hasExitSite(locker, site);
     }
 
-    DFG::ExitProfile& exitProfile() { return m_exitProfile; }
+    DFG::ExitProfile& exitProfile() LIFETIME_BOUND { return m_exitProfile; }
 #endif
 
     UnlinkedMetadataTable& metadata() { return m_metadata.get(); }
@@ -378,8 +378,8 @@ public:
         return !isBuiltinFunction();
     }
     void allocateSharedProfiles(unsigned numBinaryArithProfiles, unsigned numUnaryArithProfiles);
-    FixedVector<UnlinkedValueProfile>& unlinkedValueProfiles() { return m_valueProfiles; }
-    FixedVector<UnlinkedArrayProfile>& unlinkedArrayProfiles() { return m_arrayProfiles; }
+    FixedVector<UnlinkedValueProfile>& unlinkedValueProfiles() LIFETIME_BOUND { return m_valueProfiles; }
+    FixedVector<UnlinkedArrayProfile>& unlinkedArrayProfiles() LIFETIME_BOUND { return m_arrayProfiles; }
     unsigned numberOfValueProfiles() const { return m_valueProfiles.size(); }
     unsigned numberOfArrayProfiles() const { return m_arrayProfiles.size(); }
 
@@ -514,7 +514,7 @@ public:
     BinaryArithProfile& binaryArithProfile(unsigned i) { return m_binaryArithProfiles[i]; }
     UnaryArithProfile& unaryArithProfile(unsigned i) { return m_unaryArithProfiles[i]; }
 
-    BaselineExecutionCounter& llintExecuteCounter() { return m_llintExecuteCounter; }
+    BaselineExecutionCounter& llintExecuteCounter() LIFETIME_BOUND { return m_llintExecuteCounter; }
 
 private:
     using OutOfLineJumpTargets = UncheckedKeyHashMap<JSInstructionStream::Offset, int>;

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlockGenerator.h
@@ -111,7 +111,7 @@ public:
     }
 
     unsigned numberOfConstantIdentifierSets() const { return m_constantIdentifierSets.size(); }
-    const Vector<IdentifierSet>& constantIdentifierSets() { return m_constantIdentifierSets; }
+    const Vector<IdentifierSet>& constantIdentifierSets() LIFETIME_BOUND { return m_constantIdentifierSets; }
     unsigned addSetConstant(IdentifierSet&& set)
     {
         ASSERT(m_vm.heap.isDeferred());
@@ -121,7 +121,7 @@ public:
     }
 
     const WriteBarrier<Unknown>& constantRegister(VirtualRegister reg) const { return m_constantRegisters[reg.toConstantIndex()]; }
-    const Vector<WriteBarrier<Unknown>>& constantRegisters() { return m_constantRegisters; }
+    const Vector<WriteBarrier<Unknown>>& constantRegisters() LIFETIME_BOUND { return m_constantRegisters; }
     ALWAYS_INLINE JSValue getConstant(VirtualRegister reg) const { return m_constantRegisters[reg.toConstantIndex()].get(); }
 
     SourceCodeRepresentation constantSourceCodeRepresentation(VirtualRegister reg) const

--- a/Source/JavaScriptCore/bytecode/UnlinkedProgramCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedProgramCodeBlock.h
@@ -52,10 +52,10 @@ public:
     static void destroy(JSCell*);
 
     void setVariableDeclarations(const VariableEnvironment& environment) { m_varDeclarations = environment; }
-    const VariableEnvironment& variableDeclarations() const { return m_varDeclarations; }
+    const VariableEnvironment& variableDeclarations() const LIFETIME_BOUND { return m_varDeclarations; }
 
     void setLexicalDeclarations(const VariableEnvironment& environment) { m_lexicalDeclarations = environment; }
-    const VariableEnvironment& lexicalDeclarations() const { return m_lexicalDeclarations; }
+    const VariableEnvironment& lexicalDeclarations() const LIFETIME_BOUND { return m_lexicalDeclarations; }
 
 private:
     friend CachedProgramCodeBlock;

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -260,7 +260,7 @@ namespace JSC {
         RegisterID* propertyOffset() const { return m_propertyOffset.get(); }
         RegisterID* enumerator() const { return m_enumerator.get(); }
         RegisterID* mode() const { return m_mode.get(); }
-        const std::optional<Variable>& baseVariable() const { return m_baseVariable; }
+        const std::optional<Variable>& baseVariable() const LIFETIME_BOUND { return m_baseVariable; }
 
         void addGetInst(unsigned instIndex, int propertyRegIndex)
         {
@@ -359,7 +359,7 @@ namespace JSC {
         ~BytecodeGenerator();
         
         VM& vm() const { return m_vm; }
-        ParserArena& parserArena() const { return m_scopeNode->parserArena(); }
+        ParserArena& parserArena() const LIFETIME_BOUND { return m_scopeNode->parserArena(); }
         const CommonIdentifiers& propertyNames() const { return *m_vm.propertyNames; }
 
         bool isConstructor() const { return m_codeBlock->isConstructor(); }
@@ -1253,7 +1253,7 @@ namespace JSC {
         JSValue addBigIntConstant(const Identifier&, uint8_t radix, bool sign);
         RegisterID* addTemplateObjectConstant(Ref<TemplateObjectDescriptor>&&, int);
 
-        const JSInstructionStreamWriter& instructions() const { return m_writer; }
+        const JSInstructionStreamWriter& instructions() const LIFETIME_BOUND { return m_writer; }
 
         RegisterID* emitThrowExpressionTooDeepException();
 

--- a/Source/JavaScriptCore/debugger/Breakpoint.h
+++ b/Source/JavaScriptCore/debugger/Breakpoint.h
@@ -69,8 +69,8 @@ public:
     unsigned lineNumber() const { return m_lineNumber; }
     unsigned columnNumber() const { return m_columnNumber; }
 
-    const String& condition() const { return m_condition; }
-    const ActionsVector& actions() const { return m_actions; }
+    const String& condition() const LIFETIME_BOUND { return m_condition; }
+    const ActionsVector& actions() const LIFETIME_BOUND { return m_actions; }
     bool isAutoContinue() const { return m_autoContinue; }
 
     void resetHitCount() { m_hitCount = 0; }

--- a/Source/JavaScriptCore/debugger/DebuggerCallFrame.h
+++ b/Source/JavaScriptCore/debugger/DebuggerCallFrame.h
@@ -54,7 +54,7 @@ public:
     // line and column are in base 0 e.g. the first line is line 0.
     int line() const { return m_position.m_line.zeroBasedInt(); }
     int column() const { return m_position.m_column.zeroBasedInt(); }
-    JS_EXPORT_PRIVATE const TextPosition& position() const { return m_position; }
+    JS_EXPORT_PRIVATE const TextPosition& position() const LIFETIME_BOUND { return m_position; }
 
     JS_EXPORT_PRIVATE DebuggerScope* scope(VM&);
     JS_EXPORT_PRIVATE String functionName(VM&) const;

--- a/Source/JavaScriptCore/debugger/DebuggerScope.h
+++ b/Source/JavaScriptCore/debugger/DebuggerScope.h
@@ -100,7 +100,7 @@ private:
     DebuggerScope(VM&, Structure*, JSScope*);
     DECLARE_DEFAULT_FINISH_CREATION;
 
-    JSScope* jsScope() const { return m_scope.get(); }
+    JSScope* jsScope() const LIFETIME_BOUND { return m_scope.get(); }
 
     WriteBarrier<JSScope> m_scope;
     WriteBarrier<DebuggerScope> m_next;

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h
@@ -224,7 +224,7 @@ public:
     FiltrationResult filterByValue(AbstractValue&, FrozenValue);
     FiltrationResult filterClassInfo(AbstractValue&, const ClassInfo*);
     
-    PhiChildren* phiChildren() { return m_phiChildren.get(); }
+    PhiChildren* phiChildren() LIFETIME_BOUND { return m_phiChildren.get(); }
     
     void filterICStatus(Node*);
     

--- a/Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.h
+++ b/Source/JavaScriptCore/dfg/DFGAdaptiveStructureWatchpoint.h
@@ -39,7 +39,7 @@ public:
     AdaptiveStructureWatchpoint(const ObjectPropertyCondition&, CodeBlock*);
     AdaptiveStructureWatchpoint();
     
-    const ObjectPropertyCondition& key() const { return m_key; }
+    const ObjectPropertyCondition& key() const LIFETIME_BOUND { return m_key; }
 
     void initialize(const ObjectPropertyCondition&, CodeBlock*);
 

--- a/Source/JavaScriptCore/dfg/DFGFrozenValue.h
+++ b/Source/JavaScriptCore/dfg/DFGFrozenValue.h
@@ -67,7 +67,7 @@ public:
     bool operator!() const { return !m_value; }
     
     JSValue value() const { return m_value; }
-    JSCell* cell() const { return m_value.asCell(); }
+    JSCell* cell() const LIFETIME_BOUND { return m_value.asCell(); }
     
     template<typename T>
     T dynamicCast()

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -1063,8 +1063,8 @@ public:
 
     Profiler::Compilation* compilation() { return m_plan.compilation(); }
 
-    DesiredIdentifiers& identifiers() { return m_plan.identifiers(); }
-    DesiredWatchpoints& watchpoints() { return m_plan.watchpoints(); }
+    DesiredIdentifiers& identifiers() LIFETIME_BOUND { return m_plan.identifiers(); }
+    DesiredWatchpoints& watchpoints() LIFETIME_BOUND { return m_plan.watchpoints(); }
 
     // Returns false if the key is already invalid or unwatchable. If this is a Presence condition,
     // this also makes it cheap to query if the condition holds. Also makes sure that the GC knows
@@ -1297,7 +1297,7 @@ public:
         return result;
     }
 
-    Prefix& prefix() { return m_prefix; }
+    Prefix& prefix() LIFETIME_BOUND { return m_prefix; }
     void nextPhase() { m_prefix.phaseNumber++; }
 
     const UnlinkedSimpleJumpTable& unlinkedSwitchJumpTable(unsigned index) const { return *m_unlinkedSwitchJumpTables[index]; }

--- a/Source/JavaScriptCore/dfg/DFGJITCode.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.h
@@ -188,10 +188,10 @@ public:
         return span[span.size() - index - 1];
     }
 
-    FixedVector<OptimizingCallLinkInfo>& callLinkInfos() { return m_callLinkInfos; }
+    FixedVector<OptimizingCallLinkInfo>& callLinkInfos() LIFETIME_BOUND { return m_callLinkInfos; }
 
-    UpperTierExecutionCounter& tierUpCounter() { return m_tierUpCounter; }
-    const UpperTierExecutionCounter& tierUpCounter() const { return m_tierUpCounter; }
+    UpperTierExecutionCounter& tierUpCounter() LIFETIME_BOUND { return m_tierUpCounter; }
+    const UpperTierExecutionCounter& tierUpCounter() const LIFETIME_BOUND { return m_tierUpCounter; }
 
     uint8_t neverExecutedEntry() const { return m_neverExecutedEntry; }
 
@@ -272,7 +272,7 @@ public:
 
     RegisterSet liveRegistersToPreserveAtExceptionHandlingCallSite(CodeBlock*, CallSiteIndex) final;
 #if ENABLE(FTL_JIT)
-    CodeBlock* osrEntryBlock() { return m_osrEntryBlock.get(); }
+    CodeBlock* osrEntryBlock() LIFETIME_BOUND { return m_osrEntryBlock.get(); }
     void setOSREntryBlock(VM&, const JSCell* owner, CodeBlock* osrEntryBlock);
     void clearOSREntryBlockAndResetThresholds(CodeBlock* dfgCodeBlock);
 #endif

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.h
@@ -281,9 +281,9 @@ public:
 
     RefPtr<DFG::JITCode> jitCode() { return m_jitCode; }
     
-    Vector<Label>& blockHeads() { return m_blockHeads; }
+    Vector<Label>& blockHeads() LIFETIME_BOUND { return m_blockHeads; }
 
-    PCToCodeOriginMapBuilder& pcToCodeOriginMapBuilder() { return m_pcToCodeOriginMapBuilder; }
+    PCToCodeOriginMapBuilder& pcToCodeOriginMapBuilder() LIFETIME_BOUND { return m_pcToCodeOriginMapBuilder; }
 
     VM& vm() { return m_graph.m_vm; }
 

--- a/Source/JavaScriptCore/dfg/DFGJumpReplacement.h
+++ b/Source/JavaScriptCore/dfg/DFGJumpReplacement.h
@@ -41,7 +41,7 @@ public:
     
     void fire();
     void installVMTrapBreakpoint();
-    void* dataLocation() const { return m_source.dataLocation(); }
+    void* dataLocation() const LIFETIME_BOUND { return m_source.dataLocation(); }
 
 private:
     CodeLocationLabel<JSInternalPtrTag> m_source;

--- a/Source/JavaScriptCore/dfg/DFGMultiGetByOffsetData.h
+++ b/Source/JavaScriptCore/dfg/DFGMultiGetByOffsetData.h
@@ -131,10 +131,10 @@ public:
     {
     }
     
-    RegisteredStructureSet& set() { return m_set; }
-    const RegisteredStructureSet& set() const { return m_set; }
-    GetByOffsetMethod& method() { return m_method; }
-    const GetByOffsetMethod& method() const { return m_method; }
+    RegisteredStructureSet& set() LIFETIME_BOUND { return m_set; }
+    const RegisteredStructureSet& set() const LIFETIME_BOUND { return m_set; }
+    GetByOffsetMethod& method() LIFETIME_BOUND { return m_method; }
+    const GetByOffsetMethod& method() const LIFETIME_BOUND { return m_method; }
     
     void dumpInContext(PrintStream&, DumpContext*) const;
     void dump(PrintStream&) const;

--- a/Source/JavaScriptCore/dfg/DFGPhase.h
+++ b/Source/JavaScriptCore/dfg/DFGPhase.h
@@ -61,8 +61,8 @@ protected:
     Graph& m_graph;
     
     VM& vm() { return m_graph.m_vm; }
-    CodeBlock* codeBlock() { return m_graph.m_codeBlock; }
-    CodeBlock* profiledBlock() { return m_graph.m_profiledBlock; }
+    CodeBlock* codeBlock() LIFETIME_BOUND { return m_graph.m_codeBlock; }
+    CodeBlock* profiledBlock() LIFETIME_BOUND { return m_graph.m_profiledBlock; }
 
     // This runs validation, and uses the graph dump before the phase if possible.
     void validate();

--- a/Source/JavaScriptCore/dfg/DFGPlan.h
+++ b/Source/JavaScriptCore/dfg/DFGPlan.h
@@ -81,24 +81,24 @@ public:
     void cleanMustHandleValuesIfNecessary();
 
     BytecodeIndex osrEntryBytecodeIndex() const { return m_osrEntryBytecodeIndex; }
-    const Operands<std::optional<JSValue>>& mustHandleValues() const { return m_mustHandleValues; }
+    const Operands<std::optional<JSValue>>& mustHandleValues() const LIFETIME_BOUND { return m_mustHandleValues; }
     Profiler::Compilation* compilation() const { return m_compilation.get(); }
 
-    Finalizer* finalizer() const { return m_finalizer.get(); }
+    Finalizer* finalizer() const LIFETIME_BOUND { return m_finalizer.get(); }
     void setFinalizer(std::unique_ptr<Finalizer>&& finalizer) { m_finalizer = WTF::move(finalizer); }
 
     RefPtr<InlineCallFrameSet> inlineCallFrames() const { return m_inlineCallFrames; }
-    DesiredWatchpoints& watchpoints() { return m_watchpoints; }
-    DesiredIdentifiers& identifiers() { return m_identifiers; }
-    DesiredWeakReferences& weakReferences() { return m_weakReferences; }
-    DesiredTransitions& transitions() { return m_transitions; }
-    RecordedStatuses& recordedStatuses() { return *m_recordedStatuses.get(); }
+    DesiredWatchpoints& watchpoints() LIFETIME_BOUND { return m_watchpoints; }
+    DesiredIdentifiers& identifiers() LIFETIME_BOUND { return m_identifiers; }
+    DesiredWeakReferences& weakReferences() LIFETIME_BOUND { return m_weakReferences; }
+    DesiredTransitions& transitions() LIFETIME_BOUND { return m_transitions; }
+    RecordedStatuses& recordedStatuses() LIFETIME_BOUND { return *m_recordedStatuses.get(); }
 
     bool willTryToTierUp() const { return m_willTryToTierUp; }
     void setWillTryToTierUp(bool willTryToTierUp) { m_willTryToTierUp = willTryToTierUp; }
 
-    UncheckedKeyHashMap<BytecodeIndex, FixedVector<BytecodeIndex>>& tierUpInLoopHierarchy() { return m_tierUpInLoopHierarchy; }
-    Vector<BytecodeIndex>& tierUpAndOSREnterBytecodes() { return m_tierUpAndOSREnterBytecodes; }
+    UncheckedKeyHashMap<BytecodeIndex, FixedVector<BytecodeIndex>>& tierUpInLoopHierarchy() LIFETIME_BOUND { return m_tierUpInLoopHierarchy; }
+    Vector<BytecodeIndex>& tierUpAndOSREnterBytecodes() LIFETIME_BOUND { return m_tierUpAndOSREnterBytecodes; }
 
     DeferredCompilationCallback* callback() const { return m_callback.get(); }
     void setCallback(Ref<DeferredCompilationCallback>&& callback) { m_callback = WTF::move(callback); }

--- a/Source/JavaScriptCore/dfg/DFGSlowPathGenerator.h
+++ b/Source/JavaScriptCore/dfg/DFGSlowPathGenerator.h
@@ -67,7 +67,7 @@ public:
         return MacroAssembler::Call();
     }
 
-    const NodeOrigin& origin() const  { return m_origin; }
+    const NodeOrigin& origin() const LIFETIME_BOUND { return m_origin; }
     Node* currentNode() const { return m_currentNode; }
 
 protected:

--- a/Source/JavaScriptCore/ftl/FTLExitArgumentForOperand.h
+++ b/Source/JavaScriptCore/ftl/FTLExitArgumentForOperand.h
@@ -49,7 +49,7 @@ public:
     
     bool operator!() const { return !m_exitArgument; }
     
-    const ExitArgument& exitArgument() const { return m_exitArgument; }
+    const ExitArgument& exitArgument() const LIFETIME_BOUND { return m_exitArgument; }
     VirtualRegister operand() const { return m_operand; }
     
     void dump(PrintStream&) const;

--- a/Source/JavaScriptCore/ftl/FTLExitPropertyValue.h
+++ b/Source/JavaScriptCore/ftl/FTLExitPropertyValue.h
@@ -52,7 +52,7 @@ public:
     bool operator!() const { return !m_location; }
     
     DFG::PromotedLocationDescriptor location() const { return m_location; }
-    const ExitValue& value() const { return m_value; }
+    const ExitValue& value() const LIFETIME_BOUND { return m_value; }
     
     ExitPropertyValue withLocalsOffset(int offset) const;
     

--- a/Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.h
+++ b/Source/JavaScriptCore/ftl/FTLExitTimeObjectMaterialization.h
@@ -51,7 +51,7 @@ public:
     CodeOrigin origin() const { return m_origin; }
     
     ExitValue get(DFG::PromotedLocationDescriptor) const;
-    const Vector<ExitPropertyValue>& properties() const { return m_properties; }
+    const Vector<ExitPropertyValue>& properties() const LIFETIME_BOUND { return m_properties; }
     
     void accountForLocalsOffset(int offset);
     

--- a/Source/JavaScriptCore/ftl/FTLForOSREntryJITCode.h
+++ b/Source/JavaScriptCore/ftl/FTLForOSREntryJITCode.h
@@ -61,7 +61,7 @@ public:
     {
         m_argumentFlushFormats = WTF::move(argumentFlushFormats);
     }
-    const FixedVector<DFG::FlushFormat>& argumentFlushFormats() { return m_argumentFlushFormats; }
+    const FixedVector<DFG::FlushFormat>& argumentFlushFormats() LIFETIME_BOUND { return m_argumentFlushFormats; }
 
 private:
     FixedVector<DFG::FlushFormat> m_argumentFlushFormats;

--- a/Source/JavaScriptCore/ftl/FTLJITCode.h
+++ b/Source/JavaScriptCore/ftl/FTLJITCode.h
@@ -75,7 +75,7 @@ public:
 
     PCToCodeOriginMap* pcToCodeOriginMap() override { return common.m_pcToCodeOriginMap.get(); }
 
-    const RegisterAtOffsetList* calleeSaveRegisters() const { return &m_calleeSaveRegisters; }
+    const RegisterAtOffsetList* calleeSaveRegisters() const LIFETIME_BOUND { return &m_calleeSaveRegisters; }
 
     unsigned numberOfCompiledDFGNodes() const { return m_numberOfCompiledDFGNodes; }
     void setNumberOfCompiledDFGNodes(unsigned numberOfCompiledDFGNodes)

--- a/Source/JavaScriptCore/ftl/FTLLazySlowPath.h
+++ b/Source/JavaScriptCore/ftl/FTLLazySlowPath.h
@@ -77,7 +77,7 @@ public:
 
     CodeLocationJump<JSInternalPtrTag> patchableJump() const { return m_patchableJump; }
     CodeLocationLabel<JSInternalPtrTag> done() const { return m_done; }
-    const ScalarRegisterSet& usedRegisters() const { return m_usedRegisters; }
+    const ScalarRegisterSet& usedRegisters() const LIFETIME_BOUND { return m_usedRegisters; }
     CallSiteIndex callSiteIndex() const { return m_callSiteIndex; }
 
     void generate(CodeBlock*);

--- a/Source/JavaScriptCore/ftl/FTLSlowPathCallKey.h
+++ b/Source/JavaScriptCore/ftl/FTLSlowPathCallKey.h
@@ -83,7 +83,7 @@ public:
         return nullptr;
     }
     size_t offset() const { return m_offset; }
-    const ScalarRegisterSet& usedRegisters() const { return m_usedRegisters; }
+    const ScalarRegisterSet& usedRegisters() const LIFETIME_BOUND { return m_usedRegisters; }
     RegisterSet argumentRegistersIfClobberingCheckIsEnabled() const
     {
         RELEASE_ASSERT(Options::clobberAllRegsInFTLICSlowPath());

--- a/Source/JavaScriptCore/heap/AbstractSlotVisitor.h
+++ b/Source/JavaScriptCore/heap/AbstractSlotVisitor.h
@@ -131,10 +131,10 @@ public:
 
     virtual ~AbstractSlotVisitor() = default;
 
-    MarkStackArray& collectorMarkStack() { return m_collectorStack; }
-    MarkStackArray& mutatorMarkStack() { return m_mutatorStack; }
-    const MarkStackArray& collectorMarkStack() const { return m_collectorStack; }
-    const MarkStackArray& mutatorMarkStack() const { return m_mutatorStack; }
+    MarkStackArray& collectorMarkStack() LIFETIME_BOUND { return m_collectorStack; }
+    MarkStackArray& mutatorMarkStack() LIFETIME_BOUND { return m_mutatorStack; }
+    const MarkStackArray& collectorMarkStack() const LIFETIME_BOUND { return m_collectorStack; }
+    const MarkStackArray& mutatorMarkStack() const LIFETIME_BOUND { return m_mutatorStack; }
 
     bool isEmpty() { return m_collectorStack.isEmpty() && m_mutatorStack.isEmpty(); }
 
@@ -210,7 +210,7 @@ public:
 
     virtual void visitAsConstraint(const JSCell*) = 0;
 
-    const char* codeName() const { return m_codeName.data(); }
+    const char* codeName() const LIFETIME_BOUND { return m_codeName.data(); }
 
 protected:
     inline AbstractSlotVisitor(Heap&, CString codeName, ConcurrentPtrHashSet&);

--- a/Source/JavaScriptCore/heap/AlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/AlignedMemoryAllocator.h
@@ -49,7 +49,7 @@ public:
     virtual void dump(PrintStream&) const { }
 
     void registerDirectory(Heap&, BlockDirectory*);
-    BlockDirectory* firstDirectory() const { return m_directories.first(); }
+    BlockDirectory* firstDirectory() const LIFETIME_BOUND { return m_directories.first(); }
 
     void registerSubspace(Subspace*);
 

--- a/Source/JavaScriptCore/heap/BlockDirectory.h
+++ b/Source/JavaScriptCore/heap/BlockDirectory.h
@@ -102,7 +102,7 @@ public:
     // to release the capability.
     ALWAYS_INLINE void releaseAssertAcquiredBitVectorLock() const WTF_RELEASES_SHARED_CAPABILITY(m_bitvectorLock) WTF_IGNORES_THREAD_SAFETY_ANALYSIS { }
 
-    Lock& bitvectorLock() WTF_RETURNS_LOCK(m_bitvectorLock) { return m_bitvectorLock; }
+    Lock& bitvectorLock() LIFETIME_BOUND WTF_RETURNS_LOCK(m_bitvectorLock) { return m_bitvectorLock; }
 
 #define BLOCK_DIRECTORY_BIT_ACCESSORS(lowerBitName, capitalBitName)     \
     bool is ## capitalBitName(size_t index) const WTF_REQUIRES_SHARED_LOCK(m_bitvectorLock) { return m_bits.is ## capitalBitName(index); } \

--- a/Source/JavaScriptCore/heap/CodeBlockSet.h
+++ b/Source/JavaScriptCore/heap/CodeBlockSet.h
@@ -55,7 +55,7 @@ public:
     void clearCurrentlyExecutingAndRemoveDeadCodeBlocks(VM&);
 
     bool contains(const AbstractLocker&, void* candidateCodeBlock);
-    Lock& getLock() WTF_RETURNS_LOCK(m_lock) { return m_lock; }
+    Lock& getLock() LIFETIME_BOUND WTF_RETURNS_LOCK(m_lock) { return m_lock; }
 
     // This is expected to run only when we're not adding to the set for now. If
     // this needs to run concurrently in the future, we'll need to lock around this.

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -352,7 +352,7 @@ public:
 
     VM& vm() const;
 
-    MarkedSpace& objectSpace() { return m_objectSpace; }
+    MarkedSpace& objectSpace() LIFETIME_BOUND { return m_objectSpace; }
     MachineThreads& machineThreads() { return *m_machineThreads; }
 
     SlotVisitor& collectorSlotVisitor() { return *m_collectorSlotVisitor; }
@@ -464,7 +464,7 @@ public:
     template<typename Functor> void forEachCodeBlock(NOESCAPE const Functor&);
     template<typename Functor> void forEachCodeBlockIgnoringJITPlans(const AbstractLocker& codeBlockSetLocker, NOESCAPE const Functor&);
 
-    HandleSet* handleSet() { return &m_handleSet; }
+    HandleSet* handleSet() LIFETIME_BOUND { return &m_handleSet; }
 
     void willStartIterating();
     void didFinishIterating();
@@ -512,10 +512,10 @@ public:
     void didFreeBlock(size_t capacity);
     
     bool mutatorShouldBeFenced() const { return m_mutatorShouldBeFenced; }
-    const bool* addressOfMutatorShouldBeFenced() const { return &m_mutatorShouldBeFenced; }
+    const bool* addressOfMutatorShouldBeFenced() const LIFETIME_BOUND { return &m_mutatorShouldBeFenced; }
     
     unsigned barrierThreshold() const { return m_barrierThreshold; }
-    const unsigned* addressOfBarrierThreshold() const { return &m_barrierThreshold; }
+    const unsigned* addressOfBarrierThreshold() const LIFETIME_BOUND { return &m_barrierThreshold; }
 
     // If true, the GC believes that the mutator is currently messing with the heap. We call this
     // "having heap access". The GC may block if the mutator is in this state. If false, the GC may
@@ -582,7 +582,7 @@ public:
     
     JS_EXPORT_PRIVATE void addMarkingConstraint(std::unique_ptr<MarkingConstraint>);
     
-    HeapVerifier* verifier() const { return m_verifier.get(); }
+    HeapVerifier* verifier() const LIFETIME_BOUND { return m_verifier.get(); }
     
     void addHeapFinalizerCallback(const HeapFinalizerCallback&);
     void removeHeapFinalizerCallback(const HeapFinalizerCallback&);
@@ -667,7 +667,7 @@ private:
         void finalize(Handle<Unknown>, void* context) final;
     };
 
-    Lock& lock() { return m_lock; }
+    Lock& lock() LIFETIME_BOUND { return m_lock; }
 
     void reportExtraMemoryAllocatedPossiblyFromAlreadyMarkedCell(const JSCell*, size_t);
     JS_EXPORT_PRIVATE void reportExtraMemoryAllocatedSlowCase(GCDeferralContext*, const JSCell*, size_t);

--- a/Source/JavaScriptCore/heap/MarkedBlock.h
+++ b/Source/JavaScriptCore/heap/MarkedBlock.h
@@ -209,11 +209,11 @@ public:
         void didAddToDirectory(BlockDirectory*, unsigned index);
         void didRemoveFromDirectory();
         
-        void* start() const { return &m_block->atoms()[m_startAtom]; }
-        void* end() const { return &m_block->atoms()[endAtom]; }
-        void* atomAt(size_t i) const { return &m_block->atoms()[i]; }
+        void* start() const LIFETIME_BOUND { return &m_block->atoms()[m_startAtom]; }
+        void* end() const LIFETIME_BOUND { return &m_block->atoms()[endAtom]; }
+        void* atomAt(size_t i) const LIFETIME_BOUND { return &m_block->atoms()[i]; }
         bool contains(void* p) const { return start() <= p && p < end(); }
-        void* pageStart() const { return &m_block->atoms()[0]; }
+        void* pageStart() const LIFETIME_BOUND { return &m_block->atoms()[0]; }
 
         void dumpState(PrintStream&);
         

--- a/Source/JavaScriptCore/heap/MarkedSpace.h
+++ b/Source/JavaScriptCore/heap/MarkedSpace.h
@@ -110,7 +110,7 @@ public:
     template<typename Visitor>
     Ref<SharedTask<void(Visitor&)>> forEachWeakInParallel(Visitor&);
 
-    MarkedBlockSet& blocks() { return m_blocks; }
+    MarkedBlockSet& blocks() LIFETIME_BOUND { return m_blocks; }
 
     void willStartIterating();
     bool isIterating() const { return m_isIterating; }
@@ -159,10 +159,10 @@ public:
     HeapVersion edenVersion() const { return m_edenVersion; }
 
     void registerPreciseAllocation(PreciseAllocation*, bool isNewAllocation);
-    const Vector<PreciseAllocation*>& preciseAllocations() const { return m_preciseAllocations; }
+    const Vector<PreciseAllocation*>& preciseAllocations() const LIFETIME_BOUND { return m_preciseAllocations; }
     unsigned preciseAllocationsNurseryOffset() const { return m_preciseAllocationsNurseryOffset; }
     unsigned preciseAllocationsOffsetForThisCollection() const { return m_preciseAllocationsOffsetForThisCollection; }
-    std::optional<UncheckedKeyHashSet<HeapCell*>>& preciseAllocationSet() { return m_preciseAllocationSet; }
+    std::optional<UncheckedKeyHashSet<HeapCell*>>& preciseAllocationSet() LIFETIME_BOUND { return m_preciseAllocationSet; }
 
     void enablePreciseAllocationTracking();
     
@@ -172,9 +172,9 @@ public:
     PreciseAllocation** preciseAllocationsForThisCollectionEnd() const { return m_preciseAllocationsForThisCollectionEnd; }
     unsigned preciseAllocationsForThisCollectionSize() const { return m_preciseAllocationsForThisCollectionSize; }
     
-    BlockDirectory* firstDirectory() const { return m_directories.first(); }
+    BlockDirectory* firstDirectory() const LIFETIME_BOUND { return m_directories.first(); }
     
-    Lock& directoryLock() { return m_directoryLock; }
+    Lock& directoryLock() LIFETIME_BOUND { return m_directoryLock; }
     void addBlockDirectory(const AbstractLocker&, BlockDirectory*);
     
     // When this is true it means that we have flipped but the mark bits haven't converged yet.

--- a/Source/JavaScriptCore/heap/PreciseAllocation.h
+++ b/Source/JavaScriptCore/heap/PreciseAllocation.h
@@ -74,9 +74,9 @@ public:
     
     void lastChanceToFinalize();
     
-    JSC::Heap* heap() const { return m_weakSet.heap(); }
+    JSC::Heap* heap() const LIFETIME_BOUND { return m_weakSet.heap(); }
     VM& vm() const { return m_weakSet.vm(); }
-    WeakSet& weakSet() { return m_weakSet; }
+    WeakSet& weakSet() LIFETIME_BOUND { return m_weakSet; }
 
     static constexpr ptrdiff_t offsetOfWeakSet() { return OBJECT_OFFSETOF(PreciseAllocation, m_weakSet); }
 

--- a/Source/JavaScriptCore/heap/SlotVisitor.h
+++ b/Source/JavaScriptCore/heap/SlotVisitor.h
@@ -165,7 +165,7 @@ public:
 
     bool mutatorIsStopped() const final { return m_mutatorIsStopped; }
     
-    Lock& rightToRun() WTF_RETURNS_LOCK(m_rightToRun) { return m_rightToRun; }
+    Lock& rightToRun() LIFETIME_BOUND WTF_RETURNS_LOCK(m_rightToRun) { return m_rightToRun; }
     
     void updateMutatorIsStopped(const AbstractLocker&);
     void updateMutatorIsStopped();

--- a/Source/JavaScriptCore/heap/VerifierSlotVisitor.h
+++ b/Source/JavaScriptCore/heap/VerifierSlotVisitor.h
@@ -67,7 +67,7 @@ public:
         MarkerData& operator=(MarkerData&&) = default;
 
         ReferrerToken referrer() const { return m_referrer; }
-        StackTrace* stack() const { return m_stack.get(); }
+        StackTrace* stack() const LIFETIME_BOUND { return m_stack.get(); }
 
     private:
         ReferrerToken m_referrer;
@@ -132,7 +132,7 @@ private:
         MarkedBlockData(MarkedBlock*);
 
         MarkedBlock* block() const { return m_block; }
-        const AtomsBitSet& atoms() const { return m_atoms; }
+        const AtomsBitSet& atoms() const LIFETIME_BOUND { return m_atoms; }
 
         bool isMarked(unsigned atomNumber) { return m_atoms.get(atomNumber); }
         bool testAndSetMarked(unsigned atomNumber) { return m_atoms.testAndSet(atomNumber); }

--- a/Source/JavaScriptCore/inspector/ConsoleMessage.h
+++ b/Source/JavaScriptCore/inspector/ConsoleMessage.h
@@ -70,8 +70,8 @@ public:
     MessageSource source() const { return m_source; }
     MessageType type() const { return m_type; }
     MessageLevel level() const { return m_level; }
-    const String& message() const { return m_message; }
-    const String& url() const { return m_url; }
+    const String& message() const LIFETIME_BOUND { return m_message; }
+    const String& url() const LIFETIME_BOUND { return m_url; }
     unsigned line() const { return m_line; }
     unsigned column() const { return m_column; }
     WallTime timestamp() const { return m_timestamp; }

--- a/Source/JavaScriptCore/inspector/InjectedScriptBase.h
+++ b/Source/JavaScriptCore/inspector/InjectedScriptBase.h
@@ -58,7 +58,7 @@ public:
 
     JS_EXPORT_PRIVATE InjectedScriptBase& operator=(const InjectedScriptBase&);
 
-    const String& name() const { return m_name; }
+    const String& name() const LIFETIME_BOUND { return m_name; }
     bool hasNoValue() const { return !m_injectedScriptObject.get(); }
     JSC::JSGlobalObject* globalObject() const { return m_globalObject; }
 

--- a/Source/JavaScriptCore/inspector/InjectedScriptHost.h
+++ b/Source/JavaScriptCore/inspector/InjectedScriptHost.h
@@ -45,7 +45,7 @@ public:
     void clearAllWrappers();
 
     void setSavedResultAlias(const std::optional<String>& alias) { m_savedResultAlias = alias; }
-    const std::optional<String>& savedResultAlias() const { return m_savedResultAlias; }
+    const std::optional<String>& savedResultAlias() const LIFETIME_BOUND { return m_savedResultAlias; }
 
 private:
     PerGlobalObjectWrapperWorld m_wrappers;

--- a/Source/JavaScriptCore/inspector/ScriptCallFrame.h
+++ b/Source/JavaScriptCore/inspector/ScriptCallFrame.h
@@ -47,9 +47,9 @@ public:
     ScriptCallFrame(const String& functionName, const String& scriptName, const String& preRedirectURL, JSC::SourceID, LineColumn);
     JS_EXPORT_PRIVATE ~ScriptCallFrame();
 
-    const String& functionName() const { return m_functionName; }
-    const String& sourceURL() const { return m_scriptName; }
-    const String& preRedirectURL() const { return m_preRedirectURL; }
+    const String& functionName() const LIFETIME_BOUND { return m_functionName; }
+    const String& sourceURL() const LIFETIME_BOUND { return m_scriptName; }
+    const String& preRedirectURL() const LIFETIME_BOUND { return m_preRedirectURL; }
     unsigned lineNumber() const { return m_lineColumn.line; }
     unsigned columnNumber() const { return m_lineColumn.column; }
     JSC::SourceID sourceID() const { return m_sourceID; }

--- a/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
+++ b/Source/JavaScriptCore/inspector/agents/InspectorDebuggerAgent.h
@@ -200,7 +200,7 @@ private:
 
         Ref<JSC::Breakpoint> createDebuggerBreakpoint(JSC::BreakpointID, JSC::SourceID) const;
 
-        const Protocol::Debugger::BreakpointId& id() const { return m_id; }
+        const Protocol::Debugger::BreakpointId& id() const LIFETIME_BOUND { return m_id; }
 
         bool matchesScriptURL(const String&) const;
 

--- a/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteConnectionToTarget.h
@@ -74,8 +74,8 @@ public:
     NSString *connectionIdentifier() const;
     NSString *destination() const;
 
-    Lock& queueMutex() { return m_queueMutex; }
-    const RemoteTargetQueue& queue() const { return m_queue; }
+    Lock& queueMutex() LIFETIME_BOUND { return m_queueMutex; }
+    const RemoteTargetQueue& queue() const LIFETIME_BOUND { return m_queue; }
     RemoteTargetQueue takeQueue();
 #endif
 

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -73,7 +73,7 @@ public:
 
     CodeBlock* codeBlock() { return m_codeBlock; }
     VM& vm() { return m_codeBlock->vm(); }
-    AssemblerType_T& assembler() { return m_assembler; }
+    AssemblerType_T& assembler() LIFETIME_BOUND { return m_assembler; }
 
     void prepareCallOperation(VM& vm)
     {

--- a/Source/JavaScriptCore/jit/BaselineJITCode.h
+++ b/Source/JavaScriptCore/jit/BaselineJITCode.h
@@ -90,7 +90,7 @@ class BaselineJITCode : public DirectJITCode, public MathICHolder {
 public:
     BaselineJITCode(CodeRef<JSEntryPtrTag>, CodePtr<JSEntryPtrTag> withArityCheck);
     ~BaselineJITCode() override;
-    PCToCodeOriginMap* pcToCodeOriginMap() override { return m_pcToCodeOriginMap.get(); }
+    PCToCodeOriginMap* pcToCodeOriginMap() LIFETIME_BOUND override { return m_pcToCodeOriginMap.get(); }
 
     CodeLocationLabel<JSInternalPtrTag> getCallLinkDoneLocationForBytecodeIndex(BytecodeIndex) const;
 
@@ -144,8 +144,8 @@ public:
         return leadingSpan();
     }
 
-    BaselineExecutionCounter& executeCounter() { return m_executeCounter; }
-    const BaselineExecutionCounter& executeCounter() const { return m_executeCounter; }
+    BaselineExecutionCounter& executeCounter() LIFETIME_BOUND { return m_executeCounter; }
+    const BaselineExecutionCounter& executeCounter() const LIFETIME_BOUND { return m_executeCounter; }
 
     JSGlobalObject* m_globalObject { nullptr }; // This is not marked since owner CodeBlock will mark JSGlobalObject.
     intptr_t m_stackOffset { 0 };

--- a/Source/JavaScriptCore/jit/BinarySwitch.h
+++ b/Source/JavaScriptCore/jit/BinarySwitch.h
@@ -75,7 +75,7 @@ public:
     
     bool advance(MacroAssembler&);
     
-    MacroAssembler::JumpList& fallThrough() { return m_fallThrough; }
+    MacroAssembler::JumpList& fallThrough() LIFETIME_BOUND { return m_fallThrough; }
     
 private:
     void build(unsigned start, bool hardStart, unsigned end);

--- a/Source/JavaScriptCore/jit/CachedRecovery.h
+++ b/Source/JavaScriptCore/jit/CachedRecovery.h
@@ -49,7 +49,7 @@ public:
     CachedRecovery& operator=(CachedRecovery&) = delete;
     CachedRecovery& operator=(CachedRecovery&&) = delete;
 
-    const Vector<VirtualRegister, 1>& targets() const { return m_targets; }
+    const Vector<VirtualRegister, 1>& targets() const LIFETIME_BOUND { return m_targets; }
 
     void addTarget(VirtualRegister reg)
     {

--- a/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/GCAwareJITStubRoutine.h
@@ -102,8 +102,8 @@ public:
     PolymorphicAccessJITStubRoutine(Type, const MacroAssemblerCodeRef<JITStubRoutinePtrTag>&, VM&, FixedVector<Ref<AccessCase>>&&, FixedVector<StructureID>&&, JSCell* owner, bool isCodeImmutable);
     ~PolymorphicAccessJITStubRoutine();
 
-    const FixedVector<Ref<AccessCase>>& cases() const { return m_cases; }
-    const FixedVector<StructureID>& weakStructures() const { return m_weakStructures; }
+    const FixedVector<Ref<AccessCase>>& cases() const LIFETIME_BOUND { return m_cases; }
+    const FixedVector<StructureID>& weakStructures() const LIFETIME_BOUND { return m_weakStructures; }
 
     unsigned hash() const
     {
@@ -117,7 +117,7 @@ public:
     void addGCAwareWatchpoint();
     void addedToSharedJITStubSet();
 
-    Watchpoints& watchpoints() { return m_watchpoints; }
+    Watchpoints& watchpoints() LIFETIME_BOUND { return m_watchpoints; }
     WatchpointSet& watchpointSet() { return *m_watchpointSet.get(); }
     void invalidate();
 

--- a/Source/JavaScriptCore/jit/JITBitBinaryOpGenerator.h
+++ b/Source/JavaScriptCore/jit/JITBitBinaryOpGenerator.h
@@ -47,8 +47,8 @@ public:
     }
 
     bool didEmitFastPath() const { return m_didEmitFastPath; }
-    CCallHelpers::JumpList& endJumpList() { return m_endJumpList; }
-    CCallHelpers::JumpList& slowPathJumpList() { return m_slowPathJumpList; }
+    CCallHelpers::JumpList& endJumpList() LIFETIME_BOUND { return m_endJumpList; }
+    CCallHelpers::JumpList& slowPathJumpList() LIFETIME_BOUND { return m_slowPathJumpList; }
 
 protected:
     SnippetOperand m_leftOperand;

--- a/Source/JavaScriptCore/jit/JITDivGenerator.h
+++ b/Source/JavaScriptCore/jit/JITDivGenerator.h
@@ -55,8 +55,8 @@ public:
     void generateFastPath(CCallHelpers&);
 
     bool didEmitFastPath() const { return m_didEmitFastPath; }
-    CCallHelpers::JumpList& endJumpList() { return m_endJumpList; }
-    CCallHelpers::JumpList& slowPathJumpList() { return m_slowPathJumpList; }
+    CCallHelpers::JumpList& endJumpList() LIFETIME_BOUND { return m_endJumpList; }
+    CCallHelpers::JumpList& slowPathJumpList() LIFETIME_BOUND { return m_slowPathJumpList; }
 
 private:
     void loadOperand(CCallHelpers&, SnippetOperand&, JSValueRegs opRegs, FPRReg destFPR);

--- a/Source/JavaScriptCore/jit/JITStubRoutine.h
+++ b/Source/JavaScriptCore/jit/JITStubRoutine.h
@@ -94,7 +94,7 @@ public:
     // MacroAssemblerCodeRef is copyable, but at the cost of reference
     // counting churn. Returning a reference is a good way of reducing
     // the churn.
-    const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code() const { return m_code; }
+    const MacroAssemblerCodeRef<JITStubRoutinePtrTag>& code() const LIFETIME_BOUND { return m_code; }
     
     static CodePtr<JITStubRoutinePtrTag> asCodePtr(Ref<JITStubRoutine>&& stubRoutine)
     {

--- a/Source/JavaScriptCore/parser/ModuleScopeData.h
+++ b/Source/JavaScriptCore/parser/ModuleScopeData.h
@@ -40,7 +40,7 @@ public:
 
     static Ref<ModuleScopeData> create() { return adoptRef(*new ModuleScopeData); }
 
-    const IdentifierAliasMap& exportedBindings() const { return m_exportedBindings; }
+    const IdentifierAliasMap& exportedBindings() const LIFETIME_BOUND { return m_exportedBindings; }
 
     bool exportName(const Identifier& exportedName)
     {

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -140,7 +140,7 @@ namespace JSC {
         ParserArenaRoot(ParserArena&);
 
     public:
-        ParserArena& parserArena() { return m_arena; }
+        ParserArena& parserArena() LIFETIME_BOUND { return m_arena; }
         virtual ~ParserArenaRoot() { }
 
     protected:
@@ -158,7 +158,7 @@ namespace JSC {
         int startOffset() const { return m_position.offset; }
         int endOffset() const { return m_endOffset; }
         int lineStartOffset() const { return m_position.lineStartOffset; }
-        const JSTextPosition& position() const { return m_position; }
+        const JSTextPosition& position() const LIFETIME_BOUND { return m_position; }
         void setEndOffset(int offset) { m_endOffset = offset; }
         void setStartOffset(int offset) { m_position.offset = offset; }
 
@@ -278,8 +278,8 @@ namespace JSC {
         VariableEnvironmentNode(VariableEnvironment&& lexicalDeclaredVariables);
         VariableEnvironmentNode(VariableEnvironment&& lexicalDeclaredVariables, FunctionStack&&);
 
-        VariableEnvironment& lexicalVariables() { return m_lexicalVariables; }
-        FunctionStack& functionStack() { return m_functionStack; }
+        VariableEnvironment& lexicalVariables() LIFETIME_BOUND { return m_lexicalVariables; }
+        FunctionStack& functionStack() LIFETIME_BOUND { return m_functionStack; }
 
     protected:
         VariableEnvironment m_lexicalVariables;
@@ -398,9 +398,9 @@ namespace JSC {
             checkConsistency();
         }
 
-        const JSTextPosition& divot() const { return m_divot; }
-        const JSTextPosition& divotStart() const { return m_divotStart; }
-        const JSTextPosition& divotEnd() const { return m_divotEnd; }
+        const JSTextPosition& divot() const LIFETIME_BOUND { return m_divot; }
+        const JSTextPosition& divotStart() const LIFETIME_BOUND { return m_divotStart; }
+        const JSTextPosition& divotEnd() const LIFETIME_BOUND { return m_divotEnd; }
 
         void checkConsistency() const
         {
@@ -1943,7 +1943,7 @@ namespace JSC {
         ScopeNode(ParserArena&, const JSTokenLocation& start, const JSTokenLocation& end, LexicallyScopedFeatures);
         ScopeNode(ParserArena&, const JSTokenLocation& start, const JSTokenLocation& end, const SourceCode&, SourceElements*, VariableEnvironment&&, FunctionStack&&, VariableEnvironment&&, CodeFeatures, LexicallyScopedFeatures, InnerArrowFunctionCodeFeatures, int numConstants);
 
-        const SourceCode& source() const { return m_source; }
+        const SourceCode& source() const LIFETIME_BOUND { return m_source; }
         SourceID sourceID() const { return m_source.providerID(); }
 
         int startLine() const { return m_startLineNumber; }
@@ -1982,7 +1982,7 @@ namespace JSC {
             return usesSuperCall() || usesNewTarget();
         }
 
-        VariableEnvironment& varDeclarations() { return m_varDeclarations; }
+        VariableEnvironment& varDeclarations() LIFETIME_BOUND { return m_varDeclarations; }
 
         int neededConstants()
         {
@@ -2095,7 +2095,7 @@ namespace JSC {
     public:
         typedef Vector<ImportSpecifierNode*, 3> Specifiers;
 
-        const Specifiers& specifiers() const { return m_specifiers; }
+        const Specifiers& specifiers() const LIFETIME_BOUND { return m_specifiers; }
         void append(ImportSpecifierNode* specifier)
         {
             m_specifiers.append(specifier);
@@ -2110,7 +2110,7 @@ namespace JSC {
     public:
         using Attributes = Vector<std::tuple<const Identifier*, const Identifier*>, 3>;
 
-        const Attributes& attributes() const { return m_attributes; }
+        const Attributes& attributes() const LIFETIME_BOUND { return m_attributes; }
         void append(const Identifier& key, const Identifier& value)
         {
             m_attributes.append(std::tuple { &key, &value });
@@ -2210,7 +2210,7 @@ namespace JSC {
     public:
         typedef Vector<ExportSpecifierNode*, 3> Specifiers;
 
-        const Specifiers& specifiers() const { return m_specifiers; }
+        const Specifiers& specifiers() const LIFETIME_BOUND { return m_specifiers; }
         void append(ExportSpecifierNode* specifier)
         {
             m_specifiers.append(specifier);
@@ -2276,8 +2276,8 @@ namespace JSC {
 
         void setEndPosition(JSTextPosition);
 
-        const SourceCode& source() const { return m_source; }
-        const SourceCode& classSource() const { return m_classSource; }
+        const SourceCode& source() const LIFETIME_BOUND { return m_source; }
+        const SourceCode& classSource() const LIFETIME_BOUND { return m_classSource; }
         void setClassSource(const SourceCode& source) { m_classSource = source; }
 
         int startStartOffset() const { return m_startStartOffset; }
@@ -2574,8 +2574,8 @@ namespace JSC {
         BindingNode(const Identifier& boundProperty, const JSTextPosition& start, const JSTextPosition& end, AssignmentContext);
         const Identifier& boundProperty() const { return m_boundProperty; }
 
-        const JSTextPosition& divotStart() const { return m_divotStart; }
-        const JSTextPosition& divotEnd() const { return m_divotEnd; }
+        const JSTextPosition& divotStart() const LIFETIME_BOUND { return m_divotStart; }
+        const JSTextPosition& divotEnd() const LIFETIME_BOUND { return m_divotEnd; }
 
         bool bindValueCanThrow(BytecodeGenerator&) const final;
         RegisterID* writableDirectBindingIfPossible(BytecodeGenerator&) const final;
@@ -2616,8 +2616,8 @@ namespace JSC {
         AssignmentElementNode(ExpressionNode* assignmentTarget, const JSTextPosition& start, const JSTextPosition& end);
         const ExpressionNode* assignmentTarget() { return m_assignmentTarget; }
 
-        const JSTextPosition& divotStart() const { return m_divotStart; }
-        const JSTextPosition& divotEnd() const { return m_divotEnd; }
+        const JSTextPosition& divotStart() const LIFETIME_BOUND { return m_divotStart; }
+        const JSTextPosition& divotEnd() const LIFETIME_BOUND { return m_divotEnd; }
 
         bool bindValueCanThrow(BytecodeGenerator&) const final;
         RegisterID* writableDirectBindingIfPossible(BytecodeGenerator&) const final;

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -329,9 +329,9 @@ public:
     bool usesEval() const { return m_usesEval; }
     bool usesImportMeta() const { return m_usesImportMeta; }
 
-    const UncheckedKeyHashSet<UniquedStringImpl*>& closedVariableCandidates() const { return m_closedVariableCandidates; }
-    VariableEnvironment& declaredVariables() { return m_declaredVariables; }
-    VariableEnvironment& lexicalVariables() { return m_lexicalVariables; }
+    const UncheckedKeyHashSet<UniquedStringImpl*>& closedVariableCandidates() const LIFETIME_BOUND { return m_closedVariableCandidates; }
+    VariableEnvironment& declaredVariables() LIFETIME_BOUND { return m_declaredVariables; }
+    VariableEnvironment& lexicalVariables() LIFETIME_BOUND { return m_lexicalVariables; }
     void finalizeLexicalEnvironment()
     {
         if (m_usesEval || m_needsFullActivation)

--- a/Source/JavaScriptCore/parser/ParserError.h
+++ b/Source/JavaScriptCore/parser/ParserError.h
@@ -82,8 +82,8 @@ public:
 
     bool isValid() const { return m_type != ErrorNone; }
     SyntaxErrorType syntaxErrorType() const { return m_syntaxErrorType; }
-    const JSToken& token() const { return m_token; }
-    const String& message() const { return m_message; }
+    const JSToken& token() const LIFETIME_BOUND { return m_token; }
+    const String& message() const LIFETIME_BOUND { return m_message; }
     int line() const { return m_line; }
     ErrorType type() const { return m_type; }
 

--- a/Source/JavaScriptCore/parser/SourceCodeKey.h
+++ b/Source/JavaScriptCore/parser/SourceCodeKey.h
@@ -95,7 +95,7 @@ public:
 
     unsigned hash() const { return m_hash; }
 
-    const UnlinkedSourceCode& source() const { return m_sourceCode; }
+    const UnlinkedSourceCode& source() const LIFETIME_BOUND { return m_sourceCode; }
 
     size_t length() const { return m_sourceCode.length(); }
 

--- a/Source/JavaScriptCore/parser/SourceProvider.h
+++ b/Source/JavaScriptCore/parser/SourceProvider.h
@@ -79,14 +79,14 @@ public:
         return source().substring(start, end - start);
     }
 
-    const SourceOrigin& sourceOrigin() const { return m_sourceOrigin; }
+    const SourceOrigin& sourceOrigin() const LIFETIME_BOUND { return m_sourceOrigin; }
 
     // This is NOT the path that should be used for computing relative paths from a script. Use SourceOrigin's URL for that, the values may or may not be the same...
-    const String& sourceURL() const { return m_sourceURL; }
+    const String& sourceURL() const LIFETIME_BOUND { return m_sourceURL; }
     const String& sourceURLStripped();
-    const String& preRedirectURL() const { return m_preRedirectURL; }
-    const String& sourceURLDirective() const { return m_sourceURLDirective; }
-    const String& sourceMappingURLDirective() const { return m_sourceMappingURLDirective; }
+    const String& preRedirectURL() const LIFETIME_BOUND { return m_preRedirectURL; }
+    const String& sourceURLDirective() const LIFETIME_BOUND { return m_sourceURLDirective; }
+    const String& sourceMappingURLDirective() const LIFETIME_BOUND { return m_sourceMappingURLDirective; }
 
     TextPosition startPosition() const { return m_startPosition; }
     SourceProviderSourceType sourceType() const { return m_sourceType; }

--- a/Source/JavaScriptCore/parser/SourceProviderCache.h
+++ b/Source/JavaScriptCore/parser/SourceProviderCache.h
@@ -41,7 +41,7 @@ public:
 
     JS_EXPORT_PRIVATE void clear();
     void add(int sourcePosition, std::unique_ptr<SourceProviderCacheItem>);
-    const SourceProviderCacheItem* get(int sourcePosition) const { return m_map.get(sourcePosition); }
+    const SourceProviderCacheItem* get(int sourcePosition) const LIFETIME_BOUND { return m_map.get(sourcePosition); }
 
 private:
     UncheckedKeyHashMap<int, std::unique_ptr<SourceProviderCacheItem>, WTF::IntHash<int>, WTF::UnsignedWithZeroKeyHashTraits<int>> m_map;

--- a/Source/JavaScriptCore/profiler/ProfilerBytecode.h
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecode.h
@@ -53,7 +53,7 @@ public:
     
     unsigned bytecodeIndex() const { return m_bytecodeIndex; }
     OpcodeID opcodeID() const { return m_opcodeID; }
-    const CString& description() const { return m_description; }
+    const CString& description() const LIFETIME_BOUND { return m_description; }
     
     Ref<JSON::Value> toJSON(Dumper&) const;
 private:

--- a/Source/JavaScriptCore/profiler/ProfilerBytecodes.h
+++ b/Source/JavaScriptCore/profiler/ProfilerBytecodes.h
@@ -39,8 +39,8 @@ public:
     ~Bytecodes();
     
     size_t id() const { return m_id; }
-    const CString& inferredName() const { return m_inferredName; }
-    const CString& sourceCode() const { return m_sourceCode; }
+    const CString& inferredName() const LIFETIME_BOUND { return m_inferredName; }
+    const CString& sourceCode() const LIFETIME_BOUND { return m_sourceCode; }
     unsigned instructionCount() const { return m_instructionCount; }
     CodeBlockHash hash() const { return m_hash; }
 

--- a/Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.h
+++ b/Source/JavaScriptCore/profiler/ProfilerCompiledBytecode.h
@@ -38,8 +38,8 @@ public:
     CompiledBytecode(const OriginStack&, const CString& description);
     ~CompiledBytecode();
     
-    const OriginStack& originStack() const { return m_origin; }
-    const CString& description() const { return m_description; }
+    const OriginStack& originStack() const LIFETIME_BOUND { return m_origin; }
+    const CString& description() const LIFETIME_BOUND { return m_description; }
 
     Ref<JSON::Value> toJSON(Dumper&) const;
 

--- a/Source/JavaScriptCore/profiler/ProfilerDumper.h
+++ b/Source/JavaScriptCore/profiler/ProfilerDumper.h
@@ -86,7 +86,7 @@ public:
     }
 
     const Database& database() const { return m_database; }
-    const Keys& keys() const { return m_keys; }
+    const Keys& keys() const LIFETIME_BOUND { return m_keys; }
 
 private:
     const Database& m_database;

--- a/Source/JavaScriptCore/profiler/ProfilerEvent.h
+++ b/Source/JavaScriptCore/profiler/ProfilerEvent.h
@@ -60,7 +60,7 @@ public:
     Bytecodes* bytecodes() const { return m_bytecodes; }
     Compilation* compilation() const { return m_compilation; }
     const char* summary() const { return m_summary; }
-    const CString& detail() const { return m_detail; }
+    const CString& detail() const LIFETIME_BOUND { return m_detail; }
     
     void dump(PrintStream&) const;
     Ref<JSON::Value> toJSON(Dumper&) const;

--- a/Source/JavaScriptCore/profiler/ProfilerExecutionCounter.h
+++ b/Source/JavaScriptCore/profiler/ProfilerExecutionCounter.h
@@ -36,7 +36,7 @@ class ExecutionCounter {
 public:
     ExecutionCounter() : m_counter(0) { }
     
-    uint64_t* address() { return &m_counter; }
+    uint64_t* address() LIFETIME_BOUND { return &m_counter; }
     
     uint64_t count() const { return m_counter; }
 

--- a/Source/JavaScriptCore/profiler/ProfilerOSRExit.h
+++ b/Source/JavaScriptCore/profiler/ProfilerOSRExit.h
@@ -40,11 +40,11 @@ public:
     ~OSRExit();
     
     unsigned id() const { return m_id; }
-    const OriginStack& origin() const { return m_origin; }
+    const OriginStack& origin() const LIFETIME_BOUND { return m_origin; }
     ExitKind exitKind() const { return m_exitKind; }
     bool isWatchpoint() const { return m_isWatchpoint; }
     
-    uint64_t* counterAddress() { return &m_counter; }
+    uint64_t* counterAddress() LIFETIME_BOUND { return &m_counter; }
     uint64_t count() const { return m_counter; }
     void incCount() { m_counter++; }
 

--- a/Source/JavaScriptCore/profiler/ProfilerOSRExitSite.h
+++ b/Source/JavaScriptCore/profiler/ProfilerOSRExitSite.h
@@ -41,7 +41,7 @@ public:
     {
     }
     
-    const Vector<CodePtr<JSInternalPtrTag>>& codeAddress() const { return m_codeAddresses; }
+    const Vector<CodePtr<JSInternalPtrTag>>& codeAddress() const LIFETIME_BOUND { return m_codeAddresses; }
     
     Ref<JSON::Value> toJSON(Dumper&) const;
 

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
@@ -117,10 +117,10 @@ public:
     std::optional<ExportEntry> tryGetExportEntry(UniquedStringImpl* exportName);
 
     const Identifier& moduleKey() const { return m_moduleKey; }
-    const Vector<ModuleRequest>& requestedModules() const { return m_requestedModules; }
-    const ExportEntries& exportEntries() const { return m_exportEntries; }
-    const ImportEntries& importEntries() const { return m_importEntries; }
-    const OrderedIdentifierSet& starExportEntries() const { return m_starExportEntries; }
+    const Vector<ModuleRequest>& requestedModules() const LIFETIME_BOUND { return m_requestedModules; }
+    const ExportEntries& exportEntries() const LIFETIME_BOUND { return m_exportEntries; }
+    const ImportEntries& importEntries() const LIFETIME_BOUND { return m_importEntries; }
+    const OrderedIdentifierSet& starExportEntries() const LIFETIME_BOUND { return m_starExportEntries; }
 
     void dump();
 

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -339,7 +339,7 @@ public:
 
     void detach(VM&);
     bool isDetached() { return !m_contents.m_data; }
-    InlineWatchpointSet& detachingWatchpointSet() { return m_detachingWatchpointSet; }
+    InlineWatchpointSet& detachingWatchpointSet() LIFETIME_BOUND { return m_detachingWatchpointSet; }
 
     static constexpr ptrdiff_t offsetOfSizeInBytes() { return OBJECT_OFFSETOF(ArrayBuffer, m_contents) + OBJECT_OFFSETOF(ArrayBufferContents, m_sizeInBytes); }
     static constexpr ptrdiff_t offsetOfData() { return OBJECT_OFFSETOF(ArrayBuffer, m_contents) + OBJECT_OFFSETOF(ArrayBufferContents, m_data); }

--- a/Source/JavaScriptCore/runtime/AuxiliaryBarrier.h
+++ b/Source/JavaScriptCore/runtime/AuxiliaryBarrier.h
@@ -58,7 +58,7 @@ public:
     
     const T& get() const { return m_value; }
     
-    T* slot() { return &m_value; }
+    T* slot() LIFETIME_BOUND { return &m_value; }
     
     explicit operator bool() const { return !!m_value; }
     

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
@@ -153,7 +153,7 @@ public:
     MemorySharingMode sharingMode() const { return m_sharingMode; }
     MemoryMode mode() const { return m_mode; }
     static constexpr ptrdiff_t offsetOfSize() { return OBJECT_OFFSETOF(BufferMemoryHandle, m_size); }
-    Lock& lock() { return m_lock; }
+    Lock& lock() LIFETIME_BOUND { return m_lock; }
 
     void updateSize(size_t size, std::memory_order order = std::memory_order_seq_cst)
     {
@@ -166,7 +166,7 @@ public:
     static void* nullBasePointer();
 
 #if ENABLE(WEBASSEMBLY)
-    const ThreadSafeWeakHashSet<Wasm::InstanceAnchor>& anchors(const AbstractLocker&) const { return m_anchors; }
+    const ThreadSafeWeakHashSet<Wasm::InstanceAnchor>& anchors(const AbstractLocker&) const LIFETIME_BOUND { return m_anchors; }
     void transferAnchors(BufferMemoryHandle& newHandle);
     void registerInstance(JSWebAssemblyInstance&);
 #endif

--- a/Source/JavaScriptCore/runtime/CachedBytecode.h
+++ b/Source/JavaScriptCore/runtime/CachedBytecode.h
@@ -56,7 +56,7 @@ public:
         return adoptRef(*new CachedBytecode(CachePayload::makeMallocPayload(WTF::move(data)), WTF::move(leafExecutables)));
     }
 
-    LeafExecutableMap& leafExecutables() { return m_leafExecutables; }
+    LeafExecutableMap& leafExecutables() LIFETIME_BOUND { return m_leafExecutables; }
 
     JS_EXPORT_PRIVATE void addGlobalUpdate(Ref<CachedBytecode>);
     JS_EXPORT_PRIVATE void addFunctionUpdate(const UnlinkedFunctionExecutable*, CodeSpecializationKind, Ref<CachedBytecode>);

--- a/Source/JavaScriptCore/runtime/CachedSpecialPropertyAdaptiveStructureWatchpoint.h
+++ b/Source/JavaScriptCore/runtime/CachedSpecialPropertyAdaptiveStructureWatchpoint.h
@@ -40,7 +40,7 @@ public:
 
     void install(VM&);
 
-    const ObjectPropertyCondition& key() const { return m_key; }
+    const ObjectPropertyCondition& key() const LIFETIME_BOUND { return m_key; }
 
     void fireInternal(VM&, const FireDetail&);
     

--- a/Source/JavaScriptCore/runtime/CagedBarrierPtr.h
+++ b/Source/JavaScriptCore/runtime/CagedBarrierPtr.h
@@ -60,9 +60,9 @@ public:
         m_barrier.set(vm, cell, CagedType(std::forward<U>(value)));
     }
     
-    T* get() const { return m_barrier.get().get(); }
-    T* getMayBeNull() const { return m_barrier.get().getMayBeNull(); }
-    T* getUnsafe() const { return m_barrier.get().getUnsafe(); }
+    T* get() const LIFETIME_BOUND { return m_barrier.get().get(); }
+    T* getMayBeNull() const LIFETIME_BOUND { return m_barrier.get().getMayBeNull(); }
+    T* getUnsafe() const LIFETIME_BOUND { return m_barrier.get().getUnsafe(); }
 
     // We need the template here so that the type of U is deduced at usage time rather than class time. U should always be T.
     template<typename U = T>

--- a/Source/JavaScriptCore/runtime/ControlFlowProfiler.h
+++ b/Source/JavaScriptCore/runtime/ControlFlowProfiler.h
@@ -88,7 +88,7 @@ public:
     BasicBlockLocation* getBasicBlockLocation(SourceID, int startOffset, int endOffset);
     JS_EXPORT_PRIVATE void dumpData() const;
     Vector<BasicBlockRange> getBasicBlocksForSourceID(SourceID, VM&) const;
-    BasicBlockLocation* dummyBasicBlock() { return &m_dummyBasicBlock; }
+    BasicBlockLocation* dummyBasicBlock() LIFETIME_BOUND { return &m_dummyBasicBlock; }
     JS_EXPORT_PRIVATE bool hasBasicBlockAtTextOffsetBeenExecuted(int, SourceID, VM&); // This function exists for testing.
     JS_EXPORT_PRIVATE size_t basicBlockExecutionCountAtTextOffset(int, SourceID, VM&); // This function exists for testing.
 

--- a/Source/JavaScriptCore/runtime/ErrorInstance.h
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.h
@@ -111,7 +111,7 @@ public:
     
     JS_EXPORT_PRIVATE String tryGetMessageForDebugging();
 
-    Vector<StackFrame>* stackTrace() { return m_stackTrace.get(); }
+    Vector<StackFrame>* stackTrace() LIFETIME_BOUND { return m_stackTrace.get(); }
 
     bool materializeErrorInfoIfNeeded(VM&);
     bool materializeErrorInfoIfNeeded(VM&, PropertyName);

--- a/Source/JavaScriptCore/runtime/EvacuatedStack.h
+++ b/Source/JavaScriptCore/runtime/EvacuatedStack.h
@@ -57,7 +57,7 @@ public:
 
     // Offsets of frame records in the trailing array data, in units of Register size.
     // Ordered from lowest to highest (shallowest to deepest frames).
-    const Vector<unsigned>& frameOffsets() const { return m_frameOffsets; }
+    const Vector<unsigned>& frameOffsets() const LIFETIME_BOUND { return m_frameOffsets; }
 
     // Copy the stack data captured by this instance to the memory location identified by
     // 'base' and prepare it for execution by relocating all internal pointers. Link the
@@ -107,8 +107,8 @@ void* relocateReturnPC(void* returnPC, const CallerFrameAndPC* originalFP, const
 // slices.
 class StackSlicerBase {
 public:
-    const String& errorMessage() const { return m_errorMessage; }
-    const Vector<std::unique_ptr<EvacuatedStackSlice>>& slices() const { return m_slices; }
+    const String& errorMessage() const LIFETIME_BOUND { return m_errorMessage; }
+    const Vector<std::unique_ptr<EvacuatedStackSlice>>& slices() const LIFETIME_BOUND { return m_slices; }
 
     // Return the accumulated slices in the order from top to bottom. This places the
     // first slice to execute at the end of the vector, and the vector acts as a stack

--- a/Source/JavaScriptCore/runtime/Exception.h
+++ b/Source/JavaScriptCore/runtime/Exception.h
@@ -61,7 +61,7 @@ public:
     }
 
     JSValue value() const { return m_value.get(); }
-    const Vector<StackFrame>& stack() const { return m_stack; }
+    const Vector<StackFrame>& stack() const LIFETIME_BOUND { return m_stack; }
 
     bool didNotifyInspectorOfThrow() const { return m_didNotifyInspectorOfThrow; }
     void setDidNotifyInspectorOfThrow() { m_didNotifyInspectorOfThrow = true; }

--- a/Source/JavaScriptCore/runtime/FunctionExecutable.h
+++ b/Source/JavaScriptCore/runtime/FunctionExecutable.h
@@ -261,7 +261,7 @@ public:
 
     Box<InlineWatchpointSet> sharedPolyProtoWatchpoint() const { return m_polyProtoWatchpoint; }
 
-    ScriptExecutable* topLevelExecutable() const { return m_topLevelExecutable.get(); }
+    ScriptExecutable* topLevelExecutable() const LIFETIME_BOUND { return m_topLevelExecutable.get(); }
 
     TemplateObjectMap& ensureTemplateObjectMap(VM&);
 

--- a/Source/JavaScriptCore/runtime/FunctionRareData.h
+++ b/Source/JavaScriptCore/runtime/FunctionRareData.h
@@ -80,7 +80,7 @@ public:
     }
 
     Structure* objectAllocationStructure() { return m_objectAllocationProfile.structure(); }
-    JSObject* objectAllocationPrototype() { return m_objectAllocationProfile.prototype(); }
+    JSObject* objectAllocationPrototype() LIFETIME_BOUND { return m_objectAllocationProfile.prototype(); }
 
     InlineWatchpointSet& allocationProfileWatchpointSet()
     {
@@ -114,7 +114,7 @@ public:
     Structure* getBoundFunctionStructure() { return m_boundFunctionStructureID.get(); }
     void setBoundFunctionStructure(VM& vm, Structure* structure) { m_boundFunctionStructureID.set(vm, this, structure); }
 
-    ExecutableBase* executable() const { return m_executable.get(); }
+    ExecutableBase* executable() const LIFETIME_BOUND { return m_executable.get(); }
 
     bool hasReifiedLength() const { return m_hasReifiedLength; }
     void setHasReifiedLength() { m_hasReifiedLength = true; }

--- a/Source/JavaScriptCore/runtime/GetterSetter.h
+++ b/Source/JavaScriptCore/runtime/GetterSetter.h
@@ -83,7 +83,7 @@ public:
 
     DECLARE_VISIT_CHILDREN;
 
-    JSObject* getter() const { return m_getter.get(); }
+    JSObject* getter() const LIFETIME_BOUND { return m_getter.get(); }
 
     JSObject* getterConcurrently() const
     {
@@ -95,7 +95,7 @@ public:
     bool isGetterNull() const { return !!jsDynamicCast<NullGetterFunction*>(m_getter.get()); }
     bool isSetterNull() const { return !!jsDynamicCast<NullSetterFunction*>(m_setter.get()); }
 
-    JSObject* setter() const { return m_setter.get(); }
+    JSObject* setter() const LIFETIME_BOUND { return m_setter.get(); }
 
     JSObject* setterConcurrently() const
     {

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -336,7 +336,7 @@ public:
     int32_t year() const { return m_isoPlainDate.year(); }
     uint8_t month() const { return m_isoPlainDate.month(); }
 
-    const PlainDate& isoPlainDate() const { return m_isoPlainDate; }
+    const PlainDate& isoPlainDate() const LIFETIME_BOUND { return m_isoPlainDate; }
 private:
     PlainDate m_isoPlainDate;
 };
@@ -365,7 +365,7 @@ public:
     uint8_t month() const { return m_isoPlainDate.month(); }
     uint32_t day() const { return m_isoPlainDate.day(); }
 
-    const PlainDate& isoPlainDate() const { return m_isoPlainDate; }
+    const PlainDate& isoPlainDate() const LIFETIME_BOUND { return m_isoPlainDate; }
 private:
     PlainDate m_isoPlainDate;
 };

--- a/Source/JavaScriptCore/runtime/Identifier.h
+++ b/Source/JavaScriptCore/runtime/Identifier.h
@@ -91,7 +91,7 @@ public:
     enum class EmptyIdentifierFlag { EmptyIdentifier };
     Identifier(EmptyIdentifierFlag) : m_string(StringImpl::empty()) { ASSERT(m_string.impl()->isAtom()); }
 
-    const AtomString& string() const { return m_string; }
+    const AtomString& string() const LIFETIME_BOUND { return m_string; }
 
     UniquedStringImpl* impl() const { return m_string.impl(); }
     RefPtr<AtomStringImpl> releaseImpl() { return m_string.releaseImpl(); }

--- a/Source/JavaScriptCore/runtime/InternalFunction.h
+++ b/Source/JavaScriptCore/runtime/InternalFunction.h
@@ -78,7 +78,7 @@ public:
         return OBJECT_OFFSETOF(InternalFunction, m_globalObject);
     }
 
-    JSGlobalObject* globalObject() const { return m_globalObject.get(); }
+    JSGlobalObject* globalObject() const LIFETIME_BOUND { return m_globalObject.get(); }
 
 protected:
     JS_EXPORT_PRIVATE InternalFunction(VM&, Structure*, NativeFunction functionForCall, NativeFunction functionForConstruct = nullptr);

--- a/Source/JavaScriptCore/runtime/IntlCollator.h
+++ b/Source/JavaScriptCore/runtime/IntlCollator.h
@@ -64,7 +64,7 @@ public:
     UCollationResult compareStrings(JSGlobalObject*, StringView, StringView) const;
     JSObject* resolvedOptions(JSGlobalObject*) const;
 
-    JSBoundFunction* boundCompare() const { return m_boundCompare.get(); }
+    JSBoundFunction* boundCompare() const LIFETIME_BOUND { return m_boundCompare.get(); }
     void setBoundCompare(VM&, JSBoundFunction*);
 
     bool canDoASCIIUCADUCETComparison() const

--- a/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDateTimeFormat.h
@@ -75,7 +75,7 @@ public:
     JSValue formatRangeToParts(JSGlobalObject*, double startDate, double endDate);
     JSObject* resolvedOptions(JSGlobalObject*) const;
 
-    JSBoundFunction* boundFormat() const { return m_boundFormat.get(); }
+    JSBoundFunction* boundFormat() const LIFETIME_BOUND { return m_boundFormat.get(); }
     void setBoundFormat(VM&, JSBoundFunction*);
 
     static IntlDateTimeFormat* unwrapForOldFunctions(JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.h
@@ -90,8 +90,8 @@ public:
 
     const UnitData* units() const { return m_units; }
     unsigned fractionalDigits() const { return m_fractionalDigits; }
-    const String& numberingSystem() const { return m_numberingSystem; }
-    const CString& dataLocaleWithExtensions() const { return m_dataLocaleWithExtensions; }
+    const String& numberingSystem() const LIFETIME_BOUND { return m_numberingSystem; }
+    const CString& dataLocaleWithExtensions() const LIFETIME_BOUND { return m_dataLocaleWithExtensions; }
 
 private:
     IntlDurationFormat(VM&, Structure*);

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.h
@@ -171,7 +171,7 @@ public:
     JSValue formatRangeToParts(JSGlobalObject*, double, double) const;
     JSValue formatRangeToParts(JSGlobalObject*, IntlMathematicalValue&&, IntlMathematicalValue&&) const;
 
-    JSBoundFunction* boundFormat() const { return m_boundFormat.get(); }
+    JSBoundFunction* boundFormat() const LIFETIME_BOUND { return m_boundFormat.get(); }
     void setBoundFormat(VM&, JSBoundFunction*);
 
     enum class Style : uint8_t { Decimal, Percent, Currency, Unit };

--- a/Source/JavaScriptCore/runtime/IntlObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/IntlObjectInlines.h
@@ -364,7 +364,7 @@ public:
 
     int32_t size() const { return m_stringPointers.size(); }
     const char16_t* const* stringPointers() const { return m_stringPointers.span().data(); }
-    const int32_t* stringLengths() const { return m_stringLengths.span().data(); }
+    const int32_t* stringLengths() const LIFETIME_BOUND { return m_stringLengths.span().data(); }
 
 private:
     Vector<String, 4> m_strings;

--- a/Source/JavaScriptCore/runtime/JSArrayBufferView.h
+++ b/Source/JavaScriptCore/runtime/JSArrayBufferView.h
@@ -236,7 +236,7 @@ protected:
         bool operator!() const { return !m_structure; }
         
         Structure* structure() const { return m_structure; }
-        void* vector() const { return m_vector.getMayBeNull(); }
+        void* vector() const LIFETIME_BOUND { return m_vector.getMayBeNull(); }
         size_t length() const { return m_length; }
         size_t byteOffset() const { return m_byteOffset; }
         TypedArrayMode mode() const { return m_mode; }

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.h
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.h
@@ -54,11 +54,11 @@ public:
     
     static bool customHasInstance(JSObject*, JSGlobalObject*, JSValue);
 
-    JSObject* targetFunction() { return m_targetFunction.get(); }
+    JSObject* targetFunction() LIFETIME_BOUND { return m_targetFunction.get(); }
     JSValue boundThis() { return m_boundThis.get(); }
     unsigned boundArgsLength() const { return m_boundArgsLength; }
     JSArray* boundArgsCopy(JSGlobalObject*);
-    JSString* nameMayBeNull() { return m_nameMayBeNull.get(); }
+    JSString* nameMayBeNull() LIFETIME_BOUND { return m_nameMayBeNull.get(); }
     JSString* name()
     {
         if (m_nameMayBeNull)

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -572,46 +572,46 @@ public:
     std::unique_ptr<ThreadSafeWeakHashSet<DeferredWorkTimer::TicketData>> m_weakTickets;
 
 public:
-    JSCallee* zombieFrameCallee() const { return m_zombieFrameCallee.get(); }
+    JSCallee* zombieFrameCallee() const LIFETIME_BOUND { return m_zombieFrameCallee.get(); }
 
-    InlineWatchpointSet& arrayIteratorProtocolWatchpointSet() { return m_arrayIteratorProtocolWatchpointSet; }
-    InlineWatchpointSet& mapIteratorProtocolWatchpointSet() { return m_mapIteratorProtocolWatchpointSet; }
-    InlineWatchpointSet& setIteratorProtocolWatchpointSet() { return m_setIteratorProtocolWatchpointSet; }
-    InlineWatchpointSet& stringIteratorProtocolWatchpointSet() { return m_stringIteratorProtocolWatchpointSet; }
-    InlineWatchpointSet& stringSymbolReplaceWatchpointSet() { return m_stringSymbolReplaceWatchpointSet; }
-    InlineWatchpointSet& stringSymbolToPrimitiveWatchpointSet() { return m_stringSymbolToPrimitiveWatchpointSet; }
-    InlineWatchpointSet& arraySymbolToPrimitiveWatchpointSet() { return m_arraySymbolToPrimitiveWatchpointSet; }
-    InlineWatchpointSet& stringToStringWatchpointSet() { return m_stringToStringWatchpointSet; }
-    InlineWatchpointSet& stringValueOfWatchpointSet() { return m_stringValueOfWatchpointSet; }
-    InlineWatchpointSet& regExpPrimordialPropertiesWatchpointSet() { return m_regExpPrimordialPropertiesWatchpointSet; }
-    InlineWatchpointSet& mapSetWatchpointSet() { return m_mapSetWatchpointSet; }
-    InlineWatchpointSet& setAddWatchpointSet() { return m_setAddWatchpointSet; }
-    InlineWatchpointSet& setPrimordialPropertiesWatchpointSet() { return m_setPrimordialPropertiesWatchpointSet; }
-    InlineWatchpointSet& promiseThenWatchpointSet() { return m_promiseThenWatchpointSet; }
-    InlineWatchpointSet& promiseResolveWatchpointSet() { return m_promiseResolveWatchpointSet; }
-    InlineWatchpointSet& arraySpeciesWatchpointSet() { return m_arraySpeciesWatchpointSet; }
-    InlineWatchpointSet& promiseSpeciesWatchpointSet() { return m_promiseSpeciesWatchpointSet; }
-    InlineWatchpointSet& arrayPrototypeChainIsSaneWatchpointSet() { return m_arrayPrototypeChainIsSaneWatchpointSet; }
-    InlineWatchpointSet& objectPrototypeChainIsSaneWatchpointSet() { return m_objectPrototypeChainIsSaneWatchpointSet; }
-    InlineWatchpointSet& stringPrototypeChainIsSaneWatchpointSet() { return m_stringPrototypeChainIsSaneWatchpointSet; }
-    InlineWatchpointSet& promisePrototypeChainIsSaneWatchpointSet() { return m_promisePrototypeChainIsSaneWatchpointSet; }
-    InlineWatchpointSet& arrayJoinWatchpointSet() { return m_arrayJoinWatchpointSet; }
-    InlineWatchpointSet& arrayToStringWatchpointSet() { return m_arrayToStringWatchpointSet; }
-    InlineWatchpointSet& arrayNegativeOneWatchpointSet() { return m_arrayNegativeOneWatchpointSet; }
-    InlineWatchpointSet& arrayIsConcatSpreadableWatchpointSet() { return m_arrayIsConcatSpreadableWatchpointSet; }
+    InlineWatchpointSet& arrayIteratorProtocolWatchpointSet() LIFETIME_BOUND { return m_arrayIteratorProtocolWatchpointSet; }
+    InlineWatchpointSet& mapIteratorProtocolWatchpointSet() LIFETIME_BOUND { return m_mapIteratorProtocolWatchpointSet; }
+    InlineWatchpointSet& setIteratorProtocolWatchpointSet() LIFETIME_BOUND { return m_setIteratorProtocolWatchpointSet; }
+    InlineWatchpointSet& stringIteratorProtocolWatchpointSet() LIFETIME_BOUND { return m_stringIteratorProtocolWatchpointSet; }
+    InlineWatchpointSet& stringSymbolReplaceWatchpointSet() LIFETIME_BOUND { return m_stringSymbolReplaceWatchpointSet; }
+    InlineWatchpointSet& stringSymbolToPrimitiveWatchpointSet() LIFETIME_BOUND { return m_stringSymbolToPrimitiveWatchpointSet; }
+    InlineWatchpointSet& arraySymbolToPrimitiveWatchpointSet() LIFETIME_BOUND { return m_arraySymbolToPrimitiveWatchpointSet; }
+    InlineWatchpointSet& stringToStringWatchpointSet() LIFETIME_BOUND { return m_stringToStringWatchpointSet; }
+    InlineWatchpointSet& stringValueOfWatchpointSet() LIFETIME_BOUND { return m_stringValueOfWatchpointSet; }
+    InlineWatchpointSet& regExpPrimordialPropertiesWatchpointSet() LIFETIME_BOUND { return m_regExpPrimordialPropertiesWatchpointSet; }
+    InlineWatchpointSet& mapSetWatchpointSet() LIFETIME_BOUND { return m_mapSetWatchpointSet; }
+    InlineWatchpointSet& setAddWatchpointSet() LIFETIME_BOUND { return m_setAddWatchpointSet; }
+    InlineWatchpointSet& setPrimordialPropertiesWatchpointSet() LIFETIME_BOUND { return m_setPrimordialPropertiesWatchpointSet; }
+    InlineWatchpointSet& promiseThenWatchpointSet() LIFETIME_BOUND { return m_promiseThenWatchpointSet; }
+    InlineWatchpointSet& promiseResolveWatchpointSet() LIFETIME_BOUND { return m_promiseResolveWatchpointSet; }
+    InlineWatchpointSet& arraySpeciesWatchpointSet() LIFETIME_BOUND { return m_arraySpeciesWatchpointSet; }
+    InlineWatchpointSet& promiseSpeciesWatchpointSet() LIFETIME_BOUND { return m_promiseSpeciesWatchpointSet; }
+    InlineWatchpointSet& arrayPrototypeChainIsSaneWatchpointSet() LIFETIME_BOUND { return m_arrayPrototypeChainIsSaneWatchpointSet; }
+    InlineWatchpointSet& objectPrototypeChainIsSaneWatchpointSet() LIFETIME_BOUND { return m_objectPrototypeChainIsSaneWatchpointSet; }
+    InlineWatchpointSet& stringPrototypeChainIsSaneWatchpointSet() LIFETIME_BOUND { return m_stringPrototypeChainIsSaneWatchpointSet; }
+    InlineWatchpointSet& promisePrototypeChainIsSaneWatchpointSet() LIFETIME_BOUND { return m_promisePrototypeChainIsSaneWatchpointSet; }
+    InlineWatchpointSet& arrayJoinWatchpointSet() LIFETIME_BOUND { return m_arrayJoinWatchpointSet; }
+    InlineWatchpointSet& arrayToStringWatchpointSet() LIFETIME_BOUND { return m_arrayToStringWatchpointSet; }
+    InlineWatchpointSet& arrayNegativeOneWatchpointSet() LIFETIME_BOUND { return m_arrayNegativeOneWatchpointSet; }
+    InlineWatchpointSet& arrayIsConcatSpreadableWatchpointSet() LIFETIME_BOUND { return m_arrayIsConcatSpreadableWatchpointSet; }
     InlineWatchpointSet& numberToStringWatchpointSet()
     {
         RELEASE_ASSERT(Options::useJIT());
         return m_numberToStringWatchpointSet;
     }
-    InlineWatchpointSet& structureCacheClearedWatchpointSet() { return m_structureCacheClearedWatchpointSet; }
+    InlineWatchpointSet& structureCacheClearedWatchpointSet() LIFETIME_BOUND { return m_structureCacheClearedWatchpointSet; }
     inline InlineWatchpointSet& arrayBufferSpeciesWatchpointSet(ArrayBufferSharingMode);
 
     inline InlineWatchpointSet& typedArraySpeciesWatchpointSet(TypedArrayType);
     inline InlineWatchpointSet& typedArrayIteratorProtocolWatchpointSet(TypedArrayType);
-    InlineWatchpointSet& typedArrayConstructorSpeciesWatchpointSet() { return m_typedArrayConstructorSpeciesWatchpointSet; }
-    InlineWatchpointSet& typedArrayPrototypeIteratorProtocolWatchpointSet() { return m_typedArrayPrototypeIteratorProtocolWatchpointSet; }
-    InlineWatchpointSet& propertyDescriptorFastPathWatchpointSet() { return m_propertyDescriptorFastPathWatchpointSet; }
+    InlineWatchpointSet& typedArrayConstructorSpeciesWatchpointSet() LIFETIME_BOUND { return m_typedArrayConstructorSpeciesWatchpointSet; }
+    InlineWatchpointSet& typedArrayPrototypeIteratorProtocolWatchpointSet() LIFETIME_BOUND { return m_typedArrayPrototypeIteratorProtocolWatchpointSet; }
+    InlineWatchpointSet& propertyDescriptorFastPathWatchpointSet() LIFETIME_BOUND { return m_propertyDescriptorFastPathWatchpointSet; }
 
     bool isArrayPrototypeIteratorProtocolFastAndNonObservable();
     bool isTypedArrayPrototypeIteratorProtocolFastAndNonObservable(TypedArrayType);
@@ -689,7 +689,7 @@ public:
 
     bool hasDebugger() const { return m_debugger; }
     bool hasInteractiveDebugger() const;
-    const RuntimeFlags& runtimeFlags() const { return m_runtimeFlags; }
+    const RuntimeFlags& runtimeFlags() const LIFETIME_BOUND { return m_runtimeFlags; }
 
 #if ENABLE(DFG_JIT)
     WatchpointSet* getReferencedPropertyWatchpointSet(UniquedStringImpl*);
@@ -728,54 +728,54 @@ public:
     template<BindingCreationContext> inline void createGlobalVarBinding(const Identifier&);
 
     inline JSScope* globalScope();
-    JSGlobalLexicalEnvironment* globalLexicalEnvironment() { return m_globalLexicalEnvironment.get(); }
+    JSGlobalLexicalEnvironment* globalLexicalEnvironment() LIFETIME_BOUND { return m_globalLexicalEnvironment.get(); }
 
-    JSScope* globalScopeExtension() { return m_globalScopeExtension.get(); }
+    JSScope* globalScopeExtension() LIFETIME_BOUND { return m_globalScopeExtension.get(); }
     void setGlobalScopeExtension(JSScope*);
     void clearGlobalScopeExtension();
 
-    JSCallee* globalCallee() { return m_globalCallee.get(); }
-    JSCallee* evalCallee() { return m_evalCallee.get(); }
+    JSCallee* globalCallee() LIFETIME_BOUND { return m_globalCallee.get(); }
+    JSCallee* evalCallee() LIFETIME_BOUND { return m_evalCallee.get(); }
 
     // The following accessors return pristine values, even if a script 
     // replaces the global object's associated property.
 
-    GetterSetter* arraySpeciesGetterSetter() const { return m_arraySpeciesGetterSetter.get(); }
-    GetterSetter* typedArraySpeciesGetterSetter() const { return m_typedArraySpeciesGetterSetter.get(); }
-    GetterSetter* promiseSpeciesGetterSetter() const { return m_promiseSpeciesGetterSetter.get(); }
+    GetterSetter* arraySpeciesGetterSetter() const LIFETIME_BOUND { return m_arraySpeciesGetterSetter.get(); }
+    GetterSetter* typedArraySpeciesGetterSetter() const LIFETIME_BOUND { return m_typedArraySpeciesGetterSetter.get(); }
+    GetterSetter* promiseSpeciesGetterSetter() const LIFETIME_BOUND { return m_promiseSpeciesGetterSetter.get(); }
 
-    ArrayConstructor* arrayConstructor() const { return m_arrayConstructor.get(); }
-    RegExpConstructor* regExpConstructor() const { return m_regExpConstructor.get(); }
-    ObjectConstructor* objectConstructor() const { return m_objectConstructor.get(); }
-    FunctionConstructor* functionConstructor() const { return m_functionConstructor.get(); }
-    JSPromiseConstructor* promiseConstructor() const { return m_promiseConstructor.get(); }
-    JSInternalPromiseConstructor* internalPromiseConstructor() const { return m_internalPromiseConstructor.get(); }
-    JSIteratorConstructor* iteratorConstructor() const { return m_iteratorConstructor.get(); }
+    ArrayConstructor* arrayConstructor() const LIFETIME_BOUND { return m_arrayConstructor.get(); }
+    RegExpConstructor* regExpConstructor() const LIFETIME_BOUND { return m_regExpConstructor.get(); }
+    ObjectConstructor* objectConstructor() const LIFETIME_BOUND { return m_objectConstructor.get(); }
+    FunctionConstructor* functionConstructor() const LIFETIME_BOUND { return m_functionConstructor.get(); }
+    JSPromiseConstructor* promiseConstructor() const LIFETIME_BOUND { return m_promiseConstructor.get(); }
+    JSInternalPromiseConstructor* internalPromiseConstructor() const LIFETIME_BOUND { return m_internalPromiseConstructor.get(); }
+    JSIteratorConstructor* iteratorConstructor() const LIFETIME_BOUND { return m_iteratorConstructor.get(); }
 
-    IntlCollator* defaultCollator() const { return m_defaultCollator.get(this); }
-    IntlNumberFormat* defaultNumberFormat() const { return m_defaultNumberFormat.get(this); }
+    IntlCollator* defaultCollator() const LIFETIME_BOUND { return m_defaultCollator.get(this); }
+    IntlNumberFormat* defaultNumberFormat() const LIFETIME_BOUND { return m_defaultNumberFormat.get(this); }
 
-    NullGetterFunction* nullGetterFunction() const { return m_nullGetterFunction.get(); }
-    NullSetterFunction* nullSetterFunction() const { return m_nullSetterFunction.get(); }
-    NullSetterFunction* nullSetterStrictFunction() const { return m_nullSetterStrictFunction.get(); }
+    NullGetterFunction* nullGetterFunction() const LIFETIME_BOUND { return m_nullGetterFunction.get(); }
+    NullSetterFunction* nullSetterFunction() const LIFETIME_BOUND { return m_nullSetterFunction.get(); }
+    NullSetterFunction* nullSetterStrictFunction() const LIFETIME_BOUND { return m_nullSetterStrictFunction.get(); }
 
-    JSFunction* parseIntFunction() const { return m_parseIntFunction.get(this); }
-    JSFunction* parseFloatFunction() const { return m_parseFloatFunction.get(this); }
+    JSFunction* parseIntFunction() const LIFETIME_BOUND { return m_parseIntFunction.get(this); }
+    JSFunction* parseFloatFunction() const LIFETIME_BOUND { return m_parseFloatFunction.get(this); }
 
     JSFunction* promiseEmptyOnFulfilledFunction() const;
     JSFunction* promiseEmptyOnRejectedFunction() const;
     JSFunction* evalFunction() const;
     JSFunction* throwTypeErrorFunction() const;
-    JSFunction* objectProtoToStringFunction() const { return m_objectProtoToStringFunction.get(this); }
-    JSFunction* objectProtoToStringFunctionConcurrently() const { return m_objectProtoToStringFunction.getConcurrently(); }
-    JSFunction* arrayProtoToStringFunction() const { return m_arrayProtoToStringFunction.get(this); }
-    JSFunction* arrayProtoValuesFunction() const { return m_arrayProtoValuesFunction.get(this); }
-    JSFunction* arrayProtoValuesFunctionConcurrently() const { return m_arrayProtoValuesFunction.getConcurrently(); }
+    JSFunction* objectProtoToStringFunction() const LIFETIME_BOUND { return m_objectProtoToStringFunction.get(this); }
+    JSFunction* objectProtoToStringFunctionConcurrently() const LIFETIME_BOUND { return m_objectProtoToStringFunction.getConcurrently(); }
+    JSFunction* arrayProtoToStringFunction() const LIFETIME_BOUND { return m_arrayProtoToStringFunction.get(this); }
+    JSFunction* arrayProtoValuesFunction() const LIFETIME_BOUND { return m_arrayProtoValuesFunction.get(this); }
+    JSFunction* arrayProtoValuesFunctionConcurrently() const LIFETIME_BOUND { return m_arrayProtoValuesFunction.getConcurrently(); }
     JSFunction* iteratorProtocolFunction() const;
     JSFunction* promiseProtoThenFunction() const;
-    JSFunction* objectProtoValueOfFunction() const { return m_objectProtoValueOfFunction.get(); }
-    JSFunction* numberProtoToStringFunction() const { return m_numberProtoToStringFunction.getInitializedOnMainThread(this); }
-    JSFunction* functionProtoHasInstanceSymbolFunction() const { return m_functionProtoHasInstanceSymbolFunction.get(); }
+    JSFunction* objectProtoValueOfFunction() const LIFETIME_BOUND { return m_objectProtoValueOfFunction.get(); }
+    JSFunction* numberProtoToStringFunction() const LIFETIME_BOUND { return m_numberProtoToStringFunction.getInitializedOnMainThread(this); }
+    JSFunction* functionProtoHasInstanceSymbolFunction() const LIFETIME_BOUND { return m_functionProtoHasInstanceSymbolFunction.get(); }
     JSFunction* regExpProtoExecFunction() const;
     JSFunction* stringProtoSubstringFunction() const;
     JSFunction* performProxyObjectHasFunction() const;
@@ -794,7 +794,7 @@ public:
     JSFunction* performProxyObjectSetByValSloppyFunctionConcurrently() const;
     JSFunction* performProxyObjectSetByValStrictFunction() const;
     JSFunction* performProxyObjectSetByValStrictFunctionConcurrently() const;
-    JSObject* regExpProtoSymbolReplaceFunction() const { return m_regExpProtoSymbolReplace.get(); }
+    JSObject* regExpProtoSymbolReplaceFunction() const LIFETIME_BOUND { return m_regExpProtoSymbolReplace.get(); }
     GetterSetter* regExpProtoFlagsGetter() const;
     GetterSetter* regExpProtoDotAllGetter() const;
     GetterSetter* regExpProtoGlobalGetter() const;
@@ -804,38 +804,38 @@ public:
     GetterSetter* regExpProtoStickyGetter() const;
     GetterSetter* regExpProtoUnicodeGetter() const;
     GetterSetter* regExpProtoUnicodeSetsGetter() const;
-    GetterSetter* throwTypeErrorArgumentsCalleeGetterSetter() const { return m_throwTypeErrorArgumentsCalleeGetterSetter.get(this); }
+    GetterSetter* throwTypeErrorArgumentsCalleeGetterSetter() const LIFETIME_BOUND { return m_throwTypeErrorArgumentsCalleeGetterSetter.get(this); }
     
-    JSModuleLoader* moduleLoader() const { return m_moduleLoader.get(this); }
+    JSModuleLoader* moduleLoader() const LIFETIME_BOUND { return m_moduleLoader.get(this); }
 
-    ObjectPrototype* objectPrototype() const { return m_objectPrototype.get(); }
-    FunctionPrototype* functionPrototype() const { return m_functionPrototype.get(); }
-    ArrayPrototype* arrayPrototype() const { return m_arrayPrototype.get(); }
-    JSObject* booleanPrototype() const { return m_booleanObjectStructure.prototypeInitializedOnMainThread(this); }
-    StringPrototype* stringPrototype() const { return m_stringPrototype.get(); }
-    JSObject* numberPrototype() const { return m_numberObjectStructure.prototypeInitializedOnMainThread(this); }
-    BigIntPrototype* bigIntPrototype() const { return m_bigIntPrototype.get(); }
-    JSObject* datePrototype() const { return m_dateStructure.prototype(this); }
-    SymbolPrototype* symbolPrototype() const { return m_symbolPrototype.get(); }
-    ShadowRealmPrototype* shadowRealmPrototype() const { return m_shadowRealmPrototype.get(); }
-    RegExpPrototype* regExpPrototype() const { return m_regExpPrototype.get(); }
-    JSObject* errorPrototype() const { return m_errorStructure.prototype(this); }
-    JSIteratorPrototype* iteratorPrototype() const { return m_iteratorPrototype.get(); }
-    JSIteratorHelperPrototype* iteratorHelperPrototype() const { return m_iteratorHelperPrototype.get(); }
-    AsyncIteratorPrototype* asyncIteratorPrototype() const { return m_asyncIteratorPrototype.get(); }
-    GeneratorFunctionPrototype* generatorFunctionPrototype() const { return m_generatorFunctionPrototype.get(); }
-    GeneratorPrototype* generatorPrototype() const { return m_generatorPrototype.get(); }
-    AsyncFunctionPrototype* asyncFunctionPrototype() const { return m_asyncFunctionPrototype.get(); }
-    ArrayIteratorPrototype* arrayIteratorPrototype() const { return m_arrayIteratorPrototype.get(); }
-    MapIteratorPrototype* mapIteratorPrototype() const { return m_mapIteratorPrototype.get(); }
-    SetIteratorPrototype* setIteratorPrototype() const { return m_setIteratorPrototype.get(); }
-    JSObject* mapPrototype() const { return m_mapStructure.prototype(this); }
+    ObjectPrototype* objectPrototype() const LIFETIME_BOUND { return m_objectPrototype.get(); }
+    FunctionPrototype* functionPrototype() const LIFETIME_BOUND { return m_functionPrototype.get(); }
+    ArrayPrototype* arrayPrototype() const LIFETIME_BOUND { return m_arrayPrototype.get(); }
+    JSObject* booleanPrototype() const LIFETIME_BOUND { return m_booleanObjectStructure.prototypeInitializedOnMainThread(this); }
+    StringPrototype* stringPrototype() const LIFETIME_BOUND { return m_stringPrototype.get(); }
+    JSObject* numberPrototype() const LIFETIME_BOUND { return m_numberObjectStructure.prototypeInitializedOnMainThread(this); }
+    BigIntPrototype* bigIntPrototype() const LIFETIME_BOUND { return m_bigIntPrototype.get(); }
+    JSObject* datePrototype() const LIFETIME_BOUND { return m_dateStructure.prototype(this); }
+    SymbolPrototype* symbolPrototype() const LIFETIME_BOUND { return m_symbolPrototype.get(); }
+    ShadowRealmPrototype* shadowRealmPrototype() const LIFETIME_BOUND { return m_shadowRealmPrototype.get(); }
+    RegExpPrototype* regExpPrototype() const LIFETIME_BOUND { return m_regExpPrototype.get(); }
+    JSObject* errorPrototype() const LIFETIME_BOUND { return m_errorStructure.prototype(this); }
+    JSIteratorPrototype* iteratorPrototype() const LIFETIME_BOUND { return m_iteratorPrototype.get(); }
+    JSIteratorHelperPrototype* iteratorHelperPrototype() const LIFETIME_BOUND { return m_iteratorHelperPrototype.get(); }
+    AsyncIteratorPrototype* asyncIteratorPrototype() const LIFETIME_BOUND { return m_asyncIteratorPrototype.get(); }
+    GeneratorFunctionPrototype* generatorFunctionPrototype() const LIFETIME_BOUND { return m_generatorFunctionPrototype.get(); }
+    GeneratorPrototype* generatorPrototype() const LIFETIME_BOUND { return m_generatorPrototype.get(); }
+    AsyncFunctionPrototype* asyncFunctionPrototype() const LIFETIME_BOUND { return m_asyncFunctionPrototype.get(); }
+    ArrayIteratorPrototype* arrayIteratorPrototype() const LIFETIME_BOUND { return m_arrayIteratorPrototype.get(); }
+    MapIteratorPrototype* mapIteratorPrototype() const LIFETIME_BOUND { return m_mapIteratorPrototype.get(); }
+    SetIteratorPrototype* setIteratorPrototype() const LIFETIME_BOUND { return m_setIteratorPrototype.get(); }
+    JSObject* mapPrototype() const LIFETIME_BOUND { return m_mapStructure.prototype(this); }
     // Workaround for the name conflict between JSCell::setPrototype.
-    JSObject* jsSetPrototype() const { return m_setStructure.prototype(this); }
-    JSPromisePrototype* promisePrototype() const { return m_promisePrototype.get(); }
-    JSInternalPromisePrototype* internalPromisePrototype() const { return m_internalPromisePrototype.get(); }
-    AsyncGeneratorPrototype* asyncGeneratorPrototype() const { return m_asyncGeneratorPrototype.get(); }
-    AsyncGeneratorFunctionPrototype* asyncGeneratorFunctionPrototype() const { return m_asyncGeneratorFunctionPrototype.get(); }
+    JSObject* jsSetPrototype() const LIFETIME_BOUND { return m_setStructure.prototype(this); }
+    JSPromisePrototype* promisePrototype() const LIFETIME_BOUND { return m_promisePrototype.get(); }
+    JSInternalPromisePrototype* internalPromisePrototype() const LIFETIME_BOUND { return m_internalPromisePrototype.get(); }
+    AsyncGeneratorPrototype* asyncGeneratorPrototype() const LIFETIME_BOUND { return m_asyncGeneratorPrototype.get(); }
+    AsyncGeneratorFunctionPrototype* asyncGeneratorFunctionPrototype() const LIFETIME_BOUND { return m_asyncGeneratorFunctionPrototype.get(); }
     JSValue nullPrototype() const { return jsNull(); }
 
     Structure* debuggerScopeStructure() const { return m_debuggerScopeStructure.get(this); }
@@ -966,7 +966,7 @@ public:
     Structure* webAssemblyModuleRecordStructure() const { return m_webAssemblyModuleRecordStructure.get(this); }
     Structure* webAssemblyFunctionStructure() const { return m_webAssemblyFunctionStructure.get(this); }
     Structure* webAssemblyWrapperFunctionStructure() const { return m_webAssemblyWrapperFunctionStructure.get(this); }
-    JSWebAssemblyTag* webAssemblyJSTag() { return m_webAssemblyJSTag.get(this); }
+    JSWebAssemblyTag* webAssemblyJSTag() LIFETIME_BOUND { return m_webAssemblyJSTag.get(this); }
 #endif // ENABLE(WEBASSEMBLY)
     Structure* collatorStructure() { return m_collatorStructure.get(this); }
     Structure* dateTimeFormatStructure() { return m_dateTimeFormatStructure.get(this); }
@@ -988,10 +988,10 @@ public:
     Structure* intlPartObjectWithUnitAndSourceStructure() { return m_intlPartObjectWithUnitAndSourceStructure.get(this); }
     Structure* trustedScriptStructure() { return m_trustedScriptStructure.get(); }
 
-    JSObject* dateTimeFormatConstructor() { return m_dateTimeFormatStructure.constructor(this); }
-    JSObject* dateTimeFormatPrototype() { return m_dateTimeFormatStructure.prototype(this); }
-    JSObject* numberFormatConstructor() { return m_numberFormatStructure.constructor(this); }
-    JSObject* numberFormatPrototype() { return m_numberFormatStructure.prototype(this); }
+    JSObject* dateTimeFormatConstructor() LIFETIME_BOUND { return m_dateTimeFormatStructure.constructor(this); }
+    JSObject* dateTimeFormatPrototype() LIFETIME_BOUND { return m_dateTimeFormatStructure.prototype(this); }
+    JSObject* numberFormatConstructor() LIFETIME_BOUND { return m_numberFormatStructure.constructor(this); }
+    JSObject* numberFormatPrototype() LIFETIME_BOUND { return m_numberFormatStructure.prototype(this); }
 
     Structure* calendarStructure() { return m_calendarStructure.get(this); }
     Structure* durationStructure() { return m_durationStructure.get(this); }
@@ -1008,7 +1008,7 @@ public:
 
     void setIsITML();
 
-    RegExpGlobalData& regExpGlobalData() { return m_regExpGlobalData; }
+    RegExpGlobalData& regExpGlobalData() LIFETIME_BOUND { return m_regExpGlobalData; }
     static constexpr ptrdiff_t regExpGlobalDataOffset() { return OBJECT_OFFSETOF(JSGlobalObject, m_regExpGlobalData); }
 
     static constexpr ptrdiff_t offsetOfGlobalThis() { return OBJECT_OFFSETOF(JSGlobalObject, m_globalThis); }
@@ -1040,19 +1040,19 @@ public:
     void bumpGlobalLexicalBindingEpoch(VM&);
     unsigned globalLexicalBindingEpoch() const { return m_globalLexicalBindingEpoch; }
     static constexpr ptrdiff_t globalLexicalBindingEpochOffset() { return OBJECT_OFFSETOF(JSGlobalObject, m_globalLexicalBindingEpoch); }
-    unsigned* addressOfGlobalLexicalBindingEpoch() { return &m_globalLexicalBindingEpoch; }
+    unsigned* addressOfGlobalLexicalBindingEpoch() LIFETIME_BOUND { return &m_globalLexicalBindingEpoch; }
 
     JS_EXPORT_PRIVATE void setConsoleClient(WeakPtr<ConsoleClient>&&);
     JS_EXPORT_PRIVATE CheckedPtr<ConsoleClient> consoleClient() const;
 
     void setName(const String&);
-    const String& name() const { return m_name; }
+    const String& name() const LIFETIME_BOUND { return m_name; }
 
-    StructureCache& structureCache() { return m_structureCache; }
+    StructureCache& structureCache() LIFETIME_BOUND { return m_structureCache; }
     WeakGCMap<SymbolTable*, SymbolTable>& symbolTableCache() { return m_symbolTableCache; }
 
     inline void setUnhandledRejectionCallback(VM&, JSObject*);
-    JSObject* unhandledRejectionCallback() const { return m_unhandledRejectionCallback.get(); }
+    JSObject* unhandledRejectionCallback() const LIFETIME_BOUND { return m_unhandledRejectionCallback.get(); }
 
     static void reportUncaughtExceptionAtEventLoop(JSGlobalObject*, Exception*);
     static JSObject* currentScriptExecutionOwner(JSGlobalObject* global) { return global; }
@@ -1161,8 +1161,8 @@ public:
     bool evalEnabled() const { return m_evalEnabled; }
     bool webAssemblyEnabled() const { return m_webAssemblyEnabled; }
     TrustedTypesEnforcement trustedTypesEnforcement() const { return m_trustedTypesEnforcement; }
-    const String& evalDisabledErrorMessage() const { return m_evalDisabledErrorMessage; }
-    const String& webAssemblyDisabledErrorMessage() const { return m_webAssemblyDisabledErrorMessage; }
+    const String& evalDisabledErrorMessage() const LIFETIME_BOUND { return m_evalDisabledErrorMessage; }
+    const String& webAssemblyDisabledErrorMessage() const LIFETIME_BOUND { return m_webAssemblyDisabledErrorMessage; }
     void setEvalEnabled(bool enabled, const String& errorMessage = String())
     {
         m_evalEnabled = enabled;
@@ -1191,7 +1191,7 @@ public:
 
     VM& vm() const { return *m_vm; }
     JSObject* globalThis() const;
-    WriteBarrier<JSObject>* addressOfGlobalThis() { return &m_globalThis; }
+    WriteBarrier<JSObject>* addressOfGlobalThis() LIFETIME_BOUND { return &m_globalThis; }
     OptionSet<CodeGenerationMode> defaultCodeGenerationMode() const;
 
     FunctionExecutable* tryGetCachedFunctionExecutableForFunctionConstructor(const Identifier& name, StringView program, const SourceOrigin&, SourceTaintedOrigin, const String& sourceURL, const TextPosition& startPosition, LexicallyScopedFeatures, FunctionConstructionMode);

--- a/Source/JavaScriptCore/runtime/JSGlobalProxy.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalProxy.h
@@ -61,7 +61,7 @@ public:
 
     DECLARE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE);
 
-    JSGlobalObject* target() const { return m_target.get(); }
+    JSGlobalObject* target() const LIFETIME_BOUND { return m_target.get(); }
     static constexpr ptrdiff_t targetOffset() { return OBJECT_OFFSETOF(JSGlobalProxy, m_target); }
 
     JS_EXPORT_PRIVATE void setTarget(VM&, JSGlobalObject*);

--- a/Source/JavaScriptCore/runtime/JSMicrotaskDispatcher.h
+++ b/Source/JavaScriptCore/runtime/JSMicrotaskDispatcher.h
@@ -54,7 +54,7 @@ public:
 
     MicrotaskDispatcher* dispatcher() const { return m_dispatcher.ptr(); }
 
-    JSGlobalObject* globalObject() const { return m_globalObject.get(); }
+    JSGlobalObject* globalObject() const LIFETIME_BOUND { return m_globalObject.get(); }
 
     MicrotaskDispatcher::Type cachedType() const { return m_type; }
 

--- a/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h
+++ b/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h
@@ -68,7 +68,7 @@ public:
 
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
-    AbstractModuleRecord* moduleRecord() { return m_moduleRecord.get(); }
+    AbstractModuleRecord* moduleRecord() LIFETIME_BOUND { return m_moduleRecord.get(); }
 
 private:
     JS_EXPORT_PRIVATE JSModuleNamespaceObject(VM&, Structure*);

--- a/Source/JavaScriptCore/runtime/JSModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/JSModuleRecord.h
@@ -59,9 +59,9 @@ public:
     Synchronousness link(JSGlobalObject*, JSValue scriptFetcher);
     JS_EXPORT_PRIVATE JSValue evaluate(JSGlobalObject*, JSValue sentValue, JSValue resumeMode);
 
-    const SourceCode& sourceCode() const { return m_sourceCode; }
-    const VariableEnvironment& declaredVariables() const { return m_declaredVariables; }
-    const VariableEnvironment& lexicalVariables() const { return m_lexicalVariables; }
+    const SourceCode& sourceCode() const LIFETIME_BOUND { return m_sourceCode; }
+    const VariableEnvironment& declaredVariables() const LIFETIME_BOUND { return m_declaredVariables; }
+    const VariableEnvironment& lexicalVariables() const LIFETIME_BOUND { return m_lexicalVariables; }
 
 private:
     JSModuleRecord(VM&, Structure*, const Identifier&, const SourceCode&, const VariableEnvironment&, const VariableEnvironment&, CodeFeatures);

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -688,8 +688,8 @@ public:
         return inlineStorageUnsafe();
     }
         
-    const Butterfly* butterfly() const { return m_butterfly.get(); }
-    Butterfly* butterfly() { return m_butterfly.get(); }
+    const Butterfly* butterfly() const LIFETIME_BOUND { return m_butterfly.get(); }
+    Butterfly* butterfly() LIFETIME_BOUND { return m_butterfly.get(); }
     Dependency fencedButterfly(Butterfly*& butterfly)
     {
         return Dependency::loadAndFence(static_cast<Butterfly**>(butterflyAddress()), butterfly);

--- a/Source/JavaScriptCore/runtime/JSPromiseCombinatorsContext.h
+++ b/Source/JavaScriptCore/runtime/JSPromiseCombinatorsContext.h
@@ -50,7 +50,7 @@ public:
 
     static JSPromiseCombinatorsContext* create(VM&, JSPromiseCombinatorsGlobalContext*, uint64_t index);
 
-    JSPromiseCombinatorsGlobalContext* globalContext() const { return m_globalContext.get(); }
+    JSPromiseCombinatorsGlobalContext* globalContext() const LIFETIME_BOUND { return m_globalContext.get(); }
     uint64_t index() const { return m_index; }
 
 private:

--- a/Source/JavaScriptCore/runtime/JSPromiseReaction.h
+++ b/Source/JavaScriptCore/runtime/JSPromiseReaction.h
@@ -50,7 +50,7 @@ public:
     JSValue onFulfilled() const { return m_onFulfilled.get(); }
     JSValue onRejected() const { return m_onRejected.get(); }
     JSValue context() const { return m_context.get(); }
-    JSPromiseReaction* next() const { return m_next.get(); }
+    JSPromiseReaction* next() const LIFETIME_BOUND { return m_next.get(); }
 
     void setPromise(VM& vm, JSValue value) { m_promise.set(vm, this, value); }
     void setOnFulfilled(VM& vm, JSValue value) { m_onFulfilled.set(vm, this, value); }

--- a/Source/JavaScriptCore/runtime/JSRemoteFunction.h
+++ b/Source/JavaScriptCore/runtime/JSRemoteFunction.h
@@ -56,9 +56,9 @@ public:
 
     JS_EXPORT_PRIVATE static JSRemoteFunction* tryCreate(JSGlobalObject*, VM&, JSObject* targetCallable);
 
-    JSObject* targetFunction() { return m_targetFunction.get(); }
+    JSObject* targetFunction() LIFETIME_BOUND { return m_targetFunction.get(); }
     JSGlobalObject* targetGlobalObject() { return targetFunction()->globalObject(); }
-    JSString* nameMayBeNull() const { return m_nameMayBeNull.get(); }
+    JSString* nameMayBeNull() const LIFETIME_BOUND { return m_nameMayBeNull.get(); }
     String nameString()
     {
         if (!m_nameMayBeNull)

--- a/Source/JavaScriptCore/runtime/JSSymbolTableObject.h
+++ b/Source/JavaScriptCore/runtime/JSSymbolTableObject.h
@@ -41,7 +41,7 @@ public:
     using Base = JSScope;
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnSpecialPropertyNames;
 
-    SymbolTable* symbolTable() const { return m_symbolTable.get(); }
+    SymbolTable* symbolTable() const LIFETIME_BOUND { return m_symbolTable.get(); }
     
     JS_EXPORT_PRIVATE static bool deleteProperty(JSCell*, JSGlobalObject*, PropertyName, DeletePropertySlot&);
     JS_EXPORT_PRIVATE static void getOwnSpecialPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArrayBuilder&, DontEnumPropertiesMode);

--- a/Source/JavaScriptCore/runtime/JSWithScope.h
+++ b/Source/JavaScriptCore/runtime/JSWithScope.h
@@ -41,7 +41,7 @@ public:
 
     JS_EXPORT_PRIVATE static JSWithScope* create(VM&, JSGlobalObject*, JSScope* next, JSObject*);
 
-    JSObject* object() { return m_object.get(); }
+    JSObject* object() LIFETIME_BOUND { return m_object.get(); }
 
     DECLARE_VISIT_CHILDREN;
 

--- a/Source/JavaScriptCore/runtime/LiteralParser.h
+++ b/Source/JavaScriptCore/runtime/LiteralParser.h
@@ -87,7 +87,7 @@ public:
 
     JSONRanges() = default;
 
-    const Entry& root() const { return m_root; }
+    const Entry& root() const LIFETIME_BOUND { return m_root; }
 
     JSValue record(JSValue value)
     {

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.h
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.h
@@ -156,7 +156,7 @@ public:
 
     MarkedMicrotaskDeque() = default;
 
-    const QueuedTask& front() const { return m_queue.first(); }
+    const QueuedTask& front() const LIFETIME_BOUND { return m_queue.first(); }
 
     QueuedTask dequeue()
     {

--- a/Source/JavaScriptCore/runtime/ModuleProgramExecutable.h
+++ b/Source/JavaScriptCore/runtime/ModuleProgramExecutable.h
@@ -73,7 +73,7 @@ public:
 
     bool isAsync() const { return features() & AwaitFeature; }
 
-    SymbolTable* moduleEnvironmentSymbolTable() { return m_moduleEnvironmentSymbolTable.get(); }
+    SymbolTable* moduleEnvironmentSymbolTable() LIFETIME_BOUND { return m_moduleEnvironmentSymbolTable.get(); }
 
     TemplateObjectMap& ensureTemplateObjectMap(VM&);
 

--- a/Source/JavaScriptCore/runtime/NativeCalleeRegistry.h
+++ b/Source/JavaScriptCore/runtime/NativeCalleeRegistry.h
@@ -42,7 +42,7 @@ public:
     static void initialize();
     static NativeCalleeRegistry& singleton();
 
-    Lock& getLock() WTF_RETURNS_LOCK(m_lock) { return m_lock; }
+    Lock& getLock() LIFETIME_BOUND WTF_RETURNS_LOCK(m_lock) { return m_lock; }
 
     void registerCallee(NativeCallee* callee)
     {

--- a/Source/JavaScriptCore/runtime/NativeExecutable.h
+++ b/Source/JavaScriptCore/runtime/NativeExecutable.h
@@ -73,7 +73,7 @@ public:
         
     DECLARE_INFO;
 
-    const String& name() const { return m_name; }
+    const String& name() const LIFETIME_BOUND { return m_name; }
 
     const DOMJIT::Signature* signatureFor(CodeSpecializationKind) const;
     ImplementationVisibility implementationVisibility() const { return static_cast<ImplementationVisibility>(m_implementationVisibility); }
@@ -86,7 +86,7 @@ public:
         return m_asString.get();
     }
 
-    JSString* asStringConcurrently() const { return m_asString.get(); }
+    JSString* asStringConcurrently() const LIFETIME_BOUND { return m_asString.get(); }
     static constexpr ptrdiff_t offsetOfAsString() { return OBJECT_OFFSETOF(NativeExecutable, m_asString); }
 
 private:

--- a/Source/JavaScriptCore/runtime/NumericStrings.h
+++ b/Source/JavaScriptCore/runtime/NumericStrings.h
@@ -135,7 +135,7 @@ public:
             visitor.appendUnbarriered(m_smallIntCache[i].jsString);
     }
 
-    const StringWithJSString* smallIntCache() { return m_smallIntCache.data(); }
+    const StringWithJSString* smallIntCache() LIFETIME_BOUND { return m_smallIntCache.data(); }
 
     void initializeSmallIntCache(VM&);
 

--- a/Source/JavaScriptCore/runtime/ObjectAdaptiveStructureWatchpoint.h
+++ b/Source/JavaScriptCore/runtime/ObjectAdaptiveStructureWatchpoint.h
@@ -45,7 +45,7 @@ public:
         RELEASE_ASSERT(watchpointSet.state() == IsWatched);
     }
 
-    const ObjectPropertyCondition& key() const { return m_key; }
+    const ObjectPropertyCondition& key() const LIFETIME_BOUND { return m_key; }
 
     void install(VM&);
 

--- a/Source/JavaScriptCore/runtime/PinballCompletion.h
+++ b/Source/JavaScriptCore/runtime/PinballCompletion.h
@@ -57,9 +57,9 @@ public:
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue proto);
     static PinballCompletion* create(VM&, Vector<std::unique_ptr<EvacuatedStackSlice>>&&, CPURegister* calleeSaves, JSPromise* resultPromise);
 
-    JSPromise* resultPromise() { return m_resultPromise.get(); }
+    JSPromise* resultPromise() LIFETIME_BOUND { return m_resultPromise.get(); }
 
-    Vector<std::unique_ptr<EvacuatedStackSlice>>& slices() { return m_slices; }
+    Vector<std::unique_ptr<EvacuatedStackSlice>>& slices() LIFETIME_BOUND { return m_slices; }
     std::unique_ptr<EvacuatedStackSlice> takeTopSlice() { return m_slices.takeLast(); }
     bool hasSlices() const { return !m_slices.isEmpty(); }
 

--- a/Source/JavaScriptCore/runtime/PropertyNameArray.h
+++ b/Source/JavaScriptCore/runtime/PropertyNameArray.h
@@ -33,7 +33,7 @@ public:
 
     static Ref<PropertyNameArray> create() { return adoptRef(*new PropertyNameArray); }
 
-    PropertyNameVector& propertyNameVector() { return m_propertyNameVector; }
+    PropertyNameVector& propertyNameVector() LIFETIME_BOUND { return m_propertyNameVector; }
 
 private:
     PropertyNameArray()

--- a/Source/JavaScriptCore/runtime/RegExp.h
+++ b/Source/JavaScriptCore/runtime/RegExp.h
@@ -64,7 +64,7 @@ public:
     bool globalOrSticky() const { return global() || sticky(); }
     bool eitherUnicode() const { return unicode() || unicodeSets(); }
 
-    const String& pattern() const { return m_patternString; }
+    const String& pattern() const LIFETIME_BOUND { return m_patternString; }
 
     bool isValid() const { return !Yarr::hasError(m_constructionErrorCode); }
     ASCIILiteral errorMessage() const { return Yarr::errorMessage(m_constructionErrorCode); }
@@ -167,7 +167,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 
     bool hasValidAtom() const { return !m_atom.isNull(); }
-    const String& atom() const { return m_atom; }
+    const String& atom() const LIFETIME_BOUND { return m_atom; }
     Yarr::SpecificPattern specificPattern() const { return m_specificPattern; }
 
 private:

--- a/Source/JavaScriptCore/runtime/RegExpGlobalData.h
+++ b/Source/JavaScriptCore/runtime/RegExpGlobalData.h
@@ -34,13 +34,13 @@ class JSGlobalObject;
 
 class RegExpGlobalData {
 public:
-    RegExpCachedResult& cachedResult() { return m_cachedResult; }
+    RegExpCachedResult& cachedResult() LIFETIME_BOUND { return m_cachedResult; }
 
     void setMultiline(bool multiline) { m_multiline = multiline; }
     bool multiline() const { return m_multiline; }
 
     void setInput(JSGlobalObject*, JSString*);
-    JSString* input() { return m_cachedResult.input(); }
+    JSString* input() LIFETIME_BOUND { return m_cachedResult.input(); }
 
     DECLARE_VISIT_AGGREGATE;
 
@@ -58,7 +58,7 @@ public:
     inline MatchResult matchResult() const;
     void resetResultFromCache(JSGlobalObject* owner, RegExp*, JSString*, MatchResult, std::span<const int> ovector);
 
-    RegExpSubstringGlobalAtomCache& substringGlobalAtomCache() { return m_substringGlobalAtomCache; }
+    RegExpSubstringGlobalAtomCache& substringGlobalAtomCache() LIFETIME_BOUND { return m_substringGlobalAtomCache; }
 
 private:
     RegExpCachedResult m_cachedResult;

--- a/Source/JavaScriptCore/runtime/SamplingCounter.h
+++ b/Source/JavaScriptCore/runtime/SamplingCounter.h
@@ -48,7 +48,7 @@ public:
 
     JS_EXPORT_PRIVATE static void dump();
 
-    int64_t* addressOfCounter() { return &m_counter; }
+    int64_t* addressOfCounter() LIFETIME_BOUND { return &m_counter; }
 
 protected:
     // Effectively the contructor, however called lazily in the case of GlobalSamplingCounter.

--- a/Source/JavaScriptCore/runtime/SamplingProfiler.h
+++ b/Source/JavaScriptCore/runtime/SamplingProfiler.h
@@ -187,7 +187,7 @@ public:
     void noticeVMEntry();
     void shutdown();
     template<typename Visitor> void visit(Visitor&) WTF_REQUIRES_LOCK(m_lock);
-    Lock& getLock() WTF_RETURNS_LOCK(m_lock) { return m_lock; }
+    Lock& getLock() LIFETIME_BOUND WTF_RETURNS_LOCK(m_lock) { return m_lock; }
     void setTimingInterval(Seconds interval) { m_timingInterval = interval; }
     JS_EXPORT_PRIVATE void start();
     void startWithLock() WTF_REQUIRES_LOCK(m_lock);

--- a/Source/JavaScriptCore/runtime/ScriptExecutable.h
+++ b/Source/JavaScriptCore/runtime/ScriptExecutable.h
@@ -46,13 +46,13 @@ public:
         
     CodeBlockHash hashFor(CodeSpecializationKind) const;
 
-    const SourceCode& source() const { return m_source; }
+    const SourceCode& source() const LIFETIME_BOUND { return m_source; }
     SourceID sourceID() const { return m_source.providerID(); }
-    const SourceOrigin& sourceOrigin() const { return m_source.provider()->sourceOrigin(); }
+    const SourceOrigin& sourceOrigin() const LIFETIME_BOUND { return m_source.provider()->sourceOrigin(); }
     // This is NOT the path that should be used for computing relative paths from a script. Use SourceOrigin's URL for that, the values may or may not be the same... This should only be used for `error.sourceURL` and stack traces.
-    const String& sourceURL() const { return m_source.provider()->sourceURL(); }
-    const String& sourceURLStripped() const { return m_source.provider()->sourceURLStripped(); }
-    const String& preRedirectURL() const { return m_source.provider()->preRedirectURL(); }
+    const String& sourceURL() const LIFETIME_BOUND { return m_source.provider()->sourceURL(); }
+    const String& sourceURLStripped() const LIFETIME_BOUND { return m_source.provider()->sourceURLStripped(); }
+    const String& preRedirectURL() const LIFETIME_BOUND { return m_source.provider()->preRedirectURL(); }
     int firstLine() const { return m_source.firstLine().oneBasedInt(); }
     JS_EXPORT_PRIVATE int lastLine() const;
     unsigned startColumn() const { return m_source.startColumn().oneBasedInt(); }
@@ -83,7 +83,7 @@ public:
     bool canUseOSRExitFuzzing() const { return m_canUseOSRExitFuzzing; }
     bool isInsideOrdinaryFunction() const { return m_isInsideOrdinaryFunction; }
     
-    bool* addressOfDidTryToEnterInLoop() { return &m_didTryToEnterInLoop; }
+    bool* addressOfDidTryToEnterInLoop() LIFETIME_BOUND { return &m_didTryToEnterInLoop; }
 
     CodeFeatures features() const { return m_features; }
     LexicallyScopedFeatures lexicallyScopedFeatures() { return static_cast<LexicallyScopedFeatures>(m_lexicallyScopedFeatures); }

--- a/Source/JavaScriptCore/runtime/ShadowRealmObject.h
+++ b/Source/JavaScriptCore/runtime/ShadowRealmObject.h
@@ -50,7 +50,7 @@ public:
 
     static ShadowRealmObject* create(VM&, Structure*, JSGlobalObject*);
 
-    JSGlobalObject* globalObject() { return m_globalObject.get(); }
+    JSGlobalObject* globalObject() LIFETIME_BOUND { return m_globalObject.get(); }
 
 private:
     ShadowRealmObject(VM&, Structure*);

--- a/Source/JavaScriptCore/runtime/SourceOrigin.h
+++ b/Source/JavaScriptCore/runtime/SourceOrigin.h
@@ -45,8 +45,8 @@ public:
 
     SourceOrigin() = default;
 
-    const URL& url() const { return m_url; }
-    const String& string() const { return m_url.string(); }
+    const URL& url() const LIFETIME_BOUND { return m_url; }
+    const String& string() const LIFETIME_BOUND { return m_url.string(); }
     bool isNull() const { return url().isNull(); }
 
     ScriptFetcher* fetcher() const { return m_fetcher.get(); }

--- a/Source/JavaScriptCore/runtime/StackManager.h
+++ b/Source/JavaScriptCore/runtime/StackManager.h
@@ -42,7 +42,7 @@ public:
     class Mirror : public BasicRawSentinelNode<Mirror> {
     public:
         void* softStackLimit() const { return m_softStackLimit; }
-        void* trapAwareSoftStackLimit() const { return m_trapAwareSoftStackLimit.loadRelaxed(); }
+        void* trapAwareSoftStackLimit() const LIFETIME_BOUND { return m_trapAwareSoftStackLimit.loadRelaxed(); }
 
         static constexpr ptrdiff_t offsetOfSoftStackLimit()
         {
@@ -65,7 +65,7 @@ public:
     CONCURRENT_SAFE void cancelStop();
 
     void* softStackLimit() const { return m_softStackLimit; }
-    void* trapAwareSoftStackLimit() const { return m_trapAwareSoftStackLimit.loadRelaxed(); }
+    void* trapAwareSoftStackLimit() const LIFETIME_BOUND { return m_trapAwareSoftStackLimit.loadRelaxed(); }
 
     void setStackSoftLimit(void* newLimit);
 
@@ -81,8 +81,8 @@ public:
     void setCLoopStackLimit(void* newStackLimit);
     ALWAYS_INLINE void* currentCLoopStackPointer() const { return m_cloopStack.currentStackPointer(); }
 
-    CLoopStack& cloopStack() { return m_cloopStack; }
-    const CLoopStack& cloopStack() const { return m_cloopStack; }
+    CLoopStack& cloopStack() LIFETIME_BOUND { return m_cloopStack; }
+    const CLoopStack& cloopStack() const LIFETIME_BOUND { return m_cloopStack; }
 
     static constexpr ptrdiff_t offsetOfCLoopStack()
     {

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -416,7 +416,7 @@ public:
     
     inline bool holesMustForwardToPrototype(JSObject*) const;
         
-    JSGlobalObject* globalObject() const { return m_globalObject.get(); }
+    JSGlobalObject* globalObject() const LIFETIME_BOUND { return m_globalObject.get(); }
 
     // NOTE: This method should only be called during the creation of structures, since the global
     // object of a structure is presumed to be immutable in a bunch of places.
@@ -848,7 +848,7 @@ public:
     
     static void dumpContextHeader(PrintStream&);
     
-    ConcurrentJSLock& lock() { return m_lock; }
+    ConcurrentJSLock& lock() LIFETIME_BOUND { return m_lock; }
 
     unsigned propertyHash() const { return m_propertyHash; }
     SeenProperties seenProperties() const { return m_seenProperties; }

--- a/Source/JavaScriptCore/runtime/StructureChain.h
+++ b/Source/JavaScriptCore/runtime/StructureChain.h
@@ -50,7 +50,7 @@ public:
     }
 
     static StructureChain* create(VM&, JSObject*);
-    StructureID* head() { return m_vector.get(); }
+    StructureID* head() LIFETIME_BOUND { return m_vector.get(); }
     DECLARE_VISIT_CHILDREN;
 
     inline static Structure* createStructure(VM&, JSGlobalObject*, JSValue);

--- a/Source/JavaScriptCore/runtime/SymbolTable.h
+++ b/Source/JavaScriptCore/runtime/SymbolTable.h
@@ -752,7 +752,7 @@ public:
     DebuggerLocation debuggerLocation();
     void collectDebuggerInfo(CodeBlock*);
     
-    InferredValue<JSScope>& singleton() { return m_singleton; }
+    InferredValue<JSScope>& singleton() LIFETIME_BOUND { return m_singleton; }
 
     void notifyCreation(VM& vm, JSScope* scope, const char* reason)
     {

--- a/Source/JavaScriptCore/runtime/TemplateObjectDescriptor.h
+++ b/Source/JavaScriptCore/runtime/TemplateObjectDescriptor.h
@@ -51,8 +51,8 @@ public:
 
     unsigned hash() const { return m_hash; }
 
-    const StringVector& rawStrings() const { return m_rawStrings; }
-    const OptionalStringVector& cookedStrings() const { return m_cookedStrings; }
+    const StringVector& rawStrings() const LIFETIME_BOUND { return m_rawStrings; }
+    const OptionalStringVector& cookedStrings() const LIFETIME_BOUND { return m_cookedStrings; }
 
     bool operator==(const TemplateObjectDescriptor& other) const { return m_hash == other.m_hash && m_rawStrings == other.m_rawStrings; }
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainDate.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDate.h
@@ -56,7 +56,7 @@ public:
     std::tuple<std::optional<int32_t>, std::optional<ParsedMonthCode>, std::optional<int32_t>> static toYearMonth(JSGlobalObject*, JSObject*);
     static TemporalPlainDate* from(JSGlobalObject*, JSValue, Variant<JSObject*, TemporalOverflow>);
 
-    TemporalCalendar* calendar() { return m_calendar.get(this); }
+    TemporalCalendar* calendar() LIFETIME_BOUND { return m_calendar.get(this); }
     ISO8601::PlainDate plainDate() const { return m_plainDate; }
 
 #define JSC_DEFINE_TEMPORAL_PLAIN_DATE_FIELD(name, capitalizedName) \

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.h
@@ -51,7 +51,7 @@ public:
     static TemporalPlainDateTime* from(JSGlobalObject*, JSValue, JSObject*);
     static int32_t compare(TemporalPlainDateTime*, TemporalPlainDateTime*);
 
-    TemporalCalendar* calendar() { return m_calendar.get(this); }
+    TemporalCalendar* calendar() LIFETIME_BOUND { return m_calendar.get(this); }
     ISO8601::PlainDate plainDate() const { return m_plainDate; }
     ISO8601::PlainTime plainTime() const { return m_plainTime; }
 

--- a/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainMonthDay.h
@@ -50,7 +50,7 @@ public:
     static TemporalPlainMonthDay* from(JSGlobalObject*, JSValue, JSValue);
     static TemporalPlainMonthDay* from(JSGlobalObject*, WTF::String);
 
-    TemporalCalendar* calendar() { return m_calendar.get(this); }
+    TemporalCalendar* calendar() LIFETIME_BOUND { return m_calendar.get(this); }
     ISO8601::PlainMonthDay plainMonthDay() const { return m_plainMonthDay; }
 
 #define JSC_DEFINE_TEMPORAL_PLAIN_MONTH_DAY_FIELD(name, capitalizedName) \

--- a/Source/JavaScriptCore/runtime/TemporalPlainTime.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainTime.h
@@ -57,7 +57,7 @@ public:
     static TemporalPlainTime* from(JSGlobalObject*, JSValue, JSObject*);
     static int32_t compare(const ISO8601::PlainTime&, const ISO8601::PlainTime&);
 
-    TemporalCalendar* calendar() { return m_calendar.get(this); }
+    TemporalCalendar* calendar() LIFETIME_BOUND { return m_calendar.get(this); }
     ISO8601::PlainTime plainTime() const { return m_plainTime; }
 
 #define JSC_DEFINE_TEMPORAL_PLAIN_TIME_FIELD(name, capitalizedName) \

--- a/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h
+++ b/Source/JavaScriptCore/runtime/TemporalPlainYearMonth.h
@@ -53,7 +53,7 @@ public:
     static TemporalPlainYearMonth* from(JSGlobalObject*, JSValue, JSValue);
     static TemporalPlainYearMonth* from(JSGlobalObject*, StringView);
 
-    TemporalCalendar* calendar() { return m_calendar.get(this); }
+    TemporalCalendar* calendar() LIFETIME_BOUND { return m_calendar.get(this); }
     ISO8601::PlainYearMonth plainYearMonth() const { return m_plainYearMonth; }
 
 #define JSC_DEFINE_TEMPORAL_PLAIN_YEAR_MONTH_FIELD(name, capitalizedName) \

--- a/Source/JavaScriptCore/runtime/TypeProfiler.h
+++ b/Source/JavaScriptCore/runtime/TypeProfiler.h
@@ -108,7 +108,7 @@ public:
     void logTypesForTypeLocation(TypeLocation*, VM&);
     JS_EXPORT_PRIVATE String typeInformationForExpressionAtOffset(TypeProfilerSearchDescriptor, unsigned offset, SourceID, VM&);
     void insertNewLocation(TypeLocation*);
-    TypeLocationCache* typeLocationCache() { return &m_typeLocationCache; }
+    TypeLocationCache* typeLocationCache() LIFETIME_BOUND { return &m_typeLocationCache; }
     TypeLocation* findLocation(unsigned divot, SourceID, TypeProfilerSearchDescriptor, VM&);
     GlobalVariableID getNextUniqueVariableID() { return m_nextUniqueVariableID++; }
     TypeLocation* nextTypeLocation();

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -282,7 +282,7 @@ public:
     JS_EXPORT_PRIVATE RefPtr<JSON::Value> takeSamplingProfilerSamplesAsJSON();
 #endif
 
-    FuzzerAgent* fuzzerAgent() const { return m_fuzzerAgent.get(); }
+    FuzzerAgent* fuzzerAgent() const LIFETIME_BOUND { return m_fuzzerAgent.get(); }
     void setFuzzerAgent(std::unique_ptr<FuzzerAgent>&&);
 
     VMIdentifier identifier() const { return m_identifier; }
@@ -293,9 +293,9 @@ public:
     // Global object in which execution began.
     JS_EXPORT_PRIVATE JSGlobalObject* deprecatedVMEntryGlobalObject(JSGlobalObject*) const;
 
-    WeakRandom& random() { return m_random; }
-    WeakRandom& heapRandom() { return m_heapRandom; }
-    Integrity::Random& integrityRandom() { return m_integrityRandom; }
+    WeakRandom& random() LIFETIME_BOUND { return m_random; }
+    WeakRandom& heapRandom() LIFETIME_BOUND { return m_heapRandom; }
+    Integrity::Random& integrityRandom() LIFETIME_BOUND { return m_integrityRandom; }
 
     template<typename Type, typename Functor>
     Type& ensureSideData(void* key, const Functor&);
@@ -611,7 +611,7 @@ public:
     StringReplaceCache stringReplaceCache;
 
     bool mightBeExecutingTaintedCode() const { return m_mightBeExecutingTaintedCode; }
-    bool* addressOfMightBeExecutingTaintedCode() { return &m_mightBeExecutingTaintedCode; }
+    bool* addressOfMightBeExecutingTaintedCode() LIFETIME_BOUND { return &m_mightBeExecutingTaintedCode; }
     void setMightBeExecutingTaintedCode(bool value = true) { m_mightBeExecutingTaintedCode = value; }
 
     AtomStringTable* atomStringTable() const { return m_atomStringTable; }
@@ -1010,7 +1010,7 @@ public:
 
     bool hasTimeZoneChange() { return dateCache.hasTimeZoneChange(); }
 
-    RegExpCache* regExpCache() { return m_regExpCache.get(); }
+    RegExpCache* regExpCache() LIFETIME_BOUND { return m_regExpCache.get(); }
 
     bool isCollectorBusyOnCurrentThread() { return heap.currentThreadIsDoingGCWork(); }
 
@@ -1022,7 +1022,7 @@ public:
     bool currentThreadIsHoldingAPILock() const { return m_apiLock->currentThreadIsHoldingLock(); }
 
     JSLock& apiLock() { return m_apiLock.get(); }
-    CodeCache* codeCache() { return m_codeCache.get(); }
+    CodeCache* codeCache() LIFETIME_BOUND { return m_codeCache.get(); }
     IntlCache& intlCache() { return *m_intlCache; }
 
     JS_EXPORT_PRIVATE void whenIdle(Function<void()>&&);
@@ -1037,19 +1037,19 @@ public:
     // FIXME: Use AtomString once it got merged with Identifier.
     JS_EXPORT_PRIVATE void addImpureProperty(UniquedStringImpl*);
     
-    InlineWatchpointSet& primitiveGigacageEnabled() { return m_primitiveGigacageEnabled; }
+    InlineWatchpointSet& primitiveGigacageEnabled() LIFETIME_BOUND { return m_primitiveGigacageEnabled; }
 
-    BuiltinExecutables* builtinExecutables() { return m_builtinExecutables.get(); }
+    BuiltinExecutables* builtinExecutables() LIFETIME_BOUND { return m_builtinExecutables.get(); }
 
     bool enableTypeProfiler();
     bool disableTypeProfiler();
-    TypeProfilerLog* typeProfilerLog() { return m_typeProfilerLog.get(); }
-    TypeProfiler* typeProfiler() { return m_typeProfiler.get(); }
+    TypeProfilerLog* typeProfilerLog() LIFETIME_BOUND { return m_typeProfilerLog.get(); }
+    TypeProfiler* typeProfiler() LIFETIME_BOUND { return m_typeProfiler.get(); }
     JS_EXPORT_PRIVATE void dumpTypeProfilerData();
 
-    FunctionHasExecutedCache* functionHasExecutedCache() { return &m_functionHasExecutedCache; }
+    FunctionHasExecutedCache* functionHasExecutedCache() LIFETIME_BOUND { return &m_functionHasExecutedCache; }
 
-    ControlFlowProfiler* controlFlowProfiler() { return m_controlFlowProfiler.get(); }
+    ControlFlowProfiler* controlFlowProfiler() LIFETIME_BOUND { return m_controlFlowProfiler.get(); }
     bool enableControlFlowProfiler();
     bool disableControlFlowProfiler();
 
@@ -1129,7 +1129,7 @@ public:
     void promiseRejected(JSPromise*);
 
 #if ENABLE(EXCEPTION_SCOPE_VERIFICATION)
-    StackTrace* nativeStackTraceOfLastThrow() const { return m_nativeStackTraceOfLastThrow.get(); }
+    StackTrace* nativeStackTraceOfLastThrow() const LIFETIME_BOUND { return m_nativeStackTraceOfLastThrow.get(); }
     Thread* throwingThread() const { return m_throwingThread.get(); }
     bool needExceptionCheck() const { return m_needExceptionCheck; }
 #endif
@@ -1150,7 +1150,7 @@ public:
     ALWAYS_INLINE void mutatorFence() { heap.mutatorFence(); }
 
 #if ENABLE(DFG_DOES_GC_VALIDATION)
-    DoesGCCheck* addressOfDoesGC() { return &m_doesGC; }
+    DoesGCCheck* addressOfDoesGC() LIFETIME_BOUND { return &m_doesGC; }
     void setDoesGCExpectation(bool expectDoesGC, unsigned nodeIndex, unsigned nodeOp) { m_doesGC.set(expectDoesGC, nodeIndex, nodeOp); }
     void setDoesGCExpectation(bool expectDoesGC, DoesGCCheck::Special special) { m_doesGC.set(expectDoesGC, special); }
     void verifyCanGC() { m_doesGC.verifyCanGC(*this); }

--- a/Source/JavaScriptCore/runtime/VMThreadContext.h
+++ b/Source/JavaScriptCore/runtime/VMThreadContext.h
@@ -36,8 +36,8 @@ public:
     ~VMThreadContext();
 
     VMThreadContext* next() const { return m_next; }
-    VMTraps& traps() { return m_traps; }
-    const VMTraps& traps() const { return m_traps; }
+    VMTraps& traps() LIFETIME_BOUND { return m_traps; }
+    const VMTraps& traps() const LIFETIME_BOUND { return m_traps; }
 
     static constexpr ptrdiff_t offsetOfTraps()
     {

--- a/Source/JavaScriptCore/runtime/VMTraps.h
+++ b/Source/JavaScriptCore/runtime/VMTraps.h
@@ -208,7 +208,7 @@ public:
     }
     // Designed to be a fast check to rule out if we might need handling, and we need to ensure needHandling on the slow path.
     ALWAYS_INLINE bool maybeNeedHandling() const { return m_trapBits.loadRelaxed(); }
-    void* trapBitsAddress() { return &m_trapBits; }
+    void* trapBitsAddress() LIFETIME_BOUND { return &m_trapBits; }
     static constexpr ptrdiff_t offsetOfTrapsBits() { return OBJECT_OFFSETOF(VMTraps, m_trapBits); }
 
     enum class DeferAction {

--- a/Source/JavaScriptCore/tools/CellList.h
+++ b/Source/JavaScriptCore/tools/CellList.h
@@ -44,7 +44,7 @@ public:
     size_t size() const { return m_cells.size(); }
 
     typedef SegmentedVector<CellProfile, 64> CellProfileVector;
-    CellProfileVector& cells() { return m_cells; }
+    CellProfileVector& cells() LIFETIME_BOUND { return m_cells; }
 
     void add(CellProfile&& profile)
     {

--- a/Source/JavaScriptCore/tools/CellProfile.h
+++ b/Source/JavaScriptCore/tools/CellProfile.h
@@ -79,7 +79,7 @@ struct CellProfile {
 
     const char* className() const { return m_className; }
 
-    StackTrace* stackTrace() const { return m_stackTrace.get(); }
+    StackTrace* stackTrace() const LIFETIME_BOUND { return m_stackTrace.get(); }
     void setStackTrace(StackTrace* trace) { m_stackTrace = std::unique_ptr<StackTrace>(trace); }
 
 private:

--- a/Source/JavaScriptCore/wasm/WasmCallee.h
+++ b/Source/JavaScriptCore/wasm/WasmCallee.h
@@ -115,7 +115,7 @@ class JITCallee : public Callee {
     WTF_MAKE_COMPACT_TZONE_ALLOCATED(JITCallee);
 public:
     friend class Callee;
-    FixedVector<UnlinkedWasmToWasmCall>& wasmToWasmCallsites() { return m_wasmToWasmCallsites; }
+    FixedVector<UnlinkedWasmToWasmCall>& wasmToWasmCallsites() LIFETIME_BOUND { return m_wasmToWasmCallsites; }
 
 #if ENABLE(JIT)
     void setEntrypoint(Wasm::Entrypoint&&);
@@ -135,7 +135,7 @@ protected:
 
     CodePtr<WasmEntryPtrTag> entrypointImpl() const { return m_entrypoint.compilation->code().retagged<WasmEntryPtrTag>(); }
 
-    const RegisterAtOffsetList* calleeSaveRegistersImpl() { return &m_entrypoint.calleeSaveRegisters; }
+    const RegisterAtOffsetList* calleeSaveRegistersImpl() LIFETIME_BOUND { return &m_entrypoint.calleeSaveRegisters; }
 #else
     std::tuple<void*, void*> rangeImpl() const { return { nullptr, nullptr }; }
     CodePtr<WasmEntryPtrTag> entrypointImpl() const { return { }; }
@@ -214,7 +214,7 @@ public:
         return adoptRef(*new JSToWasmICCallee(WTF::move(calleeSaves)));
     }
 
-    const RegisterAtOffsetList* calleeSaveRegistersImpl() { return &m_calleeSaves; }
+    const RegisterAtOffsetList* calleeSaveRegistersImpl() LIFETIME_BOUND { return &m_calleeSaves; }
     CodePtr<JSEntryPtrTag> jsToWasm() { return m_jsToWasmICEntrypoint.code(); }
 
     void setEntrypoint(MacroAssemblerCodeRef<JSEntryPtrTag>&&);
@@ -379,10 +379,10 @@ public:
     bool didStartCompilingOSREntryCallee() const { return m_didStartCompilingOSREntryCallee; }
     void setDidStartCompilingOSREntryCallee(bool value) { m_didStartCompilingOSREntryCallee = value; }
 
-    TierUpCount& tierUpCounter() { return m_tierUpCounter; }
+    TierUpCount& tierUpCounter() LIFETIME_BOUND { return m_tierUpCounter; }
 
     std::optional<CodeLocationLabel<WasmEntryPtrTag>> sharedLoopEntrypoint() { return m_sharedLoopEntrypoint; }
-    const Vector<CodeLocationLabel<WasmEntryPtrTag>>& loopEntrypoints() { return m_loopEntrypoints; }
+    const Vector<CodeLocationLabel<WasmEntryPtrTag>>& loopEntrypoints() LIFETIME_BOUND { return m_loopEntrypoints; }
 
     unsigned osrEntryScratchBufferSize() const { return m_osrEntryScratchBufferSize; }
 
@@ -447,17 +447,17 @@ public:
     void setEntrypoint(CodePtr<WasmEntryPtrTag>);
     const uint8_t* bytecode() const { return m_bytecode; }
     const uint8_t* bytecodeEnd() const { return m_bytecodeEnd; }
-    const uint8_t* metadata() const { return m_metadata.span().data(); }
+    const uint8_t* metadata() const LIFETIME_BOUND { return m_metadata.span().data(); }
 
     unsigned numLocals() const { return m_numLocals; }
     unsigned localSizeToAlloc() const { return m_localSizeToAlloc; }
     unsigned rethrowSlots() const { return m_numRethrowSlotsToAlloc; }
 
-    const Vector<FunctionSpaceIndex>& callTargets() const { return m_callTargets; }
+    const Vector<FunctionSpaceIndex>& callTargets() const LIFETIME_BOUND { return m_callTargets; }
     unsigned numCallProfiles() const { return m_callTargets.size(); }
 
-    IPIntTierUpCounter& tierUpCounter() { return m_tierUpCounter; }
-    const IPIntTierUpCounter& tierUpCounter() const { return m_tierUpCounter; }
+    IPIntTierUpCounter& tierUpCounter() LIFETIME_BOUND { return m_tierUpCounter; }
+    const IPIntTierUpCounter& tierUpCounter() const LIFETIME_BOUND { return m_tierUpCounter; }
 
     FunctionSpaceIndex callTarget(unsigned callProfileIndex) const { return m_callTargets[callProfileIndex]; }
 
@@ -512,7 +512,7 @@ class WasmBuiltinCallee final : public Callee {
 public:
     WasmBuiltinCallee(const WebAssemblyBuiltin*, std::pair<const Name*, RefPtr<NameSection>>&&);
 
-    const WebAssemblyBuiltin* builtin() { return m_builtin.get(); }
+    const WebAssemblyBuiltin* builtin() LIFETIME_BOUND { return m_builtin.get(); }
     CodePtr<WasmEntryPtrTag> entrypointImpl() const { return m_trampoline; };
 
 protected:

--- a/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionIPIntMetadataGenerator.h
@@ -83,15 +83,15 @@ public:
 
     FunctionCodeIndex functionIndex() const { return m_functionIndex; }
     bool hasTailCallSuccessors() const { return m_hasTailCallSuccessors; }
-    const BitVector& tailCallSuccessors() const { return m_tailCallSuccessors; }
+    const BitVector& tailCallSuccessors() const LIFETIME_BOUND { return m_tailCallSuccessors; }
     bool tailCallClobbersInstance() const { return m_tailCallClobbersInstance ; }
     void setTailCall(uint32_t, bool);
     void setTailCallClobbersInstance() { m_tailCallClobbersInstance = true; }
 
-    const uint8_t* getBytecode() const { return m_bytecode.data(); }
-    const uint8_t* getMetadata() const { return m_metadata.span().data(); }
+    const uint8_t* getBytecode() const LIFETIME_BOUND { return m_bytecode.data(); }
+    const uint8_t* getMetadata() const LIFETIME_BOUND { return m_metadata.span().data(); }
 
-    UncheckedKeyHashMap<IPIntPC, IPIntTierUpCounter::OSREntryData>& tierUpCounter() { return m_tierUpCounter; }
+    UncheckedKeyHashMap<IPIntPC, IPIntTierUpCounter::OSREntryData>& tierUpCounter() LIFETIME_BOUND { return m_tierUpCounter; }
 
     const RTT* addSignature(const TypeDefinition&);
 

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -101,7 +101,7 @@ struct FunctionParserTypes {
         Type type() const { return m_type; }
         void setType(Type type) { m_type = type; }
 
-        ExpressionType& value() { return m_value; }
+        ExpressionType& value() LIFETIME_BOUND { return m_value; }
         ExpressionType value() const { return m_value; }
         operator ExpressionType() const { return m_value; }
 
@@ -165,8 +165,8 @@ public:
     const Type& typeOfLocal(uint32_t localIndex) const { return m_locals[localIndex]; }
     bool unreachableBlocks() const { return m_unreachableBlocks; }
 
-    ControlStack& controlStack() { return m_controlStack; }
-    Stack& expressionStack() { return m_expressionStack; }
+    ControlStack& controlStack() LIFETIME_BOUND { return m_controlStack; }
+    Stack& expressionStack() LIFETIME_BOUND { return m_expressionStack; }
 
     ControlEntry& resolveControlRef(ControlRef ref) { return m_controlStack[ref.m_index]; }
 

--- a/Source/JavaScriptCore/wasm/WasmInliningDecision.h
+++ b/Source/JavaScriptCore/wasm/WasmInliningDecision.h
@@ -52,7 +52,7 @@ public:
 
     const IPIntCallee& callee() const { return m_callee; }
     InliningNode* caller() const { return m_caller; }
-    const Vector<CallSite>& callSites() const { return m_callSites; }
+    const Vector<CallSite>& callSites() const LIFETIME_BOUND { return m_callSites; }
     bool isInlined() const { return m_isInlined; }
     bool isUnused() const { return m_isUnused; }
     uint8_t caseIndex() const { return m_caseIndex; }
@@ -89,7 +89,7 @@ public:
 
     void expand();
 
-    InliningNode* root() { return &m_root; }
+    InliningNode* root() LIFETIME_BOUND { return &m_root; }
 
 private:
     bool canInline(InliningNode*, size_t initialWasmSize, size_t inlinedWasmSize);

--- a/Source/JavaScriptCore/wasm/WasmInstanceAnchor.h
+++ b/Source/JavaScriptCore/wasm/WasmInstanceAnchor.h
@@ -47,7 +47,7 @@ public:
     static Ref<InstanceAnchor> create(Module&, JSWebAssemblyInstance*);
 
     JSWebAssemblyInstance* instance() const WTF_REQUIRES_LOCK(m_lock) { return m_instance; }
-    Lock& lock() const { return m_lock; }
+    Lock& lock() const LIFETIME_BOUND { return m_lock; }
 
     void tearDown()
     {

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -116,7 +116,7 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
         m_clobberingTailCalls = FixedBitVector(totalNumberOfFunctions);
     }
 
-    const FixedBitVector& referencedFunctions() const { return m_referencedFunctions; }
+    const FixedBitVector& referencedFunctions() const LIFETIME_BOUND { return m_referencedFunctions; }
     bool hasReferencedFunction(FunctionSpaceIndex functionIndexSpace) const { return m_referencedFunctions.test(functionIndexSpace); }
     void addReferencedFunction(FunctionSpaceIndex functionIndexSpace) const { m_referencedFunctions.concurrentTestAndSet(functionIndexSpace); }
 
@@ -181,7 +181,7 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
     }
 
     // FIXME: This should probably be FunctionCodeIndex as calling an import always clobbers the instance.
-    const FixedBitVector& clobberingTailCalls() const { return m_clobberingTailCalls; }
+    const FixedBitVector& clobberingTailCalls() const LIFETIME_BOUND { return m_clobberingTailCalls; }
     bool callCanClobberInstance(FunctionSpaceIndex functionIndexSpace) const { return m_clobberingTailCalls.test(functionIndexSpace); }
     void addClobberingTailCall(FunctionSpaceIndex functionIndexSpace) { m_clobberingTailCalls.concurrentTestAndSet(functionIndexSpace); }
 

--- a/Source/JavaScriptCore/wasm/WasmOSREntryData.h
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryData.h
@@ -65,7 +65,7 @@ public:
 
     FunctionCodeIndex functionIndex() const { return m_functionIndex; }
     uint32_t loopIndex() const { return m_loopIndex; }
-    const StackMap& values() { return m_values; }
+    const StackMap& values() LIFETIME_BOUND { return m_values; }
 
 private:
     FunctionCodeIndex m_functionIndex;

--- a/Source/JavaScriptCore/wasm/WasmTierUpCount.h
+++ b/Source/JavaScriptCore/wasm/WasmTierUpCount.h
@@ -69,9 +69,9 @@ public:
     static int32_t loopIncrement() { return Options::omgTierUpCounterIncrementForLoop(); }
     static int32_t functionEntryIncrement() { return Options::omgTierUpCounterIncrementForEntry(); }
 
-    SegmentedVector<TriggerReason, 16>& osrEntryTriggers() { return m_osrEntryTriggers; }
-    Vector<uint32_t>& outerLoops() { return m_outerLoops; }
-    Lock& getLock() { return m_lock; }
+    SegmentedVector<TriggerReason, 16>& osrEntryTriggers() LIFETIME_BOUND { return m_osrEntryTriggers; }
+    Vector<uint32_t>& outerLoops() LIFETIME_BOUND { return m_outerLoops; }
+    Lock& getLock() LIFETIME_BOUND { return m_lock; }
 
     OSREntryData& addOSREntryData(FunctionCodeIndex functionIndex, uint32_t loopIndex, StackMap&&);
     OSREntryData& osrEntryData(uint32_t loopIndex);

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -700,7 +700,7 @@ public:
 
     static RefPtr<ArrayType> tryCreate(const FieldType&);
 
-    const FieldType& elementType() const { return m_elementType; }
+    const FieldType& elementType() const LIFETIME_BOUND { return m_elementType; }
     bool hasRecursiveReference() const { return m_hasRecursiveReference; }
 
     WTF::String toString() const;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyException.h
@@ -61,7 +61,7 @@ public:
     DECLARE_VISIT_CHILDREN;
 
     const Wasm::Tag& tag() const { return m_tag.get(); }
-    const FixedVector<uint64_t>& payload() const { return m_payload; }
+    const FixedVector<uint64_t>& payload() const LIFETIME_BOUND { return m_payload; }
     JSValue getArg(JSGlobalObject*, unsigned) const;
 
     static constexpr ptrdiff_t offsetOfPayload() { return OBJECT_OFFSETOF(JSWebAssemblyException, m_payload); }

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -99,7 +99,7 @@ public:
     void initializeImports(JSGlobalObject*, JSObject* importObject, Wasm::CreationMode);
     void finalizeCreation(VM&, JSGlobalObject*, Ref<Wasm::CalleeGroup>&&, Wasm::CreationMode);
     
-    WebAssemblyModuleRecord* moduleRecord() { return m_moduleRecord.get(); }
+    WebAssemblyModuleRecord* moduleRecord() LIFETIME_BOUND { return m_moduleRecord.get(); }
 
     // FIXME(wasm-multimemory): eventually get rid of memory() with no parameters
     // Temporarily keep memory() so the code still compiles
@@ -150,7 +150,7 @@ public:
         vm.writeBarrier(this, value);
     }
 
-    JSWebAssemblyModule* jsModule() const { return m_jsModule.get(); }
+    JSWebAssemblyModule* jsModule() const LIFETIME_BOUND { return m_jsModule.get(); }
     const Wasm::ModuleInformation& moduleInformation() const { return m_moduleInformation.get(); }
 
     void clearJSCallICs(VM&);
@@ -192,7 +192,7 @@ public:
 
     void dataDrop(uint32_t dataSegmentIndex);
 
-    void* cachedMemory() const { return m_cachedMemory.getMayBeNull(); }
+    void* cachedMemory() const LIFETIME_BOUND { return m_cachedMemory.getMayBeNull(); }
     size_t cachedBoundsCheckingSize() const { return m_cachedBoundsCheckingSize; }
     size_t cachedMemorySize() const { return m_cachedMemorySize; }
 
@@ -282,8 +282,8 @@ public:
     }
     void setGlobal(unsigned, JSValue);
     void linkGlobal(unsigned, Ref<Wasm::Global>&&);
-    const BitVector& globalsToMark() { return m_globalsToMark; }
-    const BitVector& globalsToBinding() { return m_globalsToBinding; }
+    const BitVector& globalsToMark() LIFETIME_BOUND { return m_globalsToMark; }
+    const BitVector& globalsToBinding() LIFETIME_BOUND { return m_globalsToBinding; }
     JSValue getFunctionWrapper(unsigned) const;
     typename FunctionWrapperMap::ValuesConstIteratorRange functionWrappers() const { return m_functionWrappers.values(); }
     void setFunctionWrapper(unsigned, JSValue);
@@ -411,7 +411,7 @@ public:
         m_temporaryCallFrame = callFrame;
     }
 
-    void* softStackLimit() const { return m_stackMirror.softStackLimit(); }
+    void* softStackLimit() const LIFETIME_BOUND { return m_stackMirror.softStackLimit(); }
 
     void setFaultPC(Wasm::ExceptionType exception, void* pc)
     {

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyBuiltin.h
@@ -153,10 +153,10 @@ public:
     uint32_t id() const { return m_id; }
 
     // The name of the builtin function.
-    const ASCIILiteral& name() const { return m_name; }
+    const ASCIILiteral& name() const LIFETIME_BOUND { return m_name; }
 
     // The signature that a valid import of this builtin must match.
-    const WebAssemblyBuiltinSignature& signature() const { return m_signature; }
+    const WebAssemblyBuiltinSignature& signature() const LIFETIME_BOUND { return m_signature; }
 
     CodePtr<CFunctionPtrTag> wasmEntrypoint() const { return m_wasmEntrypoint; }
     CodePtr<WasmEntryPtrTag> wasmTrampoline() const { return m_wasmTrampoline; }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyCompileOptions.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyCompileOptions.h
@@ -44,8 +44,8 @@ public:
     // Create an instance if `optionsObject` is not a nullptr, or return a `nullopt`.
     static std::optional<WebAssemblyCompileOptions> tryCreate(JSGlobalObject*, JSObject* optionsObject);
 
-    const std::optional<String>& importedStringConstants() const { return m_importedStringConstants; }
-    const Vector<String>& qualifiedBuiltinSetNames() const { return m_qualifiedBuiltinSetNames; }
+    const std::optional<String>& importedStringConstants() const LIFETIME_BOUND { return m_importedStringConstants; }
+    const Vector<String>& qualifiedBuiltinSetNames() const LIFETIME_BOUND { return m_qualifiedBuiltinSetNames; }
 
     // Validate the options in the context of the given module as specified in
     // https://webassembly.github.io/js-string-builtins/js-api/#validate-builtins-and-imported-string-for-a-webassembly-module.

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunctionBase.h
@@ -51,13 +51,13 @@ public:
 
     DECLARE_VISIT_CHILDREN;
 
-    JSWebAssemblyInstance* instance() const { return m_importableFunction.targetInstance.get(); }
+    JSWebAssemblyInstance* instance() const LIFETIME_BOUND { return m_importableFunction.targetInstance.get(); }
 
     Wasm::TypeIndex typeIndex() const { return m_importableFunction.typeIndex; }
     Wasm::Type type() const { return { Wasm::TypeKind::Ref, typeIndex() }; }
     WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation() const { return m_importableFunction.entrypointLoadLocation; }
     CalleeBits boxedCallee() const { return m_importableFunction.boxedCallee; }
-    const Wasm::WasmOrJSImportableFunction& importableFunction() const { return m_importableFunction; }
+    const Wasm::WasmOrJSImportableFunction& importableFunction() const LIFETIME_BOUND { return m_importableFunction; }
     const Wasm::RTT* rtt() const { return m_importableFunction.rtt; }
     const Wasm::FunctionSignature& signature() const;
     WasmOrJSImportableFunctionCallLinkInfo* callLinkInfo() const { return m_callLinkInfo; }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.h
@@ -68,7 +68,7 @@ public:
     void initializeExports(JSGlobalObject*);
     JS_EXPORT_PRIVATE JSValue evaluate(JSGlobalObject*);
 
-    JSObject* exportsObject() const { return m_exportsObject.get(); }
+    JSObject* exportsObject() const LIFETIME_BOUND { return m_exportsObject.get(); }
 
     static constexpr ptrdiff_t offsetOfExportsObject() { return OBJECT_OFFSETOF(WebAssemblyModuleRecord, m_exportsObject); }
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyWrapperFunction.h
@@ -52,7 +52,7 @@ public:
     static WebAssemblyWrapperFunction* create(VM&, JSGlobalObject*, Structure*, JSObject*, unsigned importIndex, JSWebAssemblyInstance*, Wasm::TypeIndex, Ref<const Wasm::RTT>&&);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
-    JSObject* function() { return m_function.get(); }
+    JSObject* function() LIFETIME_BOUND { return m_function.get(); }
 
 private:
     WebAssemblyWrapperFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSObject* function, Wasm::WasmOrJSImportableFunction&&, Wasm::WasmOrJSImportableFunctionCallLinkInfo*);

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -128,8 +128,8 @@ public:
     BoyerMooreBitmap() = default;
 
     unsigned count() const { return m_count; }
-    const Map& map() const { return m_map; }
-    const BoyerMooreFastCandidates& charactersFastPath() const { return m_charactersFastPath; }
+    const Map& map() const LIFETIME_BOUND { return m_map; }
+    const BoyerMooreFastCandidates& charactersFastPath() const LIFETIME_BOUND { return m_charactersFastPath; }
 
     bool add(CharSize charSize, char32_t character)
     {
@@ -324,7 +324,7 @@ public:
         m_matchOnly16Stats.set(insnCount, stackSize, canInline, needsT2);
     }
 
-    InlineStats& get8BitInlineStats() { return m_matchOnly8Stats; }
+    InlineStats& get8BitInlineStats() LIFETIME_BOUND { return m_matchOnly8Stats; }
     InlineStats& get16BitInlineStats() { return  m_matchOnly16Stats; }
 
     MatchResult execute(std::span<const Latin1Character> input, unsigned start, int* output, MatchingContextHolder* matchingContext)


### PR DESCRIPTION
#### 75c21debe092d3a4a607c9e0524fba519b1b3276
<pre>
Adopt LIFETIME_BOUND in more places in JavaScriptCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=309480">https://bugs.webkit.org/show_bug.cgi?id=309480</a>

Reviewed by Anne van Kesteren.

* Source/JavaScriptCore/*:

Canonical link: <a href="https://commits.webkit.org/308904@main">https://commits.webkit.org/308904@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8743b545e6bcb18172cae9b79a411df606f6edec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157502 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102247 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83c26073-8cdf-4b00-b6e4-7207cefdeefc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150690 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21982 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114718 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/358c9ca2-0bf0-468a-bdbb-d0e6175d1808) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133579 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95487 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/565f2209-0342-4813-a556-534607fb5991) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16034 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13885 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5267 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140784 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125635 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159840 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9605 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2977 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122781 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123006 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33445 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21340 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133293 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77528 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18313 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10055 "Too many flaky failures: http/tests/misc/webtiming-cross-origin-and-back1.html, http/tests/navigation/success200-basic.html, http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-filtered-link-decoration-after-short-deletion.html, http/tests/security/contentSecurityPolicy/subframe-with-data-url-inheritance.html, http/tests/security/cors-post-redirect-301.html, http/tests/site-isolation/window-properties.html, http/tests/storageAccess/request-and-grant-access-then-navigate-same-site-should-have-access.https.html, http/tests/workers/service/service-worker-download-async-delegates.https.html, http/tests/xmlhttprequest/access-control-preflight-sync-not-supported.html, http/wpt/mediarecorder/MediaRecorder-audio-bitrate-mp4-opus.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180245 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20942 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84744 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46139 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20674 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20821 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20730 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->