### PR TITLE
ANGLE: Add mutex to MakeStaticString to fix data race crash

### DIFF
--- a/Source/ThirdParty/ANGLE/src/common/angleutils.cpp
+++ b/Source/ThirdParty/ANGLE/src/common/angleutils.cpp
@@ -9,6 +9,7 @@
 #endif
 
 #include "common/angleutils.h"
+#include "common/SimpleMutex.h"
 #include "common/debug.h"
 
 #include <stdio.h>
@@ -71,7 +72,9 @@ const char *MakeStaticString(const std::string &str)
 {
     // On the heap so that no destructor runs on application exit.
     static std::set<std::string> *strings = new std::set<std::string>;
-    std::set<std::string>::iterator it    = strings->find(str);
+    static angle::SimpleMutex *mutex      = new angle::SimpleMutex;
+    std::lock_guard<angle::SimpleMutex> lock(*mutex);
+    std::set<std::string>::iterator it = strings->find(str);
     if (it != strings->end())
     {
         return it->c_str();

--- a/Source/ThirdParty/ANGLE/src/common/angleutils_unittest.cpp
+++ b/Source/ThirdParty/ANGLE/src/common/angleutils_unittest.cpp
@@ -10,6 +10,12 @@
 
 #include "common/angleutils.h"
 
+#include <array>
+#include <condition_variable>
+#include <mutex>
+#include <string>
+#include <thread>
+
 namespace
 {
 
@@ -21,6 +27,62 @@ TEST(ArrayIndexString, MultipleArrayIndices)
     indices.push_back(34);
     indices.push_back(56);
     EXPECT_EQ("[56][34][12]", ArrayIndexString(indices));
+}
+
+// Tests that MakeStaticString is thread-safe.
+TEST(MakeStaticString, ThreadSafety)
+{
+    constexpr size_t kThreadCount    = 16;
+    constexpr size_t kIterationCount = 1'000;
+
+    std::array<std::thread, kThreadCount> threads;
+
+    std::mutex mutex;
+    std::condition_variable condVar;
+    size_t readyCount = 0;
+
+    std::array<std::array<const char *, kIterationCount>, kThreadCount> results = {};
+
+    for (size_t i = 0; i < kThreadCount; ++i)
+    {
+        threads[i] = std::thread([&, i]() {
+            // Wait for all threads to start, so the following loop is as simultaneously
+            // executed as possible.
+            {
+                std::unique_lock<std::mutex> lock(mutex);
+                ++readyCount;
+                if (readyCount < kThreadCount)
+                {
+                    condVar.wait(lock, [&]() { return readyCount == kThreadCount; });
+                }
+                else
+                {
+                    condVar.notify_all();
+                }
+            }
+            for (size_t j = 0; j < kIterationCount; ++j)
+            {
+                results[i][j] = MakeStaticString("extension_" + std::to_string(j));
+            }
+        });
+    }
+
+    for (size_t i = 0; i < kThreadCount; ++i)
+    {
+        threads[i].join();
+    }
+
+    // Verify all threads got valid, identical pointers for the same input strings.
+    for (size_t j = 0; j < kIterationCount; ++j)
+    {
+        EXPECT_NE(results[0][j], nullptr);
+        EXPECT_STREQ(results[0][j], ("extension_" + std::to_string(j)).c_str());
+        for (size_t i = 1; i < kThreadCount; ++i)
+        {
+            // Same input string should return the same interned pointer.
+            EXPECT_EQ(results[0][j], results[i][j]);
+        }
+    }
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
#### 3df36642bc36c52efd2db9f3a274a628d9bd94f0
<pre>
ANGLE: Add mutex to MakeStaticString to fix data race crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=309609">https://bugs.webkit.org/show_bug.cgi?id=309609</a>
<a href="https://rdar.apple.com/171048125">rdar://171048125</a>

Reviewed by Kimmo Kinnunen.

MakeStaticString() in angleutils.cpp uses a function-local static
std::set&lt;std::string&gt; without synchronization. When multiple
SharedWorker threads simultaneously initialize WebGL contexts via
OffscreenCanvas, concurrent find() and insert() operations corrupt
the red-black tree, causing NULL pointer dereference crashes in
__tree_balance_after_insert.

Add angle::SimpleMutex to protect the static set, following the
same heap-allocated mutex pattern used by debug.cpp&apos;s g_debugMutex.

* Source/ThirdParty/ANGLE/src/common/angleutils.cpp:
(MakeStaticString):
* Source/ThirdParty/ANGLE/src/common/angleutils_unittest.cpp:
(MakeStaticString_ThreadSafety_Test::TestBody):

Canonical link: <a href="https://commits.webkit.org/309080@main">https://commits.webkit.org/309080@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88cfe3185644d2289b40dce45504d567218237ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15491 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157899 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102639 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4bb7f780-b1a4-497d-80be-c77587935d1a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115040 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81880 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9f74ede-e43c-4e56-b848-be69e66ecec6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133887 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95787 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5cb7ca6e-63a9-4134-b60d-e0b8793cdd11) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16295 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14171 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5749 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125895 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160382 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13356 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123084 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21723 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123303 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33549 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21732 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133619 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77932 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18541 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10366 "Passed tests") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/21333 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (cancelled)") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21065 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21213 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21121 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->