### PR TITLE
[WTF] Random-Try: thread safe AtomString

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1716,11 +1716,6 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
     }
         
     {
-        auto* previous = Thread::currentSingleton().setCurrentAtomStringTable(nullptr);
-        auto scopeExit = makeScopeExit([&] {
-            Thread::currentSingleton().setCurrentAtomStringTable(previous);
-        });
-
         if (vm().typeProfiler())
             vm().typeProfiler()->invalidateTypeSetCache(vm());
 
@@ -2319,8 +2314,7 @@ Heap::Ticket Heap::requestCollection(GCRequest request)
     stopIfNecessary();
     
     ASSERT(vm().currentThreadIsHoldingAPILock());
-    RELEASE_ASSERT(vm().atomStringTable() == Thread::currentSingleton().atomStringTable());
-    
+
     Locker locker { *m_threadLock };
     // We may be able to steal the conn. That only works if the collector is definitely not running
     // right now. This is an optimization that prevents the collector thread from ever starting in most

--- a/Source/JavaScriptCore/runtime/Completion.cpp
+++ b/Source/JavaScriptCore/runtime/Completion.cpp
@@ -53,7 +53,7 @@ bool checkSyntax(JSGlobalObject* globalObject, const SourceCode& source, JSValue
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
+
 
     ParserError error;
     if (checkSyntaxInternal(vm, source, error))
@@ -67,7 +67,7 @@ bool checkSyntax(JSGlobalObject* globalObject, const SourceCode& source, JSValue
 bool checkSyntax(VM& vm, const SourceCode& source, ParserError& error)
 {
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
+
     return checkSyntaxInternal(vm, source, error);
 }
 
@@ -75,7 +75,7 @@ bool checkModuleSyntax(JSGlobalObject* globalObject, const SourceCode& source, P
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
+
     std::unique_ptr<ModuleProgramNode> moduleProgramNode = parseRootNode<ModuleProgramNode>(
         vm, source, ImplementationVisibility::Public, JSParserBuiltinMode::NotBuiltin,
         StrictModeLexicallyScopedFeature, JSParserScriptMode::Module, SourceParseMode::ModuleAnalyzeMode, error);
@@ -90,7 +90,7 @@ bool checkModuleSyntax(JSGlobalObject* globalObject, const SourceCode& source, P
 RefPtr<CachedBytecode> generateProgramBytecode(VM& vm, const SourceCode& source, FileSystem::FileHandle& fileHandle, BytecodeCacheError& error)
 {
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
+
 
     LexicallyScopedFeatures lexicallyScopedFeatures = NoLexicallyScopedFeatures;
     JSParserScriptMode scriptMode = JSParserScriptMode::Classic;
@@ -109,7 +109,7 @@ RefPtr<CachedBytecode> generateProgramBytecode(VM& vm, const SourceCode& source,
 RefPtr<CachedBytecode> generateModuleBytecode(VM& vm, const SourceCode& source, FileSystem::FileHandle& fileHandle, BytecodeCacheError& error)
 {
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
+
 
     LexicallyScopedFeatures lexicallyScopedFeatures = StrictModeLexicallyScopedFeature;
     JSParserScriptMode scriptMode = JSParserScriptMode::Module;
@@ -129,7 +129,7 @@ JSValue evaluate(JSGlobalObject* globalObject, const SourceCode& source, JSValue
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
+
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     if (!thisValue || thisValue.isUndefinedOrNull())
@@ -188,7 +188,7 @@ JSInternalPromise* loadAndEvaluateModule(JSGlobalObject* globalObject, Symbol* m
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
+
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     return globalObject->moduleLoader()->loadAndEvaluateModule(globalObject, moduleId, parameters, scriptFetcher);
@@ -198,7 +198,7 @@ JSInternalPromise* loadAndEvaluateModule(JSGlobalObject* globalObject, const Str
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
+
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     return globalObject->moduleLoader()->loadAndEvaluateModule(globalObject, identifierToJSValue(vm, Identifier::fromString(vm, moduleName)), parameters, scriptFetcher);
@@ -209,7 +209,7 @@ JSInternalPromise* loadAndEvaluateModule(JSGlobalObject* globalObject, const Sou
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
+
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     Symbol* key = createSymbolForEntrypointModule(vm);
@@ -224,7 +224,7 @@ JSInternalPromise* loadModule(JSGlobalObject* globalObject, const Identifier& mo
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
+
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     return globalObject->moduleLoader()->loadModule(globalObject, identifierToJSValue(vm, moduleKey), parameters, scriptFetcher);
@@ -235,7 +235,7 @@ JSInternalPromise* loadModule(JSGlobalObject* globalObject, const SourceCode& so
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
     auto scope = DECLARE_THROW_SCOPE(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
+
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     Symbol* key = createSymbolForEntrypointModule(vm);
@@ -251,7 +251,7 @@ JSValue linkAndEvaluateModule(JSGlobalObject* globalObject, const Identifier& mo
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
+
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     return globalObject->moduleLoader()->linkAndEvaluateModule(globalObject, identifierToJSValue(vm, moduleKey), scriptFetcher);
@@ -261,7 +261,7 @@ JSInternalPromise* importModule(JSGlobalObject* globalObject, const Identifier& 
 {
     VM& vm = globalObject->vm();
     JSLockHolder lock(vm);
-    RELEASE_ASSERT(vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
+
     RELEASE_ASSERT(!vm.isCollectorBusyOnCurrentThread());
 
     return globalObject->moduleLoader()->requestImportModule(globalObject, moduleName, referrer, parameters, scriptFetcher);

--- a/Source/JavaScriptCore/runtime/Identifier.cpp
+++ b/Source/JavaScriptCore/runtime/Identifier.cpp
@@ -70,11 +70,9 @@ void Identifier::dump(PrintStream& out) const
 
 #ifndef NDEBUG
 
-void Identifier::checkCurrentAtomStringTable(VM& vm)
+void Identifier::checkCurrentAtomStringTable(VM&)
 {
-    // Check the identifier table accessible through the threadspecific matches the
-    // vm's identifier table.
-    ASSERT_UNUSED(vm, vm.atomStringTable() == Thread::currentSingleton().atomStringTable());
+    // With a global singleton AtomStringTable, this check is always satisfied.
 }
 
 #else

--- a/Source/JavaScriptCore/runtime/JSLock.cpp
+++ b/Source/JavaScriptCore/runtime/JSLock.cpp
@@ -27,6 +27,7 @@
 #include "SamplingProfiler.h"
 #include <wtf/StackPointer.h>
 #include <wtf/Threading.h>
+#include <wtf/text/AtomStringTable.h>
 #include <wtf/threads/Signals.h>
 
 #if USE(WEB_THREAD)
@@ -66,7 +67,6 @@ JSLock::JSLock(VM* vm)
     : m_lockCount(0)
     , m_lockDropDepth(0)
     , m_vm(vm)
-    , m_entryAtomStringTable(nullptr)
 {
 }
 
@@ -120,9 +120,6 @@ void JSLock::didAcquireLock()
         return;
     
     auto& thread = Thread::currentSingleton();
-    ASSERT(!m_entryAtomStringTable);
-    m_entryAtomStringTable = thread.setCurrentAtomStringTable(m_vm->atomStringTable());
-    ASSERT(m_entryAtomStringTable);
 
     m_vm->setLastStackTop(thread);
 
@@ -257,7 +254,7 @@ NO_RETURN_DUE_TO_CRASH NEVER_INLINE void JSLock::dumpInfoAndCrashForLockNotOwned
     updateDumpState(0xBBBB, numZeroBytesInLock, totalZeroBytesInPage, currentZeroBytes);
 
     register VM* vmPtr __asm__("r19") = m_vm;
-    register AtomStringTable* atomStringTable __asm__("x15") = m_entryAtomStringTable;
+    register AtomStringTable* atomStringTable __asm__("x15") = &AtomStringTable::singleton();
     register JSLock* thisPtr __asm__("x14") = this;
     updateDumpState(0xCCCC, vmPtr, atomStringTable, thisPtr);
 
@@ -319,11 +316,6 @@ void JSLock::willReleaseLock()
             if (m_shouldReleaseHeapAccess)
                 protectedVM->heap.releaseAccess();
         }
-    }
-
-    if (m_entryAtomStringTable) {
-        Thread::currentSingleton().setCurrentAtomStringTable(m_entryAtomStringTable);
-        m_entryAtomStringTable = nullptr;
     }
 }
 

--- a/Source/JavaScriptCore/runtime/JSLock.h
+++ b/Source/JavaScriptCore/runtime/JSLock.h
@@ -160,7 +160,6 @@ private:
     unsigned m_lockDropDepth;
     uint32_t m_lastOwnerThread { 0 };
     VM* m_vm;
-    AtomStringTable* m_entryAtomStringTable; 
 };
 
 } // namespace

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -261,7 +261,7 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     , clientHeap(heap)
     , vmType(vmType)
     , deferredWorkTimer(DeferredWorkTimer::create(*this))
-    , m_atomStringTable(vmType == VMType::Default ? Thread::currentSingleton().atomStringTable() : new AtomStringTable)
+    , m_atomStringTable(&AtomStringTable::singleton())
     , m_symbolRegistry(makeUniqueRef<SymbolRegistry>())
     , m_privateSymbolRegistry(makeUniqueRef<SymbolRegistry>(SymbolRegistry::Type::PrivateSymbol))
     , emptyList(new ArgList)
@@ -316,7 +316,6 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
 
     // Need to be careful to keep everything consistent here
     JSLockHolder lock(this);
-    AtomStringTable* existingEntryAtomStringTable = Thread::currentSingleton().setCurrentAtomStringTable(m_atomStringTable);
     structureStructure.setWithoutWriteBarrier(Structure::createStructure(*this));
     structureRareDataStructure.setWithoutWriteBarrier(StructureRareData::createStructure(*this, nullptr, jsNull()));
     stringStructure.setWithoutWriteBarrier(JSString::createStructure(*this, nullptr, jsNull()));
@@ -396,8 +395,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         }
     }
 
-    Thread::currentSingleton().setCurrentAtomStringTable(existingEntryAtomStringTable);
-    
     Gigacage::addPrimitiveDisableCallback(primitiveGigacageDisabledCallback, this);
 
     heap.notifyIsSafeToCollect();
@@ -582,8 +579,6 @@ VM::~VM()
     delete emptyList;
 
     delete propertyNames;
-    if (vmType != VMType::Default)
-        delete m_atomStringTable;
 
     delete clientData;
     m_regExpCache.reset();

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -614,7 +614,7 @@ public:
     bool* addressOfMightBeExecutingTaintedCode() LIFETIME_BOUND { return &m_mightBeExecutingTaintedCode; }
     void setMightBeExecutingTaintedCode(bool value = true) { m_mightBeExecutingTaintedCode = value; }
 
-    AtomStringTable* atomStringTable() const { return m_atomStringTable; }
+    AtomStringTable* atomStringTable() const { return &AtomStringTable::singleton(); }
     SymbolRegistry& symbolRegistry() { return m_symbolRegistry.get(); }
     SymbolRegistry& privateSymbolRegistry() { return m_privateSymbolRegistry.get(); }
 

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -37,6 +37,7 @@
 #include <wtf/ThreadingPrimitives.h>
 #include <wtf/WTFConfig.h>
 #include <wtf/text/AtomString.h>
+#include <wtf/text/AtomStringTable.h>
 #include <wtf/threads/Signals.h>
 
 #if HAVE(QOS_CLASSES)
@@ -212,14 +213,7 @@ void Thread::initializeInThread()
         allThreads().add(*this); // Must have stack bounds before adding to allThreads()
 #endif
 
-    m_currentAtomStringTable = &m_defaultAtomStringTable;
-#if USE(WEB_THREAD)
-    // On iOS, one AtomStringTable is shared between the main UI thread and the WebThread.
-    if (isWebThread() || isUIThread()) {
-        static NeverDestroyed<AtomStringTable> sharedStringTable;
-        m_currentAtomStringTable = &sharedStringTable.get();
-    }
-#endif
+    m_currentAtomStringTable = &AtomStringTable::singleton();
 
 #if OS(LINUX)
     m_id = currentID();

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -263,14 +263,12 @@ public:
 
     AtomStringTable* atomStringTable()
     {
-        return m_currentAtomStringTable;
+        return &AtomStringTable::singleton();
     }
 
-    AtomStringTable* setCurrentAtomStringTable(AtomStringTable* atomStringTable)
+    AtomStringTable* setCurrentAtomStringTable(AtomStringTable*)
     {
-        AtomStringTable* oldAtomStringTable = m_currentAtomStringTable;
-        m_currentAtomStringTable = atomStringTable;
-        return oldAtomStringTable;
+        return &AtomStringTable::singleton();
     }
 
 #if ENABLE(STACK_STATS)
@@ -422,8 +420,7 @@ protected:
     SpecificStorage m_specificStorage;
 #endif
 
-    AtomStringTable* m_currentAtomStringTable { nullptr };
-    AtomStringTable m_defaultAtomStringTable;
+    AtomStringTable* m_currentAtomStringTable { nullptr }; // FIXME: Remove once all callers are updated.
 
 #if ENABLE(STACK_STATS)
     StackStats::PerThreadStats m_stackStats;

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -30,44 +30,24 @@
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
-#if USE(WEB_THREAD)
-#include <wtf/Lock.h>
-#endif
-
 namespace WTF {
 
 using namespace Unicode;
 
-#if USE(WEB_THREAD)
-
 class AtomStringTableLocker : public Locker<Lock> {
     WTF_MAKE_NONCOPYABLE(AtomStringTableLocker);
-
-    static Lock s_stringTableLock;
 public:
     AtomStringTableLocker()
-        : Locker<Lock>(s_stringTableLock)
+        : Locker<Lock>(AtomStringTable::singleton().lock())
     {
     }
 };
-
-Lock AtomStringTableLocker::s_stringTableLock;
-
-#else
-
-class AtomStringTableLocker {
-    WTF_MAKE_NONCOPYABLE(AtomStringTableLocker);
-public:
-    AtomStringTableLocker() { }
-};
-
-#endif // USE(WEB_THREAD)
 
 using StringTableImpl = AtomStringTable::StringTableImpl;
 
 static ALWAYS_INLINE StringTableImpl& stringTable()
 {
-    return Thread::currentSingleton().atomStringTable()->table();
+    return AtomStringTable::singleton().table();
 }
 
 template<typename T, typename HashTranslator>
@@ -78,8 +58,8 @@ static inline Ref<AtomStringImpl> addToStringTable(AtomStringTableLocker&, Strin
     // If the string is newly-translated, then we need to adopt it.
     // The boolean in the pair tells us if that is so.
     if (addResult.isNewEntry)
-        return adoptRef(uncheckedDowncast<AtomStringImpl>(*addResult.iterator->get()));
-    return *uncheckedDowncast<AtomStringImpl>(addResult.iterator->get());
+        return adoptRef(uncheckedDowncast<AtomStringImpl>(**addResult.iterator));
+    return *uncheckedDowncast<AtomStringImpl>(*addResult.iterator);
 }
 
 template<typename T, typename HashTranslator>
@@ -98,7 +78,7 @@ struct UTF16BufferTranslator {
 
     static bool equal(AtomStringTable::StringEntry const& str, const UTF16Buffer& buf)
     {
-        return WTF::equal(str.get(), buf.characters);
+        return WTF::equal(str, buf.characters);
     }
 
     static void translate(AtomStringTable::StringEntry& location, const UTF16Buffer& buf, unsigned hash)
@@ -157,7 +137,7 @@ struct SubstringTranslator8 : SubstringTranslator {
 
     static bool equal(AtomStringTable::StringEntry const& string, const SubstringLocation& buffer)
     {
-        return WTF::equal(string.get(), buffer.baseString->span8().subspan(buffer.start, buffer.length));
+        return WTF::equal(string, buffer.baseString->span8().subspan(buffer.start, buffer.length));
     }
 };
 
@@ -169,7 +149,7 @@ struct SubstringTranslator16 : SubstringTranslator {
 
     static bool equal(AtomStringTable::StringEntry const& string, const SubstringLocation& buffer)
     {
-        return WTF::equal(string.get(), buffer.baseString->span16().subspan(buffer.start, buffer.length));
+        return WTF::equal(string, buffer.baseString->span16().subspan(buffer.start, buffer.length));
     }
 };
 
@@ -193,7 +173,7 @@ RefPtr<AtomStringImpl> AtomStringImpl::add(StringImpl* baseString, unsigned star
         return addToStringTable<SubstringLocation, SubstringTranslator8>(buffer);
     return addToStringTable<SubstringLocation, SubstringTranslator16>(buffer);
 }
-    
+
 using Latin1Buffer = HashTranslatorCharBuffer<Latin1Character>;
 struct Latin1BufferTranslator {
     static unsigned NODELETE hash(const Latin1Buffer& buf)
@@ -203,7 +183,7 @@ struct Latin1BufferTranslator {
 
     static bool equal(AtomStringTable::StringEntry const& str, const Latin1Buffer& buf)
     {
-        return WTF::equal(str.get(), buf.characters);
+        return WTF::equal(str, buf.characters);
     }
 
     static void translate(AtomStringTable::StringEntry& location, const Latin1Buffer& buf, unsigned hash)
@@ -225,7 +205,7 @@ struct BufferFromStaticDataTranslator {
 
     static bool equal(AtomStringTable::StringEntry const& str, const Buffer& buf)
     {
-        return WTF::equal(str.get(), buf.characters);
+        return WTF::equal(str, buf.characters);
     }
 
     static void translate(AtomStringTable::StringEntry& location, const Buffer& buf, unsigned hash)
@@ -330,11 +310,11 @@ Ref<AtomStringImpl> AtomStringImpl::addSlowCase(StringImpl& string)
     auto addResult = stringTable().add(&string);
 
     if (addResult.isNewEntry) {
-        ASSERT(addResult.iterator->get() == &string);
+        ASSERT(*addResult.iterator == &string);
         string.setIsAtom(true);
     }
 
-    return *uncheckedDowncast<AtomStringImpl>(addResult.iterator->get());
+    return *uncheckedDowncast<AtomStringImpl>(*addResult.iterator);
 }
 
 Ref<AtomStringImpl> AtomStringImpl::addSlowCase(Ref<StringImpl>&& string)
@@ -356,59 +336,17 @@ Ref<AtomStringImpl> AtomStringImpl::addSlowCase(Ref<StringImpl>&& string)
     auto addResult = stringTable().add(string.ptr());
 
     if (addResult.isNewEntry) {
-        ASSERT(addResult.iterator->get() == string.ptr());
+        ASSERT(*addResult.iterator == string.ptr());
         string->setIsAtom(true);
         return uncheckedDowncast<AtomStringImpl>(WTF::move(string));
     }
 
-    return *uncheckedDowncast<AtomStringImpl>(addResult.iterator->get());
+    return *uncheckedDowncast<AtomStringImpl>(*addResult.iterator);
 }
 
-Ref<AtomStringImpl> AtomStringImpl::addSlowCase(AtomStringTable& stringTable, StringImpl& string)
+Ref<AtomStringImpl> AtomStringImpl::addSlowCase(AtomStringTable&, StringImpl& string)
 {
-    // This check is necessary for null symbols.
-    // Their length is zero, but they are not AtomStringImpl.
-    if (!string.length())
-        return *uncheckedDowncast<AtomStringImpl>(StringImpl::empty());
-
-    if (string.isStatic()) {
-        AtomStringTableLocker locker;
-        return addStatic(locker, stringTable.table(), string);
-    }
-
-    if (string.isSymbol()) {
-        AtomStringTableLocker locker;
-        return addSymbol(locker, stringTable.table(), string);
-    }
-
-    ASSERT_WITH_MESSAGE(!string.isAtom(), "AtomStringImpl should not hit the slow case if the string is already an atom.");
-
-    AtomStringTableLocker locker;
-    auto addResult = stringTable.table().add(&string);
-
-    if (addResult.isNewEntry) {
-        ASSERT(addResult.iterator->get() == &string);
-        string.setIsAtom(true);
-    }
-
-    return *uncheckedDowncast<AtomStringImpl>(addResult.iterator->get());
-}
-
-// When removing a string from the table, we know it's already the one in the table, so no need for a string equality check.
-struct AtomStringTableRemovalHashTranslator {
-    static unsigned hash(const AtomStringImpl* string) { return string->hash(); }
-    static bool equal(const AtomStringTable::StringEntry& a, const AtomStringImpl* b) { return a == b; }
-};
-
-void AtomStringImpl::remove(AtomStringImpl* string)
-{
-    ASSERT(string->isAtom());
-    AtomStringTableLocker locker;
-    auto& atomStringTable = stringTable();
-    auto iterator = atomStringTable.find<AtomStringTableRemovalHashTranslator>(string);
-    ASSERT_WITH_MESSAGE(iterator != atomStringTable.end(), "The string being removed is an atom in the string table of an other thread!");
-    ASSERT(string == iterator->get());
-    atomStringTable.remove(iterator);
+    return addSlowCase(string);
 }
 
 RefPtr<AtomStringImpl> AtomStringImpl::lookUpSlowCase(StringImpl& string)
@@ -422,7 +360,7 @@ RefPtr<AtomStringImpl> AtomStringImpl::lookUpSlowCase(StringImpl& string)
     auto& atomStringTable = stringTable();
     auto iterator = atomStringTable.find(&string);
     if (iterator != atomStringTable.end())
-        return uncheckedDowncast<AtomStringImpl>(iterator->get());
+        return uncheckedDowncast<AtomStringImpl>(*iterator);
     return nullptr;
 }
 
@@ -444,7 +382,7 @@ RefPtr<AtomStringImpl> AtomStringImpl::lookUp(std::span<const Latin1Character> c
     Latin1Buffer buffer { characters };
     auto iterator = table.find<Latin1BufferTranslator>(buffer);
     if (iterator != table.end())
-        return uncheckedDowncast<AtomStringImpl>(iterator->get());
+        return uncheckedDowncast<AtomStringImpl>(*iterator);
     return nullptr;
 }
 
@@ -456,7 +394,7 @@ RefPtr<AtomStringImpl> AtomStringImpl::lookUp(std::span<const char16_t> characte
     UTF16Buffer buffer { characters };
     auto iterator = table.find<UTF16BufferTranslator>(buffer);
     if (iterator != table.end())
-        return uncheckedDowncast<AtomStringImpl>(iterator->get());
+        return uncheckedDowncast<AtomStringImpl>(*iterator);
     return nullptr;
 }
 

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -33,8 +33,6 @@ public:
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> lookUp(std::span<const char16_t>);
     static RefPtr<AtomStringImpl> lookUp(StringImpl*);
 
-    static void remove(AtomStringImpl*);
-
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(std::span<const Latin1Character>);
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(std::span<const char16_t>);
     ALWAYS_INLINE static RefPtr<AtomStringImpl> add(std::span<const char> characters);
@@ -112,38 +110,30 @@ ALWAYS_INLINE Ref<AtomStringImpl> AtomStringImpl::add(ASCIILiteral literal)
 }
 
 template<typename StringTableProvider>
-ALWAYS_INLINE RefPtr<AtomStringImpl> AtomStringImpl::addWithStringTableProvider(StringTableProvider& stringTableProvider, StringImpl* string)
+ALWAYS_INLINE RefPtr<AtomStringImpl> AtomStringImpl::addWithStringTableProvider(StringTableProvider&, StringImpl* string)
 {
     if (!string)
         return nullptr;
-    return add(*stringTableProvider.atomStringTable(), *string);
+    return add(*string);
 }
 
 ALWAYS_INLINE Ref<AtomStringImpl> AtomStringImpl::add(StringImpl& string)
 {
-    if (auto* atom = dynamicDowncast<AtomStringImpl>(string)) {
-        ASSERT_WITH_MESSAGE(!string.length() || isInAtomStringTable(&string), "The atom string comes from an other thread!");
+    if (auto* atom = dynamicDowncast<AtomStringImpl>(string))
         return *atom;
-    }
     return addSlowCase(string);
 }
 
 ALWAYS_INLINE Ref<AtomStringImpl> AtomStringImpl::add(Ref<StringImpl>&& string)
 {
-    if (is<AtomStringImpl>(string)) {
-        ASSERT_WITH_MESSAGE(!string->length() || isInAtomStringTable(string.ptr()), "The atom string comes from an other thread!");
+    if (is<AtomStringImpl>(string))
         return uncheckedDowncast<AtomStringImpl>(WTF::move(string));
-    }
     return addSlowCase(WTF::move(string));
 }
 
-ALWAYS_INLINE Ref<AtomStringImpl> AtomStringImpl::add(AtomStringTable& stringTable, StringImpl& string)
+ALWAYS_INLINE Ref<AtomStringImpl> AtomStringImpl::add(AtomStringTable&, StringImpl& string)
 {
-    if (auto* atom = dynamicDowncast<AtomStringImpl>(string)) {
-        ASSERT_WITH_MESSAGE(!string.length() || isInAtomStringTable(&string), "The atom string comes from an other thread!");
-        return *atom;
-    }
-    return addSlowCase(stringTable, string);
+    return add(string);
 }
 
 #if ASSERT_ENABLED

--- a/Source/WTF/wtf/text/AtomStringTable.cpp
+++ b/Source/WTF/wtf/text/AtomStringTable.cpp
@@ -23,12 +23,52 @@
 #include "config.h"
 #include <wtf/text/AtomStringTable.h>
 
+#include <wtf/NeverDestroyed.h>
+#include <wtf/text/AtomStringImpl.h>
+
 namespace WTF {
 
-AtomStringTable::~AtomStringTable()
+struct AtomStringTableRemovalHashTranslator {
+    static unsigned hash(const StringImpl* string) { return string->existingHash(); }
+    static bool equal(const AtomStringTable::StringEntry& a, const StringImpl* b) { return a == b; }
+};
+
+AtomStringTable& AtomStringTable::singleton()
 {
-    for (const auto& string : m_table)
-        string->setIsAtom(false);
+    static LazyNeverDestroyed<AtomStringTable> table;
+    static std::once_flag flag;
+    std::call_once(flag, [&] {
+        table.construct();
+    });
+    return table;
 }
 
+bool AtomStringTable::releaseAndRemoveIfNeeded(AtomStringImpl* string)
+{
+    ASSERT(string->isAtom());
+    auto& table = singleton();
+    Locker locker { table.m_lock };
+
+    // Double check that the refcount is still s_refCountIncrement.
+    // Because Add() could have added a new reference after the load
+    // in StringImpl::deref().
+    auto oldRefCount = string->m_refCount.fetch_sub(
+        StringImpl::s_refCountIncrement, std::memory_order_acq_rel);
+
+    if (oldRefCount != StringImpl::s_refCountIncrement) {
+        // Someone called ref() (via Add()) while we were waiting for the lock.
+        // The decrement brought count from N to N-1 where N > 1.
+        // The string lives on.
+        return false;
+    }
+
+    // Last ref truly gone (refcount is now 0). Remove from table.
+    if (string->length()) {
+        auto iterator = table.m_table.find<AtomStringTableRemovalHashTranslator>(string);
+        ASSERT(iterator != table.m_table.end());
+        table.m_table.remove(iterator);
+    }
+    return true; // Caller should destroy.
 }
+
+} // namespace WTF

--- a/Source/WTF/wtf/text/AtomStringTable.h
+++ b/Source/WTF/wtf/text/AtomStringTable.h
@@ -22,29 +22,30 @@
 
 #pragma once
 
-#include <wtf/CompactPtr.h>
 #include <wtf/HashSet.h>
-#include <wtf/Packed.h>
+#include <wtf/Lock.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/StringImpl.h>
 
 namespace WTF {
 
-class StringImpl;
+class AtomStringImpl;
 
 class AtomStringTable {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(AtomStringTable);
 public:
-    // If CompactPtr is 32bit, it is more efficient than PackedPtr (6 bytes).
-    // We select underlying implementation based on CompactPtr's efficacy.
-    using StringEntry = std::conditional_t<CompactPtrTraits<StringImpl>::is32Bit, CompactPtr<StringImpl>, PackedPtr<StringImpl>>;
+    using StringEntry = StringImpl*;
     using StringTableImpl = UncheckedKeyHashSet<StringEntry>;
 
-    WTF_EXPORT_PRIVATE ~AtomStringTable();
+    WTF_EXPORT_PRIVATE static AtomStringTable& singleton();
 
     StringTableImpl& table() LIFETIME_BOUND { return m_table; }
+    Lock& lock() LIFETIME_BOUND { return m_lock; }
+
+    WTF_EXPORT_PRIVATE static bool releaseAndRemoveIfNeeded(AtomStringImpl*);
 
 private:
+    Lock m_lock;
     StringTableImpl m_table;
 };
 

--- a/Source/WTF/wtf/text/ExternalStringImpl.cpp
+++ b/Source/WTF/wtf/text/ExternalStringImpl.cpp
@@ -43,7 +43,8 @@ ExternalStringImpl::ExternalStringImpl(std::span<const Latin1Character> characte
     , m_free(WTF::move(free))
 {
     ASSERT(m_free);
-    m_hashAndFlags = (m_hashAndFlags & ~s_hashMaskBufferOwnership) | BufferExternal;
+    auto flags = m_hashAndFlags.load(std::memory_order_relaxed);
+    m_hashAndFlags.store((flags & ~s_hashMaskBufferOwnership) | BufferExternal, std::memory_order_relaxed);
 }
 
 ExternalStringImpl::ExternalStringImpl(std::span<const char16_t> characters, ExternalStringImplFreeFunction&& free)
@@ -51,7 +52,8 @@ ExternalStringImpl::ExternalStringImpl(std::span<const char16_t> characters, Ext
     , m_free(WTF::move(free))
 {
     ASSERT(m_free);
-    m_hashAndFlags = (m_hashAndFlags & ~s_hashMaskBufferOwnership) | BufferExternal;
+    auto flags = m_hashAndFlags.load(std::memory_order_relaxed);
+    m_hashAndFlags.store((flags & ~s_hashMaskBufferOwnership) | BufferExternal, std::memory_order_relaxed);
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -31,6 +31,7 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/ZippedRange.h>
 #include <wtf/text/AtomString.h>
+#include <wtf/text/AtomStringTable.h>
 #include <wtf/text/CString.h>
 #include <wtf/text/ExternalStringImpl.h>
 #include <wtf/text/ParsingUtilities.h>
@@ -123,11 +124,9 @@ StringImpl::~StringImpl()
 
     STRING_STATS_REMOVE_STRING(*this);
 
-    if (isAtom()) {
-        ASSERT(!isSymbol());
-        if (length())
-            AtomStringImpl::remove(static_cast<AtomStringImpl*>(this));
-    } else if (isSymbol()) {
+    // Atom string removal is handled by AtomStringTable::releaseAndRemoveIfNeeded()
+    // before destroy() is called via destroyIfNeeded().
+    if (isSymbol()) {
         auto& symbol = static_cast<SymbolImpl&>(*this);
         if (CheckedPtr symbolRegistry = symbol.symbolRegistry())
             SUPPRESS_UNCOUNTED_ARG symbolRegistry->remove(*symbol.asRegisteredSymbolImpl());
@@ -158,6 +157,24 @@ void StringImpl::destroy(StringImpl* stringImpl)
 {
     stringImpl->~StringImpl();
     StringImplMalloc::free(stringImpl);
+}
+
+void StringImpl::destroyIfNeeded()
+{
+    if (isAtom()) {
+        // Atom string: delegate to AtomStringTable::releaseAndRemoveIfNeeded().
+        // It acquires the table lock, then atomically decrements refcount.
+        // If refcount was still s_refCountIncrement (no re-ref), removes from table
+        // and returns true. Otherwise another thread revived this string via Add().
+        if (AtomStringTable::releaseAndRemoveIfNeeded(static_cast<AtomStringImpl*>(this)))
+            StringImpl::destroy(this);
+        return;
+    }
+
+    // Non-atom string: safe to destroy directly.
+    // No other thread can have a reference to a non-atom string with refcount 1.
+    ASSERT(m_refCount.load(std::memory_order_acquire) == s_refCountIncrement);
+    StringImpl::destroy(this);
 }
 
 Ref<StringImpl> StringImpl::createWithoutCopyingNonEmpty(std::span<const char16_t> characters)
@@ -1661,13 +1678,7 @@ NEVER_INLINE unsigned StringImpl::hashSlowCase() const
 
 unsigned StringImpl::concurrentHash() const
 {
-    unsigned hash;
-    if (is8Bit())
-        hash = StringHasher::computeHashAndMaskTop8Bits(span8());
-    else
-        hash = StringHasher::computeHashAndMaskTop8Bits(span16());
-    ASSERT(((hash << s_flagCount) >> s_flagCount) == hash);
-    return hash;
+    return hash();
 }
 
 SUPPRESS_NODELETE bool equalIgnoringNullity(std::span<const char16_t> a, StringImpl* b)

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -169,7 +169,7 @@ protected:
         const char* m_data8Char;
         const char16_t* m_data16Char;
     };
-    mutable unsigned m_hashAndFlags;
+    mutable std::atomic<uint32_t> m_hashAndFlags;
 };
 
 // FIXME: Use of StringImpl and const is rather confused.
@@ -184,6 +184,7 @@ class StringImpl : private StringImplShape, public NoVirtualDestructorBase {
     WTF_DEPRECATED_MAKE_FAST_COMPACT_ALLOCATED_WITH_HEAP_IDENTIFIER(StringImpl, StringImpl);
 
     friend class AtomStringImpl;
+    friend class AtomStringTable;
     friend class JSC::LLInt::Data;
     friend class JSC::LLIntOffsetsExtractor;
     friend class PrivateSymbolImpl;
@@ -313,7 +314,7 @@ public:
     static constexpr ptrdiff_t lengthMemoryOffset() { return OBJECT_OFFSETOF(StringImpl, m_length); }
     bool isEmpty() const { return !m_length; }
 
-    bool is8Bit() const { return m_hashAndFlags & s_hashFlag8BitBuffer; }
+    bool is8Bit() const { return m_hashAndFlags.load(std::memory_order_relaxed) & s_hashFlag8BitBuffer; }
     ALWAYS_INLINE std::span<const Latin1Character> span8() const LIFETIME_BOUND { ASSERT(is8Bit()); return unsafeMakeSpan(m_data8, length()); }
     ALWAYS_INLINE std::span<const char16_t> span16() const LIFETIME_BOUND { ASSERT(!is8Bit() || isEmpty()); return unsafeMakeSpan(m_data16, length()); }
 
@@ -324,8 +325,8 @@ public:
 
     WTF_EXPORT_PRIVATE size_t NODELETE sizeInBytes() const;
 
-    bool isSymbol() const { return m_hashAndFlags & s_hashFlagStringKindIsSymbol; }
-    bool isAtom() const { return m_hashAndFlags & s_hashFlagStringKindIsAtom; }
+    bool isSymbol() const { return m_hashAndFlags.load(std::memory_order_relaxed) & s_hashFlagStringKindIsSymbol; }
+    bool isAtom() const { return m_hashAndFlags.load(std::memory_order_acquire) & s_hashFlagStringKindIsAtom; }
     void setIsAtom(bool);
     
     bool isExternal() const { return bufferOwnership() == BufferExternal; }
@@ -354,7 +355,7 @@ private:
     // So, we shift left and right when setting and getting our hash code.
     void setHash(unsigned) const;
 
-    unsigned rawHash() const { return m_hashAndFlags >> s_flagCount; }
+    unsigned rawHash() const { return m_hashAndFlags.load(std::memory_order_relaxed) >> s_flagCount; }
 
 public:
     bool hasHash() const { return !!rawHash(); }
@@ -376,6 +377,10 @@ public:
     void ref();
     void deref();
 
+private:
+    WTF_EXPORT_PRIVATE void destroyIfNeeded();
+
+public:
     class StaticStringImpl : private StringImplShape {
         WTF_MAKE_NONCOPYABLE(StaticStringImpl);
     public:
@@ -527,7 +532,7 @@ public:
     ALWAYS_INLINE static StringStats& stringStats() { return m_stringStats; }
 #endif
 
-    BufferOwnership bufferOwnership() const { return static_cast<BufferOwnership>(m_hashAndFlags & s_hashMaskBufferOwnership); }
+    BufferOwnership bufferOwnership() const { return static_cast<BufferOwnership>(m_hashAndFlags.load(std::memory_order_relaxed) & s_hashMaskBufferOwnership); }
 
     template<typename T> static constexpr size_t headerSize() { return tailOffset<T>(); }
     
@@ -1125,10 +1130,10 @@ inline size_t StringImpl::cost() const
     // We ensure this by pre-setting the s_hashFlagDidReportCost bit in all instances of
     // StaticStringImpl. As a result, StaticStringImpl instances will always return a cost of
     // 0 here and avoid modifying m_hashAndFlags.
-    if (m_hashAndFlags & s_hashFlagDidReportCost)
+    if (m_hashAndFlags.load(std::memory_order_relaxed) & s_hashFlagDidReportCost)
         return 0;
 
-    m_hashAndFlags |= s_hashFlagDidReportCost;
+    m_hashAndFlags.fetch_or(s_hashFlagDidReportCost, std::memory_order_relaxed);
     size_t result = m_length;
     if (!is8Bit())
         result <<= 1;
@@ -1154,9 +1159,9 @@ inline void StringImpl::setIsAtom(bool isAtom)
     ASSERT(!isStatic());
     ASSERT(!isSymbol());
     if (isAtom)
-        m_hashAndFlags |= s_hashFlagStringKindIsAtom;
+        m_hashAndFlags.fetch_or(s_hashFlagStringKindIsAtom, std::memory_order_release);
     else
-        m_hashAndFlags &= ~s_hashFlagStringKindIsAtom;
+        m_hashAndFlags.fetch_and(~s_hashFlagStringKindIsAtom, std::memory_order_release);
 }
 
 inline void StringImpl::setHash(unsigned hash) const
@@ -1165,27 +1170,25 @@ inline void StringImpl::setHash(unsigned hash) const
     // in the low bits because it makes them slightly more efficient to access.
     // So, we shift left and right when setting and getting our hash code.
 
-    ASSERT(!hasHash());
     ASSERT(!isStatic());
     // Multiple clients assume that StringHasher is the canonical string hash function.
     ASSERT(hash == (is8Bit() ? StringHasher::computeHashAndMaskTop8Bits(span8()) : StringHasher::computeHashAndMaskTop8Bits(span16())));
     ASSERT(!(hash & (s_flagMask << (8 * sizeof(hash) - s_flagCount)))); // Verify that enough high bits are empty.
 
     hash <<= s_flagCount;
-    ASSERT(!(hash & m_hashAndFlags)); // Verify that enough low bits are empty after shift.
     ASSERT(hash); // Verify that 0 is a valid sentinel hash value.
 
-    m_hashAndFlags |= hash; // Store hash with flags in low bits.
+    // fetch_or is idempotent: concurrent threads computing the same hash
+    // can safely race. This matches Blink's SetHashRaw() approach.
+    m_hashAndFlags.fetch_or(hash, std::memory_order_relaxed);
 }
 
 inline void StringImpl::ref()
 {
     STRING_STATS_REF_STRING(*this);
 
-#if TSAN_ENABLED
     if (isStatic())
         return;
-#endif
 
     m_refCount.fetch_add(s_refCountIncrement, std::memory_order_relaxed);
 }
@@ -1194,16 +1197,21 @@ inline void StringImpl::deref()
 {
     STRING_STATS_DEREF_STRING(*this);
 
-#if TSAN_ENABLED
     if (isStatic())
         return;
-#endif
 
-    auto oldRefCount = m_refCount.fetch_sub(s_refCountIncrement, std::memory_order_relaxed);
-    if (oldRefCount != s_refCountIncrement)
-        return;
-
-    StringImpl::destroy(this);
+    // CAS loop: never decrement refcount to zero. When refcount equals
+    // s_refCountIncrement (last ref), delegate to destroyIfNeeded()
+    // which handles atom string removal under lock before destroying.
+    uint32_t currentRefCount = m_refCount.load(std::memory_order_relaxed);
+    do {
+        if (currentRefCount == s_refCountIncrement) {
+            destroyIfNeeded();
+            return;
+        }
+    } while (!m_refCount.compare_exchange_weak(
+        currentRefCount, currentRefCount - s_refCountIncrement,
+        std::memory_order_acq_rel, std::memory_order_relaxed));
 }
 
 inline char16_t StringImpl::at(unsigned i) const


### PR DESCRIPTION
#### 98d2036212cfb8c5719b6c1e4a8babd222d36c1e
<pre>
[WTF] Random-Try: thread safe AtomString
<a href="https://bugs.webkit.org/show_bug.cgi?id=309530">https://bugs.webkit.org/show_bug.cgi?id=309530</a>
<a href="https://rdar.apple.com/172133459">rdar://172133459</a>

Reviewed by NOBODY (OOPS!).

WIP

Not planning to land anytime soon. Just crafting to measure performance
related metrics. Likely it causes huge regression.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::runEndPhase):
(JSC::Heap::requestCollection):
* Source/JavaScriptCore/runtime/Completion.cpp:
(JSC::checkSyntax):
(JSC::checkModuleSyntax):
(JSC::generateProgramBytecode):
(JSC::generateModuleBytecode):
(JSC::evaluate):
(JSC::loadAndEvaluateModule):
(JSC::loadModule):
(JSC::linkAndEvaluateModule):
(JSC::importModule):
* Source/JavaScriptCore/runtime/Identifier.cpp:
(JSC::Identifier::checkCurrentAtomStringTable):
* Source/JavaScriptCore/runtime/JSLock.cpp:
(JSC::JSLock::JSLock):
(JSC::JSLock::didAcquireLock):
(JSC::JSLock::dumpInfoAndCrashForLockNotOwned):
(JSC::JSLock::willReleaseLock):
* Source/JavaScriptCore/runtime/JSLock.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::~VM):
* Source/JavaScriptCore/runtime/VM.h:
(JSC::VM::atomStringTable const):
* Source/WTF/wtf/Threading.cpp:
(WTF::Thread::initializeInThread):
* Source/WTF/wtf/Threading.h:
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::AtomStringTableLocker::AtomStringTableLocker):
(WTF::stringTable):
(WTF::addToStringTable):
(WTF::UTF16BufferTranslator::equal):
(WTF::HashedUTF8CharactersTranslator::equal):
(WTF::SubstringTranslator8::equal):
(WTF::SubstringTranslator16::equal):
(WTF::Latin1BufferTranslator::equal):
(WTF::BufferFromStaticDataTranslator::equal):
(WTF::AtomStringImpl::addSlowCase):
(WTF::AtomStringImpl::lookUpSlowCase):
(WTF::AtomStringImpl::lookUp):
(WTF::AtomStringTableRemovalHashTranslator::hash): Deleted.
(WTF::AtomStringTableRemovalHashTranslator::equal): Deleted.
(WTF::AtomStringImpl::remove): Deleted.
* Source/WTF/wtf/text/AtomStringImpl.h:
(WTF::AtomStringImpl::addWithStringTableProvider):
(WTF::AtomStringImpl::add):
* Source/WTF/wtf/text/AtomStringTable.cpp:
(WTF::AtomStringTableRemovalHashTranslator::hash):
(WTF::AtomStringTableRemovalHashTranslator::equal):
(WTF::AtomStringTable::singleton):
(WTF::AtomStringTable::releaseAndRemoveIfNeeded):
(WTF::AtomStringTable::~AtomStringTable): Deleted.
* Source/WTF/wtf/text/AtomStringTable.h:
* Source/WTF/wtf/text/ExternalStringImpl.cpp:
(WTF::ExternalStringImpl::ExternalStringImpl):
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::~StringImpl):
(WTF::StringImpl::destroyIfNeeded):
(WTF::StringImpl::concurrentHash const):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::is8Bit const):
(WTF::StringImpl::isSymbol const):
(WTF::StringImpl::isAtom const):
(WTF::StringImpl::rawHash const):
(WTF::StringImpl::bufferOwnership const):
(WTF::StringImpl::cost const):
(WTF::StringImpl::setIsAtom):
(WTF::StringImpl::setHash const):
(WTF::StringImpl::ref):
(WTF::StringImpl::deref):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98d2036212cfb8c5719b6c1e4a8babd222d36c1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148974 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157662 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102404 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114850 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81773 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8241fbc8-3027-4d0f-9474-f163388decd2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151934 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133708 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95608 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a79806e-5663-4efd-8410-963fd7d5bad0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16152 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14005 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5510 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140941 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125756 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160144 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9762 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3134 "Found 3 new failures in wtf/HashTable.h") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13153 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122905 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running run-layout-tests-in-stress-mode; 57 flakes 9 failures; Uploaded test results; 5 flakes 1 failures; Compiled WebKit; 1 failures; Passed layout tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123132 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21497 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133425 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77685 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18409 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10185 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180402 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21099 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84901 "Found 3 new failures in wtf/HashTable.h") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46160 "Found 1 new JSC stress test failure: Too many failures: 5689 jsc tests failed (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20831 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20979 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20887 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->