### PR TITLE
REGRESSION(300558@main): Sometimes referrer is missing after PSON

### DIFF
--- a/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy-expected.txt
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy-expected.txt
@@ -1,0 +1,3 @@
+Tests that a cross-origin navigation via PSON does not inherit the previous page's no-referrer policy.
+
+PASS: Referrer should not be empty after PSON (got: "http://127.0.0.1:8000/")

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="referrer" content="no-referrer">
+</head>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+var channel = new BroadcastChannel("referrer-policy-pson-test");
+channel.onmessage = function(e) {
+    channel.close();
+    var referrer = e.data;
+    var passed = referrer.length > 0;
+    document.body.innerHTML = "<p>Tests that a cross-origin navigation via PSON does not inherit the previous page's no-referrer policy.</p>"
+        + (passed ? "PASS" : "FAIL") + ": Referrer should not be empty after PSON (got: \"" + referrer + "\")\n";
+    if (window.testRunner)
+        testRunner.notifyDone();
+};
+
+window.open("http://127.0.0.1:8000/referrer-policy/no-referrer/resources/navigate-cross-origin.html", "_blank", "noopener");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/resources/check-referrer-policy-not-inherited.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/resources/check-referrer-policy-not-inherited.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+// On 127.0.0.1:8000 after two PSON navigations from a noopener window whose
+// opener had Referrer-Policy: no-referrer. This page should NOT inherit that
+// policy. Load a cross-origin script from localhost:8000; if the referrer
+// policy was correctly NOT inherited, the request will include a Referer header.
+function checkReferrer(referrer) {
+    var channel = new BroadcastChannel("referrer-policy-pson-test");
+    channel.postMessage(referrer);
+    channel.close();
+}
+</script>
+<script src="http://localhost:8000/referrer-policy/resources/script.py"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-back-cross-origin.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-back-cross-origin.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+// On localhost:8000. Navigate cross-origin to 127.0.0.1:8000 (PSON #2).
+window.location = "http://127.0.0.1:8000/referrer-policy/no-referrer/resources/check-referrer-policy-not-inherited.html";
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-cross-origin.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-cross-origin.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+// On 127.0.0.1:8000. Navigate cross-origin to localhost:8000 (PSON #1).
+window.location = "http://localhost:8000/referrer-policy/no-referrer/resources/navigate-back-cross-origin.html";
+</script>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -126,13 +126,16 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>
         ASSERT(&suspendedPage->process() == process.ptr());
         suspendedPage->unsuspend();
         m_mainFrame = suspendedPage->mainFrame();
+        m_mainFrame->updateReferrerPolicy(ReferrerPolicy::EmptyString);
         m_needsMainFrameObserver = true;
-    } else if (m_shouldReuseMainFrame)
+    } else if (m_shouldReuseMainFrame) {
         m_mainFrame = page.mainFrame();
+        m_mainFrame->updateReferrerPolicy(ReferrerPolicy::EmptyString);
+    }
     else {
         // Passing previous frame's url to restore the main frame's committed URL
         // as some clients may rely on it until the next load is committed.
-        Ref mainFrame = WebFrameProxy::create(page, m_frameProcess, generateFrameIdentifier(), previousMainFrame->effectiveSandboxFlags(), previousMainFrame->effectiveReferrerPolicy(), previousMainFrame->scrollingMode(), nullptr, nullptr, IsMainFrame::Yes, previousMainFrame->url());
+        Ref mainFrame = WebFrameProxy::create(page, m_frameProcess, generateFrameIdentifier(), previousMainFrame->effectiveSandboxFlags(), ReferrerPolicy::EmptyString, previousMainFrame->scrollingMode(), nullptr, nullptr, IsMainFrame::Yes, previousMainFrame->url());
         m_mainFrame = mainFrame.copyRef();
         m_needsMainFrameObserver = true;
         previousMainFrame->transferNavigationCallbackToFrame(mainFrame);


### PR DESCRIPTION
#### 5f3fc7d0c66108cb1c1dea780ef44367ee36adcf
<pre>
REGRESSION(<a href="https://commits.webkit.org/300558@main">300558@main</a>): Sometimes referrer is missing after PSON
<a href="https://bugs.webkit.org/show_bug.cgi?id=309645">https://bugs.webkit.org/show_bug.cgi?id=309645</a>
&lt;<a href="https://rdar.apple.com/169006635">rdar://169006635</a>&gt;

Reviewed by NOBODY (OOPS!).

When a page with `Referrer-Policy: no-referrer` opens a new window, the `no-referrer` policy
incorrectly persists across cross-origin navigations in the new window, even though each new
document should start with the default referrer policy. This causes authentication failures
in some websites because the Referer header is stripped from subsequent navigation requests.

<a href="https://commits.webkit.org/300558@main">300558@main</a> changed `ProvisionalPageProxy` to copy `effectiveReferrerPolicy` when creating
a new main frame during PSON (process-swap on navigation). Before this commit, the new frame
got `ReferrerPolicy::EmptyString` (the default).

This PR fixes the bug by changing the line 133 in `ProvisionalPageProxy.cpp` by replacing
`previousMainFrame-&gt;effectiveReferrerPolicy()` with `ReferrerPolicy::EmptyString` so that it
resets the referrer policy when navigating a main frame.

The analysis and test co-authored with Claude AI.

Test: http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy.html

* LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy-expected.txt: Added.
* LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy.html: Added.
* LayoutTests/http/tests/referrer-policy/no-referrer/resources/check-referrer-policy-not-inherited.html: Added.
* LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-back-cross-origin.html: Added.
* LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-cross-origin.html: Added.
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f3fc7d0c66108cb1c1dea780ef44367ee36adcf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149467 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15763 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158169 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102899 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0472c22f-bf6c-451e-8a68-5f21535c7ea6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22062 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115282 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81985 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0138f718-778d-475e-b374-a97cc5893820) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17419 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134123 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96018 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84441b41-bc16-4e3c-a4e9-f1590be1aaf1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16515 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14409 "Found 1 new API test failure: TestWebKitAPI.WebKit.PreferenceChanges (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6012 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160646 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3640 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123308 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123521 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21995 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133848 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78209 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18721 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10599 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21595 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85416 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21326 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21478 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21383 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->