### PR TITLE
Make lifetime activity use background assertion by default on macOS

### DIFF
--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -47,6 +47,7 @@
 #include "CoreIPCSecureCoding.h"
 #include "SandboxUtilities.h"
 #include <sys/sysctl.h>
+#include <wtf/cf/TypeCastsCF.h>
 #include <wtf/spi/darwin/SandboxSPI.h>
 #endif
 
@@ -351,7 +352,23 @@ void AuxiliaryProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::C
         return;
 
 #if PLATFORM(MAC) && USE(RUNNINGBOARD)
-    m_lifetimeActivity = protect(throttler())->foregroundActivity("Lifetime Activity"_s);
+    enum class LifetimeActivityState { None, Background, Foreground };
+    static LifetimeActivityState lifetimeActivityState = []() {
+        if (auto value = dynamic_cf_cast<CFStringRef>(adoptCF(CFPreferencesCopyAppValue(CFSTR("LifetimeActivityState"), kCFPreferencesCurrentApplication)))) {
+            if (CFEqual(value, CFSTR("None")))
+                return LifetimeActivityState::None;
+            if (CFEqual(value, CFSTR("BG")))
+                return LifetimeActivityState::Background;
+            if (CFEqual(value, CFSTR("FG")))
+                return LifetimeActivityState::Foreground;
+        }
+        return LifetimeActivityState::Background;
+    }();
+
+    if (lifetimeActivityState == LifetimeActivityState::Foreground)
+        m_lifetimeActivity = protect(throttler())->foregroundActivity("FG Lifetime Activity"_s);
+    else if (lifetimeActivityState == LifetimeActivityState::Background)
+        m_lifetimeActivity = protect(throttler())->backgroundActivity("BG Lifetime Activity"_s);
 #endif
 
     RefPtr connection = IPC::Connection::createServerConnection(WTF::move(connectionIdentifier), Thread::QOS::UserInteractive);


### PR DESCRIPTION
#### 6830b122e210ee623c94b06773365f7634f114b1
<pre>
Make lifetime activity use background assertion by default on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=309527">https://bugs.webkit.org/show_bug.cgi?id=309527</a>
<a href="https://rdar.apple.com/166762210">rdar://166762210</a>

Reviewed by Per Arne Vollan.

On macOS, all processes get a lifetime activity by default at creation time which currently uses a
foreground assertion. This means processes that don&apos;t use RunningBoard throttling (such as
NetworkProcess and GPUProcess) always run at foreground priority, which is higher than we intended.

This changes the default assertion used by the lifetime activity to be a background assertion
instead of a foreground activity. When any WebContent is hosting a visible webpage, this will have
no impact as NetworkProcess and GPUProcess will detect the presence of the visible webpage and boost
themselves back up to foreground priority.

* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::didFinishLaunching):

Canonical link: <a href="https://commits.webkit.org/309012@main">https://commits.webkit.org/309012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25529b3d57bb84456b42553b4b59924e389feb97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157647 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102389 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3f9684a-13fc-4445-9e87-4eb7dfa179c3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114835 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81769 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95593 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d06ee3a1-2eb4-4be4-ba21-afb0918b3d13) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16132 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13993 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5495 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125734 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160129 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3119 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13173 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122888 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21474 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18009 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123116 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33508 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21482 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133445 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77670 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18399 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10203 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21084 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84886 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20816 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20964 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20872 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->