### PR TITLE
[WPE][GStreamer][EME] inject cencparser before decryptor when available

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -85,6 +85,7 @@ static gboolean acceptCaps(GstBaseTransform*, GstPadDirection, GstCaps*);
 static GstFlowReturn transformInPlace(GstBaseTransform*, GstBuffer*);
 static gboolean sinkEventHandler(GstBaseTransform*, GstEvent*);
 static void setContext(GstElement*, GstContext*);
+static bool isCDMProxyAvailable(WebKitMediaCommonEncryptionDecrypt* self);
 
 GST_DEBUG_CATEGORY(webkit_media_common_encryption_decrypt_debug_category);
 #define GST_CAT_DEFAULT webkit_media_common_encryption_decrypt_debug_category
@@ -174,14 +175,19 @@ static GstCaps* transformCaps(GstBaseTransform* base, GstPadDirection direction,
                 gst_structure_remove_fields(outgoingStructure.get(), "base-profile", "codec_data", "height", "framerate", "level", "pixel-aspect-ratio", "profile", "rate", "width", nullptr);
 
                 auto name = WebCore::gstStructureGetName(incomingStructure);
-                gst_structure_set(outgoingStructure.get(), "protection-system", G_TYPE_STRING, klass->protectionSystemId(self).characters(),
-                    "original-media-type", G_TYPE_STRING, name.utf8() , nullptr);
+                gst_structure_set(outgoingStructure.get(), "original-media-type", G_TYPE_STRING, name.utf8(), nullptr);
+                if (!isCDMProxyAvailable(self)) {
+                    GST_WARNING_OBJECT(base, "CDM proxy is not available yet, transformed caps might be inaccurate.");
+                    gst_structure_set_name(outgoingStructure.get(), "application/x-cenc");
+                } else {
+                    gst_structure_set(outgoingStructure.get(), "protection-system", G_TYPE_STRING, klass->protectionSystemId(self).characters(), nullptr);
 
-                // GST_PROTECTION_UNSPECIFIED_SYSTEM_ID was added in the GStreamer
-                // developement git master which will ship as version 1.16.0.
-                gst_structure_set_name(outgoingStructure.get(),
-                    WebCore::GStreamerEMEUtilities::isUnspecifiedUUID(klass->protectionSystemId(self))
-                    ? "application/x-webm-enc" : "application/x-cenc");
+                    // GST_PROTECTION_UNSPECIFIED_SYSTEM_ID was added in the GStreamer
+                    // developement git master which will ship as version 1.16.0.
+                    gst_structure_set_name(outgoingStructure.get(),
+                        WebCore::GStreamerEMEUtilities::isUnspecifiedUUID(klass->protectionSystemId(self))
+                        ? "application/x-webm-enc" : "application/x-cenc");
+                }
             }
         }
 

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp
@@ -48,6 +48,9 @@ typedef struct _WebKitMediaThunderParserClass {
     GstBinClass parentClass;
 } WebKitMediaThunderParserClass;
 
+// cencparser is required only for h264 and h265 video streams.
+static constexpr std::array<ASCIILiteral, 2> cencparserMediaTypes = { "video/x-h264"_s, "video/x-h265"_s };
+
 using namespace WebCore;
 
 WEBKIT_DEFINE_TYPE(WebKitMediaThunderParser, webkit_media_thunder_parser, GST_TYPE_BIN)
@@ -207,6 +210,132 @@ static void webkitMediaThunderParserConstructed(GObject* object)
     gst_bin_sync_children_states(GST_BIN_CAST(self));
 }
 
+static void tryInsertCencparser(WebKitMediaThunderParser* self)
+{
+    auto cencparserFactory = adoptGRef(gst_element_factory_find("cencparser"));
+    if (!cencparserFactory)
+        return;
+
+    auto sinkPad = adoptGRef(gst_element_get_static_pad(GST_ELEMENT(self), "sink"));
+    auto peerPad = adoptGRef(gst_pad_get_peer(sinkPad.get()));
+    if (!peerPad) [[unlikely]] {
+        GST_WARNING_OBJECT(self, "Couldn't find peer pad.");
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    auto peerCaps = adoptGRef(gst_pad_get_current_caps(peerPad.get()));
+    if (!peerCaps) {
+        peerCaps = adoptGRef(gst_pad_query_caps(peerPad.get(), nullptr));
+        if (!peerCaps) {
+            GST_WARNING_OBJECT(self, "Couldn't get caps from peer.");
+            return;
+        }
+    }
+
+    GST_DEBUG_OBJECT(self, "Have type: %" GST_PTR_FORMAT, peerCaps.get());
+
+    bool shouldInsertCencparser = std::any_of(
+        cencparserMediaTypes.begin(), cencparserMediaTypes.end(),
+        [&peerCaps](const auto& mediaType) {
+            return doCapsHaveType(peerCaps.get(), mediaType);
+        }
+    );
+    if (!shouldInsertCencparser) {
+        GST_DEBUG_OBJECT(self, "Cencparser is not required.");
+        return;
+    }
+
+    // Sanity check.
+    auto currentSinkPadTarget = adoptGRef(gst_ghost_pad_get_target(GST_GHOST_PAD(sinkPad.get())));
+    auto currentSinkPadTargetParent = adoptGRef(gst_pad_get_parent_element(currentSinkPadTarget.get()));
+    if (gst_element_get_factory(currentSinkPadTargetParent.get()) == cencparserFactory) {
+        GST_DEBUG_OBJECT(self, "Cencparser is already inserted.");
+        return;
+    }
+
+    // Create and setup cencparser.
+    GstElement* cencparser = gst_element_factory_create(cencparserFactory.get(), nullptr);
+    if (!cencparser) {
+        GST_WARNING_OBJECT(self, "Could not create cencparser.");
+        return;
+    }
+    gst_bin_add(GST_BIN_CAST(self), cencparser);
+    gst_base_transform_set_passthrough(
+        GST_BASE_TRANSFORM(self->priv->decryptor.get()), !WebCore::areEncryptedCaps(peerCaps.get()));
+
+    // In passthrough mode, decryptor returns an empty caps result for a caps
+    // query on sink pad. This is because of lack of clear caps in its sink
+    // pad's template. That is the intersection of transformed clear caps with
+    // encrypted caps from the template produces an empty result.
+    // This empty result causes capsfilter linking to fail inside cencparser.
+    // Workaround: intercept cencparser's caps query and append the media types
+    // that cencparser expects.
+    auto decryptorSinkPad = adoptGRef(gst_element_get_static_pad(self->priv->decryptor.get(), "sink"));
+    gst_pad_add_probe(
+        decryptorSinkPad.get(),
+        static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_PULL | GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM),
+        +[](GstPad* pad, GstPadProbeInfo* info, gpointer) -> GstPadProbeReturn {
+            if (!GST_IS_QUERY(info->data) || GST_QUERY_TYPE(GST_PAD_PROBE_INFO_QUERY(info)) != GST_QUERY_CAPS)
+                return GST_PAD_PROBE_OK;
+
+            GRefPtr<GstElement> decryptor = adoptGRef(gst_pad_get_parent_element(pad));
+            if (!gst_base_transform_is_passthrough(GST_BASE_TRANSFORM(decryptor.get())))
+                return GST_PAD_PROBE_OK;
+
+            GstCaps* queryCaps = nullptr;
+            GstQuery* query = GST_PAD_PROBE_INFO_QUERY(info);
+            gst_query_parse_caps_result(query, &queryCaps);
+            if (gst_caps_is_empty(queryCaps)) {
+                GRefPtr<GstCaps> availableCaps = adoptGRef(gst_caps_new_empty());
+                for (const auto& mediaType : cencparserMediaTypes)
+                    gst_caps_append_structure(availableCaps.get(), gst_structure_new_empty(mediaType.characters()));
+
+                GstCaps* filter = nullptr;
+                gst_query_parse_caps(query, &filter);
+                if (filter) {
+                    GstCaps* intersection;
+                    intersection = gst_caps_intersect_full(filter, availableCaps.get(), GST_CAPS_INTERSECT_FIRST);
+                    gst_caps_append(queryCaps, intersection);
+                } else
+                    gst_caps_append(queryCaps, availableCaps.leakRef());
+                GST_DEBUG_OBJECT(pad, "Enriched result caps: %" GST_PTR_FORMAT, queryCaps);
+            }
+            return GST_PAD_PROBE_OK;
+        }, nullptr, nullptr);
+
+    GST_DEBUG_OBJECT(self, "Inserting %s before %s", GST_ELEMENT_NAME(cencparser), GST_ELEMENT_NAME(self->priv->decryptor.get()));
+    GRefPtr<GstPad> cencparserSinkPad = adoptGRef(gst_element_get_static_pad(cencparser, "sink"));
+    if (!gst_ghost_pad_set_target(GST_GHOST_PAD(sinkPad.get()), cencparserSinkPad.get())) {
+        GST_WARNING_OBJECT(self, "Could not change sink pad target.");
+        return;
+    }
+    if (!gst_element_link_pads_full(cencparser, "src", self->priv->decryptor.get(), "sink", GST_PAD_LINK_CHECK_NOTHING)) {
+        GST_WARNING_OBJECT(self, "Failed to link %s with %s", GST_ELEMENT_NAME(cencparser), GST_ELEMENT_NAME(self->priv->decryptor.get()));
+        return;
+    }
+    if (!gst_element_sync_state_with_parent(cencparser))
+        GST_WARNING_OBJECT(self, "Failed to sync state of %s with parent bin.", GST_ELEMENT_NAME(cencparser));
+}
+
+static GstStateChangeReturn webkitMediaThunderParserChangeState(GstElement* element, GstStateChange transition)
+{
+    WebKitMediaThunderParser* self = WEBKIT_MEDIA_THUNDER_PARSER(element);
+
+    switch (transition) {
+    case GST_STATE_CHANGE_NULL_TO_READY: {
+        tryInsertCencparser(self);
+        break;
+    }
+    default:
+        break;
+    }
+
+    GstStateChangeReturn result = GST_ELEMENT_CLASS(webkit_media_thunder_parser_parent_class)->change_state(element, transition);
+
+    return result;
+}
+
 static void webkit_media_thunder_parser_class_init(WebKitMediaThunderParserClass* klass)
 {
     GST_DEBUG_CATEGORY_INIT(webkitMediaThunderParserDebugCategory, "webkitthunderparser", 0, "Thunder parser");
@@ -215,6 +344,8 @@ static void webkit_media_thunder_parser_class_init(WebKitMediaThunderParserClass
     objectClass->constructed = webkitMediaThunderParserConstructed;
 
     auto elementClass = GST_ELEMENT_CLASS(klass);
+    elementClass->change_state = GST_DEBUG_FUNCPTR(webkitMediaThunderParserChangeState);
+
     auto padTemplateCaps = createThunderParseSinkPadTemplateCaps();
     gst_element_class_add_pad_template(elementClass, gst_pad_template_new("sink", GST_PAD_SINK, GST_PAD_ALWAYS, padTemplateCaps.get()));
     gst_element_class_add_pad_template(elementClass, gst_static_pad_template_get(&thunderParseSrcTemplate));


### PR DESCRIPTION
#### 8e3ded9679124509febacf632ba8bc172d305858
<pre>
[WPE][GStreamer][EME] inject cencparser before decryptor when available
<a href="https://bugs.webkit.org/show_bug.cgi?id=309582">https://bugs.webkit.org/show_bug.cgi?id=309582</a>

Reviewed by Xabier Rodriguez-Calvar.

cencparser is a custom parser that converts H264/H265 CENC video from
AVC to byte-stream format. It is required to be inserted before
decryptor on platforms that don&apos;t provide secure parsers and decoder
only accepts video in byte-stream format.

* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
(transformCaps):
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderParser.cpp:
(tryInsertCencparser):
(webkitMediaThunderParserChangeState):
(webkit_media_thunder_parser_class_init):

Original author: Eugene Mutavchi &lt;Ievgen_Mutavchi@comcast.com&gt;
See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1630">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1630</a>
(createThunderParseSinkPadTemplateCaps): Deleted.

Canonical link: <a href="https://commits.webkit.org/309550@main">https://commits.webkit.org/309550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6b60d41fc0c3fb2e82086cb517367ef4c670e43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149609 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158312 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103041 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151482 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22778 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115410 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82054 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17547 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96151 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16644 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14547 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6156 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160788 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3787 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13736 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123443 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123650 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33855 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22137 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133987 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78361 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18827 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10738 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21737 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85558 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21468 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21620 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21525 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->