### PR TITLE
Safari loads huggingface.co slowly

### DIFF
--- a/PerformanceTests/CSS/WhereIsRuleIndexing.html
+++ b/PerformanceTests/CSS/WhereIsRuleIndexing.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Performance test for :where()/:is() rule indexing</title>
+</head>
+<body>
+<div id="container" style="height: 1px; overflow: hidden;"></div>
+<script src="../resources/runner.js"></script>
+<script>
+
+var ruleTags = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'a', 'blockquote',
+    'strong', 'em', 'code', 'pre', 'ol', 'ul', 'li', 'table', 'img', 'hr', 'dl'];
+var style = document.createElement('style');
+var css = '';
+for (var i = 0; i < ruleTags.length; i++)
+    css += '.prose :where(' + ruleTags[i] + '):not(:where([class~="not-prose"], [class~="not-prose"] *)) { margin: ' + (i + 1) + 'px; }\n';
+style.textContent = css;
+document.head.appendChild(style);
+
+var container = document.getElementById('container');
+var domTags = ['div', 'div', 'div', 'span', 'span', 'p', 'section', 'article'];
+for (var i = 0; i < 25000; i++) {
+    var el = document.createElement(domTags[i % domTags.length]);
+    el.textContent = 'x';
+    if (i % 500 === 0)
+        el.className = 'not-prose';
+    container.appendChild(el);
+}
+
+PerfTestRunner.measureRunsPerSecond({
+    description: "Style recalculation with :where(tag) rules on a large DOM. Tests that single-argument :where()/:is() rules are indexed by tag.",
+    run: function() {
+        container.classList.add('prose');
+        container.offsetHeight;
+
+        container.classList.remove('prose');
+        container.offsetHeight;
+    }
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -291,6 +291,21 @@ void RuleSet::addRule(RuleData&& ruleData, CascadeLayerIdentifier cascadeLayerId
             case CSSSelector::PseudoClass::Scope:
                 m_hasHostOrScopePseudoClassRulesInUniversalBucket = true;
                 break;
+            case CSSSelector::PseudoClass::Is:
+            case CSSSelector::PseudoClass::Where: {
+                auto* selectorList = selector->selectorList();
+                if (selectorList && selectorList->size() == 1) {
+                    for (auto* inner = &selectorList->first(); inner; inner = inner->precedingInComplexSelector()) {
+                        if (inner->match() == CSSSelector::Match::Tag && inner->tagQName().localName() != starAtom() && !tagSelector)
+                            tagSelector = inner;
+                        if (inner->relation() != CSSSelector::Relation::Subselector)
+                            break;
+                    }
+                }
+                if (hasHostOrScopePseudoClassSubjectInSelectorList(selector->selectorList()))
+                    m_hasHostOrScopePseudoClassRulesInUniversalBucket = true;
+                break;
+            }
             default:
                 if (hasHostOrScopePseudoClassSubjectInSelectorList(selector->selectorList()))
                     m_hasHostOrScopePseudoClassRulesInUniversalBucket = true;


### PR DESCRIPTION
#### fb0de39d9421fe9f3ec4b38744d98c0dea0da74c
<pre>
Safari loads huggingface.co slowly
<a href="https://bugs.webkit.org/show_bug.cgi?id=309574">https://bugs.webkit.org/show_bug.cgi?id=309574</a>
<a href="https://rdar.apple.com/114904007">rdar://114904007</a>

Reviewed by Antti Koivisto.

CSS rules like &quot;.prose :where(h1):not(...)&quot; land in the universal
rule bucket because :where() and :is() are not examined for
indexable selectors. This causes every element to be
checked against these rules during style recalculation, which causes
performance loss on huggingface.co.

This change extracts indexable tags from single argument :where/:is
and uses them for rule bucket indexing, allowing the style engine to
skip these rules for elements which can&apos;t match, avoiding unnecessary
work.

Without the fix a full relayout on
<a href="https://huggingface.co/docs/transformers/model_doc/auto">https://huggingface.co/docs/transformers/model_doc/auto</a> takes ~1500 ms
while with the fix this takes ~500 ms. The included performance test
progresses from ~15 runs/s to ~21 runs/s.

There should be no functionality change associated with this change.
Correctness will be verified via existing tests.

* PerformanceTests/CSS/WhereIsRuleIndexing.html: Added.
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRule):

Canonical link: <a href="https://commits.webkit.org/311212@main">https://commits.webkit.org/311212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb981b97ccfbf2830076ea5cb7da552d913bd7ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157848 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102591 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151033 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21751 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114994 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81852 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17164 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133852 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; 9 api tests failed or timed out; re-run-api-tests (cancelled)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95749 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16264 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14138 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5701 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125864 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11786 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160333 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3320 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123040 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123268 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35025 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133579 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77884 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18510 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10329 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21285 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85087 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21017 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21165 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21073 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->