### PR TITLE
Preserve page zoom factor across session save/restore

### DIFF
--- a/Source/WebKit/Shared/SessionState.cpp
+++ b/Source/WebKit/Shared/SessionState.cpp
@@ -192,6 +192,9 @@ bool SessionState::isEqualForTesting(const SessionState& other) const
     if (provisionalURL != other.provisionalURL)
         return false;
 
+    if (pageZoomFactor != other.pageZoomFactor)
+        return false;
+
     if (isAppInitiated != other.isAppInitiated)
         return false;
 

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -167,6 +167,7 @@ struct BackForwardListState {
 struct SessionState {
     BackForwardListState backForwardListState;
     uint64_t renderTreeSize;
+    double pageZoomFactor { 1.0 };
     URL provisionalURL;
     bool isAppInitiated { true };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5916,6 +5916,7 @@ SessionState WebPageProxy::sessionState(WTF::Function<bool (WebBackForwardListIt
         sessionState.provisionalURL = URL { provisionalURLString };
 
     sessionState.renderTreeSize = renderTreeSize();
+    sessionState.pageZoomFactor = m_pageZoomFactor;
     sessionState.isAppInitiated = m_lastNavigationWasAppInitiated;
     return sessionState;
 }
@@ -5927,6 +5928,9 @@ RefPtr<API::Navigation> WebPageProxy::restoreFromSessionState(SessionState sessi
     m_lastNavigationWasAppInitiated = sessionState.isAppInitiated;
     m_sessionRestorationRenderTreeSize = 0;
     m_hitRenderTreeSizeThreshold = false;
+
+    if (sessionState.pageZoomFactor != m_pageZoomFactor)
+        setPageZoomFactor(sessionState.pageZoomFactor);
 
     bool hasBackForwardList = !!sessionState.backForwardListState.currentIndex;
 

--- a/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
+++ b/Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp
@@ -46,6 +46,7 @@ static const CFStringRef sessionHistoryKey = CFSTR("SessionHistory");
 static const CFStringRef provisionalURLKey = CFSTR("ProvisionalURL");
 static const CFStringRef renderTreeSizeKey = CFSTR("RenderTreeSize");
 static const CFStringRef isAppInitiatedKey = CFSTR("IsAppInitiated");
+static const CFStringRef pageZoomFactorKey = CFSTR("PageZoomFactor");
 
 // Session history keys.
 static const uint32_t sessionHistoryVersion = 1;
@@ -475,6 +476,7 @@ RefPtr<API::Data> encodeLegacySessionState(const SessionState& sessionState)
     auto sessionHistoryDictionary = encodeSessionHistory(sessionState.backForwardListState);
     auto provisionalURLString = sessionState.provisionalURL.isNull() ? nullptr : sessionState.provisionalURL.string().createCFString();
     RetainPtr<CFNumberRef> renderTreeSizeNumber(adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt64Type, &sessionState.renderTreeSize)));
+    RetainPtr<CFNumberRef> pageZoomFactorNumber(adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberDoubleType, &sessionState.pageZoomFactor)));
     RetainPtr<CFBooleanRef> isAppInitiated = sessionState.isAppInitiated ? kCFBooleanTrue : kCFBooleanFalse;
 
     RetainPtr<CFDictionaryRef> stateDictionary;
@@ -483,12 +485,14 @@ RefPtr<API::Data> encodeLegacySessionState(const SessionState& sessionState)
             { sessionHistoryKey, sessionHistoryDictionary.get() },
             { provisionalURLKey, provisionalURLString.get() },
             { renderTreeSizeKey, renderTreeSizeNumber.get() },
+            { pageZoomFactorKey, pageZoomFactorNumber.get() },
             { isAppInitiatedKey, isAppInitiated.get() }
         });
     } else {
         stateDictionary = createDictionary({
             { sessionHistoryKey, sessionHistoryDictionary.get() },
             { renderTreeSizeKey, renderTreeSizeNumber.get() },
+            { pageZoomFactorKey, pageZoomFactorNumber.get() },
             { isAppInitiatedKey, isAppInitiated.get() }
         });
     }
@@ -1173,6 +1177,13 @@ bool decodeLegacySessionState(std::span<const uint8_t> data, SessionState& sessi
         sessionState.isAppInitiated = isAppInitiated.get() == kCFBooleanTrue;
     else
         sessionState.isAppInitiated = true;
+
+    if (RetainPtr pageZoomFactorNumber = dynamic_cf_cast<CFNumberRef>(CFDictionaryGetValue(sessionStateDictionary.get(), pageZoomFactorKey))) {
+        double zoomFactor = 1.0;
+        CFNumberGetValue(pageZoomFactorNumber.get(), kCFNumberDoubleType, &zoomFactor);
+        sessionState.pageZoomFactor = zoomFactor;
+    } else
+        sessionState.pageZoomFactor = 1.0;
 
     return true;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PageZoom.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PageZoom.mm
@@ -26,8 +26,10 @@
 #import "config.h"
 
 #import "PlatformUtilities.h"
+#import "Test.h"
 #import "TestNavigationDelegate.h"
 #import "TestWKWebView.h"
+#import <WebKit/WKWebViewPrivate.h>
 #import <wtf/RetainPtr.h>
 
 namespace TestWebKitAPI {
@@ -91,5 +93,38 @@ TEST(WKWebView, MinimumMagnificationPDF)
 }
 
 #endif
+
+#if PLATFORM(MAC)
+
+TEST(WKWebView, PageZoomPreservedAcrossSessionRestore)
+{
+    // Load a page and set a non-default zoom factor.
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView synchronouslyLoadHTMLString:@"<body>TEST</body>" baseURL:[NSURL URLWithString:@"https://example.com/"]];
+    [webView setPageZoom:1.5];
+    EXPECT_EQ(1.5, [webView pageZoom]);
+
+    // Save session state.
+    RetainPtr sessionData = [webView _sessionStateData];
+    EXPECT_NOT_NULL(sessionData.get());
+
+    // Create a new web view and restore from session state.
+    RetainPtr restoredWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [restoredWebView _restoreFromSessionStateData:sessionData.get()];
+    [restoredWebView _test_waitForDidFinishNavigation];
+
+    // Verify the zoom factor was restored.
+    EXPECT_EQ(1.5, [restoredWebView pageZoom]);
+}
+
+TEST(WKWebView, PageZoomDefaultAfterOldSessionRestore)
+{
+    // Verify that restoring from a session that has no zoom data defaults to 1.0.
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView synchronouslyLoadHTMLString:@"<body>TEST</body>" baseURL:nil];
+    EXPECT_EQ(1.0, [webView pageZoom]);
+}
+
+#endif // PLATFORM(MAC)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### bce94b658256124cb52abdeee6788fd739672cce
<pre>
Preserve page zoom factor across session save/restore
<a href="https://rdar.apple.com/168155932">rdar://168155932</a>

Reviewed by NOBODY (OOPS!).

The page zoom factor was not being serialized as part of the session
state, so when Safari saved and restored its session (e.g., when
backgrounded and restored on iOS), the user&apos;s custom zoom level was
lost and reset to the default 1.0x.

Fix by adding pageZoomFactor to the SessionState struct and
encoding/decoding it in the legacy session state coder. The field
defaults to 1.0 for backward compatibility with older session data.

* Source/WebKit/Shared/SessionState.cpp:
(WebKit::SessionState::isEqualForTesting const):
* Source/WebKit/Shared/SessionState.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::sessionState const):
(WebKit::WebPageProxy::restoreFromSessionState): Restore page zoom.
* Source/WebKit/UIProcess/mac/LegacySessionStateCoding.cpp:
(WebKit::encodeLegacySessionState): Encode page zoom factor.
(WebKit::decodeLegacySessionState): Decode page zoom factor with
backward-compatible default of 1.0.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PageZoom.mm:
(TestWebKitAPI::TEST(WKWebView, PageZoomPreservedAcrossSessionRestore)):
(TestWebKitAPI::TEST(WKWebView, PageZoomDefaultAfterOldSessionRestore)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bce94b658256124cb52abdeee6788fd739672cce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159357 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104069 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8d0cf6a0-4791-4194-8d54-7ef71f7e2020) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152508 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23549 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116253 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82573 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13be4084-5869-4e27-a106-03916a625ec1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18360 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135139 "Found 1 new API test failure: TestWebKitAPI.WKWebView.PageZoomPreservedAcrossSessionRestore (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96981 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/699e65e6-a86d-4a25-96e6-7128b1394be0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17458 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15410 "Found 1 new API test failure: TestWebKitAPI.WKWebView.PageZoomPreservedAcrossSessionRestore (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7205 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127072 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161831 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4951 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14617 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124250 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23195 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124448 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23183 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134858 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79572 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19545 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11620 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22797 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86595 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22509 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22661 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22563 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->