### PR TITLE
Null dereference via structured cloning reentrancy in postMessage

### DIFF
--- a/LayoutTests/fast/dom/Window/postmessage-remove-iframe-during-clone-no-crash-expected.txt
+++ b/LayoutTests/fast/dom/Window/postmessage-remove-iframe-during-clone-no-crash-expected.txt
@@ -1,0 +1,21 @@
+Tests that removing an iframe during postMessage structured cloning does not crash. The structured clone algorithm runs JS getters, which can remove the target iframe mid-serialization.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+Testing: object getter removes iframe
+PASS object getter removes iframe did not crash.
+
+Testing: proxy ownKeys removes iframe
+PASS proxy ownKeys removes iframe did not crash.
+
+Testing: nested object deep getter removes iframe
+PASS nested object deep getter removes iframe did not crash.
+
+Testing: rapid-fire postMessage with getter
+PASS rapid-fire postMessage with getter did not crash.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/Window/postmessage-remove-iframe-during-clone-no-crash.html
+++ b/LayoutTests/fast/dom/Window/postmessage-remove-iframe-during-clone-no-crash.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("Tests that removing an iframe during postMessage structured cloning does not crash. The structured clone algorithm runs JS getters, which can remove the target iframe mid-serialization.");
+
+jsTestIsAsync = true;
+
+var testQueue = [];
+
+function queueTest(name, fn) {
+    testQueue.push({ name: name, fn: fn });
+}
+
+function runNextTest() {
+    if (!testQueue.length) {
+        finishJSTest();
+        return;
+    }
+    var test = testQueue.shift();
+    debug("");
+    debug("Testing: " + test.name);
+    test.fn(function() {
+        testPassed(test.name + " did not crash.");
+        setTimeout(runNextTest, 0);
+    });
+}
+
+function createIframe(callback) {
+    var iframe = document.createElement("iframe");
+    iframe.onload = function() { callback(iframe); };
+    document.body.appendChild(iframe);
+}
+
+// Approach 1: Object getter removes the target iframe during serialization.
+queueTest("object getter removes iframe", function(done) {
+    createIframe(function(iframe) {
+        var obj = {
+            get a() {
+                iframe.remove();
+                return 1;
+            }
+        };
+        try {
+            iframe.contentWindow.postMessage(obj, "*");
+        } catch(e) { }
+        done();
+    });
+});
+
+// Approach 2: Proxy traps remove the target iframe during serialization.
+queueTest("proxy ownKeys removes iframe", function(done) {
+    createIframe(function(iframe) {
+        var malicious = new Proxy({}, {
+            ownKeys: function() {
+                iframe.remove();
+                return ["a"];
+            },
+            getOwnPropertyDescriptor: function(target, prop) {
+                return { value: "x", writable: true, enumerable: true, configurable: true };
+            }
+        });
+        try {
+            iframe.contentWindow.postMessage(malicious, "*");
+        } catch(e) { }
+        done();
+    });
+});
+
+// Approach 3: Nested object with a deep getter removes the iframe.
+queueTest("nested object deep getter removes iframe", function(done) {
+    createIframe(function(iframe) {
+        var nested = {
+            level1: {
+                get level2() {
+                    iframe.remove();
+                    return { data: "payload" };
+                }
+            }
+        };
+        try {
+            iframe.contentWindow.postMessage(nested, "*");
+        } catch(e) { }
+        done();
+    });
+});
+
+// Approach 4: Rapid-fire postMessage calls where a getter removes the iframe.
+queueTest("rapid-fire postMessage with getter", function(done) {
+    createIframe(function(iframe) {
+        var removed = false;
+        for (var i = 0; i < 100; i++) {
+            var obj = {};
+            Object.defineProperty(obj, "prop", {
+                get: function() {
+                    if (!removed) {
+                        removed = true;
+                        iframe.remove();
+                    }
+                    return 1;
+                },
+                enumerable: true
+            });
+            try {
+                iframe.contentWindow.postMessage(obj, "*");
+            } catch(e) {
+                break;
+            }
+        }
+        done();
+    });
+});
+
+runNextTest();
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1036,6 +1036,14 @@ ExceptionOr<void> LocalDOMWindow::postMessage(JSC::JSGlobalObject& lexicalGlobal
     if (disentangledPorts.hasException())
         return disentangledPorts.releaseException();
 
+    // Serialization can run arbitrary script via getters/proxies, detaching
+    // this window. So in that case, we need to bail. But to conform to the
+    // spec, we can't bail until after port disentangling — because the spec's
+    // StructuredSerializeWithTransfer transfers ports as part of serialization.
+    // https://html.spec.whatwg.org/#window-post-message-steps (step 7).
+    if (!isCurrentlyDisplayedInFrame())
+        return { };
+
     // Capture the source of the message. We need to do this synchronously
     // in order to capture the source of the message correctly.
     Ref sourceOrigin = sourceDocument->securityOrigin();


### PR DESCRIPTION
#### b77abd4c685d1d7d44e1173043c203f6982d53bc
<pre>
Null dereference via structured cloning reentrancy in postMessage
<a href="https://bugs.webkit.org/show_bug.cgi?id=308719">https://bugs.webkit.org/show_bug.cgi?id=308719</a>

Reviewed by NOBODY (OOPS!).

Bug: postMessage() crashes with a null-pointer dereference when a
JS getter removes the target iframe during structured cloning.

Cause: postMessage() checks isCurrentlyDisplayedInFrame() before
calling SerializedScriptValue::create(), but that call runs JS
getters during structured cloning. A getter can remove the target
iframe — nulling the frame pointer. processPostMessage() then
dereferences the null frame.

Fix: Re-check isCurrentlyDisplayedInFrame() after
SerializedScriptValue::create() returns.

Test: fast/dom/Window/postmessage-remove-iframe-during-clone-no-crash.html

* LayoutTests/fast/dom/Window/postmessage-remove-iframe-during-clone-no-crash-expected.txt: Added.
* LayoutTests/fast/dom/Window/postmessage-remove-iframe-during-clone-no-crash.html: Added.
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::postMessage):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b77abd4c685d1d7d44e1173043c203f6982d53bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19742 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162104 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/106817 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155232 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26463 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118558 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83949 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/137678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99270 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/19880 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/17825 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9939 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129527 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164578 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7714 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126620 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21858 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126777 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25942 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137344 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82609 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21712 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14122 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25559 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89845 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25250 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25409 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->