### PR TITLE
Clarify Document::queueTaskToDispatchEventOnWindow()

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7026,18 +7026,11 @@ void Document::whenWindowLoadEventOrDestroyed(CompletionHandler<void()>&& comple
     };
 }
 
-void Document::queueTaskToDispatchEvent(TaskSource source, Ref<Event>&& event)
+void Document::queueTaskToDispatchEventOnWindow(LocalDOMWindow& window, TaskSource source, Ref<Event>&& event)
 {
-    queueTaskKeepingNodeAlive(*this, source, [event = WTF::move(event)](auto& document) {
-        document.dispatchEvent(event);
-    });
-}
-
-void Document::queueTaskToDispatchEventOnWindow(TaskSource source, Ref<Event>&& event)
-{
-    eventLoop().queueTask(source, [this, protectedThis = Ref { *this }, event = WTF::move(event)] {
-        if (RefPtr window = m_domWindow)
-            window->dispatchEvent(event);
+    // GCReachableRef is not needed here as JSDOMWindow is kept alive as long as the environment exists.
+    eventLoop().queueTask(source, [protectedWindow = Ref { window }, event = WTF::move(event)] {
+        protectedWindow->dispatchEvent(event);
     });
 }
 
@@ -8865,7 +8858,8 @@ void Document::enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventI
 void Document::enqueueHashchangeEvent(const String& oldURL, const String& newURL)
 {
     // FIXME: popstate event and hashchange event are supposed to fire in a single task.
-    queueTaskToDispatchEventOnWindow(TaskSource::DOMManipulation, HashChangeEvent::create(oldURL, newURL));
+    if (RefPtr window = m_domWindow)
+        queueTaskToDispatchEventOnWindow(*window, TaskSource::DOMManipulation, HashChangeEvent::create(oldURL, newURL));
 }
 
 void Document::dispatchPopstateEvent(RefPtr<SerializedScriptValue>&& stateObject)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1428,8 +1428,7 @@ public:
     bool isSecureContext() const final;
     bool isJSExecutionForbidden() const final { return false; }
 
-    void queueTaskToDispatchEvent(TaskSource, Ref<Event>&&);
-    void queueTaskToDispatchEventOnWindow(TaskSource, Ref<Event>&&);
+    void queueTaskToDispatchEventOnWindow(LocalDOMWindow&, TaskSource, Ref<Event>&&);
     void dispatchPageshowEvent(PageshowEventPersistence);
     void dispatchPagehideEvent(PageshowEventPersistence);
     WEBCORE_EXPORT void dispatchPageswapEvent(CanTriggerCrossDocumentViewTransition, RefPtr<NavigationActivation>&&);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2372,7 +2372,7 @@ void LocalDOMWindow::languagesChanged()
 {
     // https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-languages
     if (RefPtr document = this->document())
-        document->queueTaskToDispatchEventOnWindow(TaskSource::DOMManipulation, Event::create(eventNames().languagechangeEvent, Event::CanBubble::No, Event::IsCancelable::No));
+        document->queueTaskToDispatchEventOnWindow(*this, TaskSource::DOMManipulation, Event::create(eventNames().languagechangeEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
 void LocalDOMWindow::dispatchLoadEvent()

--- a/Source/WebCore/storage/StorageEventDispatcher.cpp
+++ b/Source/WebCore/storage/StorageEventDispatcher.cpp
@@ -41,6 +41,7 @@
 
 namespace WebCore {
 
+// https://html.spec.whatwg.org/multipage/webstorage.html#concept-storage-broadcast
 template<StorageType storageType>
 static void dispatchStorageEvents(const String& key, const String& oldValue, const String& newValue, const SecurityOrigin& securityOrigin, const String& url, NOESCAPE const Function<bool(Storage&)>& isSourceStorage, NOESCAPE const Function<bool(Page&)>& isRelevantPage)
 {
@@ -62,8 +63,8 @@ static void dispatchStorageEvents(const String& key, const String& oldValue, con
     for (auto& window : windows) {
         RefPtr document = window->document();
         auto result = isLocalStorage(storageType) ? window->localStorage() : window->sessionStorage();
-        if (!result.hasException()) // https://html.spec.whatwg.org/multipage/webstorage.html#the-storage-event:event-storage
-            document->queueTaskToDispatchEventOnWindow(TaskSource::DOMManipulation, StorageEvent::create(eventNames().storageEvent, key, oldValue, newValue, url, RefPtr { result.releaseReturnValue() }.get()));
+        if (!result.hasException())
+            document->queueTaskToDispatchEventOnWindow(window, TaskSource::DOMManipulation, StorageEvent::create(eventNames().storageEvent, key, oldValue, newValue, url, protect(result.releaseReturnValue())));
     }
 }
 


### PR DESCRIPTION
#### 83f05c661eccd234ad0b1a9f39f4ef16770e31ff
<pre>
Clarify Document::queueTaskToDispatchEventOnWindow()
<a href="https://bugs.webkit.org/show_bug.cgi?id=309492">https://bugs.webkit.org/show_bug.cgi?id=309492</a>

Reviewed by Ryosuke Niwa.

Also pass in the LocalDOMWindow since in the majority of cases we
already have it.

This also removes Document::queueTaskToDispatchEvent() as it is
perfectly redundant with Node::queueTaskToDispatchEvent().

Canonical link: <a href="https://commits.webkit.org/309390@main">https://commits.webkit.org/309390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7e79e8e2f3e49d65e88a6953cd398a5fb548110

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157770 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102513 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d121748-b3d6-4d1a-a204-9f19a8c38e62) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150955 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22249 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21673 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114936 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81819 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/76e2f8bd-9926-476b-96a5-768dc79c4440) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152042 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17123 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133801 "Found 1 new API test failure: TestWebKitAPI.ProcessSwap.ScrollPositionRestoration (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95695 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d43eb0a3-a102-4ec5-8c31-3333dc25745d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16220 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14090 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5623 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125826 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11726 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160253 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3242 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13248 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122985 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21597 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123214 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21605 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133519 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77806 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23130 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18474 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10278 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21207 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85009 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20939 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21087 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20995 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->