### PR TITLE
CDMSessionAVContentKeySession::isAnyKeyUsable should check that content key is available

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm
@@ -372,7 +372,11 @@ RefPtr<ArrayBuffer> CDMSessionAVContentKeySession::cachedKeyForKeyID(const Strin
 
 bool CDMSessionAVContentKeySession::isAnyKeyUsable(const Keys& keys) const
 {
-    auto requestKeys = CDMPrivateFairPlayStreaming::keyIDsForRequest(contentKeyRequest().get());
+    RetainPtr request = contentKeyRequest();
+    if (![request contentKey])
+        return false;
+
+    auto requestKeys = CDMPrivateFairPlayStreaming::keyIDsForRequest(request.get());
     for (auto& requestKey : requestKeys) {
         if (keys.containsIf([&](auto& key) { return arePointingToEqualData(key, requestKey); }))
             return true;
@@ -384,6 +388,8 @@ void CDMSessionAVContentKeySession::attachContentKeyToSample(const MediaSampleAV
 {
     AVContentKey *contentKey = [contentKeyRequest() contentKey];
     ASSERT(contentKey);
+    if (!contentKey)
+        return;
 
     NSError *error = nil;
     if (!AVSampleBufferAttachContentKey(sample.platformSample().cmSampleBuffer(), contentKey, &error))


### PR DESCRIPTION
#### ec2a9eedd03527a85fa3b7f40322b9f5e710a5f3
<pre>
CDMSessionAVContentKeySession::isAnyKeyUsable should check that content key is available
<a href="https://bugs.webkit.org/show_bug.cgi?id=309534">https://bugs.webkit.org/show_bug.cgi?id=309534</a>
<a href="https://rdar.apple.com/171478431">rdar://171478431</a>

Reviewed by Jean-Yves Avenard.

Check that `[contentKeyRequest() contentKey]` is non-nil in
`CDMSessionAVContentKeySession::isAnyKeyUsable()` so that
`canEnqueueSample()` returns false until the content key has
actually been derived.  Without this, `isAnyKeyUsable()` returns
true based solely on key ID matching, allowing samples to be
enqueued before the content key is ready.  The sample then reaches
`attachContentKeyToSample()` where `[contentKeyRequest() contentKey]`
is nil, triggering the ASSERT.

Also add a graceful nil check in `attachContentKeyToSample()` as
a safety net, keeping the existing ASSERT for debug builds.

* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVContentKeySession.mm:
(WebCore::CDMSessionAVContentKeySession::isAnyKeyUsable const):
(WebCore::CDMSessionAVContentKeySession::attachContentKeyToSample):

Canonical link: <a href="https://commits.webkit.org/309033@main">https://commits.webkit.org/309033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d08cbbca122a7746d2f7e8c8f78aa98473ef4c04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21874 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157849 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102592 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151034 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21752 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114995 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81853 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c5f8a50-e0f4-4954-a2fc-47178a87a40c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133854 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95750 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/970f91fd-a88d-42be-8e2e-392a0606a37e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16265 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14137 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5702 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125865 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160334 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3321 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123041 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123269 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33518 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21684 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133581 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77885 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18509 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10331 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21286 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85088 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21018 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21166 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21074 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->