### PR TITLE
[macOS arm64] fast/text/glyph-display-lists/glyph-display-list-* are flaky text failures.

### DIFF
--- a/LayoutTests/fast/inline/invalidation-crash-under-memory-pressure.html
+++ b/LayoutTests/fast/inline/invalidation-crash-under-memory-pressure.html
@@ -6,4 +6,6 @@ document.body.offsetHeight;
 if (window.internals)
   internals.beginSimulatedMemoryPressure();
 remove_this.remove();
+if (window.internals)
+  internals.endSimulatedMemoryPressure();
 </script>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2479,14 +2479,6 @@ webkit.org/b/306444 [ Release ] imported/w3c/web-platform-tests/editing/other/ty
 
 webkit.org/b/307850 media/modern-media-controls/tracks-support/audio-single-track.html [ Pass Timeout ]
 
-# webkit.org/b/309512 [macOS arm64] fast/text/glyph-display-lists/glyph-display-list-* are flaky text failures
-[ arm64 ] fast/text/glyph-display-lists/glyph-display-list-color.html [ Failure Pass ]
-[ arm64 ] fast/text/glyph-display-lists/glyph-display-list-gpu-process-crash.html [ Failure Pass ]
-[ arm64 ] fast/text/glyph-display-lists/glyph-display-list-scaled-unshared.html [ Failure Pass ]
-[ arm64 ] fast/text/glyph-display-lists/glyph-display-list-shadow-unshared.html [ Failure Pass ]
-[ arm64 ] fast/text/glyph-display-lists/glyph-display-list-sharing-colr.html [ Failure Pass ]
-[ arm64 ] fast/text/glyph-display-lists/glyph-display-list-svg-unshared.html [ Failure Pass ]
-
 webkit.org/b/307886 [ Release arm64 ] js/dom/promise-stack-overflow.html [ Pass Failure ]
 
 webkit.org/b/309525 [ Release ] media/video-webkit-playsinline.html [ Pass Failure ]


### PR DESCRIPTION
#### f91f808e24d7d4d1d3b7c8e0ada85698b6df02ad
<pre>
[macOS arm64] fast/text/glyph-display-lists/glyph-display-list-* are flaky text failures.
<a href="https://rdar.apple.com/172110925">rdar://172110925</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309512">https://bugs.webkit.org/show_bug.cgi?id=309512</a>

Reviewed by Jonathan Bedard.

The glyph display list tests are flaky since they rely on caching behavior and fail when caches don&apos;t work as expected.
The test fast/inline/invalidation-crash-under-memory-pressure.html calls internals.beginSimulatedMemoryPressure()
but never calls internals.endSimulatedMemoryPressure().

This leaves the m_isSimulatingMemoryPressure flag set to true in the singleton MemoryPressureHandler, which
persists across test runs and causes the glyph tests to fail

Added the missing internals.endSimulatedMemoryPressure() call to LayoutTests/fast/inline/invalidation-crash-under-memory-pressure.html:10:

* LayoutTests/fast/inline/invalidation-crash-under-memory-pressure.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/309013@main">https://commits.webkit.org/309013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2c870849025706e8f800a205f6f9d455e8a79b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157614 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102357 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22093 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114810 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81752 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95569 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16117 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13970 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5463 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125719 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160096 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122865 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21442 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17985 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123093 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21450 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133383 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77638 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22972 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18384 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10145 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21052 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20784 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20931 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20840 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->