### PR TITLE
Open a color input with display:none via a label

### DIFF
--- a/LayoutTests/fast/forms/color/display-none-input-color-chooser-shown-expected.txt
+++ b/LayoutTests/fast/forms/color/display-none-input-color-chooser-shown-expected.txt
@@ -1,0 +1,2 @@
+Pick a color
+PASS: Color picker is shown after clicking label for display:none color input

--- a/LayoutTests/fast/forms/color/display-none-input-color-chooser-shown-expected.txt
+++ b/LayoutTests/fast/forms/color/display-none-input-color-chooser-shown-expected.txt
@@ -1,0 +1,3 @@
+Pick a color
+PASS: Color chooser was opened by activating the label of a display:none color input
+PASS: Color chooser was closed after blurring the input

--- a/LayoutTests/fast/forms/color/display-none-input-color-chooser-shown.html
+++ b/LayoutTests/fast/forms/color/display-none-input-color-chooser-shown.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+<input id="colorPick" type="color" />
+<label for="colorPick" id="labelPick">Pick a color</label>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    async function runTest() {
+        if (!window.testRunner || !testRunner.runUIScript) {
+            document.getElementById("result").textContent = "FAIL: test requires testRunner.runUIScript";
+            return;
+        }
+
+        var colorPicker = document.getElementById("colorPick");
+        colorPicker.style.display = "none";
+        await UIHelper.ensurePresentationUpdate();
+
+        var label = document.getElementById("labelPick");
+        await UIHelper.activateElement(label);
+        await UIHelper.waitForColorPickerToPresent();
+        await UIHelper.ensurePresentationUpdate();
+
+        var showing = await UIHelper.isShowingColorPicker();
+        document.getElementById("result").textContent = showing
+            ? "PASS: Color picker is shown after clicking label for display:none color input"
+            : "FAIL: Color picker was not shown";
+
+        testRunner.notifyDone();
+    }
+
+    window.addEventListener("load", runTest, false);
+</script>
+<div id="result"></div>
+</body>
+</html>

--- a/LayoutTests/fast/forms/color/display-none-input-color-chooser-shown.html
+++ b/LayoutTests/fast/forms/color/display-none-input-color-chooser-shown.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+</head>
+<body>
+<input id="colorPick" type="color" />
+<label for="colorPick" id="labelPick">Pick a color</label>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    async function runTest() {
+        const result = document.getElementById("result");
+        if (!window.testRunner || !window.eventSender) {
+            result.textContent = "This test requires testRunner and eventSender.";
+            return;
+        }
+
+        const colorInput = document.getElementById("colorPick");
+        colorInput.style.display = "none";
+        await UIHelper.ensurePresentationUpdate();
+
+        await UIHelper.activateElement(document.getElementById("labelPick"));
+
+        // ColorInputType::showPicker() makes the input match :open, so this checks that the
+        // color chooser was opened. Whether the platform picker stays on screen is not
+        // checked here: on macOS it is a transient NSPopover anchored to the input's rect,
+        // which is empty for a display:none input, so it can be dismissed at any time.
+        const opened = colorInput.matches(":open");
+
+        // End the chooser, so that it is not left up for subsequent tests. The input needs
+        // to be focusable for ColorInputType::elementDidBlur() to run, hence restoring
+        // display before focusing it.
+        colorInput.style.display = "";
+        await UIHelper.ensurePresentationUpdate();
+        colorInput.focus();
+        colorInput.blur();
+        const closed = !colorInput.matches(":open");
+        colorInput.style.display = "none";
+
+        result.textContent = (opened
+            ? "PASS: Color chooser was opened by activating the label of a display:none color input\n"
+            : "FAIL: Color chooser was not opened\n")
+            + (closed
+            ? "PASS: Color chooser was closed after blurring the input"
+            : "FAIL: Color chooser was still open after blurring the input");
+
+        testRunner.notifyDone();
+    }
+
+    window.addEventListener("load", runTest, false);
+</script>
+<pre id="result"></pre>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1498,6 +1498,8 @@ webkit.org/b/296246 imported/w3c/web-platform-tests/event-timing/first-input-int
 webkit.org/b/296246 imported/w3c/web-platform-tests/event-timing/interaction-count-tap.html [ Skip ]
 webkit.org/b/296246 imported/w3c/web-platform-tests/event-timing/TapToStopFling.html [ Skip ]
 
+fast/forms/color/display-none-input-color-chooser-shown.html [ Skip ]
+
 fast/events/domactivate-sets-underlying-click-event-as-handled.html [ Failure Pass ]
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1658,6 +1658,8 @@ imported/w3c/web-platform-tests/dom/events/scrolling/scrollIntoView-in-onscroll-
 imported/w3c/web-platform-tests/dom/events/scrolling/wheel-event-composed.html [ Skip ]
 imported/w3c/web-platform-tests/dom/events/scrolling/wheel-event-no-scroll-after-prevent-default.html [ Skip ]
 
+fast/forms/color/display-none-input-color-chooser-shown.html [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of Events-related bugs
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1513,6 +1513,7 @@ fast/forms/color/color-setrangetext.html [ Skip ] # Failure
 fast/forms/color/input-appearance-color.html [ Skip ] # Failure
 fast/forms/color/input-color-onchange-event.html [ Skip ] # Failure
 fast/forms/color/input-color-readonly.html [ Skip ] # Failure
+fast/forms/color/display-none-input-color-chooser-shown.html [ Skip ] # Crash
 fast/forms/control-clip-overflow.html [ Skip ] # Failure
 fast/forms/control-clip.html [ Skip ] # Failure
 fast/forms/control-restrict-line-height.html [ Skip ] # Failure

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1575,6 +1575,7 @@ fast/forms/color/color-setrangetext.html [ Skip ] # Failure
 fast/forms/color/input-appearance-color.html [ Skip ] # Failure
 fast/forms/color/input-color-onchange-event.html [ Skip ] # Failure
 fast/forms/color/input-color-readonly.html [ Skip ] # Failure
+fast/forms/color/display-none-input-color-chooser-shown.html [ Skip ] # Crash
 fast/forms/control-clip-overflow.html [ Skip ] # Failure
 fast/forms/control-clip.html [ Skip ] # Failure
 fast/forms/control-restrict-line-height.html [ Skip ] # Failure

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2010-2016 Google Inc. All rights reserved.
  * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -249,7 +249,7 @@ void ColorInputType::attributeChanged(const QualifiedName& name)
 void ColorInputType::handleDOMActivateEvent(Event& event)
 {
     ASSERT(element());
-    if (element()->isDisabledFormControl() || !element()->renderer())
+    if (element()->isDisabledFormControl())
         return;
 
     if (!UserGestureIndicator::processingUserGesture())

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2010-2016 Google Inc. All rights reserved.
  * Copyright (C) 2015-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -250,7 +250,7 @@ void ColorInputType::attributeChanged(const QualifiedName& name)
 void ColorInputType::handleDOMActivateEvent(Event& event)
 {
     ASSERT(element());
-    if (element()->isDisabledFormControl() || !element()->renderer())
+    if (element()->isDisabledFormControl())
         return;
 
     if (!UserGestureIndicator::processingUserGesture())


### PR DESCRIPTION
#### cdf87a689ae0bd70eb8fb0a82a40ba79b1d8692c
<pre>
Open a color input with display:none via a label
<a href="https://bugs.webkit.org/show_bug.cgi?id=245449">https://bugs.webkit.org/show_bug.cgi?id=245449</a>
<a href="https://rdar.apple.com/100476630">rdar://100476630</a>

Reviewed by Aditya Keerthi.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/9447bd245501e7f1abb9b51f1420e8ef4f73c4dc">https://chromium.googlesource.com/chromium/src.git/+/9447bd245501e7f1abb9b51f1420e8ef4f73c4dc</a>

This patch fixes bug where the &apos;color&apos; input controls should be able to
accessed via label irrespective of configured with &apos;display:none&apos; (no
renderer).

Test: fast/forms/color/display-none-input-color-chooser-shown.html

* LayoutTests/fast/forms/color/display-none-input-color-chooser-shown-expected.txt: Added.
* LayoutTests/fast/forms/color/display-none-input-color-chooser-shown.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::handleDOMActivateEvent):

Canonical link: <a href="https://commits.webkit.org/318723@main">https://commits.webkit.org/318723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e8504f3ce9aee57ef035aa05f6ec481295f8f9c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/179122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/53061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/46856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/188953 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/143431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/bbadbdcb-7bfb-46b9-a03e-aa46bf8a99ac) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/180985 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/54354 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/52771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/139681 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/143431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/6c50c7a7-d446-4fd0-b6f3-b1053968e447) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/182079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/43283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/160443 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/120128 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/35eb87a3-4553-4625-a527-ed5c08ff5283) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/41954 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/40294 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/152354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/39947 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/259 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/45667 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/44539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/191171 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/52731 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/159960 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/148916 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39962 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/53411 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/36572 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/148662 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/43350 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/125682 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/120499 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/51929 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/14926 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/51314 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/51555 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/51375 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->