### PR TITLE
Move away from -[NSView dragImage:...] in WebViewImpl::startDrag()

### DIFF
--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -313,7 +313,7 @@ void PageClientImpl::didCommitLoadForMainFrame(const String&, bool)
     CheckedRef impl = *m_impl;
     impl->updateSupportsArbitraryLayoutModes();
     impl->dismissContentRelativeChildWindowsWithAnimation(true);
-    impl->clearPromisedDragImage();
+    impl->clearPromisedImageDragData();
     impl->pageDidScroll({ 0, 0 });
 #if ENABLE(WRITING_TOOLS)
     impl->hideTextAnimationView();
@@ -447,9 +447,9 @@ void PageClientImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::H
 
 void PageClientImpl::setPromisedDataForImage(const String& pasteboardName, Ref<FragmentedSharedBuffer>&& imageBuffer, const String& filename, const String& extension, const String& title, const String& url, const String& visibleURL, RefPtr<FragmentedSharedBuffer>&& archiveBuffer, const String& originIdentifier)
 {
-    auto image = BitmapImage::create();
+    Ref image = BitmapImage::create();
     image->setData(WTF::move(imageBuffer), true);
-    protect(m_impl)->setPromisedDataForImage(image.get(), filename.createNSString().get(), extension.createNSString().get(), title.createNSString().get(), url.createNSString().get(), visibleURL.createNSString().get(), archiveBuffer.get(), pasteboardName.createNSString().get(), originIdentifier.createNSString().get());
+    protect(m_impl)->setPromisedDataForImage(WTF::move(image), filename, extension, title, url, visibleURL, WTF::move(archiveBuffer), pasteboardName, originIdentifier);
 }
 
 void PageClientImpl::updateSecureInputState()

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -607,8 +607,8 @@ public:
     void startWindowDrag();
 
     void startDrag(const WebCore::DragItem&, WebCore::ShareableBitmap::Handle&& image, const std::optional<WebCore::FrameIdentifier>& = std::nullopt);
-    void setFileAndURLTypes(NSString *filename, NSString *extension, NSString *uti, NSString *title, NSString *url, NSString *visibleURL, NSPasteboard *);
-    void setPromisedDataForImage(WebCore::Image&, NSString *filename, NSString *extension, NSString *title, NSString *url, NSString *visibleURL, WebCore::FragmentedSharedBuffer* archiveBuffer, NSString *pasteboardName, NSString *pasteboardOrigin);
+    void setPromisedDataForImage(Ref<WebCore::Image>&&, const String& filename, const String& extension, const String& title, const String& url, const String& visibleURL, RefPtr<WebCore::FragmentedSharedBuffer>&& archiveBuffer, const String& pasteboardName, const String& pasteboardOrigin);
+    void writePromisedImageDragDataToPasteboard(NSPasteboard *);
     void pasteboardChangedOwner(NSPasteboard *);
     void provideDataForPasteboard(NSPasteboard *, NSString *type);
     NSArray *namesOfPromisedFilesDroppedAtDestination(NSURL *dropDestination);
@@ -789,7 +789,7 @@ public:
     bool NODELETE effectiveUserInterfaceLevelIsElevated();
 
     void takeFocus(WebCore::FocusDirection);
-    void clearPromisedDragImage();
+    void clearPromisedImageDragData() { m_promisedImageDragData.reset(); }
 
     void requestDOMPasteAccess(WebCore::DOMPasteAccessCategory, WebCore::DOMPasteRequiresInteraction, const WebCore::IntRect&, const String& originIdentifier, CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&&);
     void handleDOMPasteRequestForCategoryWithResult(WebCore::DOMPasteAccessCategory, WebCore::DOMPasteAccessResponse);
@@ -1094,9 +1094,18 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RetainPtr<NSMutableDictionary> m_remoteAccessibilityFrameCache;
     HashSet<pid_t> m_registeredRemoteAccessibilityPids;
 
-    RefPtr<WebCore::Image> m_promisedImage;
-    String m_promisedFilename;
-    String m_promisedURL;
+    struct PromisedImageDragData {
+        Ref<WebCore::Image> image;
+        String filename;
+        String extension;
+        String title;
+        String url;
+        String visibleURL;
+        String imageUTI;
+        RefPtr<WebCore::FragmentedSharedBuffer> archiveBuffer;
+        String originIdentifier;
+    };
+    std::optional<PromisedImageDragData> m_promisedImageDragData;
 
     CGFloat m_totalHeightOfBanners { 0 };
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4600,11 +4600,13 @@ void WebViewImpl::registerDraggedTypes()
 
 NSString *WebViewImpl::fileNameForFilePromiseProvider(NSFilePromiseProvider *provider, NSString *)
 {
-    RetainPtr userInfo = dynamic_objc_cast<WKPromisedAttachmentContext>(provider.userInfo);
-    if (!userInfo)
-        return nil;
+    if (RetainPtr userInfo = dynamic_objc_cast<WKPromisedAttachmentContext>(provider.userInfo))
+        return [userInfo fileName];
 
-    return [userInfo fileName];
+    if (m_promisedImageDragData)
+        return m_promisedImageDragData->filename.createNSString().autorelease();
+
+    return nil;
 }
 
 static NSError *webKitUnknownError()
@@ -4620,20 +4622,40 @@ void WebViewImpl::didPerformDragOperation(bool handled)
 void WebViewImpl::writeToURLForFilePromiseProvider(NSFilePromiseProvider *provider, NSURL *fileURL, void(^completionHandler)(NSError *))
 {
     RetainPtr userInfo = dynamic_objc_cast<WKPromisedAttachmentContext>(provider.userInfo);
-    if (!userInfo) {
+    if (userInfo) {
+        if (RefPtr attachment = m_page->attachmentForIdentifier([userInfo attachmentIdentifier])) {
+            attachment->doWithFileWrapper([fileURL = RetainPtr { fileURL }, completionHandler](NSFileWrapper *fileWrapper) {
+                NSError *attachmentWritingError = nil;
+                if ([fileWrapper writeToURL:fileURL options:0 originalContentsURL:nil error:&attachmentWritingError])
+                    completionHandler(nil);
+                else
+                    completionHandler(attachmentWritingError);
+            });
+            return;
+        }
         completionHandler(webKitUnknownError());
         return;
     }
 
-    if (auto attachment = m_page->attachmentForIdentifier(userInfo.get().attachmentIdentifier)) {
-        NSError *attachmentWritingError = nil;
-        attachment->doWithFileWrapper([&](NSFileWrapper *fileWrapper) {
-            if ([fileWrapper writeToURL:fileURL options:0 originalContentsURL:nil error:&attachmentWritingError])
+    if (m_promisedImageDragData) {
+        RetainPtr<NSData> data;
+        Ref image = m_promisedImageDragData->image;
+        if (image->data() && !image->data()->isEmpty())
+            data = protect(image->data())->makeContiguous()->createNSData();
+        if (!data && !m_promisedImageDragData->url.isEmpty()) {
+            RetainPtr imageURL = adoptNS([[NSURL alloc] initWithString:m_promisedImageDragData->url.createNSString().get()]);
+            data = [NSData dataWithContentsOfURL:imageURL.get()];
+        }
+        if (data) {
+            NSError *error = nil;
+            if ([data writeToURL:fileURL options:NSDataWritingAtomic error:&error]) {
+                if (!m_promisedImageDragData->url.isEmpty())
+                    FileSystem::setMetadataURL(fileURL.path, m_promisedImageDragData->url);
                 completionHandler(nil);
-            else
-                completionHandler(attachmentWritingError);
-        });
-        return;
+            } else
+                completionHandler(error);
+            return;
+        }
     }
 
     completionHandler(webKitUnknownError());
@@ -4679,7 +4701,7 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
     if (RefPtr frame = WebFrameProxy::webFrame(item.rootFrameID)) {
         // FIXME: The `dragLocationInWindowCoordinates` is in window coordinates (equivalent to root view), but `convertPointToMainFrameCoordinates`
         // expects the input to be in content coordinates of the frame corresponding to the given frame ID.
-        m_page->convertPointToMainFrameCoordinates(item.dragLocationInWindowCoordinates, item.rootFrameID, [weakThis = WeakPtr { *this }, promisedAttachmentInfo = item.promisedAttachmentInfo, dragNSImage = WTF::move(dragNSImage), size, lastMouseDownEvent = m_lastMouseDownEvent, frameID] (std::optional<FloatPoint> dragLocationInMainFrameCoordinates) mutable {
+        m_page->convertPointToMainFrameCoordinates(item.dragLocationInWindowCoordinates, item.rootFrameID, [weakThis = WeakPtr { *this }, promisedAttachmentInfo = item.promisedAttachmentInfo, dragNSImage = WTF::move(dragNSImage), size, lastMouseDownEvent = m_lastMouseDownEvent, frameID, &sourceAction = item.sourceAction] (std::optional<FloatPoint> dragLocationInMainFrameCoordinates) mutable {
             CheckedPtr protectedThis = weakThis.get();
             if (!protectedThis || !dragLocationInMainFrameCoordinates)
                 return;
@@ -4688,8 +4710,24 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
 
             auto clientDragLocation = IntPoint(dragLocationInMainFrameCoordinates.value());
 
+            bool isImageDrag = protectedThis->m_promisedImageDragData && sourceAction == WebCore::DragSourceAction::Image;
+            bool canUseFilePromiseForImageDrag = isImageDrag && !protectedThis->m_promisedImageDragData->imageUTI.isEmpty();
+
             RetainPtr pasteboard = [NSPasteboard pasteboardWithName:NSPasteboardNameDrag];
 
+            if (!lastMouseDownEvent) {
+                page->dragCancelled();
+                return;
+            }
+
+            RetainPtr<NSDraggingItem> draggingItem;
+
+            // beginDraggingSessionWithItems: clears the pasteboard and populates it with
+            // UTI-typed data from NSPasteboardItems. We want to restore the legacy-typed
+            // pasteboard data afterwards so that WP read paths (which expect legacy types)
+            // can find this data in the original order.
+            RetainPtr<NSArray<NSString *>> savedLegacyPasteboardTypes;
+            RetainPtr<NSMutableDictionary<NSString *, NSData *>> savedLegacyPasteboardData;
             if (promisedAttachmentInfo) {
                 RefPtr attachment = page->attachmentForIdentifier(promisedAttachmentInfo.attachmentIdentifier);
                 if (!attachment) {
@@ -4707,30 +4745,56 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
                 RetainPtr provider = adoptNS([[NSFilePromiseProvider alloc] initWithFileType:utiType.get() delegate:(id<NSFilePromiseProviderDelegate>)view.get()]);
                 RetainPtr context = adoptNS([[WKPromisedAttachmentContext alloc] initWithIdentifier:promisedAttachmentInfo.attachmentIdentifier.createNSString().get() fileName:fileName.get()]);
                 [provider setUserInfo:context.get()];
-
-                RetainPtr draggingItem = adoptNS([[NSDraggingItem alloc] initWithPasteboardWriter:provider.get()]);
+                draggingItem = adoptNS([[NSDraggingItem alloc] initWithPasteboardWriter:provider.get()]);
                 [draggingItem setDraggingFrame:NSMakeRect(clientDragLocation.x(), clientDragLocation.y() - size.height(), size.width(), size.height()) contents:dragNSImage.get()];
+            } else if (canUseFilePromiseForImageDrag) {
+                RetainPtr imageUTI = protectedThis->m_promisedImageDragData->imageUTI.createNSString();
+                RetainPtr provider = adoptNS([[NSFilePromiseProvider alloc] initWithFileType:imageUTI.get() delegate:(id<NSFilePromiseProviderDelegate>)view.get()]);
+                draggingItem = adoptNS([[NSDraggingItem alloc] initWithPasteboardWriter:provider.get()]);
+                [draggingItem setDraggingFrame:NSMakeRect(clientDragLocation.x(), clientDragLocation.y(), size.width(), size.height()) contents:dragNSImage.get()];
+            } else {
+                protectedThis->clearPromisedImageDragData();
 
-                if (!lastMouseDownEvent) {
-                    page->dragCancelled();
-                    return;
+                // NSPasteboardItem here is a placeholder to satisfy the NSDraggingItem initializer.
+                // The real data lives in the saved legacy state and is restored once the drag session starts.
+                savedLegacyPasteboardTypes = adoptNS([[pasteboard types] copy]);
+                savedLegacyPasteboardData = adoptNS([[NSMutableDictionary alloc] init]);
+                for (NSString *type in [pasteboard types]) {
+                    if (RetainPtr data = [pasteboard dataForType:type])
+                        [savedLegacyPasteboardData setObject:data.get() forKey:type];
                 }
+                RetainPtr pasteboardItem = adoptNS([[NSPasteboardItem alloc] init]);
+                [pasteboardItem setData:[NSData data] forType:UTTypeData.identifier];
+                draggingItem = adoptNS([[NSDraggingItem alloc] initWithPasteboardWriter:pasteboardItem.get()]);
+                [draggingItem setDraggingFrame:NSMakeRect(clientDragLocation.x(), clientDragLocation.y(), size.width(), size.height()) contents:dragNSImage.get()];
+            }
+            [view beginDraggingSessionWithItems:@[draggingItem.get()] event:lastMouseDownEvent.get() source:(id<NSDraggingSource>)view.get()];
 
-                [view beginDraggingSessionWithItems:@[draggingItem.get()] event:lastMouseDownEvent.get() source:(id<NSDraggingSource>)view.get()];
-
+            if (promisedAttachmentInfo) {
                 for (size_t index = 0; index < promisedAttachmentInfo.additionalTypesAndData.size(); ++index) {
                     RetainPtr nsData = protect(*promisedAttachmentInfo.additionalTypesAndData[index].second)->createNSData();
                     [pasteboard setData:nsData.get() forType:promisedAttachmentInfo.additionalTypesAndData[index].first.createNSString().get()];
                 }
+                // FIXME: should we plumb the frameID for promised blobs?
                 page->didStartDrag();
-                return;
+            } else if (isImageDrag) {
+                protectedThis->writePromisedImageDragDataToPasteboard(pasteboard.get());
+                if (page->sessionID().isEphemeral())
+                    [pasteboard _setExpirationDate:[NSDate dateWithTimeIntervalSinceNow:pasteboardExpirationDelay.seconds()]];
+                page->didStartDrag(frameID);
+            } else {
+                if (savedLegacyPasteboardTypes && [savedLegacyPasteboardTypes count]) {
+                    [pasteboard clearContents];
+                    [pasteboard addTypes:savedLegacyPasteboardTypes.get() owner:nil];
+                    for (NSString *type in savedLegacyPasteboardTypes.get()) {
+                        if (RetainPtr data = [savedLegacyPasteboardData objectForKey:type])
+                            [pasteboard setData:data.get() forType:type];
+                    }
+                    if (page->sessionID().isEphemeral())
+                        [pasteboard _setExpirationDate:[NSDate dateWithTimeIntervalSinceNow:pasteboardExpirationDelay.seconds()]];
+                }
+                page->didStartDrag(frameID);
             }
-            page->didStartDrag(frameID);
-
-            [pasteboard setString:@"" forType:PasteboardTypes::WebDummyPboardType];
-        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-            [view dragImage:dragNSImage.get() at:NSPointFromCGPoint(clientDragLocation) offset:NSZeroSize event:lastMouseDownEvent.get() pasteboard:pasteboard.get() source:view.get() slideBack:YES];
-        ALLOW_DEPRECATED_DECLARATIONS_END
         });
     }
 }
@@ -4741,78 +4805,82 @@ static bool matchesExtensionOrEquivalent(const String& filename, const String& e
         || (equalLettersIgnoringASCIICase(extension, "jpeg"_s) && filename.endsWithIgnoringASCIICase(".jpg"_s));
 }
 
-void WebViewImpl::setFileAndURLTypes(NSString *filename, NSString *extension, NSString* uti, NSString *title, NSString *url, NSString *visibleURL, NSPasteboard *pasteboard)
+void WebViewImpl::setPromisedDataForImage(Ref<WebCore::Image>&& image, const String& filename, const String& extension, const String& title, const String& url, const String& visibleURL, RefPtr<WebCore::FragmentedSharedBuffer>&& archiveBuffer, const String&, const String& originIdentifier)
 {
-    RetainPtr<NSString> filenameWithExtension;
-    if (matchesExtensionOrEquivalent(filename, extension))
-        filenameWithExtension = filename;
-    else
-        filenameWithExtension = [retainPtr([filename stringByAppendingString:@"."]) stringByAppendingString:extension];
+    String filenameWithExtension = filename;
+    if (!matchesExtensionOrEquivalent(filename, extension))
+        filenameWithExtension = makeString(filename, '.', extension);
 
-    [pasteboard setString:visibleURL forType:WebCore::legacyStringPasteboardTypeSingleton()];
-    [pasteboard setString:visibleURL forType:PasteboardTypes::WebURLPboardType];
-    [pasteboard setString:title forType:PasteboardTypes::WebURLNamePboardType];
-    [pasteboard setPropertyList:@[@[visibleURL], @[title]] forType:PasteboardTypes::WebURLsWithTitlesPboardType];
-    [pasteboard setPropertyList:@[uti] forType:WebCore::legacyFilesPromisePasteboardTypeSingleton()];
-    m_promisedFilename = filenameWithExtension.get();
-    m_promisedURL = url;
+    String uti = image->uti();
+
+    m_promisedImageDragData = {
+        .image = WTF::move(image),
+        .filename = WTF::move(filenameWithExtension),
+        .extension = extension,
+        .title = title,
+        .url = url,
+        .visibleURL = visibleURL,
+        .imageUTI = WTF::move(uti),
+        .archiveBuffer = WTF::move(archiveBuffer),
+        .originIdentifier = originIdentifier,
+    };
 }
 
-void WebViewImpl::setPromisedDataForImage(WebCore::Image& image, NSString *filename, NSString *extension, NSString *title, NSString *url, NSString *visibleURL, WebCore::FragmentedSharedBuffer* archiveBuffer, NSString *pasteboardName, NSString *originIdentifier)
+void WebViewImpl::writePromisedImageDragDataToPasteboard(NSPasteboard *pasteboard)
 {
-    RetainPtr pasteboard = [NSPasteboard pasteboardWithName:pasteboardName];
-    RetainPtr types = adoptNS([[NSMutableArray alloc] initWithObjects:WebCore::legacyFilesPromisePasteboardTypeSingleton(), nil]);
+    if (!m_promisedImageDragData)
+        return;
 
-    auto uti = image.uti();
-    if (!uti.isEmpty() && image.data() && !image.data()->isEmpty())
-        [types addObject:uti.createNSString().get()];
+    auto& data = *m_promisedImageDragData;
+    RetainPtr visibleURLString = data.visibleURL.createNSString();
+    RetainPtr titleString = data.title.createNSString();
 
-    RetainPtr<NSData> customDataBuffer;
-    if (originIdentifier.length) {
-        [types addObject:RetainPtr { @(WebCore::PasteboardCustomData::cocoaType().characters()) }.get()];
-        WebCore::PasteboardCustomData customData;
-        customData.setOrigin(originIdentifier);
-        customDataBuffer = customData.createSharedBuffer()->createNSData();
+    [pasteboard setString:visibleURLString.get() forType:WebCore::legacyStringPasteboardTypeSingleton()];
+    [pasteboard setString:visibleURLString.get() forType:PasteboardTypes::WebURLPboardType];
+    [pasteboard setString:titleString.get() forType:PasteboardTypes::WebURLNamePboardType];
+    [pasteboard setPropertyList:@[@[visibleURLString.get()], @[titleString.get()]] forType:PasteboardTypes::WebURLsWithTitlesPboardType];
+
+    RetainPtr nsURL = [NSURL URLWithString:visibleURLString.get()];
+    if (RetainPtr baseCocoaURL = [nsURL baseURL])
+        [pasteboard setPropertyList:@[[nsURL relativeString], [baseCocoaURL absoluteString]] forType:WebCore::legacyURLPasteboardTypeSingleton()];
+    else if (nsURL)
+        [pasteboard setPropertyList:@[[nsURL absoluteString], @""] forType:WebCore::legacyURLPasteboardTypeSingleton()];
+    else
+        [pasteboard setPropertyList:@[@"", @""] forType:WebCore::legacyURLPasteboardTypeSingleton()];
+
+    Ref image = data.image;
+    if (!data.imageUTI.isEmpty() && image->data() && !image->data()->isEmpty()) {
+        if (RetainPtr imageData = protect(image->data())->makeContiguous()->createNSData())
+            [pasteboard setData:imageData.get() forType:data.imageUTI.createNSString().get()];
     }
 
-    [types addObjectsFromArray:RetainPtr { archiveBuffer ? PasteboardTypes::forImagesWithArchiveSingleton() : PasteboardTypes::forImagesSingleton() }.get()];
+    if (RetainPtr tiffData = image->adapter().tiffRepresentation())
+        [pasteboard setData:bridge_cast(WTF::move(tiffData)) forType:WebCore::legacyTIFFPasteboardTypeSingleton()];
 
-    [pasteboard clearContents];
-    if (m_page->sessionID().isEphemeral())
-        [pasteboard _setExpirationDate:[NSDate dateWithTimeIntervalSinceNow:pasteboardExpirationDelay.seconds()]];
-    [pasteboard addTypes:types.get() owner:m_view.get().get()];
-    setFileAndURLTypes(filename, extension, uti.createNSString().get(), title, url, visibleURL, pasteboard.get());
-
-    if (archiveBuffer) {
-        auto nsData = archiveBuffer->makeContiguous()->createNSData();
+    if (RefPtr archiveBuffer = data.archiveBuffer) {
+        RetainPtr nsData = archiveBuffer->makeContiguous()->createNSData();
         [pasteboard setData:nsData.get() forType:UTTypeWebArchive.identifier];
         [pasteboard setData:nsData.get() forType:PasteboardTypes::WebArchivePboardType];
     }
 
-    if (customDataBuffer)
-        [pasteboard setData:customDataBuffer.get() forType:@(WebCore::PasteboardCustomData::cocoaType().characters())];
-
-    m_promisedImage = image;
-}
-
-void WebViewImpl::clearPromisedDragImage()
-{
-    m_promisedImage = nullptr;
+    if (!data.originIdentifier.isEmpty()) {
+        WebCore::PasteboardCustomData customData;
+        customData.setOrigin(data.originIdentifier);
+        [pasteboard setData:customData.createSharedBuffer()->createNSData().get() forType:@(WebCore::PasteboardCustomData::cocoaType().characters())];
+    }
 }
 
 void WebViewImpl::pasteboardChangedOwner(NSPasteboard *pasteboard)
 {
-    clearPromisedDragImage();
-    m_promisedFilename = emptyString();
-    m_promisedURL = emptyString();
+    clearPromisedImageDragData();
 }
 
 void WebViewImpl::provideDataForPasteboard(NSPasteboard *pasteboard, NSString *type)
 {
-    RefPtr promisedImage = m_promisedImage;
-    if (!promisedImage)
+    if (!m_promisedImageDragData)
         return;
 
+    Ref promisedImage = m_promisedImageDragData->image;
     if ([type isEqual:promisedImage->uti().createNSString().get()] && promisedImage->data()) {
         if (auto platformData = protect(promisedImage->data())->makeContiguous()->createNSData())
             [pasteboard setData:(__bridge NSData *)platformData.get() forType:type];
@@ -4864,20 +4932,22 @@ static RetainPtr<NSString> pathWithUniqueFilenameForPath(NSString *path)
 NSArray *WebViewImpl::namesOfPromisedFilesDroppedAtDestination(NSURL *dropDestination)
 {
     RetainPtr<NSFileWrapper> wrapper;
-    RetainPtr<NSData> data;
+    RetainPtr<NSData> nsData;
 
-    if (RefPtr promisedImage = m_promisedImage) {
-        data = protect(promisedImage->data())->makeContiguous()->createNSData();
-        wrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:data.get()]);
-    } else
-        wrapper = adoptNS([[NSFileWrapper alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:m_promisedURL.createNSString().get()]).get() options:NSFileWrapperReadingImmediate error:nil]);
+    if (m_promisedImageDragData) {
+        if (RefPtr data = m_promisedImageDragData->image->data()) {
+            nsData = data->makeContiguous()->createNSData();
+            wrapper = adoptNS([[NSFileWrapper alloc] initRegularFileWithContents:nsData.get()]);
+        } else if (!m_promisedImageDragData->url.isEmpty())
+            wrapper = adoptNS([[NSFileWrapper alloc] initWithURL:adoptNS([[NSURL alloc] initWithString:m_promisedImageDragData->url.createNSString().get()]).get() options:NSFileWrapperReadingImmediate error:nil]);
+    }
 
-    if (wrapper)
-        [wrapper setPreferredFilename:m_promisedFilename.createNSString().get()];
-    else {
+    if (!m_promisedImageDragData || !wrapper) {
         LOG_ERROR("Failed to create image file.");
         return nil;
     }
+
+    [wrapper setPreferredFilename:m_promisedImageDragData->filename.createNSString().get()];
 
     // FIXME: Report an error if we fail to create a file.
     RetainPtr<NSString> path = [retainPtr([dropDestination path]) stringByAppendingPathComponent:retainPtr([wrapper preferredFilename]).get()];
@@ -4885,8 +4955,8 @@ NSArray *WebViewImpl::namesOfPromisedFilesDroppedAtDestination(NSURL *dropDestin
     if (![wrapper writeToURL:[NSURL fileURLWithPath:path.get() isDirectory:NO] options:NSFileWrapperWritingWithNameUpdating originalContentsURL:nil error:nullptr])
         LOG_ERROR("Failed to create image file via -[NSFileWrapper writeToURL:options:originalContentsURL:error:]");
 
-    if (!m_promisedURL.isEmpty())
-        FileSystem::setMetadataURL(String(path.get()), m_promisedURL);
+    if (!m_promisedImageDragData->url.isEmpty())
+        FileSystem::setMetadataURL(path.get(), m_promisedImageDragData->url);
 
     return @[[path lastPathComponent]];
 }

--- a/Tools/TestWebKitAPI/mac/DragAndDropSimulatorMac.mm
+++ b/Tools/TestWebKitAPI/mac/DragAndDropSimulatorMac.mm
@@ -191,6 +191,11 @@ static RetainPtr<NSImage> defaultExternalDragImage()
     [_webView mouseDragToPoint:[self locationInViewForCurrentProgress]];
     [_webView waitForPendingMouseEvents];
 
+    // For site isolation, startDrag() waits for an async coordinate conversion before calling
+    // beginDraggingSessionWithItems:. Flush any pending IPC callbacks.
+    if (!_draggingSession)
+        [_webView waitForNextPresentationUpdate];
+
     TestWebKitAPI::Util::run(&_doneWaitingForDraggingSession);
 
     [_webView mouseUpAtPoint:_endLocationInWindow];
@@ -228,6 +233,15 @@ static RetainPtr<NSImage> defaultExternalDragImage()
     id dragImageContents = items[0].imageComponents.firstObject.contents;
     [self initializeDraggingInfo:pasteboard dragImage:[dragImageContents isKindOfClass:[NSImage class]] ? dragImageContents : nil source:source];
 
+    // Defer draggingEntered: to the next run loop iteration, matching real AppKit
+    // where draggingEntered: fires asynchronously after beginDraggingSessionWithItems:
+    // returns. This gives the caller (startDrag) time to restore legacy pasteboard
+    // data before the WebProcess reads the pasteboard.
+    [self performSelector:@selector(enterDragSession) withObject:nil afterDelay:0];
+}
+
+- (void)enterDragSession
+{
     _currentDragOperation = [_webView draggingEntered:_draggingInfo.get()];
     [_webView waitForNextPresentationUpdate];
     [self performSelector:@selector(continueDragSession) withObject:nil afterDelay:0];
@@ -257,6 +271,7 @@ static RetainPtr<NSImage> defaultExternalDragImage()
         [_webView draggingExited:_draggingInfo.get()];
     [_webView waitForNextPresentationUpdate];
     [(id <NSDraggingSource>)_webView.get() draggingSession:_draggingSession.get() endedAtPoint:_endLocationInWindow operation:_currentDragOperation];
+    [_webView waitForNextPresentationUpdate];
 
     _doneWaitingForDraggingSession = true;
 }

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -115,15 +115,66 @@ struct CustomMenuActionInfo {
 @dynamic _stableStateOverride;
 
 #if PLATFORM(MAC)
+- (void)_startTestDragWithImage:(NSImage *)image offset:(NSSize)offset pasteboard:(NSPasteboard *)pasteboard source:(id)source
+{
+    ++_draggingSequenceNumber;
+    RetainPtr draggingInfo = adoptNS([[WebKitTestRunnerDraggingInfo alloc] initWithImage:image offset:offset pasteboard:pasteboard source:source sequenceNumber:_draggingSequenceNumber]);
+    _currentDraggingInfo = draggingInfo;
+    [self draggingEntered:draggingInfo.get()];
+    [self draggingUpdated:draggingInfo.get()];
+}
+
 IGNORE_WARNINGS_BEGIN("deprecated-implementations")
 - (void)dragImage:(NSImage *)anImage at:(NSPoint)viewLocation offset:(NSSize)initialOffset event:(NSEvent *)event pasteboard:(NSPasteboard *)pboard source:(id)sourceObj slideBack:(BOOL)slideFlag
 IGNORE_WARNINGS_END
 {
-    ++_draggingSequenceNumber;
-    RetainPtr draggingInfo = adoptNS([[WebKitTestRunnerDraggingInfo alloc] initWithImage:anImage offset:initialOffset pasteboard:pboard source:sourceObj sequenceNumber:_draggingSequenceNumber]);
-    _currentDraggingInfo = draggingInfo;
-    [self draggingEntered:draggingInfo.get()];
-    [self draggingUpdated:draggingInfo.get()];
+    [self _startTestDragWithImage:anImage offset:initialOffset pasteboard:pboard source:sourceObj];
+}
+
+- (NSDraggingSession *)beginDraggingSessionWithItems:(NSArray<NSDraggingItem *> *)items event:(NSEvent *)event source:(id<NSDraggingSource>)source
+{
+    RetainPtr pasteboard = [NSPasteboard pasteboardWithName:NSPasteboardNameDrag];
+
+    // Save and restore legacy pasteboard data around clearContents + writeObjects:,
+    // since this override fires draggingEntered: synchronously (before the caller
+    // can restore the data itself).
+    RetainPtr savedTypes = adoptNS([[pasteboard types] copy]);
+    RetainPtr savedData = adoptNS([[NSMutableDictionary alloc] init]);
+    for (NSString *type in savedTypes.get()) {
+        if (RetainPtr data = [pasteboard dataForType:type])
+            [savedData setObject:data.get() forKey:type];
+    }
+
+    [pasteboard clearContents];
+    RetainPtr pasteboardObjects = [NSMutableArray arrayWithCapacity:items.count];
+    NSMutableArray<NSString *> *promisedFileTypes = [NSMutableArray array];
+    for (NSDraggingItem *item in items) {
+        id pasteboardObject = item.item;
+        if ([pasteboardObject isKindOfClass:[NSFilePromiseProvider class]])
+            [promisedFileTypes addObject:[(NSFilePromiseProvider *)pasteboardObject fileType]];
+        else
+            [pasteboardObjects addObject:pasteboardObject];
+    }
+    if ([pasteboardObjects count])
+        [pasteboard writeObjects:pasteboardObjects.get()];
+    if (promisedFileTypes.count) {
+        [pasteboard setPropertyList:promisedFileTypes forType:NSFilesPromisePboardType];
+        [pasteboard addTypes:@[@"NSPromiseContentsPboardType", (NSString *)kPasteboardTypeFileURLPromise] owner:nil];
+    }
+
+    if ([savedTypes count]) {
+        [pasteboard clearContents];
+        [pasteboard addTypes:savedTypes.get() owner:nil];
+        for (NSString *type in savedTypes.get()) {
+            if (RetainPtr data = [savedData objectForKey:type])
+                [pasteboard setData:data.get() forType:type];
+        }
+    }
+
+    RetainPtr dragImage = dynamic_objc_cast<NSImage>(items.firstObject.imageComponents.firstObject.contents);
+    [self _startTestDragWithImage:dragImage.get() offset:NSZeroSize pasteboard:pasteboard.get() source:source];
+
+    return adoptNS([[NSDraggingSession alloc] init]).autorelease();
 }
 
 - (void)mouseDown:(NSEvent *)event


### PR DESCRIPTION
#### 1cea00ee072af82bdc47b5e4dc8e490890bd6a78
<pre>
Move away from -[NSView dragImage:...] in WebViewImpl::startDrag()
<a href="https://bugs.webkit.org/show_bug.cgi?id=309539">https://bugs.webkit.org/show_bug.cgi?id=309539</a>
<a href="https://rdar.apple.com/172136296">rdar://172136296</a>

Reviewed by Richard Robinson.

WebViewImpl::startDrag() had two codepaths: attachment drags used
beginDraggingSessionWithItems:event:source: with NSFilePromiseProvider,
while all other drags (images, text selection, links, DHTML) used the
deprecated dragImage:at:offset:event:pasteboard:source:slideBack:. This
patch replaces the deprecated API and unifies all drag types under
beginDraggingSessionWithItems:, in anticipation of gesture recognizer
based drag-and-drop support.

This required solving three problems caused by the API difference:
beginDraggingSessionWithItems: clears the pasteboard via clearContents
then repopulates it from the NSDraggingItem&apos;s NSPasteboardWriting
objects, whereas dragImage: used the pre-populated pasteboard as-is.

1. Image drags need NSFilePromiseProvider, not NSPasteboardItem.

beginDraggingSessionWithItems: only supports file promises via
NSFilePromiseProvider. NSDragManager explicitly looks for
NSFilePromiseProvider instances among the pasteboard writers during
session creation and sets up NSFilePromiseDragSource (the glue object
that routes drop-destination requests back to the drag source&apos;s
namesOfPromisedFilesDroppedAtDestination:). Writing PboardType to the
pasteboard after session creation is too late — the NSDraggingSession
init has already checked and found no file promise infrastructure.

So, we use NSFilePromiseProvider for image drags, matching the existing
attachment path. Extend fileNameForFilePromiseProvider: and
writeToURLForFilePromiseProvider: to handle image promises by checking
for m_promisedImageDragData when no WKPromisedAttachmentContext is
present. Write supplementary pasteboard data (URLs, TIFF, web archive,
custom data with origin identifier) after beginDraggingSessionWithItems:
returns via the new writePromisedImageDragDataToPasteboard method.

Consolidate the three separate members (m_promisedImage,
m_promisedFilename, m_promisedURL) into a single PromisedImageDragData
struct that also stores the extension, title, visible URL, image UTI,
archive buffer, and origin identifier. Change setPromisedDataForImage
to store all data without touching any pasteboard — the actual writes
now happen in startDrag after the drag session is created.

2. Non-image drags need pasteboard data preserved across the clear.

For selection, link, and DHTML drags, the WebProcess pre-populates the
pasteboard with legacy-typed data (NSStringPboardType, NeXT plain
ascii pasteboard type, Apple Web Archive pasteboard type, etc.) via
PlatformPasteboard IPC. beginDraggingSessionWithItems: destroys all
of this with clearContents.

Save the legacy pasteboard types and data before the call, use a
placeholder NSPasteboardItem (with empty UTTypeData) to satisfy the
NSDraggingItem initializer, then restore the saved legacy data after
beginDraggingSessionWithItems: returns. Clear and rewrite rather than
append to preserve the original type ordering that web content observes
via dataTransfer.types. The drag loop is asynchronous for
beginDraggingSessionWithItems: (starts on the next run loop turn via
CFRunLoopObserver), so the pasteboard is correct by the time any
destination reads it.

3. Ephemeral session expiration must move to after session creation.

The old setPromisedDataForImage wrote pasteboard expiration dates for
private browsing. Since that data is now destroyed by clearContents,
set the expiration after the drag session starts for both image and
non-image paths.

Test infrastructure changes:

WKTR: Add beginDraggingSessionWithItems:event:source: override to
TestRunnerWKWebView. Extract the shared drag simulation logic into
_startTestDragWithImage:offset:pasteboard:source: so both the
deprecated dragImage: override and the new override share code. The new
override must perform the same save/restore of legacy pasteboard data
because it fires draggingEntered: synchronously (WKTR&apos;s eventSender
calls are synchronous JavaScript bindings with no run loop pumping
between calls). [NSPasteboard types] returns a live view of the
pasteboard&apos;s internal array, so snapshot it with copy before any
operation that might clear the pasteboard.

TWKAPI: Defer draggingEntered: to the next run loop iteration via
performSelector:withObject:afterDelay:0, matching real AppKit behavior
where draggingEntered: fires asynchronously after beginDraggingSessionWithItems:
returns. This gives startDrag time to restore legacy pasteboard data.
Add a wait for the dragging session to be populated for site isolation
tests where beginDraggingSessionWithItems: may be called asynchronously
after a coordinate conversion IPC round-trip. Add
waitForNextPresentationUpdate after draggingSession:endedAtPoint:operation:
so dragend events have time to propagate through cross-process IPC
chains before the test reads the events array.

* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::didCommitLoadForMainFrame):
(WebKit::PageClientImpl::setPromisedDataForImage):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::fileNameForFilePromiseProvider):
(WebKit::WebViewImpl::writeToURLForFilePromiseProvider):
(WebKit::WebViewImpl::startDrag):
(WebKit::WebViewImpl::setPromisedDataForImage):
(WebKit::WebViewImpl::writePromisedImageDragDataToPasteboard):
(WebKit::WebViewImpl::pasteboardChangedOwner):
(WebKit::WebViewImpl::provideDataForPasteboard):
(WebKit::WebViewImpl::namesOfPromisedFilesDroppedAtDestination):
(WebKit::WebViewImpl::setFileAndURLTypes): Deleted.
(WebKit::WebViewImpl::clearPromisedDragImage): Deleted.
* Tools/TestWebKitAPI/mac/DragAndDropSimulatorMac.mm:
(-[DragAndDropSimulator runFrom:to:]):
(-[DragAndDropSimulator beginDraggingSessionInWebView:withItems:source:]):
(-[DragAndDropSimulator enterDragSession]):
(-[DragAndDropSimulator continueDragSession]):
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView _startTestDragWithImage:offset:pasteboard:source:]):
(-[TestRunnerWKWebView dragImage:at:offset:event:pasteboard:source:slideBack:]):
(-[TestRunnerWKWebView beginDraggingSessionWithItems:event:source:]):
  NSFilePromiseProvider conforms to NSPasteboardWriting but is not a
  regular pasteboard item — writing it to an NSPasteboard via
  writeObjects: leaves an object that does not respond to -types, which
  crashes PlatformPasteboard::informationForItemAtIndex when it reads
  pasteboard items during performDragOperation.

  Match DragAndDropSimulator&apos;s existing handling by detecting
  NSFilePromiseProvider items, extract their file types, and write
  legacy file promise types (NSFilesPromisePboardType,
  NSPromiseContentsPboardType, kPasteboardTypeFileURLPromise) to the
  pasteboard instead of passing the raw provider to writeObjects:.

Canonical link: <a href="https://commits.webkit.org/309943@main">https://commits.webkit.org/309943@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eda1c9ca04f39fea04f9b6f667dcc8d796347863

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152106 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160849 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105563 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153980 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117503 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83340 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155066 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136527 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98216 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18760 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16715 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8683 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128406 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14410 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163315 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6461 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/16002 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125530 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24686 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125706 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34135 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24687 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136206 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81280 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20714 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12983 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24304 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88589 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23995 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24155 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24056 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->