### PR TITLE
[JSC] Add RegExp#lastIndex IC

### DIFF
--- a/JSTests/microbenchmarks/regexp-last-index-ic.js
+++ b/JSTests/microbenchmarks/regexp-last-index-ic.js
@@ -1,0 +1,15 @@
+function load(reg) {
+    return reg.lastIndex;
+}
+noInline(load);
+
+function store(reg, value) {
+    reg.lastIndex = value;
+}
+noInline(store);
+
+var reg = /test/i
+for (var i = 0; i < 2e6; ++i) {
+    load(reg);
+    store(reg, i);
+}

--- a/JSTests/stress/regexp-last-index.js
+++ b/JSTests/stress/regexp-last-index.js
@@ -1,0 +1,32 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(regexp) {
+    regexp.lastIndex = 42;
+    shouldBe(regexp.lastIndex, 42);
+    regexp.lastIndex = "hey";
+    shouldBe(regexp.lastIndex, "hey");
+}
+noInline(test);
+
+var regexp = /test/;
+for (var i = 0; i < 1e4; ++i) {
+    test(regexp);
+    test({ lastIndex: 42 });
+}
+
+function test2(regexp) {
+    regexp.lastIndex = 42;
+    shouldBe(regexp.lastIndex, "hey");
+    regexp.lastIndex = "ok";
+    shouldBe(regexp.lastIndex, "hey");
+}
+noInline(test2);
+
+var regexp2 = /test2/;
+regexp2.lastIndex = "hey";
+Object.freeze(regexp2);
+for (var i = 0; i < testLoopCount; ++i)
+    test2(regexp2);

--- a/JSTests/stress/regexp-lastindex-inline-cache.js
+++ b/JSTests/stress/regexp-lastindex-inline-cache.js
@@ -1,0 +1,77 @@
+// Test inline cache for RegExp lastIndex get
+(function testGet() {
+    let re = /foo/g;
+    let sum = 0;
+    for (let i = 0; i < testLoopCount; i++)
+        sum += re.lastIndex;
+    if (sum !== 0)
+        throw new Error("unexpected sum: " + sum);
+})();
+
+// Test inline cache for RegExp lastIndex set
+(function testSet() {
+    let re = /foo/g;
+    for (let i = 0; i < testLoopCount; i++)
+        re.lastIndex = i;
+    if (re.lastIndex !== testLoopCount - 1)
+        throw new Error("unexpected lastIndex: " + re.lastIndex);
+})();
+
+// Test inline cache for RegExp lastIndex get after exec modifies it
+(function testGetAfterExec() {
+    let re = /./g;
+    let str = "abc";
+    let sum = 0;
+    for (let i = 0; i < testLoopCount; i++) {
+        re.lastIndex = 0;
+        re.exec(str);
+        sum += re.lastIndex;
+    }
+    if (sum !== testLoopCount)
+        throw new Error("unexpected sum: " + sum);
+})();
+
+// Test inline cache with non-writable lastIndex (frozen RegExp)
+(function testNonWritable() {
+    let re = /foo/g;
+    Object.defineProperty(re, "lastIndex", { writable: false, value: 42 });
+    for (let i = 0; i < testLoopCount; i++) {
+        if (re.lastIndex !== 42)
+            throw new Error("unexpected lastIndex: " + re.lastIndex);
+    }
+
+    // Setting should silently fail in sloppy mode
+    for (let i = 0; i < testLoopCount; i++)
+        re.lastIndex = 100;
+    if (re.lastIndex !== 42)
+        throw new Error("lastIndex should still be 42: " + re.lastIndex);
+})();
+
+// Test inline cache polymorphism with RegExpObject and plain object
+(function testPolymorphic() {
+    let re = /foo/g;
+    let obj = { lastIndex: 10 };
+    function getLastIndex(o) { return o.lastIndex; }
+    for (let i = 0; i < testLoopCount; i++) {
+        let val = getLastIndex(i % 2 === 0 ? re : obj);
+        if (i % 2 === 0) {
+            if (val !== 0)
+                throw new Error("unexpected re.lastIndex: " + val);
+        } else {
+            if (val !== 10)
+                throw new Error("unexpected obj.lastIndex: " + val);
+        }
+    }
+})();
+
+// Test inline cache for set with cell values (string) to exercise write barrier
+(function testSetWithCellValue() {
+    let re = /foo/g;
+    let values = ["hello", "world", 42, true, null, undefined];
+    for (let i = 0; i < testLoopCount; i++) {
+        re.lastIndex = values[i % values.length];
+    }
+    let expected = values[(testLoopCount - 1) % values.length];
+    if (re.lastIndex !== expected)
+        throw new Error("unexpected lastIndex: " + re.lastIndex + " expected: " + expected);
+})();

--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -79,6 +79,8 @@ Ref<AccessCase> AccessCase::create(VM& vm, JSCell* owner, AccessType type, Cache
     case StringLength:
     case DirectArgumentsLength:
     case ScopedArgumentsLength:
+    case RegExpLastIndexLoad:
+    case RegExpLastIndexStore:
     case ModuleNamespaceLoad:
     case Replace:
     case ProxyObjectIn:
@@ -338,6 +340,8 @@ bool AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck() const
     case StringLength:
     case DirectArgumentsLength:
     case ScopedArgumentsLength:
+    case RegExpLastIndexLoad:
+    case RegExpLastIndexStore:
     case ModuleNamespaceLoad:
     case ProxyObjectIn:
     case ProxyObjectLoad:
@@ -484,6 +488,8 @@ bool AccessCase::requiresIdentifierNameMatch() const
     case StringLength:
     case DirectArgumentsLength:
     case ScopedArgumentsLength:
+    case RegExpLastIndexLoad:
+    case RegExpLastIndexStore:
     case ModuleNamespaceLoad:
     case ProxyObjectIn:
     case ProxyObjectLoad:
@@ -612,6 +618,8 @@ bool AccessCase::requiresInt32PropertyCheck() const
     case StringLength:
     case DirectArgumentsLength:
     case ScopedArgumentsLength:
+    case RegExpLastIndexLoad:
+    case RegExpLastIndexStore:
     case ModuleNamespaceLoad:
     case ProxyObjectIn:
     case ProxyObjectLoad:
@@ -776,6 +784,8 @@ void AccessCase::forEachDependentCell(VM&, const Functor& functor) const
     case StringLength:
     case DirectArgumentsLength:
     case ScopedArgumentsLength:
+    case RegExpLastIndexLoad:
+    case RegExpLastIndexStore:
     case ProxyObjectIn:
     case ProxyObjectLoad:
     case ProxyObjectStore:
@@ -913,6 +923,8 @@ bool AccessCase::doesCalls(VM&) const
     case StringLength:
     case DirectArgumentsLength:
     case ScopedArgumentsLength:
+    case RegExpLastIndexLoad:
+    case RegExpLastIndexStore:
     case ModuleNamespaceLoad:
     case InstanceOfHit:
     case InstanceOfMiss:
@@ -1068,6 +1080,8 @@ bool AccessCase::canReplace(const AccessCase& other) const
     case StringLength:
     case DirectArgumentsLength:
     case ScopedArgumentsLength:
+    case RegExpLastIndexLoad:
+    case RegExpLastIndexStore:
     case IndexedScopedArgumentsLoad:
     case IndexedDirectArgumentsLoad:
     case IndexedTypedArrayInt8Load:
@@ -1315,6 +1329,8 @@ inline void AccessCase::runWithDowncast(const Func& func)
     case StringLength:
     case DirectArgumentsLength:
     case ScopedArgumentsLength:
+    case RegExpLastIndexLoad:
+    case RegExpLastIndexStore:
     case CheckPrivateBrand:
     case SetPrivateBrand:
     case IndexedMegamorphicLoad:
@@ -1499,6 +1515,8 @@ bool AccessCase::canBeShared(const AccessCase& lhs, const AccessCase& rhs)
     case StringLength:
     case DirectArgumentsLength:
     case ScopedArgumentsLength:
+    case RegExpLastIndexLoad:
+    case RegExpLastIndexStore:
     case CheckPrivateBrand:
     case SetPrivateBrand:
     case IndexedMegamorphicLoad:

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -79,6 +79,8 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AccessCase);
     macro(StringLength) \
     macro(DirectArgumentsLength) \
     macro(ScopedArgumentsLength) \
+    macro(RegExpLastIndexLoad) \
+    macro(RegExpLastIndexStore) \
     macro(ModuleNamespaceLoad) \
     macro(ProxyObjectIn) \
     macro(ProxyObjectLoad) \

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -252,6 +252,8 @@ static bool needsScratchFPR(AccessCase::AccessType type)
     case AccessCase::StringLength:
     case AccessCase::DirectArgumentsLength:
     case AccessCase::ScopedArgumentsLength:
+    case AccessCase::RegExpLastIndexLoad:
+    case AccessCase::RegExpLastIndexStore:
     case AccessCase::ModuleNamespaceLoad:
     case AccessCase::ProxyObjectIn:
     case AccessCase::ProxyObjectLoad:
@@ -371,6 +373,8 @@ static bool forInBy(AccessCase::AccessType type)
     case AccessCase::StringLength:
     case AccessCase::DirectArgumentsLength:
     case AccessCase::ScopedArgumentsLength:
+    case AccessCase::RegExpLastIndexLoad:
+    case AccessCase::RegExpLastIndexStore:
     case AccessCase::CheckPrivateBrand:
     case AccessCase::SetPrivateBrand:
     case AccessCase::IndexedMegamorphicLoad:
@@ -522,6 +526,8 @@ static bool isStateless(AccessCase::AccessType type)
     case AccessCase::StringLength:
     case AccessCase::DirectArgumentsLength:
     case AccessCase::ScopedArgumentsLength:
+    case AccessCase::RegExpLastIndexLoad:
+    case AccessCase::RegExpLastIndexStore:
     case AccessCase::IndexedProxyObjectLoad:
     case AccessCase::IndexedMegamorphicLoad:
     case AccessCase::IndexedMegamorphicStore:
@@ -656,6 +662,8 @@ static bool doesJSCalls(AccessCase::AccessType type)
     case AccessCase::StringLength:
     case AccessCase::DirectArgumentsLength:
     case AccessCase::ScopedArgumentsLength:
+    case AccessCase::RegExpLastIndexLoad:
+    case AccessCase::RegExpLastIndexStore:
     case AccessCase::IndexedMegamorphicLoad:
     case AccessCase::IndexedMegamorphicStore:
     case AccessCase::IndexedInt32Load:
@@ -791,6 +799,8 @@ static bool isMegamorphic(AccessCase::AccessType type)
     case AccessCase::StringLength:
     case AccessCase::DirectArgumentsLength:
     case AccessCase::ScopedArgumentsLength:
+    case AccessCase::RegExpLastIndexLoad:
+    case AccessCase::RegExpLastIndexStore:
     case AccessCase::IndexedInt32Load:
     case AccessCase::IndexedDoubleLoad:
     case AccessCase::IndexedContiguousLoad:
@@ -916,6 +926,8 @@ bool canBeViaGlobalProxy(AccessCase::AccessType type)
     case AccessCase::StringLength:
     case AccessCase::DirectArgumentsLength:
     case AccessCase::ScopedArgumentsLength:
+    case AccessCase::RegExpLastIndexLoad:
+    case AccessCase::RegExpLastIndexStore:
     case AccessCase::IndexedMegamorphicLoad:
     case AccessCase::IndexedMegamorphicStore:
     case AccessCase::IndexedInt32Load:
@@ -2005,6 +2017,27 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
             CCallHelpers::Address(baseGPR, ScopedArguments::offsetOfTotalLength()),
             valueRegs.payloadGPR());
         jit.boxInt32(valueRegs.payloadGPR(), valueRegs);
+        succeed();
+        return;
+    }
+
+    case AccessCase::RegExpLastIndexLoad: {
+        ASSERT(!accessCase.viaGlobalProxy());
+        fallThrough.append(jit.branchIfNotType(baseGPR, RegExpObjectType));
+        jit.loadValue(CCallHelpers::Address(baseGPR, RegExpObject::offsetOfLastIndex()), valueRegs);
+        succeed();
+        return;
+    }
+
+    case AccessCase::RegExpLastIndexStore: {
+        ASSERT(!accessCase.viaGlobalProxy());
+        fallThrough.append(jit.branchIfNotType(baseGPR, RegExpObjectType));
+        fallThrough.append(
+            jit.branchTestPtr(
+                CCallHelpers::NonZero,
+                CCallHelpers::Address(baseGPR, RegExpObject::offsetOfRegExpAndFlags()),
+                CCallHelpers::TrustedImm32(RegExpObject::lastIndexIsNotWritableFlag)));
+        jit.storeValue(valueRegs, CCallHelpers::Address(baseGPR, RegExpObject::offsetOfLastIndex()));
         succeed();
         return;
     }
@@ -3809,6 +3842,8 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
 
     case AccessCase::DirectArgumentsLength:
     case AccessCase::ScopedArgumentsLength:
+    case AccessCase::RegExpLastIndexLoad:
+    case AccessCase::RegExpLastIndexStore:
     case AccessCase::ModuleNamespaceLoad:
     case AccessCase::ProxyObjectIn:
     case AccessCase::ProxyObjectLoad:

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -61,6 +61,7 @@
 #include "ModuleNamespaceAccessCase.h"
 #include "PropertyInlineCache.h"
 #include "PropertyInlineCacheClearingWatchpoint.h"
+#include "RegExpObject.h"
 #include "ScopedArguments.h"
 #include "ScratchRegisterAllocator.h"
 #include "StackAlignment.h"
@@ -477,6 +478,11 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
                 if (!arguments->overrodeThings())
                     newCase = AccessCase::create(vm, codeBlock, AccessCase::ScopedArgumentsLength, lengthPropertyName);
             }
+        }
+
+        if (!newCase && propertyName == vm.propertyNames->lastIndex) {
+            if (jsDynamicCast<RegExpObject*>(baseCell))
+                newCase = AccessCase::create(vm, codeBlock, AccessCase::RegExpLastIndexLoad, CacheableIdentifier::createFromImmortalIdentifier(vm.propertyNames->lastIndex.impl()));
         }
 
         if (!propertyName.isSymbol() && baseCell->inherits<JSModuleNamespaceObject>() && !slot.isUnset()) {
@@ -1032,7 +1038,12 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
 
         RefPtr<AccessCase> newCase;
 
-        if (slot.base() == baseValue && slot.isCacheablePut()) {
+        if (propertyName == vm.propertyNames->lastIndex) {
+            if (jsDynamicCast<RegExpObject*>(baseCell))
+                newCase = AccessCase::create(vm, codeBlock, AccessCase::RegExpLastIndexStore, propertyName);
+        }
+
+        if (!newCase && slot.base() == baseValue && slot.isCacheablePut()) {
             if (slot.type() == PutPropertySlot::ExistingProperty) {
                 // This assert helps catch bugs if we accidentally forget to disable caching
                 // when we transition then store to an existing property. This is common among


### PR DESCRIPTION
#### d2c63be26cd676053519933c4bdfbd4f2f94009f
<pre>
[JSC] Add RegExp#lastIndex IC
<a href="https://bugs.webkit.org/show_bug.cgi?id=309549">https://bugs.webkit.org/show_bug.cgi?id=309549</a>
<a href="https://rdar.apple.com/172150739">rdar://172150739</a>

Reviewed by Sosuke Suzuki.

This patch implements RegExp#lastIndex IC for load and store. This is
pretty easy since it is own property, non-configurable and data
property. So we should just load and store a value to the field. Only
thing we need to care is writable=false flag can be set so
RegExpLastIndexStore side checks this before storing.

With disabling DFG,
                                     ToT                     Patched

    regexp-last-index          52.5397+-0.4507     ^     25.8446+-16.5492       ^ definitely 2.0329x faster
    regexp-last-index-ic       29.3950+-0.4737     ^     21.9877+-1.3869        ^ definitely 1.3369x faster

Tests: JSTests/microbenchmarks/regexp-last-index-ic.js
       JSTests/stress/regexp-last-index.js
       JSTests/stress/regexp-lastindex-inline-cache.js

* JSTests/microbenchmarks/regexp-last-index-ic.js: Added.
(load):
(store):
(reg.test.i):
* JSTests/stress/regexp-last-index.js: Added.
(shouldThrow):
(test):
(test2):
* JSTests/stress/regexp-lastindex-inline-cache.js: Added.
(testGet):
(testSet):
(testGetAfterExec):
(testNonWritable):
(testPolymorphic.getLastIndex):
(testPolymorphic):
(testSetWithCellValue):
* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::create):
(JSC::AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck const):
(JSC::AccessCase::requiresIdentifierNameMatch const):
(JSC::AccessCase::requiresInt32PropertyCheck const):
(JSC::AccessCase::forEachDependentCell const):
(JSC::AccessCase::doesCalls const):
(JSC::AccessCase::canReplace const):
(JSC::AccessCase::runWithDowncast):
(JSC::AccessCase::canBeShared):
* Source/JavaScriptCore/bytecode/AccessCase.h:
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::needsScratchFPR):
(JSC::forInBy):
(JSC::isStateless):
(JSC::doesJSCalls):
(JSC::isMegamorphic):
(JSC::canBeViaGlobalProxy):
(JSC::InlineCacheCompiler::generateWithGuard):
(JSC::InlineCacheCompiler::generateAccessCase):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheGetBy):
(JSC::tryCachePutBy):

Canonical link: <a href="https://commits.webkit.org/309027@main">https://commits.webkit.org/309027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/309eec6f598d1f838e0a1412998bb41b96019f3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21962 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/15532 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157941 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21840 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/115072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152209 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/17231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/95822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5791 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/141219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/11857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160423 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10040 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/13384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/123116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/18245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/123334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/133649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22982 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/10395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/180678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21374 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/85187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/180678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21106 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/21255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/21163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->