### PR TITLE
[GTK][WPE] `WTFEndSignpost`'s format argument is ignored

### DIFF
--- a/Source/WTF/wtf/glib/SysprofAnnotator.h
+++ b/Source/WTF/wtf/glib/SysprofAnnotator.h
@@ -65,43 +65,79 @@ public:
 
     void beginMark(const void* pointer, std::span<const char> name, const char* description, ...) WTF_ATTRIBUTE_PRINTF(4, 5)
     {
-        auto key = std::make_pair(pointer, static_cast<const void*>(name.data()));
+        auto time = SYSPROF_CAPTURE_CURRENT_TIME;
 
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         Vector<char> buffer(1024);
-        va_list args;
-        va_start(args, description);
-        vsnprintf(buffer.mutableSpan().data(), buffer.size(), description, args);
-        va_end(args);
-        WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-        auto value = std::make_pair(SYSPROF_CAPTURE_CURRENT_TIME, WTF::move(buffer));
+        if (!description || description[0] == '\0') {
+            buffer.resize(0);
+            buffer.append('\0');
+        } else {
+            va_list args, copyArgs;
+            va_start(args, description);
+            va_copy(copyArgs, args);
+
+            auto descriptionLength = vsnprintf(nullptr, 0, description, args);
+            va_end(args);
+            buffer.resize(descriptionLength + 1);
+
+            vsnprintf(buffer.mutableSpan().data(), descriptionLength + 1, description, copyArgs);
+            va_end(copyArgs);
+        }
+
+        auto key = std::make_pair(pointer, static_cast<const void*>(name.data()));
+        auto value = std::make_pair(time, WTF::move(buffer));
 
         Locker locker { m_lock };
-        m_ongoingMarks.set(key, value);
+        m_ongoingMarks.set(key, WTF::move(value));
     }
 
     void endMark(const void* pointer, std::span<const char> name, const char* description, ...) WTF_ATTRIBUTE_PRINTF(4, 5)
     {
+        auto time = SYSPROF_CAPTURE_CURRENT_TIME;
+
         auto key = std::make_pair(pointer, static_cast<const void*>(name.data()));
         std::optional<TimestampAndString> value;
 
         {
             Locker locker { m_lock };
-
-            TimestampAndString v = m_ongoingMarks.take(key);
-            if (v.first)
-                value = WTF::move(v);
+            value = m_ongoingMarks.takeOptional(key);
         }
 
         if (value) {
             int64_t startTime = std::get<0>(*value);
-            const Vector<char>& description = std::get<1>(*value);
-            sysprof_collector_mark(startTime, SYSPROF_CAPTURE_CURRENT_TIME - startTime, m_processName, name.data(), description[0] ? description.span().data() : nullptr);
+            Vector<char>& buffer = std::get<1>(*value);
+
+            if (description && description[0] != '\0') {
+                va_list args, copyArgs;
+                va_start(args, description);
+                va_copy(copyArgs, args);
+
+                auto descriptionLength = vsnprintf(nullptr, 0, description, args);
+                va_end(args);
+
+                if (descriptionLength > 0) {
+                    bool needsSeparator = buffer.size() > 1;
+                    static constexpr auto separator = " | "_span;
+
+                    auto oldSize = buffer.size();
+                    buffer.resize(oldSize + (needsSeparator ? separator.size() : 0) + descriptionLength);
+
+                    auto span = buffer.mutableSpan().subspan(oldSize - 1);
+                    if (needsSeparator) {
+                        memcpySpan(span, separator);
+                        skip(span, separator.size());
+                    }
+                    vsnprintf(span.data(), descriptionLength + 1, description, copyArgs);
+                }
+                va_end(copyArgs);
+            }
+
+            sysprof_collector_mark(startTime, time - startTime, m_processName, name.data(), buffer.span().data());
         } else {
             va_list args;
             va_start(args, description);
-            sysprof_collector_mark_vprintf(SYSPROF_CAPTURE_CURRENT_TIME, 0, m_processName, name.data(), description, args);
+            sysprof_collector_mark_vprintf(time, 0, m_processName, name.data(), description, args);
             va_end(args);
         }
     }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11830,11 +11830,11 @@ void WebPageProxy::mouseEventHandlingCompleted(std::optional<WebEventType> event
     }
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
-    WTFEndSignpost(event.signpostIdentifier(), HandleMouseEvent);
+    WTFEndSignpost(event.signpostIdentifier(), HandleMouseEvent, "handled: %s", handled ? "yes" : "no");
     for (auto& coalescedEvent : event.coalescedEvents()) {
         if (coalescedEvent.signpostIdentifier() == event.signpostIdentifier())
             continue;
-        WTFEndSignpost(coalescedEvent.signpostIdentifier(), HandleMouseEvent);
+        WTFEndSignpost(coalescedEvent.signpostIdentifier(), HandleMouseEvent, "coalesced with: %" PRIuPTR, event.signpostIdentifier());
     }
 #endif
 


### PR DESCRIPTION
#### 9f2e3189a7581e2e48297c79f4dbe85833343c7c
<pre>
[GTK][WPE] `WTFEndSignpost`&apos;s format argument is ignored
<a href="https://bugs.webkit.org/show_bug.cgi?id=309497">https://bugs.webkit.org/show_bug.cgi?id=309497</a>

Reviewed by Adrian Perez de Castro.

The third argument of `WTFEndSignpost` is a `printf`-like format string,
but it is ignored in the Sysprof implementation.

This patch combines begin/end signpost descriptions into a single string
separated by &quot;|&quot; character, so that both parts are visible in Sysprof.

It also adds &quot;handled&quot; and &quot;coalesced with&quot; information to the mouse
event handling signposts, which is only available at the end of the
handling routine.

* Source/WTF/wtf/glib/SysprofAnnotator.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::mouseEventHandlingCompleted):

Canonical link: <a href="https://commits.webkit.org/309480@main">https://commits.webkit.org/309480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/485abb61067568bdd52b9c76a3fcf93190b2ca83

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17142 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104247 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24003 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116406 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153773 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97134 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17613 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15564 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7383 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142796 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127227 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162010 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11611 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5130 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14779 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124408 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23375 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124604 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33815 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135017 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79752 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19674 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11779 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182338 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22975 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86775 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46588 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22687 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22839 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->