### PR TITLE
[macOS Release] media/video-webkit-playsinline.html is a flaky text failure

### DIFF
--- a/LayoutTests/media/video-webkit-playsinline-expected.txt
+++ b/LayoutTests/media/video-webkit-playsinline-expected.txt
@@ -5,6 +5,8 @@ RUN(video.play())
 EVENT(playing)
 EXPECTED (internals.isChangingPresentationMode(video) == 'false') OK
 EXPECTED (video.webkitDisplayingFullscreen == 'true') OK
+EXPECTED (internals.isChangingPresentationMode(video) == 'false') OK
+EXPECTED (video.webkitDisplayingFullscreen == 'false') OK
 RUN(internals.settings.setInlineMediaPlaybackRequiresPlaysInlineAttribute(true))
 RUN(video.setAttribute("webkit-playsinline", ""))
 EVENT(canplaythrough)
@@ -12,6 +14,8 @@ RUN(video.play())
 EVENT(playing)
 EXPECTED (internals.isChangingPresentationMode(video) == 'false') OK
 EXPECTED (video.webkitDisplayingFullscreen == 'true') OK
+EXPECTED (internals.isChangingPresentationMode(video) == 'false') OK
+EXPECTED (video.webkitDisplayingFullscreen == 'false') OK
 RUN(internals.settings.setInlineMediaPlaybackRequiresPlaysInlineAttribute(false))
 RUN(video.removeAttribute("webkit-playsinline", ""))
 EVENT(canplaythrough)

--- a/LayoutTests/media/video-webkit-playsinline.html
+++ b/LayoutTests/media/video-webkit-playsinline.html
@@ -35,6 +35,13 @@ function testPlaysInline(requiresPlaysInline, hasWebkitPlaysInline, expectedDisp
             await testExpectedEventually('internals.isChangingPresentationMode(video)', false);
 
         testExpected('video.webkitDisplayingFullscreen', expectedDisplayingFullscreen);
+
+        if (video.webkitDisplayingFullscreen) {
+            video.webkitExitFullscreen();
+            await testExpectedEventually('internals.isChangingPresentationMode(video)', false);
+            await testExpectedEventually('video.webkitDisplayingFullscreen', false);
+        }
+
         document.body.removeChild(video);
         runNextTest();
     });

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2487,8 +2487,6 @@ webkit.org/b/307850 media/modern-media-controls/tracks-support/audio-single-trac
 
 webkit.org/b/307886 [ Release arm64 ] js/dom/promise-stack-overflow.html [ Pass Failure ]
 
-webkit.org/b/309525 [ Release ] media/video-webkit-playsinline.html [ Pass Failure ]
-
 webkit.org/b/307889 http/tests/multipart/multipart-async-image.html [ Pass Failure ]
 
 # webkit.org/b/309308 2x http/tests/site-isolation/accessibility/hit-test-X-remote-frame.html are constant text failures


### PR DESCRIPTION
#### a1a711d90907853a9a052c34fc6600a1a99727ff
<pre>
[macOS Release] media/video-webkit-playsinline.html is a flaky text failure
<a href="https://rdar.apple.com/172127512">rdar://172127512</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309525">https://bugs.webkit.org/show_bug.cgi?id=309525</a>

Reviewed by NOBODY (OOPS!).

Test 2 fails because Test 1&apos;s video is asynchronously exiting fullscreen when Test 2
attempts to enter fullscreen. The document-level m_isAnimatingFullscreen flag is still
true, causing canEnterVideoFullscreen() to return false. Test 2&apos;s video never enters
fullscreen, resulting in the text diff.

Fix adds explicit waits for isChangingPresentationMode and webkitDisplayingFullscreen to
become false. This forces all states to be settled before we proceed to the next test.

* LayoutTests/media/video-webkit-playsinline-expected.txt:
* LayoutTests/media/video-webkit-playsinline.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1a711d90907853a9a052c34fc6600a1a99727ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15233 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157639 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102381 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114833 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81766 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151911 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17030 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133689 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95591 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16137 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13991 "Found 1 new API test failure: TestWebKitAPI.TextManipulation.StartTextManipulationDoesNotFindContentInNewMainFrame (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5487 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125740 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160120 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122883 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21466 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123111 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21474 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133404 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77662 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18397 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10166 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21076 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20808 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20864 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->