### PR TITLE
Panning a PDF frequently gets into a state where it rubber bands back to where you started

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1432,7 +1432,18 @@ IntSize UnifiedPDFPlugin::contentsSize() const
 
     auto size = m_documentLayout.scaledContentsSize();
     size.scale(m_scaleFactor);
-    return expandedIntSize(size);
+    auto result = expandedIntSize(size);
+
+    // In sizeToFitContent mode (iOS full-frame PDF), the contents width is
+    // the plugin's visible width. Use it directly to avoid a rounding artifact
+    // where expandedIntSize rounds up by 1 pixel, making the plugin's own
+    // UIScrollView horizontally scrollable and causing rubber-banding.
+    if (shouldSizeToFitContent() && m_size.width() > 0) {
+        ASSERT(std::abs((result - m_size).width()) <= 1);
+        result.setWidth(m_size.width());
+    }
+
+    return result;
 }
 
 unsigned UnifiedPDFPlugin::heightForPageAtIndex(PDFDocumentLayout::PageIndex pageIndex) const

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm
@@ -1187,6 +1187,32 @@ UNIFIED_PDF_TEST(ScrollPositionAfterChangeToTwoUpContinuous)
     EXPECT_EQ([webView scrollView].contentOffset, CGPointZero);
 }
 
+UNIFIED_PDF_TEST(PluginScrollViewIsNotHorizontallyScrollableForFullFramePDF)
+{
+    // Use width 391 specifically: for test.pdf (page width 129.6pt, contentWidth 161.6),
+    // the layout scale 391/161.6 produces a scaled width of ~391.000031 in float32,
+    // which expandedIntSize rounds up to 392 — a 1-pixel mismatch that makes the
+    // plugin's UIScrollView horizontally scrollable without the fix.
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 391, 800) configuration:configurationForWebViewTestingUnifiedPDF().get()]);
+    RetainPtr request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]];
+    [webView synchronouslyLoadRequest:request.get()];
+
+    __block bool stable = false;
+    [webView _doAfterNextStablePresentationUpdate:^{
+        stable = true;
+    }];
+    TestWebKitAPI::Util::run(&stable);
+
+    RetainPtr childScrollView = dynamic_objc_cast<UIScrollView>([webView wkFirstSubviewWithClass:NSClassFromString(@"WKChildScrollView")]);
+    ASSERT_NOT_NULL(childScrollView);
+
+    CGSize contentSize = [childScrollView contentSize];
+    CGRect bounds = [childScrollView bounds];
+    EXPECT_GT(contentSize.width, 0);
+    EXPECT_GT(bounds.size.width, 0);
+    EXPECT_LE(contentSize.width, bounds.size.width);
+}
+
 #endif // PLATFORM(IOS_FAMILY)
 
 #if HAVE(UIKIT_WITH_MOUSE_SUPPORT)


### PR DESCRIPTION
#### 8828f24e7c4da08c591a057765bcdfed5bb05f00
<pre>
Panning a PDF frequently gets into a state where it rubber bands back to where you started
<a href="https://bugs.webkit.org/show_bug.cgi?id=309596">https://bugs.webkit.org/show_bug.cgi?id=309596</a>
<a href="https://rdar.apple.com/156854435">rdar://156854435</a>

Reviewed by Abrar Rahman Protyasha.

When a full-frame PDF plugin on iOS delegates scrolling to the main frame,
the plugin&apos;s own UIScrollView should have no scrollable area.
However, expandedIntSize rounding in contentsSize() can produce a width 1 pixel
larger than the plugin&apos;s visible width. This makes the plugin&apos;s UIScrollView
horizontally scrollable, causing it to capture pan gestures and rubber-band instead
of letting the main frame handle horizontal scrolling.

This is a regression from 290778@main (d8546c304004), which removed the explicit CSS
width synchronization between contentsSize() and the plugin element. Without that
synchronization, the rounding difference between expandedIntSize (ceilf) and the
CSS layout width becomes observable.

Fix by setting contentsSize().width() to the plugin&apos;s visible width when
shouldSizeToFitContent() is true, since in this mode the contents width should
always equal the plugin width.

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::contentsSize const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UnifiedPDFTests.mm:
(TestWebKitAPI::TEST): Added an API test.

Canonical link: <a href="https://commits.webkit.org/309264@main">https://commits.webkit.org/309264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5faa26cacf39794c4d278e7c7b9d6d5d2f926c15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158740 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103463 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/555bf932-64ac-4405-a747-b3d3080fe1e9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151902 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115732 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82214 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8dbfc23-f077-4003-a333-ad191983a872) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152989 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17839 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96461 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/28b1c674-fc3b-46a6-ab6b-ab83652b7dee) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16939 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14890 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6586 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126554 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161214 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4305 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123733 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22556 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123935 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33667 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134316 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78805 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19079 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11072 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22161 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85989 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21891 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22043 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21949 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->