### PR TITLE
[WPE] Add support to load settings from file

### DIFF
--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -436,23 +436,34 @@ static void automationStartedCallback(WebKitWebContext*, WebKitAutomationSession
     g_signal_connect(session, "create-web-view", G_CALLBACK(createWebViewForAutomationCallback), view);
 }
 
+static void loadConfigFile(WebKitSettings* webkitSettings
 #if ENABLE_WPE_PLATFORM
-void loadConfigFile(WPESettings* settings)
+    , WPESettings* wpeSettings
+#endif
+    )
 {
     GError* error = nullptr;
-    GKeyFile* keyFile = g_key_file_new();
+    g_autoptr(GKeyFile) keyFile = g_key_file_new();
     if (!g_key_file_load_from_file(keyFile, configFile, G_KEY_FILE_NONE, &error)) {
         g_warning("Error loading key file '%s': %s", configFile, error->message);
         g_clear_error(&error);
         return;
     }
 
-    if (!wpe_settings_load_from_keyfile(settings, keyFile, &error)) {
-        g_warning("Error parsing config file '%s': %s", configFile, error->message);
+    if (g_key_file_has_group(keyFile, "websettings")) {
+        if (!webkit_settings_apply_from_key_file(webkitSettings, keyFile, "websettings", &error)) {
+            g_warning("Error applying WebKit settings from key file '%s': %s", configFile, error->message);
+            g_clear_error(&error);
+        }
+    }
+
+#if ENABLE_WPE_PLATFORM
+    if (wpeSettings && !wpe_settings_load_from_keyfile(wpeSettings, keyFile, &error)) {
+        g_warning("Error applying WPE platform settings from key file '%s': %s", configFile, error->message);
         g_clear_error(&error);
     }
-}
 #endif
+}
 
 #if defined(USE_LIBWPE) && USE_LIBWPE
 static void activate(GApplication* application, WPEToolingBackends::ViewBackend* backend)
@@ -657,10 +668,17 @@ static void activate(GApplication* application, gpointer)
         g_signal_connect(wpeView, "event", G_CALLBACK(wpeViewEventCallback), webView);
         wpe_toplevel_set_title(wpeToplevel, defaultWindowTitle);
         g_signal_connect(webView, "notify::title", G_CALLBACK(webViewTitleChanged), wpeView);
-        if (configFile)
-            loadConfigFile(wpe_display_get_settings(wpe_view_get_display(wpeView)));
     }
 #endif
+
+    if (configFile) {
+#if ENABLE_WPE_PLATFORM
+        auto* wpeView = webkit_web_view_get_wpe_view(webView);
+        loadConfigFile(webkit_web_view_get_settings(webView), wpeView ? wpe_display_get_settings(wpe_view_get_display(wpeView)) : nullptr);
+#else
+        loadConfigFile(webkit_web_view_get_settings(webView));
+#endif
+    }
 
     openViews = g_hash_table_new_full(nullptr, nullptr, g_object_unref, nullptr);
 


### PR DESCRIPTION
#### b153c227f72d2d9742662fe573abdcc30ea9add9
<pre>
[WPE] Add support to load settings from file
<a href="https://bugs.webkit.org/show_bug.cgi?id=309576">https://bugs.webkit.org/show_bug.cgi?id=309576</a>

Reviewed by Adrian Perez de Castro.

WPE MiniBrowser already supports loading wpe-platform settings from a
key file, using wpe_settings_load_from_keyfile. This extends this
behaviour by using webkit_settings_apply_from_key_file to load web
settings when the websettings group is present in the configuration
file (--config-file=file.conf)

* Tools/MiniBrowser/wpe/main.cpp:
(loadConfigFile):
(activate):

Canonical link: <a href="https://commits.webkit.org/309047@main">https://commits.webkit.org/309047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8c6b3b547c09bb488cf4012a6bb483c51b1f186

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149102 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102533 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150975 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22269 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21693 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114946 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81831 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152062 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133811 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95705 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16227 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14103 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5643 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160274 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13258 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122996 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21617 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18132 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123226 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33529 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133529 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77826 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18482 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10287 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21227 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20959 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21107 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21015 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->