### PR TITLE
Videos inside shadow DOM not detected as children of element fullscreen, preventing docking on visionOS

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7722,6 +7722,11 @@ void HTMLMediaElement::documentFullscreenChanged(bool isChildOfElementFullscreen
     m_isChildOfElementFullscreen = isChildOfElementFullscreen;
     updatePlayerDynamicRangeLimit();
 }
+
+bool HTMLMediaElement::isChildOfElementFullscreen() const
+{
+    return m_isChildOfElementFullscreen;
+}
 #endif
 
 PlatformLayer* HTMLMediaElement::platformLayer() const

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -529,6 +529,7 @@ public:
 
 #if ENABLE(FULLSCREEN_API)
     void documentFullscreenChanged(bool isChildOfElementFullscreen);
+    WEBCORE_EXPORT bool isChildOfElementFullscreen() const;
 #endif
 
     bool hasClosedCaptions() const override;

--- a/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm
@@ -198,10 +198,7 @@ void VideoPresentationModelVideoElement::documentFullscreenChanged()
         RefPtr fullscreenElement = fullscreen->fullscreenElement();
         if (!fullscreenElement)
             return false;
-        RefPtr ancestor = videoElement->parentNode();
-        while (ancestor && ancestor != fullscreenElement)
-            ancestor = ancestor->parentNode();
-        return !!ancestor.get();
+        return videoElement->isShadowIncludingDescendantOf(*fullscreenElement);
     }();
 
     if (std::exchange(m_isChildOfElementFullscreen, isChildOfElementFullscreen) == isChildOfElementFullscreen)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4816,6 +4816,13 @@ double Internals::effectiveDynamicRangeLimitValue(const HTMLMediaElement& media)
     return media.computePlayerDynamicRangeLimit().value();
 }
 
+#if ENABLE(FULLSCREEN_API)
+bool Internals::isChildOfElementFullscreen(const HTMLMediaElement& media) const
+{
+    return media.isChildOfElementFullscreen();
+}
+#endif
+
 #endif
 
 ExceptionOr<double> Internals::getContextEffectiveDynamicRangeLimitValue(const HTMLCanvasElement& canvas)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -852,6 +852,9 @@ public:
     void NODELETE enableGStreamerHolePunching(HTMLVideoElement&);
 
     double effectiveDynamicRangeLimitValue(const HTMLMediaElement&);
+#if ENABLE(FULLSCREEN_API)
+    bool isChildOfElementFullscreen(const HTMLMediaElement&) const;
+#endif
 #endif
     ExceptionOr<double> getContextEffectiveDynamicRangeLimitValue(const HTMLCanvasElement&);
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1022,7 +1022,9 @@ enum ContentsFormat {
     [Conditional=VIDEO] double effectiveDynamicRangeLimitValue(HTMLMediaElement media);
     double getContextEffectiveDynamicRangeLimitValue(HTMLCanvasElement canvas);
     undefined setPageShouldSuppressHDR(boolean shouldSuppressHDR);
-    
+
+    [Conditional=VIDEO&FULLSCREEN_API] boolean isChildOfElementFullscreen(HTMLMediaElement media);
+
     [Conditional=VIDEO] undefined enterViewerMode(HTMLVideoElement element);
 
     undefined setIsPlayingToBluetoothOverride(optional boolean? isPlaying = null);

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -3660,6 +3660,7 @@
 		95C52728275F35E100DA7E40 /* FontShadowTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FontShadowTests.cpp; sourceTree = "<group>"; };
 		96E05A012DF7B66F00285827 /* WKWebExtensionAPIBookmarks.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionAPIBookmarks.mm; sourceTree = "<group>"; };
 		9739F73F2E5C548E002E7C61 /* ExponentialRampAtTimeTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ExponentialRampAtTimeTest.cpp; sourceTree = "<group>"; };
+		97551BE12F63E71F0056D71C /* VideoInShadowDOMElementFullscreen.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VideoInShadowDOMElementFullscreen.mm; sourceTree = "<group>"; };
 		97CB27AC2F2918DA0024DD32 /* override-complex-expression.wgsl */ = {isa = PBXFileReference; lastKnownFileType = text; path = "override-complex-expression.wgsl"; sourceTree = "<group>"; };
 		97DAA8CD2DF1F325004B3040 /* MetalCompilationTests.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = MetalCompilationTests.mm; sourceTree = "<group>"; };
 		97DAA8CF2DF70B91004B3040 /* Metal.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Metal.framework; path = System/Library/Frameworks/Metal.framework; sourceTree = SDKROOT; };
@@ -6304,6 +6305,7 @@
 			isa = PBXGroup;
 			children = (
 				A1C0982F2E12FB5800FAC83A /* ElementFullscreen.mm */,
+				97551BE12F63E71F0056D71C /* VideoInShadowDOMElementFullscreen.mm */,
 				A1D8C7942DBFFFB500A6878F /* VideoPresentationMode.mm */,
 			);
 			path = UI;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/VideoInShadowDOMElementFullscreen.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UI/VideoInShadowDOMElementFullscreen.mm
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "PlatformUtilities.h"
+#import "TestElementFullscreenDelegate.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WebKit.h>
+
+TEST(ElementFullscreen, VideoInShadowDOMIsChildOfElementFullscreen)
+{
+    if (![NSBundle.mainBundle.bundleIdentifier isEqualToString:@"org.webkit.TestWebKitAPI"])
+        return;
+
+    RetainPtr configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"WebProcessPlugInWithInternals" configureJSCForTesting:YES]);
+    [configuration setAllowsInlineMediaPlayback:YES];
+    [configuration preferences].elementFullscreenEnabled = YES;
+    [configuration setMediaTypesRequiringUserActionForPlayback:WKAudiovisualMediaTypeNone];
+    RetainPtr fullscreenDelegate = adoptNS([[TestElementFullscreenDelegate alloc] init]);
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView _setFullscreenDelegate:fullscreenDelegate.get()];
+
+    [webView synchronouslyLoadHTMLString:@"<div id='host'></div>"
+        "<script>"
+        "const host = document.getElementById('host');"
+        "const shadowRoot = host.attachShadow({ mode: 'closed' });"
+        "window.video = document.createElement('video');"
+        "video.src = 'video-with-audio.mp4';"
+        "video.muted = true;"
+        "video.playsInline = true;"
+        "shadowRoot.appendChild(video);"
+        "</script>"];
+
+    NSString *queryResult = [webView objectByEvaluatingJavaScript:@"document.getElementById('host').querySelector('video') === null ? 'true' : 'false'"];
+    EXPECT_WK_STREQ(@"true", queryResult);
+
+    [webView objectByEvaluatingJavaScript:@"video.play()"];
+    [webView waitForNextPresentationUpdate];
+
+    NSString *beforeFullscreen = [webView stringByEvaluatingJavaScript:@"window.internals.isChildOfElementFullscreen(video)"];
+    EXPECT_WK_STREQ(@"false", beforeFullscreen);
+
+    [webView evaluateJavaScript:@"document.getElementById('host').requestFullscreen()" completionHandler:nil];
+    [fullscreenDelegate waitForDidEnterElementFullscreen];
+    [webView waitForNextPresentationUpdate];
+
+    NSString *duringFullscreen = [webView stringByEvaluatingJavaScript:@"window.internals.isChildOfElementFullscreen(video)"];
+    EXPECT_WK_STREQ(@"true", duringFullscreen);
+}
+
+#endif


### PR DESCRIPTION
#### 3baee90ae42e16d461acb3bd2163ae328236c04f
<pre>
Videos inside shadow DOM not detected as children of element fullscreen, preventing docking on visionOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=309602">https://bugs.webkit.org/show_bug.cgi?id=309602</a>
<a href="https://rdar.apple.com/168093378">rdar://168093378</a>

Reviewed by Ryosuke Niwa.

The ancestor walk in documentFullscreenChanged() used parentNode(), which returns nullptr at shadow
root boundaries. Videos inside web components (e.g. Reddit&apos;s &lt;shreddit-player&gt;) were never marked
as isChildOfElementFullscreen, so bestVideoForElementFullscreen() returned nullptr and the dock
button was not shown.

Replace the manual parentNode() walk with isShadowIncludingDescendantOf(), which crosses shadow
root boundaries by walking up through shadow hosts.

* Source/WebCore/platform/cocoa/VideoPresentationModelVideoElement.mm:
(WebCore::VideoPresentationModelVideoElement::documentFullscreenChanged):

Canonical link: <a href="https://commits.webkit.org/309276@main">https://commits.webkit.org/309276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d3c45c85b2e6da8648c77b33130f2e361a99acb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149990 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16309 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158701 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103424 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d33745ba-eec9-4bfc-b416-063267a8d6a3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151863 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23163 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115712 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82202 "3 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8c40bfc-7402-43f5-88a2-2110545bac4b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96537 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16924 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14869 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6547 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12507 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161175 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4286 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123712 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123913 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33678 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22522 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134302 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78766 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19063 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11058 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22122 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85950 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21852 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22004 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21910 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->