### PR TITLE
Crash in `Messages::WebExtensionContext::MenusRemove` completion after background page reload

### DIFF
--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -416,9 +416,7 @@ void WebExtensionAPIMenus::remove(id identifier, Ref<WebExtensionCallbackHandler
             return;
         }
 
-        m_clickHandlerMap.remove(identifier);
-
-        if (m_clickHandlerMap.isEmpty())
+        if (m_clickHandlerMap.remove(identifier) && m_clickHandlerMap.isEmpty())
             WebProcess::singleton().send(Messages::WebExtensionContext::RemoveListener(*m_frameIdentifier, WebExtensionEventListenerType::MenusOnClicked, contentWorldType(), 1), extensionContext().identifier());
 
         callback->call();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
@@ -1608,6 +1608,41 @@ TEST(WKWebExtensionAPIMenus, OnClickAfterUpdate)
     [manager run];
 }
 
+TEST(WKWebExtensionAPIMenus, RemoveAfterBackgroundPageReload)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.onMessage.addListener(async (message) => {",
+        @"  if (message == 'Create') {",
+        @"    browser.menus.create({ id: 'test-item', title: 'Test' }, () => {",
+        @"      browser.test.sendMessage('Created')",
+        @"    })",
+        @"  }",
+        @"",
+        @"  if (message == 'Remove') {",
+        @"    await browser.menus.remove('test-item')",
+        @"    browser.test.sendMessage('Removed')",
+        @"  }",
+        @"})",
+        @"",
+        @"browser.test.sendMessage('Ready')",
+    ]);
+
+    auto manager = Util::loadExtension(menusManifest, @{ @"background.js": backgroundScript });
+
+    [manager runUntilTestMessage:@"Ready"];
+
+    [manager sendTestMessage:@"Create"];
+    [manager runUntilTestMessage:@"Created"];
+
+    EXPECT_TRUE(TestWebKitAPI::Util::waitFor([&] {
+        return !manager.get().context._backgroundWebView;
+    }));
+
+    [manager sendTestMessage:@"Remove"];
+    [manager runUntilTestMessage:@"Ready"];
+    [manager runUntilTestMessage:@"Removed"];
+}
+
 TEST(WKWebExtensionAPIMenus, ContextMenusNamespace)
 {
     auto *backgroundScript = Util::constructScript(@[


### PR DESCRIPTION
#### 937a450286ead04a17b18f8991d2f04c2701e888
<pre>
Crash in `Messages::WebExtensionContext::MenusRemove` completion after background page reload
<a href="https://bugs.webkit.org/show_bug.cgi?id=309520">https://bugs.webkit.org/show_bug.cgi?id=309520</a>
<a href="https://rdar.apple.com/162005238">rdar://162005238</a>

Reviewed by Timothy Hatcher.

The crash occurs when a non-persistent background page reloads and calls menus.remove().
m_frameIdentifier will be empty, and is unconditionally dereferenced. We should only send
RemoveListener when a click handler was actually removed.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::WebExtensionAPIMenus::remove):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIMenus.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIMenus, RemoveAfterBackgroundPageReload)):

Canonical link: <a href="https://commits.webkit.org/308964@main">https://commits.webkit.org/308964@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aaa055244c6002f13cabf54f354f1e035f0d074a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157618 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102361 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7732d688-ba80-4b3d-9526-a5abed2d7ae6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150804 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114814 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81754 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3853c32-f857-4fca-a4c0-c5953abfff0e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95572 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c353bc20-3ba7-4da7-922b-5ea391703872) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16118 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13975 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5467 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125720 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160100 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3091 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122870 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123098 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133389 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77642 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22948 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18386 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10151 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21056 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84858 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20788 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20936 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20844 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->