### PR TITLE
Add crash test for bug 308359

### DIFF
--- a/LayoutTests/fast/block/float/floating-first-child-button-of-select-not-cleared-expected.txt
+++ b/LayoutTests/fast/block/float/floating-first-child-button-of-select-not-cleared-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crashes.

--- a/LayoutTests/fast/block/float/floating-first-child-button-of-select-not-cleared.html
+++ b/LayoutTests/fast/block/float/floating-first-child-button-of-select-not-cleared.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<style>
+  select { flex-direction: column; }
+  button { float: left; }
+</style>
+<select id="select"></select>
+<script>
+  window.testRunner?.dumpAsText();
+  window.testRunner?.waitUntilDone();
+  select.appendChild(document.createElement("button"));
+  document.body.scrollLeft;
+  select.options.add(document.createElement("option"));
+  document.body.scrollLeft;
+  document.body.innerHTML = "PASS if no crashes.";
+  window.testRunner?.notifyDone();
+</script>


### PR DESCRIPTION
#### 733945bf30e9c82bb6413b91c9d5c0c1c6d38809
<pre>
Add crash test for bug 308359
<a href="https://bugs.webkit.org/show_bug.cgi?id=309558">https://bugs.webkit.org/show_bug.cgi?id=309558</a>

Reviewed by Alan Baradlay.

This adds a crash test for <a href="https://commits.webkit.org/308356@main">https://commits.webkit.org/308356@main</a>
where a floating first child button of a select element was later
not properly cleared. This can be reproduced by tweaking the HTML
UA style sheet with the following patch and repeating execution
of the crash test several times with ASAN or Debug builds
(e.g. by passing --repeat=50 to the run-webkit-tests script).

```
diff --git a/Source/WebCore/css/html.css b/Source/WebCore/css/html.css
index 72876e45d371..80679ee16db7 100644
--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1122,7 +1122,6 @@ select:not(:-internal-uses-menulist):enabled {

 select:not([multiple]):-internal-uses-menulist &gt; button:first-child {
     all: unset;
-    display: contents;
 }

 select::picker-icon {
```

* LayoutTests/fast/block/float/floating-first-child-button-of-select-not-cleared-expected.txt: Added.
* LayoutTests/fast/block/float/floating-first-child-button-of-select-not-cleared.html: Added.

Canonical link: <a href="https://commits.webkit.org/309046@main">https://commits.webkit.org/309046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/112dea5a27b70809b2f2246c75978b4d853cb7fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149048 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157736 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102479 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114905 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81803 "5 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152008 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133762 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95665 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16189 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14058 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5586 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125795 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11687 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160218 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13209 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122958 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123185 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33528 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21571 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133480 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77759 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18443 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10239 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21173 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20905 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21053 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->