### PR TITLE
[GLIB] Drop unsafe buffer usage from GLib's launcher

### DIFF
--- a/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp
@@ -32,15 +32,15 @@
 #include <wtf/UniStdExtras.h>
 #include <wtf/glib/Application.h>
 #include <wtf/glib/GRefPtr.h>
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/Sandbox.h>
+#include <wtf/text/CStringView.h>
 #include <wtf/text/MakeString.h>
 
 #if PLATFORM(GTK)
 #include "Display.h"
 #endif
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
 
 #if !defined(MFD_ALLOW_SEALING) && HAVE(LINUX_MEMFD_H)
 #include <linux/memfd.h>
@@ -193,7 +193,7 @@ enum class BindFlags {
     Device,
 };
 
-static void bindSymlinksRealPath(Vector<CString>& args, const String& path, const char* bindOption = "--ro-bind")
+static void bindSymlinksRealPath(Vector<CString>& args, const String& path, const ASCIILiteral bindOption = "--ro-bind"_s)
 {
     auto realPath = FileSystem::realPath(path);
     if (path != realPath) {
@@ -202,28 +202,38 @@ static void bindSymlinksRealPath(Vector<CString>& args, const String& path, cons
     }
 }
 
+static void bindIfExists(Vector<CString>& args, const CStringView& path, BindFlags bindFlags = BindFlags::ReadOnly)
+{
+    const ASCIILiteral bindType = [&] () {
+        switch (bindFlags) {
+        case BindFlags::Device:
+            return "--dev-bind-try"_s;
+        case BindFlags::ReadOnly:
+            return "--ro-bind-try"_s;
+        default:
+            return "--bind-try"_s;
+        }
+    }();
+
+    // Canonicalize the source path, otherwise a symbolic link could
+    // point to a location outside of the namespace.
+    bindSymlinksRealPath(args, path.span(), bindType);
+
+    // As /etc is exposed wholesale, do not layer extraneous bind
+    // directives on top, which could fail in the presence of symbolic
+    // links.
+    if (!startsWith(path.span(), "/etc/"_s)) {
+        auto pathString = CString(path.span());
+        args.appendVector(Vector<CString>({ bindType, pathString, pathString }));
+    }
+}
+
 static void bindIfExists(Vector<CString>& args, const char* path, BindFlags bindFlags = BindFlags::ReadOnly)
 {
     if (!path || path[0] == '\0')
         return;
 
-    const char* bindType;
-    if (bindFlags == BindFlags::Device)
-        bindType = "--dev-bind-try";
-    else if (bindFlags == BindFlags::ReadOnly)
-        bindType = "--ro-bind-try";
-    else
-        bindType = "--bind-try";
-
-    // Canonicalize the source path, otherwise a symbolic link could
-    // point to a location outside of the namespace.
-    bindSymlinksRealPath(args, String::fromUTF8(path), bindType);
-
-    // As /etc is exposed wholesale, do not layer extraneous bind
-    // directives on top, which could fail in the presence of symbolic
-    // links.
-    if (!g_str_has_prefix(path, "/etc/"))
-        args.appendVector(Vector<CString>({ bindType, path, path }));
+    bindIfExists(args, CStringView::unsafeFromUTF8(path), bindFlags);
 }
 
 static void bindDBusSession(Vector<CString>& args, XDGDBusProxy& dbusProxy, bool allowPortals)
@@ -243,16 +253,14 @@ static void bindDBusSession(Vector<CString>& args, XDGDBusProxy& dbusProxy, bool
 #if PLATFORM(X11)
 static void bindX11(Vector<CString>& args)
 {
-    const char* display = g_getenv("DISPLAY");
-    if (display && display[0] == ':' && g_ascii_isdigit(const_cast<char*>(display)[1])) {
-        const char* displayNumber = &display[1];
-        const char* displayNumberEnd = displayNumber;
-        while (g_ascii_isdigit(*displayNumberEnd))
-            displayNumberEnd++;
-
-        GUniquePtr<char> displayString(g_strndup(displayNumber, displayNumberEnd - displayNumber));
-        GUniquePtr<char> x11File(g_strdup_printf("/tmp/.X11-unix/X%s", displayString.get()));
-        bindIfExists(args, x11File.get(), BindFlags::ReadWrite);
+    auto display = String::fromUTF8(g_getenv("DISPLAY"));
+    if (!display.isNull() && display[0] == ':' && isASCIIDigit(display[1])) {
+        auto displayNumberEnd = display.find([](char16_t c) {
+            return !isASCIIDigit(c);
+        }, 1);
+        auto displayString = display.substring(1, displayNumberEnd - 1);
+        auto x11File = makeString("/tmp/.X11-unix/X"_s, displayString);
+        bindIfExists(args, x11File.utf8().data(), BindFlags::ReadWrite);
     }
 
     const char* xauth = g_getenv("XAUTHORITY");
@@ -284,8 +292,9 @@ static void bindPulse(Vector<CString>& args)
     // They can also be set as X11 props but that is getting a bit ridiculous.
     const char* pulseServer = g_getenv("PULSE_SERVER");
     if (pulseServer) {
-        if (g_str_has_prefix(pulseServer, "unix:"))
-            bindIfExists(args, pulseServer + 5, BindFlags::ReadWrite);
+        auto pulseServerString = CStringView::unsafeFromUTF8(pulseServer);
+        if (startsWith(pulseServerString.span(), "unix:"_s))
+            bindIfExists(args, CStringView::fromUTF8(pulseServerString.span().subspan(5)), BindFlags::ReadWrite);
         // else it uses tcp
     } else {
         const char* runtimeDir = g_get_user_runtime_dir();
@@ -349,8 +358,8 @@ static void bindFonts(Vector<CString>& args)
     bindIfExists(args, fontHomeConfigDir.get());
     bindIfExists(args, fontData.get());
     bindIfExists(args, fontHomeData.get());
-    for (auto* dataDir = dataDirs; dataDir && *dataDir; dataDir++) {
-        GUniquePtr<char> fontDataDir(g_build_filename(*dataDir, "fonts", nullptr));
+    for (const auto* dataDir : span(dataDirs)) {
+        GUniquePtr<char> fontDataDir(g_build_filename(dataDir, "fonts", nullptr));
         bindIfExists(args, fontDataDir.get());
     }
     bindIfExists(args, "/var/cache/fontconfig"); // Used by Debian.
@@ -397,8 +406,8 @@ static bool bindPathVar(Vector<CString>& args, const char* varname)
         return false;
 
     GUniquePtr<char*> splitPaths(g_strsplit(pathValue, ":", -1));
-    for (size_t i = 0; splitPaths.get()[i]; ++i)
-        bindIfExists(args, splitPaths.get()[i]);
+    for (const auto* path : span(splitPaths))
+        bindIfExists(args, path);
 
     return true;
 }
@@ -694,10 +703,10 @@ static int setupSeccomp()
     return tmpfd;
 }
 
-static bool shouldUnshareNetwork(ProcessLauncher::ProcessType processType, char** argv)
+static bool shouldUnshareNetwork(ProcessLauncher::ProcessType processType, Vector<char*>& argv)
 {
     // gdbserver requires network access for remote debugging.
-    if (enableDebugPermissions() && g_str_has_suffix(argv[0], "gdbserver"))
+    if (enableDebugPermissions() && endsWith(CStringView::unsafeFromUTF8(argv[0]).span(), "gdbserver"_s))
         return false;
 
     if (remoteInspectorEnabled())
@@ -726,18 +735,20 @@ static bool shouldUnshareNetwork(ProcessLauncher::ProcessType processType, char*
 
 static std::optional<CString> directoryContainingDBusSocket(const char* dbusAddress)
 {
-    if (!dbusAddress || !g_str_has_prefix(dbusAddress, "unix:"))
+    if (!dbusAddress)
         return std::nullopt;
 
-    if (const char* pathStart = strstr(dbusAddress, "path=")) {
+    auto dbusAddressString = StringView::fromLatin1(dbusAddress);
+
+    if (!dbusAddressString.startsWith("unix:"_s))
+        return std::nullopt;
+
+    if (auto pathStart = dbusAddressString.find("path="_s)) {
         pathStart += strlen("path=");
 
-        const char* pathEnd = pathStart;
-        while (*pathEnd && *pathEnd != ',')
-            pathEnd++;
-
-        CString path(std::span { pathStart, pathEnd });
-        GRefPtr<GFile> file = adoptGRef(g_file_new_for_path(path.data()));
+        auto pathEnd = dbusAddressString.find(',', pathStart);
+        auto path = pathEnd == notFound ? dbusAddressString.substring(pathStart) : dbusAddressString.substring(pathStart, pathEnd - pathStart);
+        GRefPtr<GFile> file = adoptGRef(g_file_new_for_path(path.utf8().data()));
         GRefPtr<GFile> parent = adoptGRef(g_file_get_parent(file.get()));
         if (!parent)
             return std::nullopt;
@@ -758,7 +769,7 @@ static void addExtraPaths(const HashMap<CString, SandboxPermission>& paths, Vect
     }
 }
 
-GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const ProcessLauncher::LaunchOptions& launchOptions, XDGDBusProxy& dbusProxy, char** argv, GError **error)
+GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const ProcessLauncher::LaunchOptions& launchOptions, XDGDBusProxy& dbusProxy, Vector<char*>& argv, GError **error)
 {
     ASSERT(launcher);
 
@@ -766,7 +777,7 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
     // requires a lot of access but doesn't execute arbitrary code like
     // the WebProcess where our focus lies.
     if (launchOptions.processType == ProcessLauncher::ProcessType::Network)
-        return adoptGRef(g_subprocess_launcher_spawnv(launcher, argv, error));
+        return adoptGRef(g_subprocess_launcher_spawnv(launcher, argv.span().data(), error));
 
     const char* runDir = g_get_user_runtime_dir();
     Vector<CString> sandboxArgs = {
@@ -824,10 +835,8 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
             "--bind-try", rrOutputDir.get(), rrOutputDir.get(),
         }));
     } else {
-        sandboxArgs.appendVector(Vector<CString>({
-            // In some configurations cross pid namespace debugging has issues.
-            "--unshare-pid",
-        }));
+        // In some configurations cross pid namespace debugging has issues.
+        sandboxArgs.append("--unshare-pid");
     }
 
     addExtraPaths(launchOptions.extraSandboxPaths, sandboxArgs);
@@ -957,14 +966,14 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
 #if ENABLE(DEVELOPER_MODE)
     const char* execDirectory = g_getenv("WEBKIT_EXEC_PATH");
     if (execDirectory) {
-        String parentDir = FileSystem::parentPath(FileSystem::stringFromFileSystemRepresentation(execDirectory));
+        auto parentDir = FileSystem::parentPath(FileSystem::stringFromFileSystemRepresentation(execDirectory));
         bindIfExists(sandboxArgs, parentDir.utf8().data());
     }
 
     CString executablePath = FileSystem::currentExecutablePath();
     if (!executablePath.isNull()) {
         // Our executable is `/foo/bar/bin/Process`, we want `/foo/bar` as a usable prefix
-        String parentDir = FileSystem::parentPath(FileSystem::parentPath(FileSystem::stringFromFileSystemRepresentation(executablePath.data())));
+        auto parentDir = FileSystem::parentPath(FileSystem::parentPath(FileSystem::stringFromFileSystemRepresentation(executablePath.data())));
         bindIfExists(sandboxArgs, parentDir.utf8().data());
     }
 #endif
@@ -985,20 +994,17 @@ GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher* launcher, const Proces
         "--",
     };
 
-    char** newArgv = g_newa(char*, g_strv_length(argv) + bwrapArgs.size() + 1);
+    Vector<char*> newArgv(bwrapArgs.size() + argv.size());
     size_t i = 0;
 
     for (auto& arg : bwrapArgs)
         newArgv[i++] = const_cast<char*>(arg.data());
-    for (size_t x = 0; argv[x]; x++)
-        newArgv[i++] = argv[x];
-    newArgv[i++] = nullptr;
+    for (auto& arg : argv)
+        newArgv[i++] = arg;
 
-    return adoptGRef(g_subprocess_launcher_spawnv(launcher, newArgv, error));
+    return adoptGRef(g_subprocess_launcher_spawnv(launcher, newArgv.span().data(), error));
 }
 
 };
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 #endif // ENABLE(BUBBLEWRAP_SANDBOX)

--- a/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.h
@@ -36,7 +36,7 @@ typedef struct _GSubprocessLauncher GSubprocessLauncher;
 
 namespace WebKit {
 
-GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher*, const ProcessLauncher::LaunchOptions&, XDGDBusProxy&, char** argv, GError**);
+GRefPtr<GSubprocess> bubblewrapSpawn(GSubprocessLauncher*, const ProcessLauncher::LaunchOptions&, XDGDBusProxy&, Vector<char*>& argv, GError**);
 int argumentsToFileDescriptor(const Vector<CString>&, const char*);
 
 };

--- a/Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.cpp
@@ -30,14 +30,13 @@
 
 #include <gio/gio.h>
 #include <wtf/FileSystem.h>
+#include <wtf/glib/GSpanExtras.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/Sandbox.h>
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
-
 namespace WebKit {
 
-GRefPtr<GSubprocess> flatpakSpawn(GSubprocessLauncher* launcher, const WebKit::ProcessLauncher::LaunchOptions& launchOptions, char** argv, int childProcessSocket, GError** error)
+GRefPtr<GSubprocess> flatpakSpawn(GSubprocessLauncher* launcher, const WebKit::ProcessLauncher::LaunchOptions& launchOptions, Vector<char*>& argv, int childProcessSocket, GError** error)
 {
     ASSERT(launcher);
 
@@ -97,24 +96,21 @@ GRefPtr<GSubprocess> flatpakSpawn(GSubprocessLauncher* launcher, const WebKit::P
 
     // We need to pass our full environment to the subprocess.
     GUniquePtr<char*> environ(g_get_environ());
-    for (char** variable = environ.get(); variable && *variable; variable++) {
-        GUniquePtr<char> arg(g_strconcat("--env=", *variable, nullptr));
+    for (auto* variable : span(environ)) {
+        GUniquePtr<char> arg(g_strconcat("--env=", variable, nullptr));
         flatpakArgs.append(arg.get());
     }
 
-    char** newArgv = g_newa(char*, g_strv_length(argv) + flatpakArgs.size() + 1);
+    Vector<char*> newArgv(argv.size() + flatpakArgs.size());
     size_t i = 0;
 
     for (const auto& arg : flatpakArgs)
         newArgv[i++] = const_cast<char*>(arg.data());
-    for (size_t x = 0; argv[x]; x++)
-        newArgv[i++] = argv[x];
-    newArgv[i++] = nullptr;
+    for (const auto& arg : argv)
+        newArgv[i++] = arg;
 
-    return adoptGRef(g_subprocess_launcher_spawnv(launcher, newArgv, error));
+    return adoptGRef(g_subprocess_launcher_spawnv(launcher, newArgv.span().data(), error));
 }
-
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 };
 

--- a/Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.h
+++ b/Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.h
@@ -36,7 +36,7 @@ typedef struct _GSubprocessLauncher GSubprocessLauncher;
 
 namespace WebKit {
 
-GRefPtr<GSubprocess> flatpakSpawn(GSubprocessLauncher*, const WebKit::ProcessLauncher::LaunchOptions&, char** argv, int childProcessSocket, GError**);
+GRefPtr<GSubprocess> flatpakSpawn(GSubprocessLauncher*, const WebKit::ProcessLauncher::LaunchOptions&, Vector<char*>& argv, int childProcessSocket, GError**);
 
 };
 

--- a/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
@@ -106,16 +106,12 @@ void ProcessLauncher::launchProcess()
 
 #if USE(LIBWPE) && !ENABLE(BUBBLEWRAP_SANDBOX)
     if (ProcessProviderLibWPE::singleton().isEnabled()) {
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
-        unsigned nargs = 3;
-        char** argv = g_newa(char*, nargs);
-        unsigned i = 0;
-        argv[i++] = processIdentifier.get();
-        argv[i++] = webkitSocket.get();
-        argv[i++] = nullptr;
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+        std::array<char*, 3> argv = {
+            processIdentifier.get(),
+            webkitSocket.get(),
+        };
 
-        m_processID = ProcessProviderLibWPE::singleton().launchProcess(m_launchOptions, argv, webkitSocketPair.client.value());
+        m_processID = ProcessProviderLibWPE::singleton().launchProcess(m_launchOptions, argv.data(), webkitSocketPair.client.value());
         if (m_processID <= -1)
             g_error("Unable to spawn a new child process");
 
@@ -148,7 +144,7 @@ void ProcessLauncher::launchProcess()
     }
 
     realExecutablePath = FileSystem::fileSystemRepresentation(executablePath);
-    unsigned nargs = 5; // size of the argv array for g_spawn_async()
+    unsigned nargs = 4; // size of the argv array for g_spawn_async()
 
 #if ENABLE(DEVELOPER_MODE)
     Vector<CString> prefixArgs;
@@ -165,9 +161,7 @@ void ProcessLauncher::launchProcess()
     }
 #endif
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
-
-    char** argv = g_newa(char*, nargs);
+    Vector<char*> argv(nargs);
     unsigned i = 0;
 #if ENABLE(DEVELOPER_MODE)
     // If there's a prefix command, put it before the rest of the args.
@@ -182,8 +176,6 @@ void ProcessLauncher::launchProcess()
         argv[i++] = const_cast<char*>("--configure-jsc-for-testing");
 #endif
     argv[i++] = nullptr;
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
     // Warning: we want GIO to be able to spawn with posix_spawn() rather than fork()/exec(), in
     // order to better accommodate applications that use a huge amount of memory or address space
@@ -228,7 +220,7 @@ void ProcessLauncher::launchProcess()
 #endif // ENABLE(BUBBLEWRAP_SANDBOX)
     else
 #endif // OS(LINUX)
-        process = adoptGRef(g_subprocess_launcher_spawnv(launcher.get(), argv, &error.outPtr()));
+        process = adoptGRef(g_subprocess_launcher_spawnv(launcher.get(), argv.span().data(), &error.outPtr()));
 
     if (!process.get())
         g_error("Unable to spawn a new child process: %s", error->message);

--- a/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.cpp
@@ -180,10 +180,8 @@ void XDGDBusProxy::launch(const ProcessLaunchOptions& webProcessLaunchOptions)
     if (m_args.isEmpty())
         return;
 
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN // GTK/WPE port
-
-    int syncFds[2];
-    if (pipe(syncFds) == -1)
+    std::array<int, 2> syncFds;
+    if (pipe(syncFds.data()) == -1)
         g_error("Failed to make syncfds for dbus-proxy: %s", g_strerror(errno));
     setCloseOnExec(syncFds[0]);
 
@@ -200,14 +198,10 @@ void XDGDBusProxy::launch(const ProcessLaunchOptions& webProcessLaunchOptions)
         DBUS_PROXY_EXECUTABLE,
         proxyArgsStr.get(),
     };
-    int nargs = args.size() + 1;
-    int i = 0;
-    char** argv = g_newa(char*, nargs);
-    for (const auto& arg : args)
-        argv[i++] = const_cast<char*>(arg.data());
-    argv[i] = nullptr;
-
-    WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    auto argv = args.map([](auto& arg) {
+        return const_cast<char*>(arg.data());
+    });
+    argv.append(nullptr);
 
     // Warning: we want GIO to be able to spawn with posix_spawn() rather than fork()/exec(), in
     // order to better accommodate applications that use a huge amount of memory or address space


### PR DESCRIPTION
#### e4485250a46ba7a18f2d963f4b19332cb149b74b
<pre>
[GLIB] Drop unsafe buffer usage from GLib&apos;s launcher
<a href="https://bugs.webkit.org/show_bug.cgi?id=309495">https://bugs.webkit.org/show_bug.cgi?id=309495</a>

Reviewed by Fujii Hironori.

* Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.cpp:
(WebKit::bindSymlinksRealPath):
(WebKit::bindIfExists):
(WebKit::bindX11):
(WebKit::bindPulse):
(WebKit::bindFonts):
(WebKit::bindPathVar):
(WebKit::shouldUnshareNetwork):
(WebKit::directoryContainingDBusSocket):
(WebKit::bubblewrapSpawn):
* Source/WebKit/UIProcess/Launcher/glib/BubblewrapLauncher.h:
* Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.cpp:
(WebKit::flatpakSpawn):
* Source/WebKit/UIProcess/Launcher/glib/FlatpakLauncher.h:
* Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:
(WebKit::ProcessLauncher::launchProcess):
* Source/WebKit/UIProcess/Launcher/glib/XDGDBusProxy.cpp:
(WebKit::XDGDBusProxy::launch):

Canonical link: <a href="https://commits.webkit.org/309394@main">https://commits.webkit.org/309394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3e8b710467dfb6c706b1a2929df643431d5f198

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150357 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159079 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103791 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23249 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116015 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82439 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153317 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96745 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17229 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15163 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6927 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126844 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161552 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4673 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14361 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124014 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22917 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19210 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124212 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22904 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134603 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79284 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23131 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19335 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11360 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22518 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86317 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22231 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22383 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22285 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->