### PR TITLE
git-webkit: add `create-bug` and `tracker-metadata` subcommands

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py
@@ -48,6 +48,82 @@ class Tracker(GenericTracker):
     NAME = 'Bugzilla'
     DEFAULT_TIMEOUT = 30
 
+    # Security keywords to detect in title/description.
+    # These trigger a prompt to use Security product.
+    SECURITY_KEYWORDS = [
+        # Web platform security
+        r'\bXSS\b', r'cross[- ]?site[- ]?scripting',
+        r'\bCSRF\b', r'cross[- ]?site[- ]?request[- ]?forgery',
+        r'SQL[- ]?injection', r'command[- ]?injection', r'code[- ]?injection',
+        r'same[- ]?origin', r'\bCORS\b',
+        # Memory safety
+        r'use[- ]?after[- ]?free', r'\bUAF\b',
+        r'out[- ]?of[- ]?bounds', r'\bOOB\b', r'buffer[- ]?overflow', r'buffer[- ]?overrun',
+        r'double[- ]?free',
+        r'heap[- ]?overflow', r'stack[- ]?overflow',
+        r'null[- ]?pointer[- ]?dereference', r'nullptr[- ]?dereference',
+        r'type[- ]?confusion',
+        r'integer[- ]?overflow', r'integer[- ]?underflow',
+        r'\bTOCTOU\b', r'time[- ]?of[- ]?check', r'time[- ]?of[- ]?use', r'race[- ]?condition',
+        r'uninitialized[- ]?memory', r'uninitialized[- ]?variable',
+        r'memory[- ]?corruption',
+        # Other security terms
+        r'\bvulnerability\b', r'\bexploit\b', r'security[- ]?bug', r'security[- ]?issue',
+        r'arbitrary[- ]?code[- ]?execution', r'\bRCE\b', r'remote[- ]?code[- ]?execution',
+        r'privilege[- ]?escalation', r'sandbox[- ]?escape',
+        r'information[- ]?disclosure', r'information[- ]?leak',
+        r'denial[- ]?of[- ]?service', r'\bDoS\b',
+    ]
+
+    @classmethod
+    def check_security_keywords(cls, title, description):
+        """Return list of matched security keyword patterns."""
+        text = '{} {}'.format(title or '', description or '')
+        return [p for p in cls.SECURITY_KEYWORDS if re.search(p, text, re.IGNORECASE)]
+
+    @classmethod
+    def prompt_security_classification(cls, matches, project, component):
+        """
+        If security keywords found and project is not already 'Security',
+        prompt user to confirm.  Returns (project, component).
+        """
+        if not matches or project == 'Security':
+            return project, component
+        print("WARNING: The bug description contains security-related keywords:")
+        for match in matches[:5]:
+            readable = match.replace(r'\b', '').replace('[- ]?', '-').replace(r'\.', '.')
+            print("  - {}".format(readable))
+        response = webkitcorepy.Terminal.choose(
+            "This may be a security bug. Use Security product?",
+            options=['Yes, use Security', 'No, keep {}'.format(project or 'WebKit')],
+            default='Yes, use Security',
+        )
+        if response.startswith('Yes'):
+            return 'Security', 'Security'
+        return project, component
+
+    @classmethod
+    def classify_from_radar(cls, radar_issue, project, component):
+        """
+        If radar_issue is redacted (security-sensitive), override project and
+        component to 'Security'.  Always prints a notice when forcing Security.
+        Prints an additional warning if user-supplied values are being
+        overridden.  Returns (project, component, was_forced).
+        """
+        if not radar_issue or not radar_issue.redacted:
+            return project, component, False
+
+        print("Radar {} is security-sensitive, using Security product".format(radar_issue.link))
+        overrides = []
+        if project and project != 'Security':
+            overrides.append("--project '{}'".format(project))
+        if component and component != 'Security':
+            overrides.append("--component '{}'".format(component))
+        if overrides:
+            print("WARNING: Overriding {} with 'Security'".format(' and '.join(overrides)))
+
+        return 'Security', 'Security', True
+
     class BugzillaPageParser(HTMLParser):
         def __init__(self):
             HTMLParser.__init__(self)
@@ -341,7 +417,7 @@ class Tracker(GenericTracker):
 
         return issue
 
-    def set(self, issue, assignee=None, opened=None, why=None, project=None, component=None, version=None, original=None, keywords=None, source_changes=None, state=None, substate=None, see_also=None, **properties):
+    def set(self, issue, assignee=None, opened=None, why=None, project=None, component=None, version=None, original=None, keywords=None, source_changes=None, state=None, substate=None, cc=None, see_also=None, **properties):
         update_dict = dict()
 
         if properties:
@@ -405,6 +481,9 @@ class Tracker(GenericTracker):
 
         if see_also is not None:
             update_dict['see_also'] = dict(add=see_also)
+
+        if cc is not None:
+            update_dict['cc'] = dict(add=cc)
 
         if update_dict:
             update_dict['ids'] = [issue.id]
@@ -569,8 +648,8 @@ class Tracker(GenericTracker):
             self._logins_left -= 1
         if response.status_code // 100 != 2:
             sys.stderr.write("Failed to retrieve keywords list'\n")
-            return []
-        return [value.get('name', '') for value in response.json().get('fields')[0].get('values', [])]
+            return {}
+        return {value.get('name', ''): value.get('description', '') for value in response.json().get('fields')[0].get('values', [])}
 
     def create(
         self, title, description,

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py
@@ -358,7 +358,7 @@ class Bugzilla(Base, mocks.Requests):
                 name='keywords',
                 type=8,
                 display_name='Keywords',
-                values=[dict(name='InRadar')]
+                values=[dict(name='InRadar', description='This bug also has a copy in Apple Radar.')]
             )]), url=url
         )
 

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
@@ -22,11 +22,12 @@
 
 import calendar
 import os
-import re
 import subprocess
 import sys
 import time
 import webkitcorepy
+
+from urllib.parse import urlparse
 
 from webkitcorepy import Environment, decorators
 from webkitbugspy import Issue, Tracker as GenericTracker, User, name as library_name, version as library_version
@@ -41,13 +42,6 @@ class Priority(object):
 
 
 class Tracker(GenericTracker):
-    RES = [
-        re.compile(r'<?rdar://problem/(?P<id>\d+)>?'),
-        re.compile(r'<?radar://problem/(?P<id>\d+)>?'),
-        re.compile(r'<?rdar:\/\/(?P<id>\d+)>?'),
-        re.compile(r'<?radar:\/\/(?P<id>\d+)>?'),
-        re.compile(r'<?https:\/\/rdar\.apple\.com\/(?P<id>\d+)>?'),
-    ]
 
     OTHER_BUG = 'Other Bug'
     SECURITY = 'Security'
@@ -156,12 +150,65 @@ class Tracker(GenericTracker):
             sys.stderr.write('No valid authentication session for Radar\n')
             return None
 
+    @classmethod
+    def parse_id(cls, string):
+        """Parse a radar URL string and return the numeric ID(s) as strings.
+
+        Returns a single ID string for one ID, a list of ID strings for
+        multiple IDs (ampersand-separated), or None for no match.
+        Accepts rdar://, radar://, and https://rdar.apple.com/ URL forms,
+        with optional angle brackets.
+        """
+        value = string.strip()
+        if not value:
+            return None
+
+        # Strip optional angle brackets
+        if value.startswith('<') and value.endswith('>'):
+            value = value[1:-1].strip()
+
+        parsed = urlparse(value)
+
+        # https://rdar.apple.com/N form
+        if parsed.scheme == 'https' and parsed.netloc == 'rdar.apple.com':
+            id_part = parsed.path.lstrip('/')
+            if not id_part:
+                return None
+            parts = id_part.split('&')
+            ids = [p for p in parts if p.isdigit()]
+            if not ids:
+                return None
+            if len(ids) == 1:
+                return ids[0]
+            return ids
+
+        # rdar:// or radar:// forms
+        if parsed.scheme not in ('rdar', 'radar'):
+            return None
+
+        if parsed.netloc == 'problem':
+            id_part = parsed.path.lstrip('/')
+        else:
+            id_part = parsed.netloc
+
+        if not id_part:
+            return None
+
+        parts = id_part.split('&')
+        ids = [p for p in parts if p.isdigit()]
+        if not ids:
+            return None
+        if len(ids) == 1:
+            return ids[0]
+        return ids
+
     def from_string(self, string):
-        for regex in self.RES:
-            match = regex.match(string)
-            if match:
-                return self.issue(int(match.group('id')))
-        return None
+        result = type(self).parse_id(string)
+        if result is None:
+            return None
+        if isinstance(result, list):
+            result = result[0]
+        return self.issue(int(result))
 
     def user(self, name=None, username=None, email=None):
         user = super(Tracker, self).user(name=name, username=username, email=email)

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_security_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_security_unittest.py
@@ -1,0 +1,144 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import unittest
+from webkitbugspy import bugzilla
+
+
+class TestBugzillaSecurityKeywords(unittest.TestCase):
+    def test_check_security_keywords_uaf(self):
+        matches = bugzilla.Tracker.check_security_keywords('UAF in WebCore', 'This bug causes a use-after-free crash')
+        self.assertTrue(len(matches) > 0)
+
+    def test_check_security_keywords_xss(self):
+        matches = bugzilla.Tracker.check_security_keywords('XSS vulnerability', 'Cross-site scripting attack possible')
+        self.assertTrue(len(matches) > 0)
+
+    def test_check_security_keywords_oob(self):
+        matches = bugzilla.Tracker.check_security_keywords('OOB access in array', 'Out-of-bounds read in buffer handling')
+        self.assertTrue(len(matches) > 0)
+
+    def test_check_security_keywords_toctou(self):
+        matches = bugzilla.Tracker.check_security_keywords('Race condition bug', 'TOCTOU vulnerability in file access')
+        self.assertTrue(len(matches) > 0)
+
+    def test_check_security_keywords_none(self):
+        matches = bugzilla.Tracker.check_security_keywords('Layout issue', 'Text wrapping is broken in CSS flex containers')
+        self.assertEqual(len(matches), 0)
+
+    def test_prompt_security_classification_already_security(self):
+        project, component = bugzilla.Tracker.prompt_security_classification(['use-after-free'], 'Security', 'Security')
+        self.assertEqual(project, 'Security')
+        self.assertEqual(component, 'Security')
+
+    def test_prompt_security_classification_no_matches(self):
+        project, component = bugzilla.Tracker.prompt_security_classification([], 'WebKit', 'CSS')
+        self.assertEqual(project, 'WebKit')
+        self.assertEqual(component, 'CSS')
+
+    def test_prompt_security_classification_user_accepts(self):
+        """User chooses 'Yes, use Security' at the prompt."""
+        from webkitcorepy import OutputCapture
+        from webkitcorepy.mocks import Terminal as MockTerminal
+        with MockTerminal.input('Yes'), OutputCapture() as captured:
+            project, component = bugzilla.Tracker.prompt_security_classification(
+                [r'\bUAF\b'], 'WebKit', 'Text',
+            )
+        self.assertEqual(project, 'Security')
+        self.assertEqual(component, 'Security')
+        self.assertIn('security-related keywords', captured.stdout.getvalue())
+
+    def test_prompt_security_classification_user_declines(self):
+        """User chooses 'No, keep WebKit' at the prompt."""
+        from webkitcorepy import OutputCapture
+        from webkitcorepy.mocks import Terminal as MockTerminal
+        with MockTerminal.input('No'), OutputCapture() as captured:
+            project, component = bugzilla.Tracker.prompt_security_classification(
+                [r'\bUAF\b'], 'WebKit', 'Text',
+            )
+        self.assertEqual(project, 'WebKit')
+        self.assertEqual(component, 'Text')
+        self.assertIn('security-related keywords', captured.stdout.getvalue())
+
+
+class TestBugzillaClassifyFromRadar(unittest.TestCase):
+
+    def test_classify_from_radar_no_radar(self):
+        project, component, forced = bugzilla.Tracker.classify_from_radar(None, 'WebKit', 'Text')
+        self.assertEqual(project, 'WebKit')
+        self.assertEqual(component, 'Text')
+        self.assertFalse(forced)
+
+    def test_classify_from_radar_non_redacted(self):
+        """Non-redacted radar should not force Security."""
+        from unittest.mock import MagicMock
+        radar_issue = MagicMock()
+        radar_issue.redacted = False
+        project, component, forced = bugzilla.Tracker.classify_from_radar(radar_issue, 'WebKit', 'Text')
+        self.assertEqual(project, 'WebKit')
+        self.assertEqual(component, 'Text')
+        self.assertFalse(forced)
+
+    def test_classify_from_radar_redacted_forces_security(self):
+        """Redacted radar should force Security product/component and print notice."""
+        from unittest.mock import MagicMock
+        from webkitcorepy import OutputCapture
+        radar_issue = MagicMock()
+        radar_issue.redacted = True
+        radar_issue.link = 'rdar://12345678'
+        with OutputCapture() as captured:
+            project, component, forced = bugzilla.Tracker.classify_from_radar(radar_issue, 'WebKit', 'Text')
+        self.assertEqual(project, 'Security')
+        self.assertEqual(component, 'Security')
+        self.assertTrue(forced)
+        self.assertIn('security-sensitive', captured.stdout.getvalue())
+        self.assertIn('Overriding', captured.stdout.getvalue())
+
+    def test_classify_from_radar_redacted_already_security(self):
+        """Redacted radar with Security already set should print notice but not override warning."""
+        from unittest.mock import MagicMock
+        from webkitcorepy import OutputCapture
+        radar_issue = MagicMock()
+        radar_issue.redacted = True
+        radar_issue.link = 'rdar://12345678'
+        with OutputCapture() as captured:
+            project, component, forced = bugzilla.Tracker.classify_from_radar(radar_issue, 'Security', 'Security')
+        self.assertEqual(project, 'Security')
+        self.assertEqual(component, 'Security')
+        self.assertTrue(forced)
+        self.assertIn('security-sensitive', captured.stdout.getvalue())
+        self.assertNotIn('Overriding', captured.stdout.getvalue())
+
+    def test_classify_from_radar_redacted_none_values(self):
+        """Redacted radar with None project/component should print notice (branch.py path)."""
+        from unittest.mock import MagicMock
+        from webkitcorepy import OutputCapture
+        radar_issue = MagicMock()
+        radar_issue.redacted = True
+        radar_issue.link = 'rdar://12345678'
+        with OutputCapture() as captured:
+            project, component, forced = bugzilla.Tracker.classify_from_radar(radar_issue, None, None)
+        self.assertEqual(project, 'Security')
+        self.assertEqual(component, 'Security')
+        self.assertTrue(forced)
+        self.assertIn('security-sensitive', captured.stdout.getvalue())
+        self.assertNotIn('Overriding', captured.stdout.getvalue())

--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py
@@ -590,3 +590,116 @@ What version of 'WebKit Text' should the bug be associated with?:
             captured.stderr.getvalue(),
             'Radar does not support the see_also field at this time\n',
         )
+
+
+class TestRadarParseId(unittest.TestCase):
+    """Tests for radar.Tracker.parse_id() — shared parsing of radar URL strings."""
+
+    # --- Single ID formats (returns an ID string) ---
+
+    def test_rdar_short_url(self):
+        self.assertEqual(radar.Tracker.parse_id('rdar://123456789'), '123456789')
+
+    def test_rdar_problem_url(self):
+        self.assertEqual(radar.Tracker.parse_id('rdar://problem/123456789'), '123456789')
+
+    def test_radar_short_url(self):
+        self.assertEqual(radar.Tracker.parse_id('radar://123456789'), '123456789')
+
+    def test_radar_problem_url(self):
+        self.assertEqual(radar.Tracker.parse_id('radar://problem/123456789'), '123456789')
+
+    def test_https_rdar_url(self):
+        self.assertEqual(radar.Tracker.parse_id('https://rdar.apple.com/123456789'), '123456789')
+
+    def test_rdar_short_url_with_angle_brackets(self):
+        self.assertEqual(radar.Tracker.parse_id('<rdar://123456789>'), '123456789')
+
+    def test_rdar_problem_url_with_angle_brackets(self):
+        self.assertEqual(radar.Tracker.parse_id('<rdar://problem/123456789>'), '123456789')
+
+    def test_https_rdar_url_with_angle_brackets(self):
+        self.assertEqual(radar.Tracker.parse_id('<https://rdar.apple.com/123456789>'), '123456789')
+
+    # --- Multiple IDs (returns a list of ID strings) ---
+
+    def test_rdar_ampersand_two_ids(self):
+        result = radar.Tracker.parse_id('rdar://123456789&987654321')
+        self.assertEqual(result, ['123456789', '987654321'])
+
+    def test_rdar_ampersand_three_ids(self):
+        result = radar.Tracker.parse_id('rdar://123&456&789')
+        self.assertEqual(result, ['123', '456', '789'])
+
+    def test_rdar_problem_ampersand_ids(self):
+        result = radar.Tracker.parse_id('rdar://problem/123456789&987654321&111111111')
+        self.assertEqual(result, ['123456789', '987654321', '111111111'])
+
+    # --- No match (returns None) ---
+
+    def test_bare_integer_returns_none(self):
+        self.assertIsNone(radar.Tracker.parse_id('123456789'))
+
+    def test_invalid_string_returns_none(self):
+        self.assertIsNone(radar.Tracker.parse_id('not-a-radar'))
+
+    def test_empty_string_returns_none(self):
+        self.assertIsNone(radar.Tracker.parse_id(''))
+
+    def test_https_other_url_returns_none(self):
+        self.assertIsNone(radar.Tracker.parse_id('https://example.com/123'))
+
+
+class TestRadarFromString(unittest.TestCase):
+    """Regression tests for radar.Tracker.from_string() after parse_id refactor."""
+
+    def test_rdar_short_url(self):
+        tracker = radar.Tracker()
+        issue = tracker.from_string('rdar://1234')
+        self.assertIsNotNone(issue)
+        self.assertEqual(issue.id, 1234)
+
+    def test_rdar_problem_url(self):
+        tracker = radar.Tracker()
+        issue = tracker.from_string('rdar://problem/5678')
+        self.assertIsNotNone(issue)
+        self.assertEqual(issue.id, 5678)
+
+    def test_radar_short_url(self):
+        tracker = radar.Tracker()
+        issue = tracker.from_string('radar://9999')
+        self.assertIsNotNone(issue)
+        self.assertEqual(issue.id, 9999)
+
+    def test_radar_problem_url(self):
+        tracker = radar.Tracker()
+        issue = tracker.from_string('radar://problem/4444')
+        self.assertIsNotNone(issue)
+        self.assertEqual(issue.id, 4444)
+
+    def test_https_rdar_url(self):
+        tracker = radar.Tracker()
+        issue = tracker.from_string('https://rdar.apple.com/7777')
+        self.assertIsNotNone(issue)
+        self.assertEqual(issue.id, 7777)
+
+    def test_angle_brackets(self):
+        tracker = radar.Tracker()
+        issue = tracker.from_string('<rdar://3333>')
+        self.assertIsNotNone(issue)
+        self.assertEqual(issue.id, 3333)
+
+    def test_ampersand_takes_first(self):
+        """Multi-ID URLs should take the first ID (existing behavior)."""
+        tracker = radar.Tracker()
+        issue = tracker.from_string('rdar://111&222')
+        self.assertIsNotNone(issue)
+        self.assertEqual(issue.id, 111)
+
+    def test_invalid_returns_none(self):
+        tracker = radar.Tracker()
+        self.assertIsNone(tracker.from_string('not-a-radar'))
+
+    def test_empty_returns_none(self):
+        tracker = radar.Tracker()
+        self.assertIsNone(tracker.from_string(''))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py
@@ -34,6 +34,7 @@ from .clone import Clone
 from .command import Command
 from .commit import Commit
 from .conflict import Conflict
+from .create_bug import CreateBug
 from .diff import Diff
 from .squash import Squash
 from .checkout import Checkout
@@ -55,6 +56,7 @@ from .setup import Setup
 from .show import Show
 from .trace import Trace
 from .track import Track
+from .tracker_metadata import TrackerMetadata
 
 from webkitbugspy import log as webkitbugspy_log
 from webkitcorepy import arguments, filtered_call, log as webkitcorepy_log, Terminal
@@ -95,10 +97,10 @@ def main(
 
     programs = [
         Blame, Branch, Canonicalize, Checkout,
-        Clean, Clone, Conflict, Diff, Find, Info, Land, Log, Pull,
+        Clean, Clone, Conflict, CreateBug, Diff, Find, Info, Land, Log, Pull,
         PullRequest, Revert, Review, Setup, InstallGitLFS,
         Credentials, Commit, DeletePRBranches, Squash,
-        Pickable, CherryPick, Trace, Track, Show, Publish,
+        Pickable, CherryPick, Trace, Track, TrackerMetadata, Show, Publish,
         Classify, InstallHooks,
     ] + (programs or [])
     if subversion:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py
@@ -26,7 +26,7 @@ import sys
 from .command import Command
 from .commit import Commit
 
-from webkitbugspy import Tracker, radar
+from webkitbugspy import Tracker, bugzilla, radar
 from webkitcorepy import arguments, run, string_utils, Terminal
 from webkitscmpy import local, log, remote
 
@@ -162,12 +162,11 @@ class Branch(Command):
                             input = '<rdar://problem/{}>'.format(input)
                         rdar_to_cc = Tracker.from_string(input) or False
 
-                default_proj = list(Tracker.instance().projects.keys())[0] if rdar_to_cc and rdar_to_cc.redacted else None
-                if default_proj and Terminal.choose(
-                    f"Automatically classifying bug as {default_proj}.",
-                    default='Continue', options=('Continue', 'Modify')
-                ) == 'Modify':
-                    default_proj = None
+                default_proj = None
+                if rdar_to_cc:
+                    default_proj, _, _ = bugzilla.Tracker.classify_from_radar(
+                        rdar_to_cc, None, None,
+                    )
 
                 issue = Tracker.instance().create(
                     title=args.issue,

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/create_bug.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/create_bug.py
@@ -1,0 +1,252 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+
+from .command import Command
+
+from webkitbugspy import Tracker, bugzilla, radar
+from webkitscmpy import log
+
+
+class CreateBug(Command):
+    name = 'create-bug'
+    aliases = []
+    help = 'Create a new bug on the configured bug tracker'
+
+    @classmethod
+    def parser(cls, parser, loggers=None):
+        parser.add_argument(
+            '--title', dest='title', type=str, required=True,
+            help='Bug title/summary',
+        )
+        parser.add_argument(
+            '-F', '--file', dest='description_file', type=str, default=None,
+            help='Path to file containing bug description',
+        )
+        parser.add_argument(
+            '--component', dest='component', type=str, default=None,
+            help='WebKit component (prompts if not specified)',
+        )
+        parser.add_argument(
+            '--project', dest='project', type=str, default=None,
+            help='Product name (prompts if not specified)',
+        )
+        parser.add_argument(
+            '--keywords', dest='keywords', type=str, default=None,
+            help='Comma-separated list of keywords',
+        )
+        parser.add_argument(
+            '--cc', dest='cc', type=str, default=None,
+            help='Comma-separated list of email addresses to CC',
+        )
+        parser.add_argument(
+            '--assignee', dest='assignee', type=str, default=None,
+            help='Username to assign bug to (defaults to current user)',
+        )
+        parser.add_argument(
+            '--depends-on', dest='depends_on', type=int, action='append', default=None,
+            help='Bug ID that this bug depends on (can be specified multiple times)',
+        )
+        parser.add_argument(
+            '--blocks', dest='blocks', type=int, action='append', default=None,
+            help='Bug ID that this bug blocks (can be specified multiple times)',
+        )
+        parser.add_argument(
+            '--see-also', dest='see_also', action='append', default=None,
+            help='URL to add to See Also (can be specified multiple times)',
+        )
+        parser.add_argument(
+            '--radar', dest='radar', type=str, default=None,
+            help='Radar ID to associate when creating this bug (e.g., rdar://12345678).',
+        )
+
+    @classmethod
+    def parse_radar_arg(cls, value):
+        """Validate and normalize a --radar argument to a single rdar:// string.
+
+        Accepts a bare integer ID, rdar://NNNNN, rdar://problem/NNNNN,
+        or https://rdar.apple.com/NNNNN.
+        Raises ValueError for multiple IDs or unrecognized formats.
+        Returns the normalized 'rdar://NNNNN' string.
+        """
+        value = value.strip()
+
+        # Strip optional surrounding angle brackets (e.g., <rdar://N>)
+        if value.startswith('<') and value.endswith('>'):
+            value = value[1:-1].strip()
+
+        # Bare integer ID
+        if value.isdigit():
+            return 'rdar://{}'.format(value)
+
+        # Space or comma — multiple IDs
+        if ' ' in value or ',' in value:
+            raise ValueError('only one radar ID is accepted')
+
+        # Delegate URL parsing to radar.Tracker.parse_id()
+        result = radar.Tracker.parse_id(value)
+        if result is None:
+            raise ValueError("unrecognized format; expected a numeric ID or rdar://NNNNN")
+        if isinstance(result, list):
+            raise ValueError('only one radar ID is accepted')
+        return 'rdar://{}'.format(result)
+
+    @classmethod
+    def main(cls, args, repository, **kwargs):
+        tracker = Tracker.instance()
+        if not tracker:
+            sys.stderr.write("No bug tracker configured\n")
+            return 1
+
+        # Ensure credentials are available
+        if getattr(tracker, 'credentials', None):
+            tracker.credentials(required=True, validate=True)
+
+        # Read description from file
+        description = None
+        if args.description_file:
+            try:
+                with open(args.description_file, 'r') as f:
+                    description = f.read()
+            except IOError as e:
+                sys.stderr.write("Failed to read description file '{}': {}\n".format(
+                    args.description_file, e))
+                return 1
+
+        if not description:
+            sys.stderr.write("Bug description is required (use -F/--file)\n")
+            return 1
+
+        # Start with user-specified project/component
+        project = args.project
+        component = args.component
+
+        # Check for radar and apply security override if redacted
+        radar_issue = None
+        security_forced = False
+        if args.radar:
+            try:
+                radar_str = cls.parse_radar_arg(args.radar)
+            except ValueError as e:
+                sys.stderr.write("Invalid --radar value '{}': {}\n".format(args.radar, e))
+                return 1
+            radar_issue = Tracker.from_string(radar_str)
+            if radar_issue:
+                project, component, security_forced = bugzilla.Tracker.classify_from_radar(
+                    radar_issue, project, component,
+                )
+
+        # If not forced to Security, check for security keywords in title + description
+        if not security_forced:
+            matches = bugzilla.Tracker.check_security_keywords(args.title, description)
+            if matches:
+                project, component = bugzilla.Tracker.prompt_security_classification(
+                    matches, project, component,
+                )
+
+        # Parse keywords
+        keywords = None
+        if args.keywords:
+            keywords = [k.strip() for k in args.keywords.split(',')]
+
+        # Create the bug (tracker.create prompts for project/component if not specified)
+        try:
+            issue = tracker.create(
+                title=args.title,
+                description=description,
+                project=project,
+                component=component,
+                keywords=keywords,
+            )
+        except Exception as e:
+            sys.stderr.write("Failed to create bug: {}\n".format(e))
+            return 1
+
+        if not issue:
+            sys.stderr.write("Failed to create bug\n")
+            return 1
+
+        print("Created bug: {}".format(issue.link))
+
+        # Post-creation operations
+        cls._post_create_operations(issue, tracker, args, radar_issue=radar_issue)
+
+        return 0
+
+    @classmethod
+    def _post_create_operations(cls, issue, tracker, args, radar_issue=None):
+        """Handle CC, assignee, see-also, depends-on, blocks, and radar linking after bug creation."""
+
+        # Handle assignee
+        if args.assignee:
+            try:
+                assignee_user = tracker.user(username=args.assignee)
+                if assignee_user:
+                    tracker.set(issue, assignee=assignee_user)
+                    print("Assigned to: {}".format(args.assignee))
+            except Exception as e:
+                log.warning("Failed to assign: {}".format(e))
+
+        # Handle CC list
+        if args.cc:
+            cc_list = [e.strip() for e in args.cc.split(',')]
+            # Remove the radar importer if present — cc_radar() will handle it
+            # to ensure the <rdar://N> comment and InRadar keyword come first.
+            if isinstance(tracker, bugzilla.Tracker) and getattr(tracker, 'radar_importer', None):
+                importer = tracker.radar_importer
+                importer_ids = set(filter(None, [importer.username, importer.email] + list(importer.emails)))
+                cc_list = [cc for cc in cc_list if cc not in importer_ids]
+            if cc_list:
+                try:
+                    tracker.set(issue, cc=cc_list)
+                    print("Added CC: {}".format(', '.join(cc_list)))
+                except Exception as e:
+                    log.warning("Failed to add CC: {}".format(e))
+
+        # Handle See Also
+        if args.see_also:
+            try:
+                tracker.set(issue, see_also=args.see_also)
+                print("Added See Also: {}".format(', '.join(args.see_also)))
+            except Exception as e:
+                log.warning("Failed to add See Also: {}".format(e))
+
+        # Handle relationships
+        for attr, label, apply in [
+            ('depends_on', 'depends on', lambda bug_id: tracker.relate(issue, depends_on=tracker.issue(bug_id))),
+            ('blocks', 'blocks', lambda bug_id: tracker.relate(issue, blocks=tracker.issue(bug_id))),
+        ]:
+            for bug_id in getattr(args, attr) or []:
+                try:
+                    apply(bug_id)
+                    print("Set {}: Bug {}".format(label, bug_id))
+                except Exception as e:
+                    log.warning("Failed to set {} {}: {}".format(attr, bug_id, e))
+
+        # Link to radar: post <rdar://N> comment, add InRadar keyword, CC importer.
+        # cc_radar handles the safe ordering to avoid duplicate radar creation.
+        if isinstance(tracker, bugzilla.Tracker):
+            try:
+                tracker.cc_radar(issue, radar=radar_issue)
+            except Exception as e:
+                log.warning("Failed to cc radar importer: {}".format(e))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/tracker_metadata.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/tracker_metadata.py
@@ -1,0 +1,138 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import sys
+
+from .command import Command
+
+from webkitbugspy import Tracker
+
+
+class TrackerMetadata(Command):
+    name = 'tracker-metadata'
+    aliases = []
+    help = 'Fetch and display metadata from the configured bug tracker'
+
+    PROPERTIES = [
+        'products', 'components', 'component_descriptions',
+        'keywords', 'keyword_descriptions',
+    ]
+
+    @classmethod
+    def parser(cls, parser, loggers=None):
+        parser.add_argument(
+            '--format', dest='output_format', type=str, default='json',
+            choices=['json', 'text'],
+            help='Output format (default: json)',
+        )
+        parser.add_argument(
+            '-p', '--property', dest='properties', action='append', default=None,
+            help='Property to display (can be specified multiple times). '
+                 'Available: {}'.format(', '.join(cls.PROPERTIES)),
+        )
+        parser.add_argument(
+            '--project', dest='project', type=str, default=None,
+            help='Filter components and component descriptions to a specific project',
+        )
+
+    @classmethod
+    def main(cls, args, repository, **kwargs):
+        tracker = Tracker.instance()
+        if not tracker:
+            sys.stderr.write("No bug tracker configured\n")
+            return 1
+
+        properties = args.properties or cls.PROPERTIES
+
+        for prop in properties:
+            if prop not in cls.PROPERTIES:
+                sys.stderr.write("Unknown property '{}'. Available: {}\n".format(
+                    prop, ', '.join(cls.PROPERTIES)))
+                return 1
+
+        result = cls.get_tracker_metadata(tracker, properties, args.project)
+        cls.output_result(result, args.output_format)
+        return 0
+
+    @classmethod
+    def get_tracker_metadata(cls, tracker, properties, project=None):
+        result = {}
+        projects = tracker.projects
+
+        if 'products' in properties:
+            result['products'] = sorted(projects.keys())
+
+        if 'components' in properties:
+            components = {}
+            for name, details in sorted(projects.items()):
+                if project and name != project:
+                    continue
+                components[name] = sorted(details['components'].keys())
+            result['components'] = components
+
+        if 'component_descriptions' in properties:
+            component_descriptions = {}
+            for name, details in sorted(projects.items()):
+                if project and name != project:
+                    continue
+                component_descriptions[name] = {
+                    comp: info['description']
+                    for comp, info in sorted(details['components'].items())
+                }
+            result['component_descriptions'] = component_descriptions
+
+        if 'keywords' in properties or 'keyword_descriptions' in properties:
+            if hasattr(tracker, 'valid_keywords'):
+                keywords = tracker.valid_keywords()
+            else:
+                keywords = {}
+            if 'keywords' in properties:
+                result['keywords'] = sorted(keywords.keys())
+            if 'keyword_descriptions' in properties:
+                result['keyword_descriptions'] = dict(sorted(keywords.items()))
+
+        return result
+
+    @classmethod
+    def output_result(cls, result, output_format):
+        if output_format == 'json':
+            print(json.dumps(result, indent=2, default=str))
+        else:
+            if 'products' in result:
+                print("products: {}".format(', '.join(result['products'])))
+            if 'components' in result:
+                for product, components in sorted(result['components'].items()):
+                    print("\ncomponents ({}):".format(product))
+                    for comp in components:
+                        print("  {}".format(comp))
+            if 'component_descriptions' in result:
+                for product, descs in sorted(result['component_descriptions'].items()):
+                    print("\ncomponent_descriptions ({}):".format(product))
+                    for comp, desc in sorted(descs.items()):
+                        print("  {}: {}".format(comp, desc))
+            if 'keywords' in result:
+                print("\nkeywords: {}".format(', '.join(result['keywords'])))
+            if 'keyword_descriptions' in result:
+                print("\nkeyword_descriptions:")
+                for kw, desc in sorted(result['keyword_descriptions'].items()):
+                    print("  {}: {}".format(kw, desc))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/create_bug_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/create_bug_unittest.py
@@ -1,0 +1,252 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+from unittest.mock import patch
+
+from webkitbugspy import Tracker, bugzilla, radar
+from webkitbugspy import mocks as bmocks
+from webkitcorepy import OutputCapture, testing
+from webkitcorepy.mocks import Environment
+from webkitcorepy.mocks import Terminal as MockTerminal
+
+from webkitscmpy import mocks, program
+from webkitscmpy.program.create_bug import CreateBug
+
+
+class TestCreateBug(testing.PathTestCase):
+    basepath = 'mock/repository'
+    BUGZILLA = 'https://bugs.example.com'
+
+    def setUp(self):
+        super(TestCreateBug, self).setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+        # Create description file for tests
+        self.desc_file = os.path.join(self.path, 'description.txt')
+        with open(self.desc_file, 'w') as f:
+            f.write('Test bug description')
+
+    def test_no_bugzilla_tracker(self):
+        """Test error when no bug tracker configured"""
+        with OutputCapture() as captured, mocks.local.Git(self.path), \
+             patch('webkitbugspy.Tracker._trackers', []):
+            self.assertEqual(1, program.main(
+                args=('create-bug', '--title', 'Test bug', '-F', self.desc_file),
+                path=self.path,
+            ))
+        self.assertIn('No bug tracker configured', captured.stderr.getvalue())
+
+    def test_description_file_not_found(self):
+        """Test error when description file doesn't exist"""
+        with OutputCapture() as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            self.assertEqual(1, program.main(
+                args=('create-bug', '--title', 'Test bug', '-F', '/nonexistent/file.txt'),
+                path=self.path,
+            ))
+        self.assertIn('Failed to read description file', captured.stderr.getvalue())
+
+    def test_missing_description(self):
+        """Test error when no description file specified"""
+        with OutputCapture() as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            self.assertEqual(1, program.main(
+                args=('create-bug', '--title', 'Test bug'),
+                path=self.path,
+            ))
+        self.assertIn('Bug description is required', captured.stderr.getvalue())
+
+    def test_basic_bug_creation(self):
+        """Test basic bug creation with title, description file, and component"""
+        with OutputCapture() as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            self.assertEqual(0, program.main(
+                args=('create-bug', '--title', 'Test bug', '-F', self.desc_file,
+                      '--component', 'Text', '--project', 'WebKit'),
+                path=self.path,
+            ))
+        self.assertIn('Created bug:', captured.stdout.getvalue())
+
+    def test_bug_creation_prompts_for_component(self):
+        """Test interactive prompt when component not specified"""
+        # First input selects project, second selects component
+        with MockTerminal.input('1', '1'), OutputCapture() as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            self.assertEqual(0, program.main(
+                args=('create-bug', '--title', 'Test bug', '-F', self.desc_file),
+                path=self.path,
+            ))
+        self.assertIn('Created bug:', captured.stdout.getvalue())
+
+    def test_radar_arg_accepted(self):
+        """Test that --radar is accepted and the bug is created successfully.
+        cc_radar is a no-op in this mock environment (no radar_importer configured)."""
+        with OutputCapture() as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            self.assertEqual(0, program.main(
+                args=('create-bug', '--title', 'Layout bug', '-F', self.desc_file,
+                      '--component', 'Text', '--project', 'WebKit',
+                      '--radar', 'rdar://123456789'),
+                path=self.path,
+            ))
+        self.assertIn('Created bug:', captured.stdout.getvalue())
+
+    def test_invalid_radar_arg_errors(self):
+        """Test that a malformed --radar value produces an error and no bug is created."""
+        with OutputCapture() as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            self.assertEqual(1, program.main(
+                args=('create-bug', '--title', 'Layout bug', '-F', self.desc_file,
+                      '--radar', 'not-a-radar'),
+                path=self.path,
+            ))
+        self.assertIn('Invalid --radar value', captured.stderr.getvalue())
+        self.assertNotIn('Created bug:', captured.stdout.getvalue())
+
+    def test_radar_importer_not_double_cced(self):
+        """Radar importer in --cc should be filtered out; cc_radar() handles it."""
+        importer_email = 'webkit-bug-importer@webkit.org'
+        with OutputCapture() as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(
+            self.BUGZILLA,
+            radar_importer={'name': 'WebKit Bug Importer', 'username': importer_email, 'emails': [importer_email]},
+        )]):
+            self.assertEqual(0, program.main(
+                args=('create-bug', '--title', 'Test bug', '-F', self.desc_file,
+                      '--component', 'Text', '--project', 'WebKit',
+                      '--cc', 'other@example.com,{}'.format(importer_email)),
+                path=self.path,
+            ))
+        stdout = captured.stdout.getvalue()
+        self.assertIn('Created bug:', stdout)
+        # The importer should not appear in the explicit CC output — cc_radar() handles it.
+        for line in stdout.splitlines():
+            if line.startswith('Added CC:'):
+                self.assertNotIn(importer_email, line)
+
+
+class TestCreateBugRadarArgValidation(testing.PathTestCase):
+    basepath = 'mock/repository'
+
+    def _valid(self, value):
+        """Assert parse_radar_arg succeeds and returns a string."""
+        result = CreateBug.parse_radar_arg(value)
+        self.assertIsInstance(result, str)
+        return result
+
+    def _invalid(self, value):
+        """Assert parse_radar_arg raises ValueError."""
+        with self.assertRaises(ValueError):
+            CreateBug.parse_radar_arg(value)
+
+    # --- Valid formats ---
+
+    def test_bare_id(self):
+        self.assertEqual(self._valid('123456789'), 'rdar://123456789')
+
+    def test_rdar_short_url(self):
+        self.assertEqual(self._valid('rdar://123456789'), 'rdar://123456789')
+
+    def test_rdar_long_url(self):
+        self.assertEqual(self._valid('rdar://problem/123456789'), 'rdar://123456789')
+
+    def test_rdar_short_url_with_angle_brackets(self):
+        self.assertEqual(self._valid('<rdar://123456789>'), 'rdar://123456789')
+
+    def test_rdar_long_url_with_angle_brackets(self):
+        self.assertEqual(self._valid('<rdar://problem/123456789>'), 'rdar://123456789')
+
+    def test_radar_scheme_short_url(self):
+        """radar:// scheme (alternate) is also valid."""
+        result = self._valid('radar://123456789')
+        self.assertIn('123456789', result)
+
+    # --- Invalid formats (multiple IDs) ---
+
+    def test_space_separated_ids(self):
+        self._invalid('123456789 987654321')
+
+    def test_comma_separated_ids(self):
+        self._invalid('123456789,987654321')
+
+    def test_comma_and_space_separated_ids(self):
+        self._invalid('123456789, 987654321')
+
+    def test_rdar_short_url_ampersand_ids(self):
+        self._invalid('rdar://123456789&987654321&111111111')
+
+    def test_rdar_long_url_ampersand_ids(self):
+        self._invalid('rdar://problem/123456789&987654321&111111111')
+
+    # --- Invalid formats (unrecognized) ---
+
+    def test_garbage_string(self):
+        self._invalid('not-a-radar')
+
+    def test_https_url(self):
+        """https://rdar.apple.com/ URLs are now supported by --radar via parse_id."""
+        self.assertEqual(self._valid('https://rdar.apple.com/123456789'), 'rdar://123456789')
+
+    def test_empty_string(self):
+        self._invalid('')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/tracker_metadata_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/tracker_metadata_unittest.py
@@ -1,0 +1,195 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import os
+from unittest.mock import patch
+
+from webkitbugspy import Tracker, bugzilla
+from webkitbugspy import mocks as bmocks
+from webkitcorepy import OutputCapture, testing
+from webkitcorepy.mocks import Environment
+
+from webkitscmpy import mocks, program
+
+
+class TestTrackerMetadata(testing.PathTestCase):
+    basepath = 'mock/repository'
+    BUGZILLA = 'https://bugs.example.com'
+
+    def setUp(self):
+        super(TestTrackerMetadata, self).setUp()
+        os.mkdir(os.path.join(self.path, '.git'))
+
+    def test_no_tracker(self):
+        """Test error when no bug tracker configured"""
+        with OutputCapture() as captured, mocks.local.Git(self.path), \
+             patch('webkitbugspy.Tracker._trackers', []):
+            self.assertEqual(1, program.main(
+                args=('tracker-metadata',),
+                path=self.path,
+            ))
+        self.assertIn('No bug tracker configured', captured.stderr.getvalue())
+
+    def test_json_output_all_properties(self):
+        """Test JSON output with all default properties"""
+        with OutputCapture() as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            self.assertEqual(0, program.main(
+                args=('tracker-metadata',),
+                path=self.path,
+            ))
+        data = json.loads(captured.stdout.getvalue())
+        self.assertIn('products', data)
+        self.assertIn('components', data)
+        self.assertIn('component_descriptions', data)
+        self.assertIn('keywords', data)
+        self.assertIn('keyword_descriptions', data)
+        self.assertEqual(sorted(data['products']), ['CFNetwork', 'WebKit'])
+        self.assertIn('WebKit', data['components'])
+        self.assertIn('Scrolling', data['components']['WebKit'])
+        self.assertIn('InRadar', data['keywords'])
+
+    def test_project_filter(self):
+        """Test --project filters components to a single project"""
+        with OutputCapture() as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            self.assertEqual(0, program.main(
+                args=('tracker-metadata', '--project', 'WebKit'),
+                path=self.path,
+            ))
+        data = json.loads(captured.stdout.getvalue())
+        # Products list is unfiltered
+        self.assertEqual(sorted(data['products']), ['CFNetwork', 'WebKit'])
+        # Components filtered to WebKit only
+        self.assertIn('WebKit', data['components'])
+        self.assertNotIn('CFNetwork', data['components'])
+        self.assertIn('WebKit', data['component_descriptions'])
+        self.assertNotIn('CFNetwork', data['component_descriptions'])
+
+    def test_specific_properties(self):
+        """Test selecting specific properties with -p"""
+        with OutputCapture() as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            self.assertEqual(0, program.main(
+                args=('tracker-metadata', '-p', 'products', '-p', 'keywords'),
+                path=self.path,
+            ))
+        data = json.loads(captured.stdout.getvalue())
+        self.assertIn('products', data)
+        self.assertIn('keywords', data)
+        self.assertNotIn('components', data)
+        self.assertNotIn('component_descriptions', data)
+        self.assertNotIn('keyword_descriptions', data)
+
+    def test_text_output(self):
+        """Test --format text output"""
+        with OutputCapture() as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            self.assertEqual(0, program.main(
+                args=('tracker-metadata', '--format', 'text'),
+                path=self.path,
+            ))
+        output = captured.stdout.getvalue()
+        self.assertIn('products:', output)
+        self.assertIn('WebKit', output)
+        self.assertIn('keywords:', output)
+
+    def test_invalid_property(self):
+        """Test error for unknown property"""
+        with OutputCapture() as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            self.assertEqual(1, program.main(
+                args=('tracker-metadata', '-p', 'nonexistent'),
+                path=self.path,
+            ))
+        self.assertIn('Unknown property', captured.stderr.getvalue())
+
+    def test_component_descriptions(self):
+        """Test that component descriptions are included"""
+        with OutputCapture() as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            self.assertEqual(0, program.main(
+                args=('tracker-metadata', '-p', 'component_descriptions', '--project', 'WebKit'),
+                path=self.path,
+            ))
+        data = json.loads(captured.stdout.getvalue())
+        descs = data['component_descriptions']['WebKit']
+        self.assertEqual(descs['Scrolling'], 'Bugs related to main thread and off-main thread scrolling')
+        self.assertEqual(descs['Text'], 'For bugs in text layout and rendering, including international text support.')
+
+    def test_keyword_descriptions(self):
+        """Test that keyword descriptions are included"""
+        with OutputCapture() as captured, mocks.local.Git(self.path), bmocks.Bugzilla(
+            self.BUGZILLA.split('://')[-1],
+            projects=bmocks.PROJECTS, issues=bmocks.ISSUES,
+            environment=Environment(
+                BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+                BUGS_EXAMPLE_COM_PASSWORD='password',
+            ),
+        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA)]):
+            self.assertEqual(0, program.main(
+                args=('tracker-metadata', '-p', 'keyword_descriptions'),
+                path=self.path,
+            ))
+        data = json.loads(captured.stdout.getvalue())
+        self.assertIn('InRadar', data['keyword_descriptions'])
+        self.assertEqual(
+            data['keyword_descriptions']['InRadar'],
+            'This bug also has a copy in Apple Radar.',
+        )


### PR DESCRIPTION
#### 00af9f0cd69117d359726aace2d4490d29bf1e44
<pre>
git-webkit: add `create-bug` and `tracker-metadata` subcommands
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=309535">https://bugs.webkit.org/show_bug.cgi?id=309535</a>&gt;
&lt;<a href="https://rdar.apple.com/problem/172135894">rdar://problem/172135894</a>&gt;

Reviewed by Pascoe and Jonathan Bedard.

Add two subcommands to provide a scriptable bug tracker interface,
primarily to support external tooling such as LLM-based skills.

`git-webkit create-bug` creates a new bug on the configured tracker.
It optionally links the bug to an existing radar or auto-creates a
new radar for it, and determines whether the Security product and
component are required based on the provided radar and the title and
description.

`git-webkit tracker-metadata` queries the tracker for its available
products, components, and keywords -- including descriptions -- so
external tools can discover and validate choices before calling
create-bug without extra round-trips.

Both `create-bug` and the existing `branch` subcommand share radar
URL parsing through the new `radar.Tracker.parse_id()` classmethod,
which uses `urllib.parse.urlparse()` to handle all radar URL forms
(rdar://, radar://, <a href="https://rdar.apple.com/)">https://rdar.apple.com/)</a> and extract numeric
IDs.  This replaces the `RES` compiled-regex list that
`from_string()` previously relied on, and eliminates the duplicate
`urlparse` logic that `parse_radar_arg()` previously contained.

Covered by newly added unit tests.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/bugzilla.py:
(Tracker.set):
- Add `cc` parameter.
(Tracker.SECURITY_KEYWORDS):
(Tracker.check_security_keywords):
(Tracker.prompt_security_classification):
(Tracker.classify_from_radar):
(Tracker.valid_keywords):
- Return a dict mapping keyword names to their descriptions rather
  than a list, so callers can surface contextual help.
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/mocks/bugzilla.py:
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.parse_id):
- Extract radar URL parsing into a shared classmethod that accepts
  rdar://, radar://, and <a href="https://rdar.apple.com/">https://rdar.apple.com/</a> forms with optional
  angle brackets and ampersand-separated multi-ID URLs.  Return the
  numeric ID as a string (single) or list of strings (multiple), or
  None on no match.
(Tracker.from_string):
- Delegate to parse_id() instead of iterating the RES regex list.
  For multi-ID URLs, take the first ID to preserve existing behavior.
(Tracker.RES):
- Remove the compiled-regex list, now superseded by parse_id().
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/bugzilla_security_unittest.py: Add.
(TestBugzillaSecurityKeywords):
(TestBugzillaClassifyFromRadar):
* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/tests/radar_unittest.py:
(TestRadarParseId):
- Cover all single-ID URL forms, angle brackets, ampersand multi-ID
  URLs, bare integers, and invalid inputs.
(TestRadarFromString):
- Regression tests verifying from_string() behavior is unchanged
  after the parse_id() refactor.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/__init__.py:
(main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py:
(Branch.main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/create_bug.py: Add.
(CreateBug):
(CreateBug.parser):
(CreateBug.parse_radar_arg):
- Delegate URL parsing to radar.Tracker.parse_id() instead of
  reimplementing urlparse logic.  Accept <a href="https://rdar.apple.com/N">https://rdar.apple.com/N</a>
  in addition to rdar:// and radar:// forms.  Normalize all outputs
  to <a href="https://rdar.apple.com/N">rdar://N</a> format.
(CreateBug.main):
(CreateBug._post_create_operations):
- Filter the radar importer from the explicit --cc list so cc_radar()
  can add it in the correct order (after the &lt;<a href="https://rdar.apple.com/N">rdar://N</a>&gt; comment and
  InRadar keyword), preventing a duplicate radar from being created.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/tracker_metadata.py: Add.
(TrackerMetadata):
(TrackerMetadata.parser):
(TrackerMetadata.main):
(TrackerMetadata.get_tracker_metadata):
(TrackerMetadata.output_result):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/create_bug_unittest.py: Add.
(TestCreateBug):
(TestCreateBug.test_radar_importer_not_double_cced):
(TestCreateBugRadarArgValidation):
- Update <a href="https://rdar.apple.com/problem/N">rdar://problem/N</a> tests to expect normalized <a href="https://rdar.apple.com/N">rdar://N</a> output.
  Move <a href="https://rdar.apple.com/N">https://rdar.apple.com/N</a> from invalid to valid.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/tracker_metadata_unittest.py: Add.
(TestTrackerMetadata):

Canonical link: <a href="https://commits.webkit.org/311151@main">https://commits.webkit.org/311151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06bc2dcbcc3da81cea15fecd2ad7ec1f6b1a81f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29521 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/22703 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165007 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158057 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29524 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/120941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159144 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/23143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/140257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/101616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/155505 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12779 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131884 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18088 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167486 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/19701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/129060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/155584 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29122 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/24449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/129180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29044 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/139882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/86811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23774 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23999 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/16681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28753 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/28280 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/28508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28404 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->