### PR TITLE
Bad Vector access in LineBuilder::handleInlineContent

### DIFF
--- a/LayoutTests/fast/block/inside-inlines/float-and-block-inside-inline-relayout-crash-expected.txt
+++ b/LayoutTests/fast/block/inside-inlines/float-and-block-inside-inline-relayout-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS: this test passes if it doesn't crash.

--- a/LayoutTests/fast/block/inside-inlines/float-and-block-inside-inline-relayout-crash.html
+++ b/LayoutTests/fast/block/inside-inlines/float-and-block-inside-inline-relayout-crash.html
@@ -1,0 +1,18 @@
+<style>
+* { 
+    border-style: outset;
+    white-space: pre-wrap;
+    -webkit-box-decoration-break: clone;
+}
+shadow { 
+    float: inline-end;
+}
+</style>
+<script>
+    testRunner?.dumpAsText();
+</script>
+<shadow>
+</shadow>
+<em/>
+</p>
+PASS: this test passes if it doesn't crash.

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -1436,8 +1436,12 @@ LineBuilder::Result LineBuilder::handleInlineContent(const InlineItemRange& layo
         m_line.initialize(m_lineSpanningInlineBoxes, isFirstFormattedLineCandidate());
 
         auto commitPrecedingNonContentfulContent = [&] {
+            auto& candidateRuns = lineCandidate.inlineContent.continuousContent().runs();
+            if (candidateRuns.isEmpty())
+                return;
             LineCandidate precedingNonContentfulContent;
-            auto& firstCandidateInlineItem = lineCandidate.inlineContent.continuousContent().runs().first().inlineItem;
+            auto& firstCandidateInlineItem = candidateRuns.first().inlineItem;
+
             // We should not find any inline content here, only non-contentful items like <span> or </span> or trimmed whitespace or out-of-flow content.
             for (size_t index = layoutRange.startIndex(); index < layoutRange.endIndex(); ++index) {
                 auto& inlineItem = m_inlineItemList[index];


### PR DESCRIPTION
#### d1461e7626978a809f486ddc2c49b084e9fc6384
<pre>
Bad Vector access in LineBuilder::handleInlineContent
<a href="https://bugs.webkit.org/show_bug.cgi?id=309498">https://bugs.webkit.org/show_bug.cgi?id=309498</a>
<a href="https://rdar.apple.com/171622303">rdar://171622303</a>

Reviewed by NOBODY (OOPS!).

The relayoutCandidateContent lambda in LineBuilder::handleInlineContent accesses
runs().first() without checking if the runs vector is empty. This can
crash when a block-in-inline with margin triggers the relayout path and
the current line candidate has no continuous content runs.

Guard the access by returning early from commitPrecedingNonContentfulContent
when the candidate&apos;s continuous content runs are empty.

Test: fast/block/inside-inlines/float-and-block-inside-inline-relayout-crash.html

* LayoutTests/fast/block/inside-inlines/float-and-block-inside-inline-relayout-crash-expected.txt: Added.
* LayoutTests/fast/block/inside-inlines/float-and-block-inside-inline-relayout-crash.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::LineBuilder::handleInlineContent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1461e7626978a809f486ddc2c49b084e9fc6384

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157554 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102298 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150741 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21459 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114762 "Found 1 new test failure: fast/block/inside-inlines/float-and-block-inside-inline-relayout-crash.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81730 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5142ea6a-5bb3-4fbb-a885-b5d33e809fb1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151828 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16960 "Found 1 new test failure: fast/block/inside-inlines/float-and-block-inside-inline-relayout-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133619 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95524 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9e05017a-d15e-40d3-aca2-89302a69a9ab) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16071 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13923 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5403 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160037 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3028 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13061 "Found 1 new test failure: fast/block/inside-inlines/float-and-block-inside-inline-relayout-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122819 "Found 1 new test failure: fast/block/inside-inlines/float-and-block-inside-inline-relayout-crash.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21383 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17935 "Found 1 new test failure: fast/block/inside-inlines/float-and-block-inside-inline-relayout-crash.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123049 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21391 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133333 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77579 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18350 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10095 "Found 1 new test failure: fast/block/inside-inlines/float-and-block-inside-inline-relayout-crash.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20993 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84795 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20725 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20872 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20781 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->