### PR TITLE
[JSC] Tighten JSBigInt hot path

### DIFF
--- a/Source/JavaScriptCore/runtime/JSBigInt.cpp
+++ b/Source/JavaScriptCore/runtime/JSBigInt.cpp
@@ -800,12 +800,16 @@ std::span<JSBigInt::Digit> JSBigInt::multiplySingle(std::span<const Digit> multi
         result[i] = zi; \
     } while (0)
 
-std::span<JSBigInt::Digit> JSBigInt::multiplyTextbook(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result)
+std::span<JSBigInt::Digit> JSBigInt::multiplyTextbook(std::span<const Digit> xSpan, std::span<const Digit> ySpan, std::span<Digit> resultSpan)
 {
-    ASSERT(x.size() >= y.size());
-    ASSERT(result.size() >= x.size() + y.size());
-    ASSERT(x.size());
-    ASSERT(y.size());
+    RELEASE_ASSERT(xSpan.size() >= ySpan.size());
+    RELEASE_ASSERT(resultSpan.size() >= xSpan.size() + ySpan.size());
+    RELEASE_ASSERT(xSpan.size());
+    RELEASE_ASSERT(ySpan.size());
+
+    const auto* x = xSpan.data();
+    const auto* y = ySpan.data();
+    auto* result = resultSpan.data();
 
     Digit next = 0, nextCarry = 0, carry = 0;
     // Unrolled first iteration: it's trivial.
@@ -816,15 +820,15 @@ std::span<JSBigInt::Digit> JSBigInt::multiplyTextbook(std::span<const Digit> x, 
     }
     size_t i = 1;
     // Unrolled second iteration: a little less setup.
-    if (i < y.size()) {
+    if (i < ySpan.size()) {
         Digit zi = next;
         next = 0;
         MULTIPLY_BODY(0, 1);
         i++;
     }
 
-    // Main part: since x.size() >= y.size() > i, no bounds checks are needed.
-    for (; i < y.size(); i++) {
+    // Main part: since xSpan.size() >= ySpan.size() > i, no bounds checks are needed.
+    for (; i < ySpan.size(); i++) {
         Digit temp = 0;
         Digit zi = digitAdd(next, carry, temp);
         next = nextCarry + temp;
@@ -834,10 +838,10 @@ std::span<JSBigInt::Digit> JSBigInt::multiplyTextbook(std::span<const Digit> x, 
     }
 
     // Last part: i exceeds y now, we have to be careful about bounds.
-    size_t loopEnd = x.size() + y.size() - 2;
+    size_t loopEnd = xSpan.size() + ySpan.size() - 2;
     for (; i <= loopEnd; i++) {
-        size_t maxXIndex = std::min<size_t>(i, x.size() - 1);
-        size_t maxYIndex = y.size() - 1;
+        size_t maxXIndex = std::min<size_t>(i, xSpan.size() - 1);
+        size_t maxYIndex = ySpan.size() - 1;
         size_t minXIndex = i - maxYIndex;
         Digit temp = 0;
         Digit zi = digitAdd(next, carry, temp);
@@ -851,16 +855,20 @@ std::span<JSBigInt::Digit> JSBigInt::multiplyTextbook(std::span<const Digit> x, 
     Digit temp = 0;
     result[i++] = digitAdd(next, carry, temp);
     ASSERT(!temp);
-    return result.first(i);
+    return resultSpan.first(i);
 }
 
 // For the needs of cachedMod, computes only the low result.size() digits of X * Y.
-void JSBigInt::multiplySpecialLow(std::span<const Digit> x, std::span<const Digit> y, std::span<Digit> result)
+void JSBigInt::multiplySpecialLow(std::span<const Digit> xSpan, std::span<const Digit> ySpan, std::span<Digit> resultSpan)
 {
-    ASSERT(y.size() >= 1);
-    ASSERT(x.size() >= 2);
-    ASSERT(x.size() >= y.size() - 1);
-    ASSERT(result.size());
+    RELEASE_ASSERT(ySpan.size() >= 1);
+    RELEASE_ASSERT(xSpan.size() >= 2);
+    RELEASE_ASSERT(xSpan.size() >= ySpan.size() - 1);
+    RELEASE_ASSERT(resultSpan.size());
+
+    const auto* x = xSpan.data();
+    const auto* y = ySpan.data();
+    auto* result = resultSpan.data();
 
     Digit next, nextCarry = 0, carry = 0;
     // Unrolled first iteration: it's trivial.
@@ -871,15 +879,15 @@ void JSBigInt::multiplySpecialLow(std::span<const Digit> x, std::span<const Digi
     }
     size_t i = 1;
     // Unrolled second iteration: a little less setup.
-    if (i < y.size()) {
+    if (i < ySpan.size()) {
         Digit zi = next;
         next = 0;
         MULTIPLY_BODY(0, 1);
         i++;
     }
     // Main part: no bounds checks in the loop.
-    size_t loopEnd = result.size() - 1;
-    size_t mainEnd = std::min({ x.size(), y.size(), loopEnd });
+    size_t loopEnd = resultSpan.size() - 1;
+    size_t mainEnd = std::min({ xSpan.size(), ySpan.size(), loopEnd });
     for (; i < mainEnd; i++) {
         Digit temp = 0;
         Digit zi = digitAdd(next, carry, temp);
@@ -890,8 +898,8 @@ void JSBigInt::multiplySpecialLow(std::span<const Digit> x, std::span<const Digi
     }
     // Last part: we have to be careful about bounds.
     for (; i <= loopEnd; i++) {
-        size_t maxXIndex = std::min<size_t>(i, x.size() - 1);
-        size_t maxYIndex = std::min<size_t>(i, y.size() - 1);
+        size_t maxXIndex = std::min<size_t>(i, xSpan.size() - 1);
+        size_t maxYIndex = std::min<size_t>(i, ySpan.size() - 1);
         size_t minXIndex = i - maxYIndex;
         Digit temp = 0;
         Digit zi = digitAdd(next, carry, temp);
@@ -1638,7 +1646,7 @@ std::span<const JSBigInt::Digit> JSBigInt::cachedMod(VM& vm, std::span<Digit> r,
     multiplySpecialLow(b, qSpan, productLow);
 
     // Step 4: R = A[0..n-1] - product_low[0..n-1].
-    Digit borrow = subtractAndReturnBorrow(r, a.first(n), productLow.first(n));
+    Digit borrow = subtractAndReturnBorrow(r, a, productLow.first(n));
 
     // Track the extra digit: r_high = A[n] - product_low[n] - borrow.
     Digit an = a.size() > n ? a[n] : 0;
@@ -1657,7 +1665,7 @@ std::span<const JSBigInt::Digit> JSBigInt::cachedMod(VM& vm, std::span<Digit> r,
             rHigh -= inplaceSub(r, b);
     }
 
-    return normalize(r);
+    return r.first(n);
 }
 
 template <typename BigIntImpl1, typename BigIntImpl2>
@@ -1706,11 +1714,12 @@ JSBigInt::ImplResult JSBigInt::remainderImpl(JSGlobalObject* globalObject, BigIn
         return remainder;
     }
 
+    Vector<Digit, 16> r(ySpan.size());
+
     // Cached multiplicative inverse optimization for repeated modulo with the same divisor.
     if constexpr (std::is_same_v<BigIntImpl2, HeapBigIntImpl>) {
         if (vm.m_cachedBigIntDivisor.get() == y.toHeapBigInt(globalObject)) {
             if (xSpan.size() <= 2 * ySpan.size()) {
-                Vector<Digit, 16> r(ySpan.size());
                 auto rSpan = cachedMod(vm, r.mutableSpan(), xSpan, ySpan);
                 RELEASE_AND_RETURN(scope, tryCreateFromImpl(globalObject, vm, x.sign(), rSpan));
             }
@@ -1725,7 +1734,6 @@ JSBigInt::ImplResult JSBigInt::remainderImpl(JSGlobalObject* globalObject, BigIn
         }
     }
 
-    Vector<Digit, 16> r(ySpan.size());
     std::span<const Digit> rSpan;
     if (xSpan.size() == ySpan.size())
         rSpan = remainderSameSize(r.mutableSpan(), xSpan, ySpan);


### PR DESCRIPTION
#### 22fb65b6b34b5a6016c6ea280ea11d6ea8045b33
<pre>
[JSC] Tighten JSBigInt hot path
<a href="https://bugs.webkit.org/show_bug.cgi?id=309543">https://bugs.webkit.org/show_bug.cgi?id=309543</a>
<a href="https://rdar.apple.com/172146208">rdar://172146208</a>

Reviewed by Yijia Huang.

Compiler failed to remove safe index access of std::span in the
critically hot path. We put RELEASE_ASSERT to ensure the invariant
and use normal pointer for access instead.

* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::JSBigInt::multiplyTextbook):
(JSC::JSBigInt::multiplySpecialLow):
(JSC::JSBigInt::cachedMod):
(JSC::JSBigInt::remainderImpl):

Canonical link: <a href="https://commits.webkit.org/308993@main">https://commits.webkit.org/308993@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f045e0d829834df23046d5b2cdd2bc3c6fbf1eeb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102430 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b656efa3-a6b4-4608-b90b-c4f4f9a06895) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114865 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81783 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88b9a9ad-5ceb-4bc3-81e3-161bb1a58787) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17051 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133729 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95623 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16155 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14023 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5537 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140967 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125759 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160170 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9788 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3160 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13176 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122920 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21515 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123147 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21523 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133448 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77711 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22959 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18420 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10206 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180428 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21125 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84927 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20857 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21005 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20913 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->