### PR TITLE
[JSC] DFG StringReplace strength reduction should advance past surrogate pairs for /u and /v regexps

### DIFF
--- a/JSTests/stress/dfg-string-replace-empty-match-unicode-surrogate.js
+++ b/JSTests/stress/dfg-string-replace-empty-match-unicode-surrogate.js
@@ -1,0 +1,55 @@
+// DFG StrengthReductionPhase folds StringReplace when the string, regexp, and replacement
+// are all constants. For empty matches with /gu or /gv, it must advance past a full surrogate
+// pair, not just by 1 UTF-16 code unit. Otherwise the DFG-folded result differs from the
+// runtime result.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: actual=" + JSON.stringify(actual) + " expected=" + JSON.stringify(expected));
+}
+
+// U+1D49C (MATHEMATICAL SCRIPT CAPITAL A) = surrogate pair \uD835\uDC9C
+// Expected: insertions at positions 0 and 2 (before/after the code point), not at 0,1,2
+// Non-unicode: "X\uD835X\uDC9CX" (3 insertions) — spec says unicode flag treats surrogate pair as 1 code point
+const expected_gu = "X\uD835\uDC9CX";
+
+function testReplaceGU() {
+    return "\uD835\uDC9C".replace(/(?:)/gu, "X");
+}
+noInline(testReplaceGU);
+
+function testReplaceGV() {
+    return "\uD835\uDC9C".replace(/(?:)/gv, "X");
+}
+noInline(testReplaceGV);
+
+// Also test with a replacement string (non-empty replace path)
+function testReplaceGUNonEmpty() {
+    return "\uD835\uDC9C".replace(/(?:)/gu, "_");
+}
+noInline(testReplaceGUNonEmpty);
+
+// Multiple surrogate pairs + BMP chars mixed: "a" + U+1D49C + "b" + U+1D49D
+// positions: 0(a) 1(pair) 3(b) 4(pair) 6(end) => 5 insertion points
+const expectedMixed = "_a_\uD835\uDC9C_b_\uD835\uDC9D_";
+function testMixed() {
+    return "a\uD835\uDC9Cb\uD835\uDC9D".replace(/(?:)/gu, "_");
+}
+noInline(testMixed);
+
+// Lone surrogate (unpaired) — should advance by 1 since not a valid pair
+// "\uD835a" — lead without trail => positions 0,1,2 => 3 insertions
+const expectedLone = "_\uD835_a_";
+function testLoneSurrogate() {
+    return "\uD835a".replace(/(?:)/gu, "_");
+}
+noInline(testLoneSurrogate);
+
+// Compute expected via interpreter (first iteration, before DFG)
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBe(testReplaceGU(), expected_gu);
+    shouldBe(testReplaceGV(), expected_gu);
+    shouldBe(testReplaceGUNonEmpty(), "_\uD835\uDC9C_");
+    shouldBe(testMixed(), expectedMixed);
+    shouldBe(testLoneSurrogate(), expectedLone);
+}

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1248,6 +1248,11 @@ private:
                     startPosition++;
                     if (startPosition > string.length())
                         break;
+                    if (regExp->eitherUnicode() && U16_IS_LEAD(string[startPosition - 1]) && U16_IS_TRAIL(string[startPosition])) {
+                        startPosition++;
+                        if (startPosition > string.length())
+                            break;
+                    }
                 }
             } while (regExp->global());
             if (!ok)


### PR DESCRIPTION
#### ff3314abf6283ebff217f97068c1c9e88ffc8ebc
<pre>
[JSC] DFG StringReplace strength reduction should advance past surrogate pairs for /u and /v regexps
<a href="https://bugs.webkit.org/show_bug.cgi?id=309548">https://bugs.webkit.org/show_bug.cgi?id=309548</a>

Reviewed by NOBODY (OOPS!).

When DFG strength reduction folds StringReplace with constant string,
regexp, and replacement, it replays matches at compile time. For empty
matches it advances by +1 code unit unconditionally, which splits
surrogate pairs when the regexp has the &apos;u&apos; or &apos;v&apos; flag:

    &quot;\uD835\uDC9C&quot;.replace(/(?:)/gu, &quot;X&quot;)
    Runtime: &quot;X\uD835\uDC9CX&quot; (2 insertions, correct per AdvanceStringIndex[1])
    DFG:     &quot;X\uD835X\uDC9CX&quot; (3 insertions, surrogate pair split)

The runtime fast paths in StringPrototypeInlines.h already guard this
with eitherUnicode() + U16_IS_LEAD/TRAIL since <a href="https://commits.webkit.org/308626@main">308626@main</a>. This patch
applies the same logic to the strength-reduction loop so the folded
constant matches runtime behavior.

[1]: <a href="https://tc39.es/ecma262/#sec-advancestringindex">https://tc39.es/ecma262/#sec-advancestringindex</a>

Tests: JSTests/perf-tests-local/fw-baseline/JavaScriptCore.framework/Versions/A/PrivateHeaders/InspectorBackendCommands.js
       JSTests/perf-tests-local/fw-fix1/JavaScriptCore.framework/Versions/A/PrivateHeaders/InspectorBackendCommands.js
       JSTests/perf-tests-local/fw-fixA/JavaScriptCore.framework/Versions/A/PrivateHeaders/InspectorBackendCommands.js
       JSTests/perf-tests-local/gc-stale-rearm-continuous.js
       JSTests/perf-tests-local/gc-stale-rearm-repro.js
       JSTests/stress/dfg-string-replace-empty-match-unicode-surrogate.js

* JSTests/stress/dfg-string-replace-empty-match-unicode-surrogate.js: Added.
(shouldBe):
(testReplaceGU):
(testReplaceGV):
(testReplaceGUNonEmpty):
(testMixed):
(testLoneSurrogate):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff3314abf6283ebff217f97068c1c9e88ffc8ebc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149014 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157702 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102444 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114875 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81790 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151974 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133737 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95633 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16169 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14035 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5551 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140981 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160184 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9802 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3174 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122930 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123157 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21537 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133455 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77725 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18423 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10214 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180442 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21139 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84941 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46176 "Found 1 new JSC stress test failure: Too many failures: 5621 jsc tests failed (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20871 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21019 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20927 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->