### PR TITLE
[Build] Downlevel configurations use the wrong `postprocess-framework-headers-definitions` script

### DIFF
--- a/Source/WebKit/Scripts/generate-swift-availability-macros
+++ b/Source/WebKit/Scripts/generate-swift-availability-macros
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 for search_path in "${BUILT_PRODUCTS_DIR}" "${SDKROOT}"; do
-    candidate="${search_path}/usr/local/include/WebKitAdditions/Scripts/postprocess-framework-headers-definitions"
+    candidate="${search_path}${WK_LIBRARY_HEADERS_FOLDER_PATH}/Scripts/postprocess-framework-headers-definitions"
     test -f "${candidate}" && source "${candidate}" && break
 done
 

--- a/Source/WebKit/Scripts/postprocess-header-rule
+++ b/Source/WebKit/Scripts/postprocess-header-rule
@@ -29,7 +29,7 @@ if [[ -z "${SCRIPT_HEADER_VISIBILITY}" ]]; then
 fi
 
 for search_path in "${BUILT_PRODUCTS_DIR}" "${SDKROOT}"; do
-    candidate="${search_path}/usr/local/include/WebKitAdditions/Scripts/postprocess-framework-headers-definitions"
+    candidate="${search_path}${WK_LIBRARY_HEADERS_FOLDER_PATH}/WebKitAdditions/Scripts/postprocess-framework-headers-definitions"
     test -f "${candidate}" && source "${candidate}" && break
 done
 


### PR DESCRIPTION
#### 0cc6539418448422526a1521bdda9286236b69f7
<pre>
[Build] Downlevel configurations use the wrong `postprocess-framework-headers-definitions` script
<a href="https://bugs.webkit.org/show_bug.cgi?id=309608">https://bugs.webkit.org/show_bug.cgi?id=309608</a>
<a href="https://rdar.apple.com/171676162">rdar://171676162</a>

Unreviewed build fix. Usage of this script was hard-coding its location
in the SDK to be at `./usr/local/include/WebKitAdditions`. In
downlevels, our library headers install to a `safari-sdk/` subdirectory,
so we need to search there by reading the corresponding build setting.

* Source/WebKit/Scripts/generate-swift-availability-macros:
* Source/WebKit/Scripts/postprocess-header-rule:

Canonical link: <a href="https://commits.webkit.org/309062@main">https://commits.webkit.org/309062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a081e92b88a48e026e689beb9b047ba2b762e465

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157896 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102636 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b3b2b14-d326-44b8-8767-4e493f748489) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115039 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81879 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ede0e039-341a-4508-90c5-f59e3b979255) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133882 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95785 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c61e5da7-7876-4365-82d5-960f63a51743) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/148526 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16293 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14168 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5746 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125893 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160379 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3374 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123081 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21720 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18210 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123300 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21729 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133614 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77929 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22997 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18542 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10361 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/21330 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85143 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21062 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21210 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21118 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->