### PR TITLE
copyExternalImageToTexture is not handling EXIF rotations correctly

### DIFF
--- a/LayoutTests/fast/webgpu/copy-image-mismatched-dimensions-expected.txt
+++ b/LayoutTests/fast/webgpu/copy-image-mismatched-dimensions-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: PASS: copyExternalImageToTexture correctly used intrinsic dimensions
+This test passes if it does not crash and prints PASS.

--- a/LayoutTests/fast/webgpu/copy-image-mismatched-dimensions.html
+++ b/LayoutTests/fast/webgpu/copy-image-mismatched-dimensions.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner) { testRunner.dumpAsText(); testRunner.waitUntilDone(); }
+
+// This test verifies the fix for rdar://170649679
+// It ensures copyExternalImageToTexture uses intrinsic pixel dimensions,
+// not HTML/CSS width/height attributes, to prevent heap buffer over-reads.
+
+onload = async () => {
+    try {
+        const adapter = await navigator.gpu.requestAdapter();
+        if (!adapter) {
+            console.log("FAIL: No WebGPU adapter available");
+            if (window.testRunner) testRunner.notifyDone();
+            return;
+        }
+
+        const device = await adapter.requestDevice();
+
+        // Create a 10x10 pixel red image using data URL
+        const img = document.createElement('img');
+        const canvas = document.createElement('canvas');
+        canvas.width = 10;
+        canvas.height = 10;
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = 'red';
+        ctx.fillRect(0, 0, 10, 10);
+        
+        img.src = canvas.toDataURL();
+        await new Promise(resolve => img.onload = resolve);
+
+        // Set HTML dimensions much larger than intrinsic dimensions
+        // Before the fix, this would cause an out-of-bounds heap read
+        img.width = 100;
+        img.height = 100;
+
+        // Create a texture to copy into
+        const texture = device.createTexture({
+            size: { width: 10, height: 10 },
+            format: 'rgba8unorm',
+            usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+        });
+
+        // This should use intrinsic dimensions (10x10), not HTML dimensions (100x100)
+        device.queue.copyExternalImageToTexture(
+            { source: img },
+            { texture: texture },
+            { width: 10, height: 10 }
+        );
+
+        // Wait for operations to complete
+        await device.queue.onSubmittedWorkDone();
+
+        console.log("PASS: copyExternalImageToTexture correctly used intrinsic dimensions");
+        
+    } catch (e) {
+        console.log("FAIL: " + e.message);
+    }
+    
+    if (window.testRunner) testRunner.notifyDone();
+};
+</script>
+This test passes if it does not crash and prints PASS.
+

--- a/LayoutTests/fast/webgpu/copy-image-orientation-expected.txt
+++ b/LayoutTests/fast/webgpu/copy-image-orientation-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: PASS: copyExternalImageToTexture handled image dimensions correctly
+This test passes if it does not crash and prints PASS.

--- a/LayoutTests/fast/webgpu/copy-image-orientation.html
+++ b/LayoutTests/fast/webgpu/copy-image-orientation.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner) { testRunner.dumpAsText(); testRunner.waitUntilDone(); }
+
+// This test verifies that copyExternalImageToTexture correctly handles
+// EXIF-rotated images (rdar://170649679) where dimensions are swapped.
+
+onload = async () => {
+    try {
+        const adapter = await navigator.gpu.requestAdapter();
+        if (!adapter) {
+            console.log("FAIL: No WebGPU adapter available");
+            if (window.testRunner) testRunner.notifyDone();
+            return;
+        }
+
+        const device = await adapter.requestDevice();
+
+        // Create a 20x10 pixel image (wider than tall)
+        const canvas = document.createElement('canvas');
+        canvas.width = 20;
+        canvas.height = 10;
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = 'blue';
+        ctx.fillRect(0, 0, 20, 10);
+
+        const img = document.createElement('img');
+        img.src = canvas.toDataURL();
+        await new Promise(resolve => img.onload = resolve);
+
+        // Create texture matching the intrinsic dimensions
+        // For a 90° rotated image, the oriented dimensions would be swapped (10x20)
+        // but the pixel buffer is still 20x10
+        const texture = device.createTexture({
+            size: { width: 20, height: 10 },
+            format: 'rgba8unorm',
+            usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+        });
+
+        // Copy should succeed using intrinsic dimensions
+        device.queue.copyExternalImageToTexture(
+            { source: img },
+            { texture: texture },
+            { width: 20, height: 10 }
+        );
+
+        await device.queue.onSubmittedWorkDone();
+
+        console.log("PASS: copyExternalImageToTexture handled image dimensions correctly");
+
+    } catch (e) {
+        console.log("FAIL: " + e.message);
+    }
+
+    if (window.testRunner) testRunner.notifyDone();
+};
+</script>
+This test passes if it does not crash and prints PASS.
+

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -514,8 +514,16 @@ static void imageBytesForSource(WebGPU::Queue& backing, const GPUImageCopyExtern
 
             auto rawWidth = CGImageGetWidth(platformImage.get());
             auto rawHeight = CGImageGetHeight(platformImage.get());
-            auto orientedWidth = isSVG ? rawWidth : imageElement->width();
-            auto orientedHeight = isSVG ? rawHeight : imageElement->height();
+
+            // We need to account for EXIF orientation which may swap width/height.
+            auto orientation = RefPtr { imageElement->image() }->orientation().orientation();
+            bool orientationSwapsDimensions = orientation == ImageOrientation::Orientation::OriginLeftTop
+                || orientation == ImageOrientation::Orientation::OriginRightTop
+                || orientation == ImageOrientation::Orientation::OriginRightBottom
+                || orientation == ImageOrientation::Orientation::OriginLeftBottom;
+
+            auto orientedWidth = orientationSwapsDimensions ? rawHeight : rawWidth;
+            auto orientedHeight = orientationSwapsDimensions ? rawWidth : rawHeight;
 
             if (!orientedWidth || !orientedHeight || !rawWidth || !rawHeight)
                 return callback({ }, 0, 0);
@@ -566,7 +574,6 @@ static void imageBytesForSource(WebGPU::Queue& backing, const GPUImageCopyExtern
                 }
             }();
 
-            auto orientation = RefPtr { imageElement->image() }->orientation().orientation();
             if (sizeInBytes == requiredSize && channelLayoutIsRGB && orientation == ImageOrientation::Orientation::OriginTopLeft)
                 return callback(byteSpan.first(sizeInBytes), rawWidth, rawHeight);
 


### PR DESCRIPTION
#### 9ddba6fb4ddc0982787d3b482d8a47c2322a8c60
<pre>
copyExternalImageToTexture is not handling EXIF rotations correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=309607">https://bugs.webkit.org/show_bug.cgi?id=309607</a>
<a href="https://rdar.apple.com/170649679">rdar://170649679</a>

Reviewed by Dan Glastonbury.

<a href="https://commits.webkit.org/300508@main">https://commits.webkit.org/300508@main</a> added support for EXIF data
but did not take into account that imageWidth() and imageHeight() may
not map to the physical image size.

Test: <a href="https://gpuweb.github.io/cts/standalone/?q=webgpu">https://gpuweb.github.io/cts/standalone/?q=webgpu</a>:web_platform,copyToTexture,image_file:*
continues to pass

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::imageBytesForSource):

Canonical link: <a href="https://commits.webkit.org/309030@main">https://commits.webkit.org/309030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d7681b90363967787251d3b1ae9496564e628ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15512 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157921 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0deb7b15-4d59-44fa-b501-955b35bd5872) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151102 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115052 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133898 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95802 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa07f873-9f31-483c-bfa7-c4ebc6296c6a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5771 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125910 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160403 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3398 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13366 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123097 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123316 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33516 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21753 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133631 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77953 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18555 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10377 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21354 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85167 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21086 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21235 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21142 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->