### PR TITLE
[Site Isolation] Unskip tests and update expectation based on page cache enablement

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -5491,6 +5491,11 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
     return _page->pageLoadState().networkRequestsInProgress();
 }
 
+- (BOOL)_isUsingBackForwardCache
+{
+    return _page->shouldUseBackForwardCache();
+}
+
 static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingProgressEvents events)
 {
     OptionSet<WebCore::LayoutMilestone> milestones;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -267,6 +267,7 @@ for this property.
 @property (nonatomic, copy, setter=_setCORSDisablingPatterns:) NSArray<NSString *> *_corsDisablingPatterns WK_API_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4));
 
 @property (nonatomic, readonly) BOOL _networkRequestsInProgress;
+@property (nonatomic, readonly) BOOL _isUsingBackForwardCache;
 
 @property (nonatomic, readonly, getter=_isShowingNavigationGestureSnapshot) BOOL _showingNavigationGestureSnapshot;
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2974,6 +2974,8 @@ public:
     bool hasShownSafeBrowsingWarningAfterLastLoadCommit() const { return m_hasShownSafeBrowsingWarningAfterLastLoadCommit; }
 #endif
 
+    bool shouldUseBackForwardCache() const;
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();
@@ -2985,7 +2987,6 @@ private:
     void removeAllMessageReceivers();
 
     void notifyProcessPoolToPrewarm();
-    bool shouldUseBackForwardCache() const;
 
     bool attachmentElementEnabled();
     bool modelElementEnabled();

--- a/Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache.cpp
@@ -78,10 +78,10 @@ TEST(WebKit, DidRemoveFrameFromHiearchyInBackForwardCache)
 
     PlatformWebView webView(context.get());
 
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    // In site isolation, persisted: false. PageShow events are not being restored from the back-forward cache.
-    if (isSiteIsolationEnabled(static_cast<WKWebView*>(webView.platformView())))
+    if (!isUsingBackForwardCache(static_cast<WKWebView*>(webView.platformView()))) {
+        WTFLogAlways("WebKit.DidRemoveFrameFromHiearchyInBackForwardCache: Test is skipped as backfoward cache is disabled");
         return;
+    }
 
     setPageLoaderClient(webView.page());
     setInjectedBundleClient(webView.page());

--- a/Tools/TestWebKitAPI/Tests/WebKit/LayoutMilestonesWithAllContentInFrame.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/LayoutMilestonesWithAllContentInFrame.cpp
@@ -80,11 +80,6 @@ TEST(WebKit, FirstVisuallyNonEmptyLayoutAfterPageCacheRestore)
     WKContextSetCacheModel(context.get(), kWKCacheModelPrimaryWebBrowser); // Enables the back/forward cache.
 
     PlatformWebView webView(context.get());
-
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    if (isSiteIsolationEnabled(static_cast<WKWebView*>(webView.platformView())))
-        return;
-
     WKPageNavigationClientV3 loaderClient;
     zeroBytes(loaderClient);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
@@ -971,6 +971,7 @@ static void runGoBackAfterNavigatingSameSiteIframe(ShouldEnablePageCache shouldE
     RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    const bool backForwardCacheEnabled = isUsingBackForwardCache(webView.get());
     webView.get().navigationDelegate = navigationDelegate.get();
     static bool didCommitLoadForAllFrames = false;
     static unsigned expectedCommittedFrameSize = 2;
@@ -1018,7 +1019,7 @@ static void runGoBackAfterNavigatingSameSiteIframe(ShouldEnablePageCache shouldE
 
     // Navigate main frame back.
     // For page cache case, iframe is not reloaded, so there is only one commit.
-    expectedCommittedFrameSize = shouldEnablePageCache == ShouldEnablePageCache::Yes ? 1 : 2;
+    expectedCommittedFrameSize = backForwardCacheEnabled ? 1 : 2;
     [webView goBack];
 
     TestWebKitAPI::Util::run(&didCommitLoadForAllFrames);
@@ -1036,11 +1037,6 @@ static void runGoBackAfterNavigatingSameSiteIframe(ShouldEnablePageCache shouldE
 
 TEST(WKBackForwardList, PageCacheGoBackAfterNavigatingSameSiteIframe)
 {
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
-    if (isSiteIsolationEnabled(webView.get()))
-        return;
-
     runGoBackAfterNavigatingSameSiteIframe(ShouldEnablePageCache::Yes);
 }
 
@@ -1064,6 +1060,7 @@ static void runGoBackAfterNavigatingSameSiteIframe2(ShouldEnablePageCache should
     RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    const bool backForwardCacheEnabled = isUsingBackForwardCache(webView.get());
     webView.get().navigationDelegate = navigationDelegate.get();
     static bool didCommitLoadForAllFrames = false;
     static unsigned expectedCommittedFrameSize = 2;
@@ -1111,7 +1108,7 @@ static void runGoBackAfterNavigatingSameSiteIframe2(ShouldEnablePageCache should
 
     // Navigate main frame back.
     // For page cache case, iframe is not reloaded, so there is only one commit.
-    expectedCommittedFrameSize = shouldEnablePageCache == ShouldEnablePageCache::Yes ? 1 : 2;
+    expectedCommittedFrameSize = backForwardCacheEnabled ? 1 : 2;
     [webView goBack];
 
     TestWebKitAPI::Util::run(&didCommitLoadForAllFrames);
@@ -1129,11 +1126,6 @@ static void runGoBackAfterNavigatingSameSiteIframe2(ShouldEnablePageCache should
 
 TEST(WKBackForwardList, PageCacheGoBackAfterNavigatingSameSiteIframe2)
 {
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
-    if (isSiteIsolationEnabled(webView.get()))
-        return;
-
     runGoBackAfterNavigatingSameSiteIframe2(ShouldEnablePageCache::Yes);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBInPageCache.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBInPageCache.mm
@@ -59,12 +59,6 @@ TEST(IndexedDB, IndexedDBInPageCache)
     [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    // This test relies on the back forward cache. Once it is enabled in site isolation, remove this early return.
-    if (isSiteIsolationEnabled(webView.get()))
-        return;
-
     // Load page that holds open database connection.
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"IndexedDBInPageCache" withExtension:@"html"]];
     [webView loadRequest:request];
@@ -87,5 +81,10 @@ TEST(IndexedDB, IndexedDBInPageCache)
     receivedScriptMessage = false;
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     RetainPtr<NSString> string3 = (NSString *)[lastScriptMessage body];
-    EXPECT_WK_STREQ(@"First Database Connection Closed, Second Database Connection Not Failed, Third Database Connection Opened", string3.get());
+    if (isUsingBackForwardCache(webView.get()))
+        EXPECT_WK_STREQ(@"First Database Connection Closed, Second Database Connection Not Failed, Third Database Connection Opened", string3.get());
+    else {
+        // If page is not in cache, a new connection will be opened.
+        EXPECT_WK_STREQ(@"First Database Connection Opened", string3.get());
+    }
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -849,7 +849,7 @@ static bool navigationComplete;
     EXPECT_STREQ(item.URL.absoluteString.UTF8String, expectedURL);
     EXPECT_TRUE(item.title == nil);
     EXPECT_STREQ(item.initialURL.absoluteString.UTF8String, expectedURL);
-    EXPECT_TRUE(inPageCache);
+    EXPECT_EQ(inPageCache, isUsingBackForwardCache(webView));
     isDone = true;
 }
 - (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
@@ -861,10 +861,6 @@ static bool navigationComplete;
 TEST(WKNavigation, WillGoToBackForwardListItem)
 {
     auto webView = adoptNS([[WKWebView alloc] init]);
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    if (isSiteIsolationEnabled(webView.get()))
-        return;
-
     auto delegate = adoptNS([[BackForwardDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"]]];
@@ -892,7 +888,8 @@ static bool didRejectNavigation = false;
 {
     EXPECT_EQ(item, _targetItem);
     EXPECT_TRUE(item.title == nil);
-    EXPECT_TRUE(willUseInstantBack);
+
+    EXPECT_EQ(willUseInstantBack, isUsingBackForwardCache(webView));
 
     completionHandler(_allowNavigation);
     if (!_allowNavigation)
@@ -925,7 +922,7 @@ static bool didRejectNavigation = false;
 {
     EXPECT_EQ(item, _targetItem);
     EXPECT_TRUE(item.title == nil);
-    EXPECT_TRUE(inPageCache);
+    EXPECT_EQ(inPageCache, isUsingBackForwardCache(webView));
 
     completionHandler(_allowNavigation);
     if (!_allowNavigation)
@@ -941,12 +938,6 @@ static bool didRejectNavigation = false;
 TEST(WKNavigation, ShouldGoToBackForwardListItem)
 {
     auto webView = adoptNS([[WKWebView alloc] init]);
-
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    // This test relies on the back forward cache. Once it is enabled, remove this early return.
-    if (isSiteIsolationEnabled(webView.get()))
-        return;
-
     navigationComplete = false;
     auto delegate = adoptNS([[BackForwardDelegateWithShouldGo alloc] init]);
     [webView setNavigationDelegate:delegate.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -917,11 +917,6 @@ TEST(ProcessSwap, Back)
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
 
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    // In site isolation, persisted: false. PageShow events are not being restored from the back-forward cache.
-    if (isSiteIsolationEnabled(webView.get()))
-        return;
-
     auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
@@ -998,11 +993,17 @@ TEST(ProcessSwap, Back)
     EXPECT_WK_STREQ(@"PageShow called. Persisted: false, and window.history.state is: null", receivedMessages.get()[0]);
     EXPECT_WK_STREQ(@"PageShow called. Persisted: false, and window.history.state is: null", receivedMessages.get()[1]);
     EXPECT_WK_STREQ(@"PageShow called. Persisted: false, and window.history.state is: null", receivedMessages.get()[2]);
-    EXPECT_WK_STREQ(@"PageShow called. Persisted: true, and window.history.state is: onloadCalled", receivedMessages.get()[3]);
+    if (isUsingBackForwardCache(webView.get()))
+        EXPECT_WK_STREQ(@"PageShow called. Persisted: true, and window.history.state is: onloadCalled", receivedMessages.get()[3]);
+    else
+        EXPECT_WK_STREQ(@"PageShow called. Persisted: false, and window.history.state is: onloadCalled", receivedMessages.get()[3]);
 
     // The number of suspended pages we keep around is determined at runtime.
     if ([processPool _maximumSuspendedPageCount] > 1) {
-        EXPECT_WK_STREQ(@"PageShow called. Persisted: true, and window.history.state is: onloadCalled", receivedMessages.get()[4]);
+        if (isUsingBackForwardCache(webView.get()))
+            EXPECT_WK_STREQ(@"PageShow called. Persisted: true, and window.history.state is: onloadCalled", receivedMessages.get()[4]);
+        else
+            EXPECT_WK_STREQ(@"PageShow called. Persisted: false, and window.history.state is: onloadCalled", receivedMessages.get()[4]);
         EXPECT_EQ(4u, seenPIDs.size());
     } else
         EXPECT_EQ(5u, seenPIDs.size());
@@ -1075,12 +1076,6 @@ TEST(ProcessSwap, SuspendedPageDiesAfterBackForwardListItemIsGone)
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    // Suspending pages depends on back forward cache, so suspending will always fail
-    if (isSiteIsolationEnabled(webView.get()))
-        return;
-
     auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
@@ -1145,12 +1140,10 @@ TEST(ProcessSwap, SuspendedPagesInActivityMonitor)
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    // Suspending pages depends on back forward cache, so suspending will always fail
-    if (isSiteIsolationEnabled(webView.get()))
+    if (!isUsingBackForwardCache(webView.get())) {
+        NSLog(@"ProcessSwap.SuspendedPagesInActivityMonitor: Test is skipped as backfoward cache is disabled");
         return;
-
+    }
     auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
@@ -2651,12 +2644,6 @@ TEST(ProcessSwap, ReuseSuspendedProcess)
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    // Suspending pages depends on the back forward cache, so suspending will always fail
-    if (isSiteIsolationEnabled(webView.get()))
-        return;
-
     auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
@@ -2684,8 +2671,12 @@ TEST(ProcessSwap, ReuseSuspendedProcess)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    // We should have gone back to the webkit.org process for this load since we reuse SuspendedPages' process when possible.
-    EXPECT_EQ(webkitPID, [webView _webProcessIdentifier]);
+    const bool backForwardCacheEnabled = isUsingBackForwardCache(webView.get());
+    if (backForwardCacheEnabled) {
+        // We should have gone back to the webkit.org process for this load since we reuse SuspendedPages' process when possible.
+        EXPECT_EQ(webkitPID, [webView _webProcessIdentifier]);
+    } else
+        EXPECT_NE(webkitPID, [webView _webProcessIdentifier]);
 
     request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.apple.com/main2.html"]];
     [webView loadRequest:request];
@@ -2693,8 +2684,11 @@ TEST(ProcessSwap, ReuseSuspendedProcess)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    // We should have gone back to the apple.com process for this load since we reuse SuspendedPages' process when possible.
-    EXPECT_EQ(applePID, [webView _webProcessIdentifier]);
+    if (backForwardCacheEnabled) {
+        // We should have gone back to the webkit.org process for this load since we reuse SuspendedPages' process when possible.
+        EXPECT_EQ(applePID, [webView _webProcessIdentifier]);
+    } else
+        EXPECT_NE(webkitPID, [webView _webProcessIdentifier]);
 }
 
 static constexpr auto failsToEnterPageCacheTestBytes = R"PSONRESOURCE(
@@ -3434,12 +3428,6 @@ TEST(ProcessSwap, SuspendedPageLimit)
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    // Suspending pages depends on the back forward cache, which is disabled. Once it is enabled, remove this early return.
-    if (isSiteIsolationEnabled(webView.get()))
-        return;
-
     auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
@@ -3479,8 +3467,11 @@ TEST(ProcessSwap, SuspendedPageLimit)
     // Navigations to 5 different domains, we expect to have seen 5 different PIDs
     EXPECT_EQ(5u, seenPIDs.size());
 
-    // But not all of those processes should still be alive (1 visible, maximumSuspendedPageCount suspended).
-    auto expectedProcessCount = 1 + maximumSuspendedPageCount;
+    auto expectedProcessCount = 1u;
+    if (isUsingBackForwardCache(webView.get())) {
+        // But not all of those processes should still be alive (1 visible, maximumSuspendedPageCount suspended).
+        expectedProcessCount += maximumSuspendedPageCount;
+    }
     int timeout = 20;
     while ([processPool _webProcessCountIgnoringPrewarmedAndCached] != expectedProcessCount && timeout >= 0) {
         TestWebKitAPI::Util::runFor(0.1_s);
@@ -3506,10 +3497,10 @@ TEST(ProcessSwap, PageCache1)
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    // Once it is enabled, remove this early return.
-    if (isSiteIsolationEnabled(webView.get()))
+    if (!isUsingBackForwardCache(webView.get())) {
+        NSLog(@"ProcessSwap.PageCache1: Test is skipped as backfoward cache is disabled");
         return;
+    }
 
     auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
@@ -3740,11 +3731,10 @@ TEST(ProcessSwap, PageCacheAfterProcessSwapByClient)
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    // Once it is enabled, remove this early return.
-    if (isSiteIsolationEnabled(webView.get()))
+    if (!isUsingBackForwardCache(webView.get())) {
+        NSLog(@"ProcessSwap.PageCacheAfterProcessSwapByClient: Test is skipped as backfoward cache is disabled");
         return;
-
+    }
     auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
@@ -3821,10 +3811,10 @@ TEST(ProcessSwap, PageCacheWhenNavigatingFromJS)
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    // Once it is enabled, remove this early return.
-    if (isSiteIsolationEnabled(webView.get()))
+    if (!isUsingBackForwardCache(webView.get())) {
+        NSLog(@"ProcessSwap.PageCacheWhenNavigatingFromJS: Test is skipped as backfoward cache is disabled");
         return;
+    }
 
     auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
@@ -4144,12 +4134,9 @@ TEST(ProcessSwap, NumberOfPrewarmedProcesses)
 
     EXPECT_EQ(2u + [processPool _prewarmedProcessCountLimit], [processPool _webProcessCount]);
 
-    // FIXME: The back/forward cache is currently disabled under site isolation; see rdar://161762363.
-    // With the back forward cache disabled, the web process for webkit.org will end up in the process cache.
-    if (isSiteIsolationEnabled(webView.get()))
-        EXPECT_EQ(1u, [processPool _webProcessCountIgnoringPrewarmedAndCached]);
-    else
-        EXPECT_EQ(2u, [processPool _webProcessCountIgnoringPrewarmedAndCached]);
+    // If page cache is enabled, process for webkit.org will stay active.
+    unsigned expectedActiveProcessCount = isUsingBackForwardCache(webView.get()) ? 2u : 1u;
+    EXPECT_EQ(expectedActiveProcessCount, [processPool _webProcessCountIgnoringPrewarmedAndCached]);
     EXPECT_TRUE([processPool _hasPrewarmedWebProcess]);
 }
 
@@ -4174,12 +4161,6 @@ TEST(ProcessSwap, NumberOfCachedProcesses)
     [webViewConfiguration setURLSchemeHandler:handler.get() forURLScheme:@"PSON"];
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    // Suspending pages depends on the back forward cache, which is disabled. Once it is enabled, remove this early return.
-    if (isSiteIsolationEnabled(webView.get()))
-        return;
-
     auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
@@ -5144,12 +5125,10 @@ static void runAPIControlledProcessSwappingThenBackTest(WithDelay withDelay)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
-    // Page cache is currently disabled under Site Isolation.
-    // FIXME: Remove this SI-specific expectation once rdar://161762363 is fixed.
-    if (isSiteIsolationEnabled(webView.get()))
-        EXPECT_NE(pid1, [webView _webProcessIdentifier]);
-    else
+    if (isUsingBackForwardCache(webView.get()))
         EXPECT_EQ(pid1, [webView _webProcessIdentifier]);
+    else
+        EXPECT_NE(pid1, [webView _webProcessIdentifier]);
 }
 
 TEST(ProcessSwap, APIControlledProcessSwappingThenBackWithDelay)
@@ -6840,11 +6819,10 @@ TEST(ProcessSwap, GoBackToSuspendedPageWithMainFrameIDThatIsNotOne)
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
     auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    // Suspending pages depends on the back forward cache, which is disabled. Once it is enabled, remove this early return.
-    if (isSiteIsolationEnabled(webView1.get()))
+    if (!isUsingBackForwardCache(webView1.get())) {
+        NSLog(@"ProcessSwap.GoBackToSuspendedPageWithMainFrameIDThatIsNotOne: Test is skipped as backfoward cache is disabled");
         return;
+    }
 
     auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView1 setNavigationDelegate:navigationDelegate.get()];
@@ -8017,12 +7995,6 @@ TEST(ProcessSwap, NavigateBackAfterNavigatingAwayFromCrossOriginOpenerPolicyUsin
     }
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
-
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    // The back forward cache is disabled in site isolation. Once enabled, remove this early return.
-    if (isSiteIsolationEnabled(webView.get()))
-        return;
-
     auto navigationDelegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     navigationDelegate->didSameDocumentNavigationHandler = ^{
         done = true;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm
@@ -1204,12 +1204,6 @@ TEST(ResourceLoadStatistics, BackForwardPerPageData)
     [configuration setURLSchemeHandler:schemeHandler.get() forURLScheme:@"resource-load-statistics"];
 
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
-
-    // FIXME: Page cache is currently disabled under site isolation; see rdar://161762363.
-    // This test relies on the backforward cache. Once it is enabled in site isolation, remove this early return.
-    if (isSiteIsolationEnabled(webView.get()))
-        return;
-
     [webView setNavigationDelegate:delegate.get()];
 
     static bool doneFlag = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolationUtilities.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolationUtilities.h
@@ -32,3 +32,4 @@ class WKWebView;
 #endif
 
 bool isSiteIsolationEnabled(WKWebView*);
+bool isUsingBackForwardCache(WKWebView*);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolationUtilities.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolationUtilities.mm
@@ -43,3 +43,8 @@ bool isSiteIsolationEnabled(WKWebView *webView)
 
     return false;
 }
+
+bool isUsingBackForwardCache(WKWebView *webView)
+{
+    return [webView _isUsingBackForwardCache];
+}


### PR DESCRIPTION
#### 2e17db558ff81ee2133cd231fb1114a7545efee9
<pre>
[Site Isolation] Unskip tests and update expectation based on page cache enablement
<a href="https://bugs.webkit.org/show_bug.cgi?id=309623">https://bugs.webkit.org/show_bug.cgi?id=309623</a>
<a href="https://rdar.apple.com/172234926">rdar://172234926</a>

Reviewed by Per Arne Vollan and Rupin Mittal.

Many API tests are skipped under Site Isolation because page cache is currently disabled under Site Isolation. These
tests actually fail due to missing page cache support, not because implementation of Site Isolation is incorrect -- if
we disable page cache without Site Isolation, these tests will also fail. To make this relationship more clear, this
patch introduces new testing SPI to query whether page cache is enabled (which is computed based on various settings),
and update the skipped tests to use that SPI instead. By doing this, if we turn on Site Isolation wiht page cache
support later, we don&apos;t have to update the tests separately to remove the checks for `SiteIsolationEnabled`.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _isUsingBackForwardCache]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache.cpp:
(TestWebKitAPI::TEST(WebKit, DidRemoveFrameFromHiearchyInBackForwardCache)):
* Tools/TestWebKitAPI/Tests/WebKit/LayoutMilestonesWithAllContentInFrame.cpp:
(TestWebKitAPI::TEST(WebKit, FirstVisuallyNonEmptyLayoutAfterPageCacheRestore)):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(runGoBackAfterNavigatingSameSiteIframe):
(TEST(WKBackForwardList, PageCacheGoBackAfterNavigatingSameSiteIframe)):
(runGoBackAfterNavigatingSameSiteIframe2):
(TEST(WKBackForwardList, PageCacheGoBackAfterNavigatingSameSiteIframe2)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBInPageCache.mm:
(TEST(IndexedDB, IndexedDBInPageCache)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(-[BackForwardDelegate _webView:willGoToBackForwardListItem:inPageCache:]):
(TEST(WKNavigation, WillGoToBackForwardListItem)):
(-[BackForwardDelegateWithShouldGo webView:shouldGoToBackForwardListItem:willUseInstantBack:completionHandler:]):
(-[BackForwardDelegateWithShouldGoSPI _webView:shouldGoToBackForwardListItem:inPageCache:completionHandler:]):
(TEST(WKNavigation, ShouldGoToBackForwardListItem)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
((ProcessSwap, Back)):
((ProcessSwap, SuspendedPageDiesAfterBackForwardListItemIsGone)):
((ProcessSwap, SuspendedPagesInActivityMonitor)):
((ProcessSwap, ReuseSuspendedProcess)):
((ProcessSwap, SuspendedPageLimit)):
((ProcessSwap, PageCache1)):
((ProcessSwap, PageCacheAfterProcessSwapByClient)):
((ProcessSwap, PageCacheWhenNavigatingFromJS)):
((ProcessSwap, NumberOfPrewarmedProcesses)):
((ProcessSwap, NumberOfCachedProcesses)):
((ProcessSwap, GoBackToSuspendedPageWithMainFrameIDThatIsNotOne)):
((ProcessSwap, NavigateBackAfterNavigatingAwayFromCrossOriginOpenerPolicyUsingBackForwardCache)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ResourceLoadStatistics.mm:
(TEST(ResourceLoadStatistics, BackForwardPerPageData)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolationUtilities.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolationUtilities.mm:
(isUsingBackForwardCache):

Canonical link: <a href="https://commits.webkit.org/309083@main">https://commits.webkit.org/309083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c82e530cd51a7b983f0fd856ac4e5dffab865fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149387 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22100 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158088 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/80d3964d-9a28-43ca-9828-5ac35e624547) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151260 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22554 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21978 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115207 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/46653e9c-0a40-4515-829e-8d33c3f54829) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95953 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2c853d55-0490-492f-ba14-4b46b9aa5de9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16447 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5930 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126048 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160565 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13517 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123244 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21903 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123461 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33551 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21911 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133781 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78129 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18678 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10527 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21513 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85326 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21244 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21394 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21301 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->