### PR TITLE
[build-webkit-org] Add steps to build Swift toolchain on macOS Safer-CPP

### DIFF
--- a/Tools/CISupport/Shared/steps.py
+++ b/Tools/CISupport/Shared/steps.py
@@ -269,6 +269,10 @@ class PrintSwiftVersion(steps.ShellSequence, ShellMixin):
 
         return defer.returnValue(SUCCESS)
 
+    # FIXME: Remove conditioning on platform when Sequoia Safer-CPP queue is disabled
+    def doStepIf(self, step):
+        return self.getProperty('fullPlatform', '') in {'ios-26', 'mac-tahoe'}
+
     def getResultSummary(self):
         if self.results != SUCCESS:
             return {'step': 'Failed to print Swift version'}
@@ -299,6 +303,10 @@ class GetSwiftTagName(shell.ShellCommand, ShellMixin):
             self.summary = f"Canonical Swift tag name: {self.getProperty('canonical_swift_tag')}"
             return defer.returnValue(SUCCESS)
         return defer.returnValue(FAILURE)
+
+    # FIXME: Remove conditioning on platform when Sequoia Safer-CPP queue is disabled
+    def doStepIf(self, step):
+        return self.getProperty('fullPlatform', '') in {'ios-26', 'mac-tahoe'}
 
     def getResultSummary(self):
         if self.results != SUCCESS:
@@ -337,7 +345,9 @@ class CheckOutSwiftProject(git.Git, AddToLogMixin):
         return SUCCESS
 
     def doStepIf(self, step):
-        return self.getProperty('canonical_swift_tag') and self.getProperty('current_swift_tag', '') != self.getProperty('canonical_swift_tag')
+        # FIXME: Remove conditioning on platform when Sequoia Safer-CPP queue is disabled
+        is_platform_relevant = self.getProperty('fullPlatform', '').lower() in {'ios-26', 'mac-tahoe'}
+        return is_platform_relevant and self.getProperty('canonical_swift_tag') and self.getProperty('current_swift_tag', '') != self.getProperty('canonical_swift_tag')
 
     def getResultSummary(self):
         if self.results == SKIPPED:
@@ -473,6 +483,10 @@ fi
 
         return defer.returnValue(rc)
 
+    # FIXME: Remove conditioning on platform when Sequoia Safer-CPP queue is disabled
+    def doStepIf(self, step):
+        return self.getProperty('fullPlatform', '') in {'ios-26', 'mac-tahoe'}
+
     def getResultSummary(self):
         if self.results == SKIPPED:
             return {'step': 'Metal toolchain installation skipped'}
@@ -566,7 +580,9 @@ class UpdateClang(steps.ShellSequence, ShellMixin):
         defer.returnValue(rc)
 
     def doStepIf(self, step):
-        return self.getProperty('current_llvm_revision', '') != self.getProperty('canonical_llvm_revision')
+        # FIXME: Remove conditioning on platform when Sequoia Safer-CPP queue is disabled
+        is_platform_relevant = self.getProperty('fullPlatform', '') not in {'ios-26', 'mac-tahoe'}
+        return is_platform_relevant and self.getProperty('current_llvm_revision', '') != self.getProperty('canonical_llvm_revision')
 
     def getResultSummary(self):
         if self.results == SKIPPED:

--- a/Tools/CISupport/Shared/steps_unittest.py
+++ b/Tools/CISupport/Shared/steps_unittest.py
@@ -452,6 +452,7 @@ class TestPrintSwiftVersion(BuildStepMixinAdditions, unittest.TestCase):
 
     def configureStep(self):
         self.setup_step(PrintSwiftVersion())
+        self.setProperty('fullPlatform', 'mac-tahoe')
 
     def test_success_with_tag_and_toolchain(self):
         self.configureStep()
@@ -547,6 +548,7 @@ class TestGetSwiftTagName(BuildStepMixinAdditions, unittest.TestCase):
 
     def configureStep(self):
         self.setup_step(GetSwiftTagName())
+        self.setProperty('fullPlatform', 'mac-tahoe')
 
     def test_success(self):
         self.configureStep()
@@ -755,6 +757,7 @@ class TestInstallMetalToolchain(BuildStepMixinAdditions, unittest.TestCase):
 
     def configureStep(self):
         self.setup_step(InstallMetalToolchain())
+        self.setProperty('fullPlatform', 'mac-tahoe')
 
     def test_success_symlink_created(self):
         self.configureStep()

--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -320,15 +320,13 @@ class SaferCPPStaticAnalyzerFactory(Factory):
         self.addStep(GetLLVMVersion())
         self.addStep(PrintClangVersion())
         self.addStep(CheckOutLLVMProject())
-        if platform.startswith('ios'):
-            self.addStep(GetSwiftTagName())
-            self.addStep(PrintSwiftVersion())
-            self.addStep(CheckOutSwiftProject())
-            self.addStep(UpdateSwiftCheckouts())
-            self.addStep(BuildSwift())
-            self.addStep(InstallMetalToolchain())
-        else:
-            self.addStep(UpdateClang())
+        self.addStep(GetSwiftTagName())
+        self.addStep(PrintSwiftVersion())
+        self.addStep(CheckOutSwiftProject())
+        self.addStep(UpdateSwiftCheckouts())
+        self.addStep(BuildSwift())
+        self.addStep(InstallMetalToolchain())
+        self.addStep(UpdateClang())
         self.addStep(ScanBuild())
 
 

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -391,6 +391,12 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'get-llvm-version',
             'print-clang-version',
             'checkout-llvm-project',
+            'get-swift-tag-name',
+            'print-swift-version',
+            'checkout-swift-project',
+            'update-swift-checkouts',
+            'build-swift',
+            'install-metal-toolchain',
             'update-clang',
             'scan-build'
         ],
@@ -776,6 +782,7 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'update-swift-checkouts',
             'build-swift',
             'install-metal-toolchain',
+            'update-clang',
             'scan-build'
         ],
         'Apple-iPadOS-26-Simulator-Release-WK2-Tests': [

--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -1712,11 +1712,11 @@ class ScanBuild(steps.ShellSequence, ShellMixin):
         self.commands = []
 
         build_command = f"Tools/Scripts/build-and-analyze --output-dir {os.path.join(self.getProperty('builddir'), f'build/{SCAN_BUILD_OUTPUT_DIR}')} --configuration {self.build.getProperty('configuration')} --only-smart-pointers "
-        if self.getProperty('platform', '').lower() == 'ios':
-            sdkroot = 'iphonesimulator'
+        sdkroot = 'iphonesimulator' if self.getProperty('platform', '').lower() == 'ios' else 'macosx'
+        # FIXME: Remove conditioning on platform when Sequoia Safer-CPP queue is disabled
+        if self.getProperty('platform', '').lower() == 'ios' or self.getProperty('fullPlatform', '').lower() == 'mac-tahoe':
             build_command += f'--toolchains={SWIFT_TOOLCHAIN_BUNDLE_IDENTIFIER} --swift-conditions=SWIFT_WEBKIT_TOOLCHAIN '
         else:
-            sdkroot = 'macosx'
             build_command += f"--analyzer-path={os.path.join(self.getProperty('builddir'), 'llvm-project/build/bin/clang')} --preprocessor-additions=CLANG_WEBKIT_BRANCH=1 "
         build_command += f'--scan-build-path=../llvm-project/clang/tools/scan-build/bin/scan-build --sdkroot={sdkroot} '
         build_command += '2>&1 | python3 Tools/Scripts/filter-test-logs scan-build --output build-log.txt'
@@ -2398,4 +2398,6 @@ class BuildSwift(steps.ShellSequence, ShellMixin):
         return {'step': 'Successfully built Swift'}
 
     def doStepIf(self, step):
-        return self.getProperty('canonical_swift_tag') and self.getProperty('current_swift_tag', '') != self.getProperty('canonical_swift_tag')
+        # FIXME: Remove conditioning on platform when Sequoia Safer-CPP queue is disabled
+        is_platform_relevant = self.getProperty('fullPlatform', '').lower() in {'ios', 'mac-tahoe'}
+        return is_platform_relevant and self.getProperty('canonical_swift_tag') and self.getProperty('current_swift_tag', '') != self.getProperty('canonical_swift_tag')

--- a/Tools/CISupport/build-webkit-org/steps_unittest.py
+++ b/Tools/CISupport/build-webkit-org/steps_unittest.py
@@ -2381,6 +2381,31 @@ class TestScanBuild(BuildStepMixinAdditions, unittest.TestCase):
         rc = self.run_step()
         return rc
 
+    def test_success_mac_tahoe(self):
+        self.configureStep()
+        self.setProperty('builddir', self.WORK_DIR)
+        self.setProperty('configuration', 'release')
+        self.setProperty('fullPlatform', 'mac-tahoe')
+        self.setProperty('architecture', 'arm64')
+        next_steps = []
+        self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
+
+        expected_build_command = ['/bin/bash', '--posix', '-o', 'pipefail', '-c', f'Tools/Scripts/build-and-analyze --output-dir wkdir/build/{SCAN_BUILD_OUTPUT_DIR} --configuration release --only-smart-pointers --toolchains={SWIFT_TOOLCHAIN_BUNDLE_IDENTIFIER} --swift-conditions=SWIFT_WEBKIT_TOOLCHAIN --scan-build-path=../llvm-project/clang/tools/scan-build/bin/scan-build --sdkroot=macosx 2>&1 | python3 Tools/Scripts/filter-test-logs scan-build --output build-log.txt']
+        self.expectRemoteCommands(
+            ExpectShell(workdir=self.WORK_DIR,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', f'/bin/rm -rf wkdir/build/{SCAN_BUILD_OUTPUT_DIR}'],
+                        timeout=2 * 60 * 60)
+            .exit(0),
+            ExpectShell(workdir=self.WORK_DIR,
+                        command=expected_build_command,
+                        timeout=2 * 60 * 60)
+            .log('stdio', stdout='ANALYZE SUCCEEDED No issues found.\n')
+            .exit(0)
+        )
+        self.expect_outcome(result=SUCCESS, state_string='scan-build found 0 issues')
+        rc = self.run_step()
+        return rc
+
 
 class TestParseStaticAnalyzerResults(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):
@@ -2732,6 +2757,7 @@ class TestBuildSwift(BuildStepMixinAdditions, unittest.TestCase):
         self.setup_step(BuildSwift())
         self.setProperty('architecture', 'arm64')
         self.setProperty('builddir', 'webkit')
+        self.setProperty('fullPlatform', 'mac-tahoe')
         self.setProperty('canonical_swift_tag', 'swift-6.0.3-RELEASE')
 
     def expectedShellCommand(self):


### PR DESCRIPTION
#### ccf360e1d3c4473ebd899eaf9f67fe73036bd54c
<pre>
[build-webkit-org] Add steps to build Swift toolchain on macOS Safer-CPP
<a href="https://bugs.webkit.org/show_bug.cgi?id=309521">https://bugs.webkit.org/show_bug.cgi?id=309521</a>
<a href="https://rdar.apple.com/170493518">rdar://170493518</a>

Reviewed by Aakash Jain.

Enable running Swift toolchain steps on Tahoe builds of Safer-CPP by removing
the iOS condition in SaferCPPStaticAnalyzerFactory and conditioning on platform
within each step.

These conditions should be removed once we disable the Sequoia Safer-CPP queue.

* Tools/CISupport/Shared/steps.py:
(PrintSwiftVersion):
(PrintSwiftVersion.doStepIf):
(GetSwiftTagName):
(GetSwiftTagName.doStepIf):
(CheckOutSwiftProject.doStepIf):
(doStepIf):
(UpdateClang.doStepIf):
* Tools/CISupport/Shared/steps_unittest.py:
(TestPrintSwiftVersion.configureStep):
(TestGetSwiftTagName.configureStep):
(TestInstallMetalToolchain.configureStep):
* Tools/CISupport/build-webkit-org/factories.py:
(SaferCPPStaticAnalyzerFactory.__init__):
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/CISupport/build-webkit-org/steps.py:
(ScanBuild.run):
    - Use toolchain and not clang path if mac-tahoe
(BuildSwift.doStepIf):
* Tools/CISupport/build-webkit-org/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/309018@main">https://commits.webkit.org/309018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a066508d16cb5c3123bc3ab4e8329c4cde7a09f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15410 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157815 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e2a0f916-9ee3-4e64-bb8d-1e4431aa8a5f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21718 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114967 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8285b115-64ec-43da-865f-c552446355bf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95725 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16242 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14121 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5668 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125848 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160299 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123017 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/148598 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21642 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123246 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21650 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133544 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77851 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22977 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18497 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10299 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21252 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20984 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21132 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21040 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->