### PR TITLE
[JSC] Optimize Double Mod in DFG / FTL

### DIFF
--- a/JSTests/microbenchmarks/double-mod-positive-integers.js
+++ b/JSTests/microbenchmarks/double-mod-positive-integers.js
@@ -1,0 +1,16 @@
+function doMod(a, b) {
+    return a % b;
+}
+noInline(doMod);
+
+// Use + 0.0 to ensure double representation while keeping integer values.
+var result = 0;
+for (var i = 0; i < 5000000; ++i) {
+    var divisor = 7.0;
+    if (i % 10 == 0)
+        divisor = 7.5;
+    result = (result + doMod((i + 1) + 0.0, divisor)) | 0;
+}
+
+if (result !== 15166668)
+    throw "Bad result: " + result;

--- a/JSTests/stress/double-mod-fast-path.js
+++ b/JSTests/stress/double-mod-fast-path.js
@@ -1,0 +1,78 @@
+// Test fast path for double modulo with positive integers.
+// Ported from V8 regression test for commit 40e82593f5.
+
+function doMod(a, b) {
+    return a % b;
+}
+noInline(doMod);
+
+// Run enough iterations to trigger DFG/FTL compilation.
+for (var i = 0; i < 100000; i++) {
+    // Positive integer cases (fast path).
+    var result = doMod(10, 3);
+    if (result !== 1)
+        throw new Error("Expected 10 % 3 === 1, got " + result);
+
+    result = doMod(7, 4);
+    if (result !== 3)
+        throw new Error("Expected 7 % 4 === 3, got " + result);
+
+    result = doMod(100, 7);
+    if (result !== 2)
+        throw new Error("Expected 100 % 7 === 2, got " + result);
+
+    // Large positive integers where precision matters.
+    result = doMod(2147483647, 10);
+    if (result !== 7)
+        throw new Error("Expected 2147483647 % 10 === 7, got " + result);
+
+    result = doMod(1073741824, 3);
+    if (result !== 1)
+        throw new Error("Expected 1073741824 % 3 === 1, got " + result);
+
+    // Non-integer cases (slow path).
+    result = doMod(5.5, 2);
+    if (result !== 1.5)
+        throw new Error("Expected 5.5 % 2 === 1.5, got " + result);
+
+    result = doMod(10, 3.5);
+    if (result !== 3)
+        throw new Error("Expected 10 % 3.5 === 3, got " + result);
+
+    // Negative cases (slow path).
+    result = doMod(-10, 3);
+    if (result !== -1)
+        throw new Error("Expected -10 % 3 === -1, got " + result);
+
+    result = doMod(10, -3);
+    if (result !== 1)
+        throw new Error("Expected 10 % -3 === 1, got " + result);
+
+    // Zero dividend (slow path).
+    result = doMod(0, 5);
+    if (result !== 0)
+        throw new Error("Expected 0 % 5 === 0, got " + result);
+
+    // Very large integers beyond 2^53 must use slow path for correctness.
+    // 2^100 % 3 === 1 (since 2^even ≡ 1 mod 3).
+    result = doMod(Math.pow(2, 100), 3);
+    if (result !== 1)
+        throw new Error("Expected 2^100 % 3 === 1, got " + result);
+
+    // Near the safe integer boundary.
+    result = doMod(9007199254740991, 7);
+    if (result !== 3)
+        throw new Error("Expected (2^53-1) % 7 === 3, got " + result);
+}
+
+// Additional large value test from V8.
+function testLargeValues() {
+    return 3.5e15 % 100;
+}
+noInline(testLargeValues);
+
+for (var i = 0; i < 100000; i++) {
+    var result = testLargeValues();
+    if (result !== 0)
+        throw new Error("Expected 3.5e15 % 100 === 0, got " + result);
+}

--- a/Source/JavaScriptCore/b3/B3LowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacros.cpp
@@ -35,6 +35,7 @@
 #include "B3CCallValue.h"
 #include "B3CaseCollectionInlines.h"
 #include "B3CheckValue.h"
+#include "B3ConstDoubleValue.h"
 #include "B3ConstPtrValue.h"
 #include "B3FenceValue.h"
 #include "B3InsertionSetInlines.h"
@@ -156,17 +157,116 @@ private:
                         makeDivisionChill(Mod);
                     break;
                 }
-                
+
                 if (m_value->type() == Double) {
-                    Value* functionAddress = m_insertionSet.insert<ConstPtrValue>(m_index, m_origin, tagCFunction<OperationPtrTag>(Math::fmodDouble));
-                    Value* result = m_insertionSet.insert<CCallValue>(m_index, Double, m_origin,
+                    if constexpr (!isARM64()) {
+                        // Non-ARM64: just call fmod directly.
+                        Value* functionAddress = m_insertionSet.insert<ConstPtrValue>(m_index, m_origin, tagCFunction<OperationPtrTag>(Math::fmodDouble));
+                        Value* result = m_insertionSet.insert<CCallValue>(m_index, Double, m_origin,
+                            Effects::none(),
+                            functionAddress,
+                            m_value->child(0),
+                            m_value->child(1));
+                        m_value->replaceWithIdentity(result);
+                        m_changed = true;
+                        break;
+                    }
+
+                    BasicBlock* before = m_blockInsertionSet.splitForward(m_block, m_index, &m_insertionSet);
+                    BasicBlock* fastCase = m_blockInsertionSet.insertBefore(m_block);
+                    BasicBlock* slowCase = m_blockInsertionSet.insertBefore(m_block);
+
+                    Value* left = m_value->child(0);
+                    Value* right = m_value->child(1);
+
+                    // Replace the Jump added by splitForward so we can add our own control flow.
+                    before->replaceLastWithNew<Value>(m_proc, Nop, m_origin);
+
+                    Value* zero = before->appendNew<ConstDoubleValue>(m_proc, m_origin, 0.0);
+
+                    // Check integrality and int32 range for inputs. Use
+                    // roundTowardZeroInt32Double (frint32z) when available — it checks
+                    // both in a single instruction. Otherwise, fall back to
+                    // truncateDoubleToInt32 (fcvtzs) + IToD (scvtf) round-trip.
+                    auto emitInt32RoundTrip = [&](BasicBlock* block, Value* input) -> Value* {
+#if CPU(ARM64)
+                        if (MacroAssemblerARM64::supportsRoundFloatToIntegerFloat()) {
+                            PatchpointValue* patchpoint = block->appendNew<PatchpointValue>(m_proc, Double, m_origin);
+                            patchpoint->append(input, ValueRep::SomeRegister);
+                            patchpoint->effects = Effects::none();
+                            patchpoint->setGenerator(
+                                [](CCallHelpers& jit, const StackmapGenerationParams& params) {
+                                    jit.roundTowardZeroInt32Double(params[1].fpr(), params[0].fpr());
+                                });
+                            return patchpoint;
+                        }
+#endif
+                        PatchpointValue* patchpoint = block->appendNew<PatchpointValue>(m_proc, Int32, m_origin);
+                        patchpoint->append(input, ValueRep::SomeRegister);
+                        patchpoint->effects = Effects::none();
+                        patchpoint->setGenerator(
+                            [](CCallHelpers& jit, const StackmapGenerationParams& params) {
+                                jit.truncateDoubleToInt32(params[1].fpr(), params[0].gpr());
+                            });
+                        return block->appendNew<Value>(m_proc, IToD, m_origin, patchpoint);
+                    };
+
+                    // Check left is a positive integer in int32 range.
+                    Value* leftRoundTrip = emitInt32RoundTrip(before, left);
+                    Value* leftIsInt = before->appendNew<Value>(m_proc, Equal, m_origin, left, leftRoundTrip);
+                    Value* leftIsPositive = before->appendNew<Value>(m_proc, GreaterThan, m_origin, left, zero);
+                    Value* leftOk = before->appendNew<Value>(m_proc, BitAnd, m_origin, leftIsInt, leftIsPositive);
+
+                    // Check right is a positive integer in int32 range.
+                    Value* rightRoundTrip = emitInt32RoundTrip(before, right);
+                    Value* rightIsInt = before->appendNew<Value>(m_proc, Equal, m_origin, right, rightRoundTrip);
+                    Value* rightIsPositive = before->appendNew<Value>(m_proc, GreaterThan, m_origin, right, zero);
+                    Value* rightOk = before->appendNew<Value>(m_proc, BitAnd, m_origin, rightIsInt, rightIsPositive);
+
+                    Value* bothOk = before->appendNew<Value>(m_proc, BitAnd, m_origin, leftOk, rightOk);
+                    before->appendNew<Value>(m_proc, Branch, m_origin, bothOk);
+                    before->setSuccessors(
+                        FrequentedBlock(fastCase, FrequencyClass::Normal),
+                        FrequentedBlock(slowCase, FrequencyClass::Rare));
+
+                    // Fast case: remainder = left - trunc(left / right) * right
+                    Value* divResult = fastCase->appendNew<Value>(m_proc, Div, m_origin, left, right);
+                    Value* divTrunc = fastCase->appendNew<Value>(m_proc, FTrunc, m_origin, divResult);
+                    Value* mulBack = fastCase->appendNew<Value>(m_proc, Mul, m_origin, divTrunc, right);
+                    Value* remainder = fastCase->appendNew<Value>(m_proc, Sub, m_origin, left, mulBack);
+
+                    // Validate: remainder >= 0 && remainder < right
+                    Value* remNonNeg = fastCase->appendNew<Value>(m_proc, GreaterEqual, m_origin, remainder, zero);
+                    Value* remLessThanRight = fastCase->appendNew<Value>(m_proc, LessThan, m_origin, remainder, right);
+                    Value* fastValid = fastCase->appendNew<Value>(m_proc, BitAnd, m_origin, remNonNeg, remLessThanRight);
+                    UpsilonValue* fastResult = fastCase->appendNew<UpsilonValue>(m_proc, m_origin, remainder);
+                    fastCase->appendNew<Value>(m_proc, Branch, m_origin, fastValid);
+                    fastCase->setSuccessors(
+                        FrequentedBlock(m_block, FrequencyClass::Normal),
+                        FrequentedBlock(slowCase, FrequencyClass::Rare));
+
+                    // Slow case: call fmod
+                    Value* functionAddress = slowCase->appendNew<ConstPtrValue>(m_proc, m_origin, tagCFunction<OperationPtrTag>(Math::fmodDouble));
+                    Value* slowResult = slowCase->appendNew<CCallValue>(m_proc, Double, m_origin,
                         Effects::none(),
                         functionAddress,
-                        m_value->child(0),
-                        m_value->child(1));
-                    m_value->replaceWithIdentity(result);
+                        left,
+                        right);
+                    UpsilonValue* slowUpsilon = slowCase->appendNew<UpsilonValue>(m_proc, m_origin, slowResult);
+                    slowCase->appendNew<Value>(m_proc, Jump, m_origin);
+                    slowCase->setSuccessors(FrequentedBlock(m_block));
+
+                    // Continuation: phi merging fast and slow results
+                    Value* phi = m_insertionSet.insert<Value>(m_index, Phi, Double, m_origin);
+                    fastResult->setPhi(phi);
+                    slowUpsilon->setPhi(phi);
+                    m_value->replaceWithIdentity(phi);
+                    before->updatePredecessorsAfter();
                     m_changed = true;
-                } else if (m_value->type() == Float) {
+                    break;
+                }
+
+                if (m_value->type() == Float) {
                     Value* numeratorAsDouble = m_insertionSet.insert<Value>(m_index, FloatToDouble, m_origin, m_value->child(0));
                     Value* denominatorAsDouble = m_insertionSet.insert<Value>(m_index, FloatToDouble, m_origin, m_value->child(1));
                     Value* functionAddress = m_insertionSet.insert<ConstPtrValue>(m_index, m_origin, tagCFunction<OperationPtrTag>(Math::fmodDouble));
@@ -178,17 +278,24 @@ private:
                     Value* result = m_insertionSet.insert<Value>(m_index, DoubleToFloat, m_origin, doubleMod);
                     m_value->replaceWithIdentity(result);
                     m_changed = true;
-                } else if constexpr (isARM_THUMB2()) {
+                    break;
+                }
+
+                if constexpr (isARM_THUMB2()) {
                     if (m_value->type() == Int64)
                         replaceWithBinaryCall(Math::i64_rem_s);
                     else
                         replaceWithBinaryCall(Math::i32_rem_s);
-                } else if (isARM64()) {
+                    break;
+                }
+
+                if (isARM64()) {
                     Value* divResult = m_insertionSet.insert<Value>(m_index, chill(Div), m_origin, m_value->child(0), m_value->child(1));
                     Value* multipliedBack = m_insertionSet.insert<Value>(m_index, Mul, m_origin, divResult, m_value->child(1));
                     Value* result = m_insertionSet.insert<Value>(m_index, Sub, m_origin, m_value->child(0), multipliedBack);
                     m_value->replaceWithIdentity(result);
                     m_changed = true;
+                    break;
                 }
                 break;
             }

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -6463,20 +6463,79 @@ void SpeculativeJIT::compileArithMod(Node* node)
 #endif // USE(JSVALUE64)
 
     case DoubleRepUse: {
+#if CPU(ARM64)
         SpeculateDoubleOperand op1(this, node->child1());
         SpeculateDoubleOperand op2(this, node->child2());
-        
+        FPRTemporary scratch(this);
+        FPRTemporary result(this);
+        GPRTemporary temp(this);
+
         FPRReg op1FPR = op1.fpr();
         FPRReg op2FPR = op2.fpr();
-        
-        flushRegisters();
-        
-        FPRResult result(this);
+        FPRReg scratchFPR = scratch.fpr();
+        FPRReg resultFPR = result.fpr();
+        GPRReg tempGPR = temp.gpr();
 
-        callOperationWithoutExceptionCheck(Math::fmodDouble, result.fpr(), op1FPR, op2FPR);
-        
-        doubleResult(result.fpr(), node);
+        flushRegisters();
+
+        JumpList slowCases;
+
+        // If both operands are positive integers that fit in int32,
+        // compute remainder inline.
+        // Use roundTowardZeroInt32Double (frint32z) when available — it checks
+        // integrality and int32 range in a single instruction. Otherwise, fall
+        // back to truncateDoubleToInt32 + convertInt32ToDouble round-trip
+        // (fcvtzs + scvtf).
+
+        auto emitInt32Check = [&](FPRReg inputFPR) {
+            if (supportsRoundFloatToIntegerFloat())
+                roundTowardZeroInt32Double(inputFPR, scratchFPR);
+            else {
+                truncateDoubleToInt32(inputFPR, tempGPR);
+                convertInt32ToDouble(tempGPR, scratchFPR);
+            }
+            return branchDouble(DoubleNotEqualOrUnordered, inputFPR, scratchFPR);
+        };
+
+        // Check left is a positive integer in int32 range.
+        slowCases.append(emitInt32Check(op1FPR));
+        slowCases.append(branchDoubleWithZero(DoubleLessThanOrEqualOrUnordered, op1FPR));
+
+        // Check right is a positive integer in int32 range.
+        slowCases.append(emitInt32Check(op2FPR));
+        slowCases.append(branchDoubleWithZero(DoubleLessThanOrEqualOrUnordered, op2FPR));
+
+        // Compute: remainder = left - trunc(left / right) * right
+        divDouble(op1FPR, op2FPR, resultFPR);
+        roundTowardZeroDouble(resultFPR, resultFPR);
+        mulDouble(resultFPR, op2FPR, resultFPR);
+        subDouble(op1FPR, resultFPR, resultFPR);
+
+        // Validate: remainder >= 0 && remainder < right (catches precision errors)
+        slowCases.append(branchDoubleWithZero(DoubleLessThanAndOrdered, resultFPR));
+        slowCases.append(branchDouble(DoubleGreaterThanOrEqualOrUnordered, resultFPR, op2FPR));
+
+        auto done = jump();
+
+        // Slow path: call fmod for non-int32 or imprecise cases.
+        slowCases.link(this);
+        callOperationWithoutExceptionCheck(Math::fmodDouble, resultFPR, op1FPR, op2FPR);
+
+        done.link(this);
+        doubleResult(resultFPR, node);
         return;
+#else
+        SpeculateDoubleOperand op1(this, node->child1());
+        SpeculateDoubleOperand op2(this, node->child2());
+        FPRReg op1FPR = op1.fpr();
+        FPRReg op2FPR = op2.fpr();
+        flushRegisters();
+        FPRResult result(this);
+        FPRReg resultFPR = result.fpr();
+        callOperationWithoutExceptionCheck(Math::fmodDouble, resultFPR, op1FPR, op2FPR);
+        doubleResult(resultFPR, node);
+        return;
+#endif
     }
 
     default:


### PR DESCRIPTION
#### 899d00c4aa72e7c1f6784b77b35ef39ee2541b1f
<pre>
[JSC] Optimize Double Mod in DFG / FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=309487">https://bugs.webkit.org/show_bug.cgi?id=309487</a>
<a href="https://rdar.apple.com/172067665">rdar://172067665</a>

Reviewed by Justin Michaud.

This patch adds V8&apos;s optimization[1] with a bit preferring Int32.
We use DoubleToInt32 / Int32ToDouble to detect integer since we can use
roundTowardZeroInt32Double in ARM64 if possible.
We check that the both inputs are positive integers, and then we compute
the result with div + mul + sub instead of calling fmod function.

                                             ToT                     Patched

    double-mod-positive-integers       90.2875+-0.2361     ^     31.7667+-0.5875        ^ definitely 2.8422x faster

[1]: <a href="https://chromium-review.googlesource.com/c/v8/v8/+/7594997">https://chromium-review.googlesource.com/c/v8/v8/+/7594997</a>

Test: JSTests/stress/double-mod-fast-path.js

* JSTests/microbenchmarks/double-mod-positive-integers.js: Added.
(doMod):
* JSTests/stress/double-mod-fast-path.js: Added.
(doMod):
(testLargeValues):
* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/308940@main">https://commits.webkit.org/308940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/079ceb39e5bb413c0bbc22cbbc396dd5d7771d3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157612 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6e4d9e9-66dc-4f7a-bdff-98765ddd58ad) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/22091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114807 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/026403de-b61a-46fd-bde1-d7bf1ea653e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151885 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/22091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133667 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/95567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/22091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/5461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140892 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/22091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160094 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9713 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3085 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13110 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/122864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123092 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133382 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22937 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10144 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180353 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/21050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84852 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20782 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->