### PR TITLE
Make eventSender.asyncMouse*() truly asynchronous on macOS

### DIFF
--- a/Tools/WebKitTestRunner/EventSenderProxy.h
+++ b/Tools/WebKitTestRunner/EventSenderProxy.h
@@ -37,7 +37,6 @@
 
 #if PLATFORM(COCOA)
 OBJC_CLASS NSEvent;
-OBJC_CLASS NSView;
 #endif
 
 namespace WebCore {
@@ -59,15 +58,16 @@ public:
 
     WKPoint position() const { return m_position; }
 
-    void mouseDown(unsigned button, WKEventModifiers, WKStringRef pointerType = nullptr);
-    void mouseUp(unsigned button, WKEventModifiers, WKStringRef pointerType = nullptr);
+    void mouseDown(unsigned button, WKEventModifiers, WKStringRef pointerType = nullptr, CompletionHandler<void()>&& = nullptr);
+    void mouseUp(unsigned button, WKEventModifiers, WKStringRef pointerType = nullptr, CompletionHandler<void()>&& = nullptr);
+    void mouseMoveTo(double x, double y, WKStringRef pointerType = nullptr, CompletionHandler<void()>&& = nullptr);
+
     void mouseForceDown();
     void mouseForceUp();
     void mouseForceChanged(float);
     void mouseForceClick();
     void startAndCancelMouseForceClick();
-    void mouseMoveTo(double x, double y, WKStringRef pointerType = nullptr);
-    
+
     // Legacy wheel events.
     void mouseScrollBy(int x, int y);
     void mouseScrollByWithWheelAndMomentumPhases(int x, int y, int phase, int momentum);
@@ -127,8 +127,6 @@ public:
     void scaleGestureEnd(double scale);
 #endif
 
-    void waitForPendingMouseEvents();
-
 private:
     TestController* m_testController;
 
@@ -157,7 +155,6 @@ private:
     WKEventMouseButton m_clickButton { kWKEventMouseButtonNoButton };
 #if PLATFORM(COCOA)
     int m_eventNumber { 0 };
-    RetainPtr<NSView> m_targetView;
     WTF::HashMap<WebCore::MouseButton, bool, WTF::IntHash<WebCore::MouseButton>, WTF::StrongEnumHashTraits<WebCore::MouseButton>> m_mouseButtonsCurrentlyDown;
     unsigned m_lastButtonDown { 0 };
 #else

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/EventSenderProxyIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/EventSenderProxyIOS.mm
@@ -59,16 +59,22 @@ void EventSenderProxy::updateClickCountForButton(int button)
     m_clickButton = button;
 }
 
-void EventSenderProxy::mouseDown(unsigned buttonNumber, WKEventModifiers modifiers, WKStringRef pointerType)
+void EventSenderProxy::mouseDown(unsigned buttonNumber, WKEventModifiers modifiers, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
 {
+    if (completionHandler)
+        completionHandler();
 }
 
-void EventSenderProxy::mouseUp(unsigned buttonNumber, WKEventModifiers modifiers, WKStringRef pointerType)
+void EventSenderProxy::mouseUp(unsigned buttonNumber, WKEventModifiers modifiers, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
 {
+    if (completionHandler)
+        completionHandler();
 }
 
-void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType)
+void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
 {
+    if (completionHandler)
+        completionHandler();
 }
 
 void EventSenderProxy::leapForward(int milliseconds)
@@ -149,9 +155,5 @@ void EventSenderProxy::cancelTouchPoint(int index)
 }
 
 #endif
-
-void EventSenderProxy::waitForPendingMouseEvents()
-{
-}
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1927,17 +1927,14 @@ constexpr auto eventSenderJS = R"eventSenderJS(
 if (window.eventSender) {
     let post = window.webkit.messageHandlers.webkitTestRunner.postMessage.bind(window.webkit.messageHandlers.webkitTestRunner);
 
-    eventSender.asyncMouseDown = async (button, modifierArray, pointerType, callback) => { // NOLINT
+    eventSender.asyncMouseDown = async (button, modifierArray, pointerType) => { // NOLINT
         await post(['AsyncMouseDown', button, modifierArray, pointerType]);
-        callback?.();
     };
-    eventSender.asyncMouseUp = async (button, modifierArray, pointerType, callback) => { // NOLINT
+    eventSender.asyncMouseUp = async (button, modifierArray, pointerType) => { // NOLINT
         await post(['AsyncMouseUp', button, modifierArray, pointerType]);
-        callback?.();
     };
-    eventSender.asyncMouseMoveTo = async (x, y, pointerType, callback) => { // NOLINT
+    eventSender.asyncMouseMoveTo = async (x, y, pointerType) => { // NOLINT
         await post(['AsyncMouseMoveTo', x, y, pointerType]);
-        callback?.();
     };
     eventSender.asyncKeyDown = async (key, modifiers) => { // NOLINT
         await post(['AsyncKeyDown', key, modifiers]);
@@ -2742,9 +2739,8 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         WKArrayAppendItem(array.get(), argument2);
         WKPagePostMessageToInjectedBundle(mainWebView()->page(), toWK("SetMousePosition").get(), array.get());
 
-        m_eventSenderProxy->mouseMoveTo(x, y, pointerType);
-        m_eventSenderProxy->waitForPendingMouseEvents();
-        completionHandler(nullptr);
+        m_eventSenderProxy->mouseMoveTo(x, y, pointerType,
+            [completionHandler = WTF::move(completionHandler)] mutable { completionHandler(nullptr); });
         return;
     }
 
@@ -2752,10 +2748,8 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         const auto button = static_cast<uint64_t>(doubleValue(argument));
         const auto array = arrayValue(argument2);
         const auto pointerType = stringValue(argument3);
-
-        m_eventSenderProxy->mouseDown(button, parseModifierArray(array), pointerType);
-        m_eventSenderProxy->waitForPendingMouseEvents();
-        completionHandler(nullptr);
+        m_eventSenderProxy->mouseDown(button, parseModifierArray(array), pointerType,
+            [completionHandler = WTF::move(completionHandler)] mutable { completionHandler(nullptr); });
         return;
     }
 
@@ -2763,10 +2757,8 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         const auto button = static_cast<uint64_t>(doubleValue(argument));
         const auto array = arrayValue(argument2);
         const auto pointerType = stringValue(argument3);
-
-        m_eventSenderProxy->mouseUp(button, parseModifierArray(array), pointerType);
-        m_eventSenderProxy->waitForPendingMouseEvents();
-        completionHandler(nullptr);
+        m_eventSenderProxy->mouseUp(button, parseModifierArray(array), pointerType,
+            [completionHandler = WTF::move(completionHandler)] mutable { completionHandler(nullptr); });
         return;
     }
 

--- a/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
@@ -62,6 +62,13 @@ static void waitForPendingKeyEvents(TestController* testController)
     testController->runUntil(done, 100_ms);
 }
 
+static void waitForPendingMouseEvents(TestController* testController)
+{
+    bool done = false;
+    WKPageDoAfterProcessingAllPendingMouseEvents(testController->mainWebView()->page(), &done, runPendingEventsCallback);
+    testController->runUntil(done, 100_ms);
+}
+
 // WebCore and layout tests assume this value
 static const float pixelsPerScrollTick = 40;
 
@@ -290,24 +297,31 @@ static inline unsigned stateModifierForGdkButton(unsigned button)
     return 1 << (8 + button - 1);
 }
 
-void EventSenderProxy::mouseDown(unsigned button, WKEventModifiers wkModifiers, WKStringRef pointerType)
+void EventSenderProxy::mouseDown(unsigned button, WKEventModifiers wkModifiers, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
 {
     unsigned gdkButton = eventSenderButtonToGDKButton(button);
     auto modifier = stateModifierForGdkButton(gdkButton);
 
     // If the same mouse button is already in the down position don't
     // send another event as it may confuse Xvfb.
-    if (m_mouseButtonsCurrentlyDown & modifier)
+    if (m_mouseButtonsCurrentlyDown & modifier) {
+        if (completionHandler)
+            completionHandler();
         return;
+    }
 
     updateClickCountForButton(button);
     m_mouseButtonsCurrentlyDown |= modifier;
 
     webkitWebViewBaseSynthesizeMouseEvent(toWebKitGLibAPI(m_testController->mainWebView()->platformView()),
         MouseEventType::Press, gdkButton, m_mouseButtonsCurrentlyDown, m_position.x, m_position.y, webkitModifiersToGDKModifiers(wkModifiers), m_clickCount, toWTFString(pointerType));
+    if (completionHandler) {
+        waitForPendingMouseEvents(m_testController);
+        completionHandler();
+    }
 }
 
-void EventSenderProxy::mouseUp(unsigned button, WKEventModifiers wkModifiers, WKStringRef pointerType)
+void EventSenderProxy::mouseUp(unsigned button, WKEventModifiers wkModifiers, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
 {
     unsigned gdkButton = eventSenderButtonToGDKButton(button);
     auto modifier = stateModifierForGdkButton(gdkButton);
@@ -317,15 +331,23 @@ void EventSenderProxy::mouseUp(unsigned button, WKEventModifiers wkModifiers, WK
 
     m_clickPosition = m_position;
     m_clickTime = m_time;
+    if (completionHandler) {
+        waitForPendingMouseEvents(m_testController);
+        completionHandler();
+    }
 }
 
-void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType)
+void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
 {
     m_position.x = x;
     m_position.y = y;
 
     webkitWebViewBaseSynthesizeMouseEvent(toWebKitGLibAPI(m_testController->mainWebView()->platformView()),
         MouseEventType::Motion, 0, m_mouseButtonsCurrentlyDown, m_position.x, m_position.y, 0, 0, toWTFString(pointerType));
+    if (completionHandler) {
+        waitForPendingMouseEvents(m_testController);
+        completionHandler();
+    }
 }
 
 void EventSenderProxy::mouseScrollBy(int horizontal, int vertical)
@@ -449,31 +471,5 @@ void EventSenderProxy::setTouchModifier(WKEventModifiers, bool)
 {
 }
 #endif // ENABLE(TOUCH_EVENTS)
-
-struct DoAfterProcessingAllPendingMouseEventsCallbackContext {
-    bool done { false };
-    bool timedOut { false };
-};
-
-static void doAfterProcessingAllPendingMouseEventsCallback(void* userData)
-{
-    auto* context = static_cast<DoAfterProcessingAllPendingMouseEventsCallbackContext*>(userData);
-    if (context->timedOut) {
-        delete context;
-        return;
-    }
-    context->done = true;
-}
-
-void EventSenderProxy::waitForPendingMouseEvents()
-{
-    auto* context = new DoAfterProcessingAllPendingMouseEventsCallbackContext;
-    WKPageDoAfterProcessingAllPendingMouseEvents(m_testController->mainWebView()->page(), context, doAfterProcessingAllPendingMouseEventsCallback);
-    m_testController->runUntil(context->done, 100_ms);
-    if (context->done)
-        delete context;
-    else
-        context->timedOut = true;
-}
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
@@ -56,6 +56,13 @@ static void waitForPendingKeyEvents(TestController* testController)
     testController->runUntil(done, 100_ms);
 }
 
+static void waitForPendingMouseEvents(TestController* testController)
+{
+    bool done = false;
+    WKPageDoAfterProcessingAllPendingMouseEvents(testController->mainWebView()->page(), &done, runPendingEventsCallback);
+    testController->runUntil(done, 100_ms);
+}
+
 EventSenderProxy::EventSenderProxy(TestController* testController)
     : m_testController(testController)
     // WPE event timestamps are just MonotonicTime, not actual WallTime, so we can
@@ -93,24 +100,36 @@ void EventSenderProxy::updateClickCountForButton(int button)
     m_clickButton = button;
 }
 
-void EventSenderProxy::mouseDown(unsigned button, WKEventModifiers wkModifiers, WKStringRef pointerType)
+void EventSenderProxy::mouseDown(unsigned button, WKEventModifiers wkModifiers, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
 {
     updateClickCountForButton(button);
     m_client->mouseDown(button, m_time, wkModifiers, m_position.x, m_position.y, m_clickCount, m_mouseButtonsCurrentlyDown);
+    if (completionHandler) {
+        waitForPendingMouseEvents(m_testController);
+        completionHandler();
+    }
 }
 
-void EventSenderProxy::mouseUp(unsigned button, WKEventModifiers wkModifiers, WKStringRef pointerType)
+void EventSenderProxy::mouseUp(unsigned button, WKEventModifiers wkModifiers, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
 {
     m_client->mouseUp(button, m_time, wkModifiers, m_position.x, m_position.y, m_mouseButtonsCurrentlyDown);
     m_clickPosition = m_position;
     m_clickTime = m_time;
+    if (completionHandler) {
+        waitForPendingMouseEvents(m_testController);
+        completionHandler();
+    }
 }
 
-void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType)
+void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
 {
     m_position.x = x;
     m_position.y = y;
     m_client->mouseMoveTo(x, y, m_time, m_clickButton, m_mouseButtonsCurrentlyDown);
+    if (completionHandler) {
+        waitForPendingMouseEvents(m_testController);
+        completionHandler();
+    }
 }
 
 void EventSenderProxy::mouseScrollBy(int horizontal, int vertical)
@@ -213,31 +232,5 @@ void EventSenderProxy::cancelTouchPoint(int index)
 }
 
 #endif // ENABLE(TOUCH_EVENTS)
-
-struct DoAfterProcessingAllPendingMouseEventsCallbackContext {
-    bool done { false };
-    bool timedOut { false };
-};
-
-static void doAfterProcessingAllPendingMouseEventsCallback(void* userData)
-{
-    auto* context = static_cast<DoAfterProcessingAllPendingMouseEventsCallbackContext*>(userData);
-    if (context->timedOut) {
-        delete context;
-        return;
-    }
-    context->done = true;
-}
-
-void EventSenderProxy::waitForPendingMouseEvents()
-{
-    auto* context = new DoAfterProcessingAllPendingMouseEventsCallbackContext;
-    WKPageDoAfterProcessingAllPendingMouseEvents(m_testController->mainWebView()->page(), context, doAfterProcessingAllPendingMouseEventsCallback);
-    m_testController->runUntil(context->done, 100_ms);
-    if (context->done)
-        delete context;
-    else
-        context->timedOut = true;
-}
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
+++ b/Tools/WebKitTestRunner/mac/EventSenderProxy.mm
@@ -348,7 +348,7 @@ static NSInteger swizzledEventButtonNumber()
     return TestController::singleton().eventSenderProxy()->lastButtonDown();
 }
 
-void EventSenderProxy::mouseDown(unsigned buttonNumber, WKEventModifiers modifiers, WKStringRef pointerType)
+void EventSenderProxy::mouseDown(unsigned buttonNumber, WKEventModifiers modifiers, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
 {
     auto button = WebCore::buttonFromShort(static_cast<int16_t>(buttonNumber));
     m_mouseButtonsCurrentlyDown.set(button, true);
@@ -356,63 +356,98 @@ void EventSenderProxy::mouseDown(unsigned buttonNumber, WKEventModifiers modifie
 
     updateClickCountForButton(buttonNumber);
 
-    NSEventType eventType = eventTypeForMouseButtonAndAction(button, MouseAction::Down);
-    NSEvent *event = [NSEvent mouseEventWithType:eventType
-                                        location:NSMakePoint(m_position.x, m_position.y)
-                                   modifierFlags:buildModifierFlags(modifiers)
-                                       timestamp:absoluteTimeForEventTime(currentEventTime())
-                                    windowNumber:[m_testController->mainWebView()->platformWindow() windowNumber]
-                                         context:[NSGraphicsContext currentContext] 
-                                     eventNumber:++m_eventNumber 
-                                      clickCount:m_clickCount 
-                                        pressure:WebCore::ForceAtClick];
+    auto eventType = eventTypeForMouseButtonAndAction(button, MouseAction::Down);
+    RetainPtr event = [NSEvent mouseEventWithType:eventType
+        location:NSMakePoint(m_position.x, m_position.y)
+        modifierFlags:buildModifierFlags(modifiers)
+        timestamp:absoluteTimeForEventTime(currentEventTime())
+        windowNumber:[m_testController->mainWebView()->platformWindow() windowNumber]
+        context:[NSGraphicsContext currentContext]
+        eventNumber:++m_eventNumber
+        clickCount:m_clickCount
+        pressure:WebCore::ForceAtClick];
 
-    m_targetView = [m_testController->mainWebView()->platformView() hitTest:[event locationInWindow]];
-    if (m_targetView) {
+    RetainPtr targetView = [m_testController->mainWebView()->platformView() hitTest:[event locationInWindow]];
+    if (!targetView) {
+        if (completionHandler)
+            completionHandler();
+        return;
+    }
+
+    if (button == WebCore::MouseButton::Left)
+        m_leftMouseButtonDown = true;
+
+    auto dispatchMouseDown = [event, targetView] {
         auto eventPressedMouseButtonsSwizzler = makeUnique<ClassMethodSwizzler>([NSEvent class], @selector(pressedMouseButtons), reinterpret_cast<IMP>(swizzledEventPressedMouseButtons));
         auto eventButtonNumberSwizzler = makeUnique<InstanceMethodSwizzler>([NSEvent class], @selector(buttonNumber), reinterpret_cast<IMP>(swizzledEventButtonNumber));
         [NSApp _setCurrentEvent:event];
-        [m_targetView mouseDown:event];
+        [targetView mouseDown:event];
         [NSApp _setCurrentEvent:nil];
-        if (button == WebCore::MouseButton::Left)
-            m_leftMouseButtonDown = true;
+    };
+
+    if (!completionHandler) {
+        dispatchMouseDown();
+        return;
     }
+
+    RetainPtr webView = m_testController->mainWebView()->platformView();
+    dispatch_async(mainDispatchQueueSingleton(), makeBlockPtr([dispatchMouseDown = WTF::move(dispatchMouseDown), webView, completionHandler = WTF::move(completionHandler)] mutable {
+        dispatchMouseDown();
+        [webView _doAfterProcessingAllPendingMouseEvents:makeBlockPtr([completionHandler = WTF::move(completionHandler)] mutable {
+            completionHandler();
+        }).get()];
+    }).get());
 }
 
-void EventSenderProxy::mouseUp(unsigned buttonNumber, WKEventModifiers modifiers, WKStringRef pointerType)
+void EventSenderProxy::mouseUp(unsigned buttonNumber, WKEventModifiers modifiers, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
 {
     auto button = WebCore::buttonFromShort(static_cast<int16_t>(buttonNumber));
     m_mouseButtonsCurrentlyDown.set(button, false);
     m_lastButtonDown = nsEventButtonNumberFromWebCoreMouseButton(button);
 
-    NSEventType eventType = eventTypeForMouseButtonAndAction(button, MouseAction::Up);
-    NSEvent *event = [NSEvent mouseEventWithType:eventType
-                                        location:NSMakePoint(m_position.x, m_position.y)
-                                   modifierFlags:buildModifierFlags(modifiers)
-                                       timestamp:absoluteTimeForEventTime(currentEventTime())
-                                    windowNumber:[m_testController->mainWebView()->platformWindow() windowNumber]
-                                         context:[NSGraphicsContext currentContext] 
-                                     eventNumber:++m_eventNumber 
-                                      clickCount:m_clickCount 
-                                        pressure:0.0];
+    auto eventType = eventTypeForMouseButtonAndAction(button, MouseAction::Up);
+    RetainPtr event = [NSEvent mouseEventWithType:eventType
+        location:NSMakePoint(m_position.x, m_position.y)
+        modifierFlags:buildModifierFlags(modifiers)
+        timestamp:absoluteTimeForEventTime(currentEventTime())
+        windowNumber:[m_testController->mainWebView()->platformWindow() windowNumber]
+        context:[NSGraphicsContext currentContext]
+        eventNumber:++m_eventNumber
+        clickCount:m_clickCount
+        pressure:0.0];
 
-    m_targetView = [m_testController->mainWebView()->platformView() hitTest:[event locationInWindow]];
     // FIXME: Silly hack to teach WKTR to respect capturing mouse events outside the WKView.
-    // The right solution is just to use NSApplication's built-in event sending methods, 
+    // The right solution is just to use NSApplication's built-in event sending methods,
     // instead of rolling our own algorithm for selecting an event target.
-    if (!m_targetView)
-        m_targetView = m_testController->mainWebView()->platformView();
+    RetainPtr targetView = [m_testController->mainWebView()->platformView() hitTest:[event locationInWindow]];
+    if (!targetView)
+        targetView = m_testController->mainWebView()->platformView();
 
-    ASSERT(m_targetView);
-    auto eventPressedMouseButtonsSwizzler = makeUnique<ClassMethodSwizzler>([NSEvent class], @selector(pressedMouseButtons), reinterpret_cast<IMP>(swizzledEventPressedMouseButtons));
-    auto eventButtonNumberSwizzler = makeUnique<InstanceMethodSwizzler>([NSEvent class], @selector(buttonNumber), reinterpret_cast<IMP>(swizzledEventButtonNumber));
-    [NSApp _setCurrentEvent:event];
-    [m_targetView mouseUp:event];
-    [NSApp _setCurrentEvent:nil];
     if (button == WebCore::MouseButton::Left)
         m_leftMouseButtonDown = false;
     m_clickTime = currentEventTime();
     m_clickPosition = m_position;
+
+    auto dispatchMouseUp = [event, targetView] {
+        auto eventPressedMouseButtonsSwizzler = makeUnique<ClassMethodSwizzler>([NSEvent class], @selector(pressedMouseButtons), reinterpret_cast<IMP>(swizzledEventPressedMouseButtons));
+        auto eventButtonNumberSwizzler = makeUnique<InstanceMethodSwizzler>([NSEvent class], @selector(buttonNumber), reinterpret_cast<IMP>(swizzledEventButtonNumber));
+        [NSApp _setCurrentEvent:event];
+        [targetView mouseUp:event];
+        [NSApp _setCurrentEvent:nil];
+    };
+
+    if (!completionHandler) {
+        dispatchMouseUp();
+        return;
+    }
+
+    RetainPtr webView = m_testController->mainWebView()->platformView();
+    dispatch_async(mainDispatchQueueSingleton(), makeBlockPtr([dispatchMouseUp = WTF::move(dispatchMouseUp), webView, completionHandler = WTF::move(completionHandler)] mutable {
+        dispatchMouseUp();
+        [webView _doAfterProcessingAllPendingMouseEvents:makeBlockPtr([completionHandler = WTF::move(completionHandler)] mutable {
+            completionHandler();
+        }).get()];
+    }).get());
 }
 
 void EventSenderProxy::sendMouseDownToStartPressureEvents()
@@ -615,41 +650,57 @@ void EventSenderProxy::mouseForceChanged(float force)
     IGNORE_NULL_CHECK_WARNINGS_END
 }
 
-void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType)
+void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
 {
-    NSView *view = m_testController->mainWebView()->platformView();
-    NSPoint newMousePosition = [view convertPoint:NSMakePoint(x, y) toView:nil];
-    bool isDrag = m_leftMouseButtonDown;
-    NSEvent *event = [NSEvent mouseEventWithType:(isDrag ? NSEventTypeLeftMouseDragged : NSEventTypeMouseMoved)
-                                        location:newMousePosition
-                                   modifierFlags:0 
-                                       timestamp:absoluteTimeForEventTime(currentEventTime())
-                                    windowNumber:view.window.windowNumber
-                                         context:[NSGraphicsContext currentContext] 
-                                     eventNumber:++m_eventNumber 
-                                      clickCount:(m_leftMouseButtonDown ? m_clickCount : 0) 
-                                        pressure:0];
+    auto *view = m_testController->mainWebView()->platformView();
+    auto newMousePosition = [view convertPoint:NSMakePoint(x, y) toView:nil];
+    auto isDrag = m_leftMouseButtonDown;
+    RetainPtr event = [NSEvent mouseEventWithType:(isDrag ? NSEventTypeLeftMouseDragged : NSEventTypeMouseMoved)
+        location:newMousePosition
+        modifierFlags:0
+        timestamp:absoluteTimeForEventTime(currentEventTime())
+        windowNumber:view.window.windowNumber
+        context:[NSGraphicsContext currentContext]
+        eventNumber:++m_eventNumber
+        clickCount:(m_leftMouseButtonDown ? m_clickCount : 0)
+        pressure:0];
 
-    CGEventRef cgEvent = event.CGEvent;
+    CGEventRef cgEvent = event.get().CGEvent;
     CGEventSetIntegerValueField(cgEvent, kCGMouseEventDeltaX, newMousePosition.x - m_position.x);
     CGEventSetIntegerValueField(cgEvent, kCGMouseEventDeltaY, -1 * (newMousePosition.y - m_position.y));
     event = [NSEvent eventWithCGEvent:cgEvent];
     m_position.x = newMousePosition.x;
     m_position.y = newMousePosition.y;
 
-    NSPoint windowLocation = event.locationInWindow;
+    RetainPtr webView = m_testController->mainWebView()->platformView();
+
     // Always target drags at the WKWebView to allow for drag-scrolling outside the view.
-    m_targetView = isDrag ? m_testController->mainWebView()->platformView() : [m_testController->mainWebView()->platformView() hitTest:windowLocation];
-    if (m_targetView) {
-        auto eventPressedMouseButtonsSwizzler = makeUnique<ClassMethodSwizzler>([NSEvent class], @selector(pressedMouseButtons), reinterpret_cast<IMP>(swizzledEventPressedMouseButtons));
-        [NSApp _setCurrentEvent:event];
-        if (isDrag)
-            [m_targetView mouseDragged:event];
-        else
-            [checked_objc_cast<WKWebView>(m_targetView.get()) _simulateMouseMove:event];
-        [NSApp _setCurrentEvent:nil];
-    } else
-        WTFLogAlways("mouseMoveTo failed to find a target view at %f,%f\n", windowLocation.x, windowLocation.y);
+    // For non-drag moves, _simulateMouseMove: must be called on the WKWebView directly
+    // (not on a hitTest: result, which may not be a WKWebView).
+    auto dispatchMouseMove = [event, webView, isDrag] {
+        if (isDrag) {
+            auto eventPressedMouseButtonsSwizzler = makeUnique<ClassMethodSwizzler>([NSEvent class], @selector(pressedMouseButtons), reinterpret_cast<IMP>(swizzledEventPressedMouseButtons));
+            [NSApp _setCurrentEvent:event];
+            [webView mouseDragged:event];
+            [NSApp _setCurrentEvent:nil];
+        } else {
+            [NSApp _setCurrentEvent:event];
+            [webView _simulateMouseMove:event];
+            [NSApp _setCurrentEvent:nil];
+        }
+    };
+
+    if (!completionHandler) {
+        dispatchMouseMove();
+        return;
+    }
+
+    dispatch_async(mainDispatchQueueSingleton(), makeBlockPtr([dispatchMouseMove = WTF::move(dispatchMouseMove), webView, completionHandler = WTF::move(completionHandler)] mutable {
+        dispatchMouseMove();
+        [webView _doAfterProcessingAllPendingMouseEvents:makeBlockPtr([completionHandler = WTF::move(completionHandler)] mutable {
+            completionHandler();
+        }).get()];
+    }).get());
 }
 
 void EventSenderProxy::leapForward(int milliseconds)
@@ -706,8 +757,7 @@ void EventSenderProxy::keyDown(WKStringRef key, WKEventModifiers modifiers, unsi
         dispatchKeyEvents();
 
         [webView _doAfterProcessingAllPendingKeyEvents:makeBlockPtr([completionHandler = WTF::move(completionHandler)] mutable {
-            if (completionHandler)
-                completionHandler();
+            completionHandler();
         }).get()];
     }).get());
 }
@@ -978,16 +1028,5 @@ void EventSenderProxy::scaleGestureEnd(double scale)
 }
 
 #endif // ENABLE(MAC_GESTURE_EVENTS)
-
-void EventSenderProxy::waitForPendingMouseEvents()
-{
-    if (RetainPtr targetView = std::exchange(m_targetView, nullptr)) {
-        __block bool doneProcessingMouseEvents = false;
-        [checked_objc_cast<WKWebView>(targetView.get()) _doAfterProcessingAllPendingMouseEvents:^{
-            doneProcessingMouseEvents = true;
-        }];
-        m_testController->runUntil(doneProcessingMouseEvents, 100_ms);
-    }
-}
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
+++ b/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
@@ -48,6 +48,13 @@ static void waitForPendingKeyEvents(TestController* testController)
     testController->runUntil(done, 100_ms);
 }
 
+static void waitForPendingMouseEvents(TestController* testController)
+{
+    bool done = false;
+    WKPageDoAfterProcessingAllPendingMouseEvents(testController->mainWebView()->page(), &done, runPendingEventsCallback);
+    testController->runUntil(done, 100_ms);
+}
+
 LRESULT EventSenderProxy::dispatchMessage(UINT message, WPARAM wParam, LPARAM lParam)
 {
     MSG msg { };
@@ -73,7 +80,7 @@ EventSenderProxy::EventSenderProxy(TestController* testController)
 
 EventSenderProxy::~EventSenderProxy() = default;
 
-void EventSenderProxy::mouseDown(unsigned button, WKEventModifiers wkModifiers, WKStringRef pointerType)
+void EventSenderProxy::mouseDown(unsigned button, WKEventModifiers wkModifiers, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
 {
     int messageType;
     switch (button) {
@@ -97,9 +104,13 @@ void EventSenderProxy::mouseDown(unsigned button, WKEventModifiers wkModifiers, 
     }
     WPARAM wparam = 0;
     dispatchMessage(messageType, wparam, MAKELPARAM(positionInPoint().x, positionInPoint().y));
+    if (completionHandler) {
+        waitForPendingMouseEvents(m_testController);
+        completionHandler();
+    }
 }
 
-void EventSenderProxy::mouseUp(unsigned button, WKEventModifiers wkModifiers, WKStringRef pointerType)
+void EventSenderProxy::mouseUp(unsigned button, WKEventModifiers wkModifiers, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
 {
     int messageType;
     switch (button) {
@@ -123,14 +134,22 @@ void EventSenderProxy::mouseUp(unsigned button, WKEventModifiers wkModifiers, WK
     }
     WPARAM wparam = 0;
     dispatchMessage(messageType, wparam, MAKELPARAM(positionInPoint().x, positionInPoint().y));
+    if (completionHandler) {
+        waitForPendingMouseEvents(m_testController);
+        completionHandler();
+    }
 }
 
-void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType)
+void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
 {
     m_position.x = x;
     m_position.y = y;
     WPARAM wParam = m_leftMouseButtonDown ? MK_LBUTTON : 0;
     dispatchMessage(WM_MOUSEMOVE, wParam, MAKELPARAM(positionInPoint().x, positionInPoint().y));
+    if (completionHandler) {
+        waitForPendingMouseEvents(m_testController);
+        completionHandler();
+    }
 }
 
 void EventSenderProxy::mouseScrollBy(int x, int y)
@@ -385,31 +404,5 @@ void EventSenderProxy::cancelTouchPoint(int)
 {
 }
 #endif // ENABLE(TOUCH_EVENTS)
-
-struct DoAfterProcessingAllPendingMouseEventsCallbackContext {
-    bool done { false };
-    bool timedOut { false };
-};
-
-static void doAfterProcessingAllPendingMouseEventsCallback(void* userData)
-{
-    auto* context = static_cast<DoAfterProcessingAllPendingMouseEventsCallbackContext*>(userData);
-    if (context->timedOut) {
-        delete context;
-        return;
-    }
-    context->done = true;
-}
-
-void EventSenderProxy::waitForPendingMouseEvents()
-{
-    auto* context = new DoAfterProcessingAllPendingMouseEventsCallbackContext;
-    WKPageDoAfterProcessingAllPendingMouseEvents(m_testController->mainWebView()->page(), context, doAfterProcessingAllPendingMouseEventsCallback);
-    m_testController->runUntil(context->done, 100_ms);
-    if (context->done)
-        delete context;
-    else
-        context->timedOut = true;
-}
 
 } // namespace WTR


### PR DESCRIPTION
#### e90309a175b38d5306b84838b9898764527c5e2a
<pre>
Make eventSender.asyncMouse*() truly asynchronous on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=309556">https://bugs.webkit.org/show_bug.cgi?id=309556</a>

Reviewed by Charlie Wolfe.

In bug 308884 we want to make PopUpMenu use a nested event loop to make
it equivalent to how it works in the browser. This means however that
our asynchronous events need to be truly asynchronous and not block the
thread that wants to create a nested event loop.

This builds on 308928@main which made testdriver-vendor.js use the
asyncMouse*() methods and it builds on 308970@main which led the way
with asyncKeyDown().

Only macOS ends up with truly asynchronous events as a result of this
change. The other ports should be unchanged, though they now have the
infrastructure in place to move in this direction as well should they
so desire.

Canonical link: <a href="https://commits.webkit.org/309000@main">https://commits.webkit.org/309000@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3ca201c2883071e8c40e263d77b4ad741a86632

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149077 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15360 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157765 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ccbd72dc-578a-4c30-ba05-75880401888d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150950 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114931 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95690 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ef848e6-b846-4d0b-b0bd-65e8514925a4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16218 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14085 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5618 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125824 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160248 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122980 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21592 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123209 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133511 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77801 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22964 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18472 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10270 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21202 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20934 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21082 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20990 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->