### PR TITLE
[DRAFT] Fix PCM debug mode attribution reports not being sent to server https://bugs.webkit.org/show_bug.cgi?id=309676 rdar://168776612

### DIFF
--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -99,7 +99,8 @@ void enableAdvancedPrivacyProtections(NSMutableURLRequest *request, OptionSet<We
 void setPCMDataCarriedOnRequest(WebCore::PrivateClickMeasurement::PcmDataCarried pcmDataCarried, NSMutableURLRequest *request)
 {
 #if ENABLE(TRACKER_DISPOSITION)
-    if (request._needsNetworkTrackingPrevention || pcmDataCarried == WebCore::PrivateClickMeasurement::PcmDataCarried::PersonallyIdentifiable)
+    UNUSED_PARAM(pcmDataCarried);
+    if (request._needsNetworkTrackingPrevention)
         return;
 
     request._needsNetworkTrackingPrevention = YES;


### PR DESCRIPTION
#### eaf8696acd96a1c53f554a8e6bc3fea384b05daa
<pre>
Fix PCM debug mode attribution reports not being sent to server <a href="https://bugs.webkit.org/show_bug.cgi?id=309676">https://bugs.webkit.org/show_bug.cgi?id=309676</a> <a href="https://rdar.apple.com/168776612">rdar://168776612</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309597">https://bugs.webkit.org/show_bug.cgi?id=309597</a>
<a href="https://rdar.apple.com/168776612">rdar://168776612</a>

Reviewed by NOBODY (OOPS!).

When Private Click Measurement debug mode is enabled,
fireConversionRequestImpl() sets pcmDataCarried to PersonallyIdentifiable.
In setPCMDataCarriedOnRequest(), the guard condition checked both
whether _needsNetworkTrackingPrevention was already set AND whether
pcmDataCarried was PersonallyIdentifiable, returning early for either.
This meant debug mode requests never had _needsNetworkTrackingPrevention
set to YES. Without that flag, the network stack routes requests through
privacyProxyFailClosed. Since PCM debug mode attribution reports do not
use OHTTP, they fail closed and are dropped.

* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(setPCMDataCarriedOnRequest): Remove incorrect PersonallyIdentifiable
early-return that prevented debug mode reports from being sent.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaf8696acd96a1c53f554a8e6bc3fea384b05daa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157860 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102603 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5496e87-1a05-45ef-bf59-bf0d4318a911) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115003 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81861 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16afc223-5a98-48ae-bc52-f5627a9b7af1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95758 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3128e01-60db-4a7b-b11c-922f938cb2bd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16274 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14146 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5713 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125874 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160345 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3347 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13326 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123050 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123277 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133599 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77896 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18518 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10347 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21297 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85118 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21029 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21177 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21085 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->