### PR TITLE
Funnel backgroundColor to renderer.output.clearColor

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.cpp
@@ -88,6 +88,11 @@ void MeshImpl::setCameraDistance(float distance)
     m_backing->setCameraDistance(distance);
 }
 
+void MeshImpl::setBackgroundColor(const WebModel::Float3& color)
+{
+    m_backing->setBackgroundColor(color);
+}
+
 void MeshImpl::play(bool play)
 {
     m_backing->play(play);

--- a/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.h
@@ -74,6 +74,7 @@ private:
     std::optional<WebModel::Float4x4> entityTransform() const final;
 #endif
     void setCameraDistance(float) final;
+    void setBackgroundColor(const WebModel::Float3&) final;
     void play(bool) final;
     void setEnvironmentMap(const WebModel::ImageAsset&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -47,6 +47,7 @@ class Renderer {
     }
     var pose: _Proto_Pose_v1
     var modelDistance: Float = 1.0
+    var clearColor: MTLClearColor = .init(red: 1, green: 1, blue: 1, alpha: 1)
     let memoryOwner: task_id_token_t
 
     init(device: any MTLDevice, memoryOwner: task_id_token_t) throws {
@@ -106,7 +107,7 @@ class Renderer {
 
         renderer.cameras[0].pose = pose
         renderer.cameras[0].projection = projection
-        renderer.output.clearColor = .init(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
+        renderer.output.clearColor = clearColor
         renderer.output.color = .init(texture: texture)
         renderer.meshInstances = meshInstances
 
@@ -124,6 +125,10 @@ class Renderer {
             translation: [0, 0, distance],
             rotation: simd_quatf(angle: 0, axis: [0, 0, 1]),
         )
+    }
+
+    internal func setBackgroundColor(_ color: simd_float3) {
+        clearColor = MTLClearColor(red: Double(color.x), green: Double(color.y), blue: Double(color.z), alpha: 1)
     }
 
     internal func setCameraTransform(_ transform: CameraTransform) {

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -677,6 +677,7 @@ NS_SWIFT_SENDABLE
 - (void)updateMaterial:(WKBridgeUpdateMaterial *)descriptor completionHandler:(void (^)(void))completionHandler;
 - (void)setTransform:(simd_float4x4)transform;
 - (void)setCameraDistance:(float)distance;
+- (void)setBackgroundColor:(simd_float3)color;
 - (void)setPlaying:(BOOL)play;
 - (void)setEnvironmentMap:(WKBridgeImageAsset *)imageAsset;
 

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
@@ -112,6 +112,11 @@ void RemoteMesh::setCameraDistance(float distance)
     m_backing->setCameraDistance(distance);
 }
 
+void RemoteMesh::setBackgroundColor(const WebModel::Float3& color)
+{
+    m_backing->setBackgroundColor(color);
+}
+
 void RemoteMesh::play(bool playing)
 {
     m_backing->play(playing);

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h
@@ -39,6 +39,7 @@ namespace WebCore {
 class Mesh;
 }
 namespace WebModel {
+struct Float3;
 struct Float4x4;
 struct MaterialDescriptor;
 struct MeshDescriptor;
@@ -96,6 +97,7 @@ private:
     void updateMaterial(const WebModel::UpdateMaterialDescriptor&, CompletionHandler<void(bool)>&&);
     void updateTransform(const WebModel::Float4x4& transform);
     void setCameraDistance(float);
+    void setBackgroundColor(const WebModel::Float3&);
     void play(bool);
     void setEnvironmentMap(const WebModel::ImageAsset&);
 

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in
@@ -37,6 +37,7 @@ messages -> RemoteMesh Stream {
     void UpdateMaterial(struct WebModel::UpdateMaterialDescriptor descriptor) -> (bool success)
     void UpdateTransform(struct WebModel::Float4x4 transform)
     void SetCameraDistance(float distance)
+    void SetBackgroundColor(struct WebModel::Float3 color)
     void Play(bool playing)
     void SetEnvironmentMap(struct WebModel::ImageAsset imageAsset)
 }

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -733,6 +733,11 @@ extension WKBridgeReceiver {
     }
 
     @objc
+    func setBackgroundColor(_ color: simd_float3) {
+        appRenderer.setBackgroundColor(color)
+    }
+
+    @objc
     func setPlaying(_ play: Bool) {
         // resourceContext.setEnableModelRotation(play)
     }
@@ -1453,6 +1458,10 @@ extension WKBridgeReceiver {
 
     @objc
     func setCameraDistance(_ distance: Float) {
+    }
+
+    @objc
+    func setBackgroundColor(_ color: simd_float3) {
     }
 
     @objc

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h
@@ -68,6 +68,7 @@ public:
     void NODELETE updateMaterial(const WebModel::UpdateMaterialDescriptor&);
     void NODELETE setTransform(const simd_float4x4&);
     void setCameraDistance(float);
+    void NODELETE setBackgroundColor(const simd_float3&);
     void NODELETE setEnvironmentMap(const WebModel::ImageAsset&);
     void NODELETE play(bool);
 

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
@@ -465,6 +465,15 @@ void WebMesh::setCameraDistance(float distance)
 #endif
 }
 
+void WebMesh::setBackgroundColor(const simd_float3& color)
+{
+#if ENABLE(GPU_PROCESS_MODEL)
+    [m_receiver setBackgroundColor:color];
+#else
+    UNUSED_PARAM(color);
+#endif
+}
+
 void WebMesh::setEnvironmentMap(const WebModel::ImageAsset& imageAsset)
 {
 #if ENABLE(GPU_PROCESS_MODEL)

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
@@ -262,6 +262,16 @@ void RemoteMeshProxy::setCameraDistance(float distance)
 #endif
 }
 
+void RemoteMeshProxy::setBackgroundColor(const WebModel::Float3& color)
+{
+#if ENABLE(GPU_PROCESS_MODEL)
+    auto sendResult = send(Messages::RemoteMesh::SetBackgroundColor(color));
+    UNUSED_PARAM(sendResult);
+#else
+    UNUSED_PARAM(color);
+#endif
+}
+
 bool RemoteMeshProxy::supportsTransform(const WebCore::TransformationMatrix& transformationMatrix) const
 {
 #if ENABLE(GPU_PROCESS_MODEL)

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
@@ -106,6 +106,7 @@ private:
     bool supportsTransform(const WebCore::TransformationMatrix&) const final;
     void setScale(float) final;
     void setCameraDistance(float) final;
+    void setBackgroundColor(const WebModel::Float3&) final;
     void setStageMode(WebCore::StageModeOperation) final;
 #if ENABLE(GPU_PROCESS_MODEL)
     void setRotation(float yaw, float pitch, float roll) final;

--- a/Source/WebKit/WebProcess/Model/Mesh.h
+++ b/Source/WebKit/WebProcess/Model/Mesh.h
@@ -42,6 +42,7 @@ enum class StageModeOperation : bool;
 }
 
 namespace WebModel {
+struct Float3;
 struct Float4x4;
 struct ImageAsset;
 struct MaterialDescriptor;
@@ -75,6 +76,7 @@ public:
     virtual bool supportsTransform(const WebCore::TransformationMatrix&) const { return false; }
     virtual void setScale(float) { }
     virtual void setCameraDistance(float) = 0;
+    virtual void setBackgroundColor(const WebModel::Float3&) { }
     virtual void setStageMode(WebCore::StageModeOperation) { }
     virtual void setRotation(float, float = 0.f, float = 0.f) { }
     virtual void play(bool) = 0;

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -464,9 +464,17 @@ WebCore::ModelPlayerIdentifier WebModelPlayer::identifier() const
     return m_id;
 }
 
-void WebModelPlayer::configureGraphicsLayer(WebCore::GraphicsLayer& graphicsLayer, WebCore::ModelPlayerGraphicsLayerConfiguration&&)
+void WebModelPlayer::configureGraphicsLayer(WebCore::GraphicsLayer& graphicsLayer, WebCore::ModelPlayerGraphicsLayerConfiguration&& configuration)
 {
     graphicsLayer.setContentsDisplayDelegate(contentsDisplayDelegate(), WebCore::GraphicsLayer::ContentsLayerPurpose::Canvas);
+    if (RefPtr currentModel = m_currentModel) {
+        auto backgroundColor = configuration.backgroundColor;
+        if (backgroundColor.isValid()) {
+            auto opaqueColor = backgroundColor.opaqueColor();
+            auto [r, g, b, _a] = opaqueColor.toResolvedColorComponentsInColorSpace(WebCore::ColorSpace::LinearSRGB);
+            currentModel->setBackgroundColor(simd_make_float3(r, g, b));
+        }
+    }
 }
 
 const MachSendRight* WebModelPlayer::displayBuffer() const


### PR DESCRIPTION
#### d211184f4ade1d03ec787a2dd0afe0ed6bdd4de5
<pre>
Funnel backgroundColor to renderer.output.clearColor
<a href="https://bugs.webkit.org/show_bug.cgi?id=309501">https://bugs.webkit.org/show_bug.cgi?id=309501</a>
&lt;<a href="https://rdar.apple.com/172098623">rdar://172098623</a>&gt;

Reviewed by Mike Wyrzykowski.

Align the background color behavior between ModelProcess and WebModel.
Currently it defaults to white or takes the opaque background color
value from its style.

In the future, non-opaque colors might get composited of the CSS Canvas
color value (spec in the works).
(<a href="https://www.w3.org/TR/css-color-4/#valdef-color-canvas)">https://www.w3.org/TR/css-color-4/#valdef-color-canvas)</a>

* Source/WebKit/GPUProcess/graphics/Model/MeshImpl.cpp:
(WebKit::MeshImpl::setBackgroundColor):
* Source/WebKit/GPUProcess/graphics/Model/MeshImpl.h:
Plumbing.

* Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift:
(Renderer.clearColor):
Introduce a clearColor variable defaulting to opaque white.
Use it in the render function.
(Renderer.setBackgroundColor(_:)):
Update the clearColor.

* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp:
(WebKit::RemoteMesh::setBackgroundColor):
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h:
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in:
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(Material.setBackgroundColor(_:)):
(WKBridgeReceiver.setBackgroundColor(_:)):
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h:
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm:
(WebKit::WebMesh::setBackgroundColor):
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp:
(WebKit::RemoteMeshProxy::setBackgroundColor):
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h:
* Source/WebKit/WebProcess/Model/Mesh.h:
(WebKit::Mesh::setBackgroundColor):
Plumbing.

* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::configureGraphicsLayer):
Re-implement the logic from `WebPageHostedModelView` to extract rgb
values from the `ModelPlayerGraphicsLayerConfiguration`.

Canonical link: <a href="https://commits.webkit.org/309011@main">https://commits.webkit.org/309011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/216cd92947fe5a1135be6c822ff506476e86f2a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15350 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102498 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea8c502f-5a44-474d-8f9a-888e806276f1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22234 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21658 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114925 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81814 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27168eb9-95dd-45cd-b26c-afe7a191f691) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152027 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95684 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eb9f00ed-9737-4e30-bba2-8f46afad9a9b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16209 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14077 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5608 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125815 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160238 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3227 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13232 "Found 1 new test failure: fast/attachment/mac/wide-attachment-image-controls-basic.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122976 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21582 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123205 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33506 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21590 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133503 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77789 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18466 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10262 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21192 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84994 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20924 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21072 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20980 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->