### PR TITLE
Make fast/dom/move-embedded-during-update.html more robust

### DIFF
--- a/LayoutTests/fast/dom/move-embedded-during-update.html
+++ b/LayoutTests/fast/dom/move-embedded-during-update.html
@@ -11,6 +11,7 @@ function eventhandler1() {
 function eventhandler2() {
     label.addEventListener("DOMSubtreeModified", eventhandler1);
     label.appendChild(embed);
+    setTimeout(eventhandler3, 0);
 }
 
 function eventhandler3() {
@@ -19,6 +20,6 @@ function eventhandler3() {
 }
 </script>
 
-<style onload="setTimeout(eventhandler3, 0)">AA</style>
+<style>AA</style>
 <label id="label">This test passes if it doesn't crash.</label>
 <embed id="embed" src="data:text/html,foo" onload="eventhandler2()">AA</embed>

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1325,8 +1325,6 @@ fast/dom/Window/window-focus-self.html [ Failure ]
 fast/dom/Window/window-resize-and-move-arguments.html [ Failure ]
 fast/dom/Window/window-resize.html [ Failure ]
 
-webkit.org/b/290021 fast/dom/move-embedded-during-update.html [ Skip ] # Pass Timeout
-
 webkit.org/b/288006 http/tests/dom/noreferrer-window-not-targetable.html [ Failure Pass ]
 webkit.org/b/288006 http/tests/dom/noopener-window-not-targetable.html [ Failure Pass ]
 


### PR DESCRIPTION
#### 9b74268ad2eb26a2aa11a352e5c6d9c49a226aa6
<pre>
Make fast/dom/move-embedded-during-update.html more robust
<a href="https://bugs.webkit.org/show_bug.cgi?id=290021">https://bugs.webkit.org/show_bug.cgi?id=290021</a>
<a href="https://rdar.apple.com/147891386">rdar://147891386</a>

Reviewed by NOBODY (OOPS!).

Start the eventhandler3 align-setting loop from the embed&apos;s onload
handler (eventhandler2) instead of the style element&apos;s onload. This
eliminates a race where eventhandler3 could fire before the embed
element finished loading, which became problematic after
invalidateStyleAndRenderersForSubtree() was added in
HTMLEmbedElement::attributeChanged in <a href="https://commits.webkit.org/292267@main">292267@main</a>.

* LayoutTests/fast/dom/move-embedded-during-update.html:
* LayoutTests/platform/win/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b74268ad2eb26a2aa11a352e5c6d9c49a226aa6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157547 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102291 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f75f367a-9794-4dd0-abe3-211f4f93454a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21452 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114758 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81725 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/318e652d-8e29-4b01-a1b3-c921247739d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151821 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133612 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95520 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc9b8fa9-21f5-4fdd-b6b1-f20208e67a4b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16070 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13918 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5396 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125671 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160030 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13054 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122815 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123045 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133326 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77572 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18344 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10088 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20986 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20718 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20865 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20774 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->