### PR TITLE
Fix integer truncation in mtl_buffer_pool

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.h
@@ -284,7 +284,7 @@ class ProgramExecutableMtl : public ProgramExecutableImpl
     // Scratch data:
     // Legalized buffers and their offsets. For example, uniform buffer's offset=1 is not a valid
     // offset, it will be converted to legal offset and the result is stored in this array.
-    std::vector<std::pair<mtl::BufferRef, uint32_t>> mLegalizedOffsetedUniformBuffers;
+    std::vector<std::pair<mtl::BufferRef, size_t>> mLegalizedOffsetedUniformBuffers;
     // Stores the render stages usage of each uniform buffer. Only used if the buffers are encoded
     // into an argument buffer.
     std::vector<uint32_t> mArgumentBufferRenderStageUsages;

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.mm
@@ -1097,7 +1097,7 @@ angle::Result ProgramExecutableMtl::commitUniforms(ContextMtl *context,
             // Commit
             ANGLE_TRY(bufferPool->commit(context));
             // Set buffer
-            cmdEncoder->setBuffer(shaderType, mtlBufferOut, (uint32_t)offsetOut,
+            cmdEncoder->setBuffer(shaderType, mtlBufferOut, offsetOut,
                                   mtl::kDefaultUniformsBindingIndex);
         }
 
@@ -1221,7 +1221,7 @@ angle::Result ProgramExecutableMtl::updateUniformBuffers(
 
     // This array is only used inside this function and its callees.
     ScopedAutoClearVector<uint32_t> scopeArrayClear(&mArgumentBufferRenderStageUsages);
-    ScopedAutoClearVector<std::pair<mtl::BufferRef, uint32_t>> scopeArrayClear2(
+    ScopedAutoClearVector<std::pair<mtl::BufferRef, size_t>> scopeArrayClear2(
         &mLegalizedOffsetedUniformBuffers);
     mArgumentBufferRenderStageUsages.resize(blocks.size());
     mLegalizedOffsetedUniformBuffers.resize(blocks.size());
@@ -1327,8 +1327,7 @@ angle::Result ProgramExecutableMtl::legalizeUniformBufferOffsets(ContextMtl *con
             size_t bytesToOffset = numBlocksToOffset * conversionInfo.metalSize();
 
             mLegalizedOffsetedUniformBuffers[bufferIndex].first = conversion->convertedBuffer;
-            mLegalizedOffsetedUniformBuffers[bufferIndex].second =
-                static_cast<uint32_t>(conversion->convertedOffset + bytesToOffset);
+            mLegalizedOffsetedUniformBuffers[bufferIndex].second = conversion->convertedOffset + bytesToOffset;
             // Ensure that the converted info can fit in the buffer.
             ASSERT(conversion->convertedOffset + bytesToOffset + conversionInfo.metalSize() <=
                    conversion->convertedBuffer->size());
@@ -1336,8 +1335,7 @@ angle::Result ProgramExecutableMtl::legalizeUniformBufferOffsets(ContextMtl *con
         else
         {
             mLegalizedOffsetedUniformBuffers[bufferIndex].first = bufferMtl->getCurrentBuffer();
-            mLegalizedOffsetedUniformBuffers[bufferIndex].second =
-                static_cast<uint32_t>(bufferBinding.getOffset());
+            mLegalizedOffsetedUniformBuffers[bufferIndex].second = bufferBinding.getOffset();
         }
     }
     return angle::Result::Continue;
@@ -1373,7 +1371,7 @@ angle::Result ProgramExecutableMtl::bindUniformBuffersToDiscreteSlots(
         }
 
         mtl::BufferRef mtlBuffer = mLegalizedOffsetedUniformBuffers[bufferIndex].first;
-        uint32_t offset          = mLegalizedOffsetedUniformBuffers[bufferIndex].second;
+        size_t offset            = mLegalizedOffsetedUniformBuffers[bufferIndex].second;
         cmdEncoder->setBuffer(shaderType, mtlBuffer, offset, actualBufferIdx);
     }
     return angle::Result::Continue;
@@ -1437,7 +1435,7 @@ angle::Result ProgramExecutableMtl::encodeUniformBuffersInfoArgumentBuffer(
         }
 
         mtl::BufferRef mtlBuffer = mLegalizedOffsetedUniformBuffers[bufferIndex].first;
-        uint32_t offset          = mLegalizedOffsetedUniformBuffers[bufferIndex].second;
+        size_t offset            = mLegalizedOffsetedUniformBuffers[bufferIndex].second;
         [bufferEncoder.metalArgBufferEncoder setBuffer:mtlBuffer->get()
                                                 offset:offset
                                                atIndex:actualBufferIdx];
@@ -1447,7 +1445,7 @@ angle::Result ProgramExecutableMtl::encodeUniformBuffersInfoArgumentBuffer(
     argumentBuffer->unmapAndFlushSubset(context, argumentBufferOffset,
                                         bufferEncoder.metalArgBufferEncoder.get().encodedLength);
 
-    cmdEncoder->setBuffer(shaderType, argumentBuffer, static_cast<uint32_t>(argumentBufferOffset),
+    cmdEncoder->setBuffer(shaderType, argumentBuffer, argumentBufferOffset,
                           mtl::kUBOArgumentBufferBindingIndex);
     return angle::Result::Continue;
 }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm
@@ -489,9 +489,9 @@ angle::Result VertexArrayMtl::setupDraw(const gl::Context *glContext,
                 continue;
             }
             uint32_t bufferIdx    = mtl::kVboBindingIndexStart + v;
-            uint32_t bufferOffset = static_cast<uint32_t>(mCurrentArrayBufferOffsets[v]);
             if (mCurrentArrayBuffers[v])
             {
+                size_t bufferOffset = mCurrentArrayBufferOffsets[v];
                 cmdEncoder->setVertexBuffer(mCurrentArrayBuffers[v]->getCurrentBuffer(),
                                             bufferOffset, bufferIdx);
             }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.h
@@ -92,18 +92,17 @@ class BufferPool
     angle::Result allocateNewBuffer(ContextMtl *contextMtl);
     void destroyBufferList(ContextMtl *contextMtl, std::deque<BufferRef> *buffers);
     angle::Result finalizePendingBuffer(ContextMtl *contextMtl);
-    size_t mInitialSize;
-    BufferRef mBuffer;
-    uint32_t mNextAllocationOffset;
-    uint32_t mLastFlushOffset;
-    size_t mSize;
-    size_t mAlignment;
 
+    BufferRef mBuffer;
     std::deque<BufferRef> mInFlightBuffers;
     std::deque<BufferRef> mBufferFreeList;
-
-    size_t mBuffersAllocated;
-    size_t mMaxBuffers;
+    size_t mInitialSize{0};
+    size_t mNextAllocationOffset{0};
+    size_t mLastFlushOffset{0};
+    size_t mSize{0};
+    size_t mAlignment{1};
+    size_t mBuffersAllocated{0};
+    size_t mMaxBuffers{0};
     bool mAlwaysAllocateNewBuffer;
 };
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.mm
@@ -26,14 +26,7 @@ namespace mtl
 BufferPool::BufferPool() : BufferPool(false) {}
 
 BufferPool::BufferPool(bool alwaysAllocNewBuffer)
-    : mInitialSize(0),
-      mBuffer(nullptr),
-      mNextAllocationOffset(0),
-      mLastFlushOffset(0),
-      mSize(0),
-      mAlignment(1),
-      mBuffersAllocated(0),
-      mMaxBuffers(0),
+    : mBuffer(nullptr),
       mAlwaysAllocateNewBuffer(alwaysAllocNewBuffer)
 {}
 
@@ -235,9 +228,9 @@ angle::Result BufferPool::allocate(ContextMtl *contextMtl,
 
     if (offsetOut)
     {
-        *offsetOut = static_cast<size_t>(mNextAllocationOffset);
+        *offsetOut = mNextAllocationOffset;
     }
-    mNextAllocationOffset += static_cast<uint32_t>(sizeToAllocate);
+    mNextAllocationOffset += sizeToAllocate;
     return angle::Result::Continue;
 }
 
@@ -348,7 +341,7 @@ void BufferPool::updateAlignment(Context *context, size_t alignment)
     // If alignment has changed, make sure the next allocation is done at an aligned offset.
     if (alignment != mAlignment)
     {
-        mNextAllocationOffset = roundUp(mNextAllocationOffset, static_cast<uint32_t>(alignment));
+        mNextAllocationOffset = roundUp(mNextAllocationOffset, alignment);
         mAlignment            = alignment;
     }
 }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.h
@@ -387,7 +387,7 @@ struct RenderCommandEncoderShaderStates
     void reset();
 
     std::array<id<MTLBuffer>, kMaxShaderBuffers> buffers;
-    std::array<uint32_t, kMaxShaderBuffers> bufferOffsets;
+    std::array<size_t, kMaxShaderBuffers> bufferOffsets;
     std::array<id<MTLSamplerState>, kMaxShaderSamplers> samplers;
     std::array<Optional<std::pair<float, float>>, kMaxShaderSamplers> samplerLodClamps;
     std::array<id<MTLTexture>, kMaxShaderSamplers> textures;
@@ -459,7 +459,7 @@ class RenderCommandEncoder final : public CommandEncoder
 
     RenderCommandEncoder &setBlendColor(float r, float g, float b, float a);
 
-    RenderCommandEncoder &setVertexBuffer(const BufferRef &buffer, uint32_t offset, uint32_t index)
+    RenderCommandEncoder &setVertexBuffer(const BufferRef &buffer, size_t offset, uint32_t index)
     {
         return setBuffer(gl::ShaderType::Vertex, buffer, offset, index);
     }
@@ -485,7 +485,7 @@ class RenderCommandEncoder final : public CommandEncoder
     }
 
     RenderCommandEncoder &setFragmentBuffer(const BufferRef &buffer,
-                                            uint32_t offset,
+                                            size_t offset,
                                             uint32_t index)
     {
         return setBuffer(gl::ShaderType::Fragment, buffer, offset, index);
@@ -513,11 +513,11 @@ class RenderCommandEncoder final : public CommandEncoder
 
     RenderCommandEncoder &setBuffer(gl::ShaderType shaderType,
                                     const BufferRef &buffer,
-                                    uint32_t offset,
+                                    size_t offset,
                                     uint32_t index);
     RenderCommandEncoder &setBufferForWrite(gl::ShaderType shaderType,
                                             const BufferRef &buffer,
-                                            uint32_t offset,
+                                            size_t offset,
                                             uint32_t index);
     RenderCommandEncoder &setBytes(gl::ShaderType shaderType,
                                    const void *bytes,
@@ -640,7 +640,7 @@ class RenderCommandEncoder final : public CommandEncoder
 
     RenderCommandEncoder &commonSetBuffer(gl::ShaderType shaderType,
                                           id<MTLBuffer> mtlBuffer,
-                                          uint32_t offset,
+                                          size_t offset,
                                           uint32_t index);
 
     RenderPassDesc mRenderPassDesc;
@@ -742,9 +742,9 @@ class ComputeCommandEncoder final : public CommandEncoder
 
     ComputeCommandEncoder &setComputePipelineState(id<MTLComputePipelineState> state);
 
-    ComputeCommandEncoder &setBuffer(const BufferRef &buffer, uint32_t offset, uint32_t index);
+    ComputeCommandEncoder &setBuffer(const BufferRef &buffer, size_t offset, uint32_t index);
     ComputeCommandEncoder &setBufferForWrite(const BufferRef &buffer,
-                                             uint32_t offset,
+                                             size_t offset,
                                              uint32_t index);
     ComputeCommandEncoder &setBytes(const void *bytes, size_t size, uint32_t index);
     template <typename T>

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_command_buffer.mm
@@ -184,7 +184,7 @@ inline void SetVertexBufferCmd(id<MTLRenderCommandEncoder> encoder,
                                IntermediateCommandStream *stream)
 {
     id<MTLBuffer> buffer = stream->fetch<id<MTLBuffer>>();
-    uint32_t offset      = stream->fetch<uint32_t>();
+    size_t offset      = stream->fetch<size_t>();
     uint32_t index       = stream->fetch<uint32_t>();
     [encoder setVertexBuffer:buffer offset:offset atIndex:index];
     [buffer ANGLE_MTL_RELEASE];
@@ -193,7 +193,7 @@ inline void SetVertexBufferCmd(id<MTLRenderCommandEncoder> encoder,
 inline void SetVertexBufferOffsetCmd(id<MTLRenderCommandEncoder> encoder,
                                      IntermediateCommandStream *stream)
 {
-    uint32_t offset = stream->fetch<uint32_t>();
+    size_t offset = stream->fetch<size_t>();
     uint32_t index  = stream->fetch<uint32_t>();
     [encoder setVertexBufferOffset:offset atIndex:index];
 }
@@ -235,7 +235,7 @@ inline void SetFragmentBufferCmd(id<MTLRenderCommandEncoder> encoder,
                                  IntermediateCommandStream *stream)
 {
     id<MTLBuffer> buffer = stream->fetch<id<MTLBuffer>>();
-    uint32_t offset      = stream->fetch<uint32_t>();
+    size_t offset        = stream->fetch<size_t>();
     uint32_t index       = stream->fetch<uint32_t>();
     [encoder setFragmentBuffer:buffer offset:offset atIndex:index];
     [buffer ANGLE_MTL_RELEASE];
@@ -244,8 +244,8 @@ inline void SetFragmentBufferCmd(id<MTLRenderCommandEncoder> encoder,
 inline void SetFragmentBufferOffsetCmd(id<MTLRenderCommandEncoder> encoder,
                                        IntermediateCommandStream *stream)
 {
-    uint32_t offset = stream->fetch<uint32_t>();
-    uint32_t index  = stream->fetch<uint32_t>();
+    size_t offset  = stream->fetch<size_t>();
+    uint32_t index = stream->fetch<uint32_t>();
     [encoder setFragmentBufferOffset:offset atIndex:index];
 }
 
@@ -1314,7 +1314,7 @@ void RenderCommandEncoderShaderStates::reset()
         buffer = nil;
     }
 
-    for (uint32_t &offset : bufferOffsets)
+    for (size_t &offset : bufferOffsets)
     {
         offset = 0;
     }
@@ -1968,7 +1968,7 @@ RenderCommandEncoder &RenderCommandEncoder::setBlendColor(float r, float g, floa
 
 RenderCommandEncoder &RenderCommandEncoder::setBuffer(gl::ShaderType shaderType,
                                                       const BufferRef &buffer,
-                                                      uint32_t offset,
+                                                      size_t offset,
                                                       uint32_t index)
 {
     if (index >= kMaxShaderBuffers)
@@ -1985,7 +1985,7 @@ RenderCommandEncoder &RenderCommandEncoder::setBuffer(gl::ShaderType shaderType,
 
 RenderCommandEncoder &RenderCommandEncoder::setBufferForWrite(gl::ShaderType shaderType,
                                                               const BufferRef &buffer,
-                                                              uint32_t offset,
+                                                              size_t offset,
                                                               uint32_t index)
 {
     if (index >= kMaxShaderBuffers)
@@ -2002,7 +2002,7 @@ RenderCommandEncoder &RenderCommandEncoder::setBufferForWrite(gl::ShaderType sha
 
 RenderCommandEncoder &RenderCommandEncoder::commonSetBuffer(gl::ShaderType shaderType,
                                                             id<MTLBuffer> mtlBuffer,
-                                                            uint32_t offset,
+                                                            size_t offset,
                                                             uint32_t index)
 {
     RenderCommandEncoderShaderStates &shaderStates = mStateCache.perShaderStates[shaderType];
@@ -2747,7 +2747,7 @@ ComputeCommandEncoder &ComputeCommandEncoder::setComputePipelineState(
 }
 
 ComputeCommandEncoder &ComputeCommandEncoder::setBuffer(const BufferRef &buffer,
-                                                        uint32_t offset,
+                                                        size_t offset,
                                                         uint32_t index)
 {
     if (index >= kMaxShaderBuffers)
@@ -2763,7 +2763,7 @@ ComputeCommandEncoder &ComputeCommandEncoder::setBuffer(const BufferRef &buffer,
 }
 
 ComputeCommandEncoder &ComputeCommandEncoder::setBufferForWrite(const BufferRef &buffer,
-                                                                uint32_t offset,
+                                                                size_t offset,
                                                                 uint32_t index)
 {
     if (index >= kMaxShaderBuffers)

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm
@@ -657,28 +657,28 @@ void SetupCommonBlitWithDrawStates(const gl::Context *context,
 // Overloaded functions to be used with both compute and render command encoder.
 ANGLE_INLINE void SetComputeOrVertexBuffer(RenderCommandEncoder *encoder,
                                            const BufferRef &buffer,
-                                           uint32_t offset,
+                                           size_t offset,
                                            uint32_t index)
 {
     encoder->setBuffer(gl::ShaderType::Vertex, buffer, offset, index);
 }
 ANGLE_INLINE void SetComputeOrVertexBufferForWrite(RenderCommandEncoder *encoder,
                                                    const BufferRef &buffer,
-                                                   uint32_t offset,
+                                                   size_t offset,
                                                    uint32_t index)
 {
     encoder->setBufferForWrite(gl::ShaderType::Vertex, buffer, offset, index);
 }
 ANGLE_INLINE void SetComputeOrVertexBuffer(ComputeCommandEncoder *encoder,
                                            const BufferRef &buffer,
-                                           uint32_t offset,
+                                           size_t offset,
                                            uint32_t index)
 {
     encoder->setBuffer(buffer, offset, index);
 }
 ANGLE_INLINE void SetComputeOrVertexBufferForWrite(ComputeCommandEncoder *encoder,
                                                    const BufferRef &buffer,
-                                                   uint32_t offset,
+                                                   size_t offset,
                                                    uint32_t index)
 {
     encoder->setBufferForWrite(buffer, offset, index);

--- a/Source/ThirdParty/ANGLE/src/tests/BUILD.gn
+++ b/Source/ThirdParty/ANGLE/src/tests/BUILD.gn
@@ -558,6 +558,10 @@ if (is_win || is_linux || is_chromeos || is_android || is_fuchsia || is_apple) {
     if (angle_ir) {
       configs += [ "${angle_root}:angle_translator_ir" ]
     }
+    
+    if (angle_enable_metal) {
+      sources += angle_white_box_tests_metal_sources
+    }
   }
 }
 

--- a/Source/ThirdParty/ANGLE/src/tests/angle_white_box_tests.gni
+++ b/Source/ThirdParty/ANGLE/src/tests/angle_white_box_tests.gni
@@ -23,3 +23,6 @@ angle_white_box_tests_vulkan_sources = [
   "gl_tests/VulkanMultithreadingTest.cpp",
   "gl_tests/VulkanUniformUpdatesTest.cpp",
 ]
+angle_white_box_tests_metal_sources = [
+  "gl_tests/BufferPoolTestMetal.mm",
+]

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/BufferPoolTestMetal.mm
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/BufferPoolTestMetal.mm
@@ -1,0 +1,143 @@
+//
+// Copyright 2025 The ANGLE Project Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+//
+// BufferPoolTestMetal.mm:
+//   White box tests for Metal BufferPool allocation logic, specifically for testing
+//   size_t overflow scenario.
+//
+
+#include "test_utils/ANGLETest.h"
+#include "test_utils/gl_raii.h"
+
+#include "common/apple_platform_utils.h"
+#include "common/mathutil.h"
+#include "libANGLE/Context.h"
+#include "libANGLE/Display.h"
+#include "libANGLE/renderer/metal/ContextMtl.h"
+#include "libANGLE/renderer/metal/DisplayMtl.h"
+#include "libANGLE/renderer/metal/mtl_buffer_pool.h"
+
+using namespace rx;
+using namespace angle;
+
+namespace
+{
+
+class BufferPoolTest : public ANGLETest<>
+{
+  protected:
+    BufferPoolTest()
+    {
+        setWindowWidth(1);
+        setWindowHeight(1);
+        setConfigRedBits(8);
+        setConfigGreenBits(8);
+        setConfigBlueBits(8);
+        setConfigAlphaBits(8);
+    }
+
+    ContextMtl *getContextMtl()
+    {
+        // Get the context through the display, similar to D3D11 white box tests
+        egl::Display *display = static_cast<egl::Display *>(getEGLWindow()->getDisplay());
+        gl::ContextID contextID = {
+            static_cast<GLuint>(reinterpret_cast<uintptr_t>(getEGLWindow()->getContext()))};
+        gl::Context *context = display->getContext(contextID);
+        return mtl::GetImpl(context);
+    }
+};
+
+// Test that BufferPool correctly handles allocations with size_t offsets > UINT32_MAX
+TEST_P(BufferPoolTest, AllocationOffsetNoTruncation)
+{
+    ANGLE_SKIP_TEST_IF(!IsMetalRendererAvailable());
+
+    ContextMtl *contextMtl = getContextMtl();
+    ASSERT_NE(contextMtl, nullptr);
+
+    mtl::BufferPool bufferPool;
+
+    // Use a large buffer size that will cause offset calculations to exceed UINT32_MAX
+    // when aligned.
+    constexpr size_t kLargeSize = 0xFFFFFFFF;  // UINT32_MAX + 512 (4GB bytes)
+    constexpr size_t kAlignment = 256;         // Typical Metal buffer alignment
+    constexpr size_t kSmallSize = 1024;        // Second allocation size
+
+    // Initialize buffer pool with large initial size
+    bufferPool.initialize(contextMtl, kLargeSize, kAlignment, 10);
+
+    // Perform first allocation
+    uint8_t *ptr1       = nullptr;
+    mtl::BufferRef buf1 = nullptr;
+    size_t offset1      = 0;
+    bool newBuffer1     = false;
+
+    ASSERT_EQ(bufferPool.allocate(contextMtl, kLargeSize, &ptr1, &buf1, &offset1, &newBuffer1),
+              angle::Result::Continue);
+    EXPECT_TRUE(newBuffer1);
+    EXPECT_EQ(offset1, 0u);
+    EXPECT_NE(ptr1, nullptr);
+    EXPECT_NE(buf1, nullptr);
+
+    // Fill first allocation with a known pattern (0xAA)
+    // We only fill the first 4KB to avoid spending too much time on this test
+    constexpr size_t kPatternSize = 4096;
+    memset(ptr1, 0xAA, kPatternSize);
+
+    // Commit the first allocation to ensure it's written to the buffer
+    ASSERT_EQ(bufferPool.commit(contextMtl), angle::Result::Continue);
+
+    // Perform second allocation
+    uint8_t *ptr2       = nullptr;
+    mtl::BufferRef buf2 = nullptr;
+    size_t offset2      = 0;
+    bool newBuffer2     = false;
+
+    ASSERT_EQ(bufferPool.allocate(contextMtl, kSmallSize, &ptr2, &buf2, &offset2, &newBuffer2),
+              angle::Result::Continue);
+
+    // With the fix (size_t), a new buffer should be allocated since the calculated offset
+    // exceeds the buffer size. Otherwise (no fix), the offset would truncate and
+    // potentially reuse the same buffer incorrectly, causing memory corruption.
+    EXPECT_TRUE(newBuffer2);
+
+    // The offset should be 0 in the new buffer (not a truncated large value)
+    EXPECT_EQ(offset2, 0u);
+    EXPECT_NE(ptr2, nullptr);
+    EXPECT_NE(buf2, nullptr);
+
+    // Buffers should be different
+    EXPECT_NE(buf1.get(), buf2.get());
+
+    // Fill second allocation with a different pattern (0xBB)
+    memset(ptr2, 0xBB, kSmallSize);
+
+    // Commit the second allocation
+    ASSERT_EQ(bufferPool.commit(contextMtl), angle::Result::Continue);
+
+    // Now verify that the first buffer's data wasn't corrupted
+    // With the uint32_t bug, ptr2 would have overwritten ptr1's data at offset 0
+    // because the offset wrapped around to 0 or a small value.
+    // Map the first buffer again to verify its contents
+    uint8_t *verifyPtr1 = buf1->mapWithOpt(contextMtl, true, false);
+    ASSERT_NE(verifyPtr1, nullptr);
+
+    // Check that the first pattern (0xAA) is still intact
+    // If the bug exists, this would have been overwritten with 0xBB
+    for (size_t i = 0; i < kSmallSize && i < kPatternSize; ++i)
+    {
+        EXPECT_EQ(verifyPtr1[i], 0xAA)
+            << "First buffer corrupted at byte " << i
+            << " - uint32_t truncation bug likely caused second allocation to overlap!";
+    }
+
+    buf1->unmap(contextMtl);
+    bufferPool.destroy(contextMtl);
+}
+
+}  // namespace
+
+GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(BufferPoolTest);
+ANGLE_INSTANTIATE_TEST(BufferPoolTest, ES2_METAL(), ES3_METAL());


### PR DESCRIPTION
#### 4369d90c86f60f1ff9bf122219b9a691e6afa25b
<pre>
Fix integer truncation in mtl_buffer_pool
<a href="https://bugs.webkit.org/show_bug.cgi?id=304318">https://bugs.webkit.org/show_bug.cgi?id=304318</a>
<a href="https://rdar.apple.com/166535879">rdar://166535879</a>

Reviewed by Kimmo Kinnunen.

Fix Metal backend integer overflow vulnerabilities in BufferPool

BufferPool uses uint32_t for offset tracking, causing silent truncation beyond 4GB.
Change mNextAllocationOffset and mLastFlushOffset to size_t and remove truncating casts.

Add ANGLE white box test to test BufferPool class.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.mm:
(rx::mtl::BufferPool::allocate):
(rx::mtl::BufferPool::updateAlignment):

Originally-landed-as: 301765.427@safari-7623-branch (0d65ad29c897). <a href="https://rdar.apple.com/170272088">rdar://170272088</a>
Canonical link: <a href="https://commits.webkit.org/309041@main">https://commits.webkit.org/309041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf467ca00e494f7c711292a3e72a787477b21b2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157840 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102583 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114988 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81848 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6212fa71-c962-4440-8f32-222f1907a908) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17160 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95745 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/307faa8c-1133-4870-9b3d-f33c0d0cf033) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16260 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14177 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5693 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125860 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160325 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13298 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123037 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123265 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33525 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21675 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133570 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77876 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18505 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10322 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21277 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21009 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21157 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21065 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->