### PR TITLE
[AppKit Gestures] Start converting WKAppKitGestureController to Swift (part

### DIFF
--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -363,6 +363,11 @@ module WebKit_Internal [system] {
         requires objc
     }
 
+    module WKAppKitGestureController {
+        header "../../UIProcess/mac/WKAppKitGestureController.h"
+        export *
+    }
+
     // FIXME: These parts of the module map needs work as discussed in https://github.com/WebKit/WebKit/pull/54322
 
     module WebKit_Internal_Cxx {

--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -368,6 +368,11 @@ module WebKit_Internal [system] {
         export *
     }
 
+    module ViewGestureController {
+        header "../../UIProcess/ViewGestureController.h"
+        export *
+    }
+
     // FIXME: These parts of the module map needs work as discussed in https://github.com/WebKit/WebKit/pull/54322
 
     module WebKit_Internal_Cxx {

--- a/Source/WebKit/UIProcess/ViewGestureController.h
+++ b/Source/WebKit/UIProcess/ViewGestureController.h
@@ -526,6 +526,16 @@ private:
 
     const UniqueRef<SnapshotRemovalTracker> m_snapshotRemovalTracker;
     WTF::Function<void()> m_loadCallback;
-};
+} SWIFT_SHARED_REFERENCE(refViewGestureController, derefViewGestureController);
 
 } // namespace WebKit
+
+inline void refViewGestureController(WebKit::ViewGestureController* WTF_NONNULL obj)
+{
+    WTF::ref(obj);
+}
+
+inline void derefViewGestureController(WebKit::ViewGestureController* WTF_NONNULL obj)
+{
+    WTF::deref(obj);
+}

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
@@ -95,6 +95,54 @@ NS_SWIFT_UI_ACTOR
 
 @end
 
+// MARK: WKAppKitGestureController + Click Handling
+
+@interface WKAppKitGestureController (ClickHandling)
+
+- (void)_handleClickBegan:(NSGestureRecognizer *)gesture;
+
+- (void)_handleClickEnded:(NSGestureRecognizer *)gesture;
+
+- (void)_handleClickCancelled;
+
+- (void)_endPotentialClickAndEnableDoubleClickGesturesIfNecessary;
+
+- (void)_setDoubleClickGesturesEnabled:(BOOL)enabled;
+
+@end
+
+// MARK: WKAppKitGestureController + Wheel Event Handling
+
+@interface WKAppKitGestureController (WheelEventHandling)
+
+- (void)sendWheelEventForGesture:(NSPanGestureRecognizer *)gesture;
+
+@end
+
+// MARK: WKAppKitGestureController + Momentum Handling
+
+@interface WKAppKitGestureController (MomentumHandling)
+
+- (void)startMomentumIfNeededForGesture:(NSPanGestureRecognizer *)gesture;
+
+- (void)interruptMomentumIfNeeded;
+
+@end
+
+// MARK: WKAppKitGestureController + Gesture Recognition
+
+@interface WKAppKitGestureController (GestureRecognition)
+
+- (void)panGestureRecognized:(NSGestureRecognizer *)gesture;
+
+- (void)singleClickGestureRecognized:(NSGestureRecognizer *)gesture;
+
+- (void)doubleClickGestureRecognized:(NSGestureRecognizer *)gesture;
+
+- (void)secondaryClickGestureRecognized:(NSGestureRecognizer *)gesture;
+
+@end
+
 // MARK: WKAppKitGestureController + NSGestureRecognizerDelegatePrivate
 
 @interface WKAppKitGestureController (NSGestureRecognizerDelegate) <NSGestureRecognizerDelegatePrivate>

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
@@ -29,7 +29,7 @@
 
 #if HAVE(APPKIT_GESTURES_SUPPORT)
 
-#import <AppKit/NSGestureRecognizer.h>
+#import <AppKit/NSGestureRecognizer_Private.h>
 #import <wtf/Forward.h>
 #import <wtf/ObjectIdentifier.h>
 #import <wtf/Vector.h>
@@ -52,7 +52,12 @@ OBJC_CLASS NSPanGestureRecognizer;
 #import <WebKitAdditions/WKAppKitGestureControllerAdditionsBefore.mm>
 #endif
 
-@interface WKAppKitGestureController : NSObject <NSGestureRecognizerDelegate>
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
+
+// MARK: WKAppKitGestureController
+
+NS_SWIFT_UI_ACTOR
+@interface WKAppKitGestureController : NSObject
 
 - (instancetype)initWithPage:(std::reference_wrapper<WebKit::WebPageProxy>)page viewImpl:(std::reference_wrapper<WebKit::WebViewImpl>)viewImpl;
 - (void)enableGesturesIfNeeded;
@@ -68,8 +73,34 @@ OBJC_CLASS NSPanGestureRecognizer;
 - (void)didHandleClickAsHover;
 - (void)didNotHandleClickAsClick:(const WebCore::IntPoint&)point;
 
-#endif
+#endif // ENABLE(TWO_PHASE_CLICKS)
 
 @end
+
+// MARK: WKAppKitGestureController + Internal
+
+@interface WKAppKitGestureController (Internal)
+
+@property (nonatomic, readonly) NSPanGestureRecognizer *_panGestureRecognizer;
+
+@property (nonatomic, readonly) NSPressGestureRecognizer *_singleClickGestureRecognizer;
+
+@property (nonatomic, readonly) NSClickGestureRecognizer *_doubleClickGestureRecognizer;
+
+@property (nonatomic, readonly) NSPressGestureRecognizer *_secondaryClickGestureRecognizer;
+
+@property (nonatomic, readonly, nullable) WebKit::WebViewImpl *_viewImpl;
+
+@property (nonatomic, readonly, nullable) WebKit::WebPageProxy *_page;
+
+@end
+
+// MARK: WKAppKitGestureController + NSGestureRecognizerDelegatePrivate
+
+@interface WKAppKitGestureController (NSGestureRecognizerDelegate) <NSGestureRecognizerDelegatePrivate>
+
+@end
+
+NS_HEADER_AUDIT_END(nullability, sendability)
 
 #endif // HAVE(APPKIT_GESTURES_SUPPORT)

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -150,9 +150,6 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     return -delta;
 }
 
-@interface WKAppKitGestureController () <NSGestureRecognizerDelegatePrivate>
-@end
-
 @implementation WKAppKitGestureController {
     WeakPtr<WebKit::WebPageProxy> _page;
     WeakPtr<WebKit::WebViewImpl> _viewImpl;
@@ -710,110 +707,38 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "Interrupted momentum scrolling");
 }
 
-#pragma mark - NSGestureRecognizerDelegate
+@end
 
-static BOOL isBuiltInScrollViewPanGestureRecognizer(NSGestureRecognizer *recognizer)
+@implementation WKAppKitGestureController (Internal)
+
+- (NSPanGestureRecognizer *)_panGestureRecognizer
 {
-    static Class scrollViewPanGestureClass = NSClassFromString(@"NSScrollViewPanGestureRecognizer");
-    return [recognizer isKindOfClass:scrollViewPanGestureClass];
+    return _panGestureRecognizer.get();
 }
 
-static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NSGestureRecognizer *x, NSGestureRecognizer *y)
+- (NSPressGestureRecognizer *)_singleClickGestureRecognizer
 {
-    return (a == x && b == y) || (b == x && a == y);
+    return _singleClickGestureRecognizer.get();
 }
 
-- (BOOL)gestureRecognizer:(NSGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(NSGestureRecognizer *)otherGestureRecognizer
+- (NSClickGestureRecognizer *)_doubleClickGestureRecognizer
 {
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Gesture: %@, Other gesture: %@", gestureRecognizer, otherGestureRecognizer);
-
-    if (isSamePair(gestureRecognizer, otherGestureRecognizer, _singleClickGestureRecognizer.get(), _panGestureRecognizer.get()))
-        return YES;
-
-    if (gestureRecognizer == _singleClickGestureRecognizer
-        && isBuiltInScrollViewPanGestureRecognizer(otherGestureRecognizer)
-        && [otherGestureRecognizer.view isKindOfClass:NSScrollView.class])
-        return YES;
-
-    CheckedPtr viewImpl = _viewImpl.get();
-    if (!viewImpl)
-        return NO;
-
-    RetainPtr webView = viewImpl->view();
-    if (!webView)
-        return NO;
-
-    // Allow the single click GR to be simultaneously recognized with any of those from the text selection manager.
-
-    for (NSGestureRecognizer *gestureForFailureRequirements in [[webView textSelectionManager] gesturesForFailureRequirements]) {
-        if ((gestureRecognizer == _singleClickGestureRecognizer && otherGestureRecognizer == gestureForFailureRequirements)
-            || (otherGestureRecognizer == _singleClickGestureRecognizer && gestureRecognizer == gestureForFailureRequirements))
-            return YES;
-    }
-
-    return NO;
+    return _doubleClickGestureRecognizer.get();
 }
 
-- (BOOL)gestureRecognizer:(NSGestureRecognizer *)gestureRecognizer shouldBeRequiredToFailByGestureRecognizer:(NSGestureRecognizer *)otherGestureRecognizer
+- (NSPressGestureRecognizer *)_secondaryClickGestureRecognizer
 {
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Gesture: %@, Other gesture: %@", gestureRecognizer, otherGestureRecognizer);
-
-    CheckedPtr viewImpl = _viewImpl.get();
-    if (!viewImpl)
-        return NO;
-
-    RetainPtr webView = viewImpl->view();
-    if (!webView)
-        return NO;
-
-    // Fail any gestures from the text selection manager if the secondary click GR handles them.
-
-    for (NSGestureRecognizer *gestureForFailureRequirements in [[webView textSelectionManager] gesturesForFailureRequirements]) {
-        if (gestureRecognizer == _secondaryClickGestureRecognizer && otherGestureRecognizer == gestureForFailureRequirements)
-            return YES;
-    }
-
-    return NO;
+    return _secondaryClickGestureRecognizer.get();
 }
 
-- (BOOL)gestureRecognizer:(NSGestureRecognizer *)gestureRecognizer shouldRequireFailureOfGestureRecognizer:(NSGestureRecognizer *)otherGestureRecognizer
+- (WebKit::WebViewImpl *)_viewImpl
 {
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Gesture: %@, Other gesture: %@", gestureRecognizer, otherGestureRecognizer);
-
-    if (gestureRecognizer == _singleClickGestureRecognizer && otherGestureRecognizer == _doubleClickGestureRecognizer)
-        return YES;
-
-    return NO;
+    return _viewImpl.get();
 }
 
-- (BOOL)gestureRecognizerShouldBegin:(NSGestureRecognizer *)gestureRecognizer
+- (WebKit::WebPageProxy *)_page
 {
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Gesture: %@", gestureRecognizer);
-
-    if (gestureRecognizer == _doubleClickGestureRecognizer) {
-        CheckedPtr viewImpl = _viewImpl.get();
-        if (!viewImpl || !viewImpl->allowsMagnification())
-            return NO;
-    }
-
-    if (gestureRecognizer == _secondaryClickGestureRecognizer) {
-        // FIXME: Implement logic for determining if the clicked node is not text.
-        return NO;
-    }
-
-    return YES;
-}
-
-- (BOOL)_isScrollOrZoomGestureRecognizer:(NSGestureRecognizer *)gesture
-{
-    // FIXME: Should we account for any system pan gesture recognizers?
-    return gesture == _panGestureRecognizer || [gesture isKindOfClass:[NSMagnificationGestureRecognizer class]];
-}
-
-- (BOOL)_gestureRecognizer:(NSGestureRecognizer *)preventingGestureRecognizer canPreventGestureRecognizer:(NSGestureRecognizer *)preventedGestureRecognizer
-{
-    bool isOurClickGesture = preventingGestureRecognizer == _singleClickGestureRecognizer || preventingGestureRecognizer == _secondaryClickGestureRecognizer;
-    return !isOurClickGesture || ![self _isScrollOrZoomGestureRecognizer:preventedGestureRecognizer];
+    return _page.get();
 }
 
 @end

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -266,209 +266,6 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     [gesture setEnabled:gestureEnabled];
 }
 
-#pragma mark - Gesture Recognition
-
-- (void)panGestureRecognized:(NSGestureRecognizer *)gesture
-{
-    CheckedPtr viewImpl = _viewImpl.get();
-    if (!viewImpl)
-        return;
-
-    RefPtr page = _page.get();
-    if (!page)
-        return;
-
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "%@", gesture);
-
-    RetainPtr panGesture = dynamic_objc_cast<NSPanGestureRecognizer>(gesture);
-    if (!panGesture || _panGestureRecognizer != panGesture)
-        return;
-
-    if (viewImpl->ignoresAllEvents()) {
-        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "Ignored gesture");
-        return;
-    }
-
-    if ([panGesture state] == NSGestureRecognizerStateBegan)
-        viewImpl->dismissContentRelativeChildWindowsWithAnimation(false);
-
-#if ENABLE(BANNER_VIEW_OVERLAYS)
-    viewImpl->updateBannerViewForPanGesture([panGesture state]);
-#endif
-
-    [self sendWheelEventForGesture:panGesture.get()];
-    [self startMomentumIfNeededForGesture:panGesture.get()];
-}
-
-- (void)singleClickGestureRecognized:(NSGestureRecognizer *)gesture
-{
-    CheckedPtr viewImpl = _viewImpl.get();
-    if (!viewImpl)
-        return;
-
-    RetainPtr webView = viewImpl->view();
-    if (!webView)
-        return;
-
-    RefPtr page = _page.get();
-    if (!page)
-        return;
-
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "%@", gesture);
-
-    if (_singleClickGestureRecognizer != gesture)
-        return;
-
-    switch (gesture.state) {
-    case NSGestureRecognizerStateBegan:
-        [self _handleClickBegan:gesture];
-        break;
-    case NSGestureRecognizerStateEnded:
-        [self _handleClickEnded:gesture];
-        break;
-    case NSGestureRecognizerStateCancelled:
-    case NSGestureRecognizerStateFailed:
-        [self _handleClickCancelled];
-        break;
-    default:
-        break;
-    }
-}
-
-- (void)doubleClickGestureRecognized:(NSGestureRecognizer *)gesture
-{
-    CheckedPtr viewImpl = _viewImpl.get();
-    if (!viewImpl)
-        return;
-
-    RetainPtr webView = viewImpl->view();
-    if (!webView)
-        return;
-
-    RefPtr page = _page.get();
-    if (!page)
-        return;
-
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "%@", gesture);
-
-    RetainPtr clickGesture = dynamic_objc_cast<NSClickGestureRecognizer>(gesture);
-    if (!clickGesture || _doubleClickGestureRecognizer != clickGesture)
-        return;
-
-    viewImpl->dismissContentRelativeChildWindowsWithAnimation(false);
-
-    auto magnificationOrigin = [webView convertPoint:[gesture locationInView:nil] fromView:nil];
-    protect(viewImpl->ensureGestureController())->handleSmartMagnificationGesture(magnificationOrigin);
-}
-
-- (void)secondaryClickGestureRecognized:(NSGestureRecognizer *)gesture
-{
-    CheckedPtr viewImpl = _viewImpl.get();
-    if (!viewImpl)
-        return;
-
-    RetainPtr webView = viewImpl->view();
-    if (!webView)
-        return;
-
-    RefPtr page = _page.get();
-    if (!page)
-        return;
-
-    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "%@", gesture);
-
-    if (_secondaryClickGestureRecognizer != gesture)
-        return;
-
-ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
-    auto modifierFlags = [gesture modifierFlags];
-ALLOW_NEW_API_WITHOUT_GUARDS_END
-    auto location = [gesture locationInView:nil];
-    auto windowNumber = viewImpl->windowNumber();
-
-    RetainPtr mouseDown = [NSEvent mouseEventWithType:NSEventTypeRightMouseDown location:location modifierFlags:modifierFlags timestamp:GetCurrentEventTime() windowNumber:windowNumber context:NULL eventNumber:0 clickCount:1 pressure:1.0];
-    viewImpl->mouseDown(mouseDown.get(), WebKit::WebMouseEventInputSource::Automation);
-
-    RetainPtr mouseUp = [NSEvent mouseEventWithType:NSEventTypeRightMouseUp location:location modifierFlags:modifierFlags timestamp:GetCurrentEventTime() windowNumber:windowNumber context:NULL eventNumber:0 clickCount:1 pressure:0.0];
-    viewImpl->mouseUp(mouseUp.get(), WebKit::WebMouseEventInputSource::Automation);
-}
-
-#pragma mark - Click Handling
-
-- (void)_handleClickBegan:(NSGestureRecognizer *)gesture
-{
-    CheckedPtr viewImpl = _viewImpl.get();
-    if (!viewImpl)
-        return;
-
-    RetainPtr webView = viewImpl->view();
-    if (!webView)
-        return;
-
-    RefPtr page = _page.get();
-    if (!page)
-        return;
-
-    WebCore::FloatPoint position = [gesture locationInView:webView.get()];
-    _lastInteractionLocation = position;
-
-    if (RefPtr drawingArea = page->drawingArea()) {
-        if (RefPtr remoteDrawingArea = dynamicDowncast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*drawingArea))
-            _layerTreeTransactionIdAtLastInteractionStart = remoteDrawingArea->lastCommittedMainFrameLayerTreeTransactionID();
-    }
-
-    _latestClickID = WebKit::ClickIdentifier::generate();
-    _potentialClickInProgress = true;
-    _isClickHighlightIDValid = true;
-    _isExpectingFastClickCommit = ![_doubleClickGestureRecognizer isEnabled];
-
-    page->potentialClickAtPosition(std::nullopt, WebCore::FloatPoint(position), false, *_latestClickID, WebKit::WebMouseEventInputSource::Automation);
-}
-
-- (void)_handleClickEnded:(NSGestureRecognizer *)gesture
-{
-    if (!_potentialClickInProgress)
-        return;
-
-    RefPtr page = _page.get();
-    if (!page)
-        return;
-
-    [self _endPotentialClickAndEnableDoubleClickGesturesIfNecessary];
-
-    _commitPotentialClickPointerId = WebCore::mousePointerID;
-
-    if (!_layerTreeTransactionIdAtLastInteractionStart) {
-        [self _handleClickCancelled];
-        return;
-    }
-
-    page->commitPotentialClick(std::nullopt, { }, *_layerTreeTransactionIdAtLastInteractionStart, _commitPotentialClickPointerId);
-}
-
-- (void)_handleClickCancelled
-{
-    if (!_potentialClickInProgress)
-        return;
-
-    _potentialClickInProgress = false;
-    _isClickHighlightIDValid = false;
-
-    if (RefPtr page = _page.get())
-        page->cancelPotentialClick();
-}
-
-- (void)_endPotentialClickAndEnableDoubleClickGesturesIfNecessary
-{
-    _potentialClickInProgress = false;
-    [self _setDoubleClickGesturesEnabled:YES];
-}
-
-- (void)_setDoubleClickGesturesEnabled:(BOOL)enabled
-{
-    [_doubleClickGestureRecognizer setEnabled:enabled];
-}
-
 #if ENABLE(TWO_PHASE_CLICKS)
 
 #pragma mark - Two-Phase Click Response Handlers
@@ -548,9 +345,13 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 #endif
 
-#pragma mark - Wheel Event Handling
+@end
 
-- (void)sendWheelEventForGesture:(NSPanGestureRecognizer *)gesture
+// MARK: WKAppKitGestureController + Click Handling
+
+@implementation WKAppKitGestureController (ClickHandling)
+
+- (void)_handleClickBegan:(NSGestureRecognizer *)gesture
 {
     CheckedPtr viewImpl = _viewImpl.get();
     if (!viewImpl)
@@ -564,51 +365,71 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     if (!page)
         return;
 
-    auto timestamp = MonotonicTime::fromRawSeconds([gesture timestamp]);
-    WebCore::IntPoint position { [gesture locationInView:webView.get()] };
-    auto globalPosition { WebCore::globalPoint([gesture locationInView:nil], [webView window]) };
-    auto gestureDelta { translationInView(gesture, webView.get()) };
-    auto wheelTicks { gestureDelta.scaled(1. / static_cast<float>(WebCore::Scrollbar::pixelsPerLineStep())) };
-    auto granularity = WebKit::WebWheelEvent::Granularity::ScrollByPixelWheelEvent;
-    bool directionInvertedFromDevice = false;
-    auto phase = toWheelEventPhase(gesture.state);
-    auto momentumPhase = WebKit::WebWheelEvent::Phase::None;
-    bool hasPreciseScrollingDeltas = true;
-    uint32_t scrollCount = 1;
-    auto unacceleratedScrollingDelta = gestureDelta;
-    auto ioHIDEventTimestamp = timestamp;
-    std::optional<WebCore::FloatSize> rawPlatformDelta;
-    auto momentumEndType = WebKit::WebWheelEvent::MomentumEndType::Unknown;
+    WebCore::FloatPoint position = [gesture locationInView:webView.get()];
+    _lastInteractionLocation = position;
 
-    WebKit::WebWheelEvent wheelEvent {
-        { WebKit::WebEventType::Wheel, { }, timestamp, WTF::UUID::createVersion4() },
-        WebCore::IntPoint { position },
-        WebCore::IntPoint { globalPosition },
-        gestureDelta,
-        wheelTicks,
-        granularity,
-        directionInvertedFromDevice,
-        phase,
-        momentumPhase,
-        hasPreciseScrollingDeltas,
-        scrollCount,
-        unacceleratedScrollingDelta,
-        ioHIDEventTimestamp,
-        rawPlatformDelta,
-        momentumEndType
-    };
+    if (RefPtr drawingArea = page->drawingArea()) {
+        if (RefPtr remoteDrawingArea = dynamicDowncast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*drawingArea))
+            _layerTreeTransactionIdAtLastInteractionStart = remoteDrawingArea->lastCommittedMainFrameLayerTreeTransactionID();
+    }
 
-    WebKit::NativeWebWheelEvent nativeEvent { wheelEvent };
+    _latestClickID = WebKit::ClickIdentifier::generate();
+    _potentialClickInProgress = true;
+    _isClickHighlightIDValid = true;
+    _isExpectingFastClickCommit = ![_doubleClickGestureRecognizer isEnabled];
 
-    if (viewImpl->allowsBackForwardNavigationGestures() && protect(viewImpl->ensureGestureController())->handleScrollWheelEvent(nativeEvent)) {
-        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "View gesture controller handled gesture");
+    page->potentialClickAtPosition(std::nullopt, WebCore::FloatPoint(position), false, *_latestClickID, WebKit::WebMouseEventInputSource::Automation);
+}
+
+- (void)_handleClickEnded:(NSGestureRecognizer *)gesture
+{
+    if (!_potentialClickInProgress)
+        return;
+
+    RefPtr page = _page.get();
+    if (!page)
+        return;
+
+    [self _endPotentialClickAndEnableDoubleClickGesturesIfNecessary];
+
+    _commitPotentialClickPointerId = WebCore::mousePointerID;
+
+    if (!_layerTreeTransactionIdAtLastInteractionStart) {
+        [self _handleClickCancelled];
         return;
     }
 
-    page->handleNativeWheelEvent(nativeEvent);
+    page->commitPotentialClick(std::nullopt, { }, *_layerTreeTransactionIdAtLastInteractionStart, _commitPotentialClickPointerId);
 }
 
-#pragma mark - Momentum Handling
+- (void)_handleClickCancelled
+{
+    if (!_potentialClickInProgress)
+        return;
+
+    _potentialClickInProgress = false;
+    _isClickHighlightIDValid = false;
+
+    if (RefPtr page = _page.get())
+        page->cancelPotentialClick();
+}
+
+- (void)_endPotentialClickAndEnableDoubleClickGesturesIfNecessary
+{
+    _potentialClickInProgress = false;
+    [self _setDoubleClickGesturesEnabled:YES];
+}
+
+- (void)_setDoubleClickGesturesEnabled:(BOOL)enabled
+{
+    [_doubleClickGestureRecognizer setEnabled:enabled];
+}
+
+@end
+
+// MARK: WKAppKitGestureController + Momentum Handling
+
+@implementation WKAppKitGestureController (MomentumHandling)
 
 - (void)startMomentumIfNeededForGesture:(NSPanGestureRecognizer *)gesture
 {
@@ -708,6 +529,72 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 }
 
 @end
+
+// MARK: WKAppKitGestureController + Wheel Event Handling
+
+@implementation WKAppKitGestureController (WheelEventHandling)
+
+- (void)sendWheelEventForGesture:(NSPanGestureRecognizer *)gesture
+{
+    CheckedPtr viewImpl = _viewImpl.get();
+    if (!viewImpl)
+        return;
+
+    RetainPtr webView = viewImpl->view();
+    if (!webView)
+        return;
+
+    RefPtr page = _page.get();
+    if (!page)
+        return;
+
+    auto timestamp = MonotonicTime::fromRawSeconds([gesture timestamp]);
+    WebCore::IntPoint position { [gesture locationInView:webView.get()] };
+    auto globalPosition { WebCore::globalPoint([gesture locationInView:nil], [webView window]) };
+    auto gestureDelta { translationInView(gesture, webView.get()) };
+    auto wheelTicks { gestureDelta.scaled(1. / static_cast<float>(WebCore::Scrollbar::pixelsPerLineStep())) };
+    auto granularity = WebKit::WebWheelEvent::Granularity::ScrollByPixelWheelEvent;
+    bool directionInvertedFromDevice = false;
+    auto phase = toWheelEventPhase(gesture.state);
+    auto momentumPhase = WebKit::WebWheelEvent::Phase::None;
+    bool hasPreciseScrollingDeltas = true;
+    uint32_t scrollCount = 1;
+    auto unacceleratedScrollingDelta = gestureDelta;
+    auto ioHIDEventTimestamp = timestamp;
+    std::optional<WebCore::FloatSize> rawPlatformDelta;
+    auto momentumEndType = WebKit::WebWheelEvent::MomentumEndType::Unknown;
+
+    WebKit::WebWheelEvent wheelEvent {
+        { WebKit::WebEventType::Wheel, { }, timestamp, WTF::UUID::createVersion4() },
+        WebCore::IntPoint { position },
+        WebCore::IntPoint { globalPosition },
+        gestureDelta,
+        wheelTicks,
+        granularity,
+        directionInvertedFromDevice,
+        phase,
+        momentumPhase,
+        hasPreciseScrollingDeltas,
+        scrollCount,
+        unacceleratedScrollingDelta,
+        ioHIDEventTimestamp,
+        rawPlatformDelta,
+        momentumEndType
+    };
+
+    WebKit::NativeWebWheelEvent nativeEvent { wheelEvent };
+
+    if (viewImpl->allowsBackForwardNavigationGestures() && protect(viewImpl->ensureGestureController())->handleScrollWheelEvent(nativeEvent)) {
+        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "View gesture controller handled gesture");
+        return;
+    }
+
+    page->handleNativeWheelEvent(nativeEvent);
+}
+
+@end
+
+// MARK: WKAppKitGestureController + Internal
 
 @implementation WKAppKitGestureController (Internal)
 

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureRecognizer.swift
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureRecognizer.swift
@@ -25,6 +25,122 @@
 
 import Foundation
 internal import WebKit_Internal
+private import Carbon
+
+@objc(GestureRecognition)
+@implementation
+extension WKAppKitGestureController {
+    func panGestureRecognized(_ gesture: NSGestureRecognizer) {
+        guard let page = _page, let viewImpl = unsafe _viewImpl else {
+            return
+        }
+
+        Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) \(String(reflecting: gesture))")
+
+        guard let panGesture = gesture as? NSPanGestureRecognizer, panGesture === _panGestureRecognizer else {
+            return
+        }
+
+        if unsafe viewImpl.ignoresAllEvents() {
+            Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) Ignored gesture")
+        }
+
+        if panGesture.state == .began {
+            unsafe viewImpl.dismissContentRelativeChildWindowsWithAnimation(false)
+        }
+
+        #if ENABLE_BANNER_VIEW_OVERLAYS
+        unsafe viewImpl.updateBannerViewForPanGesture(panGesture.state)
+        #endif
+
+        sendWheelEvent(forGesture: panGesture)
+        startMomentumIfNeeded(forGesture: panGesture)
+    }
+
+    func singleClickGestureRecognized(_ gesture: NSGestureRecognizer) {
+        guard let page = _page else {
+            return
+        }
+
+        Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) \(String(reflecting: gesture))")
+
+        guard _singleClickGestureRecognizer === gesture else {
+            return
+        }
+
+        switch gesture.state {
+        case .began:
+            _handleClickBegan(gesture)
+        case .ended:
+            _handleClickEnded(gesture)
+        case .cancelled, .failed:
+            _handleClickCancelled()
+        default:
+            break
+        }
+    }
+
+    func doubleClickGestureRecognized(_ gesture: NSGestureRecognizer) {
+        guard let page = _page, let viewImpl = unsafe _viewImpl, let webView = unsafe viewImpl.view() else {
+            return
+        }
+
+        Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) \(String(reflecting: gesture))")
+
+        guard let clickGesture = gesture as? NSClickGestureRecognizer, clickGesture === _doubleClickGestureRecognizer else {
+            return
+        }
+
+        unsafe viewImpl.dismissContentRelativeChildWindowsWithAnimation(false)
+
+        let magnificationOrigin = webView.convert(gesture.location(in: nil), from: nil)
+        unsafe viewImpl.gestureController()?.handleSmartMagnificationGesture(.init(magnificationOrigin))
+    }
+
+    func secondaryClickGestureRecognized(_ gesture: NSGestureRecognizer) {
+        guard let page = _page, let viewImpl = unsafe _viewImpl, let webView = unsafe viewImpl.view() else {
+            return
+        }
+
+        Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) \(String(reflecting: gesture))")
+
+        guard _secondaryClickGestureRecognizer === gesture else {
+            return
+        }
+
+        let modifierFlags = gesture.modifierFlags
+        let location = gesture.location(in: nil)
+        let windowNumber = unsafe viewImpl.windowNumber()
+
+        let mouseDown = NSEvent.mouseEvent(
+            with: .rightMouseDown,
+            location: location,
+            modifierFlags: modifierFlags,
+            timestamp: GetCurrentEventTime(),
+            windowNumber: windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        )
+
+        unsafe viewImpl.mouseDown(mouseDown, .Automation)
+
+        let mouseUp = NSEvent.mouseEvent(
+            with: .rightMouseUp,
+            location: location,
+            modifierFlags: modifierFlags,
+            timestamp: GetCurrentEventTime(),
+            windowNumber: windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 0
+        )
+
+        unsafe viewImpl.mouseUp(mouseUp, .Automation)
+    }
+}
 
 @objc(NSGestureRecognizerDelegate)
 @implementation

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureRecognizer.swift
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureRecognizer.swift
@@ -1,0 +1,176 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if HAVE_APPKIT_GESTURES_SUPPORT && compiler(>=6.2)
+
+import Foundation
+internal import WebKit_Internal
+
+@objc(NSGestureRecognizerDelegate)
+@implementation
+extension WKAppKitGestureController {
+    @objc(gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:)
+    func gestureRecognizer(
+        _ gestureRecognizer: NSGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: NSGestureRecognizer
+    ) -> Bool {
+        guard let page = _page else {
+            return false
+        }
+
+        Logger.viewGestures.log(
+            "[pageProxyID=\(page.logIdentifier())] \(#function) Gesture: \(String(reflecting: gestureRecognizer)), Other gesture: \(String(reflecting: otherGestureRecognizer))"
+        )
+
+        if Set([gestureRecognizer, otherGestureRecognizer]) == Set([_singleClickGestureRecognizer, _panGestureRecognizer]) {
+            return true
+        }
+
+        if gestureRecognizer === _singleClickGestureRecognizer
+            && otherGestureRecognizer.isBuiltInScrollViewPanGestureRecognizer
+            && otherGestureRecognizer.view is NSScrollView
+        {
+            return true
+        }
+
+        guard let webView = unsafe _viewImpl?.view() else {
+            return false
+        }
+
+        // Allow the single click GR to be simultaneously recognized with any of those from the text selection manager.
+
+        if let textSelectionManager = webView.textSelectionManager {
+            if textSelectionManager.gesturesForFailureRequirements.contains(where: {
+                Set([gestureRecognizer, otherGestureRecognizer]) == Set([_singleClickGestureRecognizer, $0])
+            }) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    @objc(gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:)
+    func gestureRecognizer(
+        _ gestureRecognizer: NSGestureRecognizer,
+        shouldBeRequiredToFailBy otherGestureRecognizer: NSGestureRecognizer
+    ) -> Bool {
+        guard let page = _page else {
+            return false
+        }
+
+        Logger.viewGestures.log(
+            "[pageProxyID=\(page.logIdentifier())] \(#function) Gesture: \(String(reflecting: gestureRecognizer)), Other gesture: \(String(reflecting: otherGestureRecognizer))"
+        )
+
+        guard let webView = unsafe _viewImpl?.view() else {
+            return false
+        }
+
+        // Fail any gestures from the text selection manager if the secondary click GR handles them.
+
+        if let textSelectionManager = webView.textSelectionManager {
+            if textSelectionManager.gesturesForFailureRequirements.contains(where: {
+                gestureRecognizer === _secondaryClickGestureRecognizer && otherGestureRecognizer === $0
+            }) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    @objc(gestureRecognizer:shouldRequireFailureOfGestureRecognizer:)
+    func gestureRecognizer(
+        _ gestureRecognizer: NSGestureRecognizer,
+        shouldRequireFailureOf otherGestureRecognizer: NSGestureRecognizer
+    ) -> Bool {
+        guard let page = _page else {
+            return false
+        }
+
+        Logger.viewGestures.log(
+            "[pageProxyID=\(page.logIdentifier())] \(#function) Gesture: \(String(reflecting: gestureRecognizer)), Other gesture: \(String(reflecting: otherGestureRecognizer))"
+        )
+
+        if gestureRecognizer === _singleClickGestureRecognizer && otherGestureRecognizer === _doubleClickGestureRecognizer {
+            return true
+        }
+
+        return false
+    }
+
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: NSGestureRecognizer) -> Bool {
+        guard let page = _page else {
+            return false
+        }
+
+        guard let viewImpl = unsafe _viewImpl else {
+            return false
+        }
+
+        Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) Gesture: \(String(reflecting: gestureRecognizer))")
+
+        if gestureRecognizer === _doubleClickGestureRecognizer {
+            if unsafe !viewImpl.allowsMagnification() {
+                return false
+            }
+        }
+
+        if gestureRecognizer === _secondaryClickGestureRecognizer {
+            // FIXME: Implement logic for determining if the clicked node is not text.
+            return false
+        }
+
+        return true
+    }
+
+    private func isScrollOrZoomGestureRecognizer(_ gestureRecognizer: NSGestureRecognizer) -> Bool {
+        // FIXME: Should we account for any system pan gesture recognizers?
+        gestureRecognizer === _panGestureRecognizer || gestureRecognizer is NSMagnificationGestureRecognizer
+    }
+
+    // swift-format-ignore: NoLeadingUnderscores
+    @objc(_gestureRecognizer:canPreventGestureRecognizer:)
+    func _gestureRecognizer(
+        _ preventingGestureRecognizer: NSGestureRecognizer!,
+        canPrevent preventedGestureRecognizer: NSGestureRecognizer!
+    ) -> Bool {
+        let isOurClickGesture =
+            preventingGestureRecognizer === _singleClickGestureRecognizer
+            || preventingGestureRecognizer === _secondaryClickGestureRecognizer
+
+        return !isOurClickGesture || !isScrollOrZoomGestureRecognizer(preventedGestureRecognizer)
+    }
+}
+
+extension NSGestureRecognizer {
+    fileprivate var isBuiltInScrollViewPanGestureRecognizer: Bool {
+        guard let scrollViewPanGestureClass: AnyClass = NSClassFromString("NSScrollViewPanGestureRecognizer") else {
+            return false
+        }
+        return isKind(of: scrollViewPanGestureClass)
+    }
+}
+
+#endif // HAVE_APPKIT_GESTURES_SUPPORT && compiler(>=6.2)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		07AF79E12D693DD7004E8D3A /* WKScrollGeometryAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07AF79E02D693DD7004E8D3A /* WKScrollGeometryAdapter.swift */; };
 		07AF79E92D695195004E8D3A /* WKUIDelegateInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 07AF79E82D695195004E8D3A /* WKUIDelegateInternal.h */; };
 		07BAEEA12ED056EE00251691 /* WebURLSchemeTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D124271E6D3F1F002B2820 /* WebURLSchemeTask.h */; };
+		07C7D2782F5E8B25007D69FB /* WKAppKitGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C7D2772F5E8B25007D69FB /* WKAppKitGestureRecognizer.swift */; };
 		07CB79962CE9435700199C49 /* WebPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07CB79952CE9435700199C49 /* WebPage.swift */; };
 		07CB79982CE943E400199C49 /* WKNavigationDelegateAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07CB79972CE943E400199C49 /* WKNavigationDelegateAdapter.swift */; };
 		07CF2D512C2147A50064DF23 /* PlatformWritingToolsUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 07CA7FE92C20FAAA00798167 /* PlatformWritingToolsUtilities.h */; };
@@ -3499,6 +3500,7 @@
 		07B93FF523AF0CB80036F8EA /* RemoteMediaPlayerConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaPlayerConfiguration.h; sourceTree = "<group>"; };
 		07BAF35623A2CC170044257E /* RemoteMediaPlayerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteMediaPlayerProxy.h; sourceTree = "<group>"; };
 		07BAF35723A2CC190044257E /* RemoteMediaPlayerProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteMediaPlayerProxy.cpp; sourceTree = "<group>"; };
+		07C7D2772F5E8B25007D69FB /* WKAppKitGestureRecognizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKAppKitGestureRecognizer.swift; sourceTree = "<group>"; };
 		07CA7FE92C20FAAA00798167 /* PlatformWritingToolsUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlatformWritingToolsUtilities.h; sourceTree = "<group>"; };
 		07CA7FEA2C20FAAA00798167 /* PlatformWritingToolsUtilities.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = PlatformWritingToolsUtilities.mm; sourceTree = "<group>"; };
 		07CB79952CE9435700199C49 /* WebPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPage.swift; sourceTree = "<group>"; };
@@ -16549,6 +16551,7 @@
 				868160CF187645370021E79D /* WindowServerConnection.mm */,
 				336E07462EBCC1C100B4D635 /* WKAppKitGestureController.h */,
 				336E07472EBCC1C100B4D635 /* WKAppKitGestureController.mm */,
+				07C7D2772F5E8B25007D69FB /* WKAppKitGestureRecognizer.swift */,
 				CDCA85C7132ABA4E00E961DF /* WKFullScreenWindowController.h */,
 				CDCA85C6132ABA4E00E961DF /* WKFullScreenWindowController.mm */,
 				9321D5851A38EE3C008052BE /* WKImmediateActionController.h */,
@@ -22168,6 +22171,7 @@
 				9356F2DF2152B72300E6D5DF /* WebSWOriginStore.cpp in Sources */,
 				9356F2E12152B76600E6D5DF /* WebSWServerConnection.cpp in Sources */,
 				9356F2E02152B75200E6D5DF /* WebSWServerToContextConnection.cpp in Sources */,
+				07C7D2782F5E8B25007D69FB /* WKAppKitGestureRecognizer.swift in Sources */,
 				A190E9422F3DB703009615AD /* WKAVContentSource.mm in Sources */,
 				C6A4CA0C2252899800169289 /* WKBundlePageMac.mm in Sources */,
 				2D931169212F61B200044BFE /* WKContentView.mm in Sources */,


### PR DESCRIPTION
#### 03a90259d3f061d2721e8d14dcf3b3eb97620533
<pre>
[AppKit Gestures] Start converting WKAppKitGestureController to Swift (part 2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=309486">https://bugs.webkit.org/show_bug.cgi?id=309486</a>
<a href="https://rdar.apple.com/172067511">rdar://172067511</a>

Reviewed by NOBODY (OOPS!).

Implement another category of methods in Swift.

* Source/WebKit/Modules/Internal/module.modulemap:
* Source/WebKit/UIProcess/ViewGestureController.h:
(refViewGestureController):
(derefViewGestureController):
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.h:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController isPotentialClickInProgress]):
(-[WKAppKitGestureController didGetClickHighlightForRequest:color:quads:topLeftRadius:topRightRadius:bottomLeftRadius:bottomRightRadius:nodeHasBuiltInClickHandling:]):
(-[WKAppKitGestureController disableDoubleClickGesturesDuringClickIfNecessary:]):
(-[WKAppKitGestureController commitPotentialClickFailed]):
(-[WKAppKitGestureController didCompleteSyntheticClick]):
(-[WKAppKitGestureController didHandleClickAsHover]):
(-[WKAppKitGestureController didNotHandleClickAsClick:]):
(-[WKAppKitGestureController sendWheelEventForGesture:]):
(-[WKAppKitGestureController panGestureRecognized:]): Deleted.
(-[WKAppKitGestureController singleClickGestureRecognized:]): Deleted.
(-[WKAppKitGestureController doubleClickGestureRecognized:]): Deleted.
(-[WKAppKitGestureController secondaryClickGestureRecognized:]): Deleted.
* Source/WebKit/UIProcess/mac/WKAppKitGestureRecognizer.swift:
(WKAppKitGestureController.panGestureRecognized(_:)):
(WKAppKitGestureController.singleClickGestureRecognized(_:)):
(WKAppKitGestureController.doubleClickGestureRecognized(_:)):
(WKAppKitGestureController.secondaryClickGestureRecognized(_:)):
</pre>
----------------------------------------------------------------------
#### e345e857d0531ff0f2b770f0f26be46bbbe7975e
<pre>
[AppKit Gestures] Start converting WKAppKitGestureController to Swift (part 1)
<a href="https://rdar.apple.com/172055446">rdar://172055446</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309475">https://bugs.webkit.org/show_bug.cgi?id=309475</a>

Reviewed by NOBODY (OOPS!).

Start converting WKAppKitGestureController piece-by-piece to Swift, starting off with the GR delegate

* Source/WebKit/Modules/Internal/module.modulemap:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.h:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController _panGestureRecognizer]):
(-[WKAppKitGestureController _singleClickGestureRecognizer]):
(-[WKAppKitGestureController _doubleClickGestureRecognizer]):
(-[WKAppKitGestureController _secondaryClickGestureRecognizer]):
(-[WKAppKitGestureController _viewImpl]):
(-[WKAppKitGestureController _page]):
(isBuiltInScrollViewPanGestureRecognizer): Deleted.
(isSamePair): Deleted.
(-[WKAppKitGestureController gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]): Deleted.
(-[WKAppKitGestureController gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:]): Deleted.
(-[WKAppKitGestureController gestureRecognizer:shouldRequireFailureOfGestureRecognizer:]): Deleted.
(-[WKAppKitGestureController gestureRecognizerShouldBegin:]): Deleted.
(-[WKAppKitGestureController _isScrollOrZoomGestureRecognizer:]): Deleted.
(-[WKAppKitGestureController _gestureRecognizer:canPreventGestureRecognizer:]): Deleted.
* Source/WebKit/UIProcess/mac/WKAppKitGestureRecognizer.swift: Added.
(WKAppKitGestureController.gestureRecognizerShouldBegin(_:)):
(WKAppKitGestureController.isScrollOrZoomGestureRecognizer(_:)):
(NSGestureRecognizer.isBuiltInScrollViewPanGestureRecognizer):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03a90259d3f061d2721e8d14dcf3b3eb97620533

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148825 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21538 "Hash 03a90259 for PR 60187 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15107 "Hash 03a90259 for PR 60187 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157515 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102255 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a36768ef-5392-4159-a4c6-3c13b73b2add) 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21990 "Hash 03a90259 for PR 60187 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21416 "Hash 03a90259 for PR 60187 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114727 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81705 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba4dfaf3-23a4-4cac-91c0-2b80631ca3b3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151785 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/21990 "Hash 03a90259 for PR 60187 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/15107 "Hash 03a90259 for PR 60187 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95495 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0b7d3a1-87d1-4fb0-8669-2f1aaee1af33) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/21990 "Hash 03a90259 for PR 60187 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/168/builds/15107 "Hash 03a90259 for PR 60187 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5277 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/21990 "Hash 03a90259 for PR 60187 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/15107 "Hash 03a90259 for PR 60187 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159848 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2985 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/15107 "Hash 03a90259 for PR 60187 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122788 "Passed tests") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21340 "Hash 03a90259 for PR 60187 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/21416 "Hash 03a90259 for PR 60187 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123013 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21348 "Hash 03a90259 for PR 60187 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/15107 "Hash 03a90259 for PR 60187 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77536 "Built successfully") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/15107 "Hash 03a90259 for PR 60187 does not build (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20950 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84752 "Failed to build and analyze WebKit") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20682 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20829 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20738 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->