### PR TITLE
Safari allows CSRF by resetting the Sec-Fetch-Site header on refresh

### DIFF
--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -965,6 +965,29 @@ void CachedResourceLoader::prepareFetch(CachedResource::Type type, CachedResourc
     // FIXME: Decide whether to support client hints
 }
 
+static bool shouldReuseExistingFetchMetadata(const LocalFrame& frame, const ResourceRequest& request, CachedResource::Type type, FetchOptions::Mode mode)
+{
+    if (mode != FetchOptions::Mode::Navigate || type != CachedResource::Type::MainResource)
+        return false;
+
+    RefPtr loader = frame.loader().activeDocumentLoader();
+    if (loader && loader->triggeringAction().type() != NavigationType::FormResubmitted)
+        return false;
+
+    ASSERT_UNUSED(request, request.hasHTTPHeaderField(HTTPHeaderName::SecFetchDest));
+    ASSERT(request.hasHTTPHeaderField(HTTPHeaderName::SecFetchMode));
+    ASSERT(request.hasHTTPHeaderField(HTTPHeaderName::SecFetchSite));
+
+    return true;
+}
+
+static bool shouldUpdateFetchMetadata(const LocalFrame& frame, const ResourceRequest& request, CachedResource::Type type, FetchOptions::Mode mode)
+{
+    return frame.document()
+        && !protect(frame.document())->quirks().shouldDisableFetchMetadata()
+        && !shouldReuseExistingFetchMetadata(frame, request, type, mode);
+}
+
 void CachedResourceLoader::updateHTTPRequestHeaders(FrameLoader& frameLoader, CachedResource::Type type, CachedResourceRequest& request)
 {
     // Implementing steps 11 to 19 of https://fetch.spec.whatwg.org/#http-network-or-cache-fetch as of 22 Feb 2022.
@@ -976,7 +999,7 @@ void CachedResourceLoader::updateHTTPRequestHeaders(FrameLoader& frameLoader, Ca
     // ability it is best to not set any FetchMetadata headers as sites generally expect
     // all of them or none.
     Ref frame = frameLoader.frame();
-    if (frame->document() && !protect(frame->document())->quirks().shouldDisableFetchMetadata()) {
+    if (shouldUpdateFetchMetadata(frame, request.resourceRequest(), type, request.options().mode)) {
         auto site = computeFetchMetadataSite(request.resourceRequest(), type, request.options().mode, frame, frame->isMainFrame() && m_documentLoader && m_documentLoader->isRequestFromClientOrUserInput());
         updateRequestFetchMetadataHeaders(request.resourceRequest(), request.options(), site);
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -5173,3 +5173,109 @@ TEST(WKNavigation, AllowResourceLoadFromBlockedPortWithCustomScheme)
     EXPECT_WK_STREQ([uiDelegate waitForAlert], "This resource was loaded");
     EXPECT_EQ(requestsSchemeHandled, 2u);
 }
+
+TEST(Navigation, FormResubmited)
+{
+    using namespace TestWebKitAPI;
+    std::optional<bool> requestHadSecFetchSiteCrossOrigin { false };
+    bool didReceiveForm { false };
+    auto httpsServer = HTTPServer(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
+        while (1) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            auto path = HTTPServer::parsePath(request);
+
+            if (path == "/main.html"_s) {
+                co_await connection.awaitableSend(HTTPResponse({ { "Content-Type"_s, "text/html"_s } }, ""
+                    "<html><body>"
+                    "<form action='https://example1.com/submit' method='POST' id='form'>"
+                    "  <input type='text' id='name' name='name' value='value'/>"
+                    "  <input type='submit'/>"
+                    "</form>"
+                    "<script>"
+                    "window.didSubmit = false;"
+                    "onload = () => alert('Ready');"
+                    "function submitForm()"
+                    "{"
+                    "  form.submit();"
+                    "}"
+                    "</script>"
+                    "</body></html>"_s).serialize());
+                continue;
+            }
+
+            if (path == "/submit"_s) {
+                didReceiveForm = true;
+                requestHadSecFetchSiteCrossOrigin = contains(request.span(), "Sec-Fetch-Site: cross-site"_span);
+                if (requestHadSecFetchSiteCrossOrigin) {
+                    co_await connection.awaitableSend(HTTPResponse({ 403, { }, ""_s }).serialize());
+                    continue;
+                }
+
+                co_await connection.awaitableSend(HTTPResponse({ { "Content-Type"_s, "text/html"_s } }, ""
+                    "<html><body>"
+                    "<script>"
+                    "window.didSubmit = true;"
+                    "</script>"
+                    "</body></html>"_s).serialize());
+                continue;
+            }
+
+            EXPECT_FALSE(true);
+        }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initNonPersistentConfiguration]);
+    [storeConfiguration setProxyConfiguration:@{
+        (NSString *)kCFStreamPropertyHTTPSProxyHost: @"127.0.0.1",
+        (NSString *)kCFStreamPropertyHTTPSProxyPort: @(httpsServer.port())
+    }];
+    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+    [configuration setWebsiteDataStore:dataStore.get()];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    auto navDelegate = adoptNS([TestNavigationDelegate new]);
+    [navDelegate allowAnyTLSCertificate];
+
+    __block bool didCommitNavigation = false;
+    navDelegate.get().didCommitNavigation = ^(WKWebView *, WKNavigation *) {
+        didCommitNavigation = true;
+    };
+
+    [webView setNavigationDelegate:navDelegate.get()];
+    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    [webView setUIDelegate:uiDelegate.get()];
+
+    // Load main page from same origin as form submission
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example1.com/main.html"]]];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "Ready");
+
+    // Submit form - same origin.
+    didReceiveForm = false;
+    requestHadSecFetchSiteCrossOrigin = { };
+    [webView evaluateJavaScript:@"submitForm();" completionHandler:nil];
+    TestWebKitAPI::Util::run(&didReceiveForm);
+    EXPECT_FALSE(requestHadSecFetchSiteCrossOrigin.value_or(true));
+
+    // Load main page from different origin as form submission
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example2.com/main.html"]]];
+    EXPECT_WK_STREQ([uiDelegate waitForAlert], "Ready");
+
+    // Submit form - cross origin
+    didReceiveForm = false;
+    didCommitNavigation = false;
+    requestHadSecFetchSiteCrossOrigin = { };
+    [webView evaluateJavaScript:@"submitForm();" completionHandler:nil];
+    TestWebKitAPI::Util::run(&didCommitNavigation);
+
+    EXPECT_TRUE(didReceiveForm);
+    EXPECT_TRUE(requestHadSecFetchSiteCrossOrigin.value_or(false));
+
+    // Submit form via reload - cross origin
+    didReceiveForm = false;
+    requestHadSecFetchSiteCrossOrigin = { };
+    [webView reload];
+    TestWebKitAPI::Util::run(&didReceiveForm);
+
+    EXPECT_TRUE(requestHadSecFetchSiteCrossOrigin.value_or(false));
+}


### PR DESCRIPTION
#### 81e651381222fbbd41bde3e211b1ea6edbfc37d8
<pre>
Safari allows CSRF by resetting the Sec-Fetch-Site header on refresh
<a href="https://rdar.apple.com/158416842">rdar://158416842</a>

Reviewed by Chris Dumez.

In case of form resubmition, we were recomputing Sec-Fetch-Site and friends from the destination origin, which was wrong.
Instead, given we already computed the Sec headers, we reuse them when resubmitting a form.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::shouldReuseExistingFetchMetadata):
(WebCore::shouldUpdateFetchMetadata):
(WebCore::CachedResourceLoader::updateHTTPRequestHeaders):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(TEST(Navigation, FormResubmited)):

Originally-landed-as: 301765.328@safari-7623-branch (00c47cad6649). <a href="https://rdar.apple.com/171560549">rdar://171560549</a>
Canonical link: <a href="https://commits.webkit.org/309498@main">https://commits.webkit.org/309498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/777b6d318c3cf0ddb5d51a390bd18dc08d67f030

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159586 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152732 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23828 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116451 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153819 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135340 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97171 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/887818bc-937c-4f81-9495-4844501a314b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15611 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7433 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127282 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13257 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162060 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5185 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124454 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23423 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/19661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124642 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33826 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23413 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135054 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79819 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19714 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11819 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23023 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/87107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22735 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22887 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22789 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->