### PR TITLE
[webkitpy][GLIB] Add support to architecture markers in TestExpectations.json

### DIFF
--- a/Tools/Scripts/webkitpy/common/test_expectations.py
+++ b/Tools/Scripts/webkitpy/common/test_expectations.py
@@ -37,9 +37,10 @@ def check_repeated_keys(args):
 
 class TestExpectations(object):
 
-    def __init__(self, port_name, expectations_file, build_type='Release'):
+    def __init__(self, port_name, expectations_file, build_type='Release', architecture=None):
         self._port_name = port_name
         self._build_type = build_type
+        self._architecture = architecture
         if os.path.isfile(expectations_file):
             with open(expectations_file, 'r') as fd:
                 self._expectations = self._load_expectation_string(fd.read())
@@ -50,20 +51,17 @@ class TestExpectations(object):
         return json.loads(expectations, object_pairs_hook=check_repeated_keys)
 
     def _port_name_for_expected(self, expected):
-        if self._port_name in expected:
-            return self._port_name
-
-        name_with_build = self._port_name + '@' + self._build_type
-        if name_with_build in expected:
-            return name_with_build
-
-        if 'all' in expected:
-            return 'all'
-
-        name_with_build = 'all@' + self._build_type
-        if name_with_build in expected:
-            return name_with_build
-
+        for port in [self._port_name, 'all']:
+            candidates = [port]
+            if self._build_type:
+                candidates.append('%s@%s' % (port, self._build_type))
+            if self._architecture:
+                candidates.append('%s:%s' % (port, self._architecture))
+            if self._build_type and self._architecture:
+                candidates.append('%s@%s:%s' % (port, self._build_type, self._architecture))
+            for key in reversed(candidates):
+                if key in expected:
+                    return key
         return None
 
     def _expected_value(self, expected, value, default):

--- a/Tools/Scripts/webkitpy/common/test_expectations_unittest.py
+++ b/Tools/Scripts/webkitpy/common/test_expectations_unittest.py
@@ -28,11 +28,12 @@ from webkitpy.common.test_expectations import TestExpectations
 
 class MockTestExpectations(TestExpectations):
 
-    def __init__(self, port, expectations, build_type='Release'):
+    def __init__(self, port, expectations, build_type='Release', architecture=None):
         host = MockHost()
         port = host.port_factory.get(port)
         self._port_name = port.name()
         self._build_type = build_type
+        self._architecture = architecture
         self._expectations = self._load_expectation_string(expectations)
 
     def is_skip(self, test, subtest):
@@ -181,6 +182,93 @@ class ExpectationsTest(unittest.TestCase):
     }
 }"""
 
+    ARCHITECTURE = """
+{
+    "TestWebKit": {
+        "subtests": {
+            "WebKit.ArmCrash": {
+                "expected": {"all:arm64": {"status": ["CRASH"], "bug": "1234"}}
+            },
+            "WebKit.GtkArmTimeout": {
+                "expected": {"gtk:arm64": {"status": ["TIMEOUT"], "bug": "1234"}}
+            },
+            "WebKit.AllFail": {
+                "expected": {"all": {"status": ["FAIL"], "bug": "1234"}}
+            }
+        }
+    }
+}"""
+
+    SPECIFICITY = """
+{
+    "TestWebKit": {
+        "subtests": {
+            "WebKit.PortVsAll": {
+                "expected": {
+                    "all:arm64": {"status": ["TIMEOUT"], "bug": "1234"},
+                    "gtk": {"status": ["FAIL"], "bug": "1234"}
+                }
+            },
+            "WebKit.ArchVsPlain": {
+                "expected": {
+                    "gtk": {"status": ["FAIL"], "bug": "1234"},
+                    "gtk:arm64": {"status": ["CRASH"], "bug": "1234"}
+                }
+            },
+            "WebKit.BuildVsPlain": {
+                "expected": {
+                    "gtk": {"status": ["FAIL"], "bug": "1234"},
+                    "gtk@Release": {"status": ["TIMEOUT"], "bug": "1234"}
+                }
+            },
+            "WebKit.FullyQualified": {
+                "expected": {
+                    "gtk": {"status": ["FAIL"], "bug": "1234"},
+                    "gtk:arm64": {"status": ["TIMEOUT"], "bug": "1234"},
+                    "gtk@Debug:arm64": {"status": ["CRASH"], "bug": "1234"}
+                }
+            },
+            "WebKit.PortVsAllFullyQualified": {
+                "expected": {
+                    "gtk": {"status": ["FAIL"], "bug": "1234"},
+                    "all@Release:arm64": {"status": ["TIMEOUT"], "bug": "1234"}
+                }
+            }
+        }
+    }
+}"""
+
+    ARCHITECTURE_SLOW = """
+{
+    "TestWebKit": {
+        "expected": {"all": {"slow": true}},
+        "subtests": {
+            "WebKit.FastOnArm": {
+                "expected": {"all:arm64": {"slow": false}}
+            }
+        }
+    }
+}"""
+
+    ARCHITECTURE_SKIP = """
+{
+    "TestSkipArch": {
+        "expected": {"all:arm64": {"status": ["SKIP"], "bug": "1234"}},
+        "subtests": {
+            "TestSkipArch.PassOnArm": {
+                "expected": {"all": {"status": ["PASS"]}}
+            }
+        }
+    },
+    "TestSkipArchSubtest": {
+        "subtests": {
+            "sub1": {
+                "expected": {"all:arm64": {"status": ["SKIP"], "bug": "1234"}}
+            }
+        }
+    }
+}"""
+
     REPEATED_KEYS = """
 {
     "TestDummy": {
@@ -301,6 +389,80 @@ class ExpectationsTest(unittest.TestCase):
         self.assert_slow('TestWebKit', 'WebKit.WKView', False)
         self.assert_slow('TestWebKit', 'WebKit.MouseMoveAfterCrash', True)
         self.assert_slow('TestWebKit', 'WebKit.WKConnection', False)
+
+    def test_architecture(self):
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE, architecture='arm64')
+        self.assert_exp('TestWebKit', 'WebKit.ArmCrash', 'CRASH')
+        self.assert_exp('TestWebKit', 'WebKit.GtkArmTimeout', 'TIMEOUT')
+        self.assert_exp('TestWebKit', 'WebKit.AllFail', 'FAIL')
+
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE, architecture='x86_64')
+        self.assert_exp('TestWebKit', 'WebKit.ArmCrash', 'PASS')
+        self.assert_exp('TestWebKit', 'WebKit.GtkArmTimeout', 'PASS')
+        self.assert_exp('TestWebKit', 'WebKit.AllFail', 'FAIL')
+
+        self.expectations = MockTestExpectations('wpe', self.ARCHITECTURE, architecture='arm64')
+        self.assert_exp('TestWebKit', 'WebKit.ArmCrash', 'CRASH')
+        self.assert_exp('TestWebKit', 'WebKit.GtkArmTimeout', 'PASS')
+        self.assert_exp('TestWebKit', 'WebKit.AllFail', 'FAIL')
+
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE)
+        self.assert_exp('TestWebKit', 'WebKit.ArmCrash', 'PASS')
+        self.assert_exp('TestWebKit', 'WebKit.AllFail', 'FAIL')
+
+    def test_specificity(self):
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Release', 'arm64')
+        self.assert_exp('TestWebKit', 'WebKit.PortVsAll', 'FAIL')
+        self.expectations = MockTestExpectations('wpe', self.SPECIFICITY, 'Release', 'arm64')
+        self.assert_exp('TestWebKit', 'WebKit.PortVsAll', 'TIMEOUT')
+
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Release', 'arm64')
+        self.assert_exp('TestWebKit', 'WebKit.ArchVsPlain', 'CRASH')
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Release', 'x86_64')
+        self.assert_exp('TestWebKit', 'WebKit.ArchVsPlain', 'FAIL')
+
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Release', 'x86_64')
+        self.assert_exp('TestWebKit', 'WebKit.BuildVsPlain', 'TIMEOUT')
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Debug', 'x86_64')
+        self.assert_exp('TestWebKit', 'WebKit.BuildVsPlain', 'FAIL')
+
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Debug', 'arm64')
+        self.assert_exp('TestWebKit', 'WebKit.FullyQualified', 'CRASH')
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Release', 'arm64')
+        self.assert_exp('TestWebKit', 'WebKit.FullyQualified', 'TIMEOUT')
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Release', 'x86_64')
+        self.assert_exp('TestWebKit', 'WebKit.FullyQualified', 'FAIL')
+
+        self.expectations = MockTestExpectations('gtk', self.SPECIFICITY, 'Release', 'arm64')
+        self.assert_exp('TestWebKit', 'WebKit.PortVsAllFullyQualified', 'FAIL')
+        self.expectations = MockTestExpectations('wpe', self.SPECIFICITY, 'Release', 'arm64')
+        self.assert_exp('TestWebKit', 'WebKit.PortVsAllFullyQualified', 'TIMEOUT')
+        self.expectations = MockTestExpectations('wpe', self.SPECIFICITY, 'Debug', 'arm64')
+        self.assert_exp('TestWebKit', 'WebKit.PortVsAllFullyQualified', 'PASS')
+
+    def test_architecture_slow(self):
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE_SLOW, architecture='arm64')
+        self.assert_slow('TestWebKit', None, True)
+        self.assert_slow('TestWebKit', 'WebKit.FastOnArm', False)
+
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE_SLOW, architecture='x86_64')
+        self.assert_slow('TestWebKit', None, True)
+        self.assert_slow('TestWebKit', 'WebKit.FastOnArm', True)
+
+    def test_architecture_skip(self):
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE_SKIP, architecture='arm64')
+        self.assert_skip('TestSkipArch', None, True)
+        self.assert_exp('TestSkipArch', 'TestSkipArch.PassOnArm', 'PASS')
+
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE_SKIP, architecture='x86_64')
+        self.assert_skip('TestSkipArch', None, False)
+
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE_SKIP, architecture='arm64')
+        self.assert_skip('TestSkipArchSubtest', None, False)
+        self.assert_skip('TestSkipArchSubtest', 'sub1', True)
+
+        self.expectations = MockTestExpectations('gtk', self.ARCHITECTURE_SKIP, architecture='x86_64')
+        self.assert_skip('TestSkipArchSubtest', 'sub1', False)
 
     def test_repeated_keys(self):
         self.assertRaises(ValueError, lambda: MockTestExpectations('gtk', self.REPEATED_KEYS))

--- a/Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner.py
+++ b/Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner.py
@@ -91,7 +91,7 @@ class WebDriverTestRunner(object):
         else:
             expectations_file = os.path.join(self._tests_dir, 'TestExpectations.json')
         build_type = 'Debug' if self._port.get_option('debug') else 'Release'
-        self._expectations = TestExpectations(self._port.name(), expectations_file, build_type)
+        self._expectations = TestExpectations(self._port.name(), expectations_file, build_type, self._port.architecture())
         for test in self._expectations._expectations.keys():
             if not os.path.isfile(os.path.join(self._tests_dir, test)):
                 _log.warning('Test %s does not exist' % test)

--- a/Tools/glib/api_test_runner.py
+++ b/Tools/glib/api_test_runner.py
@@ -64,7 +64,8 @@ class TestRunner(object):
 
         self._programs_path = common.binary_build_path(self._port)
         expectations_file = os.path.join(common.top_level_path(), "Tools", "TestWebKitAPI", "glib", "TestExpectations.json")
-        self._expectations = TestExpectations(self._port.name(), expectations_file, self._build_type)
+        self._expectations = TestExpectations(self._port.name(), expectations_file, self._build_type, self._port.architecture())
+        print("Test expectations: port=%s, build_type=%s, architecture=%s" % (self._port.name(), self._build_type, self._port.architecture()))
         self._initial_test_list = tests
         self._tests = self._get_tests(tests)
         self._disabled_tests = []


### PR DESCRIPTION
#### 3beb04a4553f614cb3232d282cb15b12042404ce
<pre>
[webkitpy][GLIB] Add support to architecture markers in TestExpectations.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=309580">https://bugs.webkit.org/show_bug.cgi?id=309580</a>

Reviewed by Carlos Alberto Lopez Perez.

Follow-up of 308721@main, which replaced the hardcoded x86 architecture
for glib ports with runtime detection.

TestExpectations.json uses a string as the key selector to decide
whether to apply or not a given expectation. This is typically one of
&apos;all&apos;, &apos;gtk&apos;, and &apos;wpe&apos;, followed by an optional &apos;@BuildType&apos; suffix.

This commit extends the expectation syntax in TestExpectations.json,
adding a marker for the architecture, after the &apos;:&apos; wildcard, to
contrast with the &apos;@&apos; used for the build type. So, an expectation that
targets WPE Debug ARM64 would be written as &apos;wpe@Debug:arm64&apos;.

With the addition of this new parameter, to account for the various
possible configurations, we also changed the precedence check to roughly
match the LayoutTests scheme, where the most specific expectation wins.
Previously, &apos;gtk&apos; would be selected over &apos;gtk@Release&apos;, for example.
Note that &apos;all&apos; is a fallback port name, so &apos;all@Debug:x86_64&apos; would
still lose over a proper port name like &apos;gtk&apos; or &apos;wpe&apos;.

As these extended configurations were rarely used (~9 commits in 8
years) and the new precedence did not break the existing tests, this
should not be a problem. The new checks are also covered by new tests.

* Tools/Scripts/webkitpy/common/test_expectations.py:
(TestExpectations.__init__):
(TestExpectations._port_name_for_expected):
* Tools/Scripts/webkitpy/common/test_expectations_unittest.py:
(MockTestExpectations.__init__):
(test_architecture):
(test_specificity):
(test_architecture_slow):
(test_architecture_skip):
* Tools/Scripts/webkitpy/webdriver_tests/webdriver_test_runner.py:
(WebDriverTestRunner.__init__):
* Tools/glib/api_test_runner.py:
(TestRunner.__init__):

Canonical link: <a href="https://commits.webkit.org/309066@main">https://commits.webkit.org/309066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e91d4145fac3461eca759448ffa16d17479df4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15635 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158051 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115171 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17326 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134006 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95919 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/148673 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5895 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126025 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160530 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13475 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123208 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18342 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123424 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33539 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21876 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133739 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78094 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/18658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10485 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21478 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21209 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/21358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->