### PR TITLE
Partial revert of 309031@main to address Swift compiler crashes

### DIFF
--- a/Source/WebGPU/WebGPU/Adapter.mm
+++ b/Source/WebGPU/WebGPU/Adapter.mm
@@ -154,7 +154,7 @@ size_t wgpuAdapterEnumerateFeatures(WGPUAdapter adapter, WGPUFeatureName* featur
 
 WGPUBool wgpuAdapterGetLimits(WGPUAdapter adapter, WGPUSupportedLimits* limits)
 {
-    return WebGPU::fromAPI(adapter).getLimits(*limits);
+    return protect(WebGPU::fromAPI(adapter))->getLimits(*limits);
 }
 
 void wgpuAdapterGetProperties(WGPUAdapter adapter, WGPUAdapterProperties* properties)
@@ -183,5 +183,5 @@ void wgpuAdapterRequestDeviceWithBlock(WGPUAdapter adapter, WGPUDeviceDescriptor
 
 WGPUBool wgpuAdapterXRCompatible(WGPUAdapter adapter)
 {
-    return WebGPU::fromAPI(adapter).isXRCompatible();
+    return protect(WebGPU::fromAPI(adapter))->isXRCompatible();
 }

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -252,7 +252,7 @@ void Buffer::destroy()
     setState(State::Destroyed);
     m_device->makeSubmitInvalidClearingEncoders(m_commandEncoders);
     m_device->removeBufferFromCache(m_buffer.gpuAddress);
-    m_buffer = m_device->placeholderBuffer();
+    m_buffer = protect(m_device)->placeholderBuffer();
 }
 
 bool Buffer::validateGetMappedRange(size_t offset, size_t rangeSize) const
@@ -421,7 +421,7 @@ void Buffer::unmap()
 {
     // https://gpuweb.github.io/gpuweb/#dom-gpubuffer-unmap
 
-    if (!validateUnmap() && !m_device->isValid())
+    if (!validateUnmap() && !protect(m_device)->isValid())
         return;
 
     decrementBufferMapCount();
@@ -509,7 +509,7 @@ static bool verifyIndexBufferData(id<MTLBuffer> buffer, uint32_t firstIndex, uin
 void Buffer::takeSlowIndexValidationPath(CommandBuffer& commandBuffer, uint32_t firstIndex, uint32_t indexCount, MTLIndexType indexType, uint32_t primitiveOffset, uint32_t vertexCount)
 {
     WTFLogAlways("WARNING: Severe performance penalty due to encoding drawIndexed calls out of order with submission"); // NOLINT
-    Ref queue = m_device->getQueue();
+    Ref queue = protect(m_device)->getQueue();
     queue->waitForAllCommitedWorkToComplete();
     queue->synchronizeResourceAndWait(m_buffer);
     bool verified = false;
@@ -537,7 +537,7 @@ void Buffer::takeSlowIndexValidationPath(CommandBuffer& commandBuffer, uint32_t 
 void Buffer::takeSlowIndirectIndexValidationPath(CommandBuffer& commandBuffer, Buffer& apiIndexBuffer, MTLIndexType indexType, uint32_t indexBufferOffsetInBytes, uint32_t indirectOffset, uint32_t minVertexCount, MTLPrimitiveType primitiveType)
 {
     WTFLogAlways("WARNING: Severe performance penalty due to encoding drawIndexedIndirect calls out of order with submission"); // NOLINT
-    Ref queue = m_device->getQueue();
+    Ref queue = protect(m_device)->getQueue();
     queue->waitForAllCommitedWorkToComplete();
     queue->synchronizeResourceAndWait(m_buffer);
     if (m_buffer.length < indexBufferOffsetInBytes + sizeof(MTLDrawIndexedPrimitivesIndirectArguments))
@@ -580,7 +580,7 @@ static bool NODELETE verifyIndirectBufferData(MTLDrawPrimitivesIndirectArguments
 void Buffer::takeSlowIndirectValidationPath(CommandBuffer& commandBuffer, uint64_t indirectOffset, uint32_t minVertexCount, uint32_t minInstanceCount)
 {
     WTFLogAlways("WARNING: Severe performance penalty due to encoding drawIndirect calls out of order with submission"); // NOLINT
-    Ref queue = m_device->getQueue();
+    Ref queue = protect(m_device)->getQueue();
     queue->waitForAllCommitedWorkToComplete();
     queue->synchronizeResourceAndWait(m_buffer);
     auto bufferSubData = span<MTLDrawPrimitivesIndirectArguments>(m_buffer, indirectOffset);
@@ -782,7 +782,7 @@ void wgpuBufferDestroy(WGPUBuffer buffer)
 
 WGPUBufferMapState wgpuBufferGetMapState(WGPUBuffer buffer)
 {
-    switch (WebGPU::fromAPI(buffer).state()) {
+    switch (protect(WebGPU::fromAPI(buffer))->state()) {
     case WebGPU::Buffer::State::Mapped:
         return WGPUBufferMapState_Mapped;
     case WebGPU::Buffer::State::MappedAtCreation:
@@ -808,7 +808,7 @@ std::span<uint8_t> wgpuBufferGetBufferContents(WGPUBuffer buffer)
 
 uint64_t wgpuBufferGetInitialSize(WGPUBuffer buffer)
 {
-    return WebGPU::fromAPI(buffer).initialSize();
+    return protect(WebGPU::fromAPI(buffer))->initialSize();
 }
 
 uint64_t wgpuBufferGetCurrentSize(WGPUBuffer buffer)
@@ -842,7 +842,7 @@ void wgpuBufferSetLabel(WGPUBuffer buffer, const char* label)
 
 WGPUBufferUsageFlags wgpuBufferGetUsage(WGPUBuffer buffer)
 {
-    return WebGPU::fromAPI(buffer).usage();
+    return protect(WebGPU::fromAPI(buffer))->usage();
 }
 
 void NODELETE wgpuBufferCopy(WGPUBuffer buffer, std::span<const uint8_t> data, size_t offset)

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -201,7 +201,7 @@ id<MTLBlitCommandEncoder> CommandEncoder::ensureBlitCommandEncoder()
         finalizeBlitCommandEncoder();
     }
 
-    if (!m_device->isValid())
+    if (!protect(m_device)->isValid())
         return nil;
 
     MTLBlitPassDescriptor *descriptor = [MTLBlitPassDescriptor new];
@@ -995,7 +995,7 @@ NSString* CommandEncoder::errorValidatingCopyBufferToTexture(const WGPUImageCopy
             return ERROR_STRING(@"source.layout.offset is not a multiple of four for depth stencil format");
     }
 
-    if (NSString* errorString = Texture::errorValidatingLinearTextureData(source.layout, fromAPI(source.buffer).initialSize(), aspectSpecificFormat, copySize))
+    if (NSString* errorString = Texture::errorValidatingLinearTextureData(source.layout, protect(fromAPI(source.buffer))->initialSize(), aspectSpecificFormat, copySize))
         return ERROR_STRING(errorString);
 #undef ERROR_STRING
     return nil;
@@ -1289,7 +1289,7 @@ NSString* CommandEncoder::errorValidatingCopyTextureToBuffer(const WGPUImageCopy
     if (NSString* error = errorValidatingImageCopyBuffer(destination))
         return ERROR_STRING(error);
 
-    if (!(fromAPI(destination.buffer).usage() & WGPUBufferUsage_CopyDst))
+    if (!(protect(fromAPI(destination.buffer))->usage() & WGPUBufferUsage_CopyDst))
         return ERROR_STRING(@"destination buffer usage does not contain CopyDst");
 
     if (NSString* error = Texture::errorValidatingTextureCopyRange(source, copySize))
@@ -1306,7 +1306,7 @@ NSString* CommandEncoder::errorValidatingCopyTextureToBuffer(const WGPUImageCopy
             return ERROR_STRING(@"destination.layout.offset is not a multiple of 4");
     }
 
-    if (NSString* errorString = Texture::errorValidatingLinearTextureData(destination.layout, fromAPI(destination.buffer).initialSize(), aspectSpecificFormat, copySize))
+    if (NSString* errorString = Texture::errorValidatingLinearTextureData(destination.layout, protect(fromAPI(destination.buffer))->initialSize(), aspectSpecificFormat, copySize))
         return ERROR_STRING(errorString);
 #undef ERROR_STRING
     return nil;
@@ -1827,7 +1827,7 @@ NSString* CommandEncoder::errorValidatingCopyTextureToTexture(const WGPUImageCop
     if (source.texture == destination.texture) {
         // Mip levels are never ranges.
         if (source.mipLevel == destination.mipLevel) {
-            switch (fromAPI(source.texture).dimension()) {
+            switch (protect(fromAPI(source.texture))->dimension()) {
             case WGPUTextureDimension_1D:
                 return ERROR_STRING(@"can't copy 1D texture to itself");
             case WGPUTextureDimension_2D: {

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -447,7 +447,7 @@ void ComputePassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup* grou
 {
     RETURN_IF_FINISHED();
 
-    auto dynamicOffsetCount = (groupPtr && groupPtr->bindGroupLayout()) ? groupPtr->bindGroupLayout()->dynamicBufferCount() : 0;
+    auto dynamicOffsetCount = (groupPtr && groupPtr->bindGroupLayout()) ? protect(groupPtr->bindGroupLayout())->dynamicBufferCount() : 0;
     if (groupIndex >= m_device->limits().maxBindGroups || (dynamicOffsets && dynamicOffsetCount != dynamicOffsets->size())) {
         makeInvalid(@"GPUComputePassEncoder.setBindGroup: groupIndex >= limits.maxBindGroups");
         return;

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -246,5 +246,5 @@ WGPUBindGroupLayout wgpuComputePipelineGetBindGroupLayout(WGPUComputePipeline co
 
 void wgpuComputePipelineSetLabel(WGPUComputePipeline computePipeline, const char* label)
 {
-    WebGPU::fromAPI(computePipeline).setLabel(WebGPU::fromAPI(label));
+    protect(WebGPU::fromAPI(computePipeline))->setLabel(WebGPU::fromAPI(label));
 }

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -1135,7 +1135,7 @@ WGPUComputePipeline wgpuDeviceCreateComputePipeline(WGPUDevice device, const WGP
 
 void wgpuDevicePauseErrorReporting(WGPUDevice device, WGPUBool pauseErrors)
 {
-    WebGPU::fromAPI(device).pauseErrorReporting(!!pauseErrors);
+    protect(WebGPU::fromAPI(device))->pauseErrorReporting(!!pauseErrors);
 }
 
 void wgpuDeviceCreateComputePipelineAsync(WGPUDevice device, const WGPUComputePipelineDescriptor* descriptor, WGPUCreateComputePipelineAsyncCallback callback, void* userdata)
@@ -1223,12 +1223,12 @@ size_t wgpuDeviceEnumerateFeatures(WGPUDevice device, WGPUFeatureName* features)
 
 WGPUBool wgpuDeviceGetLimits(WGPUDevice device, WGPUSupportedLimits* limits)
 {
-    return WebGPU::fromAPI(device).getLimits(*limits);
+    return protect(WebGPU::fromAPI(device))->getLimits(*limits);
 }
 
 WGPUQueue wgpuDeviceGetQueue(WGPUDevice device)
 {
-    return &WebGPU::fromAPI(device).getQueueReference();
+    return &protect(WebGPU::fromAPI(device))->getQueueReference();
 }
 
 WGPUBool wgpuDeviceHasFeature(WGPUDevice device, WGPUFeatureName feature)
@@ -1298,5 +1298,5 @@ void wgpuDeviceSetUncapturedErrorCallbackWithBlock(WGPUDevice device, WGPUErrorB
 
 void wgpuDeviceSetLabel(WGPUDevice device, const char* label)
 {
-    WebGPU::fromAPI(device).setLabel(WebGPU::fromAPI(label));
+    protect(WebGPU::fromAPI(device))->setLabel(WebGPU::fromAPI(label));
 }

--- a/Source/WebGPU/WebGPU/Instance.mm
+++ b/Source/WebGPU/WebGPU/Instance.mm
@@ -273,57 +273,57 @@ void wgpuInstanceRequestAdapterWithBlock(WGPUInstance instance, WGPURequestAdapt
 // Fuzzer things
 WGPUBool wgpuBufferIsValid(WGPUBuffer buffer)
 {
-    return WebGPU::fromAPI(buffer).isValid();
+    return protect(WebGPU::fromAPI(buffer))->isValid();
 }
 
 WGPUBool wgpuAdapterIsValid(WGPUAdapter adapter)
 {
-    return WebGPU::fromAPI(adapter).isValid();
+    return protect(WebGPU::fromAPI(adapter))->isValid();
 }
 
 WGPUBool wgpuBindGroupIsValid(WGPUBindGroup bindGroup)
 {
-    return WebGPU::fromAPI(bindGroup).isValid();
+    return protect(WebGPU::fromAPI(bindGroup))->isValid();
 }
 
 WGPUBool wgpuBindGroupLayoutIsValid(WGPUBindGroupLayout bindGroupLayout)
 {
-    return WebGPU::fromAPI(bindGroupLayout).isValid();
+    return protect(WebGPU::fromAPI(bindGroupLayout))->isValid();
 }
 
 WGPUBool wgpuCommandBufferIsValid(WGPUCommandBuffer commandBuffer)
 {
-    return WebGPU::fromAPI(commandBuffer).isValid();
+    return protect(WebGPU::fromAPI(commandBuffer))->isValid();
 }
 
 WGPUBool wgpuCommandEncoderIsValid(WGPUCommandEncoder commandEncoder)
 {
-    return WebGPU::fromAPI(commandEncoder).isValid();
+    return protect(WebGPU::fromAPI(commandEncoder))->isValid();
 }
 
 WGPUBool wgpuComputePassEncoderIsValid(WGPUComputePassEncoder computePassEncoder)
 {
-    return WebGPU::fromAPI(computePassEncoder).isValid();
+    return protect(WebGPU::fromAPI(computePassEncoder))->isValid();
 }
 
 WGPUBool wgpuComputePipelineIsValid(WGPUComputePipeline computePipeline)
 {
-    return WebGPU::fromAPI(computePipeline).isValid();
+    return protect(WebGPU::fromAPI(computePipeline))->isValid();
 }
 
 WGPUBool wgpuDeviceIsValid(WGPUDevice device)
 {
-    return WebGPU::fromAPI(device).isValid();
+    return protect(WebGPU::fromAPI(device))->isValid();
 }
 
 WGPUBool wgpuExternalTextureIsValid(WGPUExternalTexture externalTexture)
 {
-    return WebGPU::fromAPI(externalTexture).isValid();
+    return protect(WebGPU::fromAPI(externalTexture))->isValid();
 }
 
 WGPUBool wgpuPipelineLayoutIsValid(WGPUPipelineLayout pipelineLayout)
 {
-    return WebGPU::fromAPI(pipelineLayout).isValid();
+    return protect(WebGPU::fromAPI(pipelineLayout))->isValid();
 }
 
 WGPUBool wgpuPresentationContextIsValid(WGPUSurface presentationContext)
@@ -333,70 +333,70 @@ WGPUBool wgpuPresentationContextIsValid(WGPUSurface presentationContext)
 
 WGPUBool wgpuQuerySetIsValid(WGPUQuerySet querySet)
 {
-    return WebGPU::fromAPI(querySet).isValid();
+    return protect(WebGPU::fromAPI(querySet))->isValid();
 }
 
 WGPUBool wgpuQueueIsValid(WGPUQueue queue)
 {
-    return WebGPU::fromAPI(queue).isValid();
+    return protect(WebGPU::fromAPI(queue))->isValid();
 }
 
 WGPUBool wgpuRenderBundleEncoderIsValid(WGPURenderBundleEncoder renderBundleEncoder)
 {
-    return WebGPU::fromAPI(renderBundleEncoder).isValid();
+    return protect(WebGPU::fromAPI(renderBundleEncoder))->isValid();
 }
 
 WGPUBool wgpuRenderBundleIsValid(WGPURenderBundle renderBundle)
 {
-    return WebGPU::fromAPI(renderBundle).isValid();
+    return protect(WebGPU::fromAPI(renderBundle))->isValid();
 }
 
 WGPUBool wgpuRenderPassEncoderIsValid(WGPURenderPassEncoder renderPassEncoder)
 {
-    return WebGPU::fromAPI(renderPassEncoder).isValid();
+    return protect(WebGPU::fromAPI(renderPassEncoder))->isValid();
 }
 
 WGPUBool wgpuRenderPipelineIsValid(WGPURenderPipeline renderPipeline)
 {
-    return WebGPU::fromAPI(renderPipeline).isValid();
+    return protect(WebGPU::fromAPI(renderPipeline))->isValid();
 }
 
 WGPUBool wgpuSamplerIsValid(WGPUSampler sampler)
 {
-    return WebGPU::fromAPI(sampler).isValid();
+    return protect(WebGPU::fromAPI(sampler))->isValid();
 }
 
 WGPUBool wgpuShaderModuleIsValid(WGPUShaderModule shaderModule)
 {
-    return WebGPU::fromAPI(shaderModule).isValid();
+    return protect(WebGPU::fromAPI(shaderModule))->isValid();
 }
 
 WGPUBool wgpuTextureIsValid(WGPUTexture texture)
 {
-    return WebGPU::fromAPI(texture).isValid();
+    return protect(WebGPU::fromAPI(texture))->isValid();
 }
 
 WGPUBool wgpuTextureViewIsValid(WGPUTextureView textureView)
 {
-    return WebGPU::fromAPI(textureView).isValid();
+    return protect(WebGPU::fromAPI(textureView))->isValid();
 }
 
 WGPUBool wgpuXRBindingIsValid(WGPUXRBinding binding)
 {
-    return WebGPU::fromAPI(binding).isValid();
+    return protect(WebGPU::fromAPI(binding))->isValid();
 }
 
 WGPUBool wgpuXRSubImageIsValid(WGPUXRSubImage subImage)
 {
-    return WebGPU::fromAPI(subImage).isValid();
+    return protect(WebGPU::fromAPI(subImage))->isValid();
 }
 
 WGPUBool wgpuXRProjectionLayerIsValid(WGPUXRProjectionLayer layer)
 {
-    return WebGPU::fromAPI(layer).isValid();
+    return protect(WebGPU::fromAPI(layer))->isValid();
 }
 
 WGPUBool wgpuXRViewIsValid(WGPUXRView view)
 {
-    return WebGPU::fromAPI(view).isValid();
+    return protect(WebGPU::fromAPI(view))->isValid();
 }

--- a/Source/WebGPU/WebGPU/PipelineLayout.mm
+++ b/Source/WebGPU/WebGPU/PipelineLayout.mm
@@ -379,5 +379,5 @@ void wgpuPipelineLayoutRelease(WGPUPipelineLayout pipelineLayout)
 
 void wgpuPipelineLayoutSetLabel(WGPUPipelineLayout pipelineLayout, const char* label)
 {
-    WebGPU::fromAPI(pipelineLayout).setLabel(WebGPU::fromAPI(label));
+    protect(WebGPU::fromAPI(pipelineLayout))->setLabel(WebGPU::fromAPI(label));
 }

--- a/Source/WebGPU/WebGPU/PresentationContext.mm
+++ b/Source/WebGPU/WebGPU/PresentationContext.mm
@@ -103,7 +103,7 @@ void wgpuSwapChainRelease(WGPUSwapChain swapChain)
 
 WGPUTextureFormat wgpuSurfaceGetPreferredFormat(WGPUSurface surface, WGPUAdapter adapter)
 {
-    return WebGPU::fromAPI(surface).getPreferredFormat(WebGPU::fromAPI(adapter));
+    return protect(WebGPU::fromAPI(surface))->getPreferredFormat(protect(WebGPU::fromAPI(adapter)));
 }
 
 WGPUTexture wgpuSwapChainGetCurrentTexture(WGPUSwapChain swapChain, uint32_t index)

--- a/Source/WebGPU/WebGPU/QuerySet.mm
+++ b/Source/WebGPU/WebGPU/QuerySet.mm
@@ -253,10 +253,10 @@ void wgpuQuerySetSetLabel(WGPUQuerySet querySet, const char* label)
 
 uint32_t wgpuQuerySetGetCount(WGPUQuerySet querySet)
 {
-    return WebGPU::fromAPI(querySet).count();
+    return protect(WebGPU::fromAPI(querySet))->count();
 }
 
 WGPUQueryType wgpuQuerySetGetType(WGPUQuerySet querySet)
 {
-    return WebGPU::fromAPI(querySet).type();
+    return protect(WebGPU::fromAPI(querySet))->type();
 }

--- a/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderBundleEncoder.mm
@@ -945,7 +945,7 @@ bool RenderBundleEncoder::validToEncodeCommand() const
     if (!m_device->isValid())
         return false;
 
-    return !m_finished || (m_renderPassEncoder && m_renderPassEncoder->renderCommandEncoder() && !m_makeSubmitInvalid);
+    return !m_finished || (m_renderPassEncoder && RefPtr { m_renderPassEncoder.get() }->renderCommandEncoder() && !m_makeSubmitInvalid);
 }
 
 void RenderBundleEncoder::resetIndexBuffer()

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -1431,7 +1431,7 @@ void RenderPassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup* group
 {
     RETURN_IF_FINISHED();
 
-    auto dynamicOffsetCount = (groupPtr && groupPtr->bindGroupLayout()) ? groupPtr->bindGroupLayout()->dynamicBufferCount() : 0;
+    auto dynamicOffsetCount = (groupPtr && groupPtr->bindGroupLayout()) ? protect(groupPtr->bindGroupLayout())->dynamicBufferCount() : 0;
     if (groupIndex >= m_device->limits().maxBindGroups || (dynamicOffsets && dynamicOffsetCount != dynamicOffsets->size())) {
         makeInvalid(@"setBindGroup: groupIndex >= limits.maxBindGroups");
         return;

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -2019,5 +2019,5 @@ WGPUBindGroupLayout wgpuRenderPipelineGetBindGroupLayout(WGPURenderPipeline rend
 
 void wgpuRenderPipelineSetLabel(WGPURenderPipeline renderPipeline, const char* label)
 {
-    WebGPU::fromAPI(renderPipeline).setLabel(WebGPU::fromAPI(label));
+    protect(WebGPU::fromAPI(renderPipeline))->setLabel(WebGPU::fromAPI(label));
 }

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -3682,11 +3682,11 @@ NSString* Texture::errorValidatingImageCopyTexture(const WGPUImageCopyTexture& i
 {
     // https://gpuweb.github.io/gpuweb/#abstract-opdef-validating-gpuimagecopytexture
 
-    uint32_t blockWidth = Texture::texelBlockWidth(fromAPI(imageCopyTexture.texture).format());
+    uint32_t blockWidth = Texture::texelBlockWidth(protect(fromAPI(imageCopyTexture.texture))->format());
 
-    uint32_t blockHeight = Texture::texelBlockHeight(fromAPI(imageCopyTexture.texture).format());
+    uint32_t blockHeight = Texture::texelBlockHeight(protect(fromAPI(imageCopyTexture.texture))->format());
 
-    if (!fromAPI(imageCopyTexture.texture).isValid())
+    if (!protect(fromAPI(imageCopyTexture.texture))->isValid())
         return @"imageCopyTexture is not valid";
 
     if (imageCopyTexture.mipLevel >= fromAPI(imageCopyTexture.texture).mipLevelCount())
@@ -3698,8 +3698,8 @@ NSString* Texture::errorValidatingImageCopyTexture(const WGPUImageCopyTexture& i
     if (imageCopyTexture.origin.y % blockHeight)
         return [NSString stringWithFormat:@"imageCopyTexture.origin.y(%u) is not a multiple of the texture blockHeight(%u)", imageCopyTexture.origin.y, blockHeight];
 
-    if (Texture::isDepthOrStencilFormat(fromAPI(imageCopyTexture.texture).format())
-        || fromAPI(imageCopyTexture.texture).sampleCount() > 1) {
+    if (Texture::isDepthOrStencilFormat(protect(fromAPI(imageCopyTexture.texture))->format())
+        || protect(fromAPI(imageCopyTexture.texture))->sampleCount() > 1) {
         auto subresourceSize = imageCopyTextureSubresourceSize(imageCopyTexture);
         if (subresourceSize.width != copySize.width
             || (copySize.height > 1 && subresourceSize.height != copySize.height))
@@ -3982,9 +3982,9 @@ NSString* Texture::errorValidatingTextureCopyRange(const WGPUImageCopyTexture& i
 {
     // https://gpuweb.github.io/gpuweb/#validating-texture-copy-range
 
-    auto blockWidth = Texture::texelBlockWidth(fromAPI(imageCopyTexture.texture).format());
+    auto blockWidth = Texture::texelBlockWidth(protect(fromAPI(imageCopyTexture.texture))->format());
 
-    auto blockHeight = Texture::texelBlockHeight(fromAPI(imageCopyTexture.texture).format());
+    auto blockHeight = Texture::texelBlockHeight(protect(fromAPI(imageCopyTexture.texture))->format());
 
     auto subresourceSize = imageCopyTextureSubresourceSize(imageCopyTexture);
 
@@ -4180,40 +4180,40 @@ void wgpuTextureSetLabel(WGPUTexture texture, const char* label)
 
 uint32_t wgpuTextureGetDepthOrArrayLayers(WGPUTexture texture)
 {
-    return WebGPU::fromAPI(texture).depthOrArrayLayers();
+    return protect(WebGPU::fromAPI(texture))->depthOrArrayLayers();
 }
 
 WGPUTextureDimension wgpuTextureGetDimension(WGPUTexture texture)
 {
-    return WebGPU::fromAPI(texture).dimension();
+    return protect(WebGPU::fromAPI(texture))->dimension();
 }
 
 WGPUTextureFormat wgpuTextureGetFormat(WGPUTexture texture)
 {
-    return WebGPU::fromAPI(texture).format();
+    return protect(WebGPU::fromAPI(texture))->format();
 }
 
 uint32_t wgpuTextureGetHeight(WGPUTexture texture)
 {
-    return WebGPU::fromAPI(texture).height();
+    return protect(WebGPU::fromAPI(texture))->height();
 }
 
 uint32_t wgpuTextureGetWidth(WGPUTexture texture)
 {
-    return WebGPU::fromAPI(texture).width();
+    return protect(WebGPU::fromAPI(texture))->width();
 }
 
 uint32_t wgpuTextureGetMipLevelCount(WGPUTexture texture)
 {
-    return WebGPU::fromAPI(texture).mipLevelCount();
+    return protect(WebGPU::fromAPI(texture))->mipLevelCount();
 }
 
 uint32_t wgpuTextureGetSampleCount(WGPUTexture texture)
 {
-    return WebGPU::fromAPI(texture).sampleCount();
+    return protect(WebGPU::fromAPI(texture))->sampleCount();
 }
 
 WGPUTextureUsageFlags wgpuTextureGetUsage(WGPUTexture texture)
 {
-    return WebGPU::fromAPI(texture).usage();
+    return protect(WebGPU::fromAPI(texture))->usage();
 }

--- a/Source/WebGPU/WebGPU/TextureOrTextureView.h
+++ b/Source/WebGPU/WebGPU/TextureOrTextureView.h
@@ -52,19 +52,26 @@ public:
     {
     }
 
-#define TEXTURE_OR_VIEW_HELPER(x) auto x() const { return m_view ? m_view->x() : protect(m_texture)->x(); }
-#define TEXTURE_OR_VIEW_HELPER_REF(x) const auto& x() const { return m_view ? m_view->x() : protect(m_texture)->x(); }
-#define TEXTURE_OR_VIEW_HELPER_PROTECT(x) auto x() const { return m_view ? protect(m_view)->x() : protect(m_texture)->x(); }
+#define TEXTURE_OR_VIEW_INVOKE(x) return m_view ? RefPtr { m_view }->x() : RefPtr { m_texture }->x()
+#define TEXTURE_OR_VIEW_HELPER(x) auto x() const { TEXTURE_OR_VIEW_INVOKE(x); }
+#define TEXTURE_OR_VIEW_HELPER_NONCONST(x) auto x() { TEXTURE_OR_VIEW_INVOKE(x); }
+#define TEXTURE_OR_VIEW_HELPER_REF(x) const auto& x() const { TEXTURE_OR_VIEW_INVOKE(x); }
 
+    TEXTURE_OR_VIEW_HELPER(width)
+    TEXTURE_OR_VIEW_HELPER(height)
     TEXTURE_OR_VIEW_HELPER(is2DTexture)
     TEXTURE_OR_VIEW_HELPER(is2DArrayTexture)
     TEXTURE_OR_VIEW_HELPER(is3DTexture)
     TEXTURE_OR_VIEW_HELPER(sampleCount)
     TEXTURE_OR_VIEW_HELPER(format)
     TEXTURE_OR_VIEW_HELPER(isDestroyed)
+    TEXTURE_OR_VIEW_HELPER(depthOrArrayLayers)
     TEXTURE_OR_VIEW_HELPER(baseArrayLayer)
     TEXTURE_OR_VIEW_HELPER(baseMipLevel)
     TEXTURE_OR_VIEW_HELPER(parentTexture)
+    TEXTURE_OR_VIEW_HELPER(parentRelativeSlice)
+    TEXTURE_OR_VIEW_HELPER(previouslyCleared)
+    TEXTURE_OR_VIEW_HELPER_NONCONST(setPreviouslyCleared)
     TEXTURE_OR_VIEW_HELPER(texture)
     TEXTURE_OR_VIEW_HELPER(isValid)
     TEXTURE_OR_VIEW_HELPER(usage)
@@ -74,26 +81,20 @@ public:
     TEXTURE_OR_VIEW_HELPER_REF(apiParentTexture)
     TEXTURE_OR_VIEW_HELPER_REF(device)
 
-    TEXTURE_OR_VIEW_HELPER_PROTECT(depthOrArrayLayers)
-    TEXTURE_OR_VIEW_HELPER_PROTECT(height)
-    TEXTURE_OR_VIEW_HELPER_PROTECT(parentRelativeSlice)
-    TEXTURE_OR_VIEW_HELPER_PROTECT(previouslyCleared)
-    TEXTURE_OR_VIEW_HELPER_PROTECT(width)
-    TEXTURE_OR_VIEW_HELPER_PROTECT(setPreviouslyCleared)
-
     void setCommandEncoder(CommandEncoder& encoder)
     {
-        m_view ? protect(m_view)->setCommandEncoder(encoder) : protect(m_texture)->setCommandEncoder(encoder);
+        m_view ? RefPtr { m_view }->setCommandEncoder(encoder) : RefPtr { m_texture }->setCommandEncoder(encoder);
     }
 
     id<MTLRasterizationRateMap> rasterizationMapForSlice(uint32_t slice)
     {
-        return m_view ? m_view->rasterizationMapForSlice(slice) : m_texture->rasterizationMapForSlice(slice);
+        return m_view ? RefPtr { m_view }->rasterizationMapForSlice(slice) : RefPtr { m_texture }->rasterizationMapForSlice(slice);
     }
 
 #undef TEXTURE_OR_VIEW_INVOKE
 #undef TEXTURE_OR_VIEW_HELPER
 #undef TEXTURE_OR_VIEW_HELPER_REF
+#undef TEXTURE_OR_VIEW_HELPER_NONCONST
 
     operator bool() const { return m_texture || m_view; }
 

--- a/Source/WebGPU/WebGPU/XRProjectionLayer.mm
+++ b/Source/WebGPU/WebGPU/XRProjectionLayer.mm
@@ -212,5 +212,5 @@ void wgpuXRProjectionLayerRelease(WGPUXRProjectionLayer projectionLayer)
 
 void wgpuXRProjectionLayerStartFrame(WGPUXRProjectionLayer layer, size_t frameIndex, WTF::MachSendRight&& colorBuffer, WTF::MachSendRight&& depthBuffer, WTF::MachSendRight&& completionSyncEvent, size_t reusableTextureIndex, unsigned screenWidth, unsigned screenHeight, Vector<float>&& horizontalSamplesLeft, Vector<float>&& horizontalSamplesRight, Vector<float>&& verticalSamples)
 {
-    WebGPU::fromAPI(layer).startFrame(frameIndex, WTF::move(colorBuffer), WTF::move(depthBuffer), WTF::move(completionSyncEvent), reusableTextureIndex, screenWidth, screenHeight, WTF::move(horizontalSamplesLeft), WTF::move(horizontalSamplesRight), WTF::move(verticalSamples));
+    protect(WebGPU::fromAPI(layer))->startFrame(frameIndex, WTF::move(colorBuffer), WTF::move(depthBuffer), WTF::move(completionSyncEvent), reusableTextureIndex, screenWidth, screenHeight, WTF::move(horizontalSamplesLeft), WTF::move(horizontalSamplesRight), WTF::move(verticalSamples));
 }


### PR DESCRIPTION
#### f4ea1653987dfffd83557d163932297a01cfe9cb
<pre>
Partial revert of 309031@main to address Swift compiler crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=309647">https://bugs.webkit.org/show_bug.cgi?id=309647</a>

Unreviewed, I&apos;m reverting only the changes to Source/WebGPU/WebGPU/ since
the crash is when compiling WebGPU code.

* Source/WebGPU/WebGPU/Adapter.mm:
(wgpuAdapterGetLimits):
(wgpuAdapterXRCompatible):
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::destroy):
(WebGPU::Buffer::unmap):
(WebGPU::Buffer::takeSlowIndexValidationPath):
(WebGPU::Buffer::takeSlowIndirectIndexValidationPath):
(WebGPU::Buffer::takeSlowIndirectValidationPath):
(wgpuBufferGetMapState):
(wgpuBufferGetInitialSize):
(wgpuBufferGetUsage):
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::ensureBlitCommandEncoder):
(WebGPU::CommandEncoder::errorValidatingCopyBufferToTexture const):
(WebGPU::CommandEncoder::errorValidatingCopyTextureToBuffer const):
(WebGPU::CommandEncoder::errorValidatingCopyTextureToTexture const):
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::setBindGroup):
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(wgpuComputePipelineSetLabel):
* Source/WebGPU/WebGPU/Device.mm:
* Source/WebGPU/WebGPU/Instance.mm:
(wgpuBufferIsValid):
(wgpuAdapterIsValid):
(wgpuBindGroupIsValid):
(wgpuBindGroupLayoutIsValid):
(wgpuCommandBufferIsValid):
(wgpuCommandEncoderIsValid):
(wgpuComputePassEncoderIsValid):
(wgpuComputePipelineIsValid):
(wgpuDeviceIsValid):
(wgpuExternalTextureIsValid):
(wgpuPipelineLayoutIsValid):
(wgpuQuerySetIsValid):
(wgpuQueueIsValid):
(wgpuRenderBundleEncoderIsValid):
(wgpuRenderBundleIsValid):
(wgpuRenderPassEncoderIsValid):
(wgpuRenderPipelineIsValid):
(wgpuSamplerIsValid):
(wgpuShaderModuleIsValid):
(wgpuTextureIsValid):
(wgpuTextureViewIsValid):
(wgpuXRBindingIsValid):
(wgpuXRSubImageIsValid):
(wgpuXRProjectionLayerIsValid):
(wgpuXRViewIsValid):
* Source/WebGPU/WebGPU/PipelineLayout.mm:
(wgpuPipelineLayoutSetLabel):
* Source/WebGPU/WebGPU/PresentationContext.mm:
(wgpuSurfaceGetPreferredFormat):
* Source/WebGPU/WebGPU/QuerySet.mm:
(wgpuQuerySetGetCount):
(wgpuQuerySetGetType):
* Source/WebGPU/WebGPU/RenderBundleEncoder.mm:
(WebGPU::RenderBundleEncoder::validToEncodeCommand const):
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::setBindGroup):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(wgpuRenderPipelineSetLabel):
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::Texture::errorValidatingImageCopyTexture):
(WebGPU::Texture::errorValidatingTextureCopyRange):
(wgpuTextureGetDepthOrArrayLayers):
(wgpuTextureGetDimension):
(wgpuTextureGetFormat):
(wgpuTextureGetHeight):
(wgpuTextureGetWidth):
(wgpuTextureGetMipLevelCount):
(wgpuTextureGetSampleCount):
(wgpuTextureGetUsage):
* Source/WebGPU/WebGPU/TextureOrTextureView.h:
(WebGPU::TextureOrTextureView::setCommandEncoder):
(WebGPU::TextureOrTextureView::rasterizationMapForSlice):
* Source/WebGPU/WebGPU/XRProjectionLayer.mm:
(wgpuXRProjectionLayerStartFrame):

Canonical link: <a href="https://commits.webkit.org/309036@main">https://commits.webkit.org/309036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91a3b202b3eb33a9764a249b4db456cf14e467fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149277 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/21990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/15560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/157970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🛠 win ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/22444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/21868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/157970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 win-tests ](https://ews-build.webkit.org/#/builders/Win-Build-EWS "Waiting in queue, processing has not started yet") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152237 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/22444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/157970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/22444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/15560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/5819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/22444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/160453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/13413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/160453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/21793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/21868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/160453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/133677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22984 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/10423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/21402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/85215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/21134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/21283 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/21191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->