### PR TITLE
[visionOS] Fullscreen left-side buttons should scale with Dynamic Type

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKExtrinsicButton.mm
+++ b/Source/WebKit/UIProcess/ios/WKExtrinsicButton.mm
@@ -38,7 +38,9 @@
 
 - (CGSize)intrinsicContentSize
 {
-    return _extrinsicContentSize;
+    if (_extrinsicContentSize.width > 0 && _extrinsicContentSize.height > 0)
+        return _extrinsicContentSize;
+    return [super intrinsicContentSize];
 }
 
 #if !PLATFORM(WATCHOS)

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm
@@ -222,9 +222,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_didEndInteractionWithSystemChrome:) name:_MRUIWindowSceneDidEndRepositioningNotification object:windowScene];
 #endif
 
-#if ENABLE(LINEAR_MEDIA_PLAYER)
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(_contentSizeCategoryDidChange:) name:UIContentSizeCategoryDidChangeNotification object:nil];
-#endif
+
     _secheuristic.setParameters(WebKit::FullscreenTouchSecheuristicParameters::iosParameters());
     self._webView = webView;
 
@@ -471,13 +470,35 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return videoPresentationManager->controlsManagerInterface();
 }
 
-#if ENABLE(LINEAR_MEDIA_PLAYER)
-- (void)_contentSizeCategoryDidChange:(NSNotification *)notification
+- (void)_updateButtonImages
 {
-    if (_buttonState.contains(FullscreenVideo) && [_enterVideoFullscreenButton superview])
-        [self configureEnvironmentPickerOrFullscreenVideoButtonView];
+    RetainPtr dynamicSymbolConfiguration = [[UIImageSymbolConfiguration configurationWithTextStyle:UIFontTextStyleBody] configurationByApplyingConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightMedium]];
+
+    RetainPtr doneImage = [UIImage systemImageNamed:@"arrow.down.right.and.arrow.up.left"];
+    [_cancelButton setImage:[[doneImage imageWithConfiguration:dynamicSymbolConfiguration.get()] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
+
+    [_pipButton setImage:[[UIImage systemImageNamed:@"pip.enter" withConfiguration:dynamicSymbolConfiguration.get()] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
+    [_pipButton setImage:[[UIImage systemImageNamed:@"pip.exit" withConfiguration:dynamicSymbolConfiguration.get()] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateSelected];
+
+#if PLATFORM(VISION)
+    [_moreActionsButton setImage:[[UIImage systemImageNamed:@"ellipsis" withConfiguration:dynamicSymbolConfiguration.get()] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
+#endif
 }
 
+- (void)_contentSizeCategoryDidChange:(NSNotification *)notification
+{
+    auto alternateFullScreenControlDesignEnabled = protect(protect(*self._webView._page)->preferences())->alternateFullScreenControlDesignEnabled();
+
+    if (alternateFullScreenControlDesignEnabled)
+        [self _updateButtonImages];
+
+#if ENABLE(LINEAR_MEDIA_PLAYER)
+    if (_buttonState.contains(FullscreenVideo) && [_enterVideoFullscreenButton superview])
+        [self configureEnvironmentPickerOrFullscreenVideoButtonView];
+#endif
+}
+
+#if ENABLE(LINEAR_MEDIA_PLAYER)
 - (void)_setTopButtonLabel:(const String&)label
 {
     UIButtonConfiguration *fullscreenButtonConfiguration = [UIButtonConfiguration filledButtonConfiguration];
@@ -486,7 +507,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     fullscreenButtonConfiguration.titleLineBreakMode = NSLineBreakByClipping;
 
     RetainPtr dynamicImageConfiguration = [[UIImageSymbolConfiguration configurationWithTextStyle:UIFontTextStyleBody] configurationByApplyingConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightMedium]];
-    RetainPtr fixedImageConfiguration = [[UIImageSymbolConfiguration configurationWithPointSize:17 weight:UIImageSymbolWeightMedium] configurationByApplyingConfiguration:[UIImageSymbolConfiguration configurationWithWeight:UIImageSymbolWeightMedium]];
     NSString *symbolName = _isImmersiveVideo ? @"pano" : @"cube";
     fullscreenButtonConfiguration.image = [[UIImage systemImageNamed:symbolName withConfiguration:dynamicImageConfiguration.get()] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
 
@@ -515,7 +535,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     BOOL shouldUseCompactLayout = actualSpacing < kMinimumSpacing;
 
     if (shouldUseCompactLayout) {
-        fullscreenButtonConfiguration.image = [[UIImage systemImageNamed:symbolName withConfiguration:fixedImageConfiguration.get()] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
+        fullscreenButtonConfiguration.image = [[UIImage systemImageNamed:symbolName withConfiguration:dynamicImageConfiguration.get()] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate];
         fullscreenButtonConfiguration.contentInsets = NSDirectionalEdgeInsetsMake(12, 12, 12, 12);
         fullscreenButtonConfiguration.attributedTitle = nil;
 
@@ -807,20 +827,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)loadView
 {
-    CGSize buttonSize;
-    UIImage *doneImage;
-
     // FIXME: Rename `alternateFullScreenControlDesignEnabled` to something that explains it is for visionOS.
     auto alternateFullScreenControlDesignEnabled = protect(protect(*self._webView._page)->preferences())->alternateFullScreenControlDesignEnabled();
-    
-    if (alternateFullScreenControlDesignEnabled) {
-        buttonSize = CGSizeMake(44.0, 44.0);
-        doneImage = [UIImage systemImageNamed:@"arrow.down.right.and.arrow.up.left"];
-    } else {
-        buttonSize = CGSizeMake(60.0, 47.0);
-        NSBundle *bundle = [NSBundle bundleForClass:self.class];
-        doneImage = [UIImage imageNamed:@"Done" inBundle:bundle compatibleWithTraitCollection:nil];
-    }
     
     [self setView:adoptNS([[UIView alloc] initWithFrame:CGRectMake(0, 0, 100, 100)]).get()];
     self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
@@ -830,34 +838,33 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _animatingView.get().autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     [self.view addSubview:_animatingView.get()];
 
-    _cancelButton = [self _createButtonWithExtrinsicContentSize:buttonSize];
-    [_cancelButton setImage:[doneImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
-    [_cancelButton sizeToFit];
-    [_cancelButton addTarget:self action:@selector(_cancelAction:) forControlEvents:UIControlEventTouchUpInside];
-#if PLATFORM(APPLETV)
-    [_cancelButton setConfiguration:UIButtonConfiguration.filledButtonConfiguration];
-#endif
-
-    _pipButton = [self _createButtonWithExtrinsicContentSize:buttonSize];
-    [_pipButton setImage:[UIImage systemImageNamed:@"pip.enter"] forState:UIControlStateNormal];
-    [_pipButton setImage:[UIImage systemImageNamed:@"pip.exit"] forState:UIControlStateSelected];
-    [_pipButton sizeToFit];
-    [_pipButton addTarget:self action:@selector(_togglePiPAction:) forControlEvents:UIControlEventTouchUpInside];
-
     if (alternateFullScreenControlDesignEnabled) {
         UIButtonConfiguration *buttonConfiguration = [UIButtonConfiguration filledButtonConfiguration];
+        buttonConfiguration.contentInsets = NSDirectionalEdgeInsetsMake(12, 12, 12, 12);
+
+        _cancelButton = [WKExtrinsicButton buttonWithType:UIButtonTypeSystem];
+        [self _setupButton:_cancelButton.get()];
+        [_cancelButton setDelegate:self];
         [_cancelButton setConfiguration:buttonConfiguration];
+        [_cancelButton addTarget:self action:@selector(_cancelAction:) forControlEvents:UIControlEventTouchUpInside];
+
+        _pipButton = [WKExtrinsicButton buttonWithType:UIButtonTypeSystem];
+        [self _setupButton:_pipButton.get()];
+        [_pipButton setDelegate:self];
         [_pipButton setConfiguration:buttonConfiguration];
+        [_pipButton addTarget:self action:@selector(_togglePiPAction:) forControlEvents:UIControlEventTouchUpInside];
 
 #if PLATFORM(VISION)
         // FIXME: I think PLATFORM(VISION) is always true when `alternateFullScreenControlDesignEnabled` is true.
-        _moreActionsButton = [self _createButtonWithExtrinsicContentSize:buttonSize];
+        _moreActionsButton = [WKExtrinsicButton buttonWithType:UIButtonTypeSystem];
+        [self _setupButton:_moreActionsButton.get()];
+        [_moreActionsButton setDelegate:self];
         [_moreActionsButton setConfiguration:buttonConfiguration];
         [_moreActionsButton setMenu:self._webView.fullScreenWindowSceneDimmingAction];
         [_moreActionsButton setShowsMenuAsPrimaryAction:YES];
-        [_moreActionsButton setImage:[[UIImage systemImageNamed:@"ellipsis"] imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
 #endif
 
+        [self _updateButtonImages];
 #if ENABLE(LINEAR_MEDIA_PLAYER)
         _enterVideoFullscreenButton = [UIButton buttonWithType:UIButtonTypeSystem];
         [self _setupButton:_enterVideoFullscreenButton.get()];
@@ -876,6 +883,23 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
         [_stackView setSpacing:24.0];
     } else {
+        CGSize buttonSize = CGSizeMake(60.0, 47.0);
+        NSBundle *bundle = [NSBundle bundleForClass:self.class];
+        UIImage *doneImage = [UIImage imageNamed:@"Done" inBundle:bundle compatibleWithTraitCollection:nil];
+
+        _cancelButton = [self _createButtonWithExtrinsicContentSize:buttonSize];
+        [_cancelButton setImage:[doneImage imageWithRenderingMode:UIImageRenderingModeAlwaysTemplate] forState:UIControlStateNormal];
+        [_cancelButton sizeToFit];
+        [_cancelButton addTarget:self action:@selector(_cancelAction:) forControlEvents:UIControlEventTouchUpInside];
+#if PLATFORM(APPLETV)
+        [_cancelButton setConfiguration:UIButtonConfiguration.filledButtonConfiguration];
+#endif
+        _pipButton = [self _createButtonWithExtrinsicContentSize:buttonSize];
+        [_pipButton setImage:[UIImage systemImageNamed:@"pip.enter"] forState:UIControlStateNormal];
+        [_pipButton setImage:[UIImage systemImageNamed:@"pip.exit"] forState:UIControlStateSelected];
+        [_pipButton sizeToFit];
+        [_pipButton addTarget:self action:@selector(_togglePiPAction:) forControlEvents:UIControlEventTouchUpInside];
+
         RetainPtr<WKFullscreenStackView> stackView = adoptNS([[WKFullscreenStackView alloc] init]);
 #if PLATFORM(APPLETV)
         [stackView addArrangedSubview:_cancelButton.get()];


### PR DESCRIPTION
#### 56cc13187e5f21f382f3000825f30450e8034dcd
<pre>
[visionOS] Fullscreen left-side buttons should scale with Dynamic Type
<a href="https://bugs.webkit.org/show_bug.cgi?id=309491">https://bugs.webkit.org/show_bug.cgi?id=309491</a>
<a href="https://rdar.apple.com/172071503">rdar://172071503</a>

Reviewed by Andy Estes.

The cancel, PiP, and more actions buttons in the fullscreen UI used a fixed 44x44 extrinsic content
size, which prevented them from scaling with Dynamic Type. This was inconsistent with the View
Immersive button, which already scales correctly in compact mode.

- Use UIImageSymbolConfiguration with UIFontTextStyleBody for the button images in the alternate
  (visionOS) design path, so they scale with Dynamic Type.
- Stop setting a fixed extrinsicContentSize on these buttons in the alternate path, letting them
  size naturally via UIButtonConfiguration.
- Fix WKExtrinsicButton&apos;s intrinsicContentSize to fall through to super when no extrinsic size has
  been set, instead of returning CGSizeZero.
- Extract _updateButtonImages helper to avoid duplicating image configuration code between loadView
  and _contentSizeCategoryDidChange:.
- Move _contentSizeCategoryDidChange: outside the LINEAR_MEDIA_PLAYER guard since it now also
  updates the left-side buttons.

* Source/WebKit/UIProcess/ios/WKExtrinsicButton.mm:
(-[WKExtrinsicButton intrinsicContentSize]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenViewController.mm:
(-[WKFullScreenViewController initWithWebView:]):
(-[WKFullScreenViewController _updateButtonImages]):
(-[WKFullScreenViewController _contentSizeCategoryDidChange:]):
(-[WKFullScreenViewController _setTopButtonLabel:]):
(-[WKFullScreenViewController loadView]):

Canonical link: <a href="https://commits.webkit.org/309221@main">https://commits.webkit.org/309221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6339e92e0a1e73bd9d09df9eecf46d142a54644

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22575 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158562 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103288 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48fb6edb-c97d-4d83-8201-bc699dfdd6a3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115595 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82151 "2 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17718 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134473 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96334 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e952ead-8514-489a-a4ae-3811baa75575) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16815 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14743 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6409 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126422 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161038 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13946 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123609 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18785 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123814 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33637 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134197 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78609 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18974 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Skipped layout-tests; Passed layout tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10949 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21985 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85805 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21715 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21867 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21772 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->