### PR TITLE
Add @burg to CODEOWNERS for Inspector, WebDriver, and Automation paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,7 +77,7 @@ AllowedSPI*.toml @emw-apple
 
 /Source/JavaScriptCore @WebKit/jsc-reviewers
 /Source/JavaScriptCore/debugger @dcrousso @patrickangle
-/Source/JavaScriptCore/inspector @dcrousso @patrickangle
+/Source/JavaScriptCore/inspector @dcrousso @patrickangle @burg
 /JSTests @WebKit/jsc-reviewers
 /LayoutTests/js @WebKit/jsc-reviewers
 /Tools/TestWebKitAPI/Tests/JavaScriptCore @WebKit/jsc-reviewers
@@ -85,11 +85,11 @@ AllowedSPI*.toml @emw-apple
 # ================================================================================
 # Web Inspector
 
-/Source/WebInspectorUI @dcrousso @patrickangle
-/Tools/Scripts/webkitpy/inspector @dcrousso @patrickangle
-/LayoutTests/http/tests/inspector @dcrousso @patrickangle
-/LayoutTests/http/tests/websocket/tests/hybi/inspector @dcrousso @patrickangle
-/LayoutTests/inspector @dcrousso @patrickangle
+/Source/WebInspectorUI @dcrousso @patrickangle @burg
+/Tools/Scripts/webkitpy/inspector @dcrousso @patrickangle @burg
+/LayoutTests/http/tests/inspector @dcrousso @patrickangle @burg
+/LayoutTests/http/tests/websocket/tests/hybi/inspector @dcrousso @patrickangle @burg
+/LayoutTests/inspector @dcrousso @patrickangle @burg
 
 # ================================================================================
 # WebCore
@@ -125,7 +125,7 @@ AllowedSPI*.toml @emw-apple
 /Source/WebCore/bindings @cdumez
 /Source/WebCore/html @cdumez @rniwa
 /Source/WebCore/html/UserActivation.* @marcoscaceres
-/Source/WebCore/inspector @dcrousso @patrickangle
+/Source/WebCore/inspector @dcrousso @patrickangle @burg
 /Source/WebCore/loader @cdumez
 /Source/WebCore/page/Quirks.cpp @brentfulgham @karlcow
 /Source/WebCore/workers @cdumez
@@ -172,7 +172,7 @@ AllowedSPI*.toml @emw-apple
 /Source/WebKit/Shared/Sandbox @brentfulgham @pvollan
 /Source/WebKit/UIProcess @cdumez
 /Source/WebKit/UIProcess/Extensions @b-weinstein @xeenon
-/Source/WebKit/UIProcess/Inspector @dcrousso @patrickangle
+/Source/WebKit/UIProcess/Inspector @dcrousso @patrickangle @burg
 /Source/WebKit/WebKitSwift @rr-codes
 /Source/WebKit/UIProcess/DigitalCredentials @marcoscaceres
 /Source/WebKit/WebProcess @cdumez
@@ -180,14 +180,15 @@ AllowedSPI*.toml @emw-apple
 /Source/WebKit/WebKitSwift/IdentityDocumentServices @marcoscaceres
 /Source/WebKit/WebProcess/ApplePay @aprotyas
 /Source/WebKit/WebProcess/Extensions @b-weinstein @xeenon
-/Source/WebKit/WebProcess/Inspector @dcrousso @patrickangle
+/Source/WebKit/WebProcess/Inspector @dcrousso @patrickangle @burg
 /Source/WebKit/WebProcess/com.apple.WebProcess.sb.in  @brentfulgham @pvollan
 /Source/WebKit/Scripts/webkit/opaque_ipc_types.* @sheeparegreat
 
 # ================================================================================
 # WebDriver
 
-/Source/WebDriver/ @carlosgcampos
+/Source/WebDriver/ @carlosgcampos @burg
+/Source/WebKit/UIProcess/Automation @carlosgcampos @burg
 
 # ================================================================================
 # CMake


### PR DESCRIPTION
#### d6982432180eef8b4806d171cf4ec3614176b06d
<pre>
Add @burg to CODEOWNERS for Inspector, WebDriver, and Automation paths
<a href="https://bugs.webkit.org/show_bug.cgi?id=309532">https://bugs.webkit.org/show_bug.cgi?id=309532</a>

Reviewed by Abrar Rahman Protyasha.

Canonical link: <a href="https://commits.webkit.org/308956@main">https://commits.webkit.org/308956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28a3934edca178e3e07627081407ead33c6332aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149009 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157697 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/10660fb1-4b7d-4e86-9c9e-592c04cb3365) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114872 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133731 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95630 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e6ca7a9-7977-4f59-b8ae-a4f626d0e971) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/5546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160179 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13178 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122927 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21524 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123154 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33475 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133450 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10208 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/21134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20866 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/21014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->