### PR TITLE
[JSC] Distinguish named and numbered backreferences in Yarr

### DIFF
--- a/JSTests/stress/regexp-duplicate-named-captures.js
+++ b/JSTests/stress/regexp-duplicate-named-captures.js
@@ -215,3 +215,6 @@ testRegExpSyntaxError("(?:(?<x>c)x)(?:(?<x>a)|(?<x>b))", "", "SyntaxError: Inval
 testRegExpSyntaxError("(?:(?<x>a)|(?<x>b))(?:(?<x>c)x)", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
 testRegExpSyntaxError("(?:(?<x>c)x|(?<y>d))(?:(?<y>a)|(?<x>b))", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
 testRegExpSyntaxError("(?:(?<y>a)|(?<x>b))(?:(?<x>c)x|(?<y>d))", "", "SyntaxError: Invalid regular expression: duplicate group specifier name");
+
+// Test named capture groups backtracking doesn't confuse numbered backreferences
+testRegExp(/(?<l>x)|((?<l>(|)\1?.){2})x/, "caffeeeee", null);

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -2364,17 +2364,18 @@ public:
         m_bodyDisjunction->terms.last().m_matchDirection = matchDirection;
     }
 
-    void atomBackReference(unsigned subpatternId, MatchDirection matchDirection, unsigned inputPosition, unsigned frameLocation, Checked<unsigned> quantityMaxCount, QuantifierType quantityType, OptionSet<Flags> flags)
+    void atomBackReference(bool isNamed, unsigned subpatternId, MatchDirection matchDirection, unsigned inputPosition, unsigned frameLocation, Checked<unsigned> quantityMaxCount, QuantifierType quantityType, OptionSet<Flags> flags)
     {
         ASSERT(subpatternId);
 
         m_bodyDisjunction->terms.append(ByteTerm::BackReference(subpatternId, matchDirection, inputPosition, flags));
 
-        if (m_pattern.hasDuplicateNamedCaptureGroups()) {
+        if (isNamed && m_pattern.hasDuplicateNamedCaptureGroups()) {
             auto duplicateNamedGroupId = m_pattern.m_duplicateNamedGroupForSubpatternId[subpatternId];
             if (duplicateNamedGroupId)
                 m_bodyDisjunction->terms.last().atom.parenIds.duplicateNamedGroupId = duplicateNamedGroupId;
         }
+
         m_bodyDisjunction->terms.last().atom.quantityMaxCount = quantityMaxCount;
         m_bodyDisjunction->terms.last().atom.quantityType = quantityType;
         m_bodyDisjunction->terms.last().frameLocation = frameLocation;
@@ -2768,15 +2769,17 @@ public:
                     break;
                 }
 
-                case PatternTerm::Type::BackReference: {
+                case PatternTerm::Type::NumberedBackReference:
+                case PatternTerm::Type::NamedBackReference: {
                     auto currentInputPosition = currentCountAlreadyChecked - term.inputPosition;
                     if (currentInputPosition.hasOverflowed())
                         return ErrorCode::OffsetTooLarge;
-                    atomBackReference(term.backReferenceSubpatternId, matchDirection, currentInputPosition, term.frameLocation, term.quantityMaxCount, term.quantityType, term.m_currentFlags);
+                    atomBackReference(term.type == PatternTerm::Type::NamedBackReference, term.backReferenceSubpatternId, matchDirection, currentInputPosition, term.frameLocation, term.quantityMaxCount, term.quantityType, term.m_currentFlags);
                     break;
                 }
 
-                case PatternTerm::Type::ForwardReference:
+                case PatternTerm::Type::NumberedForwardReference:
+                case PatternTerm::Type::NamedForwardReference:
                     break;
 
                 case PatternTerm::Type::ParenthesesSubpattern: {

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -2106,7 +2106,7 @@ class YarrGenerator final : public YarrJITInfo {
             m_jit.branch32(MacroAssembler::NotEqual, patternIndex, subpatternEndAddress(subpatternId)).linkTo(loop, &m_jit);
     }
 
-    void generateBackReference(size_t opIndex)
+    void generateBackReference(bool isNamed, size_t opIndex)
     {
         YarrOp& op = m_ops[opIndex];
         PatternTerm* term = op.m_term;
@@ -2119,7 +2119,7 @@ class YarrGenerator final : public YarrJITInfo {
 #endif
 
         unsigned subpatternId = term->backReferenceSubpatternId;
-        unsigned duplicateNamedGroupId = m_pattern.hasDuplicateNamedCaptureGroups() ? m_pattern.m_duplicateNamedGroupForSubpatternId[subpatternId] : 0;
+        unsigned duplicateNamedGroupId = (isNamed && m_pattern.hasDuplicateNamedCaptureGroups()) ? m_pattern.m_duplicateNamedGroupForSubpatternId[subpatternId] : 0;
         unsigned parenthesesFrameLocation = term->frameLocation;
 
         const MacroAssembler::RegisterID characterOrTemp = m_regs.regT0;
@@ -3317,18 +3317,19 @@ class YarrGenerator final : public YarrJITInfo {
             generateAssertionWordBoundary(opIndex);
             break;
 
-        case PatternTerm::Type::ForwardReference:
-            // Forward references always match the empty string (the referenced
-            // group hasn't captured anything yet), so no code needs to be emitted.
+        case PatternTerm::Type::NumberedForwardReference:
+        case PatternTerm::Type::NamedForwardReference:
+            m_failureReason = JITFailureReason::ForwardReference;
             break;
 
         case PatternTerm::Type::ParenthesesSubpattern:
         case PatternTerm::Type::ParentheticalAssertion:
             RELEASE_ASSERT_NOT_REACHED();
 
-        case PatternTerm::Type::BackReference:
+        case PatternTerm::Type::NumberedBackReference:
+        case PatternTerm::Type::NamedBackReference:
 #if ENABLE(YARR_JIT_BACKREFERENCES)
-            generateBackReference(opIndex);
+            generateBackReference(term->type == PatternTerm::Type::NamedBackReference, opIndex);
 #else
             m_failureReason = JITFailureReason::BackReference;
 #endif
@@ -3399,15 +3400,17 @@ class YarrGenerator final : public YarrJITInfo {
             backtrackAssertionWordBoundary(opIndex);
             break;
 
-        case PatternTerm::Type::ForwardReference:
-            // Nothing to backtrack for a forward reference (always matches empty string).
+        case PatternTerm::Type::NumberedForwardReference:
+        case PatternTerm::Type::NamedForwardReference:
+            m_failureReason = JITFailureReason::ForwardReference;
             break;
 
         case PatternTerm::Type::ParenthesesSubpattern:
         case PatternTerm::Type::ParentheticalAssertion:
             RELEASE_ASSERT_NOT_REACHED();
 
-        case PatternTerm::Type::BackReference:
+        case PatternTerm::Type::NumberedBackReference:
+        case PatternTerm::Type::NamedBackReference:
 #if ENABLE(YARR_JIT_BACKREFERENCES)
             backtrackBackReference(opIndex);
 #else
@@ -5621,12 +5624,11 @@ class YarrGenerator final : public YarrJITInfo {
             // Conservatively say any assertions just match.
             return cursor;
 
-        case PatternTerm::Type::BackReference:
+        case PatternTerm::Type::NumberedBackReference:
+        case PatternTerm::Type::NamedBackReference:
+        case PatternTerm::Type::NumberedForwardReference:
+        case PatternTerm::Type::NamedForwardReference:
             return std::nullopt;
-
-        case PatternTerm::Type::ForwardReference:
-            // Forward references always match the empty string, like assertions.
-            return cursor;
 
         case PatternTerm::Type::ParenthesesSubpattern: {
             // Right now, we only support /(...)/ or /(...)?/ case.
@@ -6610,7 +6612,7 @@ public:
                     return true;
 
                 // Back references can cause backtracking
-                if (term.type == PatternTerm::Type::BackReference)
+                if (term.type == PatternTerm::Type::NumberedBackReference || term.type == PatternTerm::Type::NamedBackReference)
                     return true;
                 // ForwardReference always matches empty string - no backtracking needed.
 
@@ -6982,8 +6984,9 @@ public:
                 out.printf("Assert EOL checked-offset:(%u)", op.m_checkedOffset.value());
                 break;
 
-            case PatternTerm::Type::BackReference:
-                out.printf("BackReference pattern #%u checked-offset:(%u)", term->backReferenceSubpatternId, op.m_checkedOffset.value());
+            case PatternTerm::Type::NumberedBackReference:
+            case PatternTerm::Type::NamedBackReference:
+                out.printf("%sBackReference pattern #%u checked-offset:(%u)", term->type == PatternTerm::Type::NumberedBackReference ? "Numbered" : "Named", term->backReferenceSubpatternId, op.m_checkedOffset.value());
                 term->dumpQuantifier(out);
                 break;
 
@@ -7012,8 +7015,9 @@ public:
                 out.printf(".* enclosure checked-offset:(%u)", op.m_checkedOffset.value());
                 break;
 
-            case PatternTerm::Type::ForwardReference:
-                out.printf("ForwardReference checked-offset:(%u)", op.m_checkedOffset.value());
+            case PatternTerm::Type::NumberedForwardReference:
+            case PatternTerm::Type::NamedForwardReference:
+                out.printf("%sForwardReference <not handled> checked-offset:(%u)", term->type == PatternTerm::Type::NumberedForwardReference ? "Numbered" : "Named", op.m_checkedOffset.value());
                 break;
 
             case PatternTerm::Type::ParenthesesSubpattern:
@@ -7379,6 +7383,9 @@ static void dumpCompileFailure(JITFailureReason failure)
         break;
     case JITFailureReason::BackReference:
         dataLog("Can't JIT some patterns containing back references\n");
+        break;
+    case JITFailureReason::ForwardReference:
+        dataLog("Can't JIT some patterns containing forward references\n");
         break;
     case JITFailureReason::Lookbehind:
         dataLog("Can't JIT a pattern containing lookbehinds\n");

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -59,6 +59,7 @@ class YarrCodeBlock;
 enum class JITFailureReason : uint8_t {
     DecodeSurrogatePair,
     BackReference,
+    ForwardReference,
     Lookbehind,
     VariableCountedParenthesisWithNonZeroMinimum,
     ParenthesizedSubpattern,

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1194,10 +1194,10 @@ public:
                     continue;
                 }
                 term->backReferenceSubpatternId = namedGroupSubpatternId;
-                term->convertToBackreference();
+                term->convertToNamedBackreference();
                 m_pattern.m_containsBackreferences = true;
             } else if (term->backReferenceSubpatternId && term->backReferenceSubpatternId <= m_pattern.m_numSubpatterns) {
-                term->convertToBackreference();
+                term->convertToNumberedBackreference();
                 m_pattern.m_containsBackreferences = true;
             }
         }
@@ -1536,7 +1536,7 @@ public:
     {
         ASSERT(subpatternId);
         if (subpatternId > m_pattern.m_numSubpatterns) {
-            m_alternative->m_terms.append(PatternTerm::ForwardReference(m_flags));
+            m_alternative->m_terms.append(PatternTerm::NumberedForwardReference(m_flags));
             if (parenthesisMatchDirection() == Backward) {
                 // When matching backwards, this forward reference could actually be
                 // a backreference for a captured paren in the lookbehind yet to be parsed.
@@ -1557,7 +1557,7 @@ public:
             ASSERT((term.type == PatternTerm::Type::ParenthesesSubpattern) || (term.type == PatternTerm::Type::ParentheticalAssertion));
 
             if ((term.type == PatternTerm::Type::ParenthesesSubpattern) && term.capture() && (subpatternId == term.parentheses.subpatternId)) {
-                m_alternative->m_terms.append(PatternTerm::ForwardReference(m_flags));
+                m_alternative->m_terms.append(PatternTerm::NumberedForwardReference(m_flags));
                 return;
             }
         }
@@ -1585,14 +1585,14 @@ public:
                 ASSERT((term.type == PatternTerm::Type::ParenthesesSubpattern) || (term.type == PatternTerm::Type::ParentheticalAssertion));
 
                 if ((term.type == PatternTerm::Type::ParenthesesSubpattern) && term.capture() && (subpatternId == term.parentheses.subpatternId)) {
-                    m_alternative->m_terms.append(PatternTerm::ForwardReference(m_flags));
+                    m_alternative->m_terms.append(PatternTerm::NamedForwardReference(m_flags));
                     return;
                 }
             }
         }
 
         if (parenthesisMatchDirection() == Forward) {
-            m_alternative->m_terms.append(PatternTerm(parenIndices.last(), m_flags));
+            m_alternative->m_terms.append(PatternTerm::NamedBackReference(parenIndices.last(), m_flags));
             PatternTerm& lastTerm = m_alternative->lastTerm();
             lastTerm.m_matchDirection = parenthesisMatchDirection();
             m_pattern.m_containsBackreferences = true;
@@ -1602,7 +1602,7 @@ public:
         // When part of a lookbehind, it could be the case that a prior alternative has a duplicate
         // named capture. Therefore we create a ForwardReference that will be converted to a
         // Backreference when the lookbehind or alternative is closed.
-        m_alternative->m_terms.append(PatternTerm::ForwardReference(m_flags));
+        m_alternative->m_terms.append(PatternTerm::NamedForwardReference(m_flags));
         PatternTerm& term = m_alternative->lastTerm();
         term.m_matchDirection = parenthesisMatchDirection();
         // We record the current subpatternId, which we use when we try to convert to a back reference.
@@ -1614,7 +1614,7 @@ public:
 
     void atomNamedForwardReference(const String& subpatternName)
     {
-        m_alternative->m_terms.append(PatternTerm::ForwardReference(m_flags));
+        m_alternative->m_terms.append(PatternTerm::NamedForwardReference(m_flags));
 
         if (parenthesisMatchDirection() == Backward) {
             PatternTerm& term = m_alternative->lastTerm();
@@ -1787,14 +1787,16 @@ public:
                 term.inputPosition = currentInputPosition;
                 break;
 
-            case PatternTerm::Type::BackReference:
+            case PatternTerm::Type::NumberedBackReference:
+            case PatternTerm::Type::NamedBackReference:
                 term.inputPosition = currentInputPosition;
                 term.frameLocation = currentCallFrameSize;
                 currentCallFrameSize += YarrStackSpaceForBackTrackInfoBackReference;
                 alternative->m_hasFixedSize = false;
                 break;
 
-            case PatternTerm::Type::ForwardReference:
+            case PatternTerm::Type::NumberedForwardReference:
+            case PatternTerm::Type::NamedForwardReference:
                 break;
 
             case PatternTerm::Type::PatternCharacter:
@@ -2861,13 +2863,18 @@ void PatternTerm::dump(PrintStream& out, YarrPattern* thisPattern, unsigned nest
             out.print(",frame location ", frameLocation);
         out.println();
         break;
-    case Type::BackReference:
+    case Type::NumberedBackReference:
+    case Type::NamedBackReference:
+        out.print(type == Type::NumberedBackReference ? "numbered " : "named ");
         out.print("back reference of subpattern #", backReferenceSubpatternId);
         out.printf(" inputPosition %u", inputPosition);
         out.println();
         break;
-    case Type::ForwardReference:
-        out.println("forward reference");
+    case Type::NumberedForwardReference:
+        out.println("numbered forward reference");
+        break;
+    case Type::NamedForwardReference:
+        out.println("named forward reference");
         break;
     case Type::ParenthesesSubpattern:
         if (m_capture)

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -211,8 +211,10 @@ struct PatternTerm {
         AssertionWordBoundary,
         PatternCharacter,
         CharacterClass,
-        BackReference,
-        ForwardReference,
+        NumberedBackReference,
+        NamedBackReference,
+        NumberedForwardReference,
+        NamedForwardReference,
         ParenthesesSubpattern,
         ParentheticalAssertion,
         DotStarEnclosure,
@@ -299,7 +301,7 @@ struct PatternTerm {
     }
 
     PatternTerm(unsigned spatternId, OptionSet<Flags> currFlags)
-        : type(Type::BackReference)
+        : type(Type::NumberedBackReference)
         , m_currentFlags(currFlags)
         , m_capture(false)
         , m_invert(false)
@@ -323,9 +325,24 @@ struct PatternTerm {
         quantityMinCount = quantityMaxCount = 1;
     }
 
-    static PatternTerm ForwardReference(OptionSet<Flags> currFlags)
+    static PatternTerm NamedBackReference(unsigned subpatternId, OptionSet<Flags> currFlags)
     {
-        auto term = PatternTerm(Type::ForwardReference, currFlags);
+        PatternTerm term(subpatternId, currFlags);
+        ASSERT(term.type == Type::NumberedBackReference);
+        term.type = Type::NamedBackReference;
+        return term;
+    }
+
+    static PatternTerm NumberedForwardReference(OptionSet<Flags> currFlags)
+    {
+        auto term = PatternTerm(Type::NumberedForwardReference, currFlags);
+        term.backReferenceSubpatternId = 0;
+        return term;
+    }
+
+    static PatternTerm NamedForwardReference(OptionSet<Flags> currFlags)
+    {
+        auto term = PatternTerm(Type::NamedForwardReference, currFlags);
         term.backReferenceSubpatternId = 0;
         return term;
     }
@@ -345,10 +362,16 @@ struct PatternTerm {
         return PatternTerm(Type::AssertionWordBoundary, currFlags, invert);
     }
 
-    void convertToBackreference()
+    void convertToNumberedBackreference()
     {
-        ASSERT(type == Type::ForwardReference);
-        type = Type::BackReference;
+        ASSERT(type == Type::NumberedForwardReference);
+        type = Type::NumberedBackReference;
+    }
+
+    void convertToNamedBackreference()
+    {
+        ASSERT(type == Type::NamedForwardReference);
+        type = Type::NamedBackReference;
     }
 
     bool invert() const


### PR DESCRIPTION
#### 12ef604ef990f44957fb6991824788477160d7e6
<pre>
[JSC] Distinguish named and numbered backreferences in Yarr
<a href="https://bugs.webkit.org/show_bug.cgi?id=302560">https://bugs.webkit.org/show_bug.cgi?id=302560</a>
<a href="https://rdar.apple.com/164402403">rdar://164402403</a>

Reviewed by Keith Miller.

The duplicate named capture group feature added the ability to have duplicate
capture group names so long as they&apos;re in different disjuncts. The semantics is
to check if any of the capture groups with the same name matched.  There can be
a maximum of one match as they are restricted to different disjuncts. In this
case, Yarr mints a special &quot;duplicated named groups group&quot; id along with an
indirection table that can check if any of the groups with the same name
matched.

Currently both named and numbered backreferences are compiled to the same
PatternTerm and ByteTerm type, with named capture groups resolved to the
numbers. If the capture group number is part of a duplicated name groups group,
the special id is used instead.

The problem is that that duplicated named group resolution is done even when
the backreference was explicitly numbered. That is, in /(?&lt;k&gt;...)|(?&lt;k&gt;...\1)/,
\1 is supposed to refer to the first parentheses, but ends up referring to both
disjuncts. As shown in this example, this can be recursive!

This recursion can manifest as out of bounds when doing backtracking, because
you can end up matching a group of size N, match a disjunct of size M, then
backtrack expecting to undo size N, but end up rewinding size M.

This PR fixes this issue by distinguishing numbered and named backreference
PatternTerms, and only performing the duplicate named group logic for named
backreferences.

A new test function is added to regexp-duplicate-named-capture.js

Originally-landed-as: 301765.330@safari-7623-branch (3b3f8ae21a23). <a href="https://rdar.apple.com/171560336">rdar://171560336</a>
Canonical link: <a href="https://commits.webkit.org/309655@main">https://commits.webkit.org/309655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7178b583887f9da16eb1284a516b7f6c57ebd95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160036 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104743 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b043472-7013-4503-b0e8-786807f176c2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24352 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116832 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82949 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2643f401-296f-4b56-bbc1-2d9f6f19688c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135772 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97550 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f696315-82a8-4c2a-8906-29a9117727a7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18050 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15996 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7881 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143293 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127672 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162508 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12105 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5641 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124842 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125026 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33921 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23860 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135480 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80356 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20097 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12250 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182914 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23469 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87773 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46657 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23181 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23334 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23235 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->