### PR TITLE
Pages using the Navigation API sometimes have offset hit test locations

### DIFF
--- a/LayoutTests/http/tests/navigation-api/scroll-offset-after-navigation-back-expected.html
+++ b/LayoutTests/http/tests/navigation-api/scroll-offset-after-navigation-back-expected.html
@@ -1,0 +1,23 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 4000px;
+        }
+        
+        .box {
+            margin-top: 200px;
+            width: 100px;
+            height: 100px;
+            background-color: green;
+            cursor: pointer;
+        }
+    </style>
+</head>
+<body>
+<div id="frag"></div>
+<div class="box"></div>
+</body>
+</html>

--- a/LayoutTests/http/tests/navigation-api/scroll-offset-after-navigation-back.html
+++ b/LayoutTests/http/tests/navigation-api/scroll-offset-after-navigation-back.html
@@ -1,0 +1,59 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            height: 4000px;
+        }
+        
+        .box {
+            margin-top: 200px;
+            width: 100px;
+            height: 100px;
+            background-color: green;
+            cursor: pointer;
+        }
+    </style>
+    <script src='/js-test-resources/ui-helper.js'></script>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        async function runTest()
+        {
+            let start_url = location.href;
+
+            window.scrollTo(0, 200);
+
+            await navigation.navigate("#frag").finished;
+
+            let intercept_resolve;
+            let navigate_event;
+            navigation.onnavigate = e => {
+                navigate_event = e;
+                e.intercept({ handler: () => new Promise(r => intercept_resolve = r) });
+            };
+
+            let promises = navigation.navigate(start_url);
+            await promises.committed;
+
+            intercept_resolve();
+
+            await promises.finished;
+
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }
+        
+        window.addEventListener('load', () => {
+            // Wait for the load event so that the navigation doesn't get cvonerted into a replace navigation.
+            setTimeout(runTest, 0);
+        }, false);
+    </script>
+</head>
+<body>
+<div id="frag"></div>
+<div class="box"></div>
+</body>
+</html>

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -137,7 +137,7 @@ void NavigateEvent::processScrollBehavior(Document& document)
         if (m_navigationType == NavigationNavigationType::Reload)
             document.frame()->loader().history().restoreScrollPositionAndViewState();
         else
-            document.frame()->view()->scrollTo({ 0, 0 });
+            document.frame()->view()->setScrollPosition({ 0, 0 });
 
         return;
     }


### PR DESCRIPTION
#### 63798105bff3ae2fcfff6d6a878f85ba0b487d77
<pre>
Pages using the Navigation API sometimes have offset hit test locations
<a href="https://bugs.webkit.org/show_bug.cgi?id=309542">https://bugs.webkit.org/show_bug.cgi?id=309542</a>
<a href="https://rdar.apple.com/171752650">rdar://171752650</a>

Reviewed by Abrar Rahman Protyasha.

Navigation API was calling `LocalFrameView::scrollTo()`, which bypasses the normal async
scrolling `requestScrollPositionUpdate` machinery; there&apos;s a comment in ScrollView.h about
not calling this function. This could result in UI and web processes having different
scroll offsets.

Fix by having NavigateEvent call `setScrollPosition` instead.

Test: http/tests/navigation-api/scroll-offset-after-navigation-back.html

* LayoutTests/http/tests/navigation-api/scroll-offset-after-navigation-back-expected.html: Added.
* LayoutTests/http/tests/navigation-api/scroll-offset-after-navigation-back.html: Added.
* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::processScrollBehavior):

Canonical link: <a href="https://commits.webkit.org/308976@main">https://commits.webkit.org/308976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf7046a84e745d94d84d7c2a22d35082f262a5d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15274 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157680 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102422 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac10d221-0b6f-4803-8254-995f4e2346ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150865 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114857 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81782 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f9e71a0-281a-48e6-bf84-55626c32a822) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17046 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133716 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95615 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/57f84cfb-7c5b-4517-8211-fe142b113ec3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16150 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14020 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5529 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160162 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3152 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13161 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122912 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21507 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18039 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123139 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33490 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21515 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133433 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77703 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18417 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10193 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21117 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84919 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20849 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20997 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20905 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->