### PR TITLE
com.apple.WebKit.WebContent at libwebrtc.dylib:  webrtc::JsepTransportController::ApplyDescription_n

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport.cc
@@ -53,6 +53,20 @@ using webrtc::SdpType;
 
 namespace webrtc {
 
+namespace {
+// Helper function to safely get extension IDs, avoiding unnecessary copies
+const std::vector<int>& GetSafeExtensionIds(const std::vector<int>& extension_ids) {
+  if (extension_ids.size() > kMaxReasonableExtensionIds) {
+    RTC_LOG(LS_ERROR) << "Detected unreasonable number of encrypted extension IDs: "
+                      << extension_ids.size() << " (max expected: " << kMaxReasonableExtensionIds
+                      << "). Using empty vector to prevent crash.";
+    static const std::vector<int> kEmptyExtensionIds;
+    return kEmptyExtensionIds;
+  }
+  return extension_ids;
+}
+}  // namespace
+
 JsepTransportDescription::JsepTransportDescription() {}
 
 JsepTransportDescription::JsepTransportDescription(
@@ -61,14 +75,14 @@ JsepTransportDescription::JsepTransportDescription(
     int rtp_abs_sendtime_extn_id,
     const TransportDescription& transport_desc)
     : rtcp_mux_enabled(rtcp_mux_enabled),
-      encrypted_header_extension_ids(encrypted_header_extension_ids),
+      encrypted_header_extension_ids(GetSafeExtensionIds(encrypted_header_extension_ids)),
       rtp_abs_sendtime_extn_id(rtp_abs_sendtime_extn_id),
       transport_desc(transport_desc) {}
 
 JsepTransportDescription::JsepTransportDescription(
     const JsepTransportDescription& from)
     : rtcp_mux_enabled(from.rtcp_mux_enabled),
-      encrypted_header_extension_ids(from.encrypted_header_extension_ids),
+      encrypted_header_extension_ids(GetSafeExtensionIds(from.encrypted_header_extension_ids)),
       rtp_abs_sendtime_extn_id(from.rtp_abs_sendtime_extn_id),
       transport_desc(from.transport_desc) {}
 
@@ -80,7 +94,7 @@ JsepTransportDescription& JsepTransportDescription::operator=(
     return *this;
   }
   rtcp_mux_enabled = from.rtcp_mux_enabled;
-  encrypted_header_extension_ids = from.encrypted_header_extension_ids;
+  encrypted_header_extension_ids = GetSafeExtensionIds(from.encrypted_header_extension_ids);
   rtp_abs_sendtime_extn_id = from.rtp_abs_sendtime_extn_id;
   transport_desc = from.transport_desc;
 

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport.h
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport.h
@@ -44,6 +44,10 @@
 
 namespace webrtc {
 
+// Maximum reasonable number of encrypted header extension IDs to prevent
+// memory allocation crashes from corrupted vectors
+constexpr size_t kMaxReasonableExtensionIds = 1000;  // RTP extensions are typically < 20
+
 struct JsepTransportDescription {
  public:
   JsepTransportDescription();


### PR DESCRIPTION
#### fd0e360e55296e7598ec26217118856b5505be1d
<pre>
com.apple.WebKit.WebContent at libwebrtc.dylib:  webrtc::JsepTransportController::ApplyDescription_n
<a href="https://bugs.webkit.org/show_bug.cgi?id=309554">https://bugs.webkit.org/show_bug.cgi?id=309554</a>
<a href="https://rdar.apple.com/171963081">rdar://171963081</a>

Reviewed by NOBODY (OOPS!).

Prevent std::bad_alloc crashes when copying large corrupted encrypted_header_extension_ids
vectors during JsepTransportDescription object creation. The crash occurred when memory
corruption caused the vector to contain an unreasonable number of elements.

Changes:
- Add kMaxReasonableExtensionIds constant (1000) to jsep_transport.h
- Implement GetSafeExtensionIds() helper function that returns reference to original
  vector for normal cases (≤1000 elements) or static empty vector for corruption
- Add bounds checking to JsepTransportDescription constructor, copy constructor, and
  assignment operator
- Log detailed error messages when corruption is detected
- Gracefully degrade to empty extension IDs list instead of crashing

Performance optimizations:
- Zero-cost for normal cases: no vector copying when size is reasonable
- Reference-based validation avoids unnecessary temporary objects
- Single static empty vector reused across all corruption cases

* Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport.cc:
* Source/ThirdParty/libwebrtc/Source/webrtc/pc/jsep_transport.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd0e360e55296e7598ec26217118856b5505be1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21739 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15309 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157714 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102456 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0ecb408e-6cfe-47f2-a04b-c39e0008627b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114884 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81799 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4d8c0171-9434-4929-ae07-793283312f27) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133742 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95642 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16176 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14039 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5564 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125780 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160196 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13189 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122937 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21541 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123164 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21549 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133460 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77737 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18436 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10219 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21151 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20883 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21031 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20939 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->