### PR TITLE
RTCPeerConnection should not expose transceivers of rejected m-sections

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-iceGatheringState-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-iceGatheringState-expected.txt
@@ -8,6 +8,6 @@ FAIL gathering state and candidate callbacks should fire in the correct order as
 PASS setLocalDescription(reoffer) with a restarted transport should cause iceGatheringState to go to "gathering" and then "complete"
 PASS setLocalDescription(reoffer) with two restarted transports should cause iceGatheringState to go to "gathering" and then "complete"
 PASS sRD does not cause ICE gathering state changes
-FAIL renegotiation that closes all transports should result in ICE gathering state "new" assert_equals: PC2 transceivers should be invisible after negotiation expected 0 but got 1
+PASS renegotiation that closes all transports should result in ICE gathering state "new"
 PASS connection with one data channel should eventually have connected connection state
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setDescription-transceiver-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setDescription-transceiver-expected.txt
@@ -3,6 +3,6 @@ PASS setLocalDescription(offer) with m= section should assign mid to correspondi
 PASS setRemoteDescription(offer) with m= section and no existing transceiver should create corresponding transceiver
 PASS setLocalDescription(rollback) should unset transceiver.mid
 PASS setLocalDescription(rollback) should only unset transceiver mids associated with current round
-FAIL setRemoteDescription(rollback) should remove newly created transceiver from transceiver list assert_array_equals: Expect transceiver to be removed from pc2's transceiver list lengths differ, expected array [] length 0, got [object "[object RTCRtpTransceiver]"] length 1
+PASS setRemoteDescription(rollback) should remove newly created transceiver from transceiver list
 PASS setRemoteDescription should set transceiver inactive if its corresponding m section is rejected
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-rollback-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-setRemoteDescription-rollback-expected.txt
@@ -5,8 +5,8 @@ FAIL setRemoteDescription(rollback) after setting a local offer should reject wi
 PASS setRemoteDescription(rollback) should ignore invalid sdp content and succeed
 PASS local offer created before setRemoteDescription(remote offer) then rollback should still be usable
 PASS local offer created before setRemoteDescription(remote offer) with different transceiver level assignments then rollback should still be usable
-FAIL rollback of a remote offer should remove a transceiver assert_equals: expected 0 but got 1
-FAIL rollback of a remote offer should remove touched transceiver assert_equals: expected 0 but got 1
+PASS rollback of a remote offer should remove a transceiver
+PASS rollback of a remote offer should remove touched transceiver
 PASS rollback of a remote offer should keep a transceiver
 PASS rollback of a remote offer should keep a transceiver created by addtrack
 PASS rollback of a remote offer should keep a transceiver without tracks

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-stop-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-stop-expected.txt
@@ -6,6 +6,6 @@ PASS A stopped sendonly transceiver should generate an inactive m-section in the
 PASS A stopped inactive transceiver should generate an inactive m-section in the offer
 PASS If a transceiver is stopped locally, setting a locally generated answer should still work
 PASS If a transceiver is stopped remotely, setting a locally generated answer should still work
-FAIL If a transceiver is stopped, transceivers, senders and receivers should disappear after offer/answer assert_equals: expected 0 but got 1
+PASS If a transceiver is stopped, transceivers, senders and receivers should disappear after offer/answer
 FAIL If a transceiver is stopped, transceivers should end up in state stopped assert_equals: expected "stopped" but got "inactive"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-stopping.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-stopping.https-expected.txt
@@ -4,15 +4,15 @@ PASS [audio] Locally stopping a transceiver ends the track
 FAIL [audio] Remotely stopping a transceiver ends the track assert_equals: expected "live" but got "ended"
 FAIL [audio] Remotely stopped transceiver goes directly to stopped assert_equals: direction during negotiation expected "stopped" but got "inactive"
 PASS [audio] Rollback when transceiver is not removed does not end track
-FAIL [audio] Rollback when removing transceiver does end the track assert_equals: expected 0 but got 1
-FAIL [audio] Rollback when removing transceiver makes it stopped assert_equals: expected 0 but got 1
+FAIL [audio] Rollback when removing transceiver does end the track assert_equals: expected "live" but got "ended"
+FAIL [audio] Rollback when removing transceiver makes it stopped assert_equals: currentDirection indicate stopped expected "stopped" but got "inactive"
 PASS [audio] Glare when transceiver is not removed does not end track
 FAIL [video] Locally stopped transceiver goes from stopping to stopped assert_equals: direction after stop() expected "stopped" but got "inactive"
 PASS [video] Locally stopping a transceiver ends the track
 FAIL [video] Remotely stopping a transceiver ends the track assert_equals: expected "live" but got "ended"
 FAIL [video] Remotely stopped transceiver goes directly to stopped assert_equals: direction during negotiation expected "stopped" but got "inactive"
 PASS [video] Rollback when transceiver is not removed does not end track
-FAIL [video] Rollback when removing transceiver does end the track assert_equals: expected 0 but got 1
-FAIL [video] Rollback when removing transceiver makes it stopped assert_equals: expected 0 but got 1
+FAIL [video] Rollback when removing transceiver does end the track assert_equals: expected "live" but got "ended"
+FAIL [video] Rollback when removing transceiver makes it stopped assert_equals: currentDirection indicate stopped expected "stopped" but got "inactive"
 PASS [video] Glare when transceiver is not removed does not end track
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver.https-expected.txt
@@ -20,7 +20,7 @@ PASS checkAddTrackPairs
 PASS checkReplaceTrackNullDoesntPreventPairing
 PASS checkRemoveAndReadd
 PASS checkAddTrackExistingTransceiverThenRemove
-FAIL checkRemoveTrackNegotiation assert_equals: expected "[{currentDirection:\"inactive\"},{currentDirection:\"inactive\"}]" but got "[{currentDirection:\"inactive\"},{currentDirection:\"inactive\"},{},{}]"
+PASS checkRemoveTrackNegotiation
 FAIL checkStop assert_equals: expected "[{currentDirection:\"sendrecv\",direction:\"stopped\",receiver:{track:{kind:\"audio\",readyState:\"ended\"}},sender:{track:{kind:\"audio\"}}}]" but got "[{currentDirection:\"sendrecv\",direction:\"inactive\",receiver:{track:{kind:\"audio\",readyState:\"ended\"}},sender:{track:null}}]"
 FAIL checkStopAfterCreateOffer assert_equals: expected "[{currentDirection:\"sendrecv\",direction:\"stopped\"}]" but got "[{currentDirection:\"sendrecv\",direction:\"inactive\"}]"
 FAIL checkStopAfterSetLocalOffer assert_equals: expected "[{currentDirection:\"sendrecv\",direction:\"stopped\"}]" but got "[{currentDirection:\"sendrecv\",direction:\"inactive\"}]"
@@ -30,7 +30,7 @@ FAIL checkStopAfterSetLocalAnswer assert_equals: expected "[{currentDirection:\"
 PASS checkStopAfterClose
 FAIL checkLocalRollback assert_equals: expected "[{direction:\"stopped\"}]" but got "[{direction:\"inactive\"}]"
 PASS checkRollbackAndSetRemoteOfferWithDifferentType
-FAIL checkRemoteRollback assert_equals: expected "[]" but got "[{}]"
+FAIL checkRemoteRollback assert_equals: expected "{currentDirection:\"stopped\",mid:null}" but got "{currentDirection:\"inactive\",mid:null}"
 FAIL checkMsectionReuse assert_equals: expected "stopped" but got "inactive"
 PASS checkStopAfterCreateOfferWithReusedMsection
 PASS checkAddIceCandidateToStoppedTransceiver

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/protocol/transceiver-mline-recycling-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/protocol/transceiver-mline-recycling-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Reuses m-lines in local negotiation assert_equals: Audio m-line gets reused for video transceiver expected 1 but got 2
-FAIL Reuses m-lines in remote negotiation assert_equals: expected 0 but got 1
+PASS Reuses m-lines in local negotiation
+PASS Reuses m-lines in remote negotiation
 

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.h
@@ -213,7 +213,7 @@ public:
     };
     static void generateCertificate(Document&, const CertificateInformation&, DOMPromiseDeferred<IDLInterface<RTCCertificate>>&&);
 
-    virtual void collectTransceivers() { };
+    virtual void collectTransceivers(Vector<Ref<RTCRtpTransceiver>>&&) { };
 
     ScriptExecutionContext* context() const;
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -804,6 +804,11 @@ void RTCPeerConnection::addInternalTransceiver(Ref<RTCRtpTransceiver>&& transcei
     m_transceiverSet.append(WTF::move(transceiver));
 }
 
+void RTCPeerConnection::removeTransceiver(const RTCRtpTransceiver& transceiver)
+{
+    m_transceiverSet.remove(transceiver);
+}
+
 void RTCPeerConnection::setSignalingState(RTCSignalingState newState)
 {
     if (m_signalingState == newState)
@@ -1202,14 +1207,14 @@ void RTCPeerConnection::updateTransceiverTransports()
 // https://w3c.github.io/webrtc-pc/#set-description step 4.9.1
 void RTCPeerConnection::updateTransceiversAfterSuccessfulLocalDescription()
 {
-    protect(*m_backend)->collectTransceivers();
+    protect(*m_backend)->collectTransceivers(Vector { m_transceiverSet.list() });
     updateTransceiverTransports();
 }
 
 // https://w3c.github.io/webrtc-pc/#set-description step 4.9.2
 void RTCPeerConnection::updateTransceiversAfterSuccessfulRemoteDescription()
 {
-    protect(*m_backend)->collectTransceivers();
+    protect(*m_backend)->collectTransceivers(Vector { m_transceiverSet.list() });
     updateTransceiverTransports();
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -146,6 +146,7 @@ public:
     bool isStopped() const { return m_isStopped; }
 
     void addInternalTransceiver(Ref<RTCRtpTransceiver>&&);
+    void removeTransceiver(const RTCRtpTransceiver&);
 
     // 5.1 RTCPeerConnection extensions
     Vector<std::reference_wrapper<RTCRtpSender>> getSenders() const;

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.cpp
@@ -113,6 +113,13 @@ void RtpTransceiverSet::append(Ref<RTCRtpTransceiver>&& transceiver)
     m_transceivers.append(WTF::move(transceiver));
 }
 
+void RtpTransceiverSet::remove(const RTCRtpTransceiver& transceiver)
+{
+    m_transceivers.removeFirstMatching([&](auto& existing) {
+        return existing.ptr() == &transceiver;
+    });
+}
+
 Vector<std::reference_wrapper<RTCRtpSender>> RtpTransceiverSet::senders() const
 {
     Vector<std::reference_wrapper<RTCRtpSender>> senders;

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h
@@ -87,6 +87,7 @@ class RtpTransceiverSet {
 public:
     const Vector<Ref<RTCRtpTransceiver>>& list() const LIFETIME_BOUND { return m_transceivers; }
     void append(Ref<RTCRtpTransceiver>&&);
+    void remove(const RTCRtpTransceiver&);
 
     Vector<std::reference_wrapper<RTCRtpSender>> senders() const;
     Vector<std::reference_wrapper<RTCRtpReceiver>> receivers() const;

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1565,7 +1565,7 @@ void GStreamerMediaEndpoint::connectIncomingTrack(WebRTCTrackData& data)
             return;
         }
         const auto& trackId = data.trackId;
-        transceiver = peerConnectionBackend->newRemoteTransceiver(makeUniqueRef<GStreamerRtpTransceiverBackend>(WTF::move(rtcTransceiver)), data.type, trackId.isolatedCopy());
+        transceiver = peerConnectionBackend->addInternalTransceiver(makeUniqueRef<GStreamerRtpTransceiverBackend>(WTF::move(rtcTransceiver)), data.type, trackId.isolatedCopy());
         GST_DEBUG_OBJECT(m_pipeline.get(), "New remote transceiver created for track");
     }
 
@@ -2412,7 +2412,7 @@ void GStreamerMediaEndpoint::createSessionDescriptionFailed(RTCSdpType sdpType, 
     });
 }
 
-void GStreamerMediaEndpoint::collectTransceivers()
+void GStreamerMediaEndpoint::collectTransceivers(Vector<Ref<RTCRtpTransceiver>>&& currentTransceivers)
 {
     GUniqueOutPtr<GstWebRTCSessionDescription> description;
     g_object_get(m_webrtcBin.get(), "remote-description", &description.outPtr(), nullptr);
@@ -2424,16 +2424,19 @@ void GStreamerMediaEndpoint::collectTransceivers()
         return;
 
     GST_DEBUG_OBJECT(m_pipeline.get(), "Collecting transceivers");
-    forEachTransceiver(m_webrtcBin, [&](auto&& transceiver) -> bool {
-        RefPtr existingTransceiver = peerConnectionBackend->existingTransceiver([&](auto& transceiverBackend) {
-            return transceiver.get() == transceiverBackend.rtcTransceiver();
+    forEachTransceiver(m_webrtcBin, [&](auto&& rtcTransceiver) -> bool {
+        auto position = currentTransceivers.findIf([&](auto& transceiver) {
+            return rtcTransceiver.get() == static_cast<GStreamerRtpTransceiverBackend&>(transceiver->backend()).rtcTransceiver();
         });
-        if (existingTransceiver)
+
+        if (position != notFound) {
+            currentTransceivers.removeAt(position);
             return false;
+        }
 
         GUniqueOutPtr<char> midChars;
         unsigned mLineIndex;
-        g_object_get(transceiver.get(), "mid", &midChars.outPtr(), "mlineindex", &mLineIndex, nullptr);
+        g_object_get(rtcTransceiver.get(), "mid", &midChars.outPtr(), "mlineindex", &mLineIndex, nullptr);
         auto mid = GMallocString::unsafeAdoptFromUTF8(WTF::move(midChars));
         if (!mid)
             return false;
@@ -2444,9 +2447,12 @@ void GStreamerMediaEndpoint::collectTransceivers()
             return false;
         }
 
-        existingTransceiver = peerConnectionBackend->newRemoteTransceiver(WTF::makeUniqueRef<GStreamerRtpTransceiverBackend>(WTF::move(transceiver)), m_mediaForMid.get(String(mid.span())), trackIdFromSDPMedia(*media));
+        peerConnectionBackend->addInternalTransceiver(WTF::makeUniqueRef<GStreamerRtpTransceiverBackend>(WTF::move(rtcTransceiver)), m_mediaForMid.get(String(mid.span())), trackIdFromSDPMedia(*media));
         return false;
     });
+
+    for (auto& transceiver : currentTransceivers)
+        peerConnectionBackend->removeTransceiver(transceiver);
 }
 
 GUniquePtr<GstStructure> GStreamerMediaEndpoint::preprocessStats(const GRefPtr<GstPad>& pad, const GstStructure* stats)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -104,7 +104,7 @@ public:
 
     GStreamerRtpSenderBackend::Source createSourceForTrack(MediaStreamTrack&);
 
-    void collectTransceivers();
+    void collectTransceivers(Vector<Ref<RTCRtpTransceiver>>&&);
 
     void createSessionDescriptionSucceeded(GUniquePtr<GstWebRTCSessionDescription>&&);
     void createSessionDescriptionFailed(RTCSdpType, GUniquePtr<GError>&&);

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp
@@ -429,7 +429,7 @@ RefPtr<RTCRtpTransceiver> GStreamerPeerConnectionBackend::existingTransceiver(WT
     return nullptr;
 }
 
-Ref<RTCRtpTransceiver> GStreamerPeerConnectionBackend::newRemoteTransceiver(UniqueRef<GStreamerRtpTransceiverBackend>&& transceiverBackend, RealtimeMediaSource::Type type, String&& receiverTrackId)
+Ref<RTCRtpTransceiver> GStreamerPeerConnectionBackend::addInternalTransceiver(UniqueRef<GStreamerRtpTransceiverBackend>&& transceiverBackend, RealtimeMediaSource::Type type, String&& receiverTrackId)
 {
     auto trackKind = type == RealtimeMediaSource::Type::Audio ? "audio"_s : "video"_s;
     Ref peerConnection = m_peerConnection.get();
@@ -442,9 +442,15 @@ Ref<RTCRtpTransceiver> GStreamerPeerConnectionBackend::newRemoteTransceiver(Uniq
     return transceiver;
 }
 
-void GStreamerPeerConnectionBackend::collectTransceivers()
+void GStreamerPeerConnectionBackend::removeTransceiver(const RTCRtpTransceiver& transceiver)
 {
-    m_endpoint->collectTransceivers();
+    Ref peerConnection = m_peerConnection.get();
+    peerConnection->removeTransceiver(transceiver);
+}
+
+void GStreamerPeerConnectionBackend::collectTransceivers(Vector<Ref<RTCRtpTransceiver>>&& transceivers)
+{
+    m_endpoint->collectTransceivers(WTF::move(transceivers));
 }
 
 void GStreamerPeerConnectionBackend::removeTrack(RTCRtpSender& sender)

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
@@ -99,9 +99,10 @@ private:
     GStreamerRtpSenderBackend::Source createSourceForTrack(MediaStreamTrack&);
 
     RefPtr<RTCRtpTransceiver> existingTransceiver(WTF::Function<bool(GStreamerRtpTransceiverBackend&)>&&);
-    Ref<RTCRtpTransceiver> newRemoteTransceiver(UniqueRef<GStreamerRtpTransceiverBackend>&&, RealtimeMediaSource::Type, String&&);
+    Ref<RTCRtpTransceiver> addInternalTransceiver(UniqueRef<GStreamerRtpTransceiverBackend>&&, RealtimeMediaSource::Type, String&&);
+    void removeTransceiver(const RTCRtpTransceiver&);
 
-    void collectTransceivers() final;
+    void collectTransceivers(Vector<Ref<RTCRtpTransceiver>>&&) final;
 
     bool isLocalDescriptionSet() const final { return m_isLocalDescriptionSet; }
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.cpp
@@ -370,22 +370,28 @@ void LibWebRTCMediaEndpoint::OnSignalingChange(webrtc::PeerConnectionInterface::
 {
 }
 
-void LibWebRTCMediaEndpoint::collectTransceivers()
+void LibWebRTCMediaEndpoint::collectTransceivers(Vector<Ref<RTCRtpTransceiver>>&& currentTransceivers)
 {
     if (m_isStopped)
         return;
 
     Ref peerConnectionBackend = *m_peerConnectionBackend.get();
     for (webrtc::scoped_refptr rtcTransceiver : m_backend->GetTransceivers()) {
-        RefPtr existingTransceiver = peerConnectionBackend->existingTransceiver([&](auto& transceiverBackend) {
-            return rtcTransceiver.get() == transceiverBackend.rtcTransceiver();
+        auto position = currentTransceivers.findIf([&](auto& transceiver) {
+            return rtcTransceiver.get() == downcast<LibWebRTCRtpTransceiverBackend>(transceiver->backend()).rtcTransceiver();
         });
-        if (existingTransceiver)
+
+        if (position != notFound) {
+            currentTransceivers.removeAt(position);
             continue;
+        }
 
         Ref rtcReceiver = toRef(rtcTransceiver->receiver());
-        existingTransceiver = peerConnectionBackend->newRemoteTransceiver(makeUniqueRef<LibWebRTCRtpTransceiverBackend>(toRef(WTF::move(rtcTransceiver))), rtcReceiver->media_type() == webrtc::MediaType::AUDIO ? RealtimeMediaSource::Type::Audio : RealtimeMediaSource::Type::Video);
+        peerConnectionBackend->addInternalTransceiver(makeUniqueRef<LibWebRTCRtpTransceiverBackend>(toRef(WTF::move(rtcTransceiver))), rtcReceiver->media_type() == webrtc::MediaType::AUDIO ? RealtimeMediaSource::Type::Audio : RealtimeMediaSource::Type::Video);
     }
+
+    for (auto& transceiver : currentTransceivers)
+        peerConnectionBackend->removeTransceiver(transceiver);
 }
 
 std::optional<bool> LibWebRTCMediaEndpoint::canTrickleIceCandidates() const

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCMediaEndpoint.h
@@ -116,7 +116,7 @@ public:
     std::unique_ptr<LibWebRTCRtpTransceiverBackend> transceiverBackendFromSender(LibWebRTCRtpSenderBackend&);
 
     void setSenderSourceFromTrack(LibWebRTCRtpSenderBackend&, MediaStreamTrack&);
-    void collectTransceivers();
+    void collectTransceivers(Vector<Ref<RTCRtpTransceiver>>&&);
 
     std::optional<bool> canTrickleIceCandidates() const;
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.cpp
@@ -374,29 +374,24 @@ static inline LibWebRTCRtpTransceiverBackend& NODELETE backendFromRTPTransceiver
     return downcast<LibWebRTCRtpTransceiverBackend>(transceiver.backend());
 }
 
-RefPtr<RTCRtpTransceiver> LibWebRTCPeerConnectionBackend::existingTransceiver(Function<bool(LibWebRTCRtpTransceiverBackend&)>&& matchingFunction)
-{
-    Ref peerConnection = m_peerConnection;
-    for (auto& transceiver : peerConnection->currentTransceivers()) {
-        if (matchingFunction(backendFromRTPTransceiver(transceiver)))
-            return transceiver.ptr();
-    }
-    return nullptr;
-}
-
-Ref<RTCRtpTransceiver> LibWebRTCPeerConnectionBackend::newRemoteTransceiver(UniqueRef<LibWebRTCRtpTransceiverBackend>&& transceiverBackend, RealtimeMediaSource::Type type)
+void LibWebRTCPeerConnectionBackend::addInternalTransceiver(UniqueRef<LibWebRTCRtpTransceiverBackend>&& transceiverBackend, RealtimeMediaSource::Type type)
 {
     Ref peerConnection = m_peerConnection;
     Ref sender = RTCRtpSender::create(peerConnection, type == RealtimeMediaSource::Type::Audio ? "audio"_s : "video"_s, transceiverBackend->createSenderBackend(*this, nullptr));
     Ref receiver = createReceiver(transceiverBackend->createReceiverBackend());
     Ref transceiver = RTCRtpTransceiver::create(WTF::move(sender), WTF::move(receiver), WTF::move(transceiverBackend));
-    peerConnection->addInternalTransceiver(transceiver.copyRef());
-    return transceiver;
+    peerConnection->addInternalTransceiver(WTF::move(transceiver));
 }
 
-void LibWebRTCPeerConnectionBackend::collectTransceivers()
+void LibWebRTCPeerConnectionBackend::removeTransceiver(const RTCRtpTransceiver& transceiver)
 {
-    m_endpoint->collectTransceivers();
+    Ref peerConnection = m_peerConnection;
+    peerConnection->removeTransceiver(transceiver);
+}
+
+void LibWebRTCPeerConnectionBackend::collectTransceivers(Vector<Ref<RTCRtpTransceiver>>&& transceivers)
+{
+    m_endpoint->collectTransceivers(WTF::move(transceivers));
 }
 
 void LibWebRTCPeerConnectionBackend::removeTrack(RTCRtpSender& sender)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCPeerConnectionBackend.h
@@ -90,10 +90,10 @@ private:
     ExceptionOr<Ref<RTCRtpTransceiver>> addTransceiver(Ref<MediaStreamTrack>&&, const RTCRtpTransceiverInit&) final;
     void setSenderSourceFromTrack(LibWebRTCRtpSenderBackend&, MediaStreamTrack&);
 
-    RefPtr<RTCRtpTransceiver> existingTransceiver(Function<bool(LibWebRTCRtpTransceiverBackend&)>&&);
-    Ref<RTCRtpTransceiver> newRemoteTransceiver(UniqueRef<LibWebRTCRtpTransceiverBackend>&&, RealtimeMediaSource::Type);
+    void addInternalTransceiver(UniqueRef<LibWebRTCRtpTransceiverBackend>&&, RealtimeMediaSource::Type);
+    void removeTransceiver(const RTCRtpTransceiver&);
 
-    void collectTransceivers() final;
+    void collectTransceivers(Vector<Ref<RTCRtpTransceiver>>&&) final;
 
 private:
     bool isLocalDescriptionSet() const final { return m_isLocalDescriptionSet; }


### PR DESCRIPTION
#### a7a88d2d6ae3e9daafd19afd70e4c8c0f5bc0527
<pre>
RTCPeerConnection should not expose transceivers of rejected m-sections
<a href="https://rdar.apple.com/172083648">rdar://172083648</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309493">https://bugs.webkit.org/show_bug.cgi?id=309493</a>

Reviewed by Philippe Normand.

When setting local or remote description, we get the list of transceivers from the backend.
While we were adding new transceivers, we were not removing transceivers that the backend was no longer surfacing.

We update LibWebRTCMediaEndpoint::collectTransceivers to do this by:
1. Passing to LibWebRTCMediaEndpoint::collectTransceivers a list of the current transceivers
2. Go through the backend transceivers.
3. If a backend transceiver is not the in the list, surface a new transceiver to the RTCPeerConnection.
4. Otherwise, we remove from the list the corresponding transceiver.
5. Remaining transceivers of the list given to LibWebRTCMediaEndpoint::collectTransceivers should no longer be surfaced by RTCPeerConnection.
   We therefore remove them from the RTCPeerConnection list of transceivers.

Covered by rebased WPT tests.

Canonical link: <a href="https://commits.webkit.org/309042@main">https://commits.webkit.org/309042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62ed77e44d3052abcdee81f4023fff5be6948214

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102500 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150942 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114924 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81818 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95683 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3315ea0-2b22-4139-a557-35f67c6b8920) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16210 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14078 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5610 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11711 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160240 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3229 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122975 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123204 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33526 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21592 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133504 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77792 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18464 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10263 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21194 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84996 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20926 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21074 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20982 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->