### PR TITLE
WidthIterator: Encapsulate glyph bound computation into GlyphBounds

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -351,8 +351,8 @@ float FontCascade::width(CodePath codePathToUse, const TextRun& run, SingleThrea
     if (glyphOverflow) {
         glyphOverflow->top = std::max<double>(glyphOverflow->top, -it.minGlyphBoundingBoxY() - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().ascent()));
         glyphOverflow->bottom = std::max<double>(glyphOverflow->bottom, it.maxGlyphBoundingBoxY() - (glyphOverflow->computeBounds ? 0 : metricsOfPrimaryFont().descent()));
-        glyphOverflow->left = it.firstGlyphOverflow();
-        glyphOverflow->right = it.lastGlyphOverflow();
+        glyphOverflow->left = it.firstGlyphOverflowX();
+        glyphOverflow->right = it.lastGlyphOverflowX();
     }
     return it.runWidthSoFar();
 }

--- a/Source/WebCore/platform/graphics/WidthIterator.cpp
+++ b/Source/WebCore/platform/graphics/WidthIterator.cpp
@@ -46,9 +46,9 @@ WidthIterator::WidthIterator(const FontCascade& fontCascade, const TextRun& run,
     , m_run(run)
     , m_fallbackFonts(fallbackFonts)
     , m_expansion(run.expansion())
+    , m_glyphBounds { accountForGlyphBounds }
     , m_direction(m_run->direction())
     , m_isAfterExpansion(run.expansionBehavior().left == ExpansionBehavior::Behavior::Forbid)
-    , m_accountForGlyphBounds(accountForGlyphBounds)
     , m_enableKerning(fontCascade.enableKerning())
     , m_requiresShaping(fontCascade.requiresShaping())
     , m_forTextEmphasis(forTextEmphasis)
@@ -373,11 +373,22 @@ static void updateCharacterAndSmallCapsIfNeeded(SmallCapsState& smallCapsState, 
     }
 }
 
+void WidthIterator::GlyphBounds::computeIfNeeded(Glyph glyph, const Font& font, unsigned charIndex, float glyphWidth)
+{
+    if (!shouldCompute)
+        return;
+    auto bounds = font.boundsForGlyph(glyph);
+    if (!charIndex)
+        firstGlyphLeftOverflowX = std::max<float>(0.f, -bounds.x());
+    maxY = std::max(maxY, bounds.maxY());
+    minY = std::min(minY, bounds.y());
+    lastGlyphRightOverflowX = std::max<float>(0.f, bounds.maxX() - glyphWidth);
+}
+
 template <typename TextIterator>
 inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuffer& glyphBuffer)
 {
     // The core logic here needs to match FontCascade::widthForTextUsingSimplifiedMeasuring()
-    FloatRect bounds;
     auto& fontDescription = m_fontCascade->fontDescription();
     Ref primaryFont = m_fontCascade->primaryFont();
     AdvanceInternalState advanceInternalState(glyphBuffer, primaryFont, textIterator.currentIndex());
@@ -469,11 +480,7 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
         if (FontCascade::treatAsSpace(characterToWrite))
             advanceInternalState.charactersTreatedAsSpace.constructAndAppend(advanceInternalState.currentCharacterIndex, characterToWrite == space, characterToWrite == tabCharacter ? width : advanceInternalState.nextRangeFont->spaceWidth(Font::SyntheticBoldInclusion::Exclude));
 
-        if (m_accountForGlyphBounds) {
-            bounds = Ref { *advanceInternalState.nextRangeFont }->boundsForGlyph(glyph);
-            if (!advanceInternalState.currentCharacterIndex)
-                m_firstGlyphOverflow = std::max<float>(0, -bounds.x());
-        }
+        m_glyphBounds.computeIfNeeded(glyph, Ref { *advanceInternalState.nextRangeFont }, advanceInternalState.currentCharacterIndex, width);
 
         if (m_forTextEmphasis && !FontCascade::canReceiveTextEmphasis(characterToWrite))
             glyph = deletedGlyph;
@@ -485,12 +492,6 @@ inline void WidthIterator::advanceInternal(TextIterator& textIterator, GlyphBuff
         advanceInternalState.currentCharacterIndex = textIterator.currentIndex();
 
         m_runWidthSoFar += width;
-
-        if (m_accountForGlyphBounds) {
-            m_maxGlyphBoundingBoxY = std::max(m_maxGlyphBoundingBoxY, bounds.maxY());
-            m_minGlyphBoundingBoxY = std::min(m_minGlyphBoundingBoxY, bounds.y());
-            m_lastGlyphOverflow = std::max<float>(0, bounds.maxX() - width);
-        }
     }
     advanceInternalState.rangeFont = advanceInternalState.nextRangeFont;
     commitCurrentFontRange(advanceInternalState);

--- a/Source/WebCore/platform/graphics/WidthIterator.h
+++ b/Source/WebCore/platform/graphics/WidthIterator.h
@@ -57,10 +57,10 @@ public:
     bool advanceOneCharacter(float& width, GlyphBuffer&);
     void finalize(GlyphBuffer&);
 
-    float maxGlyphBoundingBoxY() const { ASSERT(m_accountForGlyphBounds); return m_maxGlyphBoundingBoxY; }
-    float minGlyphBoundingBoxY() const { ASSERT(m_accountForGlyphBounds); return m_minGlyphBoundingBoxY; }
-    float firstGlyphOverflow() const { ASSERT(m_accountForGlyphBounds); return m_firstGlyphOverflow; }
-    float lastGlyphOverflow() const { ASSERT(m_accountForGlyphBounds); return m_lastGlyphOverflow; }
+    float maxGlyphBoundingBoxY() const { ASSERT(m_glyphBounds.shouldCompute); return m_glyphBounds.maxY; }
+    float minGlyphBoundingBoxY() const { ASSERT(m_glyphBounds.shouldCompute); return m_glyphBounds.minY; }
+    float firstGlyphOverflowX() const { ASSERT(m_glyphBounds.shouldCompute); return m_glyphBounds.firstGlyphLeftOverflowX; }
+    float lastGlyphOverflowX() const { ASSERT(m_glyphBounds.shouldCompute); return m_glyphBounds.lastGlyphRightOverflowX; }
 
     const TextRun& run() const { return m_run; }
     float runWidthSoFar() const { return m_runWidthSoFar; }
@@ -95,6 +95,15 @@ private:
         float leftExpansion;
         float rightExpansion;
     };
+    struct GlyphBounds {
+        bool shouldCompute { false };
+        float maxY { std::numeric_limits<float>::lowest() };
+        float minY { std::numeric_limits<float>::max() };
+        float firstGlyphLeftOverflowX { 0.f };
+        float lastGlyphRightOverflowX { 0.f };
+
+        void computeIfNeeded(Glyph, const Font&, unsigned charIndex, float glyphWidth);
+    };
     AdditionalWidth calculateAdditionalWidth(GlyphBuffer&, GlyphBufferStringOffset currentCharacterIndex, unsigned leadingGlyphIndex, unsigned trailingGlyphIndex, float position) const;
     void applyAdditionalWidth(GlyphBuffer&, GlyphIndexRange, float leftAdditionalWidth, float rightAdditionalWidth, float leftExpansionAdditionalWidth, float rightExpansionAdditionalWidth);
 
@@ -113,14 +122,10 @@ private:
     float m_runWidthSoFar { 0 };
     float m_expansion { 0 };
     float m_expansionPerOpportunity { 0 };
-    float m_maxGlyphBoundingBoxY { std::numeric_limits<float>::lowest() };
-    float m_minGlyphBoundingBoxY { std::numeric_limits<float>::max() };
-    float m_firstGlyphOverflow { 0 };
-    float m_lastGlyphOverflow { 0 };
+    GlyphBounds m_glyphBounds;
     TextDirection m_direction { TextDirection::LTR };
     bool m_containsTabs { false };
     bool m_isAfterExpansion { false };
-    bool m_accountForGlyphBounds { false };
     bool m_enableKerning { false };
     bool m_requiresShaping { false };
     bool m_forTextEmphasis { false };


### PR DESCRIPTION
#### 118979af8764d1ab6c19241970eedda69f8bf3ad
<pre>
WidthIterator: Encapsulate glyph bound computation into GlyphBounds
<a href="https://bugs.webkit.org/show_bug.cgi?id=309615">https://bugs.webkit.org/show_bug.cgi?id=309615</a>
<a href="https://rdar.apple.com/172229841">rdar://172229841</a>

Reviewed by Sammy Gill.

Group glyph bounds data members into a GlyphBounds struct with a single
computeIfNeeded method.

The two bounds computation blocks in advanceInternal had
no reason to be separated as all the necessary input
is available at the same point.

Also, rename firstGlyphOverflow/lastGlyphOverflow to
firstGlyphLeftOverflowX/lastGlyphRightOverflowX to clarify overflow direction.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::width):
* Source/WebCore/platform/graphics/WidthIterator.cpp:
(WebCore::WidthIterator::GlyphBounds::computeIfNeeded):
(WebCore::WidthIterator::WidthIterator):
(WebCore::WidthIterator::advanceInternal):
* Source/WebCore/platform/graphics/WidthIterator.h:
(WebCore::WidthIterator::maxGlyphBoundingBoxY const):
(WebCore::WidthIterator::minGlyphBoundingBoxY const):
(WebCore::WidthIterator::firstGlyphOverflowX const):
(WebCore::WidthIterator::lastGlyphOverflowX const):

Canonical link: <a href="https://commits.webkit.org/309071@main">https://commits.webkit.org/309071@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c0d10858cafd82ec5943237b8cfed7ee00d4d61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149226 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102657 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151099 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115049 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81886 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95799 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/09652bed-1f89-4a34-85c0-0c14fe7b0a1a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16312 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14184 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5768 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125913 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160400 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3395 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13365 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123095 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123314 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33544 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133630 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77950 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18552 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10376 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21351 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85164 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21083 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21231 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21139 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->