### PR TITLE
WKTR: bring asyncKeyDown() to iOS

### DIFF
--- a/LayoutTests/resources/testdriver-vendor.js
+++ b/LayoutTests/resources/testdriver-vendor.js
@@ -355,10 +355,13 @@ window.test_driver_internal.send_keys = async function(element, keys)
 
     if (testRunner.isIOSFamily && testRunner.isWebKit2) {
         await new Promise((resolve) => {
-            testRunner.runUIScript(`
+            testRunner.runUIScript(`(async () => {
                 const keyList = JSON.parse('${JSON.stringify(keyList)}');
+                const modifiers = JSON.parse('${JSON.stringify(modifiers)}');
                 for (const key of keyList)
-                    uiController.keyDown(key, modifiers);`, resolve);
+                    await uiController.asyncKeyDown(key, modifiers);
+                uiController.uiScriptComplete();
+            })();`, resolve);
         });
         return;
     }

--- a/Tools/DumpRenderTree/Bindings/CodeGeneratorDumpRenderTree.pm
+++ b/Tools/DumpRenderTree/Bindings/CodeGeneratorDumpRenderTree.pm
@@ -284,7 +284,9 @@ EOF
                 my @arguments = ();
                 my @specifiedArguments = @{$operation->arguments};
 
-                $self->_includeHeaders(\%contentsIncludes, $operation->type);
+                if (not $operation->type->name eq "Promise") {
+                    $self->_includeHeaders(\%contentsIncludes, $operation->type);
+                }
 
                 if (!@specifiedArguments) {
                     push(@contents, "    UNUSED_VARIABLE(argumentCount);\n");
@@ -302,10 +304,16 @@ EOF
                     push(@arguments, $self->_argumentExpression($argument));
                 }
 
+                if ($operation->type->name eq "Promise") {
+                    push(@contents, "    JSObjectRef resolveFunction = nullptr;\n");
+                    push(@contents, "    JSObjectRef promise = JSObjectMakeDeferredPromise(context, &resolveFunction, nullptr, nullptr);\n\n");
+                    push(@arguments, "resolveFunction");
+                }
+
                 $functionCall = "impl->" . $operation->name . "(" . join(", ", @arguments) . ")";
             }
-            
-            push(@contents, "    ${functionCall};\n\n") if $operation->type->name eq "undefined";
+
+            push(@contents, "    ${functionCall};\n\n") if $operation->type->name eq "undefined" or $operation->type->name eq "Promise";
             push(@contents, "    return " . $self->_returnExpression($operation->type, $functionCall) . ";\n}\n");
         }
     }
@@ -476,6 +484,7 @@ sub _returnExpression
     my ($self, $returnType, $expression) = @_;
 
     return "JSValueMakeUndefined(context)" if $returnType->name eq "undefined";
+    return "promise" if $returnType->name eq "Promise";
     return "makeValue(context, ${expression})" if $returnType->name eq "boolean" && $returnType->isNullable;
     return "JSValueMakeBoolean(context, ${expression})" if $returnType->name eq "boolean";
     return "${expression}" if $returnType->name eq "object";

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -110,6 +110,7 @@ interface UIScriptController {
     undefined typeCharacterUsingHardwareKeyboard(DOMString character, object callback);
 
     undefined keyDown(DOMString character, object modifierArray);
+    Promise<undefined> asyncKeyDown(DOMString character, object modifierArray);
     undefined toggleCapsLock(object callback);
     undefined setContinuousSpellCheckingEnabled(boolean enabled);
     undefined setSpellCheckerResults(object results);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -233,6 +233,7 @@ public:
     virtual void typeCharacterUsingHardwareKeyboard(JSStringRef, JSValueRef) { notImplemented(); }
 
     virtual void keyDown(JSStringRef, JSValueRef) { notImplemented(); }
+    virtual void asyncKeyDown(JSStringRef, JSValueRef, JSValueRef) { notImplemented(); }
     virtual void toggleCapsLock(JSValueRef) { notImplemented(); }
     virtual void setContinuousSpellCheckingEnabled(bool) { notImplemented(); }
     virtual void setSpellCheckerResults(JSValueRef) { notImplemented(); }

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -80,6 +80,7 @@ private:
     void enterText(JSStringRef text) override;
     void typeCharacterUsingHardwareKeyboard(JSStringRef character, JSValueRef) override;
     void keyDown(JSStringRef character, JSValueRef modifierArray) override;
+    void asyncKeyDown(JSStringRef character, JSValueRef modifierArray, JSValueRef resolveCallback) override;
 
     void activateAtPoint(long x, long y, JSValueRef callback) override;
 

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -672,12 +672,12 @@ void UIScriptControllerIOS::rawKeyUp(JSStringRef key)
     [[HIDEventGenerator sharedHIDEventGenerator] sendMarkerHIDEventWithCompletionBlock:^{ /* Do nothing */ }];
 }
 
-void UIScriptControllerIOS::keyDown(JSStringRef character, JSValueRef modifierArray)
+static void dispatchKeyDownHIDEvents(JSContextRef context, JSStringRef character, JSValueRef modifierArray)
 {
     // Character can be either a single Unicode code point or the name of a special key (e.g. "downArrow").
     // HIDEventGenerator knows how to map these special keys to the appropriate keycode.
     auto inputString = toWTFString(character);
-    auto modifierFlags = parseModifierArray(m_context->jsContext(), modifierArray);
+    auto modifierFlags = parseModifierArray(context, modifierArray);
 
     for (auto& modifierFlag : modifierFlags)
         [[HIDEventGenerator sharedHIDEventGenerator] keyDown:modifierFlag.createNSString().get()];
@@ -689,8 +689,26 @@ void UIScriptControllerIOS::keyDown(JSStringRef character, JSValueRef modifierAr
         --i;
         [[HIDEventGenerator sharedHIDEventGenerator] keyUp:modifierFlags[i].createNSString().get()];
     }
+}
 
+void UIScriptControllerIOS::keyDown(JSStringRef character, JSValueRef modifierArray)
+{
+    dispatchKeyDownHIDEvents(m_context->jsContext(), character, modifierArray);
     [[HIDEventGenerator sharedHIDEventGenerator] sendMarkerHIDEventWithCompletionBlock:^{ /* Do nothing */ }];
+}
+
+void UIScriptControllerIOS::asyncKeyDown(JSStringRef character, JSValueRef modifierArray, JSValueRef resolveCallback)
+{
+    unsigned callbackID = m_context->prepareForAsyncTask(resolveCallback, CallbackTypeNonPersistent);
+
+    dispatchKeyDownHIDEvents(m_context->jsContext(), character, modifierArray);
+
+    [[HIDEventGenerator sharedHIDEventGenerator] sendMarkerHIDEventWithCompletionBlock:makeBlockPtr([protectedThis = Ref { *this }, callbackID] {
+        [protectedThis->webView() _doAfterProcessingAllPendingKeyEvents:makeBlockPtr([protectedThis, callbackID] {
+            if (protectedThis->m_context)
+                protectedThis->m_context->asyncTaskComplete(callbackID);
+        }).get()];
+    }).get()];
 }
 
 void UIScriptControllerIOS::dismissFormAccessoryView()


### PR DESCRIPTION
#### 62661a97ea652c3f57a41daaad312e425268590f
<pre>
WKTR: bring asyncKeyDown() to iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=309585">https://bugs.webkit.org/show_bug.cgi?id=309585</a>

Reviewed by NOBODY (OOPS!).

Changes to CodeGeneratorDumpRenderTree.pm mirror what
CodeGeneratorTestRunner.pm already does and were needed to address a
build issue.

(This does not help with tests expecting keyboard input as we need the
virtual keyboard for those. But it should help with tests using keys
for other purposes.)
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62661a97ea652c3f57a41daaad312e425268590f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157812 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102555 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c89068fe-266f-4f30-b97f-8d43fc731f13) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22291 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114963 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81842 "8 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a67f58a4-3d3d-498d-bbc0-1547dbab5c30) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17140 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133819 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95721 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/338f89d8-8562-4b1c-9198-5b4e12aae199) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16344 "Found 1 new test failure: imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/number-constraint-validation.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14118 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5665 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125843 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160296 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13269 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123011 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21639 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123241 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21647 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133540 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77848 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18494 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10295 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21249 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20981 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21129 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21037 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->