### PR TITLE
[DRAFT] [CSS] Add text-emphasis-position: auto support

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8450,8 +8450,6 @@ webkit.org/b/304851 imported/w3c/web-platform-tests/workers/worker-performance.w
 
 webkit.org/b/304995 [ Release ] imported/w3c/web-platform-tests/largest-contentful-paint/video-poster.html [ Pass Failure ]
 
-webkit.org/b/305404 imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-auto-001.html [ Pass ImageOnlyFailure ]
-
 webkit.org/b/305508 http/tests/resourceLoadStatistics/log-cross-site-load-with-link-decoration.html [ Pass Failure ]
 
 webkit.org/b/309370 fast/css/vertical-text-overflow-ellipsis-text-align-center.html [ Failure Pass ]

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -11874,7 +11874,7 @@
                 "computed-style-storage-path": ["m_inheritedRareData"],
                 "computed-style-storage-kind": "raw",
                 "computed-style-type": "Style::TextEmphasisPosition",
-                "parser-grammar": "[ [ over | under ] && [ right | left ]? ]@(no-single-item-opt)"
+                "parser-grammar": "auto | [ [ over | under ] && [ right | left ]? ]@(no-single-item-opt)"
             },
             "specification": {
                 "category": "css-text-decor",

--- a/Source/WebCore/style/values/text-decoration/StyleTextEmphasisPosition.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextEmphasisPosition.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "StyleTextEmphasisPosition.h"
 
+#include "Element.h"
 #include "StyleBuilderChecking.h"
 
 namespace WebCore {
@@ -34,6 +35,18 @@ auto CSSValueConversion<TextEmphasisPosition>::operator()(BuilderState& state, c
 {
     if (RefPtr primitiveValue = dynamicDowncast<CSSPrimitiveValue>(value)) {
         switch (primitiveValue->valueID()) {
+        case CSSValueAuto: {
+            // Per CSS Text Decoration Level 4, 'auto' resolves the emphasis mark position
+            // based on the language of the element. Chinese and Japanese text uses 'under right',
+            // while all other languages use 'over right'.
+            // https://drafts.csswg.org/css-text-decor-4/#propdef-text-emphasis-position
+            auto* element = state.element();
+            bool isUnderLanguage = element
+                && (startsWithLettersIgnoringASCIICase(element->effectiveLang(), "zh"_s)
+                    || startsWithLettersIgnoringASCIICase(element->effectiveLang(), "ja"_s));
+            return { isUnderLanguage ? TextEmphasisPositionValue::Under : TextEmphasisPositionValue::Over, TextEmphasisPositionValue::Right };
+        }
+
         case CSSValueOver:
             return { TextEmphasisPositionValue::Over, TextEmphasisPositionValue::Right };
         case CSSValueUnder:


### PR DESCRIPTION
#### 244b1f7d43e466aa2a26b0e9ba503b4aa0b05a60
<pre>
[CSS] Add text-emphasis-position: auto support
<a href="https://bugs.webkit.org/show_bug.cgi?id=305404">https://bugs.webkit.org/show_bug.cgi?id=305404</a>
<a href="https://rdar.apple.com/168079127">rdar://168079127</a>

Reviewed by NOBODY (OOPS!).

CSS Text Decoration Level 4 specifies that text-emphasis-position should
accept the &apos;auto&apos; keyword, which resolves the emphasis position based on
the element&apos;s content language. Chinese (zh) and Japanese (ja) text
should place emphasis marks under the text (&apos;under right&apos;), while all
other languages place them over (&apos;over right&apos;).

The parser grammar in CSSProperties.json did not include &apos;auto&apos;, so the
CSS parser rejected the value before it ever reached the style conversion
code. This patch adds &apos;auto&apos; to the grammar and handles it in the
CSSValue-to-Style conversion by resolving to the appropriate concrete
position at computed-value time based on the element&apos;s effective language.

* Source/WebCore/css/CSSProperties.json:
  - Add &apos;auto&apos; keyword to text-emphasis-position parser-grammar
* Source/WebCore/style/values/text-decoration/StyleTextEmphasisPosition.cpp:
  (WebCore::Style::CSSValueConversion&lt;TextEmphasisPosition&gt;::operator()):
  - Add CSSValueAuto case that resolves to &apos;under right&apos; for zh/ja languages,
    &apos;over right&apos; for all others, per CSS Text Decoration Level 4 spec
  - Include Element.h for effectiveLang() access
* LayoutTests/platform/ios/TestExpectations:
  - Remove flaky ImageOnlyFailure expectation for text-emphasis-position-auto-001.html
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/244b1f7d43e466aa2a26b0e9ba503b4aa0b05a60

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157691 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102433 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26498a83-4347-41b2-a73e-cf420da33a28) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21594 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114867 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-emphasis-position-computed.html imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-emphasis-position-valid.html imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-auto-001.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81786 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e66bc41-b4a9-48e2-be98-1a430a2a42d1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17055 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95625 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83bf8178-0d92-451a-8be0-69ac572b4eba) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16158 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-emphasis-position-computed.html imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-emphasis-position-valid.html imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-auto-001.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14026 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5540 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125762 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160173 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3163 "Found 2 new failures in style/values/text-decoration/StyleTextEmphasisPosition.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13171 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-emphasis-position-computed.html imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-emphasis-position-valid.html imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-auto-001.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122922 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-emphasis-position-computed.html imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-emphasis-position-valid.html imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-auto-001.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21518 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18048 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-emphasis-position-computed.html imported/w3c/web-platform-tests/css/css-text-decor/parsing/text-emphasis-position-valid.html imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-auto-001.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123149 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133443 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77714 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18421 "Passed tests") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21128 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84930 "Found 2 new failures in style/values/text-decoration/StyleTextEmphasisPosition.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20860 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21008 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20916 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->