### PR TITLE
@media (prefers-color-scheme: dark) inside iframe not matching when the iframe itself has style.colorScheme = 'dark'

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5364,7 +5364,6 @@ webkit.org/b/214453 imported/w3c/web-platform-tests/css/css-align/baseline-rules
 
 webkit.org/b/245347 imported/w3c/web-platform-tests/css/css-color/at-color-profile-001.html [ ImageOnlyFailure ]
 webkit.org/b/245347 imported/w3c/web-platform-tests/css/css-color/currentcolor-003.html [ ImageOnlyFailure ]
-webkit.org/b/214455 imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred.html [ ImageOnlyFailure ]
 
 webkit.org/b/245347 imported/w3c/web-platform-tests/css/css-color/lch-009.html [ ImageOnlyFailure ]
 webkit.org/b/245347 imported/w3c/web-platform-tests/css/css-color/lch-010.html [ ImageOnlyFailure ]
@@ -7605,6 +7604,7 @@ imported/w3c/web-platform-tests/dom/events/scrolling/wheel-event-transactions-ta
 imported/w3c/web-platform-tests/css/css-color/deprecated-sameas-002.html [ ImageOnlyFailure ]
 
 http/tests/site-isolation/touch-events [ Skip ]
+webkit.org/b/309611 http/tests/site-isolation/iframe-dark-mode.html [ ImageOnlyFailure ]
 http/tests/site-isolation/iframe-dark-mode-print.html [ ImageOnlyFailure ]
 
 # CSS syntax
@@ -8252,8 +8252,6 @@ webkit.org/b/308096 imported/w3c/web-platform-tests/css/cssom-view/scrollParent.
 
 webkit.org/b/296130 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/image-loading-lazy-in-scroller-nested-4.html [ Pass Failure ]
 webkit.org/b/281267 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/interactive-content.html [ Pass Failure ]
-
-imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-dark.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-019.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-highlight-api/painting/custom-highlight-painting-020.html [ ImageOnlyFailure ]

--- a/LayoutTests/css-dark-mode/prefers-color-scheme-ignores-document-meta-color-scheme-expected.html
+++ b/LayoutTests/css-dark-mode/prefers-color-scheme-ignores-document-meta-color-scheme-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+
+<meta name="color-scheme" content="dark">
+
+<style>
+  .box {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+
+<p>Test passes if the box is green.</p>
+<div class="box"></div>

--- a/LayoutTests/css-dark-mode/prefers-color-scheme-ignores-document-meta-color-scheme.html
+++ b/LayoutTests/css-dark-mode/prefers-color-scheme-ignores-document-meta-color-scheme.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+
+<title>prefers-color-scheme ignores meta color-scheme and only considers user's preferences</title>
+<meta name="color-scheme" content="dark">
+
+<style>
+  .box {
+    width: 100px;
+    height: 100px;
+  }
+
+  @media (prefers-color-scheme: light) {
+    .box {
+      background-color: green;
+    }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .box {
+      background-color: red;
+    }
+  }
+</style>
+
+<p>Test passes if the box is green.</p>
+<div class="box"></div>
+
+<script>
+  if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.setUseDarkAppearanceForTesting(false);
+    testRunner.notifyDone();
+  }
+</script>

--- a/LayoutTests/css-dark-mode/prefers-color-scheme-in-iframe-consults-owner-element-expected.html
+++ b/LayoutTests/css-dark-mode/prefers-color-scheme-in-iframe-consults-owner-element-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+
+<style>
+  .box {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+
+<p>Test passes if the box is green.</p>
+<div class="box"></div>

--- a/LayoutTests/css-dark-mode/prefers-color-scheme-in-iframe-consults-owner-element.html
+++ b/LayoutTests/css-dark-mode/prefers-color-scheme-in-iframe-consults-owner-element.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+
+<title>prefers-color-scheme in an iframe follows the used color scheme of its owner element, even if it's different from the environment color scheme</title>
+
+<style>
+  #ifr {
+    width: 500px;
+    height: 500px;
+    margin: 0;
+    border: 0;
+    padding: 0;
+    display: block;
+    color-scheme: light;
+  }
+</style>
+
+<p>Test passes if the box is green.</p>
+<iframe id="ifr"></iframe>
+
+<script>
+  if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.setUseDarkAppearanceForTesting(true);
+
+    ifr.addEventListener("load", () => {
+      testRunner.notifyDone();
+    })
+  }
+
+  ifr.src = "resources/prefers-color-scheme-iframe.html";
+</script>

--- a/LayoutTests/css-dark-mode/resources/prefers-color-scheme-iframe.html
+++ b/LayoutTests/css-dark-mode/resources/prefers-color-scheme-iframe.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+
+<style>
+  body {
+    margin: 0;
+  }
+
+  .box {
+    width: 100px;
+    height: 100px;
+  }
+
+  @media (prefers-color-scheme: light) {
+    .box { background-color: green; }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .box { background-color: red; }
+  }
+</style>
+
+<div class="box"></div>

--- a/LayoutTests/http/tests/css/prefers-color-scheme-in-cross-origin-iframe-consults-owner-element-expected.html
+++ b/LayoutTests/http/tests/css/prefers-color-scheme-in-cross-origin-iframe-consults-owner-element-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+
+<style>
+  .box {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+</style>
+
+<p>Test passes if the box is green.</p>
+<div class="box"></div>

--- a/LayoutTests/http/tests/css/prefers-color-scheme-in-cross-origin-iframe-consults-owner-element.html
+++ b/LayoutTests/http/tests/css/prefers-color-scheme-in-cross-origin-iframe-consults-owner-element.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+
+<title>prefers-color-scheme in an cross-origin iframe uses the used color scheme of its owner element, even if it's different from the environment color scheme</title>
+
+<style>
+  #ifr {
+    width: 500px;
+    height: 500px;
+    margin: 0;
+    border: 0;
+    padding: 0;
+    display: block;
+    color-scheme: light;
+  }
+</style>
+
+<p>Test passes if the box is green.</p>
+<iframe id="ifr"></iframe>
+
+<script>
+  if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.setUseDarkAppearanceForTesting(true);
+
+    ifr.addEventListener("load", () => {
+      testRunner.notifyDone();
+    })
+  }
+
+  ifr.src = "http://localhost:8000/css/resources/prefers-color-scheme-iframe.html";
+</script>

--- a/LayoutTests/http/tests/css/resources/prefers-color-scheme-iframe.html
+++ b/LayoutTests/http/tests/css/resources/prefers-color-scheme-iframe.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+
+<style>
+  body {
+    margin: 0;
+  }
+
+  .box {
+    width: 100px;
+    height: 100px;
+  }
+
+  @media (prefers-color-scheme: light) {
+    .box { background-color: green; }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .box { background-color: red; }
+  }
+</style>
+
+<div class="box"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-cross-origin.sub-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-cross-origin.sub-expected.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>CSS Test Reference</title>
+<style>
+  div {
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<div style="background-color: purple"></div>
+<div style="background-color: blue"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-cross-origin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-cross-origin.sub.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>prefers-color-scheme in cross-origin frame inherits color-scheme from embedding element</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-adjust/#color-scheme-effect">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7493">
+<link rel="match" href="color-scheme-iframe-preferred-ref.html">
+<style>
+  iframe {
+    display: block;
+    border: none;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<iframe style="color-scheme: dark" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-color-adjust/rendering/dark-color-scheme/support/prefers-color-scheme-blue-purple.html"></iframe>
+<iframe style="color-scheme: light" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-color-adjust/rendering/dark-color-scheme/support/prefers-color-scheme-blue-purple.html"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-dark-cross-origin.sub-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-dark-cross-origin.sub-expected.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<title>CSS Test Reference</title>
+<meta name="color-scheme" content="dark">
+<div style="background-color:purple;width:100px;height:100px"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-dark-cross-origin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-dark-cross-origin.sub.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>prefers-color-scheme in cross-origin frame inherits color-scheme from embedding element - page supports dark</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-adjust/#color-scheme-effect">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7493">
+<link rel="match" href="color-scheme-iframe-preferred-page-dark-ref.html">
+<meta name="color-scheme" content="dark">
+<style>
+  iframe {
+    display: block;
+    border: none;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<iframe style="color-scheme: normal" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-color-adjust/rendering/dark-color-scheme/support/prefers-color-scheme-blue-purple.html"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-light-cross-origin.sub-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-light-cross-origin.sub-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<title>CSS Test Reference</title>
+<div style="background-color:blue;width:100px;height:100px"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-light-cross-origin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-light-cross-origin.sub.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<title>prefers-color-scheme in cross-origin frame inherits color-scheme from embedding element - page supports light</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-adjust/#color-scheme-effect">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/7493">
+<link rel="match" href="color-scheme-iframe-preferred-page-light-ref.html">
+<meta name="color-scheme" content="light">
+<style>
+  iframe {
+    display: block;
+    border: none;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<iframe style="color-scheme: normal" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-color-adjust/rendering/dark-color-scheme/support/prefers-color-scheme-blue-purple.html"></iframe>

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -798,6 +798,20 @@ static const IdentifierSchema& overflowInlineFeatureSchema()
 }
 
 #if ENABLE(DARK_MODE_CSS)
+static bool frameUsesDarkAppearanceForPrefersColorScheme(const Frame& frame)
+{
+    if (RefPtr parent = frame.parent()) {
+        // From CSS Media Queries Level 5: if the frame is a subframe, its preferred color scheme
+        // is the color scheme of its owner element:
+        // > the preferred color scheme must reflect the value of the used color scheme on the
+        // > embedding node in the embedding document.
+        // FIXME (webkit.org/b/309611): this should recurse up to the main frame.
+        return protect(parent->virtualView())->ownerElementOfChildFrameUsesDarkAppearance(frame);
+    }
+
+    return protect(frame.page())->useDarkAppearance();
+}
+
 static const IdentifierSchema& prefersColorSchemeFeatureSchema()
 {
     static MainThreadNeverDestroyed<IdentifierSchema> schema {
@@ -805,8 +819,7 @@ static const IdentifierSchema& prefersColorSchemeFeatureSchema()
         FixedVector { CSSValueLight, CSSValueDark },
         MediaQueryDynamicDependency::Appearance,
         [](auto& context) {
-            Ref page = *context.document->frame()->page();
-            bool useDarkAppearance = page->useDarkAppearance();
+            bool useDarkAppearance = frameUsesDarkAppearanceForPrefersColorScheme(*context.document->frame());
 
             return MatchingIdentifiers { useDarkAppearance ? CSSValueDark : CSSValueLight };
         }

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4368,24 +4368,22 @@ void Page::setUseColorAppearance(bool useDarkAppearance, bool useElevatedUserInt
 bool Page::useDarkAppearance() const
 {
 #if ENABLE(DARK_MODE_CSS)
-    RefPtr localMainFrame = this->localMainFrame();
-
-    // FIXME: If this page is being printed, this function should return false.
-    // Currently remote mainFrame() does not have this information.
-    if (!localMainFrame)
-        return m_useDarkAppearance;
-
-    RefPtr view = localMainFrame->view();
-    if (!view || view->mediaType() != screenAtom())
-        return false;
-
+    // This overrides everything else.
     if (m_useDarkAppearanceOverride)
         return m_useDarkAppearanceOverride.value();
 
-    if (auto* documentLoader = localMainFrame->loader().documentLoader()) {
-        auto colorSchemePreference = documentLoader->colorSchemePreference();
-        if (colorSchemePreference != ColorSchemePreference::NoPreference)
-            return colorSchemePreference == ColorSchemePreference::Dark;
+    if (RefPtr localMainFrame = this->localMainFrame()) {
+        // Printed page should always use light appearance (i.e return false)
+        // FIXME: implement this logic for remote main frames.
+        RefPtr view = localMainFrame->view();
+        if (!view || view->mediaType() != screenAtom())
+            return false;
+
+        if (auto* documentLoader = localMainFrame->loader().documentLoader()) {
+            auto colorSchemePreference = documentLoader->colorSchemePreference();
+            if (colorSchemePreference != ColorSchemePreference::NoPreference)
+                return colorSchemePreference == ColorSchemePreference::Dark;
+        }
     }
 
     return m_useDarkAppearance;


### PR DESCRIPTION
#### 34fc452fa59fe306b3f8bb7fac98a6c51e40cbaa
<pre>
@media (prefers-color-scheme: dark) inside iframe not matching when the iframe itself has style.colorScheme = &apos;dark&apos;
<a href="https://rdar.apple.com/142072593">rdar://142072593</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=284973">https://bugs.webkit.org/show_bug.cgi?id=284973</a>

Reviewed by Simon Fraser.

From CSS Media Queries Level 5 [1]: if the frame is a subframe, its preferred color scheme
is the color scheme of its owner element [2]:

&gt; the preferred color scheme must reflect the value of the used color scheme on the
&gt; embedding node in the embedding document.

The spec only mentions this for embedded SVG, but this also applies to iframes,
as resolved in [3]:

&gt; RESOLVED: Context-dependent color scheme propagation works for iframes (including
&gt; cross-origin) unless specifically restricted

This patch implements this resolution by using
FrameView::ownerElementOfChildFrameUsesDarkAppearance to query for the color scheme
of the iframe&apos;s owner element.

[1]: <a href="https://drafts.csswg.org/mediaqueries-5/#prefers-color-scheme">https://drafts.csswg.org/mediaqueries-5/#prefers-color-scheme</a>
[2]: <a href="https://drafts.csswg.org/mediaqueries-5/#">https://drafts.csswg.org/mediaqueries-5/#</a>:~:text=the%20preferred%20color%20scheme
[3]: <a href="https://github.com/w3c/csswg-drafts/issues/7493#issuecomment-1201691078">https://github.com/w3c/csswg-drafts/issues/7493#issuecomment-1201691078</a>

Tests: css-dark-mode/prefers-color-scheme-ignores-document-meta-color-scheme.html
       css-dark-mode/prefers-color-scheme-in-iframe-consults-owner-element.html
       http/tests/css/prefers-color-scheme-in-cross-origin-iframe-consults-owner-element.html
       imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred.html
       imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-dark.html
       imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-light.html
       imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-cross-origin.sub.html
       imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-dark-cross-origin.sub.html
       imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-light-cross-origin.sub.html

* LayoutTests/TestExpectations:
* LayoutTests/css-dark-mode/prefers-color-scheme-ignores-document-meta-color-scheme-expected.html: Added.
* LayoutTests/css-dark-mode/prefers-color-scheme-ignores-document-meta-color-scheme.html: Added.
* LayoutTests/css-dark-mode/prefers-color-scheme-in-iframe-consults-owner-element-expected.html: Added.
* LayoutTests/css-dark-mode/prefers-color-scheme-in-iframe-consults-owner-element.html: Added.
* LayoutTests/css-dark-mode/resources/prefers-color-scheme-iframe.html: Added.
* LayoutTests/http/tests/css/prefers-color-scheme-in-cross-origin-iframe-consults-owner-element-expected.html: Added.
* LayoutTests/http/tests/css/prefers-color-scheme-in-cross-origin-iframe-consults-owner-element.html: Added.
* LayoutTests/http/tests/css/resources/prefers-color-scheme-iframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-cross-origin.sub-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-cross-origin.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-dark-cross-origin.sub-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-dark-cross-origin.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-light-cross-origin.sub-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-preferred-page-light-cross-origin.sub.html: Added.
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::frameUsesDarkAppearanceForPrefersColorScheme):
    - Add new function to answer the prefers-color-schema query, taking into
      account the color scheme of the owner element.

(WebCore::MQ::Features::prefersColorSchemeFeatureSchema):
    - Call frameUsesDarkAppearanceForPrefersColorScheme to answer the query.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::useDarkAppearance const):
    - Rewrite the logic to be easier to follow.

Canonical link: <a href="https://commits.webkit.org/310465@main">https://commits.webkit.org/310465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab148ff845ac5808eaae18531992ff4a81dbd180

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162479 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107187 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/214de5de-2f2a-4f81-b435-4f1df8d8ca02) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155602 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118862 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/107187 "An unexpected error occured. Recent messages:Printed configuration") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40b5ecba-6c72-4d24-8f9c-e396f44487e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138035 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99572 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3c1a172-92c0-4690-81c6-1929fe7b53d3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20201 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18156 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10312 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129850 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164950 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8084 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17488 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126940 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22187 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127107 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34523 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26312 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137689 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82990 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22014 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14471 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25929 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90217 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25620 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25780 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25680 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->