### PR TITLE
Make location.ancestorOrigins not return stale origins after iframe removal

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-inactive-document.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-inactive-document.sub-expected.txt
@@ -1,0 +1,4 @@
+
+PASS location.ancestorOrigins returns empty list after iframe is removed and referenced Location's relevant document is null
+PASS location.ancestorOrigins returns empty list when iframe navigated away and referenced Location's relevant document is null
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-inactive-document.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-inactive-document.sub.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Location.ancestorOrigins lifetime behavior</title>
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/browsing-the-web.html#dom-location-ancestororigins">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+      function createIframeAndNavigate(test, src) {
+        return new Promise(resolve => {
+          const iframe = document.createElement("iframe");
+          iframe.onload = () => {
+            resolve(iframe);
+          }
+          iframe.src = src;
+          document.body.appendChild(iframe);
+          test.add_cleanup(() => {
+            iframe.remove();
+          });
+        });
+      }
+
+
+      promise_test(async t => {
+        assert_implements(location.ancestorOrigins, "location.ancestorOrigins not implemented");
+        const iframe = await createIframeAndNavigate(t, "about:blank");
+        assert_array_equals(
+          iframe.contentWindow.location.ancestorOrigins,
+          [location.origin],
+          "Initial ancestorOrigins should match expected placeholder value"
+        );
+
+        const loc = iframe.contentWindow.location;
+        iframe.remove();
+
+        assert_array_equals(
+          Array.from(loc.ancestorOrigins),
+          [],
+          "ancestorOrigins should be empty after iframe removal"
+        );
+      }, "location.ancestorOrigins returns empty list after iframe is removed and referenced Location's relevant document is null");
+
+      promise_test(async t => {
+        assert_implements(location.ancestorOrigins, "location.ancestorOrigins not implemented");
+        const iframe = await createIframeAndNavigate(t, "about:blank");
+        assert_array_equals(
+          iframe.contentWindow.location.ancestorOrigins,
+          [location.origin],
+          "Initial ancestorOrigins should match expected placeholder value"
+        );
+
+        const loc = iframe.contentWindow.location;
+        await new Promise(resolve => {
+          iframe.onload = resolve;
+          iframe.src = "http://{{hosts[alt][]}}:{{ports[http][0]}}/common/blank.html";
+        });
+
+        assert_array_equals(
+          Array.from(loc.ancestorOrigins),
+          [],
+          "ancestorOrigins should be empty after iframe navigation"
+        );
+      }, "location.ancestorOrigins returns empty list when iframe navigated away and referenced Location's relevant document is null");
+    </script>
+  </body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-new-object-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-new-object-expected.txt
@@ -1,0 +1,3 @@
+
+PASS location.ancestorOrigins new object semantics
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-new-object.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-new-object.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>location.ancestorOrigins new object semantics</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe></iframe>
+<script>
+test(() => {
+  assert_implements(location.ancestorOrigins);
+  const iframe = document.querySelector('iframe');
+  const iframeLoc = iframe.contentWindow.location;
+  assert_array_equals(iframeLoc.ancestorOrigins, [window.origin]);
+  assert_equals(iframeLoc.ancestorOrigins, iframeLoc.ancestorOrigins, 'should return the same object before removing the iframe');
+  const ancestorOriginsBeforeRemoval = iframeLoc.ancestorOrigins;
+  iframe.remove();
+  assert_array_equals(iframeLoc.ancestorOrigins, []);
+  assert_not_equals(iframeLoc.ancestorOrigins, ancestorOriginsBeforeRemoval, 'should return a new object after removing the iframe');
+  assert_equals(iframeLoc.ancestorOrigins, iframeLoc.ancestorOrigins, 'should return the same object on subsequent access');
+});
+</script>

--- a/Source/WebCore/bindings/js/JSLocationCustom.cpp
+++ b/Source/WebCore/bindings/js/JSLocationCustom.cpp
@@ -28,6 +28,8 @@
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMWindowCustom.h"
 #include "WebCoreJSClientData.h"
+#include "WebCoreOpaqueRoot.h"
+#include "WebCoreOpaqueRootInlines.h"
 #include <JavaScriptCore/JSFunction.h>
 #include <JavaScriptCore/Lookup.h>
 #include <wtf/RuntimeApplicationChecks.h>
@@ -196,5 +198,14 @@ bool JSLocation::preventExtensions(JSObject*, JSGlobalObject*)
 {
     return false;
 }
+
+template<typename Visitor>
+void JSLocation::visitAdditionalChildren(Visitor& visitor)
+{
+    if (auto* ancestorOrigins = wrapped().cachedAncestorOrigins())
+        addWebCoreOpaqueRoot(visitor, WebCoreOpaqueRoot(ancestorOrigins));
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSLocation);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DOMStringList.h
+++ b/Source/WebCore/dom/DOMStringList.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "WebCoreOpaqueRoot.h"
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
@@ -68,5 +69,7 @@ private:
 
     Vector<String> m_strings;
 };
+
+inline WebCoreOpaqueRoot root(DOMStringList* list) { return WebCoreOpaqueRoot { list }; }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DOMStringList.idl
+++ b/Source/WebCore/dom/DOMStringList.idl
@@ -24,6 +24,7 @@
  */
 
 [
+    GenerateIsReachable=Impl,
     Exposed=(Window,Worker)
 ] interface DOMStringList {
     readonly attribute unsigned long length;

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -132,15 +132,20 @@ String Location::origin() const
 
 Ref<DOMStringList> Location::ancestorOrigins() const
 {
-    auto origins = DOMStringList::create();
     RefPtr frame = this->frame();
-    if (!frame)
-        return origins;
-    for (RefPtr ancestor = frame->tree().parent(); ancestor; ancestor = ancestor->tree().parent()) {
-        if (RefPtr origin = ancestor->frameDocumentSecurityOrigin())
-            origins->append(origin->toString());
+    if (!frame) {
+        if (!m_ancestorOrigins || m_ancestorOrigins->length())
+            m_ancestorOrigins = DOMStringList::create();
+        return *m_ancestorOrigins;
     }
-    return origins;
+    if (!m_ancestorOrigins) {
+        m_ancestorOrigins = DOMStringList::create();
+        for (RefPtr ancestor = frame->tree().parent(); ancestor; ancestor = ancestor->tree().parent()) {
+            if (RefPtr origin = ancestor->frameDocumentSecurityOrigin())
+                m_ancestorOrigins->append(origin->toString());
+        }
+    }
+    return *m_ancestorOrigins;
 }
 
 String Location::hash() const

--- a/Source/WebCore/page/Location.h
+++ b/Source/WebCore/page/Location.h
@@ -73,6 +73,7 @@ public:
     String toString() const { return href(); }
 
     Ref<DOMStringList> ancestorOrigins() const;
+    DOMStringList* cachedAncestorOrigins() const { return m_ancestorOrigins.get(); }
 
     DOMWindow* window() { return m_window.get(); }
 
@@ -86,6 +87,7 @@ private:
     Frame* NODELETE frame();
     const Frame* frame() const;
 
+    mutable RefPtr<DOMStringList> m_ancestorOrigins;
     WeakPtr<DOMWindow, WeakPtrImplWithEventTargetData> m_window;
 };
 

--- a/Source/WebCore/page/Location.idl
+++ b/Source/WebCore/page/Location.idl
@@ -38,6 +38,7 @@
     CustomPut,
     ExportMacro=WEBCORE_EXPORT,
     GenerateIsReachable=ReachableFromDOMWindow,
+    JSCustomMarkFunction,
     IsImmutablePrototypeExoticObject,
     LegacyUnforgeable,
     Exposed=Window
@@ -60,5 +61,5 @@
 
     readonly attribute USVString origin;
 
-    [SameObject, CachedAttribute] readonly attribute DOMStringList ancestorOrigins;
+    readonly attribute DOMStringList ancestorOrigins;
 };


### PR DESCRIPTION
#### de0ea2ba7c3a7ac888fab3e1b94716e649294599
<pre>
Make location.ancestorOrigins not return stale origins after iframe removal
<a href="https://bugs.webkit.org/show_bug.cgi?id=305922">https://bugs.webkit.org/show_bug.cgi?id=305922</a>

Reviewed by Ryosuke Niwa.

This change addresses <a href="https://github.com/whatwg/html/pull/12071">https://github.com/whatwg/html/pull/12071</a> by
removing [SameObject, CachedAttribute] from the ancestorOrigins WebIDL
and caching the DOMStringList on a member variable instead.

When the document is active, the cached list is returned. When it
becomes inactive (frame() returns null), the cached list is replaced
with an empty one — giving a new JS identity, per spec.

To keep the DOMStringList JS wrapper alive across GC (preserving identity),
this uses the “Reachable from Opaque Roots” mechanism: JSLocation’s
visitAdditionalChildren adds the cached DOMStringList as an opaque root,
and [GenerateIsReachable=Impl] on DOMStringList checks for it.

Test: imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-inactive-document.sub.html
      imported/w3c/web-platform-tests/html/browsers/history/the-location-interface/location-ancestor-origins-new-object.html

* Source/WebCore/bindings/js/JSLocationCustom.cpp:
(WebCore::JSLocation::visitAdditionalChildren):
* Source/WebCore/dom/DOMStringList.h:
(WebCore::root):
* Source/WebCore/dom/DOMStringList.idl:
* Source/WebCore/page/Location.cpp:
(WebCore::Location::ancestorOrigins):
* Source/WebCore/page/Location.h:
* Source/WebCore/page/Location.idl:

Canonical link: <a href="https://commits.webkit.org/309126@main">https://commits.webkit.org/309126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bc8f79d9cc1203eaa35b7d5af47a36f11032260

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158200 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151371 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22667 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22093 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115304 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17443 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134158 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96046 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16539 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14441 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6043 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126148 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160677 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3672 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13630 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123338 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18483 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123549 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22026 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133882 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78240 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23023 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18739 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10633 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21626 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85447 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21357 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21509 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21414 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->