### PR TITLE
[JSC] Split PropertyInlineCache into subclasses

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -1152,7 +1152,11 @@ inline void CodeBlock::forEachPropertyInlineCache(Func func)
 #if ENABLE(JIT)
     if (JSC::JITCode::isOptimizingJIT(jitType())) {
 #if ENABLE(DFG_JIT)
-        for (auto* propertyCache : jitCode()->dfgCommon()->m_propertyInlineCaches) {
+        for (auto* propertyCache : jitCode()->dfgCommon()->m_handlerPropertyInlineCaches) {
+            if (func(*propertyCache) == IterationStatus::Done)
+                return;
+        }
+        for (auto* propertyCache : jitCode()->dfgCommon()->m_repatchingPropertyInlineCaches) {
             if (func(*propertyCache) == IterationStatus::Done)
                 return;
         }

--- a/Source/JavaScriptCore/bytecode/InlineAccess.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineAccess.cpp
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "config.h"
@@ -149,7 +149,7 @@ void InlineAccess::dumpCacheSizesAndCrash()
 }
 
 
-ALWAYS_INLINE static bool linkCodeInline(const char* name, CCallHelpers& jit, PropertyInlineCache& propertyCache)
+ALWAYS_INLINE static bool linkCodeInline(const char* name, CCallHelpers& jit, RepatchingPropertyInlineCache& propertyCache)
 {
     if (jit.m_assembler.buffer().codeSize() <= propertyCache.inlineCodeSize()) {
         bool needsBranchCompaction = true;
@@ -179,11 +179,12 @@ bool InlineAccess::generateSelfPropertyAccess(PropertyInlineCache& propertyCache
     if (!hasConstantIdentifier(propertyCache.accessType))
         return false;
 
-    if (propertyCache.useHandlerIC)
+    auto* repatchingIC = dynamicDowncast<RepatchingPropertyInlineCache>(propertyCache);
+    if (!repatchingIC)
         return false;
 
     CCallHelpers jit;
-    
+
     GPRReg base = propertyCache.m_baseGPR;
     JSValueRegs value = propertyCache.valueRegs();
 
@@ -198,11 +199,11 @@ bool InlineAccess::generateSelfPropertyAccess(PropertyInlineCache& propertyCache
         jit.loadPtr(CCallHelpers::Address(base, JSObject::butterflyOffset()), value.payloadGPR());
         storage = value.payloadGPR();
     }
-    
+
     jit.loadValue(
         MacroAssembler::Address(storage, offsetRelativeToBase(offset)), value);
 
-    return linkCodeInline("property access", jit, propertyCache);
+    return linkCodeInline("property access", jit, *repatchingIC);
 }
 
 ALWAYS_INLINE static GPRReg getScratchRegister(PropertyInlineCache& propertyCache)
@@ -236,7 +237,7 @@ bool InlineAccess::canGenerateSelfPropertyReplace(PropertyInlineCache& propertyC
     if (!hasConstantIdentifier(propertyCache.accessType))
         return false;
 
-    if (propertyCache.useHandlerIC)
+    if (propertyCache.isHandlerIC())
         return false;
 
     if (isInlineOffset(offset))
@@ -250,10 +251,11 @@ bool InlineAccess::generateSelfPropertyReplace(PropertyInlineCache& propertyCach
     if (!hasConstantIdentifier(propertyCache.accessType))
         return false;
 
-    ASSERT(canGenerateSelfPropertyReplace(propertyCache, offset));
-
-    if (propertyCache.useHandlerIC)
+    auto* repatchingIC = dynamicDowncast<RepatchingPropertyInlineCache>(propertyCache);
+    if (!repatchingIC)
         return false;
+
+    ASSERT(canGenerateSelfPropertyReplace(propertyCache, offset));
 
     CCallHelpers jit;
 
@@ -277,7 +279,7 @@ bool InlineAccess::generateSelfPropertyReplace(PropertyInlineCache& propertyCach
     jit.storeValue(
         value, MacroAssembler::Address(storage, offsetRelativeToBase(offset)));
 
-    return linkCodeInline("property replace", jit, propertyCache);
+    return linkCodeInline("property replace", jit, *repatchingIC);
 }
 
 bool InlineAccess::isCacheableArrayLength(PropertyInlineCache& propertyCache, JSArray* array)
@@ -287,7 +289,7 @@ bool InlineAccess::isCacheableArrayLength(PropertyInlineCache& propertyCache, JS
     if (!hasConstantIdentifier(propertyCache.accessType))
         return false;
 
-    if (propertyCache.useHandlerIC)
+    if (propertyCache.isHandlerIC())
         return propertyCache.preconfiguredCacheType == CacheType::ArrayLength;
 
     if (!hasFreeRegister(propertyCache))
@@ -303,8 +305,8 @@ bool InlineAccess::generateArrayLength(PropertyInlineCache& propertyCache, JSArr
     if (!hasConstantIdentifier(propertyCache.accessType))
         return false;
 
-    // ArrayLength fast path does not need any modification.
-    if (propertyCache.useHandlerIC)
+    auto* repatchingIC = dynamicDowncast<RepatchingPropertyInlineCache>(propertyCache);
+    if (!repatchingIC)
         return false;
 
     CCallHelpers jit;
@@ -321,7 +323,7 @@ bool InlineAccess::generateArrayLength(PropertyInlineCache& propertyCache, JSArr
     jit.load32(CCallHelpers::Address(value.payloadGPR(), ArrayStorage::lengthOffset()), value.payloadGPR());
     jit.boxInt32(value.payloadGPR(), value);
 
-    return linkCodeInline("array length", jit, propertyCache);
+    return linkCodeInline("array length", jit, *repatchingIC);
 }
 
 bool InlineAccess::isCacheableStringLength(PropertyInlineCache& propertyCache)
@@ -329,7 +331,7 @@ bool InlineAccess::isCacheableStringLength(PropertyInlineCache& propertyCache)
     if (!hasConstantIdentifier(propertyCache.accessType))
         return false;
 
-    if (propertyCache.useHandlerIC)
+    if (propertyCache.isHandlerIC())
         return propertyCache.preconfiguredCacheType == CacheType::StringLength;
 
     return hasFreeRegister(propertyCache);
@@ -342,7 +344,8 @@ bool InlineAccess::generateStringLength(PropertyInlineCache& propertyCache)
     if (!hasConstantIdentifier(propertyCache.accessType))
         return false;
 
-    if (propertyCache.useHandlerIC)
+    auto* repatchingIC = dynamicDowncast<RepatchingPropertyInlineCache>(propertyCache);
+    if (!repatchingIC)
         return false;
 
     CCallHelpers jit;
@@ -367,7 +370,7 @@ bool InlineAccess::generateStringLength(PropertyInlineCache& propertyCache)
     done.link(&jit);
     jit.boxInt32(value.payloadGPR(), value);
 
-    return linkCodeInline("string length", jit, propertyCache);
+    return linkCodeInline("string length", jit, *repatchingIC);
 }
 
 
@@ -378,7 +381,8 @@ bool InlineAccess::generateSelfInAccess(PropertyInlineCache& propertyCache, Stru
     if (!hasConstantIdentifier(propertyCache.accessType))
         return false;
 
-    if (propertyCache.useHandlerIC)
+    auto* repatchingIC = dynamicDowncast<RepatchingPropertyInlineCache>(propertyCache);
+    if (!repatchingIC)
         return false;
 
     GPRReg base = propertyCache.m_baseGPR;
@@ -390,7 +394,7 @@ bool InlineAccess::generateSelfInAccess(PropertyInlineCache& propertyCache, Stru
         MacroAssembler::TrustedImm32(std::bit_cast<uint32_t>(structure->id()))).linkThunk(propertyCache.slowPathStartLocation, &jit);
     jit.boxBoolean(true, value);
 
-    return linkCodeInline("in access", jit, propertyCache);
+    return linkCodeInline("in access", jit, *repatchingIC);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -1023,7 +1023,7 @@ void InlineCacheCompiler::restoreScratch()
 
 inline bool InlineCacheCompiler::useHandlerIC() const
 {
-    return m_propertyCache.useHandlerIC;
+    return m_propertyCache.isHandlerIC();
 }
 
 void InlineCacheCompiler::succeed()
@@ -1034,7 +1034,7 @@ void InlineCacheCompiler::succeed()
         m_jit->ret();
         return;
     }
-    if (m_propertyCache.useHandlerIC) {
+    if (m_propertyCache.isHandlerIC()) {
         m_jit->farJump(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfDoneLocation()), JSInternalPtrTag);
         return;
     }
@@ -1076,7 +1076,7 @@ const ScalarRegisterSet& InlineCacheCompiler::calculateLiveRegistersForCallAndEx
         }
 
         auto liveRegistersForCall = RegisterSet(m_liveRegistersToPreserveAtExceptionHandlingCallSite.toRegisterSet(), m_allocator->usedRegisters());
-        if (m_propertyCache.useHandlerIC)
+        if (m_propertyCache.isHandlerIC())
             liveRegistersForCall.add(m_propertyCache.m_propertyCacheGPR, IgnoreVectors);
         liveRegistersForCall.exclude(calleeSaveRegisters().includeWholeRegisterWidth());
         m_liveRegistersForCall = liveRegistersForCall.toScalarRegisterSet();
@@ -1107,7 +1107,7 @@ auto InlineCacheCompiler::preserveLiveRegistersToStackForCall(const RegisterSet&
 auto InlineCacheCompiler::preserveLiveRegistersToStackForCallWithoutExceptions() -> SpillState
 {
     RegisterSet liveRegisters = m_allocator->usedRegisters();
-    if (m_propertyCache.useHandlerIC)
+    if (m_propertyCache.isHandlerIC())
         liveRegisters.add(m_propertyCache.m_propertyCacheGPR, IgnoreVectors);
     liveRegisters.exclude(calleeSaveRegisters().includeWholeRegisterWidth());
     liveRegisters.filter(RegisterSet::allScalarRegisters());
@@ -1334,7 +1334,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByIdSlowPathCodeGenerator(VM& vm
     jit.prepareCallOperation(vm);
     jit.setupArguments<SlowOperation>(baseJSR, propertyCacheGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 1>() == propertyCacheGPR, "Needed for branch to slow operation via PropertyCache");
-    jit.call(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
+    jit.call(CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
 
     jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
 
@@ -1363,7 +1363,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByIdWithThisSlowPathCodeGenerato
     jit.prepareCallOperation(vm);
     jit.setupArguments<SlowOperation>(baseJSR, thisJSR, propertyCacheGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 2>() == propertyCacheGPR, "Needed for branch to slow operation via PropertyCache");
-    jit.call(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
+    jit.call(CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
 
     jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
 
@@ -1393,7 +1393,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValSlowPathCodeGenerator(VM& v
     jit.prepareCallOperation(vm);
     jit.setupArguments<SlowOperation>(baseJSR, propertyJSR, propertyCacheGPR, profileGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 2>() == propertyCacheGPR, "Needed for branch to slow operation via PropertyCache");
-    jit.call(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
+    jit.call(CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
 
     jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
 
@@ -1422,7 +1422,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getPrivateNameSlowPathCodeGenerator
     jit.prepareCallOperation(vm);
     jit.setupArguments<SlowOperation>(baseJSR, propertyJSR, propertyCacheGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 2>() == propertyCacheGPR, "Needed for branch to slow operation via PropertyCache");
-    jit.call(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
+    jit.call(CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
 
     jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
 
@@ -1454,7 +1454,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithThisSlowPathCodeGenerat
     jit.prepareCallOperation(vm);
     jit.setupArguments<SlowOperation>(baseJSR, propertyJSR, thisJSR, propertyCacheGPR, profileGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 3>() == propertyCacheGPR, "Needed for branch to slow operation via PropertyCache");
-    jit.call(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
+    jit.call(CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
 
     jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
 
@@ -1484,7 +1484,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByIdSlowPathCodeGenerator(VM& vm
     jit.prepareCallOperation(vm);
     jit.setupArguments<SlowOperation>(valueJSR, baseJSR, propertyCacheGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 2>() == propertyCacheGPR, "Needed for branch to slow operation via PropertyCache");
-    jit.call(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
+    jit.call(CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
 
     jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
 
@@ -1514,7 +1514,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValSlowPathCodeGenerator(VM& v
     // Call slow operation
     jit.prepareCallOperation(vm);
     jit.setupArguments<SlowOperatoin>(baseJSR, propertyJSR, valueJSR, propertyCacheGPR, profileGPR);
-    jit.call(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
+    jit.call(CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
 #if CPU(ARM_THUMB2)
     // ARMv7 clobbers metadataTable register. Thus we need to restore them back here.
     JIT::emitMaterializeMetadataAndConstantPoolRegisters(jit);
@@ -1547,7 +1547,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> instanceOfSlowPathCodeGenerator(VM&
     jit.prepareCallOperation(vm);
     jit.setupArguments<SlowOperation>(valueJSR, protoJSR, propertyCacheGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 2>() == propertyCacheGPR, "Needed for branch to slow operation via PropertyCache");
-    jit.call(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
+    jit.call(CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
 
     jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
 
@@ -1575,7 +1575,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> delByIdSlowPathCodeGenerator(VM& vm
     jit.prepareCallOperation(vm);
     jit.setupArguments<SlowOperation>(baseJSR, propertyCacheGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 1>() == propertyCacheGPR, "Needed for branch to slow operation via PropertyCache");
-    jit.call(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
+    jit.call(CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
 
     jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
 
@@ -1604,7 +1604,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> delByValSlowPathCodeGenerator(VM& v
     jit.prepareCallOperation(vm);
     jit.setupArguments<SlowOperation>(baseJSR, propertyJSR, propertyCacheGPR);
     static_assert(preferredArgumentGPR<SlowOperation, 2>() == propertyCacheGPR, "Needed for branch to slow operation via PropertyCache");
-    jit.call(CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
+    jit.call(CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), OperationPtrTag);
 
     jit.emitNonPatchableExceptionCheck(vm).linkThunk(CodeLocationLabel(vm.getCTIStub(CommonJITThunkID::HandleException).retaggedCode<NoPtrTag>()), &jit);
 
@@ -2996,7 +2996,7 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         {
             // Handle the case where we are allocating out-of-line using an operation.
             InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
-            if (m_propertyCache.useHandlerIC) {
+            if (m_propertyCache.isHandlerIC()) {
                 callSiteIndexForExceptionHandlingOrOriginal();
                 jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
             } else
@@ -3127,7 +3127,7 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         {
             // Handle the case where we are allocating out-of-line using an operation.
             InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
-            if (m_propertyCache.useHandlerIC) {
+            if (m_propertyCache.isHandlerIC()) {
                 callSiteIndexForExceptionHandlingOrOriginal();
                 jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
             } else
@@ -3323,7 +3323,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
         // exception handling call site.
         InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
 
-        if (m_propertyCache.useHandlerIC) {
+        if (m_propertyCache.isHandlerIC()) {
             callSiteIndexForExceptionHandlingOrOriginal();
             jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
         } else
@@ -3459,7 +3459,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
         // exception handling call site.
         InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
 
-        if (m_propertyCache.useHandlerIC) {
+        if (m_propertyCache.isHandlerIC()) {
             callSiteIndexForExceptionHandlingOrOriginal();
             jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
         } else
@@ -3549,7 +3549,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
         if (isGetter)
             jit.setupResults(valueRegs);
 
-        if (m_propertyCache.useHandlerIC) {
+        if (m_propertyCache.isHandlerIC()) {
             jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), scratchGPR);
             if (useHandlerIC())
                 jit.addPtr(CCallHelpers::TrustedImm32(-(sizeof(CallerFrameAndPC) + maxFrameExtentForSlowPathCall + m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), scratchGPR);
@@ -3690,7 +3690,7 @@ void InlineCacheCompiler::generateAccessCase(unsigned index, AccessCase& accessC
                 extraRegistersToPreserve.add(valueRegs, IgnoreVectors);
                 InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall(extraRegistersToPreserve);
 
-                if (m_propertyCache.useHandlerIC) {
+                if (m_propertyCache.isHandlerIC()) {
                     callSiteIndexForExceptionHandlingOrOriginal();
                     jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
                 } else
@@ -3966,7 +3966,7 @@ void InlineCacheCompiler::emitDOMJITGetter(JSGlobalObject* globalObjectForDOMJIT
     GPRReg baseGPR = m_propertyCache.m_baseGPR;
     GPRReg scratchGPR = m_scratchGPR;
 
-    if (m_propertyCache.useHandlerIC) {
+    if (m_propertyCache.isHandlerIC()) {
         callSiteIndexForExceptionHandlingOrOriginal();
         jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
     } else
@@ -4069,7 +4069,7 @@ void InlineCacheCompiler::emitDOMJITGetter(JSGlobalObject* globalObjectForDOMJIT
         usedRegisters.add(reg, IgnoreVectors);
     for (FPRReg reg : fpScratch)
         usedRegisters.add(reg, IgnoreVectors);
-    if (m_propertyCache.useHandlerIC)
+    if (m_propertyCache.isHandlerIC())
         usedRegisters.add(m_propertyCache.m_propertyCacheGPR, IgnoreVectors);
     auto registersToSpillForCCall = RegisterSet::registersToSaveForCCall(usedRegisters);
 
@@ -4125,7 +4125,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
 
     InlineCacheCompiler::SpillState spillState = preserveLiveRegistersToStackForCall();
 
-    if (m_propertyCache.useHandlerIC) {
+    if (m_propertyCache.isHandlerIC()) {
         callSiteIndexForExceptionHandlingOrOriginal();
         jit.transfer32(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCallSiteIndex()), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
     } else
@@ -4282,7 +4282,7 @@ void InlineCacheCompiler::emitProxyObjectAccess(unsigned index, AccessCase& acce
         jit.setupResults(valueRegs);
 
 
-    if (m_propertyCache.useHandlerIC) {
+    if (m_propertyCache.isHandlerIC()) {
         jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), m_scratchGPR);
         if (useHandlerIC())
             jit.addPtr(CCallHelpers::TrustedImm32(-(sizeof(CallerFrameAndPC) + maxFrameExtentForSlowPathCall + m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), m_scratchGPR);
@@ -5008,7 +5008,7 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
     m_jit = &jit;
 
     if (ASSERT_ENABLED) {
-        if (m_propertyCache.useHandlerIC) {
+        if (m_propertyCache.isHandlerIC()) {
             jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), jit.scratchRegister());
             jit.addPtr(jit.scratchRegister(), GPRInfo::callFrameRegister, jit.scratchRegister());
         } else
@@ -5162,7 +5162,7 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
         // of something that isn't patchable. The slow path will decrement "countdown" and will only
         // patch things if the countdown reaches zero. We increment the slow path count here to ensure
         // that the slow path does not try to patch.
-        if (m_propertyCache.useHandlerIC)
+        if (m_propertyCache.isHandlerIC())
             jit.add8(CCallHelpers::TrustedImm32(1), CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfCountdown()));
         else {
             jit.move(CCallHelpers::TrustedImmPtr(&m_propertyCache.countdown), m_scratchGPR);
@@ -5191,7 +5191,7 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
         InlineCacheCompiler::SpillState spillState = this->spillStateForJSCall();
         ASSERT(!spillState.isEmpty());
         jit.loadPtr(vm().addressOfCallFrameForCatch(), GPRInfo::callFrameRegister);
-        if (m_propertyCache.useHandlerIC) {
+        if (m_propertyCache.isHandlerIC()) {
             ASSERT(!JITCode::isBaselineCode(m_jitType));
             jit.loadPtr(CCallHelpers::Address(GPRInfo::jitDataRegister, BaselineJITData::offsetOfStackOffset()), m_scratchGPR);
             jit.addPtr(CCallHelpers::TrustedImm32(-(m_preservedReusedRegisterState.numberOfBytesPreserved + spillState.numberOfStackBytesUsedForRegisterPreservation)), m_scratchGPR);
@@ -5223,7 +5223,7 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
     }
 
     CodeLocationLabel<JSInternalPtrTag> successLabel = m_propertyCache.doneLocation;
-    if (m_propertyCache.useHandlerIC) {
+    if (m_propertyCache.isHandlerIC()) {
         JIT_COMMENT(jit, "failure far jump");
         failure.link(&jit);
         jit.farJump(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfSlowPathStartLocation()), JITStubRoutinePtrTag);
@@ -5239,12 +5239,12 @@ AccessGenerationResult InlineCacheCompiler::compile(const GCSafeConcurrentJSLock
     }
 
 
-    if (m_propertyCache.useHandlerIC)
+    if (m_propertyCache.isHandlerIC())
         ASSERT(m_success.empty());
 
     dataLogLnIf(InlineCacheCompilerInternal::verbose, FullCodeOrigin(codeBlock, m_propertyCache.codeOrigin), ": Generating polymorphic access stub for ", listDump(keys));
 
-    MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_propertyCache.accessType), "%s", toCString("Access stub for ", *codeBlock, " ", m_propertyCache.codeOrigin, " with start: ", m_propertyCache.startLocation, " with return point ", successLabel, ": ", listDump(keys)).data());
+    MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_propertyCache.accessType), "%s", toCString("Access stub for ", *codeBlock, " ", m_propertyCache.codeOrigin, " with start: ", downcast<RepatchingPropertyInlineCache>(m_propertyCache).startLocation, " with return point ", successLabel, ": ", listDump(keys)).data());
 
     CodeBlock* owner = codeBlock;
     FixedVector<StructureID> weakStructures(WTF::move(m_weakStructures));
@@ -6913,7 +6913,7 @@ AccessGenerationResult InlineCacheCompiler::compileHandler(const GCSafeConcurren
         return compileOneAccessCaseHandler(poly, codeBlock, *megamorphicCase, WTF::move(additionalWatchpointSets));
 
     additionalWatchpointSets.appendVector(WTF::move(sets));
-    ASSERT(m_propertyCache.useHandlerIC);
+    ASSERT(m_propertyCache.isHandlerIC());
     return compileOneAccessCaseHandler(poly, codeBlock, accessCase, WTF::move(additionalWatchpointSets));
 }
 
@@ -7729,9 +7729,9 @@ AccessGenerationResult InlineCacheCompiler::compileOneAccessCaseHandler(const Ve
     ASSERT(m_success.empty());
 
     auto keys = FixedVector<Ref<AccessCase>> { Ref { accessCase } };
-    dataLogLnIf(InlineCacheCompilerInternal::verbose, FullCodeOrigin(codeBlock, m_propertyCache.codeOrigin), ": Generating polymorphic access stub for ", listDump(keys));
+    dataLogLnIf(InlineCacheCompilerInternal::verbose, FullCodeOrigin(codeBlock, m_propertyCache.codeOrigin), ": Generating polymorphic access stub handler for ", listDump(keys));
 
-    MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_propertyCache.accessType), "%s", toCString("Access stub for ", *codeBlock, " ", m_propertyCache.codeOrigin, " with start: ", m_propertyCache.startLocation, ": ", listDump(keys)).data());
+    MacroAssemblerCodeRef<JITStubRoutinePtrTag> code = FINALIZE_CODE_FOR(codeBlock, linkBuffer, JITStubRoutinePtrTag, categoryName(m_propertyCache.accessType), "%s", toCString("Access stub handler for ", *codeBlock, " ", m_propertyCache.codeOrigin, ": ", listDump(keys)).data());
 
     if (statelessType) {
         auto stub = createPreCompiledICJITStubRoutine(WTF::move(code), vm, codeBlock);

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.cpp
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "config.h"
@@ -83,13 +83,16 @@ void PropertyInlineCache::initInByIdSelf(const ConcurrentJSLockerBase& locker, C
 
 void PropertyInlineCache::deref()
 {
-    m_stub.reset();
+    if (auto* repatchingIC = dynamicDowncast<RepatchingPropertyInlineCache>(*this))
+        repatchingIC->m_stub.reset();
 }
 
 void PropertyInlineCache::aboutToDie()
 {
-    if (m_inlinedHandler)
-        m_inlinedHandler->aboutToDie();
+    if (auto* handlerIC = dynamicDowncast<HandlerPropertyInlineCache>(*this)) {
+        if (handlerIC->m_inlinedHandler)
+            handlerIC->m_inlinedHandler->aboutToDie();
+    }
 
     if (auto* cursor = m_handler.get()) {
         while (cursor) {
@@ -154,7 +157,7 @@ AccessGenerationResult PropertyInlineCache::addAccessCase(const GCSafeConcurrent
     AccessGenerationResult result = ([&](Ref<AccessCase>&& accessCase) -> AccessGenerationResult {
         dataLogLnIf(PropertyInlineCacheInternal::verbose, "Adding access case: ", accessCase);
 
-        if (useHandlerIC) {
+        if (is<HandlerPropertyInlineCache>(*this)) {
             auto list = listedAccessCases(locker);
             auto result = upgradeForPolyProtoIfNecessary(locker, vm, codeBlock, list, accessCase.get());
             dataLogLnIf(PropertyInlineCacheInternal::verbose, "Had stub, result: ", result);
@@ -182,10 +185,10 @@ AccessGenerationResult PropertyInlineCache::addAccessCase(const GCSafeConcurrent
             return compiler.compileHandler(locker, WTF::move(list), codeBlock, accessCase.get());
         }
 
-        ASSERT(!useHandlerIC);
+        auto& repatchingIC = downcast<RepatchingPropertyInlineCache>(*this);
         AccessGenerationResult result;
-        if (m_stub) {
-            result = m_stub->addCases(locker, vm, codeBlock, *this, nullptr, accessCase);
+        if (repatchingIC.m_stub) {
+            result = repatchingIC.m_stub->addCases(locker, vm, codeBlock, *this, nullptr, accessCase);
             dataLogLnIf(PropertyInlineCacheInternal::verbose, "Had stub, result: ", result);
 
             if (result.shouldResetStubAndFireWatchpoints())
@@ -210,7 +213,7 @@ AccessGenerationResult PropertyInlineCache::addAccessCase(const GCSafeConcurrent
             }
 
             setCacheType(locker, CacheType::Stub);
-            m_stub = WTF::move(access);
+            repatchingIC.m_stub = WTF::move(access);
         }
 
         ASSERT(m_cacheType == CacheType::Stub);
@@ -235,26 +238,23 @@ AccessGenerationResult PropertyInlineCache::addAccessCase(const GCSafeConcurrent
         clearBufferedStructures();
 
         InlineCacheCompiler compiler(codeBlock->jitType(), vm, globalObject, ecmaMode, *this);
-        result = compiler.compile(locker, *m_stub, codeBlock);
+        result = compiler.compile(locker, *repatchingIC.m_stub, codeBlock);
 
         dataLogLnIf(PropertyInlineCacheInternal::verbose, "Regeneration result: ", result);
 
         RELEASE_ASSERT(!result.buffered());
-        
+
         if (!result.generatedSomeCode())
             return result;
 
-        // If we are using DataIC, we will continue using inlined code for the first case.
-        if (!useHandlerIC) {
-            // When we first transition to becoming a Stub, we might still be running the inline
-            // access code. That's because when we first transition to becoming a Stub, we may
-            // be buffered, and we have not yet generated any code. Once the Stub finally generates
-            // code, we're no longer running the inline access code, so we can then clear out
-            // m_inlineAccessBaseStructureID. The reason we don't clear m_inlineAccessBaseStructureID while
-            // we're buffered is because we rely on it to reset during GC if m_inlineAccessBaseStructureID
-            // is collected.
-            m_inlineAccessBaseStructureID.clear();
-        }
+        // Repatching IC: When we first transition to becoming a Stub, we might still be running the inline
+        // access code. That's because when we first transition to becoming a Stub, we may
+        // be buffered, and we have not yet generated any code. Once the Stub finally generates
+        // code, we're no longer running the inline access code, so we can then clear out
+        // m_inlineAccessBaseStructureID. The reason we don't clear m_inlineAccessBaseStructureID while
+        // we're buffered is because we rely on it to reset during GC if m_inlineAccessBaseStructureID
+        // is collected.
+        m_inlineAccessBaseStructureID.clear();
 
         // If we generated some code then we don't want to attempt to repatch in the future until we
         // gather enough cases.
@@ -262,7 +262,7 @@ AccessGenerationResult PropertyInlineCache::addAccessCase(const GCSafeConcurrent
         return result;
     })(accessCase.releaseNonNull());
     if (result.generatedSomeCode()) {
-        if (useHandlerIC)
+        if (is<HandlerPropertyInlineCache>(*this))
             prependHandler(codeBlock, Ref { *result.handler() }, result.generatedMegamorphicCode());
         else
             rewireStubAsJumpInAccess(codeBlock, Ref { *result.handler() });
@@ -276,8 +276,10 @@ void PropertyInlineCache::reset(const ConcurrentJSLockerBase& locker, CodeBlock*
 {
     clearBufferedStructures();
     m_inlineAccessBaseStructureID.clear();
-    if (m_inlinedHandler)
-        clearInlinedHandler(codeBlock);
+    if (auto* handlerIC = dynamicDowncast<HandlerPropertyInlineCache>(*this)) {
+        if (handlerIC->m_inlinedHandler)
+            handlerIC->clearInlinedHandler(codeBlock);
+    }
 
     if (m_cacheType == CacheType::Unset)
         return;
@@ -401,8 +403,10 @@ void PropertyInlineCache::visitAggregateImpl(Visitor& visitor)
     } else
         m_identifier.visitAggregate(visitor);
 
-    if (m_inlinedHandler)
-        m_inlinedHandler->visitAggregate(visitor);
+    if (auto* handlerIC = dynamicDowncast<HandlerPropertyInlineCache>(*this)) {
+        if (handlerIC->m_inlinedHandler)
+            handlerIC->m_inlinedHandler->visitAggregate(visitor);
+    }
     if (auto* cursor = m_handler.get()) {
         while (cursor) {
             cursor->visitAggregate(visitor);
@@ -410,8 +414,10 @@ void PropertyInlineCache::visitAggregateImpl(Visitor& visitor)
         }
     }
 
-    if (m_stub)
-        m_stub->visitAggregate(visitor);
+    if (auto* repatchingIC = dynamicDowncast<RepatchingPropertyInlineCache>(*this)) {
+        if (repatchingIC->m_stub)
+            repatchingIC->m_stub->visitAggregate(visitor);
+    }
 }
 
 DEFINE_VISIT_AGGREGATE(PropertyInlineCache);
@@ -439,8 +445,10 @@ void PropertyInlineCache::visitWeak(const ConcurrentJSLockerBase& locker, CodeBl
     if (Structure* structure = inlineAccessBaseStructure())
         isValid &= vm.heap.isMarked(structure);
 
-    if (m_inlinedHandler)
-        isValid &= m_inlinedHandler->visitWeak(vm);
+    if (auto* handlerIC = dynamicDowncast<HandlerPropertyInlineCache>(*this)) {
+        if (handlerIC->m_inlinedHandler)
+            isValid &= handlerIC->m_inlinedHandler->visitWeak(vm);
+    }
     if (auto* cursor = m_handler.get()) {
         while (cursor) {
             isValid &= cursor->visitWeak(vm);
@@ -448,8 +456,10 @@ void PropertyInlineCache::visitWeak(const ConcurrentJSLockerBase& locker, CodeBl
         }
     }
 
-    if (m_stub)
-        isValid &= m_stub->visitWeak(vm);
+    if (auto* repatchingIC = dynamicDowncast<RepatchingPropertyInlineCache>(*this)) {
+        if (repatchingIC->m_stub)
+            isValid &= repatchingIC->m_stub->visitWeak(vm);
+    }
 
     if (isValid)
         return;
@@ -464,18 +474,18 @@ void PropertyInlineCache::propagateTransitions(Visitor& visitor)
     if (Structure* structure = inlineAccessBaseStructure())
         structure->markIfCheap(visitor);
 
-    if (useHandlerIC) {
-        if (m_inlinedHandler)
-            m_inlinedHandler->propagateTransitions(visitor);
+    if (auto* handlerIC = dynamicDowncast<HandlerPropertyInlineCache>(*this)) {
+        if (handlerIC->m_inlinedHandler)
+            handlerIC->m_inlinedHandler->propagateTransitions(visitor);
         if (auto* cursor = m_handler.get()) {
             while (cursor) {
                 cursor->propagateTransitions(visitor);
                 cursor = cursor->next();
             }
         }
-    } else {
-        if (m_stub)
-            m_stub->propagateTransitions(visitor);
+    } else if (auto* repatchingIC = dynamicDowncast<RepatchingPropertyInlineCache>(*this)) {
+        if (repatchingIC->m_stub)
+            repatchingIC->m_stub->propagateTransitions(visitor);
     }
 }
 
@@ -484,25 +494,26 @@ template void PropertyInlineCache::propagateTransitions(SlotVisitor&);
 
 CallLinkInfo* PropertyInlineCache::callLinkInfoAt(const ConcurrentJSLocker& locker, unsigned index, const AccessCase& accessCase)
 {
-    if (!useHandlerIC) {
-        if (!m_handler)
-            return nullptr;
-        return m_handler->callLinkInfoAt(locker, index);
-    }
-
-    if (m_inlinedHandler) {
-        if (m_inlinedHandler->accessCase() == &accessCase)
-            return m_inlinedHandler->callLinkInfoAt(locker, 0);
-    }
-
-    if (auto* cursor = m_handler.get()) {
-        while (cursor) {
-            if (cursor->accessCase() == &accessCase)
-                return cursor->callLinkInfoAt(locker, 0);
-            cursor = cursor->next();
+    if (auto* handlerIC = dynamicDowncast<HandlerPropertyInlineCache>(*this)) {
+        if (handlerIC->m_inlinedHandler) {
+            if (handlerIC->m_inlinedHandler->accessCase() == &accessCase)
+                return handlerIC->m_inlinedHandler->callLinkInfoAt(locker, 0);
         }
+
+        if (auto* cursor = m_handler.get()) {
+            while (cursor) {
+                if (cursor->accessCase() == &accessCase)
+                    return cursor->callLinkInfoAt(locker, 0);
+                cursor = cursor->next();
+            }
+        }
+        return nullptr;
     }
-    return nullptr;
+
+    // Repatching IC path
+    if (!m_handler)
+        return nullptr;
+    return m_handler->callLinkInfoAt(locker, index);
 }
 
 PropertyInlineCacheSummary PropertyInlineCache::summary(const ConcurrentJSLocker& locker, VM& vm) const
@@ -534,10 +545,10 @@ PropertyInlineCacheSummary PropertyInlineCache::summary(const ConcurrentJSLocker
 
     if (tookSlowPath || sawNonCell)
         return takesSlowPath;
-    
+
     if (!everConsidered)
         return PropertyInlineCacheSummary::NoInformation;
-    
+
     return simple;
 }
 
@@ -545,7 +556,7 @@ PropertyInlineCacheSummary PropertyInlineCache::summary(const ConcurrentJSLocker
 {
     if (!propertyCache)
         return PropertyInlineCacheSummary::NoInformation;
-    
+
     return propertyCache->summary(locker, vm);
 }
 
@@ -598,7 +609,7 @@ static CodePtr<OperationPtrTag> slowOperationFromUnlinkedPropertyInlineCache(con
         return operationGetByValWithThisOptimize;
     case AccessType::HasPrivateName:
         return operationHasPrivateNameOptimize;
-    case AccessType::HasPrivateBrand: 
+    case AccessType::HasPrivateBrand:
         return operationHasPrivateBrandOptimize;
     case AccessType::GetPrivateName:
         return operationGetPrivateNameOptimize;
@@ -802,7 +813,7 @@ void PropertyInlineCache::initializePredefinedRegisters()
     }
 }
 
-void PropertyInlineCache::initializeFromUnlinkedPropertyInlineCache(VM& vm, CodeBlock* codeBlock, const BaselineUnlinkedPropertyInlineCache& unlinkedPropertyCache)
+void HandlerPropertyInlineCache::initializeFromUnlinkedPropertyInlineCache(VM& vm, CodeBlock* codeBlock, const BaselineUnlinkedPropertyInlineCache& unlinkedPropertyCache)
 {
     ASSERT(!isCompilationThread());
     accessType = unlinkedPropertyCache.accessType;
@@ -819,7 +830,6 @@ void PropertyInlineCache::initializeFromUnlinkedPropertyInlineCache(VM& vm, Code
     m_globalObject = codeBlock->globalObject();
     callSiteIndex = CallSiteIndex(BytecodeIndex(unlinkedPropertyCache.bytecodeIndex.offset()));
     codeOrigin = CodeOrigin(unlinkedPropertyCache.bytecodeIndex);
-    useHandlerIC = true;
     initializeWithUnitHandler(codeBlock, InlineCacheCompiler::generateSlowPathHandler(vm, accessType));
     propertyIsInt32 = unlinkedPropertyCache.propertyIsInt32;
     canBeMegamorphic = unlinkedPropertyCache.canBeMegamorphic;
@@ -834,7 +844,7 @@ void PropertyInlineCache::initializeFromUnlinkedPropertyInlineCache(VM& vm, Code
 }
 
 #if ENABLE(DFG_JIT)
-void PropertyInlineCache::initializeFromDFGUnlinkedPropertyInlineCache(CodeBlock* codeBlock, const DFG::UnlinkedPropertyInlineCache& unlinkedPropertyCache)
+void HandlerPropertyInlineCache::initializeFromDFGUnlinkedPropertyInlineCache(CodeBlock* codeBlock, const DFG::UnlinkedPropertyInlineCache& unlinkedPropertyCache)
 {
     ASSERT(!isCompilationThread());
     accessType = unlinkedPropertyCache.accessType;
@@ -854,7 +864,6 @@ void PropertyInlineCache::initializeFromDFGUnlinkedPropertyInlineCache(CodeBlock
         m_globalObject = baselineCodeBlockForInlineCallFrame(codeOrigin.inlineCallFrame())->globalObject();
     else
         m_globalObject = codeBlock->globalObject();
-    useHandlerIC = true;
     initializeWithUnitHandler(codeBlock, InlineCacheCompiler::generateSlowPathHandler(codeBlock->vm(), accessType));
 
     propertyIsInt32 = unlinkedPropertyCache.propertyIsInt32;
@@ -873,7 +882,7 @@ void PropertyInlineCache::initializeFromDFGUnlinkedPropertyInlineCache(CodeBlock
 }
 #endif
 
-void PropertyInlineCache::setInlinedHandler(CodeBlock* codeBlock, Ref<InlineCacheHandler>&& handler)
+void HandlerPropertyInlineCache::setInlinedHandler(CodeBlock* codeBlock, Ref<InlineCacheHandler>&& handler)
 {
     ASSERT(!m_inlinedHandler);
     VM& vm = codeBlock->vm();
@@ -910,9 +919,8 @@ void PropertyInlineCache::setInlinedHandler(CodeBlock* codeBlock, Ref<InlineCach
     }
 }
 
-void PropertyInlineCache::clearInlinedHandler(CodeBlock* codeBlock)
+void HandlerPropertyInlineCache::clearInlinedHandler(CodeBlock* codeBlock)
 {
-    ASSERT(useHandlerIC);
     m_inlinedHandler->removeOwner(codeBlock);
     m_inlinedHandler = nullptr;
     m_inlineAccessBaseStructureID.clear();
@@ -920,31 +928,30 @@ void PropertyInlineCache::clearInlinedHandler(CodeBlock* codeBlock)
 
 void PropertyInlineCache::initializeWithUnitHandler(CodeBlock* codeBlock, Ref<InlineCacheHandler>&& handler)
 {
-    if (useHandlerIC) {
-        if (m_inlinedHandler)
-            clearInlinedHandler(codeBlock);
-        ASSERT(!m_inlinedHandler);
+    if (auto* handlerIC = dynamicDowncast<HandlerPropertyInlineCache>(*this)) {
+        if (handlerIC->m_inlinedHandler)
+            handlerIC->clearInlinedHandler(codeBlock);
+        ASSERT(!handlerIC->m_inlinedHandler);
         if (m_handler)
             m_handler->removeOwner(codeBlock);
         m_handler = WTF::move(handler);
         m_handler->addOwner(codeBlock);
     } else {
-        ASSERT(!m_inlinedHandler);
         m_handler = WTF::move(handler);
     }
 }
 
 void PropertyInlineCache::prependHandler(CodeBlock* codeBlock, Ref<InlineCacheHandler>&& handler, bool isMegamorphic)
 {
-    ASSERT(useHandlerIC);
+    auto& handlerIC = downcast<HandlerPropertyInlineCache>(*this);
     if (isMegamorphic) {
         initializeWithUnitHandler(codeBlock, WTF::move(handler));
         return;
     }
 
-    if (!m_inlinedHandler) {
+    if (!handlerIC.m_inlinedHandler) {
         if (preconfiguredCacheType != CacheType::Unset && preconfiguredCacheType == handler->cacheType()) {
-            setInlinedHandler(codeBlock, WTF::move(handler));
+            handlerIC.setInlinedHandler(codeBlock, WTF::move(handler));
             return;
         }
     }
@@ -956,17 +963,17 @@ void PropertyInlineCache::prependHandler(CodeBlock* codeBlock, Ref<InlineCacheHa
 
 void PropertyInlineCache::rewireStubAsJumpInAccess(CodeBlock* codeBlock, Ref<InlineCacheHandler>&& handler)
 {
+    ASSERT(!isHandlerIC());
     CodeLocationLabel label { handler->callTarget() };
     initializeWithUnitHandler(codeBlock, WTF::move(handler));
-    if (!useHandlerIC)
-        CCallHelpers::replaceWithJump(startLocation.retagged<JSInternalPtrTag>(), label);
+    CCallHelpers::replaceWithJump(downcast<RepatchingPropertyInlineCache>(*this).startLocation.retagged<JSInternalPtrTag>(), label);
 }
 
 void PropertyInlineCache::resetStubAsJumpInAccess(CodeBlock* codeBlock)
 {
-    if (useHandlerIC) {
-        if (m_inlinedHandler)
-            clearInlinedHandler(codeBlock);
+    if (auto* handlerIC = dynamicDowncast<HandlerPropertyInlineCache>(*this)) {
+        if (handlerIC->m_inlinedHandler)
+            handlerIC->clearInlinedHandler(codeBlock);
         auto* cursor = m_handler.get();
         while (cursor) {
             cursor->removeOwner(codeBlock);
@@ -982,15 +989,19 @@ void PropertyInlineCache::resetStubAsJumpInAccess(CodeBlock* codeBlock)
 Vector<AccessCase*, 16> PropertyInlineCache::listedAccessCases(const AbstractLocker&) const
 {
     Vector<AccessCase*, 16> cases;
-    if (m_stub) {
-        for (unsigned i = 0; i < m_stub->size(); ++i)
-            cases.append(&m_stub->at(i));
-        return cases;
+    if (auto* repatchingIC = dynamicDowncast<RepatchingPropertyInlineCache>(*this)) {
+        if (repatchingIC->m_stub) {
+            for (unsigned i = 0; i < repatchingIC->m_stub->size(); ++i)
+                cases.append(&repatchingIC->m_stub->at(i));
+            return cases;
+        }
     }
 
-    if (m_inlinedHandler) {
-        if (auto* access = m_inlinedHandler->accessCase())
-            cases.append(access);
+    if (auto* handlerIC = dynamicDowncast<HandlerPropertyInlineCache>(*this)) {
+        if (handlerIC->m_inlinedHandler) {
+            if (auto* access = handlerIC->m_inlinedHandler->accessCase())
+                cases.append(access);
+        }
     }
 
     if (auto* cursor = m_handler.get()) {

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCache.h
@@ -20,7 +20,7 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #pragma once
@@ -42,9 +42,10 @@
 #include <wtf/Lock.h>
 #include <wtf/TZoneMalloc.h>
 
-namespace JSC {
 
 #if ENABLE(JIT)
+
+namespace JSC {
 
 namespace DFG {
 struct UnlinkedPropertyInlineCache;
@@ -98,23 +99,18 @@ enum class AccessType : int8_t {
 static constexpr unsigned numberOfAccessTypes = 0 JSC_FOR_EACH_PROPERTY_INLINE_CACHE_ACCESS_TYPE(JSC_INCREMENT_ACCESS_TYPE);
 #undef JSC_INCREMENT_ACCESS_TYPE
 
+enum class PropertyInlineCacheType : uint8_t { Handler, Repatching };
+
 struct UnlinkedPropertyInlineCache;
 struct BaselineUnlinkedPropertyInlineCache;
+
+class HandlerPropertyInlineCache;
+class RepatchingPropertyInlineCache;
 
 class PropertyInlineCache {
     WTF_MAKE_NONCOPYABLE(PropertyInlineCache);
     WTF_MAKE_TZONE_ALLOCATED(PropertyInlineCache);
 public:
-    PropertyInlineCache(AccessType accessType, CodeOrigin codeOrigin)
-        : codeOrigin(codeOrigin)
-        , accessType(accessType)
-        , bufferingCountdown(Options::initialRepatchBufferingCountdown())
-    {
-    }
-
-    PropertyInlineCache()
-        : PropertyInlineCache(AccessType::GetById, { })
-    { }
 
     ~PropertyInlineCache();
 
@@ -131,8 +127,6 @@ public:
     void deref();
     void aboutToDie();
 
-    void initializeFromUnlinkedPropertyInlineCache(VM&, CodeBlock*, const BaselineUnlinkedPropertyInlineCache&);
-    void initializeFromDFGUnlinkedPropertyInlineCache(CodeBlock*, const DFG::UnlinkedPropertyInlineCache&);
     void initializePredefinedRegisters();
 
     DECLARE_VISIT_AGGREGATE;
@@ -140,26 +134,17 @@ public:
     // Check if the stub has weak references that are dead. If it does, then it resets itself,
     // either entirely or just enough to ensure that those dead pointers don't get used anymore.
     void visitWeak(const ConcurrentJSLockerBase&, CodeBlock*);
-    
+
     // This returns true if it has marked everything that it will ever mark.
     template<typename Visitor> void propagateTransitions(Visitor&);
-        
+
     PropertyInlineCacheSummary summary(const ConcurrentJSLocker&, VM&) const;
-    
+
     static PropertyInlineCacheSummary summary(const ConcurrentJSLocker&, VM&, const PropertyInlineCache*);
 
     CacheableIdentifier identifier() const { return m_identifier; }
 
     bool containsPC(void* pc) const;
-
-    uint32_t inlineCodeSize() const
-    {
-        if (useHandlerIC)
-            return 0;
-        int32_t inlineSize = MacroAssembler::differenceBetweenCodePtr(startLocation, doneLocation);
-        ASSERT(inlineSize >= 0);
-        return inlineSize;
-    }
 
     JSValueRegs valueRegs() const
     {
@@ -189,6 +174,8 @@ public:
     }
 
     bool thisValueIsInExtraGPR() const { return accessType == AccessType::GetByIdWithThis || accessType == AccessType::GetByValWithThis; }
+
+    bool isHandlerIC() const { return m_icType == PropertyInlineCacheType::Handler; }
 
 #if ASSERT_ENABLED
     void checkConsistency();
@@ -241,7 +228,7 @@ private:
     {
         AssertNoGC assertNoGC;
 
-        
+
         // This method is called from the Optimize variants of IC slow paths. The first part of this
         // method tries to determine if the Optimize variant should really behave like the
         // non-Optimize variant and leave the IC untouched.
@@ -250,7 +237,7 @@ private:
         // to determine if this Structure would impact the IC at all. We know that it won't, if we
         // have already buffered something on its behalf. That's what the m_bufferedStructures set is
         // for.
-        
+
         everConsidered = true;
         if (!countdown) {
             // Check if we have been doing repatching too frequently. If so, then we should cool off
@@ -268,12 +255,12 @@ private:
                     numberOfCoolDowns,
                     static_cast<uint8_t>(std::numeric_limits<uint8_t>::max() - 1));
                 WTF::incrementWithSaturation(numberOfCoolDowns);
-                
+
                 // We may still have had something buffered. Trigger generation now.
                 bufferingCountdown = 0;
                 return true;
             }
-            
+
             // We don't want to return false due to buffering indefinitely.
             if (!bufferingCountdown) {
                 // Note that when this returns true, it's possible that we will not even get an
@@ -281,12 +268,12 @@ private:
                 // repatching.
                 return true;
             }
-            
+
             bufferingCountdown--;
 
             if (!structure)
                 return true;
-            
+
             // Now protect the IC buffering. We want to proceed only if this is a structure that
             // we don't already have a case buffered for. Note that if this returns true but the
             // bufferingCountdown is not zero then we will buffer the access case for later without
@@ -348,8 +335,19 @@ private:
             });
     }
 
-    void setInlinedHandler(CodeBlock*, Ref<InlineCacheHandler>&&);
-    void clearInlinedHandler(CodeBlock*);
+protected:
+    PropertyInlineCache(PropertyInlineCacheType icType, AccessType accessType, CodeOrigin codeOrigin)
+        : codeOrigin(codeOrigin)
+        , accessType(accessType)
+        , bufferingCountdown(Options::initialRepatchBufferingCountdown())
+        , m_icType(icType)
+    {
+    }
+
+    PropertyInlineCache(PropertyInlineCacheType icType)
+        : PropertyInlineCache(icType, AccessType::GetById, { })
+    { }
+
     void initializeWithUnitHandler(CodeBlock*, Ref<InlineCacheHandler>&&);
     void prependHandler(CodeBlock*, Ref<InlineCacheHandler>&&, bool isMegamorphic);
     void rewireStubAsJumpInAccess(CodeBlock*, Ref<InlineCacheHandler>&&);
@@ -359,10 +357,9 @@ public:
     static constexpr ptrdiff_t offsetOfInlineAccessBaseStructureID() { return OBJECT_OFFSETOF(PropertyInlineCache, m_inlineAccessBaseStructureID); }
     static constexpr ptrdiff_t offsetOfInlineHolder() { return OBJECT_OFFSETOF(PropertyInlineCache, m_inlineHolder); }
     static constexpr ptrdiff_t offsetOfDoneLocation() { return OBJECT_OFFSETOF(PropertyInlineCache, doneLocation); }
-    static constexpr ptrdiff_t offsetOfSlowPathStartLocation() { return OBJECT_OFFSETOF(PropertyInlineCache, slowPathStartLocation); }
-    static constexpr ptrdiff_t offsetOfSlowOperation() { return OBJECT_OFFSETOF(PropertyInlineCache, m_slowOperation); }
     static constexpr ptrdiff_t offsetOfCountdown() { return OBJECT_OFFSETOF(PropertyInlineCache, countdown); }
     static constexpr ptrdiff_t offsetOfCallSiteIndex() { return OBJECT_OFFSETOF(PropertyInlineCache, callSiteIndex); }
+    static constexpr ptrdiff_t offsetOfSlowPathStartLocation() { return OBJECT_OFFSETOF(PropertyInlineCache, slowPathStartLocation); }
     static constexpr ptrdiff_t offsetOfHandler() { return OBJECT_OFFSETOF(PropertyInlineCache, m_handler); }
     static constexpr ptrdiff_t offsetOfGlobalObject() { return OBJECT_OFFSETOF(PropertyInlineCache, m_globalObject); }
 
@@ -402,21 +399,14 @@ public:
     WriteBarrierStructureID m_inlineAccessBaseStructureID;
     JSCell* m_inlineHolder { nullptr };
     CacheableIdentifier m_identifier;
-    // This is either the start of the inline IC for *byId caches. or the location of patchable jump for 'instanceof' caches.
-    // If useHandlerIC is true, then it is nullptr.
-    CodeLocationLabel<JITStubRoutinePtrTag> startLocation;
     CodeLocationLabel<JSInternalPtrTag> doneLocation;
     CodeLocationLabel<JITStubRoutinePtrTag> slowPathStartLocation;
 
-    union {
-        CodeLocationCall<JSInternalPtrTag> m_slowPathCallLocation;
-        CodePtr<OperationPtrTag> m_slowOperation;
-    };
-
     JSGlobalObject* m_globalObject { nullptr };
 private:
-    std::unique_ptr<PolymorphicAccess> m_stub;
-    RefPtr<InlineCacheHandler> m_inlinedHandler;
+    // Handler chain: used by both modes. Handler IC uses this as the main dispatch chain
+    // (accessed from JIT via offsetOfHandler()). Repatching IC uses it in
+    // rewireStubAsJumpInAccess() and initializeWithUnitHandler().
     RefPtr<InlineCacheHandler> m_handler;
     // Represents those structures that already have buffered AccessCases in the PolymorphicAccess.
     // Note that it's always safe to clear this. If we clear it prematurely, then if we see the same
@@ -429,6 +419,7 @@ public:
 
     CallSiteIndex callSiteIndex;
 
+    // FIXME: These should only be needed by the repatching ICs but it's slightly non-trivial to move them there as different AccessTypes use different pinned registers.
     GPRReg m_baseGPR { InvalidGPRReg };
     GPRReg m_valueGPR { InvalidGPRReg };
     GPRReg m_extraGPR { InvalidGPRReg };
@@ -445,7 +436,7 @@ public:
 #endif
 
     AccessType accessType { AccessType::GetById };
-private:
+protected:
     CacheType m_cacheType { CacheType::Unset };
 public:
     CacheType preconfiguredCacheType { CacheType::Unset };
@@ -467,13 +458,59 @@ public:
     bool propertyIsInt32 : 1 { false };
     bool propertyIsSymbol : 1 { false };
     bool canBeMegamorphic : 1 { false };
-    bool useHandlerIC : 1 { false };
+    const PropertyInlineCacheType m_icType : 1;
 };
 
-inline CodeOrigin getPropertyInlineCacheCodeOrigin(PropertyInlineCache& propertyInlineCache)
-{
-    return propertyInlineCache.codeOrigin;
-}
+// HandlerPropertyInlineCache: Used by Baseline JIT and DFG.
+// Data-only dispatch through a handler chain — code is never rewritten.
+class HandlerPropertyInlineCache final : public PropertyInlineCache {
+    WTF_MAKE_NONCOPYABLE(HandlerPropertyInlineCache);
+public:
+    HandlerPropertyInlineCache()
+        : PropertyInlineCache(PropertyInlineCacheType::Handler)
+    { }
+
+    HandlerPropertyInlineCache(AccessType accessType, CodeOrigin codeOrigin)
+        : PropertyInlineCache(PropertyInlineCacheType::Handler, accessType, codeOrigin)
+    { }
+
+    void initializeFromUnlinkedPropertyInlineCache(VM&, CodeBlock*, const BaselineUnlinkedPropertyInlineCache&);
+    void initializeFromDFGUnlinkedPropertyInlineCache(CodeBlock*, const DFG::UnlinkedPropertyInlineCache&);
+
+    void setInlinedHandler(CodeBlock*, Ref<InlineCacheHandler>&&);
+    void clearInlinedHandler(CodeBlock*);
+
+    static constexpr ptrdiff_t offsetOfSlowOperation() { return OBJECT_OFFSETOF(HandlerPropertyInlineCache, m_slowOperation); }
+
+    CodePtr<OperationPtrTag> m_slowOperation;
+    RefPtr<InlineCacheHandler> m_inlinedHandler;
+};
+
+// RepatchingPropertyInlineCache: Used by FTL (when handler IC is not enabled) and 32-bit DFG.
+// Classic inline cache where code is recompiled/repatched on the fly.
+class RepatchingPropertyInlineCache final : public PropertyInlineCache {
+    WTF_MAKE_NONCOPYABLE(RepatchingPropertyInlineCache);
+public:
+    RepatchingPropertyInlineCache()
+        : PropertyInlineCache(PropertyInlineCacheType::Repatching)
+    { }
+
+    RepatchingPropertyInlineCache(AccessType accessType, CodeOrigin codeOrigin)
+        : PropertyInlineCache(PropertyInlineCacheType::Repatching, accessType, codeOrigin)
+    { }
+
+    // This is either the start of the inline IC for *byId caches, or the location of patchable jump for 'instanceof' caches.
+    CodeLocationLabel<JITStubRoutinePtrTag> startLocation;
+    CodeLocationCall<JSInternalPtrTag> m_slowPathCallLocation;
+    std::unique_ptr<PolymorphicAccess> m_stub;
+
+    uint32_t inlineCodeSize() const
+    {
+        int32_t inlineSize = MacroAssembler::differenceBetweenCodePtr(startLocation, doneLocation);
+        ASSERT(inlineSize >= 0);
+        return inlineSize;
+    }
+};
 
 inline auto appropriateGetByIdOptimizeFunction(AccessType type) -> decltype(&operationGetByIdOptimize)
 {
@@ -591,13 +628,23 @@ struct BaselineUnlinkedPropertyInlineCache : JSC::UnlinkedPropertyInlineCache {
     BytecodeIndex bytecodeIndex;
 };
 
-#endif
-
 } // namespace JSC
 
-namespace WTF {
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::HandlerPropertyInlineCache)
+    static bool isType(const JSC::PropertyInlineCache& cache)
+    {
+        return cache.isHandlerIC();
+    }
+SPECIALIZE_TYPE_TRAITS_END()
 
-#if ENABLE(JIT)
+SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::RepatchingPropertyInlineCache)
+    static bool isType(const JSC::PropertyInlineCache& cache)
+    {
+        return !cache.isHandlerIC();
+    }
+SPECIALIZE_TYPE_TRAITS_END()
+
+namespace WTF {
 
 template<typename T> struct DefaultHash;
 template<> struct DefaultHash<JSC::AccessType> : public IntHash<JSC::AccessType> { };
@@ -605,6 +652,6 @@ template<> struct DefaultHash<JSC::AccessType> : public IntHash<JSC::AccessType>
 template<typename T> struct HashTraits;
 template<> struct HashTraits<JSC::AccessType> : public StrongEnumHashTraits<JSC::AccessType> { };
 
-#endif
-
 } // namespace WTF
+
+#endif // ENABLE(JIT)

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -323,11 +323,11 @@ void ftlThunkAwareRepatchCall(CodeBlock* codeBlock, CodeLocationCall<JSInternalP
 
 static void repatchSlowPathCall(CodeBlock* codeBlock, PropertyInlineCache& propertyCache, CodePtr<CFunctionPtrTag> newCalleeFunction)
 {
-    if (propertyCache.useHandlerIC) {
-        propertyCache.m_slowOperation = newCalleeFunction.retagged<OperationPtrTag>();
+    if (auto* handlerIC = dynamicDowncast<HandlerPropertyInlineCache>(propertyCache)) {
+        handlerIC->m_slowOperation = newCalleeFunction.retagged<OperationPtrTag>();
         return;
     }
-    ftlThunkAwareRepatchCall(codeBlock, propertyCache.m_slowPathCallLocation, newCalleeFunction);
+    ftlThunkAwareRepatchCall(codeBlock, downcast<RepatchingPropertyInlineCache>(propertyCache).m_slowPathCallLocation, newCalleeFunction);
 }
 
 enum InlineCacheAction {

--- a/Source/JavaScriptCore/dfg/DFGCommonData.h
+++ b/Source/JavaScriptCore/dfg/DFGCommonData.h
@@ -132,7 +132,9 @@ public:
     FixedVector<JumpReplacement> m_jumpReplacements;
     FixedVector<std::unique_ptr<BoyerMooreHorspoolTable<uint8_t>>> m_stringSearchTable8;
     FixedVector<std::unique_ptr<ConcatKeyAtomStringCache>> m_concatKeyAtomStringCaches;
-    Bag<PropertyInlineCache> m_propertyInlineCaches;
+    // FIXME: These seem like they should be FixedVectors.
+    Bag<HandlerPropertyInlineCache> m_handlerPropertyInlineCaches;
+    Bag<RepatchingPropertyInlineCache> m_repatchingPropertyInlineCaches;
     Bag<OptimizingCallLinkInfo> m_callLinkInfos;
     Bag<DirectCallLinkInfo> m_directCallLinkInfos;
     Yarr::YarrBoyerMooreData m_boyerMooreData;

--- a/Source/JavaScriptCore/dfg/DFGJITCode.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.h
@@ -153,10 +153,10 @@ private:
     FixedVector<Value> m_constants;
 };
 
-class JITData final : public ButterflyArray<JITData, PropertyInlineCache, void*> {
+class JITData final : public ButterflyArray<JITData, HandlerPropertyInlineCache, void*> {
     friend class JSC::LLIntOffsetsExtractor;
 public:
-    using Base = ButterflyArray<JITData, PropertyInlineCache, void*>;
+    using Base = ButterflyArray<JITData, HandlerPropertyInlineCache, void*>;
     using ExitVector = FixedVector<MacroAssemblerCodeRef<OSRExitPtrTag>>;
 
     static constexpr ptrdiff_t offsetOfExits() { return OBJECT_OFFSETOF(JITData, m_exits); }
@@ -182,7 +182,7 @@ public:
         return leadingSpan();
     }
 
-    PropertyInlineCache& propertyCache(unsigned index)
+    HandlerPropertyInlineCache& propertyCache(unsigned index)
     {
         auto span = propertyInlineCaches();
         return span[span.size() - index - 1];

--- a/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCompiler.cpp
@@ -286,7 +286,8 @@ void JITCompiler::link(LinkBuffer& linkBuffer)
     m_jitCode->m_unlinkedPropertyInlineCaches = FixedVector<UnlinkedPropertyInlineCache>(m_unlinkedPropertyInlineCaches.size());
     if (m_jitCode->m_unlinkedPropertyInlineCaches.size())
         std::move(m_unlinkedPropertyInlineCaches.begin(), m_unlinkedPropertyInlineCaches.end(), m_jitCode->m_unlinkedPropertyInlineCaches.begin());
-    ASSERT(m_jitCode->common.m_propertyInlineCaches.isEmpty());
+    ASSERT(m_jitCode->common.m_handlerPropertyInlineCaches.isEmpty());
+    ASSERT(m_jitCode->common.m_repatchingPropertyInlineCaches.isEmpty());
 #endif
 
     for (auto& record : m_jsDirectCalls) {
@@ -556,7 +557,7 @@ void JITCompiler::loadConstant(LinkerIR::Constant index, GPRReg dest)
 void JITCompiler::loadPropertyInlineCache(PropertyInlineCacheIndex index, GPRReg dest)
 {
 #if USE(JSVALUE64)
-    subPtr(GPRInfo::jitDataRegister, TrustedImm32(static_cast<uintptr_t>(index.m_index + 1) * sizeof(PropertyInlineCache)), dest);
+    subPtr(GPRInfo::jitDataRegister, TrustedImm32(static_cast<uintptr_t>(index.m_index + 1) * sizeof(HandlerPropertyInlineCache)), dest);
 #else
     UNUSED_PARAM(index);
     UNUSED_PARAM(dest);
@@ -640,7 +641,7 @@ std::tuple<CompileTimePropertyInlineCache, PropertyInlineCacheIndex> JITCompiler
     DFG::UnlinkedPropertyInlineCache* propertyCache = &m_unlinkedPropertyInlineCaches.alloc();
     return std::tuple { propertyCache, PropertyInlineCacheIndex { index } };
 #else
-    PropertyInlineCache* propertyCache = jitCode()->common.m_propertyInlineCaches.add();
+    PropertyInlineCache* propertyCache = jitCode()->common.m_handlerPropertyInlineCaches.add();
     return std::tuple { propertyCache, PropertyInlineCacheIndex(0) };
 #endif
 }

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -180,7 +180,7 @@ void SpeculativeJIT::cachedGetById(Node* node, CodeOrigin codeOrigin, JSValueReg
     loadPropertyInlineCache(propertyCacheConstant, BaselineJITRegisters::GetById::propertyCacheGPR);
     gen.generateDataICFastPath(*this);
     auto slowPath = slowPathICCall(
-        slowCases, this, propertyCacheConstant, BaselineJITRegisters::GetById::propertyCacheGPR, Address(BaselineJITRegisters::GetById::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), appropriateGetByIdOptimizeFunction(type),
+        slowCases, this, propertyCacheConstant, BaselineJITRegisters::GetById::propertyCacheGPR, Address(BaselineJITRegisters::GetById::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), appropriateGetByIdOptimizeFunction(type),
         DontSpill, ExceptionCheckRequirement::CheckNeeded,
         resultRegs, BaselineJITRegisters::GetById::baseJSR, BaselineJITRegisters::GetById::propertyCacheGPR);
 
@@ -216,7 +216,7 @@ void SpeculativeJIT::cachedGetByIdWithThis(Node* node, CodeOrigin codeOrigin, JS
     loadPropertyInlineCache(propertyCacheConstant, BaselineJITRegisters::GetByIdWithThis::propertyCacheGPR);
     gen.generateDataICFastPath(*this);
     auto slowPath = slowPathICCall(
-        slowCases, this, propertyCacheConstant, BaselineJITRegisters::GetByIdWithThis::propertyCacheGPR, Address(BaselineJITRegisters::GetByIdWithThis::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), operationGetByIdWithThisOptimize,
+        slowCases, this, propertyCacheConstant, BaselineJITRegisters::GetByIdWithThis::propertyCacheGPR, Address(BaselineJITRegisters::GetByIdWithThis::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), operationGetByIdWithThisOptimize,
         DontSpill, ExceptionCheckRequirement::CheckNeeded,
         resultRegs, BaselineJITRegisters::GetByIdWithThis::baseJSR, BaselineJITRegisters::GetByIdWithThis::thisJSR, BaselineJITRegisters::GetByIdWithThis::propertyCacheGPR);
 
@@ -2738,7 +2738,7 @@ void SpeculativeJIT::compileGetByVal(Node* node, const ScopedLambda<std::tuple<J
         loadPropertyInlineCache(propertyCacheConstant, BaselineJITRegisters::GetByVal::propertyCacheGPR);
         gen.generateDataICFastPath(*this);
         auto slowPath = slowPathICCall(
-            slowCases, this, propertyCacheConstant, BaselineJITRegisters::GetByVal::propertyCacheGPR, Address(BaselineJITRegisters::GetByVal::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), operationGetByValOptimize,
+            slowCases, this, propertyCacheConstant, BaselineJITRegisters::GetByVal::propertyCacheGPR, Address(BaselineJITRegisters::GetByVal::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), operationGetByValOptimize,
             resultRegs, BaselineJITRegisters::GetByVal::baseJSR, BaselineJITRegisters::GetByVal::propertyJSR, BaselineJITRegisters::GetByVal::propertyCacheGPR, BaselineJITRegisters::GetByVal::profileGPR);
 
         addGetByVal(gen, slowPath.get());
@@ -5943,7 +5943,7 @@ void SpeculativeJIT::compile(Node* node)
             loadPropertyInlineCache(propertyCacheConstant, BaselineJITRegisters::InByVal::propertyCacheGPR);
             gen.generateDataICFastPath(*this);
             auto slowPath = slowPathICCall(
-                slowCases, this, propertyCacheConstant, BaselineJITRegisters::InByVal::propertyCacheGPR, Address(BaselineJITRegisters::InByVal::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), operationInByValOptimize,
+                slowCases, this, propertyCacheConstant, BaselineJITRegisters::InByVal::propertyCacheGPR, Address(BaselineJITRegisters::InByVal::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), operationInByValOptimize,
                 DontSpill, ExceptionCheckRequirement::CheckNeeded,
                 resultRegs, BaselineJITRegisters::InByVal::baseJSR, BaselineJITRegisters::InByVal::propertyJSR, BaselineJITRegisters::InByVal::propertyCacheGPR, BaselineJITRegisters::InByVal::profileGPR);
 
@@ -6975,7 +6975,7 @@ void SpeculativeJIT::compileGetByValWithThis(Node* node)
     loadPropertyInlineCache(propertyCacheConstant, BaselineJITRegisters::GetByValWithThis::propertyCacheGPR);
     gen.generateDataICFastPath(*this);
     auto slowPath = slowPathICCall(
-        slowCases, this, propertyCacheConstant, BaselineJITRegisters::GetByValWithThis::propertyCacheGPR, Address(BaselineJITRegisters::GetByValWithThis::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), operationGetByValWithThisOptimize,
+        slowCases, this, propertyCacheConstant, BaselineJITRegisters::GetByValWithThis::propertyCacheGPR, Address(BaselineJITRegisters::GetByValWithThis::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), operationGetByValWithThisOptimize,
         resultRegs.payloadGPR(), BaselineJITRegisters::GetByValWithThis::baseJSR, BaselineJITRegisters::GetByValWithThis::propertyJSR, BaselineJITRegisters::GetByValWithThis::thisJSR, BaselineJITRegisters::GetByValWithThis::propertyCacheGPR, BaselineJITRegisters::GetByValWithThis::profileGPR);
 
     addGetByValWithThis(gen, slowPath.get());
@@ -7068,7 +7068,7 @@ void SpeculativeJIT::compileDeleteById(Node* node)
         gen.generateDataICFastPath(*this);
         ASSERT(!gen.propertyCache());
         auto slowPath = slowPathICCall(
-            slowCases, this, propertyCacheConstant, BaselineJITRegisters::DelById::propertyCacheGPR, Address(BaselineJITRegisters::DelById::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), operation,
+            slowCases, this, propertyCacheConstant, BaselineJITRegisters::DelById::propertyCacheGPR, Address(BaselineJITRegisters::DelById::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), operation,
             resultRegs.payloadGPR(), BaselineJITRegisters::DelById::baseJSR, BaselineJITRegisters::DelById::propertyCacheGPR);
 
         addDelById(gen, slowPath.get());
@@ -7135,7 +7135,7 @@ void SpeculativeJIT::compileDeleteByVal(Node* node)
         gen.generateDataICFastPath(*this);
         ASSERT(!gen.propertyCache());
         auto slowPath = slowPathICCall(
-            slowCases, this, propertyCacheConstant, BaselineJITRegisters::DelByVal::propertyCacheGPR, Address(BaselineJITRegisters::DelByVal::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), operation,
+            slowCases, this, propertyCacheConstant, BaselineJITRegisters::DelByVal::propertyCacheGPR, Address(BaselineJITRegisters::DelByVal::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), operation,
             resultRegs.payloadGPR(), BaselineJITRegisters::DelByVal::baseJSR, BaselineJITRegisters::DelByVal::propertyJSR, BaselineJITRegisters::DelByVal::propertyCacheGPR);
 
         addDelByVal(gen, slowPath.get());
@@ -7192,7 +7192,7 @@ void SpeculativeJIT::compileInById(Node* node)
     gen.generateDataICFastPath(*this);
     ASSERT(!gen.propertyCache());
     auto slowPath = slowPathICCall(
-        slowCases, this, propertyCacheConstant, BaselineJITRegisters::InById::propertyCacheGPR, Address(BaselineJITRegisters::InById::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), operationInByIdOptimize,
+        slowCases, this, propertyCacheConstant, BaselineJITRegisters::InById::propertyCacheGPR, Address(BaselineJITRegisters::InById::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), operationInByIdOptimize,
         DontSpill, ExceptionCheckRequirement::CheckNeeded,
         resultRegs, BaselineJITRegisters::InById::baseJSR, BaselineJITRegisters::InById::propertyCacheGPR);
 
@@ -7238,7 +7238,7 @@ void SpeculativeJIT::compileInByVal(Node* node)
     gen.generateDataICFastPath(*this);
     ASSERT(!gen.propertyCache());
     auto slowPath = slowPathICCall(
-        slowCases, this, propertyCacheConstant, BaselineJITRegisters::InByVal::propertyCacheGPR, Address(BaselineJITRegisters::InByVal::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), operationInByValOptimize,
+        slowCases, this, propertyCacheConstant, BaselineJITRegisters::InByVal::propertyCacheGPR, Address(BaselineJITRegisters::InByVal::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), operationInByValOptimize,
         DontSpill, ExceptionCheckRequirement::CheckNeeded,
         resultRegs, BaselineJITRegisters::InByVal::baseJSR, BaselineJITRegisters::InByVal::propertyJSR, BaselineJITRegisters::InByVal::propertyCacheGPR, BaselineJITRegisters::InByVal::profileGPR);
 
@@ -7290,7 +7290,7 @@ void SpeculativeJIT::compileHasPrivate(Node* node, AccessType type)
     gen.generateDataICFastPath(*this);
     ASSERT(!gen.propertyCache());
     auto slowPath = slowPathICCall(
-        slowCases, this, propertyCacheConstant, BaselineJITRegisters::InByVal::propertyCacheGPR, Address(BaselineJITRegisters::InByVal::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), type == AccessType::HasPrivateName ? operationHasPrivateNameOptimize : operationHasPrivateBrandOptimize,
+        slowCases, this, propertyCacheConstant, BaselineJITRegisters::InByVal::propertyCacheGPR, Address(BaselineJITRegisters::InByVal::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), type == AccessType::HasPrivateName ? operationHasPrivateNameOptimize : operationHasPrivateBrandOptimize,
         DontSpill, ExceptionCheckRequirement::CheckNeeded,
         resultRegs, BaselineJITRegisters::InByVal::baseJSR, BaselineJITRegisters::InByVal::propertyJSR, BaselineJITRegisters::InByVal::propertyCacheGPR);
 
@@ -7414,7 +7414,7 @@ void SpeculativeJIT::compilePutByVal(Node* node)
         loadPropertyInlineCache(propertyCacheConstant, BaselineJITRegisters::PutByVal::propertyCacheGPR);
         gen.generateDataICFastPath(*this);
         auto slowPath = slowPathICCall(
-            slowCases, this, propertyCacheConstant, BaselineJITRegisters::PutByVal::propertyCacheGPR, Address(BaselineJITRegisters::PutByVal::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), operation,
+            slowCases, this, propertyCacheConstant, BaselineJITRegisters::PutByVal::propertyCacheGPR, Address(BaselineJITRegisters::PutByVal::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), operation,
             NoResult, BaselineJITRegisters::PutByVal::baseJSR, BaselineJITRegisters::PutByVal::propertyJSR, BaselineJITRegisters::PutByVal::valueJSR, BaselineJITRegisters::PutByVal::propertyCacheGPR, BaselineJITRegisters::PutByVal::profileGPR);
 
         addPutByVal(gen, slowPath.get());
@@ -7569,7 +7569,7 @@ void SpeculativeJIT::compileGetPrivateNameByVal(Node* node, JSValueRegs baseRegs
     loadPropertyInlineCache(propertyCacheConstant, BaselineJITRegisters::GetByVal::propertyCacheGPR);
     gen.generateDataICFastPath(*this);
     auto slowPath = slowPathICCall(
-        slowCases, this, propertyCacheConstant, BaselineJITRegisters::GetByVal::propertyCacheGPR, Address(BaselineJITRegisters::GetByVal::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), operationGetPrivateNameOptimize,
+        slowCases, this, propertyCacheConstant, BaselineJITRegisters::GetByVal::propertyCacheGPR, Address(BaselineJITRegisters::GetByVal::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), operationGetPrivateNameOptimize,
         result.regs(), BaselineJITRegisters::GetByVal::baseJSR, BaselineJITRegisters::GetByVal::propertyJSR, BaselineJITRegisters::GetByVal::propertyCacheGPR);
 
     addGetByVal(gen, slowPath.get());
@@ -7685,7 +7685,7 @@ void SpeculativeJIT::compilePutPrivateName(Node* node)
     loadPropertyInlineCache(propertyCacheConstant, BaselineJITRegisters::PutByVal::propertyCacheGPR);
     gen.generateDataICFastPath(*this);
     auto slowPath = slowPathICCall(
-        slowCases, this, propertyCacheConstant, BaselineJITRegisters::PutByVal::propertyCacheGPR, Address(BaselineJITRegisters::PutByVal::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), operation,
+        slowCases, this, propertyCacheConstant, BaselineJITRegisters::PutByVal::propertyCacheGPR, Address(BaselineJITRegisters::PutByVal::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), operation,
         NoResult, BaselineJITRegisters::PutByVal::baseJSR, BaselineJITRegisters::PutByVal::propertyJSR, BaselineJITRegisters::PutByVal::valueJSR, BaselineJITRegisters::PutByVal::propertyCacheGPR, BaselineJITRegisters::PutByVal::profileGPR);
 
     addPutByVal(gen, slowPath.get());
@@ -7734,7 +7734,7 @@ void SpeculativeJIT::compileCheckPrivateBrand(Node* node)
     loadPropertyInlineCache(propertyCacheConstant, BaselineJITRegisters::PrivateBrand::propertyCacheGPR);
     gen.generateDataICFastPath(*this);
     auto slowPath = slowPathICCall(
-        slowCases, this, propertyCacheConstant, BaselineJITRegisters::PrivateBrand::propertyCacheGPR, Address(BaselineJITRegisters::PrivateBrand::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), operationCheckPrivateBrandOptimize, NoResult,
+        slowCases, this, propertyCacheConstant, BaselineJITRegisters::PrivateBrand::propertyCacheGPR, Address(BaselineJITRegisters::PrivateBrand::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), operationCheckPrivateBrandOptimize, NoResult,
         BaselineJITRegisters::PrivateBrand::baseJSR, BaselineJITRegisters::PrivateBrand::propertyJSR, BaselineJITRegisters::PrivateBrand::propertyCacheGPR);
 
     addPrivateBrandAccess(gen, slowPath.get());
@@ -7782,7 +7782,7 @@ void SpeculativeJIT::compileSetPrivateBrand(Node* node)
     loadPropertyInlineCache(propertyCacheConstant, BaselineJITRegisters::PrivateBrand::propertyCacheGPR);
     gen.generateDataICFastPath(*this);
     auto slowPath = slowPathICCall(
-        slowCases, this, propertyCacheConstant, BaselineJITRegisters::PrivateBrand::propertyCacheGPR, Address(BaselineJITRegisters::PrivateBrand::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), operationSetPrivateBrandOptimize, NoResult,
+        slowCases, this, propertyCacheConstant, BaselineJITRegisters::PrivateBrand::propertyCacheGPR, Address(BaselineJITRegisters::PrivateBrand::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), operationSetPrivateBrandOptimize, NoResult,
         BaselineJITRegisters::PrivateBrand::baseJSR, BaselineJITRegisters::PrivateBrand::propertyJSR, BaselineJITRegisters::PrivateBrand::propertyCacheGPR);
 
     addPrivateBrandAccess(gen, slowPath.get());
@@ -7819,7 +7819,7 @@ void SpeculativeJIT::compileInstanceOf(Node* node)
 
         loadPropertyInlineCache(propertyCacheConstant, BaselineJITRegisters::Instanceof::propertyCacheGPR);
         gen.generateDataICFastPath(*this);
-        auto slowPath = slowPathICCall(slowCases, this, propertyCacheConstant, BaselineJITRegisters::Instanceof::propertyCacheGPR, Address(BaselineJITRegisters::Instanceof::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), operationInstanceOfOptimize, resultGPR, BaselineJITRegisters::Instanceof::valueJSR, BaselineJITRegisters::Instanceof::protoJSR, BaselineJITRegisters::Instanceof::propertyCacheGPR);
+        auto slowPath = slowPathICCall(slowCases, this, propertyCacheConstant, BaselineJITRegisters::Instanceof::propertyCacheGPR, Address(BaselineJITRegisters::Instanceof::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), operationInstanceOfOptimize, resultGPR, BaselineJITRegisters::Instanceof::valueJSR, BaselineJITRegisters::Instanceof::protoJSR, BaselineJITRegisters::Instanceof::propertyCacheGPR);
 
         addInstanceOf(gen, slowPath.get());
         addSlowPathGenerator(WTF::move(slowPath));
@@ -7928,7 +7928,7 @@ void SpeculativeJIT::cachedPutById(Node*, CodeOrigin codeOrigin, GPRReg baseGPR,
     auto* operation = appropriatePutByIdOptimizeFunction(accessType);
     loadPropertyInlineCache(propertyCacheConstant, BaselineJITRegisters::PutById::propertyCacheGPR);
     gen.generateDataICFastPath(*this);
-    auto slowPath = slowPathICCall(slowCases, this, propertyCacheConstant, BaselineJITRegisters::PutById::propertyCacheGPR, Address(BaselineJITRegisters::PutById::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), operation, NoResult, BaselineJITRegisters::PutById::valueJSR, BaselineJITRegisters::PutById::baseJSR, BaselineJITRegisters::PutById::propertyCacheGPR);
+    auto slowPath = slowPathICCall(slowCases, this, propertyCacheConstant, BaselineJITRegisters::PutById::propertyCacheGPR, Address(BaselineJITRegisters::PutById::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), operation, NoResult, BaselineJITRegisters::PutById::valueJSR, BaselineJITRegisters::PutById::baseJSR, BaselineJITRegisters::PutById::propertyCacheGPR);
 
     addPutById(gen, slowPath.get());
     addSlowPathGenerator(WTF::move(slowPath));
@@ -8314,7 +8314,7 @@ void SpeculativeJIT::compileEnumeratorPutByVal(Node* node)
             loadPropertyInlineCache(propertyCacheConstant, BaselineJITRegisters::PutByVal::propertyCacheGPR);
             gen.generateDataICFastPath(*this);
             auto slowPath = slowPathICCall(
-                slowCases, this, propertyCacheConstant, BaselineJITRegisters::PutByVal::propertyCacheGPR, Address(BaselineJITRegisters::PutByVal::propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), operation,
+                slowCases, this, propertyCacheConstant, BaselineJITRegisters::PutByVal::propertyCacheGPR, Address(BaselineJITRegisters::PutByVal::propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), operation,
                 NoResult, BaselineJITRegisters::PutByVal::baseJSR, BaselineJITRegisters::PutByVal::propertyJSR, BaselineJITRegisters::PutByVal::valueJSR, BaselineJITRegisters::PutByVal::propertyCacheGPR, BaselineJITRegisters::PutByVal::profileGPR);
 
             addPutByVal(gen, slowPath.get());

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -4712,10 +4712,10 @@ private:
                 CCallHelpers::Call slowPathCall;
                 if (Options::useHandlerICInFTL()) {
                     jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                    generator->propertyCache()->m_slowOperation = operationGetByValWithThisOptimize;
+                    downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = operationGetByValWithThisOptimize;
                     slowPathCall = callOperation(
                         *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                        exceptions.get(), CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), resultGPR,
+                        exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), resultGPR,
                         baseGPR, propertyGPR, thisValueGPR, propertyCacheGPR, CCallHelpers::TrustedImmPtr(nullptr)).call();
                 } else {
                     slowPathCall = callOperation(
@@ -4864,10 +4864,10 @@ private:
                     CCallHelpers::Call slowPathCall;
                     if (Options::useHandlerICInFTL()) {
                         jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                        generator->propertyCache()->m_slowOperation = operationGetPrivateNameOptimize;
+                        downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = operationGetPrivateNameOptimize;
                         slowPathCall = callOperation(
                             *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                            exceptions.get(), CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), resultGPR,
+                            exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), resultGPR,
                             baseGPR, propertyGPR, propertyCacheGPR).call();
                     } else {
                         slowPathCall = callOperation(
@@ -5019,10 +5019,10 @@ private:
                 CCallHelpers::Call slowPathCall;
                 if (Options::useHandlerICInFTL()) {
                     jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                    generator->propertyCache()->m_slowOperation = appropriatePrivateAccessFunction(accessType);
+                    downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = appropriatePrivateAccessFunction(accessType);
                     slowPathCall = callOperation(
                         *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                        exceptions.get(), CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), InvalidGPRReg,
+                        exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), InvalidGPRReg,
                         baseGPR, brandGPR, propertyCacheGPR).call();
                 } else {
                     slowPathCall = callOperation(
@@ -5238,10 +5238,10 @@ private:
                 CCallHelpers::Call slowPathCall;
                 if (Options::useHandlerICInFTL()) {
                     jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                    generator->propertyCache()->m_slowOperation = operation;
+                    downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = operation;
                     slowPathCall = callOperation(
                         *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                        exceptions.get(), CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), InvalidGPRReg,
+                        exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), InvalidGPRReg,
                         baseGPR, propertyGPR, valueGPR, propertyCacheGPR, CCallHelpers::TrustedImmPtr(nullptr)).call();
                 } else {
                     slowPathCall = callOperation(
@@ -5605,10 +5605,10 @@ private:
                         auto* operation = appropriatePutByIdOptimizeFunction(accessType);
                         if (Options::useHandlerICInFTL()) {
                             jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                            generator->propertyCache()->m_slowOperation = operation;
+                            downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = operation;
                             slowPathCall = callOperation(
                                 *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                                exceptions.get(), CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), InvalidGPRReg,
+                                exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), InvalidGPRReg,
                                 params[1].gpr(), params[0].gpr(), propertyCacheGPR).call();
                         } else {
                             slowPathCall = callOperation(
@@ -6559,10 +6559,10 @@ IGNORE_CLANG_WARNINGS_END
                     CCallHelpers::Call slowPathCall;
                     if (Options::useHandlerICInFTL()) {
                         jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                        generator->propertyCache()->m_slowOperation = operationGetByValOptimize;
+                        downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = operationGetByValOptimize;
                         slowPathCall = callOperation(
                             *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                            exceptions.get(), CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), resultGPR,
+                            exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), resultGPR,
                             baseGPR, propertyGPR, propertyCacheGPR, CCallHelpers::TrustedImmPtr(nullptr)).call();
                     } else {
                         slowPathCall = callOperation(
@@ -7286,10 +7286,10 @@ IGNORE_CLANG_WARNINGS_END
                     auto operation = isDirect ? (ecmaMode.isStrict() ? operationDirectPutByValStrictOptimize : operationDirectPutByValSloppyOptimize) : (ecmaMode.isStrict() ? operationPutByValStrictOptimize : operationPutByValSloppyOptimize);
                     if (Options::useHandlerICInFTL()) {
                         jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                        generator->propertyCache()->m_slowOperation = operation;
+                        downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = operation;
                         slowPathCall = callOperation(
                             *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                            exceptions.get(), CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), InvalidGPRReg,
+                            exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), InvalidGPRReg,
                             baseGPR, propertyGPR, valueGPR, propertyCacheGPR, CCallHelpers::TrustedImmPtr(nullptr)).call();
                     } else {
                         slowPathCall = callOperation(
@@ -7955,10 +7955,10 @@ IGNORE_CLANG_WARNINGS_END
                         if constexpr (kind == DelByKind::ByIdStrict || kind == DelByKind::ByIdSloppy) {
                             if (Options::useHandlerICInFTL()) {
                                 jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                                generator->propertyCache()->m_slowOperation = optimizationFunction;
+                                downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = optimizationFunction;
                                 slowPathCall = callOperation(
                                     *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                                    exceptions.get(), CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), returnGPR,
+                                    exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), returnGPR,
                                     base, propertyCacheGPR).call();
                             } else {
                                 slowPathCall = callOperation(
@@ -7969,10 +7969,10 @@ IGNORE_CLANG_WARNINGS_END
                         } else {
                             if (Options::useHandlerICInFTL()) {
                                 jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                                generator->propertyCache()->m_slowOperation = optimizationFunction;
+                                downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = optimizationFunction;
                                 slowPathCall = callOperation(
                                     *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                                    exceptions.get(), CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), returnGPR,
+                                    exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), returnGPR,
                                     base, subscript, propertyCacheGPR).call();
                             } else {
                                 slowPathCall = callOperation(
@@ -16256,10 +16256,10 @@ IGNORE_CLANG_WARNINGS_END
                         if constexpr (type == AccessType::InById) {
                             if (Options::useHandlerICInFTL()) {
                                 jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                                generator->propertyCache()->m_slowOperation = optimizationFunction;
+                                downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = optimizationFunction;
                                 slowPathCall = callOperation(
                                     *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                    exceptions.get(), CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), returnGPR,
+                                    exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), returnGPR,
                                     base, propertyCacheGPR).call();
                             } else {
                                 slowPathCall = callOperation(
@@ -16270,10 +16270,10 @@ IGNORE_CLANG_WARNINGS_END
                         } else if constexpr (type == AccessType::InByVal) {
                             if (Options::useHandlerICInFTL()) {
                                 jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                                generator->propertyCache()->m_slowOperation = optimizationFunction;
+                                downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = optimizationFunction;
                                 slowPathCall = callOperation(
                                     *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                    exceptions.get(), CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), returnGPR,
+                                    exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), returnGPR,
                                     base, subscript, propertyCacheGPR, CCallHelpers::TrustedImmPtr(nullptr)).call();
                             } else {
                                 slowPathCall = callOperation(
@@ -16284,10 +16284,10 @@ IGNORE_CLANG_WARNINGS_END
                         } else {
                             if (Options::useHandlerICInFTL()) {
                                 jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                                generator->propertyCache()->m_slowOperation = optimizationFunction;
+                                downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = optimizationFunction;
                                 slowPathCall = callOperation(
                                     *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                    exceptions.get(), CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), returnGPR,
+                                    exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), returnGPR,
                                     base, subscript, propertyCacheGPR).call();
                             } else {
                                 slowPathCall = callOperation(
@@ -16812,10 +16812,10 @@ IGNORE_CLANG_WARNINGS_END
                         CCallHelpers::Call slowPathCall;
                         if (Options::useHandlerICInFTL()) {
                             jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                            generator->propertyCache()->m_slowOperation = optimizationFunction;
+                            downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = optimizationFunction;
                             slowPathCall = callOperation(
                                 *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                exceptions.get(), CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), resultGPR,
+                                exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), resultGPR,
                                 valueGPR, prototypeGPR, propertyCacheGPR).call();
                         } else {
                             slowPathCall = callOperation(
@@ -17659,10 +17659,10 @@ IGNORE_CLANG_WARNINGS_END
                 auto operation = ecmaMode.isStrict() ? operationPutByValStrictOptimize : operationPutByValSloppyOptimize;
                 if (Options::useHandlerICInFTL()) {
                     jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                    generator->propertyCache()->m_slowOperation = operation;
+                    downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = operation;
                     slowPathCall = callOperation(
                         *state, params.unavailableRegisters(), jit, nodeSemanticOrigin,
-                        exceptions.get(), CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), InvalidGPRReg,
+                        exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), InvalidGPRReg,
                         baseGPR, propertyGPR, valueGPR, propertyCacheGPR, CCallHelpers::TrustedImmPtr(nullptr)).call();
                 } else {
                     slowPathCall = callOperation(
@@ -19191,10 +19191,10 @@ IGNORE_CLANG_WARNINGS_END
                         CCallHelpers::Call slowPathCall;
                         if (Options::useHandlerICInFTL()) {
                             jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                            generator->propertyCache()->m_slowOperation = optimizationFunction;
+                            downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = optimizationFunction;
                             slowPathCall = callOperation(
                                 *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                exceptions.get(), CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), params[0].gpr(),
+                                exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), params[0].gpr(),
                                 params[1].gpr(), propertyCacheGPR).call();
                         } else {
                             slowPathCall = callOperation(
@@ -19281,10 +19281,10 @@ IGNORE_CLANG_WARNINGS_END
                         CCallHelpers::Call slowPathCall;
                         if (Options::useHandlerICInFTL()) {
                             jit.move(CCallHelpers::TrustedImmPtr(generator->propertyCache()), propertyCacheGPR);
-                            generator->propertyCache()->m_slowOperation = optimizationFunction;
+                            downcast<HandlerPropertyInlineCache>(*generator->propertyCache()).m_slowOperation = optimizationFunction;
                             slowPathCall = callOperation(
                                 *state, params.unavailableRegisters(), jit, semanticNodeOrigin,
-                                exceptions.get(), CCallHelpers::Address(propertyCacheGPR, PropertyInlineCache::offsetOfSlowOperation()), params[0].gpr(),
+                                exceptions.get(), CCallHelpers::Address(propertyCacheGPR, HandlerPropertyInlineCache::offsetOfSlowOperation()), params[0].gpr(),
                                 params[1].gpr(), params[2].gpr(), propertyCacheGPR).call();
                         } else {
                             slowPathCall = callOperation(

--- a/Source/JavaScriptCore/ftl/FTLState.cpp
+++ b/Source/JavaScriptCore/ftl/FTLState.cpp
@@ -170,9 +170,9 @@ State::~State() = default;
 PropertyInlineCache* State::addPropertyInlineCache()
 {
     ASSERT(!graph.m_plan.isUnlinked());
-    auto* propertyCache = jitCode->common.m_propertyInlineCaches.add();
-    propertyCache->useHandlerIC = Options::useHandlerICInFTL();
-    return propertyCache;
+    if (Options::useHandlerICInFTL())
+        return jitCode->common.m_handlerPropertyInlineCaches.add();
+    return jitCode->common.m_repatchingPropertyInlineCaches.add();
 }
 
 OptimizingCallLinkInfo* State::addCallLinkInfo(CodeOrigin codeOrigin)

--- a/Source/JavaScriptCore/jit/BaselineJITCode.h
+++ b/Source/JavaScriptCore/jit/BaselineJITCode.h
@@ -115,10 +115,10 @@ public:
     bool m_isShareable { true };
 };
 
-class BaselineJITData final : public ButterflyArray<BaselineJITData, PropertyInlineCache, void*> {
+class BaselineJITData final : public ButterflyArray<BaselineJITData, HandlerPropertyInlineCache, void*> {
     friend class LLIntOffsetsExtractor;
 public:
-    using Base = ButterflyArray<BaselineJITData, PropertyInlineCache, void*>;
+    using Base = ButterflyArray<BaselineJITData, HandlerPropertyInlineCache, void*>;
 
     static std::unique_ptr<BaselineJITData> create(unsigned propertyCacheSize, unsigned poolSize, CodeBlock* codeBlock)
     {
@@ -133,7 +133,7 @@ public:
     static constexpr ptrdiff_t offsetOfJITExecutionActiveThreshold() { return OBJECT_OFFSETOF(BaselineJITData, m_executeCounter) + OBJECT_OFFSETOF(BaselineExecutionCounter, m_activeThreshold); }
     static constexpr ptrdiff_t offsetOfJITExecutionTotalCount() { return OBJECT_OFFSETOF(BaselineJITData, m_executeCounter) + OBJECT_OFFSETOF(BaselineExecutionCounter, m_totalCount); }
 
-    PropertyInlineCache& propertyCache(unsigned index)
+    HandlerPropertyInlineCache& propertyCache(unsigned index)
     {
         auto span = propertyInlineCaches();
         return span[span.size() - index - 1];

--- a/Source/JavaScriptCore/jit/JITInlineCacheGenerator.cpp
+++ b/Source/JavaScriptCore/jit/JITInlineCacheGenerator.cpp
@@ -63,10 +63,10 @@ void JITInlineCacheGenerator::finalize(
     LinkBuffer& fastPath, LinkBuffer& slowPath, CodeLocationLabel<JITStubRoutinePtrTag> start)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useHandlerIC);
-    m_propertyCache->startLocation = start;
+    auto& repatchingIC = downcast<RepatchingPropertyInlineCache>(*m_propertyCache);
+    repatchingIC.startLocation = start;
     m_propertyCache->doneLocation = fastPath.locationOf<JSInternalPtrTag>(m_done);
-    m_propertyCache->m_slowPathCallLocation = slowPath.locationOf<JSInternalPtrTag>(m_slowPathCall);
+    repatchingIC.m_slowPathCallLocation = slowPath.locationOf<JSInternalPtrTag>(m_slowPathCall);
     m_propertyCache->slowPathStartLocation = slowPath.locationOf<JITStubRoutinePtrTag>(m_slowPathBegin);
 }
 
@@ -91,12 +91,12 @@ void JITByIdGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 {
     ASSERT(m_propertyCache);
     JITInlineCacheGenerator::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
 }
 
 void JITByIdGenerator::generateFastCommon(CCallHelpers& jit, size_t inlineICSize)
 {
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
     jit.padBeforePatch(); // On ARMv7, this ensures that the patchable jump does not make the inline code too large.
     m_start = jit.label();
     size_t startSize = jit.m_assembler.buffer().codeSize();
@@ -168,7 +168,7 @@ static void generateGetByIdInlineAccessBaselineDataIC(CCallHelpers& jit, GPRReg 
 void JITGetByIdGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
     generateFastCommon(jit, m_isLengthAccess ? InlineAccess::sizeForLengthAccess() : InlineAccess::sizeForPropertyAccess());
 }
 
@@ -200,7 +200,7 @@ JITGetByIdWithThisGenerator::JITGetByIdWithThisGenerator(
 void JITGetByIdWithThisGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
     generateFastCommon(jit, InlineAccess::sizeForPropertyAccess());
 }
 
@@ -259,7 +259,7 @@ void JITPutByIdGenerator::generateDataICFastPath(CCallHelpers& jit)
 void JITPutByIdGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
     generateFastCommon(jit, InlineAccess::sizeForPropertyReplace());
 }
 
@@ -274,7 +274,7 @@ JITDelByValGenerator::JITDelByValGenerator(CodeBlock* codeBlock, CompileTimeProp
 void JITDelByValGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
     m_start = jit.label();
     m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
@@ -290,7 +290,7 @@ void JITDelByValGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 {
     ASSERT(m_propertyCache);
     Base::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
 }
 
 JITDelByIdGenerator::JITDelByIdGenerator(CodeBlock* codeBlock, CompileTimePropertyInlineCache propertyCache, JITType jitType, CodeOrigin codeOrigin, CallSiteIndex callSiteIndex, AccessType accessType, const RegisterSet& usedRegisters, CacheableIdentifier propertyName, JSValueRegs base, JSValueRegs result, GPRReg propertyCacheGPR)
@@ -304,7 +304,7 @@ JITDelByIdGenerator::JITDelByIdGenerator(CodeBlock* codeBlock, CompileTimeProper
 void JITDelByIdGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
     m_start = jit.label();
     m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
@@ -320,7 +320,7 @@ void JITDelByIdGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 {
     ASSERT(m_propertyCache);
     Base::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
 }
 
 JITInByValGenerator::JITInByValGenerator(CodeBlock* codeBlock, CompileTimePropertyInlineCache propertyCache, JITType jitType, CodeOrigin codeOrigin, CallSiteIndex callSiteIndex, AccessType accessType, const RegisterSet& usedRegisters, JSValueRegs base, JSValueRegs property, JSValueRegs result, GPRReg arrayProfileGPR, GPRReg propertyCacheGPR)
@@ -334,7 +334,7 @@ JITInByValGenerator::JITInByValGenerator(CodeBlock* codeBlock, CompileTimeProper
 void JITInByValGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
     m_start = jit.label();
     m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
@@ -352,7 +352,7 @@ void JITInByValGenerator::finalize(
     ASSERT(m_start.isSet());
     ASSERT(m_propertyCache);
     Base::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
 }
 
 JITInByIdGenerator::JITInByIdGenerator(
@@ -381,7 +381,7 @@ static void generateInByIdInlineAccessBaselineDataIC(CCallHelpers& jit, GPRReg p
 void JITInByIdGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
     generateFastCommon(jit, InlineAccess::sizeForPropertyAccess());
 }
 
@@ -411,7 +411,7 @@ JITInstanceOfGenerator::JITInstanceOfGenerator(
 void JITInstanceOfGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
     m_start = jit.label();
     m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
@@ -427,7 +427,7 @@ void JITInstanceOfGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath
 {
     ASSERT(m_propertyCache);
     Base::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
 }
 
 JITGetByValGenerator::JITGetByValGenerator(CodeBlock* codeBlock, CompileTimePropertyInlineCache propertyCache, JITType jitType, CodeOrigin codeOrigin, CallSiteIndex callSiteIndex, AccessType accessType, const RegisterSet& usedRegisters, JSValueRegs base, JSValueRegs property, JSValueRegs result, GPRReg arrayProfileGPR, GPRReg propertyCacheGPR)
@@ -443,7 +443,7 @@ JITGetByValGenerator::JITGetByValGenerator(CodeBlock* codeBlock, CompileTimeProp
 void JITGetByValGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
     m_start = jit.label();
     m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
@@ -465,7 +465,7 @@ void JITGetByValGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 {
     ASSERT(m_propertyCache);
     Base::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
 }
 
 JITGetByValWithThisGenerator::JITGetByValWithThisGenerator(CodeBlock* codeBlock, CompileTimePropertyInlineCache propertyCache, JITType jitType, CodeOrigin codeOrigin, CallSiteIndex callSiteIndex, AccessType accessType, const RegisterSet& usedRegisters, JSValueRegs base, JSValueRegs property, JSValueRegs thisRegs, JSValueRegs result, GPRReg arrayProfileGPR, GPRReg propertyCacheGPR)
@@ -481,7 +481,7 @@ JITGetByValWithThisGenerator::JITGetByValWithThisGenerator(CodeBlock* codeBlock,
 void JITGetByValWithThisGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
     m_start = jit.label();
     m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
@@ -505,7 +505,7 @@ void JITGetByValWithThisGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& sl
 {
     ASSERT(m_propertyCache);
     Base::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
 }
 
 JITPutByValGenerator::JITPutByValGenerator(CodeBlock* codeBlock, CompileTimePropertyInlineCache propertyCache, JITType jitType, CodeOrigin codeOrigin, CallSiteIndex callSiteIndex, AccessType accessType, const RegisterSet& usedRegisters, JSValueRegs base, JSValueRegs property, JSValueRegs value, GPRReg arrayProfileGPR, GPRReg propertyCacheGPR)
@@ -521,7 +521,7 @@ JITPutByValGenerator::JITPutByValGenerator(CodeBlock* codeBlock, CompileTimeProp
 void JITPutByValGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
     m_start = jit.label();
     m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
@@ -537,7 +537,7 @@ void JITPutByValGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& slowPath)
 {
     ASSERT(m_propertyCache);
     Base::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
 }
 
 JITPrivateBrandAccessGenerator::JITPrivateBrandAccessGenerator(CodeBlock* codeBlock, CompileTimePropertyInlineCache propertyCache, JITType jitType, CodeOrigin codeOrigin, CallSiteIndex callSiteIndex, AccessType accessType, const RegisterSet& usedRegisters, JSValueRegs base, JSValueRegs brand, GPRReg propertyCacheGPR)
@@ -552,7 +552,7 @@ JITPrivateBrandAccessGenerator::JITPrivateBrandAccessGenerator(CodeBlock* codeBl
 void JITPrivateBrandAccessGenerator::generateFastPath(CCallHelpers& jit)
 {
     ASSERT(m_propertyCache);
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
     m_start = jit.label();
     m_slowPathJump = jit.patchableJump();
     m_done = jit.label();
@@ -568,7 +568,7 @@ void JITPrivateBrandAccessGenerator::finalize(LinkBuffer& fastPath, LinkBuffer& 
 {
     ASSERT(m_propertyCache);
     Base::finalize(fastPath, slowPath, fastPath.locationOf<JITStubRoutinePtrTag>(m_start));
-    ASSERT(!m_propertyCache->useHandlerIC);
+    ASSERT(is<RepatchingPropertyInlineCache>(*m_propertyCache));
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/JITInlines.h
+++ b/Source/JavaScriptCore/jit/JITInlines.h
@@ -590,7 +590,7 @@ ALWAYS_INLINE void JIT::loadGlobalObject(GPRReg result)
 
 ALWAYS_INLINE void JIT::loadPropertyInlineCache(CCallHelpers& jit, PropertyInlineCacheIndex index, GPRReg result)
 {
-    jit.subPtr(GPRInfo::jitDataRegister, TrustedImm32(static_cast<uintptr_t>(index.m_index + 1) * sizeof(PropertyInlineCache)), result);
+    jit.subPtr(GPRInfo::jitDataRegister, TrustedImm32(static_cast<uintptr_t>(index.m_index + 1) * sizeof(HandlerPropertyInlineCache)), result);
 }
 
 ALWAYS_INLINE void JIT::loadPropertyInlineCache(PropertyInlineCacheIndex index, GPRReg result)


### PR DESCRIPTION
#### d042d9b75315a2ad189d7baae74828ca68f9b5c7
<pre>
[JSC] Split PropertyInlineCache into subclasses
<a href="https://bugs.webkit.org/show_bug.cgi?id=309568">https://bugs.webkit.org/show_bug.cgi?id=309568</a>
<a href="https://rdar.apple.com/172190152">rdar://172190152</a>

Reviewed by Yusuke Suzuki.

Split the monolithic PropertyInlineCache class into a base class with two subclasses:
HandlerPropertyInlineCache (used by Baseline JIT and DFG) and RepatchingPropertyInlineCache
(used by FTL and 32-bit DFG). The useHandlerIC boolean field is replaced by a
PropertyInlineCacheType enum and WTF type trait infrastructure, enabling dynamicDowncast&lt;&gt;
and is&lt;&gt; checks throughout. Mode-specific fields — m_slowOperation and m_inlinedHandler for
handler ICs; startLocation, m_slowPathCallLocation, m_stub, and inlineCodeSize() for
repatching ICs — are moved to the appropriate subclass.

DFG::CommonData now holds two separate Bags (m_handlerPropertyInlineCaches and
m_repatchingPropertyInlineCaches) instead of a single m_propertyInlineCaches bag, and
FTL::State::addPropertyInlineCache() selects which bag to use based on the
useHandlerICInFTL option.

I also added a FIXME to move the various regs (m_baseGPR, m_extraGPR, etc) to
RepatchingPropertyInlineCache and have HandlerPropertyInlineCache use fixed
values. This is slightly non-trivial because the different AccessTypes use
different registers for each of the values.

Canonical link: <a href="https://commits.webkit.org/309143@main">https://commits.webkit.org/309143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6072637a4ca595d701f46f65aeec97b4fa08f666

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149350 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158049 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102782 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/63c4628a-fd1d-4a98-99bc-11e16c4ca813) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115166 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81938 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95914 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7715aba3-31ba-4677-9d36-1401d44fc2bf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16419 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14302 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5893 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141320 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126019 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160528 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10141 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3521 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13490 "Found 1 new test failure: fast/attachment/mac/wide-attachment-image-controls-basic.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123209 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123425 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133754 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78092 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23032 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18657 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10500 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180779 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21476 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85289 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46321 "Build was cancelled. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21207 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21356 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21264 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->