### PR TITLE
Implement eventSender.asyncKeyDown() and adopt it in testdriver-vendor.js

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y-dialog-disconnected-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/user-activation/y-dialog-disconnected-expected.txt
@@ -1,4 +1,4 @@
 b0
 
-FAIL Disconnect dialog with close request assert_false: d1 should now be closed. expected false got true
+PASS Disconnect dialog with close request
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/chrome-object-tab-focus-bug-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/chrome-object-tab-focus-bug-expected.txt
@@ -1,4 +1,4 @@
-Pressing TAB twice should focus/highlight end checkbox
+Pressing TAB twice should focus end text box
 
 start  end
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/chrome-object-tab-focus-bug.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/chrome-object-tab-focus-bug.html
@@ -9,11 +9,11 @@
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 
-<p>Pressing TAB twice should focus/highlight end checkbox</p>
+<p>Pressing TAB twice should focus end text box</p>
 
 <input type="checkbox" id="start">start</a>
 <object type='text/html' data='data:text/html,' width='16' height='16'></object>
-<input type="checkbox" id="end" >end</a>
+<input id="end">end</a>
 
 <script>
 
@@ -24,20 +24,15 @@ let object = document.querySelector("object");
 let end = document.querySelector("#end");
 let tab = "\uE004";
 
-t.step( _ => {
-  document.querySelector("#start").focus();
+addEventListener("load", t.step_func(_ => {
+  start.focus();
   assert_equals(document.activeElement, start, "start got focus");
-  test_driver.send_keys(document.activeElement, tab).then( _ => {
-    t.step( _ => {
-      assert_equals(document.activeElement, object, "object got focus");
-      test_driver.send_keys(document.activeElement, tab).then( _ => {
-        t.step( _ => {
-          assert_equals(document.activeElement, end, "end got focus");
-          t.done();
-        });
-      });
-    });
-  });
-});
+  test_driver.send_keys(document.activeElement, tab).then(t.step_func(_ => {
+    assert_equals(document.activeElement, object, "object got focus");
+    test_driver.send_keys(document.activeElement, tab).then(t.step_func_done(_ => {
+      assert_equals(document.activeElement, end, "end got focus");
+    }));
+  }));
+}));
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-popover-closedby-simple-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-popover-closedby-simple-expected.txt
@@ -1,9 +1,9 @@
 Unrelated
 
-FAIL Dialog closedby=any parent, popover child assert_equals: dialog should close on second ESC, if closedby is not none expected false but got true
-FAIL Dialog closedby=closerequest parent, popover child assert_true: clicking on popover should always leave everything open expected true got false
-FAIL Dialog closedby=none parent, popover child assert_equals: dialog should close on second ESC, if closedby is not none expected false but got true
-FAIL Popover parent, dialog closedby=any child assert_equals: dialog should close after first ESC, if closedby!=none expected false but got true
-FAIL Popover parent, dialog closedby=closerequest child assert_true: clicking on dialog should always leave everything open expected true got false
-FAIL Popover parent, dialog closedby=none child assert_equals: dialog should close after first ESC, if closedby!=none expected false but got true
+FAIL Dialog closedby=any parent, popover child assert_true: dialog should stay open for first ESC expected true got false
+FAIL Dialog closedby=closerequest parent, popover child assert_true: dialog should stay open for first ESC expected true got false
+FAIL Dialog closedby=none parent, popover child assert_true: dialog should stay open for first ESC expected true got false
+FAIL Popover parent, dialog closedby=any child assert_true: popover should stay open for first ESC expected true got false
+FAIL Popover parent, dialog closedby=closerequest child assert_true: popover should stay open for first ESC expected true got false
+FAIL Popover parent, dialog closedby=none child assert_true: popover should stay open for first ESC expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/non-modal-canceling-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/non-modal-canceling-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Non-modal dialogs should not be cancelable via ESC assert_false: Escape does close a modal dialog expected false got true
+PASS Non-modal dialogs should not be cancelable via ESC
 

--- a/LayoutTests/imported/w3c/web-platform-tests/uievents/textInput/basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/uievents/textInput/basic-expected.txt
@@ -1,10 +1,9 @@
 Type "a" into each text field below.
 
 
+a
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT textInput: basic, <input> Test timed out
-NOTRUN textInput: basic, <textarea>
-NOTRUN textInput: basic, <div contenteditable="true">
+FAIL textInput: basic, <input> assert_equals: expected 1 but got 0
+FAIL textInput: basic, <textarea> assert_equals: expected 1 but got 0
+FAIL textInput: basic, <div contenteditable="true"> assert_equals: expected 1 but got 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/uievents/textInput/delete-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/uievents/textInput/delete-expected.txt
@@ -1,9 +1,9 @@
 Press Delete (Fn+Backspace for macOS) in each text field below.
 
 
-abc
+ac
 
-FAIL textInput: delete, <input> assert_equals: expected "ac" but got "abc"
-FAIL textInput: delete, <textarea> assert_equals: expected "ac" but got "abc"
-FAIL textInput: delete, <div contenteditable="true"> assert_equals: expected "ac" but got "abc"
+PASS textInput: delete, <input>
+PASS textInput: delete, <textarea>
+PASS textInput: delete, <div contenteditable="true">
 

--- a/LayoutTests/imported/w3c/web-platform-tests/uievents/textInput/delete-selection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/uievents/textInput/delete-selection-expected.txt
@@ -1,9 +1,9 @@
 Press Delete (Fn+Backspace for macOS) in each text field below.
 
 
-abc
+ac
 
-FAIL textInput: delete selection, <input> assert_equals: expected "ac" but got "abc"
-FAIL textInput: delete selection, <textarea> assert_equals: expected "ac" but got "abc"
-FAIL textInput: delete selection, <div contenteditable="true"> assert_equals: expected "ac" but got "abc"
+PASS textInput: delete selection, <input>
+PASS textInput: delete selection, <textarea>
+PASS textInput: delete selection, <div contenteditable="true">
 

--- a/LayoutTests/imported/w3c/web-platform-tests/uievents/textInput/enter-textarea-contenteditable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/uievents/textInput/enter-textarea-contenteditable-expected.txt
@@ -2,8 +2,8 @@ Press Enter in each text field below.
 
 
 
-Harness Error (TIMEOUT), message = null
 
-TIMEOUT textInput: Enter key for textarea and contenteditable, <textarea> Test timed out
-NOTRUN textInput: Enter key for textarea and contenteditable, <div contenteditable="true">
+
+FAIL textInput: Enter key for textarea and contenteditable, <textarea> assert_equals: expected 1 but got 0
+FAIL textInput: Enter key for textarea and contenteditable, <div contenteditable="true"> assert_equals: expected 1 but got 0
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/interaction/focus/chrome-object-tab-focus-bug-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/interaction/focus/chrome-object-tab-focus-bug-expected.txt
@@ -1,6 +1,0 @@
-Pressing TAB twice should focus/highlight end checkbox
-
-start  end
-
-FAIL focus advances with tab key thorough object element assert_equals: object got focus expected Element node <object type="text/html" data="data:text/html," width="16... but got Element node <input type="checkbox" id="end"></input>
-

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -5803,9 +5803,11 @@ imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/click-orde
 imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/mousemove-across.html [ Skip ]
 imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/mousemove-between.html [ Skip ]
 imported/w3c/web-platform-tests/uievents/order-of-events/mouse-events/mouseover-out.html [ Skip ]
+imported/w3c/web-platform-tests/uievents/textInput/basic.html [ Skip ]
 imported/w3c/web-platform-tests/uievents/textInput/delete-selection.html [ Skip ]
 imported/w3c/web-platform-tests/uievents/textInput/delete.html [ Skip ]
 imported/w3c/web-platform-tests/uievents/textInput/enter-input.html [ Skip ]
+imported/w3c/web-platform-tests/uievents/textInput/enter-textarea-contenteditable.html [ Skip ]
 
 imported/w3c/web-platform-tests/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-events-onerror.html [ Pass Failure ]
 imported/w3c/web-platform-tests/uievents/click/click_events_on_input.html [ Pass Failure ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/interaction/focus/chrome-object-tab-focus-bug-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/interaction/focus/chrome-object-tab-focus-bug-expected.txt
@@ -1,4 +1,4 @@
-Pressing TAB twice should focus/highlight end checkbox
+Pressing TAB twice should focus end text box
 
 start  end
 

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/html/interaction/focus/chrome-object-tab-focus-bug-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/html/interaction/focus/chrome-object-tab-focus-bug-expected.txt
@@ -1,6 +1,0 @@
-Pressing TAB twice should focus/highlight end checkbox
-
-start  end
-
-FAIL focus advances with tab key thorough object element assert_equals: object got focus expected Element node <object type="text/html" data="data:text/html," width="16... but got Element node <body><p>Pressing TAB twice should focus/highlight end ch...
-

--- a/LayoutTests/resources/testdriver-vendor.js
+++ b/LayoutTests/resources/testdriver-vendor.js
@@ -364,7 +364,7 @@ window.test_driver_internal.send_keys = async function(element, keys)
     }
 
     for (const key of keyList)
-        eventSender.keyDown(key, modifiers);
+        await eventSender.asyncKeyDown(key, modifiers);
 }
 
 /**

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3535,3 +3535,12 @@ void WKPageDoAfterProcessingAllPendingMouseEvents(WKPageRef page, void* context,
         completionHandler(context);
     });
 }
+
+#if !PLATFORM(COCOA)
+void WKPageDoAfterProcessingAllPendingKeyEvents(WKPageRef page, void* context, WKPageDoAfterProcessingAllPendingKeyEventsFunction completionHandler)
+{
+    protect(toImpl(page))->doAfterProcessingAllPendingKeyEvents([context, completionHandler] {
+        completionHandler(context);
+    });
+}
+#endif

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -23,8 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef WKPagePrivate_h
-#define WKPagePrivate_h
+#pragma once
 
 #include <WebKit/WKBase.h>
 #include <WebKit/WKPage.h>
@@ -240,8 +239,11 @@ WK_EXPORT void WKPageFindStringForTesting(WKPageRef page, void* context, WKStrin
 typedef void (*WKPageDoAfterProcessingAllPendingMouseEventsFunction)(void* functionContext);
 WK_EXPORT void WKPageDoAfterProcessingAllPendingMouseEvents(WKPageRef page, void* context, WKPageDoAfterProcessingAllPendingMouseEventsFunction function);
 
+#if !defined(__APPLE__)
+typedef void (*WKPageDoAfterProcessingAllPendingKeyEventsFunction)(void* functionContext);
+WK_EXPORT void WKPageDoAfterProcessingAllPendingKeyEvents(WKPageRef page, void* context, WKPageDoAfterProcessingAllPendingKeyEventsFunction function);
+#endif
+
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* WKPagePrivate_h */

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -129,6 +129,7 @@ typedef NSVisualEffectView _WKPlatformVisualEffectView;
 - (void)_setThrottleStateForTesting:(int)type;
 
 - (void)_doAfterProcessingAllPendingMouseEvents:(dispatch_block_t)action;
+- (void)_doAfterProcessingAllPendingKeyEvents:(dispatch_block_t)action;
 
 + (void)_setApplicationBundleIdentifier:(NSString *)bundleIdentifier;
 + (void)_clearApplicationBundleIdentifierTestingOverride;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -524,6 +524,13 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     });
 }
 
+- (void)_doAfterProcessingAllPendingKeyEvents:(dispatch_block_t)action
+{
+    _page->doAfterProcessingAllPendingKeyEvents([action = makeBlockPtr(action)] {
+        action();
+    });
+}
+
 + (void)_setApplicationBundleIdentifier:(NSString *)bundleIdentifier
 {
     setApplicationBundleIdentifierOverride(String(bundleIdentifier));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4295,6 +4295,29 @@ void WebPageProxy::flushPendingMouseEventCallbacks()
     internals().callbackHandlersAfterProcessingPendingMouseEvents.clear();
 }
 
+void WebPageProxy::doAfterProcessingAllPendingKeyEvents(WTF::Function<void ()>&& action)
+{
+    if (!isProcessingKeyboardEvents()) {
+        action();
+        return;
+    }
+
+    internals().callbackHandlersAfterProcessingPendingKeyEvents.append(WTF::move(action));
+}
+
+void WebPageProxy::didFinishProcessingAllPendingKeyEvents()
+{
+    flushPendingKeyEventCallbacks();
+}
+
+void WebPageProxy::flushPendingKeyEventCallbacks()
+{
+    for (auto& callback : internals().callbackHandlersAfterProcessingPendingKeyEvents)
+        callback();
+
+    internals().callbackHandlersAfterProcessingPendingKeyEvents.clear();
+}
+
 #if PLATFORM(IOS_FAMILY)
 void WebPageProxy::dispatchWheelEventWithoutScrolling(const WebWheelEvent& event, CompletionHandler<void(bool)>&& completionHandler)
 {
@@ -11812,6 +11835,7 @@ void WebPageProxy::keyEventHandlingCompleted(std::optional<WebEventType> eventTy
     if (!canProcessMoreKeyEvents) {
         if (RefPtr automationSession = configuration().processPool().automationSession())
             automationSession->keyboardEventsFlushedForPage(*this);
+        didFinishProcessingAllPendingKeyEvents();
     }
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1464,6 +1464,10 @@ public:
     void didFinishProcessingAllPendingMouseEvents();
     void flushPendingMouseEventCallbacks();
 
+    void doAfterProcessingAllPendingKeyEvents(Function<void()>&&);
+    void didFinishProcessingAllPendingKeyEvents();
+    void flushPendingKeyEventCallbacks();
+
     bool NODELETE isProcessingWheelEvents() const;
     void handleNativeWheelEvent(const NativeWebWheelEvent&);
     void continueWheelEventHandling(const WebWheelEvent&, const WebCore::WheelEventHandlingResult&, std::optional<bool> willStartSwipe);

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -265,6 +265,7 @@ public:
     WebCore::LayoutSize baseLayoutViewportSize;
     std::optional<WebCore::FontAttributes> cachedFontAttributesAtSelectionStart;
     Vector<Function<void()>> callbackHandlersAfterProcessingPendingMouseEvents;
+    Vector<Function<void()>> callbackHandlersAfterProcessingPendingKeyEvents;
     WebCore::FloatSize defaultUnobscuredSize;
     EditorState editorState;
     WebCore::IntSize fixedLayoutSize;

--- a/Tools/WebKitTestRunner/EventSenderProxy.h
+++ b/Tools/WebKitTestRunner/EventSenderProxy.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <wtf/CompletionHandler.h>
 #include <wtf/Deque.h>
 #include <wtf/HashFunctions.h>
 #include <wtf/HashMap.h>
@@ -92,7 +93,7 @@ public:
 
     void leapForward(int milliseconds);
 
-    void keyDown(WKStringRef key, WKEventModifiers, unsigned location);
+    void keyDown(WKStringRef key, WKEventModifiers, unsigned location, CompletionHandler<void()>&& = nullptr);
     void rawKeyDown(WKStringRef key, WKEventModifiers, unsigned location);
     void rawKeyUp(WKStringRef key, WKEventModifiers, unsigned location);
 

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/EventSenderProxyIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/EventSenderProxyIOS.mm
@@ -29,6 +29,7 @@
 #import "PlatformWebView.h"
 #import "StringFunctions.h"
 #import "TestController.h"
+#import <wtf/CompletionHandler.h>
 #import <wtf/RetainPtr.h>
 #import <WebKit/WKString.h>
 
@@ -75,8 +76,10 @@ void EventSenderProxy::leapForward(int milliseconds)
     m_time += milliseconds / 1000.0;
 }
 
-void EventSenderProxy::keyDown(WKStringRef key, WKEventModifiers modifiers, unsigned keyLocation)
+void EventSenderProxy::keyDown(WKStringRef key, WKEventModifiers modifiers, unsigned keyLocation, CompletionHandler<void()>&& completionHandler)
 {
+    if (completionHandler)
+        completionHandler();
 }
 
 void EventSenderProxy::rawKeyDown(WKStringRef key, WKEventModifiers modifiers, unsigned keyLocation)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1939,6 +1939,9 @@ if (window.eventSender) {
         await post(['AsyncMouseMoveTo', x, y, pointerType]);
         callback?.();
     };
+    eventSender.asyncKeyDown = async (key, modifiers) => { // NOLINT
+        await post(['AsyncKeyDown', key, modifiers]);
+    };
 }
 )eventSenderJS";
 
@@ -2764,6 +2767,14 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         m_eventSenderProxy->mouseUp(button, parseModifierArray(array), pointerType);
         m_eventSenderProxy->waitForPendingMouseEvents();
         completionHandler(nullptr);
+        return;
+    }
+
+    if (WKStringIsEqualToUTF8CString(command, "AsyncKeyDown")) {
+        const auto key = stringValue(argument);
+        const auto array = arrayValue(argument2);
+        m_eventSenderProxy->keyDown(key, parseModifierArray(array), 0,
+            [completionHandler = WTF::move(completionHandler)] mutable { completionHandler(nullptr); });
         return;
     }
 

--- a/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
@@ -41,12 +41,26 @@
 #include <gdk/gdk.h>
 #include <gdk/gdkkeysyms.h>
 #include <webkit/WebKitWebViewBaseInternal.h>
+#include <wtf/CompletionHandler.h>
+#include <wtf/Seconds.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/UniqueArray.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WTR {
+
+static void runPendingEventsCallback(void* userData)
+{
+    *static_cast<bool*>(userData) = true;
+}
+
+static void waitForPendingKeyEvents(TestController* testController)
+{
+    bool done = false;
+    WKPageDoAfterProcessingAllPendingKeyEvents(testController->mainWebView()->page(), &done, runPendingEventsCallback);
+    testController->runUntil(done, 100_ms);
+}
 
 // WebCore and layout tests assume this value
 static const float pixelsPerScrollTick = 40;
@@ -248,9 +262,13 @@ static inline void processKeyEvent(WebKitWebViewBase* webViewBase, WKStringRef k
     webkitWebViewBaseSynthesizeKeyEvent(webViewBase, type, gdkKeySym, modifiers, ShouldTranslateKeyboardState::No);
 }
 
-void EventSenderProxy::keyDown(WKStringRef keyRef, WKEventModifiers wkModifiers, unsigned location)
+void EventSenderProxy::keyDown(WKStringRef keyRef, WKEventModifiers wkModifiers, unsigned location, CompletionHandler<void()>&& completionHandler)
 {
     processKeyEvent(toWebKitGLibAPI(m_testController->mainWebView()->platformView()), keyRef, wkModifiers, location, KeyEventType::Insert);
+    if (completionHandler) {
+        waitForPendingKeyEvents(m_testController);
+        completionHandler();
+    }
 }
 
 void EventSenderProxy::rawKeyDown(WKStringRef key, WKEventModifiers wkModifiers, unsigned keyLocation)

--- a/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
@@ -30,7 +30,9 @@
 #include "TestController.h"
 #include <WebCore/NotImplemented.h>
 #include <WebKit/WKPagePrivate.h>
+#include <wtf/CompletionHandler.h>
 #include <wtf/MonotonicTime.h>
+#include <wtf/Seconds.h>
 
 #if USE(LIBWPE)
 #include "EventSenderProxyClientLibWPE.h"
@@ -41,6 +43,18 @@
 #endif
 
 namespace WTR {
+
+static void runPendingEventsCallback(void* userData)
+{
+    *static_cast<bool*>(userData) = true;
+}
+
+static void waitForPendingKeyEvents(TestController* testController)
+{
+    bool done = false;
+    WKPageDoAfterProcessingAllPendingKeyEvents(testController->mainWebView()->page(), &done, runPendingEventsCallback);
+    testController->runUntil(done, 100_ms);
+}
 
 EventSenderProxy::EventSenderProxy(TestController* testController)
     : m_testController(testController)
@@ -122,9 +136,13 @@ void EventSenderProxy::leapForward(int milliseconds)
     m_time += milliseconds / 1000.0;
 }
 
-void EventSenderProxy::keyDown(WKStringRef keyRef, WKEventModifiers wkModifiers, unsigned location)
+void EventSenderProxy::keyDown(WKStringRef keyRef, WKEventModifiers wkModifiers, unsigned location, CompletionHandler<void()>&& completionHandler)
 {
     m_client->keyDown(keyRef, m_time, wkModifiers, location);
+    if (completionHandler) {
+        waitForPendingKeyEvents(m_testController);
+        completionHandler();
+    }
 }
 
 void EventSenderProxy::rawKeyDown(WKStringRef keyRef, WKEventModifiers wkModifiers, unsigned location)

--- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
+++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
@@ -42,8 +42,10 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <pal/spi/cocoa/IOKitSPI.h>
+#import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/darwin/DispatchExtras.h>
 
 @interface NSApplication (Details)
 - (void)_setCurrentEvent:(NSEvent *)event;
@@ -655,11 +657,11 @@ void EventSenderProxy::leapForward(int milliseconds)
     m_time += milliseconds / 1000.0;
 }
 
-void EventSenderProxy::keyDown(WKStringRef key, WKEventModifiers modifiers, unsigned keyLocation)
+void EventSenderProxy::keyDown(WKStringRef key, WKEventModifiers modifiers, unsigned keyLocation, CompletionHandler<void()>&& completionHandler)
 {
-    RetainPtr<ModifierKeys> modifierKeys = [ModifierKeys modifierKeysWithKey:toWTFString(key).createNSString().get() modifiers:buildModifierFlags(modifiers) keyLocation:keyLocation];
+    RetainPtr modifierKeys = [ModifierKeys modifierKeysWithKey:toWTFString(key).createNSString().get() modifiers:buildModifierFlags(modifiers) keyLocation:keyLocation];
 
-    NSEvent *event = [NSEvent keyEventWithType:NSEventTypeKeyDown
+    RetainPtr keyDownEvent = [NSEvent keyEventWithType:NSEventTypeKeyDown
         location:NSMakePoint(5, 5)
         modifierFlags:modifierKeys->modifierFlags
         timestamp:absoluteTimeForEventTime(currentEventTime())
@@ -670,24 +672,44 @@ void EventSenderProxy::keyDown(WKStringRef key, WKEventModifiers modifiers, unsi
         isARepeat:NO
         keyCode:modifierKeys->keyCode];
 
-    [NSApp _setCurrentEvent:event];
-    [[m_testController->mainWebView()->platformWindow() firstResponder] keyDown:event];
-    [NSApp _setCurrentEvent:nil];
+    RetainPtr keyUpEvent = [NSEvent keyEventWithType:NSEventTypeKeyUp
+        location:NSMakePoint(5, 5)
+        modifierFlags:modifierKeys->modifierFlags
+        timestamp:absoluteTimeForEventTime(currentEventTime())
+        windowNumber:[m_testController->mainWebView()->platformWindow() windowNumber]
+        context:[NSGraphicsContext currentContext]
+        characters:modifierKeys->eventCharacter.get()
+        charactersIgnoringModifiers:modifierKeys->charactersIgnoringModifiers.get()
+        isARepeat:NO
+        keyCode:modifierKeys->keyCode];
 
-    event = [NSEvent keyEventWithType:NSEventTypeKeyUp
-                        location:NSMakePoint(5, 5)
-                        modifierFlags:modifierKeys->modifierFlags
-                        timestamp:absoluteTimeForEventTime(currentEventTime())
-                        windowNumber:[m_testController->mainWebView()->platformWindow() windowNumber]
-                        context:[NSGraphicsContext currentContext]
-                        characters:modifierKeys->eventCharacter.get()
-                        charactersIgnoringModifiers:modifierKeys->charactersIgnoringModifiers.get()
-                        isARepeat:NO
-                        keyCode:modifierKeys->keyCode];
+    RetainPtr firstResponder = [m_testController->mainWebView()->platformWindow() firstResponder];
 
-    [NSApp _setCurrentEvent:event];
-    [[m_testController->mainWebView()->platformWindow() firstResponder] keyUp:event];
-    [NSApp _setCurrentEvent:nil];
+    auto dispatchKeyEvents = [keyDownEvent, keyUpEvent, firstResponder] {
+        [NSApp _setCurrentEvent:keyDownEvent];
+        [firstResponder keyDown:keyDownEvent];
+        [NSApp _setCurrentEvent:nil];
+
+        [NSApp _setCurrentEvent:keyUpEvent];
+        [firstResponder keyUp:keyUpEvent];
+        [NSApp _setCurrentEvent:nil];
+    };
+
+    if (!completionHandler) {
+        dispatchKeyEvents();
+        return;
+    }
+
+    RetainPtr webView = m_testController->mainWebView()->platformView();
+
+    dispatch_async(mainDispatchQueueSingleton(), makeBlockPtr([dispatchKeyEvents = WTF::move(dispatchKeyEvents), webView, completionHandler = WTF::move(completionHandler)] mutable {
+        dispatchKeyEvents();
+
+        [webView _doAfterProcessingAllPendingKeyEvents:makeBlockPtr([completionHandler = WTF::move(completionHandler)] mutable {
+            if (completionHandler)
+                completionHandler();
+        }).get()];
+    }).get());
 }
 
 void EventSenderProxy::rawKeyDown(WKStringRef key, WKEventModifiers modifiers, unsigned keyLocation)

--- a/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
+++ b/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
@@ -31,8 +31,22 @@
 #include "TestController.h"
 #include <WebCore/NotImplemented.h>
 #include <WebKit/WKPagePrivate.h>
+#include <wtf/CompletionHandler.h>
+#include <wtf/Seconds.h>
 
 namespace WTR {
+
+static void runPendingEventsCallback(void* userData)
+{
+    *static_cast<bool*>(userData) = true;
+}
+
+static void waitForPendingKeyEvents(TestController* testController)
+{
+    bool done = false;
+    WKPageDoAfterProcessingAllPendingKeyEvents(testController->mainWebView()->page(), &done, runPendingEventsCallback);
+    testController->runUntil(done, 100_ms);
+}
 
 LRESULT EventSenderProxy::dispatchMessage(UINT message, WPARAM wParam, LPARAM lParam)
 {
@@ -198,7 +212,7 @@ static void pumpMessageQueue()
     }
 }
 
-void EventSenderProxy::keyDown(WKStringRef keyRef, WKEventModifiers wkModifiers, unsigned location)
+void EventSenderProxy::keyDown(WKStringRef keyRef, WKEventModifiers wkModifiers, unsigned location, CompletionHandler<void()>&& completionHandler)
 {
     int virtualKeyCode = 0;
     int charCode = 0;
@@ -312,6 +326,10 @@ void EventSenderProxy::keyDown(WKStringRef keyRef, WKEventModifiers wkModifiers,
 
     if (wkModifiers || needsShiftKeyModifier)
         SetKeyboardState(keyState);
+    if (completionHandler) {
+        waitForPendingKeyEvents(m_testController);
+        completionHandler();
+    }
 }
 
 void EventSenderProxy::rawKeyDown(WKStringRef key, WKEventModifiers modifiers, unsigned keyLocation)


### PR DESCRIPTION
#### 0ee94fc199f70a4bf8921781f5d45579c7809306
<pre>
Implement eventSender.asyncKeyDown() and adopt it in testdriver-vendor.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=309489">https://bugs.webkit.org/show_bug.cgi?id=309489</a>

Reviewed by Wenson Hsieh.

In bug 308884 we want to fix the test implementation PopUpMenu on macOS
and to do that properly we need event dispatch to be (truly)
asynchronous, including for keyDown as that can be used to open
&lt;select&gt;. To keep the number of changes small and make test rebasing
more easily attributable we introduce this as its own change.

A side benefit of using asynchronous dispatch here and waiting for the
website event listeners to be fully processed is that it is more
closely representative of end user behavior. As such the test
progressions are representative of how WebKit already behaves.

Upstream web-platform-tests change to remove flakiness and
platform-specificness:

    <a href="https://github.com/web-platform-tests/wpt/pull/58384">https://github.com/web-platform-tests/wpt/pull/58384</a>

Canonical link: <a href="https://commits.webkit.org/308970@main">https://commits.webkit.org/308970@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c9372edbbaa6635a0712ce49e15226b6c831574

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149051 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157739 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3304c59-c9cf-4b82-b400-f40ce2897ec2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150924 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114907 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c4ddf0da-270f-436c-8fbd-7fbf5939fbf8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133772 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95667 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e189aef5-519f-41b5-9804-e62149bc40fa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16194 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14061 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5589 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125800 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160221 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3211 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13219 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122960 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21566 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123187 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21574 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133490 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77762 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22949 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18448 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10249 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21176 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84978 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20908 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21056 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20964 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->