### PR TITLE
[List Marker] Collapse anonymous blocks for outside marker when blockification prevents line-box parenting

### DIFF
--- a/LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block-expected.html
+++ b/LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<style>
+    div.item {
+      font-family: Ahem;
+      font-size: 20px;
+    }
+</style>
+<div class="item">
+    <div style="display: flex">
+        <img style="width: 20px; height: 20px">
+        <div></div>
+        X
+    </div>
+</div>

--- a/LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block.html
+++ b/LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+    ul {
+      margin: 0;
+      padding: 0;
+    }
+    li {
+      font-family: Ahem;
+      font-size: 20px;
+      list-style-position: outside;
+      color: transparent;
+    }
+    li > * {
+      color: black;
+    }
+</style>
+<ul>
+    <li>
+        <div style="display: flex">
+            <img style="width: 20px; height: 20px">
+            <div></div>
+            X
+        </div>
+    </li>
+</ul>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
@@ -29,6 +29,8 @@
 #include "InlineFormattingContext.h"
 #include "InlineLineBox.h"
 #include "LayoutBoxGeometry.h"
+#include "LayoutBoxInlines.h"
+#include "LayoutElementBox.h"
 #include "RenderStyle+GettersInlines.h"
 
 namespace WebCore {
@@ -214,8 +216,14 @@ bool InlineQuirks::shouldCollapseLineBoxHeight(const Line::RunList& lineContent,
     if (!lineContent.size() || numberOfOutsideListMarkers != 1)
         return false;
 
-    if (!lineContent[0].isListMarkerOutside()) {
-        ASSERT(lineContent[0].isListMarkerInside());
+    auto& marker = lineContent[0];
+    auto* markerBox = dynamicDowncast<Layout::ElementBox>(marker.layoutBox());
+    ASSERT(markerBox);
+    if (!markerBox)
+        return false;
+
+    if (!marker.isListMarkerOutside()) {
+        ASSERT(marker.isListMarkerInside());
         return false;
     }
 
@@ -229,14 +237,18 @@ bool InlineQuirks::shouldCollapseLineBoxHeight(const Line::RunList& lineContent,
             ++emptyInlineBoxCount;
     }
 
-    if (lineContent[0].isListMarkerOutside() && emptyInlineBoxCount && emptyInlineBoxCount == lineContent.size() - 1) {
-        // This is to handle non-contentful lines introduced by block boxes. They are supposed to be collapsed so that
-        // the block content can be placed next to the list marker.
-        // Regular inline content would never produced a line with inline box only runs. Also inline content like <li><span><br>
-        // is not supposed to produce a collapsed line box.
-        // The underlying issue is the assumption that we shouldn’t collapse when rootBox is a list item (see below).
+    // This is to handle non-contentful lines introduced by block boxes. They are supposed to be collapsed so that
+    // the block content can be placed next to the list marker.
+    // Regular inline content would never produced a line with inline box only runs. Also inline content like <li><span><br>
+    // is not supposed to produce a collapsed line box.
+    // The underlying issue is the assumption that we shouldn’t collapse when rootBox is a list item (see below).
+    if (emptyInlineBoxCount && emptyInlineBoxCount == lineContent.size() - 1)
         return true;
-    }
+
+    // When an outside marker ends up in an anonymous block because blockification (e.g., by a flex/grid container)
+    // prevented finding a line box parent, collapse the line box so it doesn’t inflate the list item.
+    if (markerBox->shouldCollapseAnonymousBlockParentForListMarker())
+        return true;
 
     auto& rootBox = formattingContext().root();
     if (rootBox.isAnonymous() || rootBox.isListItem())

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -247,6 +247,19 @@ void BoxTreeUpdater::adjustStyleIfNeeded(const RenderElement& renderer, RenderSt
         adjustStyle(*firstLineStyle);
 }
 
+static void updateListMarkerAttributes(const RenderListMarker& listMarkerRenderer, Layout::ElementBox& layoutBox)
+{
+    auto listMarkerAttributes = EnumSet<Layout::ElementBox::ListMarkerAttribute> { };
+    if (listMarkerRenderer.isImage())
+        listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Image);
+    if (!listMarkerRenderer.isInside())
+        listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Outside);
+    if (listMarkerRenderer.shouldCollapseAnonymousBlockParent())
+        listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::ShouldCollapseAnonymousBlockParent);
+
+    layoutBox.setListMarkerAttributes(listMarkerAttributes);
+}
+
 UniqueRef<Layout::Box> BoxTreeUpdater::createLayoutBox(RenderObject& renderer)
 {
     std::unique_ptr<RenderStyle> firstLineStyle = firstLineStyleFor(renderer);
@@ -301,12 +314,9 @@ UniqueRef<Layout::Box> BoxTreeUpdater::createLayoutBox(RenderObject& renderer)
     adjustStyleIfNeeded(renderElement, style, firstLineStyle.get());
 
     if (CheckedPtr listMarkerRenderer = dynamicDowncast<RenderListMarker>(renderElement)) {
-        EnumSet<Layout::ElementBox::ListMarkerAttribute> listMarkerAttributes;
-        if (listMarkerRenderer->isImage())
-            listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Image);
-        if (!listMarkerRenderer->isInside())
-            listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Outside);
-        return makeUniqueRef<Layout::ElementBox>(elementAttributes(renderElement), listMarkerAttributes, WTF::move(style), WTF::move(firstLineStyle));
+        auto layoutBox = makeUniqueRef<Layout::ElementBox>(elementAttributes(renderElement), EnumSet<Layout::ElementBox::ListMarkerAttribute> { }, WTF::move(style), WTF::move(firstLineStyle));
+        updateListMarkerAttributes(*listMarkerRenderer, layoutBox.get());
+        return layoutBox;
     }
 
     return makeUniqueRef<Layout::ElementBox>(elementAttributes(renderElement), WTF::move(style), WTF::move(firstLineStyle));
@@ -382,17 +392,6 @@ static void updateContentCharacteristic(const RenderText& rendererText, Layout::
         contentCharacteristic.add(Layout::InlineTextBox::ContentCharacteristic::CanUseSimplifiedContentMeasuring);
 
     inlineTextBox.setContentCharacteristic(contentCharacteristic);
-}
-
-static void updateListMarkerAttributes(const RenderListMarker& listMarkerRenderer, Layout::ElementBox& layoutBox)
-{
-    auto listMarkerAttributes = EnumSet<Layout::ElementBox::ListMarkerAttribute> { };
-    if (listMarkerRenderer.isImage())
-        listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Image);
-    if (!listMarkerRenderer.isInside())
-        listMarkerAttributes.add(Layout::ElementBox::ListMarkerAttribute::Outside);
-
-    layoutBox.setListMarkerAttributes(listMarkerAttributes);
 }
 
 void BoxTreeUpdater::updateStyle(const RenderObject& renderer)

--- a/Source/WebCore/layout/layouttree/LayoutElementBox.h
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.h
@@ -43,9 +43,10 @@ class ElementBox : public Box {
 public:
     ElementBox(ElementAttributes&&, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle = nullptr, EnumSet<BaseTypeFlag> = { ElementBoxFlag });
 
-    enum class ListMarkerAttribute : bool {
+    enum class ListMarkerAttribute : uint8_t {
         Image,
         Outside,
+        ShouldCollapseAnonymousBlockParent,
     };
     ElementBox(ElementAttributes&&, EnumSet<ListMarkerAttribute>, RenderStyle&&, std::unique_ptr<RenderStyle>&& firstLineStyle = nullptr);
 
@@ -94,6 +95,7 @@ public:
 
     bool isListMarkerImage() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::Image); }
     bool isListMarkerOutside() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::Outside); }
+    bool shouldCollapseAnonymousBlockParentForListMarker() const { return m_replacedData && m_replacedData->listMarkerAttributes.contains(ListMarkerAttribute::ShouldCollapseAnonymousBlockParent); }
 
     // FIXME: This is temporary until after list marker content is accessible by IFC (webkit.org/b/294342)
     void setListMarkerLayoutBounds(std::pair<float, float> layoutBounds) { m_replacedData->layoutBounds = layoutBounds; }

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -76,6 +76,17 @@ public:
 
     std::pair<float, float> layoutBounds() const { return m_layoutBounds; }
 
+    bool shouldCollapseAnonymousBlockParent() const { return m_shouldCollapseAnonymousBlockParent; }
+    void setShouldCollapseAnonymousBlockParent(bool value)
+    {
+        if (value) {
+            ASSERT(parent());
+            ASSERT(parent()->isAnonymousBlock());
+            ASSERT(!isInside());
+        }
+        m_shouldCollapseAnonymousBlockParent = value;
+    }
+
 private:
     void willBeDestroyed() final;
     ASCIILiteral renderName() const final { return "RenderListMarker"_s; }
@@ -112,6 +123,7 @@ private:
     LayoutUnit m_lineOffsetForListItem;
     LayoutUnit m_lineLogicalOffsetForListItem;
     std::pair<float, float> m_layoutBounds;
+    bool m_shouldCollapseAnonymousBlockParent { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -38,10 +38,18 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderTreeBuilder::List);
 
-static std::pair<RenderBlock*, RenderBlock*> findParentOfEmptyOrFirstLineBox(RenderBlock& blockContainer, const RenderListMarker& marker)
+struct LineBoxParentSearchResult {
+    CheckedPtr<RenderBlock> parent;
+    CheckedPtr<RenderBlock> fallbackParent;
+    // FIXME: handle all block level children, not just replaced elements that got blockified.
+    bool failedDueToBlockification { false };
+};
+
+static LineBoxParentSearchResult findParentOfEmptyOrFirstLineBox(RenderBlock& blockContainer, const RenderListMarker& marker)
 {
     auto inQuirksMode = blockContainer.document().inQuirksMode();
     RenderBlock* fallbackParent = { };
+    bool failedDueToBlockification = false;
 
     for (auto& child : childrenOfType<RenderObject>(blockContainer)) {
         if (&child == &marker)
@@ -49,7 +57,7 @@ static std::pair<RenderBlock*, RenderBlock*> findParentOfEmptyOrFirstLineBox(Ren
 
         if (child.isInline()) {
             if (!is<RenderInline>(child) || !isEmptyInline(downcast<RenderInline>(child)))
-                return { &blockContainer, { } };
+                return { &blockContainer, { }, false };
             fallbackParent = &blockContainer;
         }
 
@@ -62,39 +70,55 @@ static std::pair<RenderBlock*, RenderBlock*> findParentOfEmptyOrFirstLineBox(Ren
         if (is<RenderListItem>(blockContainer) && inQuirksMode && child.node() && isHTMLListElement(*child.node()))
             break;
 
-        if (!is<RenderBlock>(child) || is<RenderTable>(child))
+        if (!is<RenderBlock>(child) || is<RenderTable>(child)) {
+            // FIXME: handle all block level children, not just replaced elements that got blockified.
+            if (!child.isInline() && child.style().originalDisplay().isInlineType())
+                failedDueToBlockification = true;
             break;
+        }
 
         auto& blockChild = downcast<RenderBlock>(child);
-        auto [ nestedParent, nestedFallbackParent ] = findParentOfEmptyOrFirstLineBox(blockChild, marker);
-        if (nestedParent)
-            return { nestedParent, { } };
+        auto nestedResult = findParentOfEmptyOrFirstLineBox(blockChild, marker);
+        if (nestedResult.parent) {
+            // Finding a line box parent is mutually exclusive with blockification failure.
+            ASSERT(!nestedResult.failedDueToBlockification);
+            return { nestedResult.parent, { }, false };
+        }
+
+        // Propagate the blockification failure bit from nested searches so that we know whether the search failed due to blockification or because there was no inline content.
+        failedDueToBlockification |= nestedResult.failedDueToBlockification;
 
         if (!fallbackParent) {
-            if (nestedFallbackParent)
-                fallbackParent = nestedFallbackParent;
+            if (nestedResult.fallbackParent)
+                fallbackParent = nestedResult.fallbackParent;
             else if (auto* firstInFlowChild = blockChild.firstInFlowChild(); !firstInFlowChild || firstInFlowChild == &marker)
                 fallbackParent = &blockChild;
         }
     }
 
-    return { { }, fallbackParent };
+    return { { }, fallbackParent, failedDueToBlockification };
 }
 
-static RenderBlock* parentCandidateForMarker(RenderListItem& listItemRenderer, const RenderListMarker& marker)
+struct MarkerParentSearchResult {
+    CheckedPtr<RenderBlock> parent;
+    bool shouldCollapseAnonymousBlockParent { false };
+};
+
+static MarkerParentSearchResult parentCandidateForMarker(RenderListItem& listItemRenderer, const RenderListMarker& marker)
 {
     if (marker.isInside()) {
         if (auto* firstChild = dynamicDowncast<RenderBlock>(listItemRenderer.firstChild())) {
             if (!firstChild->isAnonymous())
-                return &listItemRenderer;
+                return { &listItemRenderer, false };
             // We may have created this anonymous block for the marker itself. Let's keep it in there.
             if (firstChild->firstChild() == &marker && !marker.nextSibling())
-                return firstChild;
+                return { firstChild, false };
         }
-        return findParentOfEmptyOrFirstLineBox(listItemRenderer, marker).first;
+        auto result = findParentOfEmptyOrFirstLineBox(listItemRenderer, marker);
+        return { result.parent, false };
     }
-    auto [parentCandidate, fallbackParent] = findParentOfEmptyOrFirstLineBox(listItemRenderer, marker);
-    return parentCandidate ? parentCandidate : fallbackParent;
+    auto result = findParentOfEmptyOrFirstLineBox(listItemRenderer, marker);
+    return { result.parent ? result.parent : result.fallbackParent, result.failedDueToBlockification };
 }
 
 static RenderObject* firstNonMarkerChild(RenderBlock& parent)
@@ -135,22 +159,25 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
             return;
         }
 
-        auto* newParent = parentCandidateForMarker(listItemRenderer, *markerRenderer);
-        if (!newParent) {
+        auto searchResult = parentCandidateForMarker(listItemRenderer, *markerRenderer);
+        if (!searchResult.parent) {
             if (currentParent->isAnonymousBlock()) {
-                // If the marker is currently contained inside an anonymous box. then we are the only item in that anonymous box
-                // (since no line box parent was found). It's ok to just leave the marker where it is in this case.
+                // For outside markers, if the search failed because a flex/grid container blockified a replaced
+                // child (e.g., <img>), we should collapse the anonymous block's height so it doesn't inflate the list item.
+                markerRenderer->setShouldCollapseAnonymousBlockParent(searchResult.shouldCollapseAnonymousBlockParent);
+                // If the marker is currently contained inside an anonymous box, we are the only item in that anonymous box
+                // since no line box parent was found. It's ok to just leave the marker where it is in this case.
                 return;
             }
-            newParent = &listItemRenderer;
+            searchResult.parent = &listItemRenderer;
             if (auto* multiColumnFlow = listItemRenderer.multiColumnFlow())
-                newParent = multiColumnFlow;
+                searchResult.parent = multiColumnFlow;
         }
 
-        if (newParent == currentParent)
+        if (searchResult.parent == currentParent)
             return;
 
-        m_builder.attach(*newParent, m_builder.detach(*currentParent, *markerRenderer, WillBeDestroyed::No, RenderTreeBuilder::CanCollapseAnonymousBlock::No), firstNonMarkerChild(*newParent));
+        m_builder.attach(*searchResult.parent, m_builder.detach(*currentParent, *markerRenderer, WillBeDestroyed::No, RenderTreeBuilder::CanCollapseAnonymousBlock::No), firstNonMarkerChild(*searchResult.parent));
         // If current parent is an anonymous block that has lost all its children, destroy it.
         if (currentParent->isAnonymousBlock() && !currentParent->firstChild() && !downcast<RenderBlock>(*currentParent).continuation())
             m_builder.destroy(*currentParent);
@@ -160,17 +187,18 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
     RenderPtr<RenderListMarker> newMarkerRenderer = WebCore::createRenderer<RenderListMarker>(listItemRenderer, WTF::move(newStyle));
     newMarkerRenderer->initializeStyle();
     listItemRenderer.setMarkerRenderer(*newMarkerRenderer);
-    auto* newParent = parentCandidateForMarker(listItemRenderer, *newMarkerRenderer);
-    if (!newParent) {
-        // If the marker is currently contained inside an anonymous box,
-        // then we are the only item in that anonymous box (since no line box
-        // parent was found). It's ok to just leave the marker where it is
-        // in this case.
-        newParent = &listItemRenderer;
+    auto searchResult = parentCandidateForMarker(listItemRenderer, *newMarkerRenderer);
+    auto shouldCollapseAnonymousBlockParent = !searchResult.parent && !newMarkerRenderer->isInside() && searchResult.shouldCollapseAnonymousBlockParent;
+    if (!searchResult.parent) {
+        searchResult.parent = &listItemRenderer;
         if (auto* multiColumnFlow = listItemRenderer.multiColumnFlow())
-            newParent = multiColumnFlow;
+            searchResult.parent = multiColumnFlow;
     }
-    m_builder.attach(*newParent, WTF::move(newMarkerRenderer), firstNonMarkerChild(*newParent));
+    m_builder.attach(*searchResult.parent, WTF::move(newMarkerRenderer), firstNonMarkerChild(*searchResult.parent));
+    // For outside markers, if the search failed because a flex/grid container blockified a replaced
+    // child (e.g., <img>), we should collapse the anonymous block's height so it doesn't inflate the list item.
+    if (shouldCollapseAnonymousBlockParent)
+        listItemRenderer.markerRenderer()->setShouldCollapseAnonymousBlockParent(true);
 }
 
 }


### PR DESCRIPTION
#### 376d3ef4163021f3bcebe93dbcb60dc92caa7100
<pre>
[List Marker] Collapse anonymous blocks for outside marker when blockification prevents line-box parenting
<a href="https://bugs.webkit.org/show_bug.cgi?id=309925">https://bugs.webkit.org/show_bug.cgi?id=309925</a>
&lt;<a href="https://rdar.apple.com/165933903">rdar://165933903</a>&gt;

Reviewed by Alan Baradlay.

findParentOfEmptyOrFirstLineBox sometimes fails to find a suitable line-box
parent when a list item contains a flex or grid container because flex/grid
containers blockify inline content like &lt;svg&gt; and &lt;img&gt;. In this case, we
fall back to creating an anonymous block to parent the list marker. However,
this causes layout issues because the anonymous block&apos;s inherited line height
pushes the visible content down (and no longer next to the list marker).

This fixes the issue by detecting parenting failure due to blockification
and flagging the marker to collapse its parent block.

* LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block-expected.html: Added.
* LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block.html: Added.
* Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp:
(WebCore::Layout::InlineQuirks::shouldCollapseLineBoxHeight const):
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
(WebCore::LayoutIntegration::updateListMarkerAttributes):
(WebCore::LayoutIntegration::BoxTreeUpdater::createLayoutBox):
* Source/WebCore/layout/layouttree/LayoutElementBox.h:
(WebCore::Layout::ElementBox::shouldCollapseAnonymousBlockParentForListMarker const):
* Source/WebCore/rendering/RenderListMarker.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp:
(WebCore::findParentOfEmptyOrFirstLineBox):
(WebCore::parentCandidateForMarker):
(WebCore::RenderTreeBuilder::List::updateItemMarker):

Canonical link: <a href="https://commits.webkit.org/309272@main">https://commits.webkit.org/309272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53a8ef86ed2da32ab9ba6ff71092789ac743ae20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16426 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158818 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103541 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df944f07-f3de-4c9d-8fe4-b36858a9d7bd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115795 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3625cb3-9609-4bbe-8bae-467865c98993) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153067 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96524 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c941be4-b790-4dfa-8092-274476fd66d3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17008 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14957 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6664 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126623 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161292 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4383 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14144 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123799 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19004 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124000 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33673 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134387 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78883 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19127 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11144 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22266 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86067 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21981 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22133 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22035 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->