### PR TITLE
[ iOS Release ] http/tests/misc/embed-image-load-outlives-gc-without-crashing.html is a flakey timeout

### DIFF
--- a/LayoutTests/http/tests/misc/embed-image-load-outlives-gc-without-crashing.html
+++ b/LayoutTests/http/tests/misc/embed-image-load-outlives-gc-without-crashing.html
@@ -43,8 +43,8 @@ function removeTheDiv() {
 	setTimeout("forceGC();", 0);
 }
 
-requestAnimationFrame(() => {
+setTimeout(() => {
     setTimeout("removeTheDiv();", 0);
-});
+}, 0);
 
 </script>


### PR DESCRIPTION
#### bd9598e8f499bcf19441fbd4da814fd12cb50820
<pre>
[ iOS Release ] http/tests/misc/embed-image-load-outlives-gc-without-crashing.html is a flakey timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=295989">https://bugs.webkit.org/show_bug.cgi?id=295989</a>
<a href="https://rdar.apple.com/155885979">rdar://155885979</a>

Reviewed by Chris Dumez.

Based on Claude&apos;s analysis, this test flakiness comes from requestAnimationFrame sometimes not firing in iOS.
On iOS, requestAnimationFrame callbacks only fire when the compositor schedules a rendering update, which may
or may not happen after a call to requestAnimationFrame in the test.

Try replacing requestAnimationFrame with setTimeout to make it more reliable.

* LayoutTests/http/tests/misc/embed-image-load-outlives-gc-without-crashing.html:

Canonical link: <a href="https://commits.webkit.org/308977@main">https://commits.webkit.org/308977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/327ea4e3c5c34e8637f5a36e9e73159829634c46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157727 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/942302e4-b0b5-4831-a545-2a81780b7dbe) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114897 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac2de1f5-31b1-46a8-82f8-1faf7206d5c2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151999 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17087 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95656 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16186 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14049 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5577 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11682 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160209 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122951 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123178 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21562 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133475 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77750 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22951 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18447 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10234 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21164 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20896 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21044 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20952 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->