### PR TITLE
Remove SVGTransformDistance::distance()

### DIFF
--- a/Source/WebCore/svg/SVGTransformDistance.cpp
+++ b/Source/WebCore/svg/SVGTransformDistance.cpp
@@ -25,8 +25,6 @@
 #include "FloatSize.h"
 #include "SVGTransformValue.h"
 
-#include <math.h>
-
 namespace WebCore {
     
 SVGTransformDistance::SVGTransformDistance()
@@ -199,30 +197,6 @@ SVGTransformValue SVGTransformDistance::addToSVGTransform(const SVGTransformValu
     
     ASSERT_NOT_REACHED();
     return { };
-}
-
-float SVGTransformDistance::distance() const
-{
-    switch (m_type) {
-    case SVGTransformValue::SVG_TRANSFORM_MATRIX:
-        ASSERT_NOT_REACHED();
-#if !ASSERT_ENABLED
-        [[fallthrough]];
-#endif
-    case SVGTransformValue::SVG_TRANSFORM_UNKNOWN:
-        return 0;
-    case SVGTransformValue::SVG_TRANSFORM_ROTATE:
-        return std::hypot(m_angle, m_cx, m_cy);
-    case SVGTransformValue::SVG_TRANSFORM_SCALE:
-        return static_cast<float>(std::hypot(m_transform.a(), m_transform.d()));
-    case SVGTransformValue::SVG_TRANSFORM_TRANSLATE:
-        return static_cast<float>(std::hypot(m_transform.e(), m_transform.f()));
-    case SVGTransformValue::SVG_TRANSFORM_SKEWX:
-    case SVGTransformValue::SVG_TRANSFORM_SKEWY:
-        return m_angle;
-    }
-    ASSERT_NOT_REACHED();
-    return 0;
 }
 
 }

--- a/Source/WebCore/svg/SVGTransformDistance.h
+++ b/Source/WebCore/svg/SVGTransformDistance.h
@@ -34,8 +34,7 @@ public:
     SVGTransformValue addToSVGTransform(const SVGTransformValue&) const;
 
     static SVGTransformValue addSVGTransforms(const SVGTransformValue&, const SVGTransformValue&, unsigned repeatCount = 1);
-    
-    float distance() const;
+
 private:
     SVGTransformDistance(SVGTransformValue::SVGTransformType, float angle, float cx, float cy, const AffineTransform&);
         


### PR DESCRIPTION
#### 57f640de7c9372b43177e34176b3f0b3ff736704
<pre>
Remove SVGTransformDistance::distance()
<a href="https://bugs.webkit.org/show_bug.cgi?id=309531">https://bugs.webkit.org/show_bug.cgi?id=309531</a>
<a href="https://rdar.apple.com/172143359">rdar://172143359</a>

Reviewed by Vitor Roriz.

This looks like DEADCODE. This function is not called from anywhere.
<a href="https://searchfox.org/wubkat/search?q=symbol">https://searchfox.org/wubkat/search?q=symbol</a>:_ZNK7WebCore20SVGTransformDistance8distanceEv&amp;redirect=false

* Source/WebCore/svg/SVGTransformDistance.cpp:
(WebCore::SVGTransformDistance::distance const): Deleted.
* Source/WebCore/svg/SVGTransformDistance.h:

Canonical link: <a href="https://commits.webkit.org/308961@main">https://commits.webkit.org/308961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b585f895d13130ec470e8aab3bc3f2c8c009e3e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21710 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157685 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3fb84e52-752b-4383-8944-715e48352ed0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150870 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114862 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7097cb56-57e1-4dad-8b88-5a9de8ba6d1b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133722 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95620 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e080a2b-ceb7-49cf-be3f-b8a61d9b61af) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14022 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5534 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125758 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11646 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160167 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3157 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13168 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122917 "Found 1 new test failure: imported/w3c/web-platform-tests/uievents/mouse/mouse_boundary_events_after_reappending_last_over_target.tentative.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123144 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133440 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22946 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10199 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21122 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84924 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20854 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21002 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->