### PR TITLE
Service worker registrations database import may delay navigations significantly

### DIFF
--- a/Source/WTF/wtf/SuspendableWorkQueue.cpp
+++ b/Source/WTF/wtf/SuspendableWorkQueue.cpp
@@ -103,6 +103,15 @@ void SuspendableWorkQueue::dispatch(Function<void()>&& function)
     });
 }
 
+void SuspendableWorkQueue::dispatchWithQOS(Function<void()>&& function, QOS qos)
+{
+    RELEASE_ASSERT(function);
+    WorkQueue::dispatchWithQOS([protectedThis = Ref { *this }, function = WTF::move(function)] {
+        protectedThis->suspendIfNeeded();
+        function();
+    }, qos);
+}
+
 void SuspendableWorkQueue::dispatchAfter(Seconds seconds, Function<void()>&& function)
 {
     RELEASE_ASSERT(function);

--- a/Source/WTF/wtf/SuspendableWorkQueue.h
+++ b/Source/WTF/wtf/SuspendableWorkQueue.h
@@ -41,6 +41,7 @@ public:
     void suspend(Function<void()>&& suspendFunction, CompletionHandler<void()>&& suspensionCompletionHandler);
     void resume();
     void dispatch(Function<void()>&&) final;
+    void dispatchWithQOS(Function<void()>&&, QOS);
     void dispatchAfter(Seconds, Function<void()>&&) final;
     void dispatchSync(Function<void()>&&) final;
     bool isSuspended() const;

--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
@@ -174,20 +174,6 @@ static HashMap<URL, ImportedScriptAttributes> stripScriptSources(const MemoryCom
     return mapWithoutScripts;
 }
 
-static MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript> populateScriptSourcesFromDisk(SWScriptStorage& scriptStorage, const ServiceWorkerRegistrationKey& registrationKey, HashMap<URL, ImportedScriptAttributes>&& map)
-{
-    MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript> importedScripts;
-    for (auto& pair : map) {
-        auto importedScript = scriptStorage.retrieve(registrationKey, pair.key);
-        if (!importedScript) {
-            RELEASE_LOG_ERROR(ServiceWorker, "RegistrationDatabase::populateScriptSourcesFromDisk: Failed to retrieve imported script for %s from disk", pair.key.string().utf8().data());
-            continue;
-        }
-        importedScripts.add(pair.key, ServiceWorkerContextData::ImportedScript { WTF::move(importedScript), WTF::move(pair.value.responseURL), WTF::move(pair.value.mimeType) });
-    }
-    return importedScripts;
-}
-
 ASCIILiteral SWRegistrationDatabase::statementString(StatementType type) const
 {
     switch (type) {
@@ -430,7 +416,8 @@ std::optional<Vector<ServiceWorkerContextData>> SWRegistrationDatabase::importRe
                 RELEASE_LOG_ERROR(ServiceWorker, "SWRegistrationDatabase::importRegistrations failed to decode scriptResourceMapWithoutScripts");
                 continue;
             }
-            scriptResourceMap = populateScriptSourcesFromDisk(scriptStorage(), *key, WTF::move(*scriptResourceMapWithoutScripts));
+            for (auto& [url, attrs] : *scriptResourceMapWithoutScripts)
+                scriptResourceMap.add(WTF::move(url), ServiceWorkerContextData::ImportedScript { ScriptBuffer(), WTF::move(attrs.responseURL), WTF::move(attrs.mimeType) });
         }
 
         auto certificateInfoDataSpan = statement->columnBlobAsSpan(12);
@@ -477,17 +464,11 @@ std::optional<Vector<ServiceWorkerContextData>> SWRegistrationDatabase::importRe
             continue;
         }
 
-        auto script = scriptStorage().retrieve(*key, scriptURL);
-        if (!script) {
-            RELEASE_LOG_ERROR(ServiceWorker, "SWRegistrationDatabase::importRegistrations failed to retrieve main script for %s from disk", scriptURL.string().utf8().data());
-            continue;
-        }
-
         auto workerIdentifier = ServiceWorkerIdentifier::generate();
         auto registrationIdentifier = ServiceWorkerRegistrationIdentifier::generate();
         auto serviceWorkerData = ServiceWorkerData { workerIdentifier, registrationIdentifier, scriptURL, ServiceWorkerState::Activated, *workerType };
         auto registration = ServiceWorkerRegistrationData { WTF::move(*key), registrationIdentifier, WTF::move(scopeURL), *updateViaCache, lastUpdateCheckTime, std::nullopt, std::nullopt, WTF::move(serviceWorkerData) };
-        auto contextData = ServiceWorkerContextData { std::nullopt, WTF::move(registration), workerIdentifier, WTF::move(script), WTF::move(*certificateInfo), WTF::move(*contentSecurityPolicy), WTF::move(*coep), WTF::move(referrerPolicy), WTF::move(scriptURL), *workerType, true, LastNavigationWasAppInitiated::Yes, WTF::move(scriptResourceMap), std::nullopt, WTF::move(*navigationPreloadState), WTF::move(*routes) };
+        auto contextData = ServiceWorkerContextData { std::nullopt, WTF::move(registration), workerIdentifier, ScriptBuffer(), WTF::move(*certificateInfo), WTF::move(*contentSecurityPolicy), WTF::move(*coep), WTF::move(referrerPolicy), WTF::move(scriptURL), *workerType, true, LastNavigationWasAppInitiated::Yes, WTF::move(scriptResourceMap), std::nullopt, WTF::move(*navigationPreloadState), WTF::move(*routes) };
 
         registrations.append(WTF::move(contextData));
     }
@@ -626,6 +607,25 @@ void SWRegistrationDatabase::deleteAllFiles()
     SQLiteFileSystem::deleteDatabaseFile(databaseFilePath(m_directory));
     FileSystem::deleteNonEmptyDirectory(scriptDirectoryPath(m_directory));
     FileSystem::deleteEmptyDirectory(m_directory);
+}
+
+std::optional<ServiceWorkerScripts> SWRegistrationDatabase::retrieveWorkerScripts(ServiceWorkerIdentifier identifier, const ServiceWorkerRegistrationKey& registrationKey, const URL& mainScriptURL, const Vector<URL>& importedScriptURLs)
+{
+    auto mainScript = scriptStorage().retrieve(registrationKey, mainScriptURL);
+    if (!mainScript) {
+        RELEASE_LOG_ERROR(ServiceWorker, "SWRegistrationDatabase::retrieveWorkerScripts failed to retrieve main script from disk");
+        return std::nullopt;
+    }
+
+    MemoryCompactRobinHoodHashMap<URL, ScriptBuffer> importedScripts;
+    for (auto& scriptURL : importedScriptURLs) {
+        if (auto script = scriptStorage().retrieve(registrationKey, scriptURL))
+            importedScripts.add(scriptURL, WTF::move(script));
+        else
+            RELEASE_LOG_ERROR(ServiceWorker, "SWRegistrationDatabase::retrieveWorkerScripts failed to retrieve imported script from disk");
+    }
+
+    return ServiceWorkerScripts { identifier, WTF::move(mainScript), WTF::move(importedScripts) };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.h
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.h
@@ -48,6 +48,7 @@ public:
     
     WEBCORE_EXPORT std::optional<Vector<ServiceWorkerContextData>> importRegistrations();
     WEBCORE_EXPORT std::optional<Vector<ServiceWorkerScripts>> updateRegistrations(const Vector<ServiceWorkerContextData>&, const Vector<ServiceWorkerRegistrationKey>&);
+    WEBCORE_EXPORT std::optional<ServiceWorkerScripts> retrieveWorkerScripts(ServiceWorkerIdentifier, const ServiceWorkerRegistrationKey&, const URL& mainScriptURL, const Vector<URL>& importedScriptURLs);
     WEBCORE_EXPORT void deleteAllFiles();
     
 private:

--- a/Source/WebCore/workers/service/server/SWRegistrationStore.h
+++ b/Source/WebCore/workers/service/server/SWRegistrationStore.h
@@ -25,10 +25,12 @@
 
 #pragma once
 
+#include <WebCore/ServiceWorkerIdentifier.h>
 #include <optional>
 #include <wtf/Forward.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/URLHash.h>
 
 namespace WebCore {
 
@@ -36,6 +38,7 @@ class SWServerRegistration;
 class ServiceWorkerRegistrationKey;
 
 struct ServiceWorkerContextData;
+struct ServiceWorkerScripts;
 
 class SWRegistrationStore : public RefCountedAndCanMakeWeakPtr<SWRegistrationStore> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(SWRegistrationStore);
@@ -47,6 +50,7 @@ public:
     virtual void importRegistrations(CompletionHandler<void(std::optional<Vector<ServiceWorkerContextData>>&&)>&&) = 0;
     virtual void updateRegistration(const ServiceWorkerContextData&) = 0;
     virtual void removeRegistration(const ServiceWorkerRegistrationKey&) = 0;
+    virtual void retrieveWorkerScripts(ServiceWorkerIdentifier, const ServiceWorkerRegistrationKey&, const URL& scriptURL, const Vector<URL>& importedScriptURLs, CompletionHandler<void(std::optional<ServiceWorkerScripts>&&)>&&) = 0;
 
 protected:
     SWRegistrationStore() = default;

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -227,11 +227,36 @@ void SWServer::addRegistrationFromStore(ServiceWorkerContextData&& data, Complet
             protectedThis->addRegistration(registration.copyRef());
 
             Ref worker = SWServerWorker::create(*protectedThis, registration, data.scriptURL, data.script, data.certificateInfo, data.contentSecurityPolicy, data.crossOriginEmbedderPolicy, WTF::move(data.referrerPolicy), data.workerType, data.serviceWorkerIdentifier, WTF::move(data.scriptResourceMap), WTF::move(data.routes));
+            worker->setNeedsScriptLoading();
             registration->updateRegistrationState(ServiceWorkerRegistrationState::Active, worker.ptr());
             worker->setState(ServiceWorkerState::Activated);
         }
         completionHandler();
     });
+}
+
+void SWServer::loadWorkerScripts(const SWServerWorker& worker, CompletionHandler<void()>&& callback)
+{
+    RefPtr store = m_registrationStore;
+    if (!store) {
+        callback();
+        return;
+    }
+
+    store->retrieveWorkerScripts(worker.identifier(), worker.registrationKey(), worker.scriptURL(), worker.importedScriptURLs(),
+        [weakThis = WeakPtr { *this }, workerIdentifier = worker.identifier(), callback = WTF::move(callback)](auto&& result) mutable {
+            RefPtr protectedThis = weakThis;
+            if (!protectedThis)
+                return callback();
+
+            if (RefPtr worker = protectedThis->workerByID(workerIdentifier)) {
+                if (result)
+                    worker->setWorkerScripts(WTF::move(result->mainScript), WTF::move(result->importedScripts));
+                else
+                    worker->didFailToLoadWorkerScripts();
+            }
+            callback();
+        });
 }
 
 void SWServer::didSaveWorkerScriptsToDisk(ServiceWorkerIdentifier serviceWorkerIdentifier, ScriptBuffer&& mainScript, MemoryCompactRobinHoodHashMap<URL, ScriptBuffer>&& importedScripts)
@@ -1053,6 +1078,16 @@ void SWServer::runServiceWorkerIfNecessary(SWServerWorker& worker, RunServiceWor
     if (worker.isTerminating()) {
         worker.whenTerminated([weakThis = WeakPtr { *this }, identifier = worker.identifier(), callback = WTF::move(callback)]() mutable {
             RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return callback(nullptr);
+            protectedThis->runServiceWorkerIfNecessary(identifier, WTF::move(callback));
+        });
+        return;
+    }
+
+    if (worker.needsScriptLoading()) {
+        loadWorkerScripts(worker, [weakThis = WeakPtr { *this }, identifier = worker.identifier(), callback = WTF::move(callback)]() mutable {
+            RefPtr protectedThis = weakThis;
             if (!protectedThis)
                 return callback(nullptr);
             protectedThis->runServiceWorkerIfNecessary(identifier, WTF::move(callback));

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -236,6 +236,7 @@ public:
     void registrationStoreImportComplete();
     void registrationStoreDatabaseFailedToOpen();
     void storeRegistrationForWorker(SWServerWorker&);
+    void loadWorkerScripts(const SWServerWorker&, CompletionHandler<void()>&&);
 
     WEBCORE_EXPORT void getOriginsWithRegistrations(CompletionHandler<void(const HashSet<SecurityOriginData>&)>&&);
 

--- a/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.cpp
@@ -100,6 +100,15 @@ void SWServerJobQueue::scriptFetchFinished(const ServiceWorkerJobDataIdentifier&
 
     registration->setLastUpdateTime(WallTime::now());
 
+    // If the newest worker needs script loading (lazy import from store), load scripts before comparison.
+    if (newestWorker && newestWorker->needsScriptLoading()) {
+        server->loadWorkerScripts(*newestWorker, [weakThis = WeakPtr { *this }, jobDataIdentifier, requestingProcessIdentifier, result = WTF::move(result)]() mutable {
+            if (CheckedPtr checkedThis = weakThis.get())
+                checkedThis->scriptFetchFinished(jobDataIdentifier, requestingProcessIdentifier, WTF::move(result));
+        });
+        return;
+    }
+
     // If newestWorker is not null, newestWorker's script url equals job's script url with the exclude fragments
     // flag set, and script's source text is a byte-for-byte match with newestWorker's script resource's source
     // text, then:

--- a/Source/WebCore/workers/service/server/SWServerJobQueue.h
+++ b/Source/WebCore/workers/service/server/SWServerJobQueue.h
@@ -39,7 +39,7 @@ class SWServerWorker;
 class ServiceWorkerJob;
 struct WorkerFetchResult;
 
-class SWServerJobQueue final : public CanMakeCheckedPtr<SWServerJobQueue> {
+class SWServerJobQueue final : public CanMakeCheckedPtr<SWServerJobQueue>, public CanMakeWeakPtr<SWServerJobQueue> {
     WTF_MAKE_TZONE_ALLOCATED(SWServerJobQueue);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SWServerJobQueue);
 public:

--- a/Source/WebCore/workers/service/server/SWServerWorker.cpp
+++ b/Source/WebCore/workers/service/server/SWServerWorker.cpp
@@ -92,7 +92,7 @@ ServiceWorkerContextData SWServerWorker::contextData() const
     RefPtr registration = m_registration.get();
     ASSERT(registration);
 
-    return { std::nullopt, registration->data(), m_data.identifier, m_script, m_certificateInfo, m_contentSecurityPolicy, m_crossOriginEmbedderPolicy, m_referrerPolicy, m_data.scriptURL, m_data.type, false, m_lastNavigationWasAppInitiated, m_scriptResourceMap, registration->serviceWorkerPageIdentifier(), registration->navigationPreloadState(), WTF::map(m_routes, [](auto& route) { return route.copy(); }) };
+    return { std::nullopt, registration->data(), m_data.identifier, script(), m_certificateInfo, m_contentSecurityPolicy, m_crossOriginEmbedderPolicy, m_referrerPolicy, m_data.scriptURL, m_data.type, false, m_lastNavigationWasAppInitiated, m_scriptResourceMap, registration->serviceWorkerPageIdentifier(), registration->navigationPreloadState(), WTF::map(m_routes, [](auto& route) { return route.copy(); }) };
 }
 
 void SWServerWorker::updateAppInitiatedValue(LastNavigationWasAppInitiated lastNavigationWasAppInitiated)
@@ -293,6 +293,18 @@ void SWServerWorker::didSaveScriptsToDisk(ScriptBuffer&& mainScript, MemoryCompa
         ASSERT(it->value.script == pair.value); // Do a memcmp to make sure the scripts are identical.
         it->value.script = WTF::move(pair.value);
     }
+}
+
+void SWServerWorker::setWorkerScripts(ScriptBuffer&& mainScript, MemoryCompactRobinHoodHashMap<URL, ScriptBuffer>&& importedScripts)
+{
+    ASSERT(m_needsScriptLoading);
+    m_script = WTF::move(mainScript);
+    for (auto& [url, script] : importedScripts) {
+        auto it = m_scriptResourceMap.find(url);
+        if (it != m_scriptResourceMap.end())
+            it->value.script = WTF::move(script);
+    }
+    m_needsScriptLoading = false;
 }
 
 void SWServerWorker::skipWaiting()

--- a/Source/WebCore/workers/service/server/SWServerWorker.h
+++ b/Source/WebCore/workers/service/server/SWServerWorker.h
@@ -88,7 +88,7 @@ public:
     const ServiceWorkerRegistrationKey& registrationKey() const LIFETIME_BOUND { return m_registrationKey; }
     RegistrableDomain firstPartyForCookies() const { return m_registrationKey.firstPartyForCookies(); }
     const URL& scriptURL() const LIFETIME_BOUND { return m_data.scriptURL; }
-    const ScriptBuffer& script() const LIFETIME_BOUND { return m_script; }
+    const ScriptBuffer& script() const LIFETIME_BOUND { ASSERT(!m_needsScriptLoading); return m_script; }
     const CertificateInfo& certificateInfo() const LIFETIME_BOUND { return m_certificateInfo; }
     WorkerType type() const { return m_data.type; }
 
@@ -112,6 +112,11 @@ public:
     void matchAll(const ServiceWorkerClientQueryOptions&, ServiceWorkerClientsMatchAllCallback&&);
     void setScriptResource(URL&&, ServiceWorkerContextData::ImportedScript&&);
     void didSaveScriptsToDisk(ScriptBuffer&& mainScript, MemoryCompactRobinHoodHashMap<URL, ScriptBuffer>&& importedScripts);
+    void setWorkerScripts(ScriptBuffer&& mainScript, MemoryCompactRobinHoodHashMap<URL, ScriptBuffer>&& importedScripts);
+
+    bool needsScriptLoading() const { return m_needsScriptLoading; }
+    void setNeedsScriptLoading() { m_needsScriptLoading = true; }
+    void didFailToLoadWorkerScripts() { m_needsScriptLoading = false; }
 
     WEBCORE_EXPORT void skipWaiting();
     bool isSkipWaitingFlagSet() const { return m_isSkipWaitingFlagSet; }
@@ -206,6 +211,7 @@ private:
     bool m_isActivateEventFired { false };
     ApproximateTime m_lastNeedRunningTime;
     Vector<ServiceWorkerRoute> m_routes;
+    bool m_needsScriptLoading { false };
 };
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
@@ -94,6 +94,14 @@ void WebSWRegistrationStore::removeRegistration(const WebCore::ServiceWorkerRegi
     scheduleUpdateIfNecessary();
 }
 
+void WebSWRegistrationStore::retrieveWorkerScripts(WebCore::ServiceWorkerIdentifier identifier, const WebCore::ServiceWorkerRegistrationKey& registrationKey, const URL& scriptURL, const Vector<URL>& importedScriptURLs, CompletionHandler<void(std::optional<WebCore::ServiceWorkerScripts>&&)>&& callback)
+{
+    if (RefPtr manager = m_manager.get())
+        manager->retrieveServiceWorkerScripts(identifier, registrationKey, scriptURL, Vector<URL> { importedScriptURLs }, WTF::move(callback));
+    else
+        callback(std::nullopt);
+}
+
 void WebSWRegistrationStore::scheduleUpdateIfNecessary()
 {
     ASSERT(RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
@@ -58,6 +58,7 @@ private:
     void importRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>&&)>&&);
     void updateRegistration(const WebCore::ServiceWorkerContextData&);
     void removeRegistration(const WebCore::ServiceWorkerRegistrationKey&);
+    void retrieveWorkerScripts(WebCore::ServiceWorkerIdentifier, const WebCore::ServiceWorkerRegistrationKey&, const URL& scriptURL, const Vector<URL>& importedScriptURLs, CompletionHandler<void(std::optional<WebCore::ServiceWorkerScripts>&&)>&&);
 
     void scheduleUpdateIfNecessary();
     void updateToStorage(CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -2179,7 +2179,9 @@ void NetworkStorageManager::importServiceWorkerRegistrations(CompletionHandler<v
     if (m_closed)
         return completionHandler(std::nullopt);
 
-    workQueue().dispatch([this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
+    RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrations: Starting import", this);
+    auto startTime = MonotonicTime::now();
+    workQueue().dispatchWithQOS([this, protectedThis = Ref { *this }, startTime, completionHandler = WTF::move(completionHandler)]() mutable {
         assertIsCurrent(workQueue());
 
         std::optional<Vector<WebCore::ServiceWorkerContextData>> result;
@@ -2199,10 +2201,15 @@ void NetworkStorageManager::importServiceWorkerRegistrations(CompletionHandler<v
                 result = WTF::move(registrations);
         }
 
-        RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), result = crossThreadCopy(WTF::move(result)), completionHandler = WTF::move(completionHandler)]() mutable {
+        RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), startTime, result = crossThreadCopy(WTF::move(result)), completionHandler = WTF::move(completionHandler)]() mutable {
+            auto elapsed = MonotonicTime::now() - startTime;
+            if (elapsed > 2_s)
+                RELEASE_LOG_ERROR(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrations: Imported %zu registrations in %.0f ms", protectedThis.ptr(), result ? result->size() : 0, elapsed.milliseconds());
+            else
+                RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrations: Imported %zu registrations in %.0f ms", protectedThis.ptr(), result ? result->size() : 0, elapsed.milliseconds());
             completionHandler(WTF::move(result));
         });
-    });
+    }, WorkQueue::QOS::UserInitiated);
 }
 
 void NetworkStorageManager::updateServiceWorkerRegistrations(Vector<WebCore::ServiceWorkerContextData>&& registrationsToUpdate, Vector<WebCore::ServiceWorkerRegistrationKey>&& registrationsToDelete, CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerScripts>>)>&& completionHandler)
@@ -2225,6 +2232,28 @@ void NetworkStorageManager::updateServiceWorkerRegistrations(Vector<WebCore::Ser
             completionHandler(WTF::move(result));
         });
     });
+}
+
+void NetworkStorageManager::retrieveServiceWorkerScripts(WebCore::ServiceWorkerIdentifier identifier, const WebCore::ServiceWorkerRegistrationKey& registrationKey, const URL& mainScriptURL, Vector<URL>&& importedScriptURLs, CompletionHandler<void(std::optional<WebCore::ServiceWorkerScripts>&&)>&& completionHandler)
+{
+    ASSERT(RunLoop::isMain());
+
+    if (m_closed)
+        return completionHandler(std::nullopt);
+
+    workQueue().dispatchWithQOS([this, protectedThis = Ref { *this }, identifier, registrationKey = crossThreadCopy(registrationKey), mainScriptURL = crossThreadCopy(mainScriptURL), importedScriptURLs = crossThreadCopy(WTF::move(importedScriptURLs)), completionHandler = WTF::move(completionHandler)]() mutable {
+        assertIsCurrent(workQueue());
+
+        std::optional<WebCore::ServiceWorkerScripts> result;
+        if (m_sharedServiceWorkerStorageManager)
+            result = m_sharedServiceWorkerStorageManager->retrieveWorkerScripts(identifier, registrationKey, mainScriptURL, importedScriptURLs);
+        else
+            result = originStorageManager(registrationKey.clientOrigin())->serviceWorkerStorageManager().retrieveWorkerScripts(identifier, registrationKey, mainScriptURL, importedScriptURLs);
+
+        RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), result = crossThreadCopy(WTF::move(result)), completionHandler = WTF::move(completionHandler)]() mutable {
+            completionHandler(WTF::move(result));
+        });
+    }, WorkQueue::QOS::UserInitiated);
 }
 
 void NetworkStorageManager::migrateServiceWorkerRegistrationsToOrigins()

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -153,6 +153,7 @@ public:
     void clearServiceWorkerRegistrations(CompletionHandler<void()>&&);
     void importServiceWorkerRegistrations(CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerContextData>>&&)>&&);
     void updateServiceWorkerRegistrations(Vector<WebCore::ServiceWorkerContextData>&&, Vector<WebCore::ServiceWorkerRegistrationKey>&&, CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerScripts>>)>&&);
+    void retrieveServiceWorkerScripts(WebCore::ServiceWorkerIdentifier, const WebCore::ServiceWorkerRegistrationKey&, const URL& mainScriptURL, Vector<URL>&& importedScriptURLs, CompletionHandler<void(std::optional<WebCore::ServiceWorkerScripts>&&)>&&);
     const String& path() const LIFETIME_BOUND { return m_pathNormalizedMainThread; }
     const String& customIDBStoragePath() const LIFETIME_BOUND { return m_customIDBStoragePathNormalizedMainThread; }
 

--- a/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.cpp
@@ -75,4 +75,12 @@ std::optional<Vector<WebCore::ServiceWorkerScripts>> ServiceWorkerStorageManager
     return std::nullopt;
 }
 
+std::optional<WebCore::ServiceWorkerScripts> ServiceWorkerStorageManager::retrieveWorkerScripts(WebCore::ServiceWorkerIdentifier identifier, const WebCore::ServiceWorkerRegistrationKey& registrationKey, const URL& mainScriptURL, const Vector<URL>& importedScriptURLs)
+{
+    if (auto database = ensureDatabase())
+        return database->retrieveWorkerScripts(identifier, registrationKey, mainScriptURL, importedScriptURLs);
+
+    return std::nullopt;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.h
@@ -40,6 +40,7 @@ public:
     void clearAllRegistrations();
     std::optional<Vector<WebCore::ServiceWorkerContextData>> importRegistrations();
     std::optional<Vector<WebCore::ServiceWorkerScripts>> updateRegistrations(const Vector<WebCore::ServiceWorkerContextData>&, const Vector<WebCore::ServiceWorkerRegistrationKey>&);
+    std::optional<WebCore::ServiceWorkerScripts> retrieveWorkerScripts(WebCore::ServiceWorkerIdentifier, const WebCore::ServiceWorkerRegistrationKey&, const URL& mainScriptURL, const Vector<URL>& importedScriptURLs);
 
 private:
     WebCore::SWRegistrationDatabase* ensureDatabase();

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -411,6 +411,76 @@ navigator.serviceWorker.register('/sw.js').then(function(reg) {
 </script>
 )SWRESOURCE"_s;
 
+static constexpr auto mainRegisteringWorkerInScopeBytes = R"SWRESOURCE(
+<script>
+try {
+function log(msg)
+{
+    window.webkit.messageHandlers.sw.postMessage(msg);
+}
+
+navigator.serviceWorker.register('/scope/sw.js').then(function(reg) {
+    if (reg.active) {
+        log("FAIL: Registration already has an active worker");
+        return;
+    }
+    worker = reg.installing;
+    worker.addEventListener('statechange', function() {
+        if (worker.state == 'activated')
+            log("PASS: Registration was successful and service worker was activated");
+    });
+}).catch(function(error) {
+    log("Registration failed with: " + error);
+});
+} catch(e) {
+    log("Exception: " + e);
+}
+</script>
+)SWRESOURCE"_s;
+
+// This page is loaded at a path OUTSIDE the service worker's scope so that the navigation does
+// not trigger runServiceWorkerIfNecessary (which would load scripts before the update check).
+// It finds the existing registration via getRegistrations(), calls update() to force an update
+// check, and verifies no new worker is installed (meaning scripts were lazy-loaded from disk and
+// matched the fetched script).
+static constexpr auto mainUpdatingRestoredWorkerBytes = R"SWRESOURCE(
+<script>
+try {
+function log(msg)
+{
+    window.webkit.messageHandlers.sw.postMessage(msg);
+}
+
+navigator.serviceWorker.getRegistrations().then(function(registrations) {
+    if (registrations.length === 0) {
+        log("FAIL: No registrations found");
+        return;
+    }
+    var reg = registrations[0];
+    if (!reg.active) {
+        log("FAIL: Registration has no active worker");
+        return;
+    }
+    reg.update().then(function() {
+        if (reg.installing) {
+            log("FAIL: Update installed a new worker, scripts should have matched");
+        } else if (reg.active) {
+            log("PASS: Update completed without installing a new worker");
+        } else {
+            log("FAIL: No active worker after update");
+        }
+    }).catch(function(error) {
+        log("FAIL: Update failed: " + error);
+    });
+}).catch(function(error) {
+    log("FAIL: getRegistrations failed: " + error);
+});
+} catch(e) {
+    log("Exception: " + e);
+}
+</script>
+)SWRESOURCE"_s;
+
 static constexpr auto mainBytesForSessionIDTest = R"SWRESOURCE(
 <script>
 
@@ -668,6 +738,83 @@ TEST(ServiceWorkers, RestoreFromDisk)
 
     configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"PASS: Registration already has an active worker"]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
+
+    webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    [webView loadRequest:server.request("/second.html"_s)];
+
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+}
+
+// This test verifies that the lazy script loading path in SWServerJobQueue::scriptFetchFinished()
+// works correctly. When service worker registrations are restored from disk, scripts are not loaded
+// during import. When an update check triggers scriptFetchFinished(), the existing worker's scripts
+// must be loaded from disk before the byte-for-byte comparison can happen. After scripts are loaded
+// and the comparison succeeds (same script), no new worker should be installed.
+//
+// Key details:
+// - The network process is terminated between phases to force a fresh import from disk
+//   (otherwise the SWServer retains registrations in memory with scripts already loaded).
+// - The SW is registered under /scope/ so the phase 2 page (at /second.html) is outside the scope,
+//   preventing the navigation from triggering runServiceWorkerIfNecessary (which would load scripts
+//   before the update check).
+// - Phase 2 uses registration.update() instead of register() to force an actual update check
+//   (register() with the same script URL takes a "directly reusable" fast path that skips the
+//   update check entirely).
+TEST(ServiceWorkers, UpdateCheckAfterRestoreFromDisk)
+{
+    [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
+
+    // Start with a clean slate data store
+    [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+
+    RetainPtr<SWMessageHandlerForRestoreFromDiskTest> messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"PASS: Registration was successful and service worker was activated"]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
+
+    TestWebKitAPI::HTTPServer server({
+        { "/scope/first.html"_s, { mainRegisteringWorkerInScopeBytes } },
+        { "/second.html"_s, { mainUpdatingRestoredWorkerBytes } },
+        { "/scope/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, scriptBytes } },
+    });
+
+    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    // Phase 1: Register a service worker under /scope/ and wait for it to activate.
+    [webView loadRequest:server.request("/scope/first.html"_s)];
+
+    TestWebKitAPI::Util::run(&done);
+
+    // Flush registrations to disk and terminate the network process so that Phase 2 will
+    // import registrations from disk (with lazy script loading) in a fresh network process.
+    [[WKWebsiteDataStore defaultDataStore] _storeServiceWorkerRegistrations:^{
+        done = true;
+    }];
+    done = false;
+    TestWebKitAPI::Util::run(&done);
+    done = false;
+
+    webView = nullptr;
+    configuration = nullptr;
+    messageHandler = nullptr;
+
+    [[WKWebsiteDataStore defaultDataStore] _terminateNetworkProcess];
+
+    // Phase 2: Create a new web view, restoring registrations from disk with lazy script loading.
+    // Navigate to /second.html which is OUTSIDE the SW scope (/scope/) so the navigation does not
+    // start the worker. The page calls registration.update() to trigger an update check which calls
+    // scriptFetchFinished(). Since the worker was restored with lazy scripts (needsScriptLoading()
+    // is true), scripts are loaded from disk before the comparison. After comparison succeeds (same
+    // script), no new worker is installed.
+    configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    messageHandler = adoptNS([[SWMessageHandlerForRestoreFromDiskTest alloc] initWithExpectedMessage:@"PASS: Update completed without installing a new worker"]);
     [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
 
     webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);


### PR DESCRIPTION
#### c824c7c2a2bea535b178a94352d064fd893ab154
<pre>
Service worker registrations database import may delay navigations significantly
<a href="https://bugs.webkit.org/show_bug.cgi?id=309559">https://bugs.webkit.org/show_bug.cgi?id=309559</a>
<a href="https://rdar.apple.com/172007435">rdar://172007435</a>

Reviewed by Youenn Fablet.

Split service worker registration import into two phases to avoid blocking
navigations on unnecessary disk I/O. Previously, importServiceWorkerRegistrations()
loaded both metadata from SQLite and script bodies from disk for every registration.

Now, phase 1 imports only metadata (with empty script buffers), allowing
registrationStoreImportComplete() to fire quickly. Script bodies are loaded lazily
from disk (phase 2) when a worker actually needs to run or when a script comparison
is needed during updates.

The import dispatch QOS is also bumped to UserInitiated since it is blocking a user
initiated navigation.

Test: ServiceWorkers.UpdateCheckAfterRestoreFromDisk

* Source/WTF/wtf/SuspendableWorkQueue.cpp:
(WTF::SuspendableWorkQueue::dispatchWithQOS):
* Source/WTF/wtf/SuspendableWorkQueue.h:
* Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp:
(WebCore::SWRegistrationDatabase::importRegistrationsImpl):
(WebCore::SWRegistrationDatabase::retrieveWorkerScripts):
(WebCore::populateScriptSourcesFromDisk): Deleted.
* Source/WebCore/workers/service/server/SWRegistrationDatabase.h:
* Source/WebCore/workers/service/server/SWRegistrationStore.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::addRegistrationFromStore):
(WebCore::SWServer::loadWorkerScripts):
(WebCore::SWServer::runServiceWorkerIfNecessary):
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebCore/workers/service/server/SWServerJobQueue.cpp:
(WebCore::SWServerJobQueue::scriptFetchFinished):
* Source/WebCore/workers/service/server/SWServerJobQueue.h:
* Source/WebCore/workers/service/server/SWServerWorker.cpp:
(WebCore::SWServerWorker::contextData const):
(WebCore::SWServerWorker::setWorkerScripts):
* Source/WebCore/workers/service/server/SWServerWorker.h:
(WebCore::SWServerWorker::needsScriptLoading const):
(WebCore::SWServerWorker::setNeedsScriptLoading):
(WebCore::SWServerWorker::didFailToLoadWorkerScripts):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp:
(WebKit::WebSWRegistrationStore::retrieveWorkerScripts):
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::importServiceWorkerRegistrations):
(WebKit::NetworkStorageManager::retrieveServiceWorkerScripts):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.cpp:
(WebKit::ServiceWorkerStorageManager::retrieveWorkerScripts):
* Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
((ServiceWorkers, UpdateCheckAfterRestoreFromDisk)):

Canonical link: <a href="https://commits.webkit.org/309165@main">https://commits.webkit.org/309165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00d9f70139f86bc3b909ba74d82e76c65a474443

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149593 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15891 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158296 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103025 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/581d2437-1b3e-42bb-a8f7-cda7ccac1e30) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115398 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82044 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/90fcf4ab-af2c-4d25-9750-883f2432a5c0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152553 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96139 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13a336b9-4ca3-4e88-b82e-89e7724e0c2c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16628 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14534 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6140 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141583 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126236 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160772 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10387 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3770 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123431 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22114 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18575 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123638 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33598 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133982 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78345 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18816 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Passed layout tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10733 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181022 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21721 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85542 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21452 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21604 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21509 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->