### PR TITLE
MobileSafari at WebKit:  WTF::Function<void (bool)>::operator() const

### DIFF
--- a/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
+++ b/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
@@ -104,7 +104,10 @@ void WebParentalControlsURLFilter::allowURL(const URL& url, CompletionHandler<vo
         [protect(ensureWebContentFilter()) allowURL:url.createNSURL().get() completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)](BOOL didAllow, NSError *) mutable {
             RELEASE_LOG(Loading, "WebParentalControlsURLFilter::allowURL result %d.\n", didAllow);
             callOnMainRunLoop([didAllow, completionHandler = WTF::move(completionHandler)] mutable {
-                completionHandler(didAllow);
+                // BEWebContentFilter may call the completion handler more than once (rdar://172157523
+                // was filed for this). Guard against this to avoid a null dereference crash.
+                if (completionHandler)
+                    completionHandler(didAllow);
             });
         }).get()];
     });


### PR DESCRIPTION
#### 970e6c681fe1112879fad9698426b9279b7226a3
<pre>
MobileSafari at WebKit:  WTF::Function&lt;void (bool)&gt;::operator() const
<a href="https://bugs.webkit.org/show_bug.cgi?id=309555">https://bugs.webkit.org/show_bug.cgi?id=309555</a>
<a href="https://rdar.apple.com/171864197">rdar://171864197</a>

Reviewed by David Kilzer and Ryosuke Niwa.

The crash is super generic so it was not obvious what the root cause was
at first. However, looking at the recent logging before the crash, the
issue became clearer:
  1. Parental controls are active — ParentalControlsURLFilter::isEnabled
     returns 1
  2. Content filter blocks the navigation — &quot;Ignoring request to load
      this main resource because it was handled by content filter&quot;
  3. User attempts to unblock — a synthetic click triggers the unblock
     flow
  4. Remote PIN entry service fails — attempt to open
     com.apple.WebContentFilter.remoteUI.WebContentAnalysisUI returns
     NotFound / InvalidRequest
  5. WCRRemotePINEntryViewController is nil — the PIN entry view
     controller failed to initialize
  6. Two allowURL result 0 messages from different threads (0x036ed and
     0x031bc) — the unblock is denied
  7. Crash — a null CompletionHandler&lt;void(bool)&gt; is invoked from the
     main RunLoop

The issue appears to be that [BEWebContentFilter allowURL:completionHandler:]
may call its completion handler more than once (<a href="https://rdar.apple.com/172157523">rdar://172157523</a>). Until
this is fixed, we&apos;re guarding against it on WebKit side by null checking
the completion handler before calling it.

* Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm:
(WebKit::WebParentalControlsURLFilter::allowURL):

Canonical link: <a href="https://commits.webkit.org/308967@main">https://commits.webkit.org/308967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94f75e83cb2e57939831632350221ac867d4ef9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21741 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157716 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21619 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114889 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a359954-00d4-404c-90c1-86fc90b02f46) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133746 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95647 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/20696481-f170-4306-9b41-f87876d76a74) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16174 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14040 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5566 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125778 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160198 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3188 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122940 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18064 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123167 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33482 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133464 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77739 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18426 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10223 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21153 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84955 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20885 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21033 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20941 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->