### PR TITLE
ScriptElement should defer prepareScript until all DocumentFragment children are inserted

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/127-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/127-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (FAIL), message = SyntaxError: Unexpected end of script
-
-FAIL scheduler: appending non-text children to script  assert_array_equals: lengths differ, expected array ["inline script #1", "inline script #2", "end inline script #2", "end inline script #1"] length 4, got ["inline script #1", "end inline script #1"] length 2
+PASS scheduler: appending non-text children to script
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/128-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/128-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (FAIL), message = SyntaxError: Unexpected end of script
-
-FAIL scheduler: appending script element to script  assert_array_equals: lengths differ, expected array ["inline script #1", "inline script #3", "inline script #2", "end inline script #2", "end inline script #1"] length 5, got ["inline script #1", "inline script #3", "end inline script #1"] length 3
+PASS scheduler: appending script element to script
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/130-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/130-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (FAIL), message = SyntaxError: Unexpected end of script
-
-FAIL scheduler: appending external script element to script  assert_array_equals: lengths differ, expected array ["inline script #1", "inline script #2", "end inline script #2", "end inline script #1", "external script #1"] length 5, got ["inline script #1", "end inline script #1", "external script #1"] length 3
+PASS scheduler: appending external script element to script
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -64,6 +64,7 @@
 #include "SVGUseElement.h"
 #include "ScriptController.h"
 #include "ScriptDisallowedScope.h"
+#include "ScriptElement.h"
 #include "SelectorQuery.h"
 #include "SerializedNode.h"
 #include "SlotAssignment.h"
@@ -582,21 +583,26 @@ ExceptionOr<void> ContainerNode::insertBefore(Node& newChild, RefPtr<Node>&& ref
 
     InspectorInstrumentation::willInsertDOMNode(protect(document()), *this);
 
-    ChildListMutationScope mutation(*this);
-    for (auto& child : targets) {
-        // Due to arbitrary code running in response to a DOM mutation event it's
-        // possible that "next" is no longer a child of "this".
-        // It's also possible that "child" has been inserted elsewhere.
-        // In either of those cases, we'll just stop.
-        if (next->parentNode() != this)
-            break;
-        if (child->parentNode())
-            break;
+    {
+        CheckedPtr element = dynamicDowncast<Element>(*this);
+        ScriptElement::BatchChildInsertionScope batchScope(element ? dynamicDowncastScriptElement(*element) : nullptr);
 
-        executeNodeInsertionWithScriptAssertion(*this, child.get(), next.ptr(), ChildChange::Source::API, ReplacedAllChildren::No, [&] {
-            child->setTreeScopeRecursively(treeScope());
-            insertBeforeCommon(next, child);
-        });
+        ChildListMutationScope mutation(*this);
+        for (auto& child : targets) {
+            // Due to arbitrary code running in response to a DOM mutation event it's
+            // possible that "next" is no longer a child of "this".
+            // It's also possible that "child" has been inserted elsewhere.
+            // In either of those cases, we'll just stop.
+            if (next->parentNode() != this)
+                break;
+            if (child->parentNode())
+                break;
+
+            executeNodeInsertionWithScriptAssertion(*this, child.get(), next.ptr(), ChildChange::Source::API, ReplacedAllChildren::No, [&] {
+                child->setTreeScopeRecursively(treeScope());
+                insertBeforeCommon(next, child);
+            });
+        }
     }
 
     dispatchSubtreeModifiedEvent();
@@ -722,24 +728,28 @@ ExceptionOr<void> ContainerNode::replaceChild(Node& newChild, Node& oldChild)
 
     InspectorInstrumentation::willInsertDOMNode(protect(document()), *this);
 
-    // Add the new child(ren).
-    for (auto& child : targets) {
-        // Due to arbitrary code running in response to a DOM mutation event it's
-        // possible that "refChild" is no longer a child of "this".
-        // It's also possible that "child" has been inserted elsewhere.
-        // In either of those cases, we'll just stop.
-        if (refChild && refChild->parentNode() != this)
-            break;
-        if (child->parentNode())
-            break;
+    {
+        CheckedPtr element = dynamicDowncast<Element>(*this);
+        ScriptElement::BatchChildInsertionScope batchScope(element ? dynamicDowncastScriptElement(*element) : nullptr);
 
-        executeNodeInsertionWithScriptAssertion(*this, child.get(), refChild.get(), ChildChange::Source::API, ReplacedAllChildren::No, [&] {
-            child->setTreeScopeRecursively(treeScope());
-            if (refChild)
-                insertBeforeCommon(*refChild, child.get());
-            else
-                appendChildCommon(child);
-        });
+        for (auto& child : targets) {
+            // Due to arbitrary code running in response to a DOM mutation event it's
+            // possible that "refChild" is no longer a child of "this".
+            // It's also possible that "child" has been inserted elsewhere.
+            // In either of those cases, we'll just stop.
+            if (refChild && refChild->parentNode() != this)
+                break;
+            if (child->parentNode())
+                break;
+
+            executeNodeInsertionWithScriptAssertion(*this, child.get(), refChild.get(), ChildChange::Source::API, ReplacedAllChildren::No, [&] {
+                child->setTreeScopeRecursively(treeScope());
+                if (refChild)
+                    insertBeforeCommon(*refChild, child.get());
+                else
+                    appendChildCommon(child);
+            });
+        }
     }
 
     dispatchSubtreeModifiedEvent();
@@ -919,20 +929,24 @@ ExceptionOr<void> ContainerNode::appendChildWithoutPreInsertionValidityCheck(Nod
 
     InspectorInstrumentation::willInsertDOMNode(protect(document()), *this);
 
-    // Now actually add the child(ren)
-    ChildListMutationScope mutation(*this);
-    for (auto& child : targets) {
-        // If the child has a parent again, just stop what we're doing, because
-        // that means someone is doing something with DOM mutation -- can't re-parent
-        // a child that already has a parent.
-        if (child->parentNode())
-            break;
+    {
+        CheckedPtr element = dynamicDowncast<Element>(*this);
+        ScriptElement::BatchChildInsertionScope batchScope(element ? dynamicDowncastScriptElement(*element) : nullptr);
 
-        // Append child to the end of the list
-        executeNodeInsertionWithScriptAssertion(*this, child.get(), nullptr, ChildChange::Source::API, ReplacedAllChildren::No, [&] {
-            child->setTreeScopeRecursively(treeScope());
-            appendChildCommon(child);
-        });
+        ChildListMutationScope mutation(*this);
+        for (auto& child : targets) {
+            // If the child has a parent again, just stop what we're doing, because
+            // that means someone is doing something with DOM mutation -- can't re-parent
+            // a child that already has a parent.
+            if (child->parentNode())
+                break;
+
+            // Append child to the end of the list
+            executeNodeInsertionWithScriptAssertion(*this, child.get(), nullptr, ChildChange::Source::API, ReplacedAllChildren::No, [&] {
+                child->setTreeScopeRecursively(treeScope());
+                appendChildCommon(child);
+            });
+        }
     }
 
     dispatchSubtreeModifiedEvent();
@@ -965,19 +979,24 @@ ExceptionOr<void> ContainerNode::insertChildrenBeforeWithoutPreInsertionValidity
 
     InspectorInstrumentation::willInsertDOMNode(protect(document()), *this);
 
-    ChildListMutationScope mutation(*this);
-    for (auto& child : newChildren) {
-        if (refChild && refChild->parentNode() != this) // Event listeners moved nextChild elsewhere.
-            break;
-        if (child->parentNode()) // Event listeners inserted this child elsewhere.
-            break;
-        executeNodeInsertionWithScriptAssertion(*this, child.get(), refChild.get(), ChildChange::Source::API, ReplacedAllChildren::No, [&] {
-            child->setTreeScopeRecursively(treeScope());
-            if (refChild)
-                insertBeforeCommon(*refChild, child.get());
-            else
-                appendChildCommon(child);
-        });
+    {
+        CheckedPtr element = dynamicDowncast<Element>(*this);
+        ScriptElement::BatchChildInsertionScope batchScope(element ? dynamicDowncastScriptElement(*element) : nullptr);
+
+        ChildListMutationScope mutation(*this);
+        for (auto& child : newChildren) {
+            if (refChild && refChild->parentNode() != this) // Event listeners moved nextChild elsewhere.
+                break;
+            if (child->parentNode()) // Event listeners inserted this child elsewhere.
+                break;
+            executeNodeInsertionWithScriptAssertion(*this, child.get(), refChild.get(), ChildChange::Source::API, ReplacedAllChildren::No, [&] {
+                child->setTreeScopeRecursively(treeScope());
+                if (refChild)
+                    insertBeforeCommon(*refChild, child.get());
+                else
+                    appendChildCommon(child);
+            });
+        }
     }
 
     dispatchSubtreeModifiedEvent();

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -107,11 +107,24 @@ void ScriptElement::didFinishInsertingNode()
 
 void ScriptElement::childrenChanged(const ContainerNode::ChildChange& childChange)
 {
-    if (m_parserInserted == ParserInserted::No && childChange.isInsertion() && element().isConnected())
-        prepareScript(); // FIXME: Provide a real starting line number here.
+    if (m_parserInserted == ParserInserted::No && childChange.isInsertion() && element().isConnected()) {
+        if (m_batchChildInsertionCount)
+            m_needsPrepareAfterBatch = true;
+        else
+            prepareScript(); // FIXME: Provide a real starting line number here.
+    }
 
     if (childChange.source == ContainerNode::ChildChange::Source::API)
         m_childrenChangedByAPI = true;
+}
+
+void ScriptElement::endBatchChildInsertion()
+{
+    ASSERT(m_batchChildInsertionCount);
+    if (!--m_batchChildInsertionCount && m_needsPrepareAfterBatch) {
+        m_needsPrepareAfterBatch = false;
+        prepareScript();
+    }
 }
 
 void ScriptElement::finishParsingChildren()

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -63,6 +63,26 @@ public:
 
     void executePendingScript(PendingScript&);
 
+    class BatchChildInsertionScope final {
+        WTF_MAKE_NONCOPYABLE(BatchChildInsertionScope);
+    public:
+        explicit BatchChildInsertionScope(ScriptElement* scriptElement)
+            : m_scriptElement(scriptElement)
+        {
+            if (m_scriptElement) [[unlikely]]
+                ++m_scriptElement->m_batchChildInsertionCount;
+        }
+
+        ~BatchChildInsertionScope()
+        {
+            if (RefPtr scriptElement = m_scriptElement) [[unlikely]]
+                scriptElement->endBatchChildInsertion();
+        }
+
+    private:
+        RefPtr<ScriptElement> m_scriptElement;
+    };
+
     virtual bool hasAsyncAttribute() const = 0;
     virtual bool hasDeferAttribute() const = 0;
     virtual bool hasSourceAttribute() const = 0;
@@ -120,6 +140,7 @@ protected:
     virtual void unblockRendering() { }
 
 private:
+    void endBatchChildInsertion();
     void executeScriptAndDispatchEvent(LoadableScript&);
 
     std::optional<ScriptType> determineScriptType() const;
@@ -155,7 +176,9 @@ private:
     bool m_willExecuteInOrder : 1 { false };
     bool m_childrenChangedByAPI : 1 { false };
     bool m_hasRelevantLoadEventsListener : 1 { false };
+    bool m_needsPrepareAfterBatch : 1 { false };
     ScriptType m_scriptType : bitWidthOfScriptType { ScriptType::Classic };
+    unsigned m_batchChildInsertionCount { 0 };
     AtomString m_characterEncoding;
     AtomString m_fallbackCharacterEncoding;
     RefPtr<LoadableScript> m_loadableScript;


### PR DESCRIPTION
#### 16b0f826fe7d166364c0ade1507cd3d6597b872c
<pre>
ScriptElement should defer prepareScript until all DocumentFragment children are inserted
<a href="https://bugs.webkit.org/show_bug.cgi?id=309583">https://bugs.webkit.org/show_bug.cgi?id=309583</a>
<a href="https://rdar.apple.com/172204515">rdar://172204515</a>

Reviewed by NOBODY (OOPS!).

When appendChild(fragment) is called on a connectedelement,
WebKit inserts each child from the fragment one at a time, firing
childrenChanged() after each. ScriptElement::childrenChanged() calls
prepareScript() immediately, so the script executes with only the first
text node&apos;s content — producing a SyntaxError and setting
m_alreadyStarted, which prevents any later execution once the remaining
children arrive.

Add a BatchChildInsertionScope RAII guard that defers prepareScript()
until all children from the fragment have been inserted. The scope is
applied in the four ContainerNode multi-target insertion paths:
insertBefore, replaceChild, appendChildWithoutPreInsertionValidityCheck,
and insertChildrenBeforeWithoutPreInsertionValidityCheck. When the
parent is not a script element, the scope is a no-op. The scope is
block-scoped so that prepareScript() runs before dispatchSubtreeModifiedEvent().

* Source/WebCore/dom/ScriptElement.h:
(WebCore::ScriptElement::BatchChildInsertionScope::BatchChildInsertionScope): Added.
(WebCore::ScriptElement::BatchChildInsertionScope::~BatchChildInsertionScope): Added.
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::childrenChanged): Defer prepareScript when
batch depth is non-zero.
(WebCore::ScriptElement::endBatchChildInsertion): Added; calls
prepareScript once the batch counter reaches zero.
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::insertBefore):
(WebCore::ContainerNode::replaceChild):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/127-expected.txt: Progression.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/128-expected.txt: Ditto.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/130-expected.txt: Ditto.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16b0f826fe7d166364c0ade1507cd3d6597b872c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16391 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158783 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103506 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33a9a679-ebe8-4923-a190-3f2f1acce4af) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115761 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82237 "8 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4fb6910b-ec7f-43b7-a770-a50a8d95cdf2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17874 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134636 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96490 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/463cfe97-e7ac-488a-8b57-d7ac61107c95) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16974 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14924 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6629 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126589 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161257 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4348 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123764 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22632 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18971 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123966 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22619 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134355 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78848 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19102 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11111 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22231 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86032 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21946 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22098 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22000 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->