### PR TITLE
[Filters] FETile software applier should use the filter's operating color space

### DIFF
--- a/LayoutTests/svg/filters/feTile-color-interpolation-filters-expected.svg
+++ b/LayoutTests/svg/filters/feTile-color-interpolation-filters-expected.svg
@@ -1,0 +1,7 @@
+<svg version="1.2" width="400" height="200" xmlns="http://www.w3.org/2000/svg">
+  <!-- Reference: both rectangles should be rgb(50%,50%,50%) = #808080.
+       feFlood produces the specified color; feTile should preserve it regardless
+       of the color-interpolation-filters setting. -->
+  <rect fill="rgb(50%,50%,50%)" x="20" y="20" width="150" height="150"/>
+  <rect fill="rgb(50%,50%,50%)" x="190" y="20" width="150" height="150"/>
+</svg>

--- a/LayoutTests/svg/filters/feTile-color-interpolation-filters.svg
+++ b/LayoutTests/svg/filters/feTile-color-interpolation-filters.svg
@@ -1,0 +1,41 @@
+<svg version="1.2" width="400" height="200" xmlns="http://www.w3.org/2000/svg">
+  <!-- Test that feTile preserves colors correctly under both sRGB and linearRGB
+       color-interpolation-filters modes. With the bug (rdar://167786547), feTile
+       hardcoded its intermediate buffer to sRGB, causing a color space mismatch
+       when operating in linearRGB and producing washed-out colors. -->
+  <defs>
+    <!-- sRGB filter: feFlood -> feTile. The tiled output should match the flood color. -->
+    <filter id="tile-sRGB" color-interpolation-filters="sRGB"
+            filterUnits="objectBoundingBox" primitiveUnits="objectBoundingBox"
+            x="0" y="0" width="1" height="1">
+      <feFlood flood-color="rgb(50%,50%,50%)" flood-opacity="1.0"
+               x="0" y="0" width="0.5" height="0.5" result="half"/>
+      <feTile in="half"/>
+    </filter>
+
+    <!-- linearRGB filter: feFlood -> feTile. The tiled output should also match
+         the flood color, even though the internal pipeline uses linearRGB. -->
+    <filter id="tile-linearRGB" color-interpolation-filters="linearRGB"
+            filterUnits="objectBoundingBox" primitiveUnits="objectBoundingBox"
+            x="0" y="0" width="1" height="1">
+      <feFlood flood-color="rgb(50%,50%,50%)" flood-opacity="1.0"
+               x="0" y="0" width="0.5" height="0.5" result="half"/>
+      <feTile in="half"/>
+    </filter>
+
+    <!-- Reference: just feFlood without tiling, in linearRGB, to show the correct color. -->
+    <filter id="flood-linearRGB" color-interpolation-filters="linearRGB"
+            filterUnits="objectBoundingBox" primitiveUnits="objectBoundingBox"
+            x="0" y="0" width="1" height="1">
+      <feFlood flood-color="rgb(50%,50%,50%)" flood-opacity="1.0"
+               x="0" y="0" width="1" height="1"/>
+    </filter>
+  </defs>
+
+  <!-- Left: feTile in sRGB mode. Should produce rgb(50%,50%,50%). -->
+  <rect filter="url(#tile-sRGB)" x="20" y="20" width="150" height="150"/>
+
+  <!-- Center: feTile in linearRGB mode. Should produce the same visual as the
+       feFlood alone in linearRGB mode (right). Before the fix, this was washed out. -->
+  <rect filter="url(#tile-linearRGB)" x="190" y="20" width="150" height="150"/>
+</svg>

--- a/Source/WebCore/platform/graphics/filters/software/FETileSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FETileSoftwareApplier.cpp
@@ -53,7 +53,7 @@ bool FETileSoftwareApplier::apply(const Filter& filter, std::span<const Ref<Filt
     auto maxResultRect = result.maxEffectRect(filter);
     maxResultRect.scale(filter.filterScale());
 
-    auto tileImage = ImageBuffer::create(tileRect.size(), filter.renderingMode(), RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
+    auto tileImage = ImageBuffer::create(tileRect.size(), filter.renderingMode(), RenderingPurpose::Unspecified, 1, m_effect->operatingColorSpace(), PixelFormat::BGRA8);
     if (!tileImage)
         return false;
 


### PR DESCRIPTION
#### 1961088f6db8cc978d5c5116dcb34b9248319c63
<pre>
[Filters] FETile software applier should use the filter&apos;s operating color space
<a href="https://bugs.webkit.org/show_bug.cgi?id=305066">https://bugs.webkit.org/show_bug.cgi?id=305066</a>
<a href="https://rdar.apple.com/167786547">rdar://167786547</a>

Reviewed by NOBODY (OOPS!).

The FETile software applier hardcodes DestinationColorSpace::SRGB() when
creating its intermediate tile image buffer. When the SVG filter uses
linearRGB color interpolation (color-interpolation-filters=&quot;linearRGB&quot;),
this causes a color space mismatch: input data in linearSRGB is drawn
into an sRGB buffer, then tiled back into a linearSRGB result, producing
washed-out colors. The fix is to use m_effect-&gt;operatingColorSpace(),
consistent with every other software filter applier.

* Source/WebCore/platform/graphics/filters/software/FETileSoftwareApplier.cpp:
(WebCore::FETileSoftwareApplier::apply): Use m_effect-&gt;operatingColorSpace()
instead of hardcoded DestinationColorSpace::SRGB() for the intermediate tile
image buffer.
* LayoutTests/svg/filters/feTile-color-interpolation-filters.svg: Added.
* LayoutTests/svg/filters/feTile-color-interpolation-filters-expected.svg: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1961088f6db8cc978d5c5116dcb34b9248319c63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157705 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102447 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22184 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114876 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81791 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2836bf89-cc50-4ce1-95ef-613a56d937c4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133738 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95634 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/91dac065-a31b-46c2-8b3f-26aff727f288) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16166 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14032 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5555 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125770 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160187 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3177 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122932 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21532 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18055 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123159 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21540 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133456 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77728 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18427 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10215 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21142 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84944 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20874 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21022 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20930 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->