### PR TITLE
Obscured content insets may obscure vertical scrollbars

### DIFF
--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -768,9 +768,11 @@ void ScrollView::updateScrollbars(const ScrollPosition& desiredPosition)
         auto horizontalOffset = leftOffset + (shouldPlaceVerticalScrollbarOnLeft() && m_verticalScrollbar ? m_verticalScrollbar->occupiedWidth() : 0.f);
         auto barWidth = width() - (m_verticalScrollbar ? m_verticalScrollbar->occupiedWidth() : 0.f) - leftOffset - rightOffset;
 
+        auto horizontalScrollbarY = height() - m_horizontalScrollbar->height() - contentInsets.bottom();
+
         m_horizontalScrollbar->setFrameRect(roundedIntRect({
             horizontalOffset,
-            static_cast<float>(height() - m_horizontalScrollbar->height()),
+            static_cast<float>(horizontalScrollbarY),
             barWidth,
             static_cast<float>(m_horizontalScrollbar->height())
         }));
@@ -805,8 +807,10 @@ void ScrollView::updateScrollbars(const ScrollPosition& desiredPosition)
 
         auto barHeight = height() - (m_horizontalScrollbar ? m_horizontalScrollbar->occupiedHeight() : 0) - topOffset - bottomOffset;
 
+        auto verticalScrollbarX = isRTL ? contentInsets.left() : width() - m_verticalScrollbar->width() - contentInsets.right();
+
         m_verticalScrollbar->setFrameRect(roundedIntRect({
-            shouldPlaceVerticalScrollbarOnLeft() ? 0.f : width() - m_verticalScrollbar->width(),
+            verticalScrollbarX,
             topOffset,
             static_cast<float>(m_verticalScrollbar->width()),
             barHeight

--- a/Tools/TestWebKitAPI/Tests/mac/ScrollbarTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ScrollbarTests.mm
@@ -411,6 +411,83 @@ TEST(ScrollbarTests, ScrollbarAvoidanceInConcentricContainerWithNonUniformCorner
     runTestCaseWithCornerRadii(container, webView, caseTwo);
 }
 
+TEST(ScrollbarTests, VerticalScrollbarXPositionAccountsForObscuredContentInsets)
+{
+    RetainPtr webView = scrollbarAvoidanceTestWebView();
+
+    [webView synchronouslyLoadHTMLString:@"<body style='height: 2000px;'></body>"];
+    [webView stringByEvaluatingJavaScript:@"internals.setUsesOverlayScrollbars(false)"];
+    [webView waitForNextPresentationUpdate];
+
+    auto frameWidth = [webView frame].size.width;
+
+    auto verticalFrameRect = scrollbarFrameRect(webView.get(), ScrollbarType::Vertical);
+    ASSERT_TRUE(verticalFrameRect);
+
+    auto scrollbarWidth = verticalFrameRect->size.width;
+    EXPECT_EQ(verticalFrameRect->origin.x, frameWidth - scrollbarWidth);
+
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(0, 0, 0, 50)];
+    [webView waitForNextPresentationUpdate];
+
+    verticalFrameRect = scrollbarFrameRect(webView.get(), ScrollbarType::Vertical);
+    ASSERT_TRUE(verticalFrameRect);
+
+    EXPECT_EQ(verticalFrameRect->origin.x, frameWidth - scrollbarWidth - 50);
+
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(0, 0, 0, 0)];
+
+    [webView synchronouslyLoadHTMLString:@"<html dir='rtl'><body style='height: 2000px;'></body></html>"];
+    [webView stringByEvaluatingJavaScript:@"internals.setUsesOverlayScrollbars(false)"];
+    [webView waitForNextPresentationUpdate];
+
+    verticalFrameRect = scrollbarFrameRect(webView.get(), ScrollbarType::Vertical);
+    ASSERT_TRUE(verticalFrameRect);
+
+    EXPECT_EQ(verticalFrameRect->origin.x, 0);
+
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(0, 50, 0, 0)];
+    [webView waitForNextPresentationUpdate];
+
+    verticalFrameRect = scrollbarFrameRect(webView.get(), ScrollbarType::Vertical);
+    ASSERT_TRUE(verticalFrameRect);
+
+    EXPECT_EQ(verticalFrameRect->origin.x, 50);
+
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(0, 0, 0, 0)];
+}
+
+TEST(ScrollbarTests, HorizontalScrollbarYPositionAccountsForObscuredContentInsets)
+{
+    RetainPtr webView = scrollbarAvoidanceTestWebView();
+
+    [webView synchronouslyLoadHTMLString:@"<body style='width: 2000px;'></body>"];
+    [webView stringByEvaluatingJavaScript:@"internals.setUsesOverlayScrollbars(false)"];
+    [webView waitForNextPresentationUpdate];
+
+    auto frameHeight = [webView frame].size.height;
+
+    auto horizontalFrameRect = scrollbarFrameRect(webView.get(), ScrollbarType::Horizontal);
+    EXPECT_TRUE(horizontalFrameRect.has_value());
+    if (!horizontalFrameRect.has_value())
+        return;
+
+    auto scrollbarHeight = horizontalFrameRect->size.height;
+    EXPECT_EQ(horizontalFrameRect->origin.y, frameHeight - scrollbarHeight);
+
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(0, 0, 50, 0)];
+    [webView waitForNextPresentationUpdate];
+
+    horizontalFrameRect = scrollbarFrameRect(webView.get(), ScrollbarType::Horizontal);
+    EXPECT_TRUE(horizontalFrameRect.has_value());
+    if (!horizontalFrameRect.has_value())
+        return;
+
+    EXPECT_EQ(horizontalFrameRect->origin.y, frameHeight - scrollbarHeight - 50);
+
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(0, 0, 0, 0)];
+}
+
 #endif // HAVE(NSVIEW_CORNER_CONFIGURATION)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 6c09de98275732ed84e2bd9859dc3c49732babea
<pre>
Obscured content insets may obscure vertical scrollbars
<a href="https://bugs.webkit.org/show_bug.cgi?id=309639">https://bugs.webkit.org/show_bug.cgi?id=309639</a>
<a href="https://rdar.apple.com/172224593">rdar://172224593</a>

Reviewed by Wenson Hsieh, Abrar Rahman Protyasha, and Aditya Keerthi.

When an obscured content inset exists on the same edge as the
vertical scrollbar, the scrollbar does not shift accordingly.

Shift the vertical scrollbar by the appropriate content
inset amount in ScrollView::updateScrollbars.

Test: Tools/TestWebKitAPI/Tests/mac/ScrollbarTests.mm

* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::updateScrollbars):
* Tools/TestWebKitAPI/Tests/mac/ScrollbarTests.mm:
(TestWebKitAPI::TEST(ScrollbarTests, VerticalScrollbarXPositionAccountsForObscuredContentInsets)):

Canonical link: <a href="https://commits.webkit.org/309072@main">https://commits.webkit.org/309072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73625bc6328f81e90f028c2bdcf98d0ec3ce43dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149287 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157980 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102718 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0066a9b-d013-4668-96b2-b365988f0881) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151160 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115104 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81914 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9ade710-8891-4b63-ba0e-e56346430a6d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95853 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d605faa-d75e-47d6-8e26-ed1fcda0f2d1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16366 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14236 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5829 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125966 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160463 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3458 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13415 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123146 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21803 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18276 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123363 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133679 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78011 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22999 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18594 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10425 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21412 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85225 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21144 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21293 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21201 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->