### PR TITLE
[WPE] Unreviewed layout test gardening

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -4338,7 +4338,6 @@ imported/w3c/web-platform-tests/css/css-backgrounds/background-size/vector/wide-
 # Flaky tests detected both on GTK and WPE on May2023
 webkit.org/b/257624 animations/background-position.html [ ImageOnlyFailure Pass ]
 webkit.org/b/257624 http/tests/workers/service/postmessage-after-terminating-hung-worker.html [ Timeout Pass ]
-webkit.org/b/257624 imported/w3c/web-platform-tests/navigation-timing/nav2_test_redirect_xserver.html [ Failure Pass ]
 
 webkit.org/b/258162 fast/images/image-alt-text-vertical.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/navigation-timing/nav2_test_redirect_xserver-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/navigation-timing/nav2_test_redirect_xserver-expected.txt
@@ -1,8 +1,0 @@
-Description
-
-This test validates the values of the window.performance.getEntriesByType("navigation")[0].redirectCount and the window.performance.getEntriesByType("navigation")[0].redirectStart/End times for a cross-origin server side redirect navigation.
-
-
-
-PASS Navigation Timing 2 WPT
-

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/navigation-timing/nav2_test_redirect_xserver-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/navigation-timing/nav2_test_redirect_xserver-expected.txt
@@ -1,8 +1,0 @@
-Description
-
-This test validates the values of the window.performance.getEntriesByType("navigation")[0].redirectCount and the window.performance.getEntriesByType("navigation")[0].redirectStart/End times for a cross-origin server side redirect navigation.
-
-
-
-FAIL Navigation Timing 2 WPT Error: assert_equals: Expected redirectEnd to be 0. expected 0 but got 6
-


### PR DESCRIPTION
#### 90984501e7fb6917a1fc9ea30fd0f4e0e111ee56
<pre>
[WPE] Unreviewed layout test gardening

- Test &apos;nav2_test_redirect_xserver.html&apos; is no longer flaky in WebKitGTK.
- The test was failing in WPEWebKit because it had a different baseline.
- Removed both WPEWebKit and WebKitGTK baselines (WebKitGTK baseline
  was equals to the generic baseline).

Canonical link: <a href="https://commits.webkit.org/308994@main">https://commits.webkit.org/308994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/769f61e4f35b947513333bbf7ea122c00d55e0e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157726 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102468 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21629 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114896 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81801 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151998 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133756 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95655 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16183 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14048 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5576 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125787 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160208 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122950 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21553 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123177 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133474 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77749 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22960 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18434 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10233 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21163 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20895 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21043 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20951 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->