### PR TITLE
REGRESSION(iOS17): fast/forms/listbox-bidi-align.html is constantly failing.

### DIFF
--- a/LayoutTests/platform/gtk/fast/text/international/bidi-menulist-expected.txt
+++ b/LayoutTests/platform/gtk/fast/text/international/bidi-menulist-expected.txt
@@ -31,9 +31,9 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (142,19) size 1x17
         RenderMenuList {SELECT} at (0,37) size 200x30 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
           RenderSelectFallbackButton {DIV} at (1,1) size 198x28
-            RenderText at (5,5) size 84x18
-              text run at (5,5) width 26: "abc"
-              text run at (31,5) width 58 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
+            RenderText at (93,5) size 84x18
+              text run at (93,5) width 27: "abc"
+              text run at (119,5) width 58 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
         RenderBR {BR} at (200,43) size 0x18
       RenderBlock {DIV} at (0,208) size 200x19
         RenderText {#text} at (0,1) size 87x17

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7083,8 +7083,6 @@ css3/scroll-snap/ios/scroll-snap-mainframe-pinch-out.html [ Skip ]
 
 webkit.org/b/263052 fast/events/ios/keydown-keyup-keypress-keys-in-non-editable-using-chinese-keyboard.html [ Skip ]
 
-webkit.org/b/263662 fast/forms/listbox-bidi-align.html [ Failure ]
-
 webkit.org/b/260640 [ Release arm64 ] editing/execCommand/apply-inline-style-to-element-with-no-renderer-crash.html [ Pass Failure ]
 
 # This test relies on mouse input.

--- a/LayoutTests/platform/ios/fast/forms/listbox-bidi-align-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/listbox-bidi-align-expected.txt
@@ -1,134 +1,134 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x274
-  RenderBlock {HTML} at (0,0) size 800x274
-    RenderBody {BODY} at (8,8) size 784x258
+layer at (0,0) size 800x277
+  RenderBlock {HTML} at (0,0) size 800x277
+    RenderBody {BODY} at (8,8) size 784x261
       RenderBlock (anonymous) at (0,0) size 784x40
-        RenderText {#text} at (0,0) size 615x19
+        RenderText {#text} at (0,0) size 615x20
           text run at (0,0) width 615: "This test verifies the visual alignment of items in a select element while changing text direction."
-        RenderBR {BR} at (614,0) size 1x19
-        RenderText {#text} at (0,20) size 438x19
+        RenderBR {BR} at (614,0) size 1x20
+        RenderText {#text} at (0,20) size 438x20
           text run at (0,20) width 438: "All the items in the following select elements should be left-aligned."
-      RenderTable {TABLE} at (0,40) size 638x52
-        RenderTableSection {TBODY} at (0,0) size 638x52
-          RenderTableRow {TR} at (0,2) size 638x23
-            RenderTableCell {TD} at (2,2) size 160x23 [r=0 c=0 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 158x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+      RenderTable {TABLE} at (0,40) size 666x53
+        RenderTableSection {TBODY} at (0,0) size 666x53
+          RenderTableRow {TR} at (0,2) size 666x24
+            RenderTableCell {TD} at (2,2) size 160x24 [r=0 c=0 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 158x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
                 RenderSelectFallbackButton {DIV} at (6,3) size 146x14
                   RenderText at (0,0) size 0x14
                     text run at (0,0) width 0: " "
-            RenderTableCell {TD} at (164,2) size 154x23 [r=0 c=1 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 152x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-                RenderSelectFallbackButton {DIV} at (6,3) size 140x14
+            RenderTableCell {TD} at (164,2) size 168x24 [r=0 c=1 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 166x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+                RenderSelectFallbackButton {DIV} at (6,3) size 154x14
                   RenderText at (0,0) size 0x14
                     text run at (0,0) width 0: " "
-            RenderTableCell {TD} at (320,2) size 160x23 [r=0 c=2 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 158x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+            RenderTableCell {TD} at (334,2) size 160x24 [r=0 c=2 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 158x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
                 RenderSelectFallbackButton {DIV} at (6,3) size 146x14
-                  RenderText at (146,0) size 0x14
-                    text run at (146,0) width 0 RTL: " "
-            RenderTableCell {TD} at (482,2) size 154x23 [r=0 c=3 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 152x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+                  RenderText at (0,0) size 0x14
+                    text run at (0,0) width 0 RTL: " "
+            RenderTableCell {TD} at (496,2) size 168x24 [r=0 c=3 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 166x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+                RenderSelectFallbackButton {DIV} at (6,3) size 154x14
+                  RenderText at (0,0) size 0x14
+                    text run at (0,0) width 0 RTL: " "
+          RenderTableRow {TR} at (0,27) size 666x24
+            RenderTableCell {TD} at (2,27) size 160x24 [r=1 c=0 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 158x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+                RenderSelectFallbackButton {DIV} at (6,3) size 146x14
+                  RenderText at (0,0) size 0x14
+                    text run at (0,0) width 0: " "
+            RenderTableCell {TD} at (164,27) size 168x24 [r=1 c=1 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 166x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+                RenderSelectFallbackButton {DIV} at (6,3) size 154x14
+                  RenderText at (0,0) size 0x14
+                    text run at (0,0) width 0: " "
+      RenderBlock (anonymous) at (0,93) size 784x20
+        RenderText {#text} at (0,0) size 447x20
+          text run at (0,0) width 447: "All the items in the following select elements should be right-aligned."
+      RenderTable {TABLE} at (0,113) size 652x53
+        RenderTableSection {TBODY} at (0,0) size 652x53
+          RenderTableRow {TR} at (0,2) size 652x24
+            RenderTableCell {TD} at (2,2) size 167x24 [r=0 c=0 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 165x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+                RenderSelectFallbackButton {DIV} at (6,3) size 153x14
+                  RenderText at (153,0) size 0x14
+                    text run at (153,0) width 0 RTL: " "
+            RenderTableCell {TD} at (171,2) size 154x24 [r=0 c=1 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 152x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
                 RenderSelectFallbackButton {DIV} at (6,3) size 140x14
                   RenderText at (140,0) size 0x14
                     text run at (140,0) width 0 RTL: " "
-          RenderTableRow {TR} at (0,27) size 638x23
-            RenderTableCell {TD} at (2,27) size 160x23 [r=1 c=0 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 158x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-                RenderSelectFallbackButton {DIV} at (6,3) size 146x14
-                  RenderText at (0,0) size 0x14
-                    text run at (0,0) width 0: " "
-            RenderTableCell {TD} at (164,27) size 154x23 [r=1 c=1 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 152x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+            RenderTableCell {TD} at (327,2) size 167x24 [r=0 c=2 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 165x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+                RenderSelectFallbackButton {DIV} at (6,3) size 153x14
+                  RenderText at (153,0) size 0x14
+                    text run at (153,0) width 0 RTL: " "
+            RenderTableCell {TD} at (496,2) size 154x24 [r=0 c=3 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 152x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
                 RenderSelectFallbackButton {DIV} at (6,3) size 140x14
-                  RenderText at (0,0) size 0x14
-                    text run at (0,0) width 0: " "
-      RenderBlock (anonymous) at (0,92) size 784x20
-        RenderText {#text} at (0,0) size 447x19
-          text run at (0,0) width 447: "All the items in the following select elements should be right-aligned."
-      RenderTable {TABLE} at (0,112) size 630x52
-        RenderTableSection {TBODY} at (0,0) size 630x52
-          RenderTableRow {TR} at (0,2) size 630x23
-            RenderTableCell {TD} at (2,2) size 167x23 [r=0 c=0 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 165x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+                  RenderText at (140,0) size 0x14
+                    text run at (140,0) width 0 RTL: " "
+          RenderTableRow {TR} at (0,27) size 652x24
+            RenderTableCell {TD} at (2,27) size 167x24 [r=1 c=0 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 165x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
                 RenderSelectFallbackButton {DIV} at (6,3) size 153x14
                   RenderText at (153,0) size 0x14
-                    text run at (153,0) width 0 RTL: " "
-            RenderTableCell {TD} at (171,2) size 143x23 [r=0 c=1 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 141x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-                RenderSelectFallbackButton {DIV} at (6,3) size 129x14
-                  RenderText at (129,0) size 0x14
-                    text run at (129,0) width 0 RTL: " "
-            RenderTableCell {TD} at (316,2) size 167x23 [r=0 c=2 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 165x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-                RenderSelectFallbackButton {DIV} at (6,3) size 153x14
-                  RenderText at (153,0) size 0x14
-                    text run at (153,0) width 0 RTL: " "
-            RenderTableCell {TD} at (485,2) size 143x23 [r=0 c=3 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 141x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-                RenderSelectFallbackButton {DIV} at (6,3) size 129x14
-                  RenderText at (129,0) size 0x14
-                    text run at (129,0) width 0 RTL: " "
-          RenderTableRow {TR} at (0,27) size 630x23
-            RenderTableCell {TD} at (2,27) size 167x23 [r=1 c=0 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 165x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-                RenderSelectFallbackButton {DIV} at (6,3) size 153x14
-                  RenderText at (0,0) size 0x14
-                    text run at (0,0) width 0: " "
-            RenderTableCell {TD} at (171,27) size 143x23 [r=1 c=1 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 141x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-                RenderSelectFallbackButton {DIV} at (6,3) size 129x14
-                  RenderText at (0,0) size 0x14
-                    text run at (0,0) width 0: " "
-      RenderBlock (anonymous) at (0,164) size 784x20
-        RenderText {#text} at (0,0) size 456x19
+                    text run at (153,0) width 0: " "
+            RenderTableCell {TD} at (171,27) size 154x24 [r=1 c=1 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 152x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+                RenderSelectFallbackButton {DIV} at (6,3) size 140x14
+                  RenderText at (140,0) size 0x14
+                    text run at (140,0) width 0: " "
+      RenderBlock (anonymous) at (0,166) size 784x20
+        RenderText {#text} at (0,0) size 456x20
           text run at (0,0) width 456: "All the items in the following select elements should be center-aligned."
-      RenderTable {TABLE} at (0,184) size 668x27
-        RenderTableSection {TBODY} at (0,0) size 668x27
-          RenderTableRow {TR} at (0,2) size 668x23
-            RenderTableCell {TD} at (2,2) size 177x23 [r=0 c=0 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 175x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+      RenderTable {TABLE} at (0,186) size 696x28
+        RenderTableSection {TBODY} at (0,0) size 696x28
+          RenderTableRow {TR} at (0,2) size 696x24
+            RenderTableCell {TD} at (2,2) size 177x24 [r=0 c=0 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 175x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
                 RenderSelectFallbackButton {DIV} at (6,3) size 163x14
-                  RenderText at (163,0) size 0x14
-                    text run at (163,0) width 0 RTL: " "
-            RenderTableCell {TD} at (181,2) size 152x23 [r=0 c=1 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 150x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-                RenderSelectFallbackButton {DIV} at (6,3) size 138x14
-                  RenderText at (138,0) size 0x14
-                    text run at (138,0) width 0 RTL: " "
-            RenderTableCell {TD} at (335,2) size 177x23 [r=0 c=2 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 175x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+                  RenderText at (75,0) size 1x14
+                    text run at (75,0) width 1 RTL: " "
+            RenderTableCell {TD} at (181,2) size 166x24 [r=0 c=1 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 164x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+                RenderSelectFallbackButton {DIV} at (6,3) size 152x14
+                  RenderText at (70,0) size 0x14
+                    text run at (70,0) width 0 RTL: " "
+            RenderTableCell {TD} at (349,2) size 177x24 [r=0 c=2 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 175x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
                 RenderSelectFallbackButton {DIV} at (6,3) size 163x14
-                  RenderText at (0,0) size 0x14
-                    text run at (0,0) width 0: " "
-            RenderTableCell {TD} at (514,2) size 152x23 [r=0 c=3 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 150x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-                RenderSelectFallbackButton {DIV} at (6,3) size 138x14
-                  RenderText at (0,0) size 0x14
-                    text run at (0,0) width 0: " "
-      RenderBlock (anonymous) at (0,211) size 784x20
-        RenderText {#text} at (0,0) size 296x19
+                  RenderText at (75,0) size 1x14
+                    text run at (75,0) width 1: " "
+            RenderTableCell {TD} at (528,2) size 166x24 [r=0 c=3 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 164x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+                RenderSelectFallbackButton {DIV} at (6,3) size 152x14
+                  RenderText at (70,0) size 0x14
+                    text run at (70,0) width 0: " "
+      RenderBlock (anonymous) at (0,213) size 784x21
+        RenderText {#text} at (0,0) size 296x20
           text run at (0,0) width 296: "The following tables check mixed alignments."
-      RenderTable {TABLE} at (0,231) size 710x27
-        RenderTableSection {TBODY} at (0,0) size 710x27
-          RenderTableRow {TR} at (0,2) size 710x23
-            RenderTableCell {TD} at (2,2) size 172x23 [r=0 c=0 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 170x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+      RenderTable {TABLE} at (0,233) size 744x28
+        RenderTableSection {TBODY} at (0,0) size 744x28
+          RenderTableRow {TR} at (0,2) size 744x24
+            RenderTableCell {TD} at (2,2) size 172x24 [r=0 c=0 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 170x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
                 RenderSelectFallbackButton {DIV} at (6,3) size 158x14
                   RenderText at (158,0) size 0x14
                     text run at (158,0) width 0 RTL: " "
-            RenderTableCell {TD} at (176,2) size 172x23 [r=0 c=1 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 170x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+            RenderTableCell {TD} at (176,2) size 172x24 [r=0 c=1 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 170x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
                 RenderSelectFallbackButton {DIV} at (6,3) size 158x14
                   RenderText at (0,0) size 0x14
                     text run at (0,0) width 0: " "
-            RenderTableCell {TD} at (350,2) size 178x23 [r=0 c=2 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 176x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-                RenderSelectFallbackButton {DIV} at (6,3) size 164x14
-                  RenderText at (164,0) size 0x14
-                    text run at (164,0) width 0 RTL: " "
-            RenderTableCell {TD} at (530,2) size 178x23 [r=0 c=3 rs=1 cs=1]
-              RenderMenuList {SELECT} at (1,2) size 176x20 [color=#007AFF] [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
-                RenderSelectFallbackButton {DIV} at (6,3) size 164x14
+            RenderTableCell {TD} at (350,2) size 195x24 [r=0 c=2 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 193x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+                RenderSelectFallbackButton {DIV} at (6,3) size 181x14
+                  RenderText at (181,0) size 0x14
+                    text run at (181,0) width 0 RTL: " "
+            RenderTableCell {TD} at (547,2) size 195x24 [r=0 c=3 rs=1 cs=1]
+              RenderMenuList {SELECT} at (1,2) size 193x21 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
+                RenderSelectFallbackButton {DIV} at (6,3) size 181x14
                   RenderText at (0,0) size 0x14
                     text run at (0,0) width 0: " "

--- a/LayoutTests/platform/ios/fast/text/international/bidi-menulist-expected.txt
+++ b/LayoutTests/platform/ios/fast/text/international/bidi-menulist-expected.txt
@@ -31,9 +31,9 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (117,20) size 1x20
         RenderMenuList {SELECT} at (0,40) size 200x20 [bgcolor=#E9E9EA] [border: (1px solid #FFFFFF)]
           RenderSelectFallbackButton {DIV} at (6,3) size 188x14
-            RenderText at (0,0) size 60x14
-              text run at (0,0) width 20: "abc"
-              text run at (19,0) width 41 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
+            RenderText at (128,0) size 60x14
+              text run at (128,0) width 20: "abc"
+              text run at (147,0) width 41 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
         RenderBR {BR} at (200,39) size 0x19
       RenderBlock {DIV} at (0,196) size 200x20
         RenderText {#text} at (0,0) size 69x20

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/text/international/bidi-menulist-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/text/international/bidi-menulist-expected.txt
@@ -31,9 +31,9 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (117,18) size 1x18
         RenderMenuList {SELECT} at (0,36) size 200x18 [bgcolor=#FFFFFF]
           RenderSelectFallbackButton {DIV} at (0,0) size 200x19
-            RenderText at (8,2) size 60x13
-              text run at (8,2) width 20: "abc"
-              text run at (27,2) width 41 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
+            RenderText at (117,2) size 60x13
+              text run at (117,2) width 20: "abc"
+              text run at (136,2) width 41 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
         RenderBR {BR} at (200,34) size 0x19
       RenderBlock {DIV} at (0,179) size 200x20
         RenderText {#text} at (0,1) size 82x19

--- a/LayoutTests/platform/mac-wk2/fast/text/international/bidi-menulist-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/text/international/bidi-menulist-expected.txt
@@ -31,9 +31,9 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (117,18) size 1x18
         RenderMenuList {SELECT} at (0,36) size 200x21 [color=#000000D8] [bgcolor=#FFFFFF] [border: (1px solid #000000D8)]
           RenderSelectFallbackButton {DIV} at (1,1) size 198x19
-            RenderText at (8,2) size 60x13
-              text run at (8,2) width 20: "abc"
-              text run at (27,2) width 41 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
+            RenderText at (115,2) size 60x13
+              text run at (115,2) width 20: "abc"
+              text run at (134,2) width 41 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
         RenderBR {BR} at (200,35) size 0x19
       RenderBlock {DIV} at (0,183) size 200x20
         RenderText {#text} at (0,1) size 82x19

--- a/LayoutTests/platform/mac/fast/text/international/bidi-menulist-expected.txt
+++ b/LayoutTests/platform/mac/fast/text/international/bidi-menulist-expected.txt
@@ -31,9 +31,9 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (117,18) size 1x18
         RenderMenuList {SELECT} at (0,36) size 200x18 [bgcolor=#FFFFFF]
           RenderSelectFallbackButton {DIV} at (0,0) size 200x19
-            RenderText at (8,2) size 60x13
-              text run at (8,2) width 20: "abc"
-              text run at (27,2) width 41 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
+            RenderText at (117,2) size 60x13
+              text run at (117,2) width 20: "abc"
+              text run at (136,2) width 41 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
         RenderBR {BR} at (200,35) size 0x18
       RenderBlock {DIV} at (0,179) size 200x19
         RenderText {#text} at (0,1) size 82x18

--- a/LayoutTests/platform/wpe/fast/text/international/bidi-menulist-expected.txt
+++ b/LayoutTests/platform/wpe/fast/text/international/bidi-menulist-expected.txt
@@ -31,9 +31,9 @@ layer at (0,0) size 800x600
         RenderBR {BR} at (142,19) size 1x17
         RenderMenuList {SELECT} at (0,37) size 200x31 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
           RenderSelectFallbackButton {DIV} at (1,1) size 198x29
-            RenderText at (5,6) size 87x17
-              text run at (5,6) width 29: "abc"
-              text run at (34,6) width 58 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
+            RenderText at (90,6) size 87x17
+              text run at (90,6) width 30: "abc"
+              text run at (119,6) width 58 RTL: "\x{5D0}\x{5E4}\x{5E8}\x{5E1}\x{5DE}\x{5D5}\x{5DF}"
         RenderBR {BR} at (200,44) size 0x17
       RenderBlock {DIV} at (0,210) size 200x19
         RenderText {#text} at (0,1) size 87x17

--- a/Source/WebCore/html/shadow/SelectFallbackButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SelectFallbackButtonElement.cpp
@@ -35,6 +35,7 @@
 #include "RenderTheme.h"
 #include "ResolvedStyle.h"
 #include "StyleResolver.h"
+#include "StyleTextAlign.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -76,10 +77,13 @@ std::optional<Style::UnadjustedStyle> SelectFallbackButtonElement::resolveCustom
     // min-width: 0; is needed for correct shrinking.
     style->setLogicalMinWidth(0_css_px);
 
-    // Set text-align based on the select's direction (not its text-align property).
-    // This matches the old RenderMenuList behavior where text-align followed the
-    // select's bidi direction, not its CSS text-align property.
-    style->setTextAlign(hostStyle->writingMode().isBidiLTR() ? Style::TextAlign::Left : Style::TextAlign::Right);
+    auto hostTextAlign = hostStyle->textAlign();
+    if (hostTextAlign == Style::TextAlign::Start)
+        style->setTextAlign(hostStyle->writingMode().isBidiLTR() ? Style::TextAlign::Left : Style::TextAlign::Right);
+    else if (hostTextAlign == Style::TextAlign::End)
+        style->setTextAlign(hostStyle->writingMode().isBidiLTR() ? Style::TextAlign::Right : Style::TextAlign::Left);
+    else
+        style->setTextAlign(hostTextAlign);
 
     // Apply direction and unicodeBidi from the selected option for proper bidirectional text rendering.
     Ref selectElement = this->selectElement();

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -387,7 +387,16 @@ Style::PaddingBox RenderThemeIOS::popupInternalPaddingBox(const RenderStyle& sty
         // FIXME: Reduce code duplication with toTruncatedPaddingEdge.
         auto value = Style::PaddingEdge::Fixed { static_cast<float>(std::trunc(padding + Style::evaluate<float>(style.usedBorderTopWidth(),  Style::ZoomNeeded { }))) / style.usedZoom() };
 
-        if (style.writingMode().isBidiRTL())
+        bool padLeft = [&] {
+            auto textAlign = style.textAlign();
+            if (textAlign == Style::TextAlign::Start)
+                return style.writingMode().isBidiRTL();
+            if (textAlign == Style::TextAlign::End)
+                return style.writingMode().isBidiLTR();
+            return textAlign == Style::TextAlign::Right;
+        }();
+
+        if (padLeft)
             return { 0_css_px, 0_css_px, 0_css_px, value };
         return { 0_css_px, value, 0_css_px, 0_css_px };
     }


### PR DESCRIPTION
#### 4f4eee548d96f4ba5404afdd5e11acba00642d90
<pre>
REGRESSION(iOS17): fast/forms/listbox-bidi-align.html is constantly failing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=263662">https://bugs.webkit.org/show_bug.cgi?id=263662</a>
<a href="https://rdar.apple.com/117478129">rdar://117478129</a>

Reviewed by Anne van Kesteren.

There were a few issues here. First, there seems to have been some system change to font sizes.
Second, the new class SelectFallbackButtonElement was not properly setting the text alignment.
And similarly, the internal padding was not respecting the text alignment.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/fast/forms/listbox-bidi-align-expected.txt:
* Source/WebCore/html/shadow/SelectFallbackButtonElement.cpp:
(WebCore::SelectFallbackButtonElement::resolveCustomStyle):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::popupInternalPaddingBox const):

Canonical link: <a href="https://commits.webkit.org/309054@main">https://commits.webkit.org/309054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d42befad195803d3f79af41899b07ef8133ba9b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21980 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15550 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157959 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102698 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21858 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115089 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81907 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17253 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133935 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95839 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16352 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14222 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5809 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125952 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160441 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3437 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123134 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123352 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33532 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21791 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133668 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77991 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18592 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10414 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21392 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85205 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21124 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21273 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21181 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->