### PR TITLE
ReadableByteStreamController should be tied to the promise it is waiting to be settled to prevent GC

### DIFF
--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
@@ -223,7 +223,7 @@ ExceptionOr<void> ReadableByteStreamController::start(JSDOMGlobalObject& globalO
         startPromise = DOMPromise::create(globalObject, *promise);
     }
 
-    handleSourcePromise(*startPromise, [weakThis = WeakPtr { *this }](auto& globalObject, auto&& error) {
+    handleSourcePromise(globalObject, *startPromise, [weakThis = WeakPtr { *this }](auto& globalObject, auto&& error) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -508,7 +508,7 @@ void ReadableByteStreamController::callPullIfNeeded(JSDOMGlobalObject& globalObj
     m_pulling = true;
 
     auto promise = m_pullAlgorithmWrapper(globalObject, *this);
-    handleSourcePromise(promise, [weakThis = WeakPtr { *this }](auto& globalObject, auto&& error) {
+    handleSourcePromise(globalObject, promise, [weakThis = WeakPtr { *this }](auto& globalObject, auto&& error) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -757,7 +757,7 @@ void ReadableByteStreamController::runCancelSteps(JSDOMGlobalObject& globalObjec
     m_queueTotalSize = 0;
 
     auto promise = m_cancelAlgorithmWrapper(globalObject, *this, reason);
-    handleSourcePromise(promise, [callback = WTF::move(callback)](auto&, auto&& reason) mutable {
+    handleSourcePromise(globalObject, promise, [callback = WTF::move(callback)](auto&, auto&& reason) mutable {
         callback(WTF::move(reason));
     });
 }
@@ -991,9 +991,10 @@ void ReadableByteStreamController::handleQueueDrain(JSDOMGlobalObject& globalObj
         callPullIfNeeded(globalObject);
 }
 
-void ReadableByteStreamController::handleSourcePromise(DOMPromise& algorithmPromise, Callback&& callback)
+void ReadableByteStreamController::handleSourcePromise(JSDOMGlobalObject& globalObject, DOMPromise& algorithmPromise, Callback&& callback)
 {
-    algorithmPromise.whenSettledWithResult([callback = WTF::move(callback)](auto* globalObject, bool isFulfilled, auto result) mutable {
+    auto thisValue = toJS(&globalObject, &globalObject, *this);
+    DOMPromise::whenPromiseIsSettled(&globalObject, algorithmPromise.promise(), [callback = WTF::move(callback)](auto* globalObject, bool isFulfilled, auto result) mutable {
         RefPtr context = globalObject ? globalObject->scriptExecutionContext() : nullptr;
         if (!context || context->activeDOMObjectsAreSuspended() || context->activeDOMObjectsAreStopped())
             return;
@@ -1002,7 +1003,7 @@ void ReadableByteStreamController::handleSourcePromise(DOMPromise& algorithmProm
             return;
         }
         callback(*globalObject, { });
-    });
+    }, thisValue.getObject());
 }
 
 template<typename Visitor>

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.h
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.h
@@ -163,7 +163,7 @@ private:
     void fillReadRequestFromQueue(JSDOMGlobalObject&, Ref<ReadableStreamReadRequest>&&);
     void handleQueueDrain(JSDOMGlobalObject&);
 
-    static void handleSourcePromise(DOMPromise&, Callback&&);
+    void handleSourcePromise(JSDOMGlobalObject&, DOMPromise&, Callback&&);
 
     WeakRef<ReadableStream> m_stream;
     bool m_pullAgain { false };

--- a/Source/WebCore/bindings/js/JSDOMPromise.cpp
+++ b/Source/WebCore/bindings/js/JSDOMPromise.cpp
@@ -42,10 +42,10 @@ auto DOMPromise::whenSettledWithResult(Function<void(JSDOMGlobalObject*, bool, J
 {
     if (isSuspended())
         return IsCallbackRegistered::No;
-    return whenPromiseIsSettled(globalObject(), promise(), WTF::move(callback));
+    return whenPromiseIsSettled(globalObject(), promise(), WTF::move(callback), nullptr);
 }
 
-auto DOMPromise::whenPromiseIsSettled(JSDOMGlobalObject* globalObject, JSC::JSPromise* promise, Function<void(JSDOMGlobalObject*, bool, JSC::JSValue)>&& callback) -> IsCallbackRegistered
+auto DOMPromise::whenPromiseIsSettled(JSDOMGlobalObject* globalObject, JSC::JSPromise* promise, Function<void(JSDOMGlobalObject*, bool, JSC::JSValue)>&& callback, JSC::JSObject* protectedWrapper) -> IsCallbackRegistered
 {
     auto& lexicalGlobalObject = *globalObject;
     auto& vm = lexicalGlobalObject.vm();
@@ -59,7 +59,12 @@ auto DOMPromise::whenPromiseIsSettled(JSDOMGlobalObject* globalObject, JSC::JSPr
         return JSC::JSValue::encode(JSC::jsUndefined());
     });
 
-    auto* thisHandler = JSC::JSBoundFunction::create(vm, globalObject, handler, promise, { }, 0, jsEmptyString(vm), JSC::makeSource("createWhenPromiseSettledFunction"_s, JSC::SourceOrigin(), JSC::SourceTaintedOrigin::Untainted));
+    JSC::MarkedArgumentBuffer boundArgs;
+    if (protectedWrapper)
+        boundArgs.append(protectedWrapper);
+    ASSERT(!boundArgs.hasOverflowed());
+
+    auto* thisHandler = JSC::JSBoundFunction::create(vm, globalObject, handler, promise, boundArgs, protectedWrapper ? 1 : 0, jsEmptyString(vm), JSC::makeSource("createWhenPromiseSettledFunction"_s, JSC::SourceOrigin(), JSC::SourceTaintedOrigin::Untainted));
     if (!thisHandler) [[unlikely]]
         return IsCallbackRegistered::No;
 

--- a/Source/WebCore/bindings/js/JSDOMPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMPromise.h
@@ -59,7 +59,7 @@ public:
     enum class Status { Pending, Fulfilled, Rejected };
     WEBCORE_EXPORT Status status() const;
 
-    static IsCallbackRegistered whenPromiseIsSettled(JSDOMGlobalObject*, JSC::JSPromise*, Function<void(JSDOMGlobalObject*, bool, JSC::JSValue)>&&);
+    static IsCallbackRegistered whenPromiseIsSettled(JSDOMGlobalObject*, JSC::JSPromise*, Function<void(JSDOMGlobalObject*, bool, JSC::JSValue)>&&, JSC::JSObject* protectedWrapper = nullptr);
 
 private:
     DOMPromise(JSDOMGlobalObject& globalObject, JSC::JSPromise& promise)


### PR DESCRIPTION
#### 1c0b52378f3ab81f863c92762edcecfaf5aa5e1a
<pre>
ReadableByteStreamController should be tied to the promise it is waiting to be settled to prevent GC
<a href="https://rdar.apple.com/171376465">rdar://171376465</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309560">https://bugs.webkit.org/show_bug.cgi?id=309560</a>

Reviewed by Chris Dumez.

When readable stream controller is waiting for a promise (start, pull or cancel callback promise), there is a risk of GC.
We make sure that the controller JS wrapper is tied to the JS function callback given to the promise so that we tie the promise and controller for GC.
This ensures that we wait for the promise to be resolved to let GC collect the controller (and stream and reader).

Covered by imported/w3c/web-platform-tests/streams/readable-byte-streams/respond-after-enqueue.any.worker.html when run with collectContinuously equal to true.

Canonical link: <a href="https://commits.webkit.org/308984@main">https://commits.webkit.org/308984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/079a7cbc874ae85f9f53303ea04582a95dd6c3ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157738 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102481 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a2576d4-9e79-4616-bd7a-bee89fce9401) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150923 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114908 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81804 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c0d1ed5-0144-41ed-b3f5-d5e02b1af503) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95668 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c92f005-fb8c-4f24-8460-467b65f303c9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16198 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14060 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5588 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125804 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11690 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160220 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3210 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13212 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122961 "Found 1 new test failure: imported/w3c/web-platform-tests/uievents/mouse/mouse_boundary_events_after_reappending_last_over_target.tentative.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18086 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123188 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33495 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133483 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77761 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18449 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10242 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21175 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84977 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20907 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21055 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20963 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->