### PR TITLE
[iOS] fast/viewport/iOS tests are constant test failures because tests are screen size dependent

### DIFF
--- a/LayoutTests/fast/viewport/ios/shrink-to-fit-content-constant-width-expected.txt
+++ b/LayoutTests/fast/viewport/ios/shrink-to-fit-content-constant-width-expected.txt
@@ -3,8 +3,9 @@ This test verifies that a page with a constant width viewport smaller than the a
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS minScale is expectedScale
 PASS innerWidth is 300
+PASS minScale > 1 is true
+PASS zoomScale is minScale
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/viewport/ios/shrink-to-fit-content-constant-width.html
+++ b/LayoutTests/fast/viewport/ios/shrink-to-fit-content-constant-width.html
@@ -31,9 +31,10 @@ addEventListener("load", async () => {
 
     await UIHelper.ensurePresentationUpdate();
     minScale = (await UIHelper.minimumZoomScale()).toFixed(2);
-    expectedScale = (screen.width / 300).toFixed(2);
-    shouldBe("minScale", "expectedScale");
+    zoomScale = (await UIHelper.zoomScale()).toFixed(2);
     shouldBe("innerWidth", "300");
+    shouldBeTrue("minScale > 1");
+    shouldBe("zoomScale", "minScale");
     finishJSTest();
 });
 </script>

--- a/LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-constant-width-expected.txt
+++ b/LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-constant-width-expected.txt
@@ -3,8 +3,9 @@ This test verifies that a page with a constant width viewport smaller than the a
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS minScale is expectedScale
-PASS innerWidth is 1000
+PASS innerWidth <= 1000 is true
+PASS minScale < 1 is true
+PASS zoomScale is minScale
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-constant-width.html
+++ b/LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-constant-width.html
@@ -31,9 +31,10 @@ addEventListener("load", async () => {
 
     await UIHelper.ensurePresentationUpdate();
     minScale = (await UIHelper.minimumZoomScale()).toFixed(2);
-    expectedScale = (screen.width / 1000).toFixed(2);
-    shouldBe("minScale", "expectedScale");
-    shouldBe("innerWidth", "1000");
+    zoomScale = (await UIHelper.zoomScale()).toFixed(2);
+    shouldBeTrue("innerWidth <= 1000");
+    shouldBeTrue("minScale < 1");
+    shouldBe("zoomScale", "minScale");
     finishJSTest();
 });
 </script>

--- a/LayoutTests/fast/viewport/ios/shrink-to-fit-content-responsive-viewport-with-horizontal-overflow-expected.txt
+++ b/LayoutTests/fast/viewport/ios/shrink-to-fit-content-responsive-viewport-with-horizontal-overflow-expected.txt
@@ -3,8 +3,9 @@ This test verifies that the shrink-to-fit-content heuristic prevents horizontal 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS minScale is expectedScale
 PASS innerWidth became 960
+PASS minScale < 1 is true
+PASS zoomScale is minScale
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/viewport/ios/shrink-to-fit-content-responsive-viewport-with-horizontal-overflow.html
+++ b/LayoutTests/fast/viewport/ios/shrink-to-fit-content-responsive-viewport-with-horizontal-overflow.html
@@ -33,9 +33,12 @@ addEventListener("load", async () => {
 
     await UIHelper.ensurePresentationUpdate();
     minScale = (await UIHelper.minimumZoomScale()).toFixed(2);
-    expectedScale = (screen.width / 960).toFixed(2);
-    shouldBe("minScale", "expectedScale");
-    shouldBecomeEqual("innerWidth", "960", finishJSTest);
+    zoomScale = (await UIHelper.zoomScale()).toFixed(2);
+    shouldBecomeEqual("innerWidth", "960", () => {
+        shouldBeTrue("minScale < 1");
+        shouldBe("zoomScale", "minScale");
+        finishJSTest();
+    });
 });
 </script>
 </head>

--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -167,11 +167,7 @@ scrollingcoordinator/ios/fixed-scrolling-with-keyboard.html [ Skip ]
 # Failure only on iPad simulator 
 webkit.org/b/307451 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional.html [ Pass Failure ]
 
-# webkit.org/b/307469 4x fast/viewport/iOS tests are constant text failures on iPad
 fast/viewport/ios/viewport-fit-auto-safe-area-inset-change.html [ Failure ]
-fast/viewport/ios/shrink-to-fit-content-responsive-viewport-with-horizontal-overflow.html [ Failure ]
-fast/viewport/ios/shrink-to-fit-content-large-constant-width.html [ Failure ]
-fast/viewport/ios/shrink-to-fit-content-constant-width.html [ Failure ]
 
 webkit.org/b/307477 editing/selection/ios/scrolling-to-focused-element-inside-iframe.html [ Failure ]
 


### PR DESCRIPTION
#### 274c0e66e30436807d25d86e4f1061736bd1330b
<pre>
[iOS] fast/viewport/iOS tests are constant test failures because tests are screen size dependent
<a href="https://bugs.webkit.org/show_bug.cgi?id=307469">https://bugs.webkit.org/show_bug.cgi?id=307469</a>
<a href="https://rdar.apple.com/170088582">rdar://170088582</a>

Reviewed by NOBODY (OOPS!).

There were four tests that were reported as failing on the
iOS 26 iPad simulator:

fast/viewport/ios/viewport-fit-auto-safe-area-inset-change.html
- This test is not considered a regression as it never passed on iPad. This is because
the values are hardcoded for iPhone. Thus, this will be tracked as
<a href="https://bugs.webkit.org/show_bug.cgi?id=309593">https://bugs.webkit.org/show_bug.cgi?id=309593</a> as a followup.
For now, this test remains marked as a failure.

fast/viewport/ios/shrink-to-fit-content-responsive-viewport-with-horizontal-overflow.html
- This test has a bar of width 960px. This page&apos;s widest content is the bar and the content
width ends up being 960 so in this case, it&apos;s correct to explicitly check for this hardcoded value.
This tests shrinks the page to fit so the minScale &lt; 1.

fast/viewport/ios/shrink-to-fit-content-large-constant-width.html
- The explicit width=1000 means the viewport is larger than the actual view,
so the page must zoom out to fit, making minScale &lt; 1. The layout width
may be at most 1000 so there is a check for &lt;= 1000.

fast/viewport/ios/shrink-to-fit-content-constant-width.html
- The page has a width viewport smaller (explicitly 300) than the actual view width so
the page must zoom in to fill the view, making minScale &gt; 1. In the previous
version of the test, different iPad simulators would yield a minScale of ~2.5-3.5. Don&apos;t
expect hardcoded values to be screen size agnostic.

All of these tests were written with the assumption that the iPad screen width size is always 768.
It is unclear why updating the simulators would reveal this issue since the iPad simulator had been changed
a while ago, but it is the correct thing to do, that is to make these tests screen size agnostic.

Update the expected files for these changed tests. Un-garden the three shrink-to-fit tests.

* LayoutTests/fast/viewport/ios/shrink-to-fit-content-constant-width-expected.txt:
* LayoutTests/fast/viewport/ios/shrink-to-fit-content-constant-width.html:
* LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-constant-width-expected.txt:
* LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-constant-width.html:
* LayoutTests/fast/viewport/ios/shrink-to-fit-content-responsive-viewport-with-horizontal-overflow-expected.txt:
* LayoutTests/fast/viewport/ios/shrink-to-fit-content-responsive-viewport-with-horizontal-overflow.html:
* LayoutTests/platform/ipad/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/274c0e66e30436807d25d86e4f1061736bd1330b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21906 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157881 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102624 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f78f509-c76f-4c2d-97c0-30c7e883477b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115019 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81874 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81eca6ea-019e-430b-881d-0aaa17f25754) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152153 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17184 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; layout-tests (exception)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133871 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95775 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/20382922-f55f-4ac4-b946-7116ab135360) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16284 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14156 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5734 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160367 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123062 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21708 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18192 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed layout tests; layout-tests (exception)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123288 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; 2 api tests failed or timed out; Compiled WebKit (cancelled)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133602 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77917 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18534 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10350 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21318 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21050 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21198 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21106 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->