### PR TITLE
[DRAFT] [CSS] Fix computed style for position-area inlined in position-try-fallbacks

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt
@@ -3,7 +3,7 @@ SIBLING
 
 FAIL UA styles of base appearance <select>. assert_equals: min-inline-size expected "calc-size(auto, max(size, 24px))" but got "0px"
 PASS UA styles of base appearance select::picker-icon.
-FAIL UA styles of base appearance ::picker(select) assert_equals: position-try-fallbacks expected "start span-end, end span-start, start span-start" but got "block-start span-inline-end, block-end span-inline-start, block-start span-inline-start"
+PASS UA styles of base appearance ::picker(select)
 PASS UA styles of base appearance <option>.
 PASS UA styles of base appearance option::checkmark.
 PASS UA styles of base appearance <optgroup>.

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8478,8 +8478,6 @@ webkit.org/b/306998 [ Debug ] inspector/dom/customElementState.html [ Skip ]
 webkit.org/b/306998 [ Debug ] inspector/injected-script/observable.html [ Skip ]
 webkit.org/b/306998 [ Debug ] inspector/page/filter-cookies-for-domain.html [ Skip ]
 
-webkit.org/b/309283 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style.html [ Failure ]
-
 webkit.org/b/307091 inspector/network/intercept-aborted-request.html [ Skip ]
 
 # Requires mousedown

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2333,8 +2333,6 @@ webkit.org/b/298903 webrtc/video-rotation-black.html [ Pass Failure ]
 
 webkit.org/b/298416 [ Debug ] http/tests/websocket/construct-in-detached-frame.html [ Skip ]
 
-webkit.org/b/309283 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style.html [ Failure ]
-
 webkit.org/b/299561 imported/w3c/web-platform-tests/css/css-anchor-position/anchor-scroll-chained-003.html [ Pass ]
 
 webkit.org/b/299830 imported/w3c/web-platform-tests/storage-access-api/hasStorageAccess-insecure.sub.window.html [ Pass Failure ]

--- a/Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp
+++ b/Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp
@@ -28,6 +28,8 @@
 #include "StylePositionTryFallback.h"
 
 #include "StyleBuilderChecking.h"
+#include "CSSPropertyParserConsumer+Anchor.h"
+#include "CSSValuePair.h"
 #include "StylePrimitiveKeyword+CSSValueConversion.h"
 #include "StylePrimitiveKeyword+CSSValueCreation.h"
 #include "StylePrimitiveKeyword+Logging.h"
@@ -135,16 +137,51 @@ auto CSSValueConversion<PositionTryFallback>::operator()(BuilderState& state, co
     };
 }
 
+// Return the computed-value form of a position-area CSS value stored in a
+// PositionTryFallback::PositionArea's ImmutableStyleProperties.
+//
+// When a position-area is inlined in position-try-fallbacks (e.g.
+// "position-try-fallbacks: block-start span-inline-end, ..."), the raw
+// specified CSS value is stored as-is. At computed-value time the block-/inline-
+// axis prefixes must be stripped when the two keywords are on opposite axes.
+// For example, "block-start span-inline-end" must become "start span-end".
+//
+// This mirrors the logic in CSSValueCreation<PositionAreaValue> which calls
+// valueForPositionArea(..., ValueType::Computed) via the PositionAreaValue
+// style type, but that path is only used for the standalone position-area
+// property, not for inlined position-area values inside position-try-fallbacks.
+static Ref<CSSValue> computedPositionAreaCSSValue(const PositionTryFallback::PositionArea& positionArea)
+{
+    using namespace CSSPropertyParserHelpers;
+
+    Ref rawValue = RefPtr { positionArea.properties }->getPropertyCSSValue(CSSPropertyPositionArea).releaseNonNull();
+
+    // Only two-keyword position-area values require computed-value normalization.
+    // Single-keyword values (e.g. "center", "start") have no block-/inline- prefix
+    // to strip and are already in their canonical computed form.
+    if (!rawValue->isPair())
+        return rawValue;
+
+    auto dim1 = rawValue->first().valueID();
+    auto dim2 = rawValue->second().valueID();
+
+    if (auto computed = valueForPositionArea(dim1, dim2, ValueType::Computed))
+        return computed.releaseNonNull();
+
+    // Fallback: return the raw value unchanged if normalization fails.
+    return rawValue;
+}
+
 auto CSSValueCreation<PositionTryFallback::PositionArea>::operator()(CSSValuePool&, const RenderStyle&, const PositionTryFallback::PositionArea& value) -> Ref<CSSValue>
 {
-    return RefPtr { value.properties }->getPropertyCSSValue(CSSPropertyPositionArea).releaseNonNull();
+    return computedPositionAreaCSSValue(value);
 }
 
 // MARK: - Serialization
 
 void Serialize<PositionTryFallback::PositionArea>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle&, const PositionTryFallback::PositionArea& value)
 {
-    builder.append(RefPtr { value.properties }->getPropertyCSSValue(CSSPropertyPositionArea)->cssText(context));
+    builder.append(computedPositionAreaCSSValue(value)->cssText(context));
 }
 
 // MARK: - Logging


### PR DESCRIPTION
#### 2e6bfa0e7b013fc61fee06a87b8bcd83e4f16ac0
<pre>
[CSS] Fix computed style for position-area inlined in position-try-fallbacks
<a href="https://bugs.webkit.org/show_bug.cgi?id=309283">https://bugs.webkit.org/show_bug.cgi?id=309283</a>
<a href="https://rdar.apple.com/171830921">rdar://171830921</a>

Reviewed by NOBODY (OOPS!).

When a position-area value is inlined in `position-try-fallbacks` (e.g.
`position-try-fallbacks: block-start span-inline-end, ...`), the
computed-value serialization was not applying the axis-prefix normalization
required by the CSS Anchor Positioning spec.

Per the spec, when the two keywords of a position-area are explicitly on
opposite logical axes (block vs. inline), the block-/inline- axis prefixes
must be stripped at computed-value time.  For example, `block-start
span-inline-end` must serialize as `start span-end`.

The standalone `position-area` property already normalized correctly via
`CSSValueCreation&lt;PositionAreaValue&gt;`, but the inlined path in
`position-try-fallbacks` bypassed this by returning the raw specified
`CSSValue` from `ImmutableStyleProperties`.

Fix by adding a `computedPositionAreaCSSValue()` helper that extracts
keyword IDs from two-keyword `CSSValuePair` values and passes them through
`valueForPositionArea(..., ValueType::Computed)` for normalization.

* Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp:
(WebCore::Style::computedPositionAreaCSSValue): Add. Normalize position-area CSSValues to their computed form.
(WebCore::Style::CSSValueCreation&lt;PositionTryFallback::PositionArea&gt;::operator()): Use `computedPositionAreaCSSValue()`.
(WebCore::Style::Serialize&lt;PositionTryFallback::PositionArea&gt;::operator()): Use `computedPositionAreaCSSValue()`.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt: Update to PASS for the ::picker(select) subtest.
* LayoutTests/platform/ios/TestExpectations: Remove now-passing failure entry for bug 309283.
* LayoutTests/platform/mac-wk2/TestExpectations: Remove now-passing failure entry for bug 309283.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e6bfa0e7b013fc61fee06a87b8bcd83e4f16ac0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149018 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157706 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102448 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d85da86-983d-4ada-a574-6b7a7b1da3ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150891 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22185 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21609 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114878 "Found 1 new test failure: fast/forms/appearance-base/internal-auto-base-function.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81798 "8 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f758b9f-86d7-434e-bd1c-a32d01f86471) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151978 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17065 "Found 1 new test failure: fast/forms/appearance-base/internal-auto-base-function.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95636 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c20f6eda-2243-4e55-bc02-73d8b0d97099) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16167 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14033 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5556 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125771 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11659 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160188 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3178 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13181 "Found 1 new test failure: fast/forms/appearance-base/internal-auto-base-function.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122933 "Found 1 new test failure: fast/forms/appearance-base/internal-auto-base-function.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21533 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18056 "Found 1 new test failure: fast/forms/appearance-base/internal-auto-base-function.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123160 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133453 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77729 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18428 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10211 "Found 1 new test failure: fast/forms/appearance-base/internal-auto-base-function.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21143 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84945 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20875 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21023 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20931 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->