### PR TITLE
Changing color-scheme doesn't repaint background of composited iframes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic-cross-origin.sub-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic-cross-origin.sub-expected.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<style>
+  :root {
+    color-scheme: light;
+  }
+
+  .spacer {
+    height: 300vh;
+
+    /* Hack so WebKit will put this iframe in a layer */
+    will-change: transform;
+  }
+</style>
+
+<p>This iframe should have light background.</p>
+<!-- Spacer to make the iframe scroll -->
+<div class="spacer"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic-cross-origin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic-cross-origin.sub.html
@@ -1,0 +1,44 @@
+<!doctype html>
+
+<html class="reftest-wait">
+
+<title>CSS Color Adjustment Test: Cross-origin frame with a light color-scheme should get an opaque background when parent frame changes from light to dark</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-adjust/#color-scheme-effect">
+<link rel="match" href="support/light-frame-scrolling.html">
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<style>
+  :root {
+    color-scheme: light;
+  }
+  html, body {
+    margin: 0;
+    height: 100%;
+  }
+  iframe {
+    margin: 0;
+    border: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+</style>
+
+<iframe src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-color-adjust/rendering/dark-color-scheme/support/light-frame-scrolling.html" onload="iframeLoaded()"></iframe>
+<script>
+  async function iframeLoaded() {
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    document.querySelector(":root").style.colorScheme = "dark";
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    takeScreenshot();
+  }
+</script>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic-expected.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<style>
+  :root {
+    color-scheme: light;
+  }
+
+  .spacer {
+    height: 300vh;
+
+    /* Hack so WebKit will put this iframe in a layer */
+    will-change: transform;
+  }
+</style>
+
+<p>This iframe should have light background.</p>
+<!-- Spacer to make the iframe scroll -->
+<div class="spacer"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic.html
@@ -1,0 +1,44 @@
+<!doctype html>
+
+<html class="reftest-wait">
+
+<title>CSS Color Adjustment Test: Same-origin frame with a light color-scheme should get an opaque background when parent frame changes from light to dark</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-adjust/#color-scheme-effect">
+<link rel="match" href="support/light-frame-scrolling.html">
+<script src="/common/reftest-wait.js"></script>
+<script src="/common/rendering-utils.js"></script>
+<style>
+  :root {
+    color-scheme: light;
+  }
+  html, body {
+    margin: 0;
+    height: 100%;
+  }
+  iframe {
+    margin: 0;
+    border: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+  }
+</style>
+
+<iframe src="support/light-frame-scrolling.html" scrolling="yes" onload="iframeLoaded()"></iframe>
+<script>
+  async function iframeLoaded() {
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    document.querySelector(":root").style.colorScheme = "dark";
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    takeScreenshot();
+  }
+</script>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/support/light-frame-scrolling.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/support/light-frame-scrolling.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<style>
+  :root {
+    color-scheme: light;
+  }
+
+  .spacer {
+    height: 300vh;
+
+    /* Hack so WebKit will put this iframe in a layer */
+    will-change: transform;
+  }
+</style>
+
+<p>This iframe should have light background.</p>
+<!-- Spacer to make the iframe scroll -->
+<div class="spacer"></div>

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -27,17 +27,20 @@
 #include "Frame.h"
 
 #include "ContainerNodeInlines.h"
+#include "DocumentView.h"
 #include "FrameInlines.h"
 #include "FrameLoader.h"
 #include "FrameLoaderClient.h"
 #include "HTMLFrameOwnerElement.h"
 #include "HTMLIFrameElement.h"
 #include "LocalDOMWindow.h"
+#include "LocalFrameView.h"
 #include "NavigationScheduler.h"
 #include "NodeDocument.h"
 #include "OwnerPermissionsPolicyData.h"
 #include "Page.h"
 #include "RemoteFrame.h"
+#include "RemoteFrameLayoutInfo.h"
 #include "RenderElement.h"
 #include "RenderWidget.h"
 #include "ScrollingCoordinator.h"
@@ -346,7 +349,29 @@ void Frame::updateFrameTreeSyncData(Ref<FrameTreeSyncData>&& data)
 
 void Frame::updateFrameTreeSyncData(const FrameTreeSyncSerializationData& data)
 {
+    auto invalidateChildFrameForDarkAppearanceChange = [&](const auto& oldMap, const auto& newMap) {
+        for (RefPtr child = tree().firstChild(); child; child = child->tree().nextSibling()) {
+            RefPtr localChild = dynamicDowncast<LocalFrame>(child);
+            if (!localChild)
+                continue;
+
+            auto oldFrameInfo = oldMap.getOptional(child->frameID());
+            auto newFrameInfo = newMap.getOptional(child->frameID());
+
+            if (!oldFrameInfo || !newFrameInfo || oldFrameInfo->useDarkAppearance != newFrameInfo->useDarkAppearance) {
+                RefPtr localChildView = localChild->view();
+
+                localChildView->invalidateForBaseBackgroundOrColorSchemeChange();
+                protect(localChildView->layoutContext())->scheduleLayout();
+            }
+        }
+    };
+
+    auto oldChildrenFrameLayoutMap = m_frameTreeSyncData->childrenFrameLayoutInfo;
+
     protect(frameTreeSyncData())->update(data);
+
+    invalidateChildFrameForDarkAppearanceChange(oldChildrenFrameLayoutMap, m_frameTreeSyncData->childrenFrameLayoutInfo);
 }
 
 bool Frame::frameCanCreatePaymentSession() const

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4259,6 +4259,13 @@ Color LocalFrameView::baseBackgroundColor() const
     return m_baseBackgroundColor;
 }
 
+void LocalFrameView::invalidateForBaseBackgroundOrColorSchemeChange()
+{
+    recalculateScrollbarOverlayStyle();
+    setNeedsLayoutAfterViewConfigurationChange();
+    setNeedsCompositingConfigurationUpdate();
+}
+
 void LocalFrameView::setBaseBackgroundColor(const Color& backgroundColor)
 {
     Color newBaseBackgroundColor = backgroundColor.isValid() ? backgroundColor : Color::white;
@@ -4273,9 +4280,7 @@ void LocalFrameView::setBaseBackgroundColor(const Color& backgroundColor)
     if (!isViewForDocumentInFrame())
         return;
 
-    recalculateScrollbarOverlayStyle();
-    setNeedsLayoutAfterViewConfigurationChange();
-    setNeedsCompositingConfigurationUpdate();
+    invalidateForBaseBackgroundOrColorSchemeChange();
 }
 
 #if ENABLE(DARK_MODE_CSS)

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -215,6 +215,7 @@ public:
     // True if the FrameView is not transparent, and the base background color is opaque.
     bool NODELETE hasOpaqueBackground() const;
 
+    WEBCORE_EXPORT void invalidateForBaseBackgroundOrColorSchemeChange();
     WEBCORE_EXPORT Color NODELETE baseBackgroundColor() const;
     WEBCORE_EXPORT void setBaseBackgroundColor(const Color&);
     WEBCORE_EXPORT void updateBackgroundRecursively(const std::optional<Color>& backgroundColor);

--- a/Source/WebCore/rendering/RenderFrameBase.cpp
+++ b/Source/WebCore/rendering/RenderFrameBase.cpp
@@ -46,6 +46,25 @@ RenderFrameBase::RenderFrameBase(Type type, HTMLFrameElementBase& element, Rende
 
 RenderFrameBase::~RenderFrameBase() = default;
 
+void RenderFrameBase::styleDidChange(Style::Difference diff, const RenderStyle* oldStyle)
+{
+    RenderWidget::styleDidChange(diff, oldStyle);
+
+    if (!oldStyle || diff < Style::DifferenceResult::Repaint)
+        return;
+
+    RefPtr childFrameView = dynamicDowncast<LocalFrameView>(widget());
+    if (!childFrameView)
+        return;
+
+    RefPtr document = this->document();
+
+    if (document->useDarkAppearance(oldStyle) != document->useDarkAppearance(protect(&style()))) {
+        childFrameView->invalidateForBaseBackgroundOrColorSchemeChange();
+        protect(childFrameView->layoutContext())->scheduleLayout();
+    }
+}
+
 inline bool shouldExpandFrame(LayoutUnit width, LayoutUnit height, bool hasFixedWidth, bool hasFixedHeight)
 {
     // If the size computed to zero never expand.

--- a/Source/WebCore/rendering/RenderFrameBase.h
+++ b/Source/WebCore/rendering/RenderFrameBase.h
@@ -36,12 +36,12 @@ class RenderView;
 class RenderFrameBase : public RenderWidget {
     WTF_MAKE_TZONE_ALLOCATED(RenderFrameBase);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderFrameBase);
+
 protected:
     RenderFrameBase(Type, HTMLFrameElementBase&, RenderStyle&&);
     virtual ~RenderFrameBase();
 
-private:
-    void widget() const = delete;
+    void styleDidChange(Style::Difference, const RenderStyle* oldStyle) final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderWidget.h
+++ b/Source/WebCore/rendering/RenderWidget.h
@@ -81,7 +81,7 @@ protected:
     RenderWidget(Type, HTMLFrameOwnerElement&, RenderStyle&&);
 
     void willBeDestroyed() override;
-    void styleDidChange(Style::Difference, const RenderStyle* oldStyle) final;
+    void styleDidChange(Style::Difference, const RenderStyle* oldStyle) override;
     void layout() override;
     void paint(PaintInfo&, const LayoutPoint&) override;
     bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction) override;


### PR DESCRIPTION
#### bf18b1f243b2076c19b9fe9fbcca7610de274c21
<pre>
Changing color-scheme doesn&apos;t repaint background of composited iframes
<a href="https://rdar.apple.com/171658244">rdar://171658244</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309097">https://bugs.webkit.org/show_bug.cgi?id=309097</a>

Reviewed by Alan Baradlay.

CSS Color Adjustment Module Level 1 [1] dictates that if the used color scheme of the
child frame&apos;s owner element is different than the used color scheme of the child frame,
the background of the child frame must be opaque and not transparent.

As a consequence, if initially the parent and child frame have the same used color
scheme, then the parent changes its used color scheme, the child frame should repaint
its background to be opaque. This patch implements this behavior through two pathways.

1) Child frame lives in the same process as the parent frame: when the parent frame&apos;s
color scheme changes, RenderFrameBase::styleDidChange will directly invalidate the layout
of the child frame.

2) Child frame lives in a different process (Site Isolation): when the parent frame&apos;s color
scheme changes, it synchronizes its color scheme to other processes using FrameTreeSyncData
(implemented in 308950@main). When other processes update the parent frame&apos;s FrameTreeSyncData,
we add a hook to invalidate the layout of child frames affected by the new color scheme.

[1]: <a href="https://drafts.csswg.org/css-color-adjust/">https://drafts.csswg.org/css-color-adjust/</a>

Tests: imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic-cross-origin.sub.html
       imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic-cross-origin.sub-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic-cross-origin.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/support/light-frame-scrolling.html: Added.
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::updateFrameTreeSyncData):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::invalidateForBaseBackgroundOrColorSchemeChange):
(WebCore::LocalFrameView::setBaseBackgroundColor):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/rendering/RenderFrameBase.cpp:
(WebCore::RenderFrameBase::styleDidChange):
* Source/WebCore/rendering/RenderFrameBase.h:
* Source/WebCore/rendering/RenderWidget.h:

Canonical link: <a href="https://commits.webkit.org/309567@main">https://commits.webkit.org/309567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5b1e0f06baa489d1bf6efbfe7ead3d340417eef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159612 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104321 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01597de0-3ca6-4b3c-ac24-401603d1a21e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116477 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82702 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18598 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135370 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97197 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17693 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15638 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7459 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162086 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5211 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14855 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124481 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23449 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124668 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33865 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23439 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135084 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79846 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19739 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11849 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23049 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87172 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22761 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22913 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22815 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->