### PR TITLE
Web Inspector: Sources: White color on light background for selected DOM node key in a Map in the Scope Chain sidebar

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/FormattedValue.css
+++ b/Source/WebInspectorUI/UserInterface/Views/FormattedValue.css
@@ -67,6 +67,10 @@
     color: hsl(0, 0%, 50%);
 }
 
+.formatted-node {
+    isolation: isolate; /* Create a new stacking context to ensure z-index: -1 for .selection-area works within this boundary instead of an ancestor like .tree-outline.object which obscures the selection area behind a solid color element. */
+}
+
 .formatted-node, .formatted-node-preview {
     white-space: wrap;
 }


### PR DESCRIPTION
#### 2b2c81c579408863dfd8fe19d91dc4bfba822fd5
<pre>
Web Inspector: Sources: White color on light background for selected DOM node key in a Map in the Scope Chain sidebar
<a href="https://bugs.webkit.org/show_bug.cgi?id=309569">https://bugs.webkit.org/show_bug.cgi?id=309569</a>
<a href="https://rdar.apple.com/171840122">rdar://171840122</a>

Reviewed by Simon Fraser.

The selected node of a DOM tree outline has white text that&apos;s supposed to contrast
with the accent color (usually blue) of the `.selection-area` element that&apos;s used as a backdrop.

The `.selection-area` element has a `z-index: -1` so that it appears behind the tree element content.

In the Elements tab, `.tree-outline.dom` is a top-level element. There&apos;s no ancestor with creating
a stacking context above it. The `z-index: -1` element renders behind the tree content but is still
visible because there&apos;s nothing opaque behind it in the same stacking context.

But in the Scope Chain sidebar, the `.tree-outline.dom` is nested inside a `.tree-outline.object li`
which has `overflow: hidden` that creates a new stacking context. In this case, the `.selection-area` element
gets painted behind the stacking context root (the `.tree-outline.object li`), which has an opaque background
from the sidebar panel.

This patch creates a new stacking context for the `.formatted-node` element
to scope the `z-index: -1` to it instead of the ancestor.

This difference of paint behavior is evident when using `WI.FormattedValue` with DOM nodes in the Console,
where the backdrop is visible, compared to the use in the Scope Sidebar nested within a `WI.ObjectTreeView`
which wraps a `WI.TreeOutline`.

* Source/WebInspectorUI/UserInterface/Views/FormattedValue.css:
(.formatted-node):

Canonical link: <a href="https://commits.webkit.org/309006@main">https://commits.webkit.org/309006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70b753fdba730114558fa70a4861ede19c17514c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157816 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/93fc8ff1-43b8-474f-b003-78b2f4508884) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/22295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21719 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/114970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152088 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/22295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/95728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8087e065-5562-473b-b0f8-f192e1e151f0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/22295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5669 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/22295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160300 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13274 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/123018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/18153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/123247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33504 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133545 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/10300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/21253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/85055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/21133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/21041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->