### PR TITLE
Cell background in collapsed-border table extends into adjacent cells' border space at table edges

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset-expected-mismatch.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<title>CSS Test Reference (mismatch): collapsed border cell background fills full width</title>
+<style>
+th {
+    border: 0px solid red;
+}
+tr.green {
+    background: green;
+}
+td {
+    border: 50px solid red;
+    padding: 6px 12px;
+    text-align: left;
+    vertical-align: top;
+}
+.table {
+    overflow-x: auto;
+    max-width: 810px;
+}
+table {
+    border-collapse: collapse;
+    border: none;
+}
+</style>
+<div class="table-wrapper">
+    <div class="table">
+        <table>
+            <thead>
+                <tr class="green">
+                    <th>Key</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Key</td>
+                    <td>
+                        <p>If you group based on datetime and the filter creates a
+                            time period, potential missing values are automatically
+                            substituted by default values.</p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset-notref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset-notref.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<title>CSS Test Reference (mismatch): collapsed border cell background fills full width</title>
+<style>
+th {
+    border: 0px solid red;
+}
+tr.green {
+    background: green;
+}
+td {
+    border: 50px solid red;
+    padding: 6px 12px;
+    text-align: left;
+    vertical-align: top;
+}
+.table {
+    overflow-x: auto;
+    max-width: 810px;
+}
+table {
+    border-collapse: collapse;
+    border: none;
+}
+</style>
+<div class="table-wrapper">
+    <div class="table">
+        <table>
+            <thead>
+                <tr class="green">
+                    <th>Key</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Key</td>
+                    <td>
+                        <p>If you group based on datetime and the filter creates a
+                            time period, potential missing values are automatically
+                            substituted by default values.</p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<title>CSS Test: collapsed border cell background does not extend into other cells' border space</title>
+<link rel="help" href="https://drafts.csswg.org/css2/tables.html#collapsing-borders">
+<link rel="mismatch" href="collapsed-border-background-inset-notref.html">
+<style>
+th {
+    border: 0px solid red;
+    background: green;
+}
+td {
+    border: 50px solid red;
+    padding: 6px 12px;
+    text-align: left;
+    vertical-align: top;
+}
+.table {
+    overflow-x: auto;
+    max-width: 810px;
+}
+table {
+    border-collapse: collapse;
+    border: none;
+}
+</style>
+<div class="table-wrapper">
+    <div class="table">
+        <table>
+            <thead>
+                <tr>
+                    <th>Key</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>Key</td>
+                    <td>
+                        <p>If you group based on datetime and the filter creates a
+                            time period, potential missing values are automatically
+                            substituted by default values.</p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -1602,6 +1602,50 @@ void RenderTableCell::paintBackgroundsBehindCell(PaintInfo& paintInfo, LayoutPoi
         fillRect.moveBy(backgroundPaintOffset);
     } else
         fillRect = LayoutRect { adjustedPaintOffset, size() };
+
+    // When painting a cell's own background with collapsed borders, inset the
+    // fill rect at the table's outer edges to match this cell's collapsed
+    // border extent. The cell's allocated width includes space for the maximum
+    // collapsed border inner halves across all cells in the same column. If
+    // this cell has narrower borders at the table edge, its background should
+    // not paint into that extra space. Interior column edges are not adjusted
+    // so that cell backgrounds remain continuous across the row.
+    if (backgroundObject == this && tableElt->collapseBorders()) {
+        bool isFirstColumn = !tableElt->colToEffCol(col());
+        bool isLastColumn = tableElt->colToEffCol(col() + colSpan() - 1) == tableElt->numEffCols() - 1;
+
+        LayoutUnit leftInset;
+        LayoutUnit rightInset;
+
+        if (isFirstColumn || isLastColumn) {
+            LayoutUnit cellLeftHalf = isFirstColumn ? borderHalfLeft(false) : 0_lu;
+            LayoutUnit cellRightHalf = isLastColumn ? borderHalfRight(false) : 0_lu;
+            LayoutUnit maxLeftHalf = cellLeftHalf;
+            LayoutUnit maxRightHalf = cellRightHalf;
+
+            for (auto* cell = tableElt->cellAbove(this); cell; cell = tableElt->cellAbove(cell)) {
+                if (isFirstColumn)
+                    maxLeftHalf = std::max(maxLeftHalf, cell->borderHalfLeft(false));
+                if (isLastColumn)
+                    maxRightHalf = std::max(maxRightHalf, cell->borderHalfRight(false));
+            }
+            for (auto* cell = tableElt->cellBelow(this); cell; cell = tableElt->cellBelow(cell)) {
+                if (isFirstColumn)
+                    maxLeftHalf = std::max(maxLeftHalf, cell->borderHalfLeft(false));
+                if (isLastColumn)
+                    maxRightHalf = std::max(maxRightHalf, cell->borderHalfRight(false));
+            }
+
+            leftInset = maxLeftHalf - cellLeftHalf;
+            rightInset = maxRightHalf - cellRightHalf;
+        }
+
+        if (leftInset || rightInset) {
+            fillRect.shiftXEdgeBy(leftInset);
+            fillRect.shiftMaxXEdgeBy(-rightInset);
+        }
+    }
+
     auto compositeOp = document().compositeOperatorForBackgroundColor(color, *this);
 
     BackgroundPainter painter { *this, paintInfo };


### PR DESCRIPTION
#### 1d39fb9b1f02c7ff74d321a06faaa488463b4c37
<pre>
Cell background in collapsed-border table extends into adjacent cells&apos; border space at table edges
<a href="https://bugs.webkit.org/show_bug.cgi?id=309488">https://bugs.webkit.org/show_bug.cgi?id=309488</a>
<a href="https://rdar.apple.com/172068907">rdar://172068907</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium

When a table uses border-collapse and cells in the same column have different
border widths, the column width includes space for the maximum collapsed border
inner halves. Cells with narrower borders paint their background across the full
allocated width, extending into space that belongs to other cells&apos; borders.

Fix by insetting the cell&apos;s background fill rect at the table&apos;s outer edges
(first and last columns) to account for the difference between this cell&apos;s
border half and the maximum border half in that column. Interior column edges
are left unadjusted so backgrounds remain continuous across the row.

* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::paintBackgroundsBehindCell):

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset-expected-mismatch.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset-notref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset.html: Added.

Canonical link: <a href="https://commits.webkit.org/308969@main">https://commits.webkit.org/308969@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f025fba88f9fbfcee84f489f15d345ccc0f15b98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157730 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/741bc058-e89c-437c-a3eb-0a8ba11afd5e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150915 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114900 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd76919c-b5fd-4bdf-82fc-5956e83ce2ed) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17088 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95659 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e1c2248-b463-4f0d-8728-3d08bdf304b5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16187 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14051 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5580 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160212 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3202 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13207 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122954 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21557 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18077 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123181 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/33486 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21565 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133478 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77753 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18438 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10237 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21167 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84969 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20899 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21047 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20955 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->