### PR TITLE
[Post-commit CI] Recognize a macOS deployment target config parameter for back-deployed builds

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -316,6 +316,7 @@
                   },
                   { "name": "Apple-Sequoia-Release-Build", "factory": "BuildFactory",
                   "platform": "mac-sequoia", "configuration": "release", "architectures": ["x86_64", "arm64"],
+                  "deployment_target": "15.4",
                   "triggers": [
                       "sequoia-release-tests-wk1", "sequoia-release-tests-wk2",
                       "sequoia-release-applesilicon-tests-wk2",

--- a/Tools/CISupport/build-webkit-org/factories.py
+++ b/Tools/CISupport/build-webkit-org/factories.py
@@ -31,9 +31,9 @@ class Factory(factory.BuildFactory):
     shouldInstallDependencies = True
     shouldUseCrossTargetImage = False
 
-    def __init__(self, platform, configuration, architectures, buildOnly, additionalArguments, device_model, triggers=None):
+    def __init__(self, platform, configuration, architectures, buildOnly, additionalArguments, device_model, triggers=None, deployment_target=None):
         factory.BuildFactory.__init__(self)
-        self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architecture=' '.join(architectures), buildOnly=buildOnly, additionalArguments=additionalArguments, device_model=device_model, triggers=triggers))
+        self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architecture=' '.join(architectures), buildOnly=buildOnly, additionalArguments=additionalArguments, device_model=device_model, triggers=triggers, deployment_target=deployment_target))
         self.addStep(PrintConfiguration())
         self.addStep(CheckOutSource())
         self.addStep(CheckOutSpecificRevision())
@@ -55,8 +55,8 @@ class BuildFactory(Factory):
     shouldRunJSCBundleStep = False
     shouldRunMiniBrowserBundleStep = False
 
-    def __init__(self, platform, configuration, architectures, triggers=None, additionalArguments=None, device_model=None):
-        Factory.__init__(self, platform, configuration, architectures, True, additionalArguments, device_model, triggers=triggers)
+    def __init__(self, platform, configuration, architectures, triggers=None, additionalArguments=None, device_model=None, deployment_target=None):
+        Factory.__init__(self, platform, configuration, architectures, True, additionalArguments, device_model, triggers=triggers, deployment_target=deployment_target)
 
         if platform.startswith("playstation"):
             self.addStep(CompileWebKit(timeout=2 * 60 * 60))

--- a/Tools/CISupport/build-webkit-org/loadConfig.py
+++ b/Tools/CISupport/build-webkit-org/loadConfig.py
@@ -97,7 +97,7 @@ def loadBuilderConfig(c, is_test_mode_enabled=False, setup_main_schedulers=True,
         factoryName = builder.pop('factory')
         factory = globals()[factoryName]
         factorykwargs = {}
-        for key in ['platform', 'configuration', 'architectures', 'triggers', 'additionalArguments', 'device_model']:
+        for key in ['platform', 'configuration', 'architectures', 'triggers', 'additionalArguments', 'device_model', 'deployment_target']:
             value = builder.pop(key, None)
             if value:
                 factorykwargs[key] = value

--- a/Tools/CISupport/build-webkit-org/loadConfig_unittest.py
+++ b/Tools/CISupport/build-webkit-org/loadConfig_unittest.py
@@ -48,8 +48,9 @@ class ConfigDotJSONTest(unittest.TestCase):
     def test_builder_keys(self):
         config = self.get_config()
         valid_builder_keys = ['additionalArguments', 'architectures', 'builddir', 'configuration', 'description',
-                              'defaultProperties', 'device_model', 'env', 'factory', 'icon', 'locks', 'name', 'platform', 'properties',
-                              'remotes', 'runTests', 'shortname', 'tags', 'triggers', 'workernames', 'workerbuilddir']
+                              'defaultProperties', 'deployment_target', 'device_model', 'env', 'factory', 'icon', 'locks',
+                              'name', 'platform', 'properties', 'remotes', 'runTests', 'shortname', 'tags', 'triggers',
+                              'workernames', 'workerbuilddir']
         for builder in config.get('builders', []):
             for key in builder:
                 self.assertTrue(key in valid_builder_keys, f"Unexpected key {key} for builder {builder.get('name')}")
@@ -75,6 +76,13 @@ class ConfigDotJSONTest(unittest.TestCase):
         for scheduler in config['schedulers']:
             if scheduler.get('type') == 'Triggerable':
                 self.assertTrue(len(scheduler.get('builderNames')) == 1, f"scheduler {scheduler['name']} triggers multiple builders.")
+
+    def test_deployment_target_on_intended_queues(self):
+        config = self.get_config()
+        for builder in config['builders']:
+            if builder.get('deployment_target'):
+                self.assertTrue(builder.get('platform').startswith('mac-'),
+                                f'custom deployment target only implemented for macOS builders, but found on "{builder["name"]}" with platform "{builder["platform"]}"')
 
 
 class TagsForBuilderTest(unittest.TestCase):

--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -179,7 +179,7 @@ class ConfigureBuild(buildstep.BuildStep, AddToLogMixin):
     description = ["configuring build"]
     descriptionDone = ["configured build"]
 
-    def __init__(self, platform, configuration, architecture, buildOnly, additionalArguments, device_model, triggers, *args, **kwargs):
+    def __init__(self, platform, configuration, architecture, buildOnly, additionalArguments, device_model, triggers, deployment_target=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.platform = platform
         if platform != 'jsc-only':
@@ -191,6 +191,7 @@ class ConfigureBuild(buildstep.BuildStep, AddToLogMixin):
         self.additionalArguments = additionalArguments
         self.device_model = device_model
         self.triggers = triggers
+        self.deployment_target = deployment_target
 
     @defer.inlineCallbacks
     def run(self):
@@ -203,6 +204,8 @@ class ConfigureBuild(buildstep.BuildStep, AddToLogMixin):
         self.setProperty("additionalArguments", self.additionalArguments)
         self.setProperty("device_model", self.device_model)
         self.setProperty("triggers", self.triggers)
+        if self.deployment_target:
+            self.setProperty("deployment_target", self.deployment_target)
         yield self._addToLog('stdio', 'Set build properties')
         return defer.returnValue(SUCCESS)
 
@@ -405,6 +408,9 @@ class CompileWebKit(shell.Compile, CustomFlagsMixin, ShellMixin, AddToLogMixin):
                 # Some projects (namely lldbWebKitTester) require full debug info, and may override this.
                 build_command += ['DEBUG_INFORMATION_FORMAT=dwarf-with-dsym']
                 build_command += ['CLANG_DEBUG_INFORMATION_LEVEL=\\$\\(WK_OVERRIDE_DEBUG_INFORMATION_LEVEL:default=line-tables-only\\)']
+            deployment_target = self.getProperty('deployment_target')
+            if deployment_target and platform == 'mac':
+                build_command += [f'MACOSX_DEPLOYMENT_TARGET={deployment_target}']
 
         build_command += self.customBuildFlag(platform, self.getProperty('fullPlatform'))
 


### PR DESCRIPTION
#### a92a26de26157f566cf2d0fd5bedbbb5a06c31d5
<pre>
[Post-commit CI] Recognize a macOS deployment target config parameter for back-deployed builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=307195">https://bugs.webkit.org/show_bug.cgi?id=307195</a>
<a href="https://rdar.apple.com/151877838">rdar://151877838</a>

Reviewed by Aakash Jain.

In EWS and post-commit CI, add an optional `deployment_target` field to
config.json. Store it as a property of the build and plumb it through to
the build-webkit line, where it is used to override the
MACOSX_DEPLOYMENT_TARGET build setting. Set the deployment target in the
existing Sequoia queue.

EWS has equivalent logic landing in a separate patch.

* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/build-webkit-org/factories.py:
(Factory.__init__):
(BuildFactory.__init__):
* Tools/CISupport/build-webkit-org/loadConfig.py:
(loadBuilderConfig):
* Tools/CISupport/build-webkit-org/loadConfig_unittest.py:
(ConfigDotJSONTest.test_builder_keys):
(ConfigDotJSONTest.test_deployment_target_on_intended_queues):
* Tools/CISupport/build-webkit-org/steps.py:
(ConfigureBuild.__init__):
(ConfigureBuild.run):
(CompileWebKit.run):

Canonical link: <a href="https://commits.webkit.org/309101@main">https://commits.webkit.org/309101@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28043d6a9ca5d25e6898605cee14ae49bfb0262d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15429 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157834 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102577 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c599264-5ee9-4ea5-95ca-4f9d4dd9bfb8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151019 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114979 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81845 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7edf3815-6a8c-4b18-b5ea-7aeb29fbd549) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152106 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133840 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95736 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16251 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14128 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; 3 api tests failed or timed out; re-run-api-tests (cancelled)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5687 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125857 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; 2 api tests failed or timed out; re-run-api-tests (cancelled)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11770 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160318 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123027 "Passed tests") | | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/148544 "Failed EWS unit tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123256 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21669 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133563 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77870 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23015 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18502 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10317 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21271 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21003 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21151 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21059 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->