### PR TITLE
Perf tests CSS/HasWithChildCombinatorInIs.html and Layout/subgrids-spanning-many-rows.html fail due to visible text in output

### DIFF
--- a/PerformanceTests/CSS/HasWithChildCombinatorInIs.html
+++ b/PerformanceTests/CSS/HasWithChildCombinatorInIs.html
@@ -41,7 +41,6 @@ for (let i = 0; i < 100; i++) {
 
     for (let j = 0; j < 30; j++) {
         const li = document.createElement('li');
-        li.textContent = `Item ${j}`;
         ol.appendChild(li);
     }
 

--- a/PerformanceTests/Layout/subgrids-spanning-many-rows.html
+++ b/PerformanceTests/Layout/subgrids-spanning-many-rows.html
@@ -18,18 +18,18 @@
 
 <body>
 <div id="grid">
-  <div class="subgrid">Row</div>
-  <div class="subgrid">Row</div>
-  <div class="subgrid">Row</div>
-  <div class="subgrid">Row</div>
-  <div class="subgrid">Row</div>
-  <div class="subgrid">Row</div>
-  <div class="subgrid">Row</div>
-  <div class="subgrid">Row</div>
-  <div class="subgrid">Row</div>
-  <div class="subgrid">Row</div>
-  <div class="subgrid">Row</div>
-  <div class="subgrid">Row</div>
+  <div class="subgrid"></div>
+  <div class="subgrid"></div>
+  <div class="subgrid"></div>
+  <div class="subgrid"></div>
+  <div class="subgrid"></div>
+  <div class="subgrid"></div>
+  <div class="subgrid"></div>
+  <div class="subgrid"></div>
+  <div class="subgrid"></div>
+  <div class="subgrid"></div>
+  <div class="subgrid"></div>
+  <div class="subgrid"></div>
 </div>
 </body>
 <script>


### PR DESCRIPTION
#### e2dcd48beed0bd539555f16d9a970c06e11d5770
<pre>
Perf tests CSS/HasWithChildCombinatorInIs.html and Layout/subgrids-spanning-many-rows.html fail due to visible text in output
<a href="https://bugs.webkit.org/show_bug.cgi?id=309579">https://bugs.webkit.org/show_bug.cgi?id=309579</a>
<a href="https://rdar.apple.com/172199389">rdar://172199389</a>

Reviewed by Sammy Gill.

The perf test runner treats any non-metric output as an error, and these tests had visible text content that got included in dumpAsText output.
This patch removes unnecessary visible text from both tests.

* PerformanceTests/CSS/HasWithChildCombinatorInIs.html:
* PerformanceTests/Layout/subgrids-spanning-many-rows.html:

Canonical link: <a href="https://commits.webkit.org/309022@main">https://commits.webkit.org/309022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97a83fbf24201e232f1b44d68c8387870ff38559

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157798 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102541 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21701 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114953 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81830 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17132 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133812 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95711 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16229 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14106 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5651 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125835 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160282 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13259 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123001 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21625 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123231 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21633 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133530 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77834 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22979 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18483 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10288 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21235 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20967 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21115 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21023 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->