### PR TITLE
REGRESSION(308999@main): Broke ews-build tests

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -4527,7 +4527,9 @@ class RunWebKitTestsInSiteIsolationMode(RunWebKitTestsInStressMode):
 
     def setLayoutTestCommand(self):
         if self.layout_test_class == RunWebKit1Tests:
-            self.setProperty('use-dump-render-tree', True)
+            self.setProperty('layout-test-driver', 'DumpRenderTree')
+        else:
+            self.setProperty('layout-test-driver', 'WebKitTestRunner')
         RunWebKitTests.setLayoutTestCommand(self)
 
         self.command += ['--site-isolation']

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -1594,6 +1594,7 @@ class TestRunJavaScriptCoreTests(BuildStepMixinAdditions, unittest.TestCase):
         self.setup_step(RunJavaScriptCoreTests())
         self.prefix = RunJavaScriptCoreTests.prefix
         self.command_extra = RunJavaScriptCoreTests.command_extra
+        RunJavaScriptCoreTests.filter_failures_using_results_db = lambda self, stress_test_failures, binary_failures: ''
         if platform:
             self.setProperty('platform', platform)
         if fullPlatform:
@@ -2521,7 +2522,7 @@ class TestRunWebKitTestsInSiteIsolationMode(BuildStepMixinAdditions, unittest.Te
                         logfiles={'json': self.jsonFileName},
                         log_environ=False,
                         timeout=19800,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 10 --skipped always --site-isolation test1 test2 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release -2 --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 10 --skipped always --site-isolation test1 test2 2>&1 | Tools/Scripts/filter-test-logs layout'],
                         )
             .exit(0),
         )
@@ -2543,7 +2544,7 @@ class TestRunWebKitTestsInSiteIsolationMode(BuildStepMixinAdditions, unittest.Te
                         logfiles={'json': self.jsonFileName},
                         log_environ=False,
                         timeout=19800,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --dump-render-tree --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 10 --skipped always --site-isolation test1 test2 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release -1 --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 10 --skipped always --site-isolation test1 test2 2>&1 | Tools/Scripts/filter-test-logs layout'],
                         )
             .exit(0),
         )
@@ -2561,7 +2562,7 @@ class TestRunWebKitTestsInSiteIsolationMode(BuildStepMixinAdditions, unittest.Te
                         logfiles={'json': self.jsonFileName},
                         log_environ=False,
                         timeout=19800,
-                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 10 --skipped always --site-isolation test 2>&1 | Tools/Scripts/filter-test-logs layout'],
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'python3 Tools/Scripts/run-webkit-tests --no-build --no-show-results --no-new-test-results --clobber-old-results --release -2 --results-directory layout-test-results --debug-rwt-logging --exit-after-n-failures 10 --skipped always --site-isolation test 2>&1 | Tools/Scripts/filter-test-logs layout'],
                         )
             .log('stdio', stdout='9 failures found.')
             .exit(2),
@@ -10318,6 +10319,7 @@ class TestFindUnexpectedStaticAnalyzerResults(BuildStepMixinAdditions, unittest.
     def test_changed_expectations_no_match(self):
         self.configureStep(True)
         FindUnexpectedStaticAnalyzerResults.decode_results_data = lambda self: {'passes': {'WebCore': {'NoUncountedMemberChecker': ['css/ShorthandSerializer.cpp']}}, 'failures': {'WebCore': {'NoUncountedMemberChecker': ['inspector/agents/worker/WorkerWorkerAgent.h']}}}
+        FindUnexpectedStaticAnalyzerResults.filter_results_using_results_db = lambda self, logText: False
         self.setProperty('user_removed_tests', [])
         self.setProperty('user_added_tests', ['WebCore/css/ShorthandSerializer.cpp/NoUncountedMemberChecker'])
         next_steps = []


### PR DESCRIPTION
#### 6cf40ad19e18a4096a180f6e65bdb1dfd0b8105d
<pre>
REGRESSION(308999@main): Broke ews-build tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=309603">https://bugs.webkit.org/show_bug.cgi?id=309603</a>
<a href="https://rdar.apple.com/172223600">rdar://172223600</a>

Unreviewed test fix.

* Tools/CISupport/ews-build/steps.py:
(RunWebKitTestsInSiteIsolationMode.setLayoutTestCommand): Use the idioms from 308998@main.
* Tools/CISupport/ews-build/steps_unittest.py:
(TestRunWebKitTestsInSiteIsolationMode.test_success): Rebaseline.
(TestRunWebKitTestsInSiteIsolationMode.test_success_wk1): Ditto.
(TestRunWebKitTestsInSiteIsolationMode.test_failure): Ditto.

Canonical link: <a href="https://commits.webkit.org/309016@main">https://commits.webkit.org/309016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09cdf2627151e4be141c3f8764d7509eec7d218f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21903 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/15473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157878 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151063 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/22357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/21781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/115016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152150 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/22357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/95772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95f356a5-d334-4080-8a57-12ca935a9b85) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/22357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/15473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/5731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/22357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/11807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160364 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/13327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/123060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/148588 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/21781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/123286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/133600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22975 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/10348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/21315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/21047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/21195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/21103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->