### PR TITLE
TOCTOU issue in `RemoteQueue::WriteBuffer`, leading to shader's OOB accesses

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "RemoteBufferMessages.h"
+#include "RemoteBufferProxy.h"
 #include "StreamServerConnection.h"
 #include "WebGPUObjectHeap.h"
 
@@ -111,7 +112,7 @@ void RemoteBuffer::copy(std::optional<WebCore::SharedMemoryHandle>&& dataHandle,
 {
     auto sharedData = dataHandle ? WebCore::SharedMemory::map(WTF::move(*dataHandle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr;
     auto data = sharedData ? sharedData->span() : std::span<const uint8_t> { };
-    if (!m_isMapped || !m_mapModeFlags.contains(WebCore::WebGPU::MapMode::Write)) {
+    if (!m_isMapped || !m_mapModeFlags.contains(WebCore::WebGPU::MapMode::Write) || data.size() <= WebGPU::maxCrossProcessResourceCopySize) {
         completionHandler(false);
         return;
     }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(GPU_PROCESS)
 
+#include "RemoteBufferProxy.h"
 #include "RemoteQueueMessages.h"
 #include "StreamServerConnection.h"
 #include "WebGPUObjectHeap.h"
@@ -92,7 +93,7 @@ void RemoteQueue::writeBuffer(
     auto data = dataHandle ? WebCore::SharedMemory::map(WTF::move(*dataHandle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr;
     auto convertedBuffer = protect(m_objectHeap)->convertBufferFromBacking(buffer);
     ASSERT(convertedBuffer);
-    if (!convertedBuffer) {
+    if (!convertedBuffer || !data || data->size() <= WebGPU::maxCrossProcessResourceCopySize) {
         completionHandler(false);
         return;
     }
@@ -130,7 +131,7 @@ void RemoteQueue::writeTexture(
     ASSERT(convertedDestination);
     auto convertedSize = objectHeap->convertFromBacking(size);
     ASSERT(convertedSize);
-    if (!convertedDestination || !convertedDestination || !convertedSize) {
+    if (!convertedDestination || !convertedDestination || !convertedSize || !data || data->size() <= WebGPU::maxCrossProcessResourceCopySize) {
         completionHandler(false);
         return;
     }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.cpp
@@ -91,8 +91,7 @@ void RemoteBufferProxy::copyFrom(std::span<const uint8_t> span, size_t offset)
     if (!m_mapModeFlags.contains(WebCore::WebGPU::MapMode::Write))
         return;
 
-    size_t actualCopySize = span.size() - offset;
-    if (actualCopySize > maxCrossProcessResourceCopySize) {
+    if (span.size() > maxCrossProcessResourceCopySize) {
         auto handle = WebCore::SharedMemoryHandle::createCopy(span, WebCore::SharedMemory::Protection::ReadOnly);
         auto sendResult = sendWithAsyncReply(Messages::RemoteBuffer::Copy(WTF::move(handle), offset), [](auto) {
         });


### PR DESCRIPTION
#### 48fc66a95fabd7a4b124a4bf8f3b13389a249823
<pre>
TOCTOU issue in `RemoteQueue::WriteBuffer`, leading to shader&apos;s OOB accesses
<a href="https://bugs.webkit.org/show_bug.cgi?id=303927">https://bugs.webkit.org/show_bug.cgi?id=303927</a>
<a href="https://rdar.apple.com/166211636">rdar://166211636</a>

Reviewed by Dan Glastonbury.

There is a race window from a compromised web process where it can
pass a shared memory handle, pass GPU process side CPU validation, and
then perform writes to the shmem from the compromised WCP.

Address this by ensuring GPU process shmem paths are only taken when the
shmem data size exceeds the expected amount, which is currently 16 MB.

No new test since issue relies on one process completing a data write
before a memcpy call completes, race window is small and original repro
is not consistently reproducible.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp:
(WebKit::RemoteBuffer::copy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp:
(WebKit::RemoteQueue::writeBuffer):
(WebKit::RemoteQueue::writeTexture):

Originally-landed-as: 301765.395@safari-7623-branch (30072d25bc76). <a href="https://rdar.apple.com/171556720">rdar://171556720</a>
Canonical link: <a href="https://commits.webkit.org/309107@main">https://commits.webkit.org/309107@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e10f8243e2179a24ce79b86ec4b329d50ba8e272

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149392 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158093 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102824 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9dbc76ba-5b46-4bef-afae-172b8d16be68) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115212 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81955 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/417c873e-b8d8-4318-ae53-4e5f93c6f282) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134052 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95957 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3127bb0-e5ab-4255-9997-f532aec8afa0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16451 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14350 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5935 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126052 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160570 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3563 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13520 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123248 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18380 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123465 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33565 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21916 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133784 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78134 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18680 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10530 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21518 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85331 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21249 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21399 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21306 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->