### PR TITLE
REGRESSION (260067@main): Tabbing position lost when button is disabled

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-after-disabled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-after-disabled-expected.txt
@@ -1,0 +1,4 @@
+First Target Third
+
+PASS Tab after disabling a focused button moves focus to the next focusable element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-after-disabled.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-after-disabled.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test focus sequential navigation after disabling focused element</title>
+<link rel="author" title="Aditya Keerthi" href="https://github.com/pxlcoder">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#focus-fixup-rule">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interaction.html#sequential-focus-navigation">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+</head>
+<body>
+<button id="first" tabindex="1">First</button>
+<button id="target" tabindex="2">Target</button>
+<button id="third" tabindex="3">Third</button>
+<script>
+
+promise_test(async t => {
+    const target = document.getElementById("target");
+    const third = document.getElementById("third");
+
+    target.disabled = false;
+    target.focus();
+    assert_equals(document.activeElement, target, "Target button must be focused");
+
+    target.disabled = true;
+    await new Promise(requestAnimationFrame);
+    await new Promise(requestAnimationFrame);
+    assert_not_equals(document.activeElement, target, "Disabled button must not be focused");
+
+    await test_driver.send_keys(document.body, "\ue004");
+    assert_equals(document.activeElement, third, "Tab should move focus to the next element after the disabled button");
+}, "Tab after disabling a focused button moves focus to the next focusable element");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7804,6 +7804,7 @@ media/modern-media-controls/scrubber-support/scrubber-support-seek-back.html [ S
 # Following test fails due to lack of `tabbing` to move focus
 imported/w3c/web-platform-tests/html/interaction/focus/focus-01.html [ Skip ]
 imported/w3c/web-platform-tests/html/interaction/focus/focus-02.html [ Skip ]
+imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-after-disabled.html [ Skip ]
 imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-negative.html [ Skip ]
 imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-order.html [ Skip ]
 imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-and-the-tabindex-attribute/focus-tabindex-positive.html [ Skip ]

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2310,8 +2310,10 @@ void Page::updateRendering()
 
     runProcessingStep(RenderingUpdateStep::FocusFixup, [&] (Document& document) {
         if (RefPtr focusedElement = document.focusedElement()) {
-            if (!focusedElement->isFocusable())
+            if (!focusedElement->isFocusable()) {
                 document.setFocusedElement(nullptr);
+                document.setFocusNavigationStartingNode(focusedElement.get());
+            }
         }
     });
 


### PR DESCRIPTION
#### 487ec443bd23024a0677533a9991380a55c3f64b
<pre>
REGRESSION (260067@main): Tabbing position lost when button is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=309544">https://bugs.webkit.org/show_bug.cgi?id=309544</a>
<a href="https://rdar.apple.com/120676409">rdar://120676409</a>

Reviewed by Ryosuke Niwa and Abrar Rahman Protyasha.

260067@main implemented the focus fixup rule to clear focus from an element
that is no longer focusable (e.g. a button that became disabled). This change
also had the effect of resetting the sequential focus navigation starting point.
Consequently, the next Tab key press started focus navigation from the
beginning of the document instead of advancing from where the disabled element
was.

Fix by preserving the sequential focus navigation starting point by resetting
it to the now-unfocusable element after clearing focus, the same way the
element-removal code path already does.

* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-after-disabled-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigation-after-disabled.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):

Canonical link: <a href="https://commits.webkit.org/308991@main">https://commits.webkit.org/308991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9dea3d8aa366a2784534aee19b155c4c932cbab3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21743 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15313 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157718 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102460 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85501f18-83b0-45b2-be12-b3d85c3fa49e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150903 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114888 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/31c6bc71-162d-4b90-bb5a-1944d0348008) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151990 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17080 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133747 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95646 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d1e2025-f3df-4ec2-a09d-43984ac63627) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16180 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14041 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5568 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125784 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160200 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3190 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13194 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122943 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21545 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123170 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21553 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133465 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77741 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22957 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18429 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10224 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21155 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84957 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20887 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21035 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20943 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->