### PR TITLE
Calling upgrade on a candidate with a different registry erroneously upgrades the element

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/CustomElementRegistry-upgrade-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/CustomElementRegistry-upgrade-expected.txt
@@ -1,6 +1,7 @@
 
 PASS upgrade is a function on both global and scoped CustomElementRegistry
 PASS upgrade is a no-op when called on a shadow root with no association
+PASS upgrade is a no-op when called on an element associated with a different registry
 PASS upgrade should upgrade a candidate element when called on a shadow root with an association
 PASS upgrade should not upgrade a candidate element not associated with a registry
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/CustomElementRegistry-upgrade.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/CustomElementRegistry-upgrade.html
@@ -48,6 +48,16 @@ test(() => {
 }, 'upgrade is a no-op when called on a shadow root with no association');
 
 test(() => {
+    const registry1 = new CustomElementRegistry;
+    const registry2 = new CustomElementRegistry;
+    const element = document.createElement('a-b', {customElementRegistry: registry1});
+    registry1.define('a-b', class ABElement1 extends HTMLElement { });
+    assert_false(element.matches(':defined'));
+    registry2.upgrade(element);
+    assert_false(element.matches(':defined'));
+}, 'upgrade is a no-op when called on an element associated with a different registry');
+
+test(() => {
     const registry = new CustomElementRegistry;
     registry.define('a-b', class ABElement extends HTMLElement {
         elementInternals;

--- a/Source/WebCore/dom/CustomElementRegistry.cpp
+++ b/Source/WebCore/dom/CustomElementRegistry.cpp
@@ -184,7 +184,7 @@ void CustomElementRegistry::upgrade(Node& root)
         return;
 
     RefPtr element = dynamicDowncast<Element>(*containerNode);
-    if (element && element->isCustomElementUpgradeCandidate())
+    if (element && element->isCustomElementUpgradeCandidate() && CustomElementRegistry::registryForElement(*element) == this)
         CustomElementReactionQueue::tryToUpgradeElement(*element);
 
     upgradeElementsInShadowIncludingDescendants(*this, *containerNode);


### PR DESCRIPTION
#### ca90cbd6ebfb976906a3ff19248e2ab5a7fb2065
<pre>
Calling upgrade on a candidate with a different registry erroneously upgrades the element
<a href="https://bugs.webkit.org/show_bug.cgi?id=307878">https://bugs.webkit.org/show_bug.cgi?id=307878</a>
<a href="https://rdar.apple.com/170846743">rdar://170846743</a>

Reviewed by Chris Dumez.

The bug was caused by the missing check for registry identity check. Fixed the bug by adding one.

Test: imported/w3c/web-platform-tests/custom-elements/registries/CustomElementRegistry-upgrade.html

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/CustomElementRegistry-upgrade-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/registries/CustomElementRegistry-upgrade.html:
* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::CustomElementRegistry::upgrade):

Canonical link: <a href="https://commits.webkit.org/308962@main">https://commits.webkit.org/308962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5c799483a5a0fe835c294e1f6af7ef88c6afe54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157678 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/729c62e2-5baf-45f5-ac59-7b912ea23fae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114855 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c1556a7-9091-467d-91cb-03e4cab596be) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133717 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95613 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f528b68b-1f04-4fa4-960e-a807d8039c5b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16149 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14016 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5527 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125753 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11640 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160160 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3150 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122911 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21505 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18035 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123138 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133434 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22947 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10194 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21115 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84917 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20847 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20995 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->