### PR TITLE
[JSC] GetById megamorphic IC should handle String too

### DIFF
--- a/JSTests/stress/megamorphic-ic-string-load-invalidate-2.js
+++ b/JSTests/stress/megamorphic-ic-string-load-invalidate-2.js
@@ -1,0 +1,31 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(base) {
+    return base.ok;
+}
+noInline(test);
+String.prototype.ok = 42;
+
+var array = [
+];
+for (var i = 0; i < 16; ++i) {
+    array.push({
+        ["Hello" + i]: i,
+        ok: 42,
+    });
+}
+array.push("Hey");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    for (var v of array)
+        shouldBe(test(v), 42);
+}
+
+shouldBe(test("Hey"), 42);
+delete String.prototype.ok;
+shouldBe(test("Hey"), undefined);
+shouldBe(test("OK"), undefined);
+shouldBe(test(array[0]), 42);

--- a/JSTests/stress/megamorphic-ic-string-load-invalidate.js
+++ b/JSTests/stress/megamorphic-ic-string-load-invalidate.js
@@ -1,0 +1,30 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(base) {
+    return base.ok;
+}
+noInline(test);
+
+Object.prototype.ok = 42;
+
+var array = [
+];
+for (var i = 0; i < 16; ++i) {
+    array.push({
+        ["Hello" + i]: i
+    });
+}
+array.push("Hey");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    for (var v of array)
+        shouldBe(test(v), 42);
+}
+
+shouldBe(test("Hey"), 42);
+String.prototype.ok = 0;
+shouldBe(test("Hey"), 0);
+shouldBe(test("OK"), 0);

--- a/JSTests/stress/megamorphic-ic-string-miss-invalidate.js
+++ b/JSTests/stress/megamorphic-ic-string-miss-invalidate.js
@@ -1,0 +1,28 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test(base) {
+    return base.ok;
+}
+noInline(test);
+
+var array = [
+];
+for (var i = 0; i < 16; ++i) {
+    array.push({
+        ["Hello" + i]: i
+    });
+}
+array.push("Hey");
+
+for (var i = 0; i < testLoopCount; ++i) {
+    for (var v of array)
+        shouldBe(test(v), undefined);
+}
+
+shouldBe(test("Hey"), undefined);
+String.prototype.ok = 42;
+shouldBe(test("Hey"), 42);
+shouldBe(test("OK"), 42);

--- a/JSTests/stress/megamorphic-ic-string.js
+++ b/JSTests/stress/megamorphic-ic-string.js
@@ -1,0 +1,204 @@
+// This test verifies that megamorphic get IC works correctly for string primitive
+// property access (e.g., "hello".substring).
+
+function makeObject(i) {
+    let o = {};
+    // Create many different structure shapes to force megamorphic IC.
+    o["prop" + i] = i;
+    o.common = 42;
+    return o;
+}
+
+// Test 1: String method access through a megamorphic IC site.
+// Mix many object shapes with string accesses at the same IC site.
+function test1() {
+    let objects = [];
+    for (let i = 0; i < 100; i++)
+        objects.push(makeObject(i));
+
+    function access(base) {
+        return base.substring;
+    }
+    noInline(access);
+
+    // Warm up with many different object shapes to make the IC megamorphic.
+    for (let i = 0; i < 100; i++) {
+        for (let j = 0; j < 100; j++)
+            access(objects[j]);
+    }
+
+    // Now access string property through the same megamorphic IC.
+    let str = "hello";
+    for (let i = 0; i < 10000; i++) {
+        let result = access(str);
+        if (typeof result !== "function")
+            throw new Error("Test 1 failed: expected function, got " + typeof result);
+    }
+}
+test1();
+
+// Test 2: Multiple string methods through megamorphic IC sites.
+function test2() {
+    let objects = [];
+    for (let i = 0; i < 100; i++)
+        objects.push(makeObject(i));
+
+    function getCharAt(base) { return base.charAt; }
+    function getIndexOf(base) { return base.indexOf; }
+    function getSlice(base) { return base.slice; }
+    noInline(getCharAt);
+    noInline(getIndexOf);
+    noInline(getSlice);
+
+    // Make ICs megamorphic.
+    for (let i = 0; i < 100; i++) {
+        for (let j = 0; j < 100; j++) {
+            getCharAt(objects[j]);
+            getIndexOf(objects[j]);
+            getSlice(objects[j]);
+        }
+    }
+
+    let str = "hello world";
+    for (let i = 0; i < 10000; i++) {
+        let c = getCharAt(str);
+        let idx = getIndexOf(str);
+        let s = getSlice(str);
+        if (typeof c !== "function" || typeof idx !== "function" || typeof s !== "function")
+            throw new Error("Test 2 failed: expected functions");
+    }
+}
+test2();
+
+// Test 3: Interleaved string and object accesses at the same IC site.
+function test3() {
+    let objects = [];
+    for (let i = 0; i < 100; i++) {
+        let o = makeObject(i);
+        o.substring = i;
+        objects.push(o);
+    }
+
+    function access(base) {
+        return base.substring;
+    }
+    noInline(access);
+
+    // Make IC megamorphic.
+    for (let i = 0; i < 100; i++) {
+        for (let j = 0; j < 100; j++)
+            access(objects[j]);
+    }
+
+    let str = "hello";
+    for (let i = 0; i < 10000; i++) {
+        // Alternate between string and object accesses.
+        let strResult = access(str);
+        if (typeof strResult !== "function")
+            throw new Error("Test 3 failed: string access returned " + typeof strResult);
+
+        let objResult = access(objects[i % 100]);
+        if (typeof objResult !== "number")
+            throw new Error("Test 3 failed: object access returned " + typeof objResult);
+    }
+}
+test3();
+
+// Test 4: Verify correct results after String.prototype modification.
+function test4() {
+    let objects = [];
+    for (let i = 0; i < 100; i++)
+        objects.push(makeObject(i));
+
+    function access(base) {
+        return base.testProp4;
+    }
+    noInline(access);
+
+    // Make IC megamorphic.
+    for (let i = 0; i < 100; i++) {
+        for (let j = 0; j < 100; j++)
+            access(objects[j]);
+    }
+
+    let str = "hello";
+
+    // Should be undefined before adding to prototype.
+    for (let i = 0; i < 1000; i++) {
+        let result = access(str);
+        if (result !== undefined)
+            throw new Error("Test 4 failed: expected undefined before adding, got " + result);
+    }
+
+    // Add a property to String.prototype.
+    String.prototype.testProp4 = "added";
+
+    for (let i = 0; i < 1000; i++) {
+        let result = access(str);
+        if (result !== "added")
+            throw new Error("Test 4 failed: expected 'added', got " + result);
+    }
+
+    // Delete the property.
+    delete String.prototype.testProp4;
+
+    for (let i = 0; i < 1000; i++) {
+        let result = access(str);
+        if (result !== undefined)
+            throw new Error("Test 4 failed: expected undefined after delete, got " + result);
+    }
+}
+test4();
+
+// Test 5: Property from Object.prototype via string.
+function test5() {
+    let objects = [];
+    for (let i = 0; i < 100; i++)
+        objects.push(makeObject(i));
+
+    function access(base) {
+        return base.hasOwnProperty;
+    }
+    noInline(access);
+
+    // Make IC megamorphic.
+    for (let i = 0; i < 100; i++) {
+        for (let j = 0; j < 100; j++)
+            access(objects[j]);
+    }
+
+    let str = "hello";
+    for (let i = 0; i < 10000; i++) {
+        let result = access(str);
+        if (typeof result !== "function")
+            throw new Error("Test 5 failed: expected function, got " + typeof result);
+    }
+}
+test5();
+
+// Test 6: Calling string method through megamorphic IC produces correct result.
+function test6() {
+    let objects = [];
+    for (let i = 0; i < 100; i++)
+        objects.push(makeObject(i));
+
+    function callSubstring(base, start, end) {
+        return base.substring(start, end);
+    }
+    noInline(callSubstring);
+
+    // Make IC megamorphic (access .substring on many shapes).
+    for (let i = 0; i < 100; i++) {
+        for (let j = 0; j < 100; j++) {
+            try { callSubstring(objects[j], 0, 1); } catch (e) { }
+        }
+    }
+
+    let str = "hello world";
+    for (let i = 0; i < 10000; i++) {
+        let result = callSubstring(str, 0, 5);
+        if (result !== "hello")
+            throw new Error("Test 6 failed: expected 'hello', got " + result);
+    }
+}
+test6();

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -2923,18 +2923,31 @@ void InlineCacheCompiler::generateWithGuard(unsigned index, AccessCase& accessCa
         GPRReg scratch2GPR = allocator.allocateScratchGPR();
         GPRReg scratch3GPR = allocator.allocateScratchGPR();
         GPRReg scratch4GPR = allocator.allocateScratchGPR();
+        GPRReg scratch5GPR = allocator.allocateScratchGPR();
 
         ScratchRegisterAllocator::PreservedState preservedState = allocator.preserveReusedRegistersByPushing(jit, ScratchRegisterAllocator::ExtraStackSpace::NoExtraSpace);
 
         CCallHelpers::JumpList slowCases;
+
+        jit.move(baseGPR, scratch5GPR);
+        auto isString = jit.branchIfString(scratch5GPR);
+        auto label = jit.label();
         if (useHandlerIC()) {
             jit.loadPtr(CCallHelpers::Address(GPRInfo::handlerGPR, InlineCacheHandler::offsetOfUid()), scratch4GPR);
-            slowCases.append(jit.loadMegamorphicProperty(vm, baseGPR, scratch4GPR, nullptr, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
+            slowCases.append(jit.loadMegamorphicProperty(vm, scratch5GPR, scratch4GPR, nullptr, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
         } else
-            slowCases.append(jit.loadMegamorphicProperty(vm, baseGPR, InvalidGPRReg, uid, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
+            slowCases.append(jit.loadMegamorphicProperty(vm, scratch5GPR, InvalidGPRReg, uid, valueRegs.payloadGPR(), scratchGPR, scratch2GPR, scratch3GPR));
 
         allocator.restoreReusedRegistersByPopping(jit, preservedState);
         succeed();
+
+        isString.link(jit);
+        if (useHandlerIC()) {
+            jit.loadPtr(CCallHelpers::Address(m_propertyCache.m_propertyCacheGPR, PropertyInlineCache::offsetOfGlobalObject()), scratch5GPR);
+            jit.loadPtr(CCallHelpers::Address(scratch5GPR, JSGlobalObject::offsetOfStringPrototype()), scratch5GPR);
+        } else
+            jit.move(CCallHelpers::TrustedImmPtr(m_globalObject->stringPrototype()), scratch5GPR);
+        jit.jump().linkTo(label, jit);
 
         if (allocator.didReuseRegisters()) {
             slowCases.link(&jit);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -7987,14 +7987,22 @@ void SpeculativeJIT::compileGetByIdMegamorphic(Node* node)
     GPRTemporary scratch1(this);
     GPRTemporary scratch2(this);
     GPRTemporary scratch3(this);
+    GPRTemporary scratch4(this);
 
     GPRReg baseGPR = base.gpr();
     GPRReg scratch1GPR = scratch1.gpr();
     GPRReg scratch2GPR = scratch2.gpr();
     GPRReg scratch3GPR = scratch3.gpr();
+    GPRReg scratch4GPR = scratch4.gpr();
 
     UniquedStringImpl* uid = node->cacheableIdentifier().uid();
-    JumpList slowCases = loadMegamorphicProperty(vm(), baseGPR, InvalidGPRReg, uid, scratch3GPR, scratch1GPR, scratch2GPR, scratch3GPR);
+    JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+
+    move(baseGPR, scratch4GPR);
+    auto notString = branchIfNotString(scratch4GPR);
+    loadLinkableConstant(LinkableConstant(*this, globalObject->stringPrototype()), scratch4GPR);
+    notString.link(this);
+    JumpList slowCases = loadMegamorphicProperty(vm(), scratch4GPR, InvalidGPRReg, uid, scratch3GPR, scratch1GPR, scratch2GPR, scratch3GPR);
     addSlowPathGenerator(slowPathCall(slowCases, this, operationGetByIdMegamorphicGeneric, scratch3GPR, LinkableConstant::globalObject(*this, node), baseGPR, node->cacheableIdentifier().rawBits()));
     jsValueResult(scratch3GPR, node);
 }

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -4416,7 +4416,7 @@ private:
         patchpoint->append(m_notCellMask, ValueRep::lateReg(GPRInfo::notCellMaskRegister));
         patchpoint->append(m_numberTag, ValueRep::lateReg(GPRInfo::numberTagRegister));
         patchpoint->clobber(RegisterSet::macroClobberedGPRs());
-        patchpoint->numGPScratchRegisters = 3;
+        patchpoint->numGPScratchRegisters = 4;
 
         RefPtr<PatchpointExceptionHandle> exceptionHandle = preparePatchpointForExceptions(patchpoint);
 
@@ -4443,8 +4443,13 @@ private:
             GPRReg scratch1GPR = params.gpScratch(0);
             GPRReg scratch2GPR = params.gpScratch(1);
             GPRReg scratch3GPR = params.gpScratch(2);
+            GPRReg scratch4GPR = params.gpScratch(3);
 
-            CCallHelpers::JumpList slowCases = jit.loadMegamorphicProperty(state->vm(), baseGPR, InvalidGPRReg, uid, resultGPR, scratch1GPR, scratch2GPR, scratch3GPR);
+            jit.move(baseGPR, scratch4GPR);
+            auto notString = jit.branchIfNotString(scratch4GPR);
+            jit.move(CCallHelpers::TrustedImmPtr(globalObject->stringPrototype()), scratch4GPR);
+            notString.link(jit);
+            CCallHelpers::JumpList slowCases = jit.loadMegamorphicProperty(state->vm(), scratch4GPR, InvalidGPRReg, uid, resultGPR, scratch1GPR, scratch2GPR, scratch3GPR);
             CCallHelpers::Label doneForSlow = jit.label();
 
             params.addLatePath([=](CCallHelpers& jit) {

--- a/Source/JavaScriptCore/jit/BaselineJITRegisters.h
+++ b/Source/JavaScriptCore/jit/BaselineJITRegisters.h
@@ -156,10 +156,11 @@ namespace GetById {
     static constexpr GPRReg scratch2GPR { scratchRegisters[1] };
     static constexpr GPRReg scratch3GPR { scratchRegisters[2] };
     static constexpr GPRReg scratch4GPR { scratchRegisters[3] };
+    static constexpr GPRReg scratch5GPR { scratchRegisters[4] };
 
     static_assert(noOverlap(baseJSR, propertyCacheGPR), "Required for DataIC");
     static_assert(noOverlap(resultJSR, propertyCacheGPR));
-    static_assert(noOverlap(baseJSR, propertyCacheGPR, scratch1GPR, scratch2GPR, scratch3GPR, scratch4GPR), "Required for HandlerIC");
+    static_assert(noOverlap(baseJSR, propertyCacheGPR, scratch1GPR, scratch2GPR, scratch3GPR, scratch4GPR, scratch5GPR), "Required for HandlerIC");
 }
 
 namespace GetByIdWithThis {

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -404,18 +404,23 @@ static ALWAYS_INLINE JSValue getByIdMegamorphic(JSGlobalObject* globalObject, VM
     auto* uid = identifier.uid();
     PropertySlot slot(thisValue, PropertySlot::InternalMethodType::Get);
 
+    JSObject* baseObject = nullptr;
     if (!baseValue.isObject()) [[unlikely]] {
-        if (propertyCache && propertyCache->considerRepatchingCacheMegamorphic(vm))
-            repatchGetBySlowPathCall(callFrame->codeBlock(), *propertyCache, kind);
-        return baseValue.get(globalObject, uid, slot);
-    }
+        if (!baseValue.isString()) [[unlikely]] {
+            if (propertyCache && propertyCache->considerRepatchingCacheMegamorphic(vm))
+                repatchGetBySlowPathCall(callFrame->codeBlock(), *propertyCache, kind);
+            return baseValue.get(globalObject, uid, slot);
+        }
 
-    JSObject* baseObject = asObject(baseValue);
+        baseObject = globalObject->stringPrototype();
+    } else
+        baseObject = asObject(baseValue);
+
     JSObject* object = baseObject;
     bool shouldGiveUp = false;
     bool cacheable = true;
     while (true) {
-        if (TypeInfo::overridesGetOwnPropertySlot(object->inlineTypeFlags()) && object->type() != ArrayType && object->type() != JSFunctionType && object != globalObject->arrayPrototype()) [[unlikely]] {
+        if (TypeInfo::overridesGetOwnPropertySlot(object->inlineTypeFlags()) && object->type() != ArrayType && object->type() != JSFunctionType && object->type() != DerivedStringObjectType && object != globalObject->arrayPrototype()) [[unlikely]] {
             if (propertyCache && propertyCache->considerRepatchingCacheMegamorphic(vm))
                 repatchGetBySlowPathCall(callFrame->codeBlock(), *propertyCache, kind);
             if (object->getNonIndexPropertySlot(globalObject, uid, slot))
@@ -433,7 +438,7 @@ static ALWAYS_INLINE JSValue getByIdMegamorphic(JSGlobalObject* globalObject, VM
         if (hasProperty) {
             if (cacheable && slot.isCacheableValue() && slot.cachedOffset() <= MegamorphicCache::maxOffset) [[likely]] {
                 if (slot.slotBase() == baseObject || !baseObject->structure()->isDictionary())
-                    vm.megamorphicCache()->initAsHit(baseObject->structureID(), uid, slot.slotBase(), slot.cachedOffset(), slot.slotBase() == baseObject);
+                    vm.megamorphicCache()->initAsHit(baseObject->structureID(), uid, slot.slotBase(), slot.cachedOffset(), slot.slotBase() == thisValue);
                 else {
                     if (baseObject->structure()->hasBeenFlattenedBefore()) [[unlikely]] {
                         if (propertyCache && propertyCache->considerRepatchingCacheMegamorphic(vm))

--- a/Source/JavaScriptCore/runtime/BigIntPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/BigIntPrototype.cpp
@@ -70,6 +70,7 @@ void BigIntPrototype::finishCreation(VM& vm, JSGlobalObject*)
     Base::finishCreation(vm);
     ASSERT(inherits(info()));
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+    structure()->setMayBePrototype(true);
 }
 
 // ------------------------------ Functions ---------------------------

--- a/Source/JavaScriptCore/runtime/BooleanPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/BooleanPrototype.cpp
@@ -57,6 +57,7 @@ void BooleanPrototype::finishCreation(VM& vm, JSGlobalObject*)
     setInternalValue(vm, jsBoolean(false));
 
     ASSERT(inherits(info()));
+    structure()->setMayBePrototype(true);
 }
 
 // ------------------------------ Functions ---------------------------

--- a/Source/JavaScriptCore/runtime/NumberPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/NumberPrototype.cpp
@@ -84,6 +84,7 @@ void NumberPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     putDirectWithoutTransition(vm, vm.propertyNames->toString, globalObject->numberProtoToStringFunction(), static_cast<unsigned>(PropertyAttribute::DontEnum));
     ASSERT(inherits(info()));
     globalObject->installNumberPrototypeWatchpoint(this);
+    structure()->setMayBePrototype(true);
 }
 
 // ------------------------------ Functions ---------------------------

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -188,6 +188,8 @@ void StringPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->toWellFormed, stringProtoFuncToWellFormed, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
 
     // The constructor will be added later, after StringConstructor has been built
+
+    structure()->setMayBePrototype(true);
 }
 
 StringPrototype* StringPrototype::create(VM& vm, JSGlobalObject* globalObject, Structure* structure)

--- a/Source/JavaScriptCore/runtime/SymbolPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SymbolPrototype.cpp
@@ -66,6 +66,7 @@ void SymbolPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSFunction* toPrimitiveFunction = JSFunction::create(vm, globalObject, 1, "[Symbol.toPrimitive]"_s, symbolProtoFuncValueOf, ImplementationVisibility::Public);
     putDirectWithoutTransition(vm, vm.propertyNames->toPrimitiveSymbol, toPrimitiveFunction, PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();
+    structure()->setMayBePrototype(true);
 }
 
 // ------------------------------ Functions ---------------------------


### PR DESCRIPTION
#### 65d02142320f137310829f11c8522761c1cb9725
<pre>
[JSC] GetById megamorphic IC should handle String too
<a href="https://bugs.webkit.org/show_bug.cgi?id=309646">https://bugs.webkit.org/show_bug.cgi?id=309646</a>
<a href="https://rdar.apple.com/172251161">rdar://172251161</a>

Reviewed by Yijia Huang.

This patch extends megamorphic GetById IC to accept String as a base
value. We found a case that we are giving up when we encounter a String
cell as a base value in the megamorphic IC. To achieve that we load
String.prototype when base value is a String and starting with that. But
operation function should take original String as a base since we may
call getter etc. which should have the original String as a |this|
value.

Test: JSTests/stress/megamorphic-ic-string.js
* JSTests/stress/megamorphic-ic-string.js: Added.
(makeObject):
(test1.access):
(test1):
(test2.getCharAt):
(test2.getIndexOf):
(test2.getSlice):
(test2):
(test3.access):
(test3):
(test4.access):
(test4):
(test5.access):
(test5):
(test6.callSubstring):
(test6):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::getByIdMegamorphic):
* Source/JavaScriptCore/runtime/BigIntPrototype.cpp:
(JSC::BigIntPrototype::finishCreation):
* Source/JavaScriptCore/runtime/BooleanPrototype.cpp:
(JSC::BooleanPrototype::finishCreation):
* Source/JavaScriptCore/runtime/NumberPrototype.cpp:
(JSC::NumberPrototype::finishCreation):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::StringPrototype::finishCreation):
* Source/JavaScriptCore/runtime/SymbolPrototype.cpp:
(JSC::SymbolPrototype::finishCreation):

Canonical link: <a href="https://commits.webkit.org/309095@main">https://commits.webkit.org/309095@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4fb2f8e901a79fb226b879c716d25e8e70ff1cf6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15615 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158028 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102763 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6f04741-c196-45cc-8003-c3aa3cefed3b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21923 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115149 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81928 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133996 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95897 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d2bd8f8-96fa-462c-b21b-67ec469b255b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16405 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14284 "Found 1 new API test failure: TestWebKitAPI.DeviceScaleFactorOnBack.WebKit2 (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5875 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141302 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160510 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10123 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3503 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13465 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123190 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123407 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21856 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133729 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78073 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23009 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18642 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10475 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180761 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21458 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85271 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46318 "Build was cancelled. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21189 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21338 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21246 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->