### PR TITLE
Dispatch mouse boundary events when entering fullscreen

### DIFF
--- a/LayoutTests/fullscreen/fullscreen-clears-hover-on-overlay-expected.txt
+++ b/LayoutTests/fullscreen/fullscreen-clears-hover-on-overlay-expected.txt
@@ -1,0 +1,12 @@
+Tests that entering fullscreen dispatches boundary events so that JS-driven hover state on a full-coverage overlay is properly cleared.
+
+Fullscreen content
+
+Enter Fullscreen
+EXPECTED (fsBtn.style.backgroundColor == 'rgba(0, 0, 255, 0.2)') OK
+EVENT(webkitfullscreenchange)
+EXPECTED (document.fullscreenElement == '[object HTMLDivElement]') OK
+EXPECTED (overlayReceivedLeave == 'true') OK
+EXPECTED (fsBtn.style.backgroundColor == '') OK
+END OF TEST
+

--- a/LayoutTests/fullscreen/fullscreen-clears-hover-on-overlay.html
+++ b/LayoutTests/fullscreen/fullscreen-clears-hover-on-overlay.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="full-screen-test.js"></script>
+<style>
+#target { position: relative; width: 300px; height: 200px; background: #eee; }
+#overlay { position: absolute; inset: 0; display: flex; flex-direction: column; }
+#fs-btn { padding: 8px; margin-top: auto; }
+</style>
+</head>
+<body>
+<p>Tests that entering fullscreen dispatches boundary events so that
+JS-driven hover state on a full-coverage overlay is properly cleared.</p>
+<div id="target">
+    <div id="overlay">
+        <p>Fullscreen content</p>
+        <button id="fs-btn">Enter Fullscreen</button>
+    </div>
+</div>
+<script>
+    var target = document.getElementById('target');
+    var overlay = document.getElementById('overlay');
+    var fsBtn = document.getElementById('fs-btn');
+    var overlayReceivedLeave = false;
+
+    // Simulate React Native Web's Pressable pattern: the full-coverage overlay
+    // div has pointerenter/pointerleave handlers that control hover styling on
+    // a child button via inline background-color.
+    overlay.addEventListener('pointerenter', function() {
+        fsBtn.style.backgroundColor = 'rgba(0, 0, 255, 0.2)';
+    });
+    overlay.addEventListener('pointerleave', function() {
+        overlayReceivedLeave = true;
+        fsBtn.style.backgroundColor = '';
+    });
+
+    var callback;
+    waitForEvent(document, 'webkitfullscreenchange', function(event) {
+        if (callback)
+            callback(event);
+    });
+
+    // Position the mouse over the fullscreen button (inside the overlay)
+    // before entering fullscreen. This establishes the overlay's hover state.
+    if (window.eventSender) {
+        var btnRect = fsBtn.getBoundingClientRect();
+        eventSender.mouseMoveTo(btnRect.left + btnRect.width / 2, btnRect.top + btnRect.height / 2);
+    }
+
+    testExpected("fsBtn.style.backgroundColor", "rgba(0, 0, 255, 0.2)");
+
+    callback = function() {
+        testExpected("document.fullscreenElement", target);
+
+        // Boundary events are dispatched after the fullscreen layout change,
+        // so wait before checking.
+        setTimeout(function() {
+            // The overlay (position:absolute inset:0) expands to fill the
+            // screen on fullscreen. Without the fix, pointerleave would never
+            // fire on the overlay because the cursor remains inside it.
+            testExpected("overlayReceivedLeave", true);
+            testExpected("fsBtn.style.backgroundColor", "");
+
+            endTest();
+        }, 300);
+    };
+
+    runWithKeyDown(function() { target.requestFullscreen(); });
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -37,6 +37,7 @@
 #include "DocumentView.h"
 #include "Element.h"
 #include "ElementInlines.h"
+#include "EventHandler.h"
 #include "EventLoop.h"
 #include "EventNames.h"
 #include "FrameDestructionObserverInlines.h"
@@ -412,6 +413,10 @@ bool DocumentFullscreen::didEnterFullscreen()
     INFO_LOG(LOGIDENTIFIER);
 
     fullscreenElement->didBecomeFullscreenElement();
+
+    if (RefPtr frame = document().frame(); frame && !protect(document())->quirks().needsSuppressPostLayoutBoundaryEventsQuirk())
+        frame->eventHandler().dispatchMouseBoundaryEventsAfterFullscreenChange();
+
     return true;
 }
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3166,6 +3166,19 @@ void EventHandler::clearElementUnderMouse()
     imageOverlayController->elementUnderMouseDidChange(protect(m_frame), nullptr);
 }
 
+void EventHandler::dispatchMouseBoundaryEventsAfterFullscreenChange()
+{
+    if (!m_elementUnderMouse || !m_lastKnownMousePosition)
+        return;
+
+    auto modifiers = PlatformKeyboardEvent::currentStateOfModifierKeys();
+    PlatformMouseEvent syntheticEvent(valueOrDefault(m_lastKnownMousePosition), m_lastKnownMouseGlobalPosition,
+        MouseButton::None, PlatformEvent::Type::NoType, 0, modifiers,
+        MonotonicTime::now(), 0, SyntheticClickType::NoTap, MouseEventInputSource::UserDriven);
+    updateMouseEventTargetNode(eventNames().mouseoutEvent, nullptr, syntheticEvent, FireMouseOverOut::Yes);
+    m_lastKnownMousePosition = std::nullopt;
+}
+
 bool EventHandler::isElementAnAncestorOfLastElementUnderMouse(Element* element) const
 {
     if (!element)

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -428,6 +428,7 @@ public:
 
     WEBCORE_EXPORT void updateMouseEventTargetAfterLayoutIfNeeded();
     WEBCORE_EXPORT void scheduleMouseEventTargetUpdateAfterLayout();
+    WEBCORE_EXPORT void dispatchMouseBoundaryEventsAfterFullscreenChange();
 
     ScrollableArea* enclosingScrollableArea(Node*) const;
 


### PR DESCRIPTION
#### 4771a54c1936e9729dc7a20fca5c27894698347c
<pre>
Dispatch mouse boundary events when entering fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=309586">https://bugs.webkit.org/show_bug.cgi?id=309586</a>
<a href="https://rdar.apple.com/157694866">rdar://157694866</a>

Reviewed by Aditya Keerthi.

After entering fullscreen, Chrome and Firefox dispatch pointer/mouse
boundary events for elements that were under the cursor. Safari does not,
causing JS-driven hover state to stick when sites use pointerenter/
pointerleave on a full-coverage overlay (position:absolute inset:0) to
manage hover styling — after fullscreen the overlay fills the screen, the
cursor stays inside it, and pointerleave never fires. Reduced test case
is attached to the radar.

scheduleMouseEventTargetUpdateAfterLayout does not help here: it
re-hit-tests and only fires events when the target element changes, but
the overlay is still under the cursor after fullscreen.

Add dispatchMouseBoundaryEventsAfterFullscreenChange() which dispatches
mouseout to a null target in didEnterFullscreen(), walking the ancestor
chain to fire mouseleave/pointerleave on every element. Clear the saved
mouse position so timer-based updates don&apos;t re-establish stale hover.

Not specified — the Fullscreen spec says nothing about hover or boundary
events. This aligns with Chrome and Firefox behavior.

I have verified the layout test fails without the fix, and passes with it.

* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::didEnterFullscreen):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::dispatchMouseBoundaryEventsAfterFullscreenChange):
* Source/WebCore/page/EventHandler.h:
* LayoutTests/fullscreen/fullscreen-clears-hover-on-overlay-expected.txt:
* LayoutTests/fullscreen/fullscreen-clears-hover-on-overlay.html:

Canonical link: <a href="https://commits.webkit.org/311986@main">https://commits.webkit.org/311986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01ce463d5e6c6cb668d19b3446a529f39635bf7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31976 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/25083 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167380 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112635 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d65afde7-8c9a-4d57-acf5-ae3a43191e6f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160420 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/32044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31963 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122812 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86181 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/35275b1a-22ca-4a60-bc3b-6db31ddb0b30) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/25070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103482 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/46acb628-0d57-442a-8415-313d837ec541) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/24127 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/22518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/15151 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133814 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169870 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/15615 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21847 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130997 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31666 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/26583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/131111 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35495 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31612 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/142015 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89518 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25808 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18823 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/31123 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/97137 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30643 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30916 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30797 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->