### PR TITLE
[GStreamer] media/mediacapabilities/mediacapabilities-decodingInfo-spatialRendering.html is a permanent failure

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3555,8 +3555,6 @@ webkit.org/b/174242 media/video-suppress-hdr-fullscreen.html [ Skip ]
 # Requires unsupported captive portal codec and container restrictions
 webkit.org/b/242145 media/mediacapabilities/mediacapabilities-allowed-codecs.html [ Skip ]
 webkit.org/b/242145 media/mediacapabilities/mediacapabilities-allowed-containers.html [ Skip ]
-# Reports supported for <= 2 channels
-webkit.org/b/309552 media/mediacapabilities/mediacapabilities-decodingInfo-spatialRendering.html [ Failure ]
 
 # These tests require platform support.
 media/media-allowed-codecs.html [ Skip ]

--- a/Source/WebCore/platform/graphics/gstreamer/PlatformMediaEngineConfigurationFactoryGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/PlatformMediaEngineConfigurationFactoryGStreamer.cpp
@@ -59,9 +59,14 @@ void createMediaPlayerDecodingConfigurationGStreamer(PlatformMediaDecodingConfig
     PlatformMediaCapabilitiesDecodingInfo info;
     info.supported = lookupResult.isSupported;
     info.powerEfficient = lookupResult.isUsingHardware;
-    info.configuration = WTF::move(configuration);
     info.smooth = lookupResult.isSupported;
 
+    if (configuration.audio && configuration.audio->spatialRendering.value_or(false)) {
+        auto channelCount = configuration.audio->channels.toDouble();
+        info.supported &= channelCount > 2;
+    }
+
+    info.configuration = WTF::move(configuration);
     callback(WTF::move(info));
 }
 
@@ -77,5 +82,7 @@ void createMediaPlayerEncodingConfigurationGStreamer(PlatformMediaEncodingConfig
 
     callback(WTF::move(info));
 }
-}
-#endif
+
+} // namespace WebCore
+
+#endif // USE(GSTREAMER)


### PR DESCRIPTION
#### 2e671edb26754810ef3f5711a68b1b9f843ce6d6
<pre>
[GStreamer] media/mediacapabilities/mediacapabilities-decodingInfo-spatialRendering.html is a permanent failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=309552">https://bugs.webkit.org/show_bug.cgi?id=309552</a>

Reviewed by Xabier Rodriguez-Calvar.

Report audio spatial rendering as unsupported if the channel count is less or equal to two.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/PlatformMediaEngineConfigurationFactoryGStreamer.cpp:
(WebCore::createMediaPlayerDecodingConfigurationGStreamer):

Canonical link: <a href="https://commits.webkit.org/309050@main">https://commits.webkit.org/309050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7903571bdb2f48f4be6130ed66022992c9944447

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158007 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151186 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115130 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17285 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95878 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5856 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160490 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123173 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18303 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123389 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33531 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133709 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78037 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18621 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10455 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21439 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85252 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21170 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21319 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->