### PR TITLE
[JSC] Micro-optimize triggerPromiseReactions

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -15642,7 +15642,7 @@ void SpeculativeJIT::compileCreatePromise(Node* node)
     else
         emitAllocateJSObjectWithKnownSize<JSPromise>(resultGPR, structureGPR, butterfly, scratch1GPR, scratch2GPR, slowCases, sizeof(JSPromise), SlowAllocationResult::UndefinedBehavior);
     storeTrustedValue(jsNumber(static_cast<int32_t>(JSPromise::Status::Pending)), Address(resultGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(static_cast<unsigned>(JSPromise::Field::Flags))));
-    storeTrustedValue(jsUndefined(), Address(resultGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(static_cast<unsigned>(JSPromise::Field::ReactionsOrResult))));
+    storeTrustedValue(JSValue(), Address(resultGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(static_cast<unsigned>(JSPromise::Field::ReactionsOrResult))));
     mutatorFence(vm());
 
     addSlowPathGenerator(slowPathCall(slowCases, this, node->isInternalPromise() ? operationCreateInternalPromise : operationCreatePromise, resultGPR, LinkableConstant::globalObject(*this, node), calleeGPR));

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -10007,7 +10007,7 @@ IGNORE_CLANG_WARNINGS_END
         else
             promise = allocateObject<JSPromise>(m_out.phi(pointerType(), promiseStructure, derivedStructure), m_out.intPtrZero, slowCase);
         m_out.store64(m_out.constInt64(JSValue::encode(jsNumber(static_cast<int32_t>(JSPromise::Status::Pending)))), promise, m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSPromise::Field::Flags)]);
-        m_out.store64(m_out.constInt64(JSValue::encode(jsUndefined())), promise, m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSPromise::Field::ReactionsOrResult)]);
+        m_out.store64(m_out.constInt64(JSValue::encode(JSValue())), promise, m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSPromise::Field::ReactionsOrResult)]);
         mutatorFence();
         ValueFromBlock fastResult = m_out.anchor(promise);
         m_out.jump(continuation);

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -467,8 +467,10 @@ void Interpreter::getAsyncStackTrace(JSCell* owner, Vector<StackFrame>& results,
     auto getContextValueFromPromise = [&](JSPromise* promise) -> JSValue {
         if (promise && promise->status() == JSPromise::Status::Pending) {
             JSValue reactionsValue = promise->internalField(JSPromise::Field::ReactionsOrResult).get();
-            if (auto* reaction = jsDynamicCast<JSPromiseReaction*>(reactionsValue))
-                return reaction->context();
+            if (reactionsValue) {
+                if (auto* reaction = jsDynamicCast<JSPromiseReaction*>(reactionsValue))
+                    return reaction->context();
+            }
         }
         return JSValue();
     };

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -811,10 +811,11 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         if (!promiseSpeciesWatchpointIsValid(vm, promise)) [[unlikely]]
             RELEASE_AND_RETURN(scope, promiseResolveThenableJobWithInternalMicrotaskFastSlow(globalObject, promise, task, context));
 
+        JSValue reactionsOrResult = promise->reactionsOrResult();
         switch (promise->status()) {
         case JSPromise::Status::Pending: {
             JSValue encodedTask = jsNumber(static_cast<int32_t>(task));
-            auto* reaction = JSPromiseReaction::create(vm, jsUndefined(), encodedTask, encodedTask, context, jsDynamicCast<JSPromiseReaction*>(promise->reactionsOrResult()));
+            auto* reaction = JSPromiseReaction::create(vm, jsUndefined(), encodedTask, encodedTask, context, reactionsOrResult ? jsCast<JSPromiseReaction*>(reactionsOrResult) : nullptr);
             promise->setReactionsOrResult(vm, reaction);
             promise->markAsHandled();
             break;
@@ -822,12 +823,12 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         case JSPromise::Status::Rejected: {
             if (!promise->isHandled())
                 globalObject->globalObjectMethodTable()->promiseRejectionTracker(globalObject, promise, JSPromiseRejectionOperation::Handle);
-            JSPromise::rejectWithInternalMicrotask(vm, globalObject, promise->reactionsOrResult(), task, context);
+            JSPromise::rejectWithInternalMicrotask(vm, globalObject, reactionsOrResult, task, context);
             promise->markAsHandled();
             break;
         }
         case JSPromise::Status::Fulfilled: {
-            JSPromise::fulfillWithInternalMicrotask(vm, globalObject, promise->reactionsOrResult(), task, context);
+            JSPromise::fulfillWithInternalMicrotask(vm, globalObject, reactionsOrResult, task, context);
             break;
         }
         }

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -255,7 +255,7 @@ void JSPromise::performPromiseThen(VM& vm, JSGlobalObject* globalObject, JSValue
     JSValue reactionsOrResult = this->reactionsOrResult();
     switch (status()) {
     case JSPromise::Status::Pending: {
-        auto* reaction = JSPromiseReaction::create(vm, promiseOrCapability, onFulfilled, onRejected, jsUndefined(), jsDynamicCast<JSPromiseReaction*>(reactionsOrResult));
+        auto* reaction = JSPromiseReaction::create(vm, promiseOrCapability, onFulfilled, onRejected, jsUndefined(), reactionsOrResult ? jsCast<JSPromiseReaction*>(reactionsOrResult) : nullptr);
         setReactionsOrResult(vm, reaction);
         markAsHandled();
         break;
@@ -280,7 +280,7 @@ void JSPromise::performPromiseThenWithInternalMicrotask(VM& vm, JSGlobalObject* 
     switch (status()) {
     case JSPromise::Status::Pending: {
         JSValue encodedTask = jsNumber(static_cast<int32_t>(task));
-        auto* reaction = JSPromiseReaction::create(vm, promise, encodedTask, encodedTask, context, jsDynamicCast<JSPromiseReaction*>(reactionsOrResult));
+        auto* reaction = JSPromiseReaction::create(vm, promise, encodedTask, encodedTask, context, reactionsOrResult ? jsCast<JSPromiseReaction*>(reactionsOrResult) : nullptr);
         setReactionsOrResult(vm, reaction);
         markAsHandled();
         break;
@@ -324,7 +324,7 @@ void JSPromise::rejectPromise(VM& vm, JSGlobalObject* globalObject, JSValue argu
 {
     ASSERT(status() == Status::Pending);
     int32_t flags = this->flags();
-    auto* reactions = jsDynamicCast<JSPromiseReaction*>(this->reactionsOrResult());
+    JSValue reactions = this->reactionsOrResult();
     internalField(Field::Flags).setWithoutWriteBarrier(jsNumber(static_cast<int32_t>(flags | static_cast<uint32_t>(Status::Rejected))));
     internalField(Field::ReactionsOrResult).set(vm, this, argument);
 
@@ -333,19 +333,20 @@ void JSPromise::rejectPromise(VM& vm, JSGlobalObject* globalObject, JSValue argu
 
     if (!reactions)
         return;
-    triggerPromiseReactions(vm, globalObject, Status::Rejected, reactions, argument);
+    triggerPromiseReactions(vm, globalObject, Status::Rejected, jsCast<JSPromiseReaction*>(reactions), argument);
 }
 
 void JSPromise::fulfillPromise(VM& vm, JSGlobalObject* globalObject, JSValue argument)
 {
     ASSERT(status() == Status::Pending);
     int32_t flags = this->flags();
-    auto* reactions = jsDynamicCast<JSPromiseReaction*>(this->reactionsOrResult());
+    JSValue reactions = this->reactionsOrResult();
     internalField(Field::Flags).setWithoutWriteBarrier(jsNumber(static_cast<int32_t>(flags | static_cast<uint32_t>(Status::Fulfilled))));
     internalField(Field::ReactionsOrResult).set(vm, this, argument);
+
     if (!reactions)
         return;
-    triggerPromiseReactions(vm, globalObject, Status::Fulfilled, reactions, argument);
+    triggerPromiseReactions(vm, globalObject, Status::Fulfilled, jsCast<JSPromiseReaction*>(reactions), argument);
 }
 
 void JSPromise::resolvePromise(JSGlobalObject* globalObject, VM& vm, JSValue resolution)
@@ -550,8 +551,28 @@ std::tuple<JSFunction*, JSFunction*> JSPromise::createResolvingFunctionsWithInte
 
 void JSPromise::triggerPromiseReactions(VM& vm, JSGlobalObject* globalObject, Status status, JSPromiseReaction* head, JSValue argument)
 {
-    if (!head)
+    bool isResolved = status == JSPromise::Status::Fulfilled;
+
+    auto queue = [&](JSPromiseReaction* reaction) ALWAYS_INLINE_LAMBDA {
+        JSValue promise = reaction->promise();
+        JSValue handler = isResolved ? reaction->onFulfilled() : reaction->onRejected();
+        JSValue context = reaction->context();
+        JSValue arg = argument;
+        InternalMicrotask task = InternalMicrotask::PromiseReactionJob;
+        if (handler.isInt32()) {
+            task = static_cast<InternalMicrotask>(handler.asInt32());
+            handler = arg;
+            arg = context;
+        } else
+            ASSERT(context.isUndefinedOrNull());
+        globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(status), promise, handler, arg);
+    };
+
+    ASSERT(head);
+    if (!head->next()) [[likely]] {
+        queue(head);
         return;
+    }
 
     // Reverse the order of singly-linked-list.
     JSPromiseReaction* previous = nullptr;
@@ -566,22 +587,12 @@ void JSPromise::triggerPromiseReactions(VM& vm, JSGlobalObject* globalObject, St
     }
     head = previous;
 
-    bool isResolved = status == JSPromise::Status::Fulfilled;
     auto* current = head;
-    while (current) {
-        JSValue promise = current->promise();
-        JSValue handler = isResolved ? current->onFulfilled() : current->onRejected();
-        JSValue context = current->context();
-        current = current->next();
-
-        if (handler.isInt32()) {
-            auto task = static_cast<InternalMicrotask>(handler.asInt32());
-            globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(status), promise, argument, context);
-            continue;
-        }
-        ASSERT(context.isUndefinedOrNull());
-        globalObject->queueMicrotask(vm, InternalMicrotask::PromiseReactionJob, static_cast<uint8_t>(status), promise, handler, argument);
-    }
+    do {
+        auto* next = current->next();
+        queue(current);
+        current = next;
+    } while (current);
 }
 
 void JSPromise::resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject* globalObject, VM& vm, JSValue resolution, InternalMicrotask task, JSValue context)

--- a/Source/JavaScriptCore/runtime/JSPromise.h
+++ b/Source/JavaScriptCore/runtime/JSPromise.h
@@ -65,7 +65,7 @@ public:
     {
         return { {
             jsNumber(static_cast<int32_t>(Status::Pending)),
-            jsUndefined(),
+            JSValue(),
         } };
     }
 
@@ -91,7 +91,6 @@ public:
             return jsUndefined();
         return internalField(Field::ReactionsOrResult).get();
     }
-
 
     JS_EXPORT_PRIVATE static JSPromise* resolvedPromise(JSGlobalObject*, JSValue);
     JS_EXPORT_PRIVATE static JSPromise* rejectedPromise(JSGlobalObject*, JSValue);
@@ -156,13 +155,14 @@ protected:
     JSPromise(VM&, Structure*);
     void finishCreation(VM&);
 
-    static void triggerPromiseReactions(VM&, JSGlobalObject*, JSPromise::Status, JSPromiseReaction* head, JSValue argument);
-
     inline int32_t flags() const
     {
         JSValue value = internalField(Field::Flags).get();
         return value.asInt32AsAnyInt();
     }
+
+private:
+    static void triggerPromiseReactions(VM&, JSGlobalObject*, JSPromise::Status, JSPromiseReaction* head, JSValue argument);
 };
 
 static constexpr PropertyOffset promiseCapabilityResolvePropertyOffset = 0;


### PR DESCRIPTION
#### b6d94e4de12fab00aa972f7ad5c6358995ea558c
<pre>
[JSC] Micro-optimize triggerPromiseReactions
<a href="https://bugs.webkit.org/show_bug.cgi?id=309490">https://bugs.webkit.org/show_bug.cgi?id=309490</a>
<a href="https://rdar.apple.com/172069345">rdar://172069345</a>

Reviewed by Yijia Huang.

1. We store JSEmpty to JSPromise reactionsOrResult field instead, which
   makes checking empty super fast.
2. triggerPromiseReactions should have a fast path for one reaction case
   as it is very common.

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCreatePromise):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::getAsyncStackTrace):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::runInternalMicrotask):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::performPromiseThen):
(JSC::JSPromise::performPromiseThenWithInternalMicrotask):
(JSC::JSPromise::rejectPromise):
(JSC::JSPromise::fulfillPromise):
(JSC::JSPromise::triggerPromiseReactions):
* Source/JavaScriptCore/runtime/JSPromise.h:
(JSC::JSPromise::initialValues):

Canonical link: <a href="https://commits.webkit.org/308926@main">https://commits.webkit.org/308926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9dadfd759e1424d6a2617bed2d8805c178bbcdb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21562 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157535 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102279 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e080852e-cc48-481d-95df-44ddbb34b2bb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114751 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81719 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45a1ebd6-fec4-48a4-8f71-36003b7cf957) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133602 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95513 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/caa10e5e-d096-41db-a932-11a7af995a27) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16059 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13909 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5303 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140816 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159873 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9637 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3009 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122810 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17921 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123040 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21372 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133316 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77560 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22928 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18334 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10078 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180277 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20974 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84776 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46143 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20706 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20853 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20762 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->