### PR TITLE
[JSC] DFG should preserve ToNumber side-effect for Math.pow with one argument

### DIFF
--- a/JSTests/stress/math-pow-one-argument-to-number.js
+++ b/JSTests/stress/math-pow-one-argument-to-number.js
@@ -1,0 +1,38 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+let counter = 0;
+let obj = { valueOf() { counter++; return 1; } };
+
+function test(x) {
+    return Math.pow(x);
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i++)
+    shouldBe(Number.isNaN(test(obj)), true);
+
+shouldBe(counter, testLoopCount);
+
+for (let i = 0; i < testLoopCount; i++)
+    shouldBe(Number.isNaN(test(42)), true);
+
+function testThrow(x) {
+    return Math.pow(x);
+}
+noInline(testThrow);
+
+for (let i = 0; i < testLoopCount; i++)
+    shouldBe(Number.isNaN(testThrow(1.5)), true);
+
+let throwObj = { valueOf() { throw new Error("ok"); } };
+let caught = false;
+try {
+    testThrow(throwObj);
+} catch (e) {
+    caught = true;
+    shouldBe(e.message, "ok");
+}
+shouldBe(caught, true);

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -2630,9 +2630,16 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
         }
 
         case PowIntrinsic: {
-            if (argumentCountIncludingThis < 3) {
-                // Math.pow() and Math.pow(x) return NaN.
+            if (argumentCountIncludingThis == 1) {
+                // Math.pow() returns NaN.
                 insertChecks();
+                setResult(addToGraph(JSConstant, OpInfo(m_constantNaN)));
+                return CallOptimizationResult::Inlined;
+            }
+            if (argumentCountIncludingThis == 2) {
+                // Math.pow(x) returns NaN, but ToNumber(x) may have side effects.
+                insertChecks();
+                addToGraph(Phantom, Edge(get(virtualRegisterForArgumentIncludingThis(1, registerOffset)), NumberUse));
                 setResult(addToGraph(JSConstant, OpInfo(m_constantNaN)));
                 return CallOptimizationResult::Inlined;
             }


### PR DESCRIPTION
#### dfddac02cb487ee92e448f97775662f2e1571c2c
<pre>
[JSC] DFG should preserve ToNumber side-effect for Math.pow with one argument
<a href="https://bugs.webkit.org/show_bug.cgi?id=309541">https://bugs.webkit.org/show_bug.cgi?id=309541</a>

Reviewed by Justin Michaud.

When Math.pow(x) is called with a single argument, DFG ByteCodeParser
unconditionally folds it to a NaN constant and drops the argument
entirely. However, the runtime implementation (mathProtoFuncPow) always
calls argument(0).toNumber(), which has observable side effects:
valueOf/Symbol.toPrimitive invocations, or throwing TypeError for
Symbol/BigInt.

This causes tier-inconsistent behavior: before DFG tier-up, valueOf is
invoked on every call; after tier-up, the side effect silently
disappears.

Fix by splitting the &lt; 3 argument check: for the 1-argument case, emit
a Phantom with NumberUse edge on the argument before returning NaN.
This forces OSR exit when a non-number is passed, falling back to
baseline where ToNumber runs correctly. This mirrors the existing
pattern in handleMinMax for Math.max(x)/Math.min(x).

Test: JSTests/stress/math-pow-one-argument-to-number.js

* JSTests/stress/math-pow-one-argument-to-number.js: Added.
(shouldBe):
(let.obj.valueOf):
(test):
(testThrow):
(let.throwObj.valueOf):
(catch):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):

Canonical link: <a href="https://commits.webkit.org/308954@main">https://commits.webkit.org/308954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ae5653a94c13397eb302a45406db9027cbc2252

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157677 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21580 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114856 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151949 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95614 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/5526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140956 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160159 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9777 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3149 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13159 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122910 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21504 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18033 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123137 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33474 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133431 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10191 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/180417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/21114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84916 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/180417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/20994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->