### PR TITLE
[libpas] Quickly use bitfit heaps (as possible) when retag-on-scavenge is enabled

### DIFF
--- a/Source/bmalloc/bmalloc/bmalloc.cpp
+++ b/Source/bmalloc/bmalloc/bmalloc.cpp
@@ -178,27 +178,7 @@ void enableMiniMode(bool forceMiniMode)
     pas_physical_page_sharing_pool_balancing_enabled = true;
     pas_physical_page_sharing_pool_balancing_enabled_for_utility = true;
 
-    // Switch to bitfit allocation for anything that isn't isoheaped.
-    bmalloc_intrinsic_runtime_config.base.max_segregated_object_size = 0;
-    bmalloc_primitive_runtime_config.base.max_segregated_object_size = 0;
-    bmalloc_intrinsic_runtime_config.base.max_bitfit_object_size = UINT_MAX;
-    bmalloc_primitive_runtime_config.base.max_bitfit_object_size = UINT_MAX;
-
-    // If large-object delegation is enabled, we don't want to override that
-    // just because we've entered mini-mode.
-    // One way we could get around that would be to leave the bitfit object
-    // size limits the way they are. However, in cases where the bitfit
-    // size-limit had previously been constrained for performance, e.g. by
-    // setting them to 0, we do want enableMiniMode to be able to re-expand
-    // them.
-    // So we take the object-delegation path to be a special case and make
-    // sure to re-apply after performing the above expansion.
-    PAS_IGNORE_WARNINGS_BEGIN("unreachable-code");
-#if defined(PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
-    if (PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
-        pas_mte_force_nontaggable_user_allocations_into_large_heap();
-#endif // defined(PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
-    PAS_IGNORE_WARNINGS_END;
+    pas_bmalloc_force_allocations_into_bitfit_heaps_where_available();
 #else
     BUNUSED_PARAM(forceMiniMode);
 #endif // BENABLE(LIBPAS)

--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.c
@@ -189,6 +189,26 @@ static void pas_mte_do_initialization(void)
         *medium_byte = 1; // Tag libpas medium objects in privileged processes
         *hardened_byte = 1;
     }
+
+    PAS_IGNORE_WARNINGS_BEGIN("unreachable-code");
+    // Retag-on-scavenge functionally supports both segregated and bitfit heaps.
+    // However, true to the name, for segregated heaps the retag operation only
+    // takes place on the scavenging path.
+    // For bitfit heaps, there is no such path: as such, freed bitfit objects are
+    // immediately retagged. This closes the window where attackers could in
+    // theory exploit a UAF.
+    // As such, when retag-on-scavenge is enabled, we prefer to allocate from
+    // bitfit heaps to exploit this property -- the exception of course being
+    // isoheaps, due to the intrinsic type-unsafety of bitfit heaps.
+    // In practice, for privileged processes this already takes place when WebCore
+    // enables fastMiniMode(), but that enablement takes place later on and as such
+    // can allow for some local-allocators to sneak by. This is not a problem for
+    // mini-mode because a few stray allocations there won't hurt, but for a
+    // security boundary those stray allocations are more of a problem. So we force
+    // this here, prior to the creation of such segregated directories.
+    if (PAS_MTE_FEATURE_ENABLED(PAS_MTE_FEATURE_RETAG_ON_SCAVENGE))
+        pas_bmalloc_force_allocations_into_bitfit_heaps_where_available();
+    PAS_IGNORE_WARNINGS_END;
 }
 
 static bool pas_mte_is_enabled(void)
@@ -343,6 +363,33 @@ void pas_mte_ensure_initialized(void)
 #endif
 void pas_mte_ensure_initialized(void) { }
 #endif // PAS_OS(DARWIN)
+
+void pas_bmalloc_force_allocations_into_bitfit_heaps_where_available(void)
+{
+#if PAS_ENABLE_BMALLOC
+    // Switch to bitfit allocation for anything that isn't isoheaped.
+    bmalloc_intrinsic_runtime_config.base.max_segregated_object_size = 0;
+    bmalloc_primitive_runtime_config.base.max_segregated_object_size = 0;
+    bmalloc_intrinsic_runtime_config.base.max_bitfit_object_size = UINT_MAX;
+    bmalloc_primitive_runtime_config.base.max_bitfit_object_size = UINT_MAX;
+#endif
+
+    // If large-object delegation is enabled, we don't want to override that
+    // just because we've entered mini-mode.
+    // One way we could get around that would be to leave the bitfit object
+    // size limits the way they are. However, in cases where the bitfit
+    // size-limit had previously been constrained for performance, e.g. by
+    // setting them to 0, we do want enableMiniMode to be able to re-expand
+    // them.
+    // So we take the object-delegation path to be a special case and make
+    // sure to re-apply after performing the above expansion.
+    PAS_IGNORE_WARNINGS_BEGIN("unreachable-code");
+#if defined(PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
+    if (PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
+        pas_mte_force_nontaggable_user_allocations_into_large_heap();
+#endif // defined(PAS_MTE_USE_LARGE_OBJECT_DELEGATION)
+    PAS_IGNORE_WARNINGS_END;
+}
 
 void pas_mte_force_nontaggable_user_allocations_into_large_heap(void)
 {

--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
@@ -200,6 +200,7 @@ extern "C" {
 #endif
 void pas_mte_ensure_initialized(void);
 void pas_mte_force_nontaggable_user_allocations_into_large_heap(void);
+void pas_bmalloc_force_allocations_into_bitfit_heaps_where_available(void);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
#### dee9781145cfd9b0d1f009a019aaa5098abdf68b
<pre>
[libpas] Quickly use bitfit heaps (as possible) when retag-on-scavenge is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=309598">https://bugs.webkit.org/show_bug.cgi?id=309598</a>
<a href="https://rdar.apple.com/172220367">rdar://172220367</a>

Reviewed by Mark Lam.

Retag-on-scavenge functionally supports both segregated and bitfit
heaps. Bitfit allocations, however, are tagged immediately when the
object is freed.
As such, when retag-on-scavenge is enabled, we should prefer to allocate
from bitfit heaps to exploit this property -- the exception of course
being isoheaps, due to the intrinsic type-unsafety of bitfit heaps.

Notably, this already kinda happens in privileged processes, where
WebCore enables fastMiniMode during process setup. However, this happens
late enough that several local-allocators are able to first allocate
objects, populating a goodly number of segregated size-directories which
can thereafter be used for allocating segregated objects. This isn’t a
problem for mini-mode because the goal there is just to reduce memory
usage, so some stray allocations aren’t going to crater the feature, but
for us it is — the security boundary provided by any eventual
retag-on-free solution would be much weakened if attackers could go
through objects allocated sufficiently-early-on.

So concretely, this patch does two things:
  1. Extend the “mini-mode”-style segregated-heap disablement to cover
     WebContent processes when Retag-on-Scavenge is enabled;
  2. Hoist this enablement to early enough in the process lifetime
     that no segregated directories can sneak by before we disable them.

Canonical link: <a href="https://commits.webkit.org/309573@main">https://commits.webkit.org/309573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d723e1978c745404544aaa0e2ad0623e901ad834

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102609 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e67733f4-e8c0-4ce5-b8af-bc59562548ce) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21769 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115008 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81864 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc649300-3621-4816-8849-5c3a289d2666) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95763 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab48c605-fe2c-4854-9bf6-efe1cc4d02e0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16281 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14152 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5719 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141145 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125881 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160352 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9966 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13354 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123055 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18198 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123281 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33868 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21701 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133611 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77902 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18528 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10358 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180607 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21303 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46282 "Build was cancelled. Recent messages:Printed configuration") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21035 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21183 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21091 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->