### PR TITLE
Use enum class IsResponsive instead of bool in WebProcessProxy::isResponsive() and add defensive null check.

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessCache.cpp
+++ b/Source/WebKit/UIProcess/WebProcessCache.cpp
@@ -143,12 +143,12 @@ bool WebProcessCache::addProcessIfPossible(Ref<WebProcessProxy>&& process)
     m_pendingAddRequests.add(requestIdentifier, CachedProcess::create(process.copyRef(), m_cachedProcessLifetime));
 
     WEBPROCESSCACHE_RELEASE_LOG("addProcessIfPossible: Checking if process is responsive before caching it", process->processID());
-    process->isResponsive([this, protectedThis = Ref { *this }, process, requestIdentifier](bool isResponsive) {
+    process->isResponsive([this, protectedThis = Ref { *this }, process, requestIdentifier](WebProcessProxy::IsResponsive isResponsive) {
         auto cachedProcess = m_pendingAddRequests.take(requestIdentifier);
         if (!cachedProcess)
             return;
 
-        if (!isResponsive) {
+        if (isResponsive == WebProcessProxy::IsResponsive::No) {
             WEBPROCESSCACHE_RELEASE_LOG_ERROR("addProcessIfPossible(): Not caching process because it is not responsive", cachedProcess->process().processID());
             return;
         }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -389,7 +389,7 @@ WebProcessProxy::~WebProcessProxy()
 
     auto isResponsiveCallbacks = WTF::move(m_isResponsiveCallbacks);
     for (auto& callback : isResponsiveCallbacks)
-        callback(false);
+        callback(IsResponsive::No);
 
     while (m_numberOfTimesSuddenTerminationWasDisabled-- > 0)
         WebCore::enableSuddenTermination();
@@ -1344,7 +1344,7 @@ void WebProcessProxy::processDidTerminateOrFailedToLaunch(ProcessTerminationReas
 
     auto isResponsiveCallbacks = std::exchange(m_isResponsiveCallbacks, { });
     for (auto& callback : isResponsiveCallbacks)
-        callback(false);
+        callback(IsResponsive::No);
 
     if (isStandaloneServiceWorkerProcess())
         protect(processPool())->serviceWorkerProcessCrashed(*this, reason);
@@ -1408,9 +1408,8 @@ void WebProcessProxy::didBecomeUnresponsive()
     for (Ref page : pages())
         page->processDidBecomeUnresponsive(*this);
 
-    bool isWebProcessResponsive = false;
     for (auto& callback : isResponsiveCallbacks)
-        callback(isWebProcessResponsive);
+        callback(IsResponsive::No);
 
     // If the web process becomes unresponsive and only runs service/shared workers, kill it ourselves since there are no native clients to do it.
     if (isRunningWorkers() && m_pageMap.isEmpty()) {
@@ -2050,13 +2049,16 @@ void WebProcessProxy::updateMediaStreamingActivity()
     }
 }
 
-void WebProcessProxy::isResponsive(CompletionHandler<void(bool isWebProcessResponsive)>&& callback)
+void WebProcessProxy::isResponsive(CompletionHandler<void(IsResponsive)>&& callback)
 {
     if (m_isResponsive == NoOrMaybe::No) {
         if (callback) {
             RunLoop::mainSingleton().dispatch([callback = WTF::move(callback)]() mutable {
-                bool isWebProcessResponsive = false;
-                callback(isWebProcessResponsive);
+                if (!callback) {
+                    RELEASE_LOG_FAULT(Process, "WebProcessProxy::isResponsive: completion handler is null in RunLoop dispatch");
+                    return;
+                }
+                callback(IsResponsive::No);
             });
         }
         return;
@@ -2070,7 +2072,7 @@ void WebProcessProxy::isResponsive(CompletionHandler<void(bool isWebProcessRespo
             return;
 
         for (auto& isResponsive : std::exchange(weakThis->m_isResponsiveCallbacks, { }))
-            isResponsive(true);
+            isResponsive(IsResponsive::Yes);
     });
 }
 
@@ -2087,7 +2089,7 @@ void WebProcessProxy::isResponsiveWithLazyStop()
                 return;
 
             for (auto& isResponsive : std::exchange(weakThis->m_isResponsiveCallbacks, { }))
-                isResponsive(true);
+                isResponsive(IsResponsive::Yes);
         }, UseLazyStop::Yes);
     }
 }

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -361,7 +361,8 @@ public:
 
     void windowServerConnectionStateChanged();
 
-    void isResponsive(CompletionHandler<void(bool isWebProcessResponsive)>&&);
+    enum class IsResponsive : bool { No, Yes };
+    void isResponsive(CompletionHandler<void(IsResponsive)>&&);
     void isResponsiveWithLazyStop();
     void didReceiveBackgroundResponsivenessPing();
 
@@ -828,7 +829,7 @@ private:
     std::optional<WebCore::Site> m_mainFrameSite;
 
     enum class NoOrMaybe { No, Maybe } m_isResponsive;
-    Vector<CompletionHandler<void(bool webProcessIsResponsive)>> m_isResponsiveCallbacks;
+    Vector<CompletionHandler<void(IsResponsive)>> m_isResponsiveCallbacks;
 
     VisibleWebPageCounter m_visiblePageCounter;
     RefPtr<WebsiteDataStore> m_websiteDataStore;


### PR DESCRIPTION
#### ca7420fa1b18e72d3de1ffa26978efa7fef2944b
<pre>
Use enum class IsResponsive instead of bool in WebProcessProxy::isResponsive() and add defensive null check.
<a href="https://bugs.webkit.org/show_bug.cgi?id=309506">https://bugs.webkit.org/show_bug.cgi?id=309506</a>
<a href="https://rdar.apple.com/171864197">rdar://171864197</a>

Reviewed by NOBODY (OOPS!).

A crash in WTF::Function&lt;void (bool)&gt;::operator() was reported via
StabilityTracer, where the CompletionHandler&apos;s internal Function had
a null m_callableWrapper when invoked from RunLoop::performWork().

The only code path in WebKit matching this exact stack signature is
WebProcessProxy::isResponsive(), which dispatches a
CompletionHandler&lt;void(bool)&gt; to RunLoop when m_isResponsive is No.

This patch:
- Replaces CompletionHandler&lt;void(bool)&gt; with
  CompletionHandler&lt;void(IsResponsive)&gt; using a new enum class, so
  future crashes are immediately identifiable in crash stacks
  (WTF::Function&lt;void (WebKit::WebProcessProxy::IsResponsive)&gt;
  instead of the generic WTF::Function&lt;void (bool)&gt;).
- Adds a defensive null check with RELEASE_LOG_FAULT before invoking
  the completion handler in the RunLoop dispatch path.

* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::~WebProcessProxy):
(WebKit::WebProcessProxy::processDidTerminateOrFailedToLaunch):
(WebKit::WebProcessProxy::didBecomeUnresponsive):
(WebKit::WebProcessProxy::isResponsive):
(WebKit::WebProcessProxy::isResponsiveWithLazyStop):
* Source/WebKit/UIProcess/WebProcessCache.cpp:
(WebKit::WebProcessCache::addProcessIfPossible):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca7420fa1b18e72d3de1ffa26978efa7fef2944b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157577 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102321 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5115a3cc-e615-4ffa-9542-b74fa012c7ee) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22057 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114778 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81741 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133638 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95540 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e98cafb-334e-4906-b06d-25be2299fbe4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16093 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13941 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5426 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125694 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160060 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3051 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122837 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123067 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133352 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77602 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18363 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10114 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21016 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84818 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20748 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20895 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20804 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->