### PR TITLE
[Build Speed] Remove JSCJSValueInlines.h from JSValueInWrappedObject.h and other WebCore binding headers

### DIFF
--- a/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
+++ b/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
@@ -45,7 +45,7 @@ namespace JSC {
 template <class Parent>
 inline JSCallbackObject<Parent>* JSCallbackObject<Parent>::asCallbackObject(JSValue value)
 {
-    ASSERT(asObject(value)->inherits(info()));
+    ASSERT(asObject(value)->inheritsSlow(info()));
     return jsCast<JSCallbackObject*>(asObject(value));
 }
 
@@ -53,7 +53,7 @@ template <class Parent>
 inline JSCallbackObject<Parent>* JSCallbackObject<Parent>::asCallbackObject(EncodedJSValue encodedValue)
 {
     JSValue value = JSValue::decode(encodedValue);
-    ASSERT(asObject(value)->inherits(info()));
+    ASSERT(asObject(value)->inheritsSlow(info()));
     return jsCast<JSCallbackObject*>(asObject(value));
 }
 

--- a/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_separate_header.py
+++ b/Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_separate_header.py
@@ -104,6 +104,10 @@ class FunctionExecutable;
             (["WebCore"],
                 ("JavaScriptCore", "runtime/JSFunction.h"),
             ),
+
+            (["WebCore"],
+                ("JavaScriptCore", "heap/SlotVisitorInlines.h"),
+            ),
         ]
 
         return '\n'.join(self.generate_includes_from_entries(header_includes))

--- a/Source/JavaScriptCore/heap/GCAssertions.h
+++ b/Source/JavaScriptCore/heap/GCAssertions.h
@@ -37,7 +37,7 @@
 
 #define ASSERT_GC_OBJECT_INHERITS(object, classInfo) do {\
     ASSERT_GC_OBJECT_LOOKS_VALID(object); \
-    RELEASE_ASSERT(object->inherits(classInfo)); \
+    RELEASE_ASSERT(object->inheritsSlow(classInfo)); \
 } while (0)
 
 // Used to avoid triggering -Wundefined-bool-conversion.

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -332,8 +332,8 @@ public:
 
     bool isMarked(const void*);
     static bool testAndSetMarked(HeapVersion, const void*);
-    
-    static size_t cellSize(const void*);
+
+    static inline size_t cellSize(const void*);
 
     void writeBarrier(const JSCell* from);
     void writeBarrier(const JSCell* from, JSValue to);
@@ -373,8 +373,8 @@ public:
 
     MutatorState mutatorState() const { return m_mutatorState; }
     std::optional<CollectionScope> collectionScope() const { return m_collectionScope; }
-    bool hasHeapAccess() const;
-    bool worldIsStopped() const;
+    bool hasHeapAccess() const { return m_worldState.load() & hasAccessBit; }
+    bool worldIsStopped() const { return m_worldIsStopped; }
     bool worldIsRunning() const { return !worldIsStopped(); }
 
     // We're always busy on the collection threads. On the main thread, this returns true if we're
@@ -428,8 +428,16 @@ public:
     // 2. Use this API may trigger JSRopeString::resolveRope. If this API need
     // to be used when resolving a rope string, then make sure to call this API
     // after the rope string is completely resolved.
-    void reportExtraMemoryAllocated(const JSCell*, size_t);
-    void reportExtraMemoryAllocated(GCDeferralContext*, const JSCell*, size_t);
+    void reportExtraMemoryAllocated(const JSCell* cell, size_t size)
+    {
+        if (size > minExtraMemory)
+            reportExtraMemoryAllocatedSlowCase(nullptr, cell, size);
+    }
+    void reportExtraMemoryAllocated(GCDeferralContext* deferralContext, const JSCell* cell, size_t size)
+    {
+        if (size > minExtraMemory)
+            reportExtraMemoryAllocatedSlowCase(deferralContext, cell, size);
+    }
     JS_EXPORT_PRIVATE void reportExtraMemoryVisited(size_t);
 
 #if ENABLE(RESOURCE_USAGE)
@@ -439,7 +447,11 @@ public:
 #endif
 
     // Use this API to report non-GC memory if you can't use the better API above.
-    void deprecatedReportExtraMemory(size_t);
+    void deprecatedReportExtraMemory(size_t size)
+    {
+        if (size > minExtraMemory)
+            deprecatedReportExtraMemorySlowCase(size);
+    }
 
     JS_EXPORT_PRIVATE void reportAbandonedObjectGraph();
 
@@ -456,11 +468,11 @@ public:
     JS_EXPORT_PRIVATE TypeCountSet protectedObjectTypeCounts();
     JS_EXPORT_PRIVATE TypeCountSet objectTypeCounts();
 
-    UncheckedKeyHashSet<MarkedVectorBase*>& markListSet();
+    UncheckedKeyHashSet<MarkedVectorBase*>& markListSet() { return m_markListSet; }
 
-    template<typename Functor> void forEachProtectedCell(const Functor&);
-    template<typename Functor> void forEachCodeBlock(NOESCAPE const Functor&);
-    template<typename Functor> void forEachCodeBlockIgnoringJITPlans(const AbstractLocker& codeBlockSetLocker, NOESCAPE const Functor&);
+    template<typename Functor> inline void forEachProtectedCell(const Functor&);
+    template<typename Functor> inline void forEachCodeBlock(NOESCAPE const Functor&);
+    template<typename Functor> inline void forEachCodeBlockIgnoringJITPlans(const AbstractLocker& codeBlockSetLocker, NOESCAPE const Functor&);
 
     HandleSet* handleSet() LIFETIME_BOUND { return &m_handleSet; }
 
@@ -491,10 +503,10 @@ public:
     CodeBlockSet& codeBlockSet() { return *m_codeBlocks; }
 
 #if USE(FOUNDATION)
-    template<typename T> void releaseSoon(RetainPtr<T>&&);
+    template<typename T> inline void releaseSoon(RetainPtr<T>&&);
 #endif
 #ifdef JSC_GLIB_API_ENABLED
-    void releaseSoon(std::unique_ptr<JSCGLibWrapperObject>&&);
+    inline void releaseSoon(std::unique_ptr<JSCGLibWrapperObject>&&);
 #endif
 
     JS_EXPORT_PRIVATE void registerWeakGCHashTable(WeakGCHashTable*);
@@ -518,7 +530,7 @@ public:
     // If true, the GC believes that the mutator is currently messing with the heap. We call this
     // "having heap access". The GC may block if the mutator is in this state. If false, the GC may
     // currently be doing things to the heap that make the heap unsafe to access for the mutator.
-    bool hasAccess() const;
+    bool hasAccess() const { return m_worldState.loadRelaxed() & hasAccessBit; }
     
     // If the mutator does not currently have heap access, this function will acquire it. If the GC
     // is currently using the lack of heap access to do dangerous things to the heap then this
@@ -536,7 +548,12 @@ public:
     // Ordinarily, you should use the ReleaseHeapAccessScope to release and then reacquire heap
     // access. You should do this anytime you're about do perform a blocking operation, like waiting
     // on the ParkingLot.
-    void releaseAccess();
+    void releaseAccess()
+    {
+        if (m_worldState.compareExchangeWeak(hasAccessBit, 0))
+            return;
+        releaseAccessSlow();
+    }
     
     // This is like a super optimized way of saying:
     //
@@ -556,12 +573,12 @@ public:
     // mutator has permanent heap access (like the DOM does). If you have good event handling
     // discipline (i.e. you don't block the runloop) then you can be sure that stopIfNecessary() will
     // already be called for you at the right times.
-    void stopIfNecessary();
+    inline void stopIfNecessary();
     
     // This gives the conn to the collector.
     void relinquishConn();
     
-    bool mayNeedToStop();
+    bool mayNeedToStop() { return m_worldState.loadRelaxed() != hasAccessBit; }
 
     void performIncrement(size_t bytes);
     
@@ -594,7 +611,7 @@ public:
     }
 
     template<typename Func>
-    void forEachSlotVisitor(const Func&);
+    inline void forEachSlotVisitor(const Func&);
     
     Seconds totalGCTime() const { return m_totalGCTime; }
 
@@ -772,9 +789,9 @@ private:
 
     bool shouldDoFullCollection();
 
-    void incrementDeferralDepth();
-    void decrementDeferralDepth();
-    void decrementDeferralDepthAndGCIfNeeded();
+    inline void incrementDeferralDepth();
+    inline void decrementDeferralDepth();
+    inline void decrementDeferralDepthAndGCIfNeeded();
     JS_EXPORT_PRIVATE void decrementDeferralDepthAndGCIfNeededSlow();
 
     size_t visitCount();
@@ -1237,7 +1254,7 @@ public:
     Heap(JSC::Heap&);
     ~Heap();
 
-    VM& vm() const;
+    inline VM& vm() const;
     JSC::Heap& server() { return m_server; }
 
     // FIXME GlobalGC: need a GCClient::Heap::lastChanceToFinalize() and in there,

--- a/Source/JavaScriptCore/heap/HeapInlines.h
+++ b/Source/JavaScriptCore/heap/HeapInlines.h
@@ -56,16 +56,6 @@ inline JSC::Heap* Heap::heap(const JSValue v)
     return heap(v.asCell());
 }
 
-inline bool Heap::hasHeapAccess() const
-{
-    return m_worldState.load() & hasAccessBit;
-}
-
-inline bool Heap::worldIsStopped() const
-{
-    return m_worldIsStopped;
-}
-
 ALWAYS_INLINE bool Heap::isMarked(const void* rawCell)
 {
     ASSERT(!m_isMarkingForGCVerifier);
@@ -215,29 +205,6 @@ inline void Heap::decrementDeferralDepthAndGCIfNeeded()
     }
 }
 
-inline UncheckedKeyHashSet<MarkedVectorBase*>& Heap::markListSet()
-{
-    return m_markListSet;
-}
-
-inline void Heap::reportExtraMemoryAllocated(const JSCell* cell, size_t size)
-{
-    if (size > minExtraMemory)
-        reportExtraMemoryAllocatedSlowCase(nullptr, cell, size);
-}
-
-inline void Heap::reportExtraMemoryAllocated(GCDeferralContext* deferralContext, const JSCell* cell, size_t size)
-{
-    if (size > minExtraMemory)
-        reportExtraMemoryAllocatedSlowCase(deferralContext, cell, size);
-}
-
-inline void Heap::deprecatedReportExtraMemory(size_t size)
-{
-    if (size > minExtraMemory) 
-        deprecatedReportExtraMemorySlowCase(size);
-}
-
 inline void Heap::acquireAccess()
 {
     if constexpr (validateDFGDoesGC)
@@ -246,23 +213,6 @@ inline void Heap::acquireAccess()
     if (m_worldState.compareExchangeWeak(0, hasAccessBit))
         return;
     acquireAccessSlow();
-}
-
-inline bool Heap::hasAccess() const
-{
-    return m_worldState.loadRelaxed() & hasAccessBit;
-}
-
-inline void Heap::releaseAccess()
-{
-    if (m_worldState.compareExchangeWeak(hasAccessBit, 0))
-        return;
-    releaseAccessSlow();
-}
-
-inline bool Heap::mayNeedToStop()
-{
-    return m_worldState.loadRelaxed() != hasAccessBit;
 }
 
 inline void Heap::stopIfNecessary()

--- a/Source/JavaScriptCore/heap/Strong.h
+++ b/Source/JavaScriptCore/heap/Strong.h
@@ -116,29 +116,9 @@ public:
 
     ExternalType get() const { return HandleTypes<T>::getFromSlot(this->slot()); }
 
-    inline void set(VM&, ExternalType);
-
-    template <typename U> Strong& operator=(const Strong<U>& other)
-    {
-        if (!other.slot()) {
-            clear();
-            return *this;
-        }
-
-        set(*HandleSet::heapFor(other.slot())->vm(), other.get());
-        return *this;
-    }
-
-    Strong& operator=(const Strong& other)
-    {
-        if (!other.slot()) {
-            clear();
-            return *this;
-        }
-
-        set(HandleSet::heapFor(other.slot())->vm(), other.get());
-        return *this;
-    }
+    inline void set(VM&, ExternalType); // Defined in StrongInlines.h
+    template <typename U> inline Strong& operator=(const Strong<U>& other); // Defined in StrongInlines.h
+    Strong& operator=(const Strong& other); // Defined in StrongInlines.h
 
     void clear()
     {

--- a/Source/JavaScriptCore/heap/StrongInlines.h
+++ b/Source/JavaScriptCore/heap/StrongInlines.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/VM.h>
 
 #if ENABLE(REFTRACKER)
@@ -54,6 +53,30 @@ inline void Strong<T, shouldStrongDestructorGrabLock>::set(VM& vm, ExternalType 
     if (!slot())
         setSlot(vm.heap.handleSet()->allocate());
     set(value);
+}
+
+template <typename T, ShouldStrongDestructorGrabLock shouldStrongDestructorGrabLock>
+template <typename U> Strong<T, shouldStrongDestructorGrabLock>& Strong<T, shouldStrongDestructorGrabLock>::operator=(const Strong<U>& other)
+{
+    if (!other.slot()) {
+        clear();
+        return *this;
+    }
+
+    set(*HandleSet::heapFor(other.slot())->vm(), other.get());
+    return *this;
+}
+
+template <typename T, ShouldStrongDestructorGrabLock shouldStrongDestructorGrabLock>
+Strong<T, shouldStrongDestructorGrabLock>& Strong<T, shouldStrongDestructorGrabLock>::operator=(const Strong& other)
+{
+    if (!other.slot()) {
+        clear();
+        return *this;
+    }
+
+    set(HandleSet::heapFor(other.slot())->vm(), other.get());
+    return *this;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSArray.h
+++ b/Source/JavaScriptCore/runtime/JSArray.h
@@ -65,9 +65,9 @@ protected:
     }
 
 public:
-    static JSArray* tryCreate(VM&, Structure*, unsigned initialLength = 0);
-    static JSArray* tryCreate(VM&, Structure*, unsigned initialLength, unsigned vectorLengthHint);
-    static JSArray* create(VM&, Structure*, unsigned initialLength = 0);
+    inline static JSArray* tryCreate(VM&, Structure*, unsigned initialLength = 0);
+    inline static JSArray* tryCreate(VM&, Structure*, unsigned initialLength, unsigned vectorLengthHint);
+    inline static JSArray* create(VM&, Structure*, unsigned initialLength = 0);
     static JSArray* createWithButterfly(VM&, GCDeferralContext*, Structure*, Butterfly*);
 
     // tryCreateUninitializedRestricted is used for fast construction of arrays whose size and
@@ -222,60 +222,6 @@ inline Butterfly* tryCreateArrayButterfly(VM& vm, JSObject* intendedOwner, unsig
     storage->m_indexBias = 0;
     storage->m_numValuesInVector = 0;
     return butterfly;
-}
-
-inline JSArray* JSArray::tryCreate(VM& vm, Structure* structure, unsigned initialLength, unsigned vectorLengthHint)
-{
-    ASSERT(vectorLengthHint >= initialLength);
-    unsigned outOfLineStorage = structure->outOfLineCapacity();
-
-    Butterfly* butterfly;
-    IndexingType indexingType = structure->indexingType();
-    if (!hasAnyArrayStorage(indexingType)) [[likely]] {
-        ASSERT(
-            hasUndecided(indexingType)
-            || hasInt32(indexingType)
-            || hasDouble(indexingType)
-            || hasContiguous(indexingType));
-
-        if (vectorLengthHint > MAX_STORAGE_VECTOR_LENGTH) [[unlikely]]
-            return nullptr;
-
-        unsigned vectorLength = Butterfly::optimalContiguousVectorLength(structure, vectorLengthHint);
-        void* temp = vm.auxiliarySpace().allocate(
-            vm,
-            Butterfly::totalSize(0, outOfLineStorage, true, vectorLength * sizeof(EncodedJSValue)),
-            nullptr, AllocationFailureMode::ReturnNull);
-        if (!temp)
-            return nullptr;
-        butterfly = Butterfly::fromBase(temp, 0, outOfLineStorage);
-        butterfly->setVectorLength(vectorLength);
-        butterfly->setPublicLength(initialLength);
-        Butterfly::clearRange(indexingType, butterfly, 0, vectorLength);
-    } else {
-        ASSERT(
-            indexingType == ArrayWithSlowPutArrayStorage
-            || indexingType == ArrayWithArrayStorage);
-        butterfly = tryCreateArrayButterfly(vm, nullptr, initialLength);
-        if (!butterfly)
-            return nullptr;
-        for (unsigned i = 0; i < BASE_ARRAY_STORAGE_VECTOR_LEN; ++i)
-            butterfly->arrayStorage()->m_vector[i].clear();
-    }
-
-    return createWithButterfly(vm, nullptr, structure, butterfly);
-}
-
-inline JSArray* JSArray::tryCreate(VM& vm, Structure* structure, unsigned initialLength)
-{
-    return tryCreate(vm, structure, initialLength, initialLength);
-}
-
-inline JSArray* JSArray::create(VM& vm, Structure* structure, unsigned initialLength)
-{
-    JSArray* result = JSArray::tryCreate(vm, structure, initialLength);
-    RELEASE_ASSERT_RESOURCE_AVAILABLE(result, MemoryExhaustion, "Crash intentionally because memory is exhausted.");
-    return result;
 }
 
 inline JSArray* JSArray::createWithButterfly(VM& vm, GCDeferralContext* deferralContext, Structure* structure, Butterfly* butterfly)

--- a/Source/JavaScriptCore/runtime/JSArrayInlines.h
+++ b/Source/JavaScriptCore/runtime/JSArrayInlines.h
@@ -33,6 +33,60 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
+inline JSArray* JSArray::tryCreate(VM& vm, Structure* structure, unsigned initialLength, unsigned vectorLengthHint)
+{
+    ASSERT(vectorLengthHint >= initialLength);
+    unsigned outOfLineStorage = structure->outOfLineCapacity();
+
+    Butterfly* butterfly;
+    IndexingType indexingType = structure->indexingType();
+    if (!hasAnyArrayStorage(indexingType)) [[likely]] {
+        ASSERT(
+            hasUndecided(indexingType)
+            || hasInt32(indexingType)
+            || hasDouble(indexingType)
+            || hasContiguous(indexingType));
+
+        if (vectorLengthHint > MAX_STORAGE_VECTOR_LENGTH) [[unlikely]]
+            return nullptr;
+
+        unsigned vectorLength = Butterfly::optimalContiguousVectorLength(structure, vectorLengthHint);
+        void* temp = vm.auxiliarySpace().allocate(
+            vm,
+            Butterfly::totalSize(0, outOfLineStorage, true, vectorLength * sizeof(EncodedJSValue)),
+            nullptr, AllocationFailureMode::ReturnNull);
+        if (!temp)
+            return nullptr;
+        butterfly = Butterfly::fromBase(temp, 0, outOfLineStorage);
+        butterfly->setVectorLength(vectorLength);
+        butterfly->setPublicLength(initialLength);
+        Butterfly::clearRange(indexingType, butterfly, 0, vectorLength);
+    } else {
+        ASSERT(
+            indexingType == ArrayWithSlowPutArrayStorage
+            || indexingType == ArrayWithArrayStorage);
+        butterfly = tryCreateArrayButterfly(vm, nullptr, initialLength);
+        if (!butterfly)
+            return nullptr;
+        for (unsigned i = 0; i < BASE_ARRAY_STORAGE_VECTOR_LEN; ++i)
+            butterfly->arrayStorage()->m_vector[i].clear();
+    }
+
+    return createWithButterfly(vm, nullptr, structure, butterfly);
+}
+
+inline JSArray* JSArray::tryCreate(VM& vm, Structure* structure, unsigned initialLength)
+{
+    return tryCreate(vm, structure, initialLength, initialLength);
+}
+
+inline JSArray* JSArray::create(VM& vm, Structure* structure, unsigned initialLength)
+{
+    JSArray* result = JSArray::tryCreate(vm, structure, initialLength);
+    RELEASE_ASSERT_RESOURCE_AVAILABLE(result, MemoryExhaustion, "Crash intentionally because memory is exhausted.");
+    return result;
+}
+
 inline Structure* JSArray::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype, IndexingType indexingType)
 {
     return Structure::create(vm, globalObject, prototype, TypeInfo(ArrayType, StructureFlags), info(), indexingType);

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -281,9 +281,9 @@ public:
     inline bool isGetterSetter() const; // Defined in JSCJSValueCellInlines.h
     inline bool isCustomGetterSetter() const; // Defined in JSCJSValueCellInlines.h
     inline bool isObject() const; // Defined in JSCJSValueCellInlines.h
-    bool inherits(const ClassInfo*) const;
-    template<typename Target> bool inherits() const;
-    const ClassInfo* classInfoOrNull() const;
+    inline bool inherits(const ClassInfo*) const; // Defined in JSCJSValueCellInlines.h
+    template<typename Target> inline bool inherits() const; // Defined in JSCJSValueCellInlines.h
+    inline const ClassInfo* classInfoOrNull() const; // Defined in JSCJSValueCellInlines.h
 
     // Non-inline versions of above for use in header ASSERT macros:
     JS_EXPORT_PRIVATE bool NODELETE isGetterSetterSlow() const;
@@ -376,7 +376,7 @@ public:
     bool isCell() const;
     JSCell* asCell() const;
 
-    Structure* structureOrNull() const;
+    inline Structure* structureOrNull() const; // Defined in JSCJSValueCellInlines.h
 
     JS_EXPORT_PRIVATE void dump(PrintStream&) const;
     void dumpInContext(PrintStream&, DumpContext*) const;

--- a/Source/JavaScriptCore/runtime/JSCell.cpp
+++ b/Source/JavaScriptCore/runtime/JSCell.cpp
@@ -169,6 +169,16 @@ double JSCell::toNumber(JSGlobalObject* globalObject) const
     return jsSecureCast<const JSObject*>(this)->toNumber(globalObject);
 }
 
+bool JSCell::isObjectSlow() const
+{
+    return isObject();
+}
+
+bool JSCell::inheritsSlow(const ClassInfo* info) const
+{
+    return inherits(info);
+}
+
 JSObject* JSCell::toObjectSlow(JSGlobalObject* globalObject) const
 {
     Integrity::auditStructureID(structureID());

--- a/Source/JavaScriptCore/runtime/JSCell.h
+++ b/Source/JavaScriptCore/runtime/JSCell.h
@@ -82,7 +82,7 @@ template<typename T> void* tryAllocateCell(VM&, GCDeferralContext*, size_t = siz
     ALWAYS_INLINE void finishCreation(JSC::VM& vm) \
     { \
         Base::finishCreation(vm); \
-        ASSERT(inherits(info())); \
+        ASSERT(inheritsSlow(info())); \
     } \
     static constexpr int __unusedFooterAfterDefaultFinishCreation = 0
 #else
@@ -124,21 +124,23 @@ protected:
 
 public:
     // Querying the type.
-    bool isString() const;
-    bool isHeapBigInt() const;
-    bool isSymbol() const;
-    bool isObject() const;
-    bool isGetterSetter() const;
-    bool isCustomGetterSetter() const;
-    bool isProxy() const;
+    bool isString() const { return m_type == StringType; }
+    bool isHeapBigInt() const { return m_type == HeapBigIntType; }
+    bool isSymbol() const { return m_type == SymbolType; }
+    JS_EXPORT_PRIVATE bool isObjectSlow() const;
+    bool isObject() const { return TypeInfo::isObject(m_type); }
+    bool isGetterSetter() const { return m_type == GetterSetterType; }
+    bool isCustomGetterSetter() const { return m_type == CustomGetterSetterType; }
+    bool isProxy() const { return m_type == GlobalProxyType || m_type == ProxyObjectType; }
     bool isCallable();
     bool isConstructor();
     template<Concurrency> TriState isCallableWithConcurrency();
     template<Concurrency> TriState isConstructorWithConcurrency();
     bool inherits(const ClassInfo*) const;
+    JS_EXPORT_PRIVATE bool inheritsSlow(const ClassInfo*) const;
     template<typename Target> bool inherits() const;
     JS_EXPORT_PRIVATE bool NODELETE isValidCallee() const;
-    bool isAPIValueWrapper() const;
+    bool isAPIValueWrapper() const { return m_type == APIValueWrapperType; }
     
     // Each cell has a built-in lock. Currently it's simply available for use if you need it. It's
     // a full-blown WTF::Lock. Note that this lock is currently used in JSArray and that lock's
@@ -149,12 +151,12 @@ public:
     // Locker locker { cell->cellLock() };
     JSCellLock& cellLock() const { return *reinterpret_cast<JSCellLock*>(const_cast<JSCell*>(this)); }
     
-    JSType type() const;
-    IndexingType indexingTypeAndMisc() const;
-    IndexingType indexingMode() const;
-    IndexingType indexingType() const;
+    JSType type() const { return m_type; }
+    IndexingType indexingTypeAndMisc() const { return m_indexingTypeAndMisc; }
+    IndexingType indexingMode() const { return indexingTypeAndMisc() & AllArrayTypes; }
+    IndexingType indexingType() const { return indexingTypeAndMisc() & AllWritableArrayTypes; }
     StructureID structureID() const { return m_structureID; }
-    Structure* structure() const;
+    Structure* structure() const { return m_structureID.decode(); }
     void setStructure(VM&, Structure*);
     void setStructureIDDirectly(StructureID id) { m_structureID = id; }
     void clearStructure() { m_structureID = StructureID(); }
@@ -181,7 +183,7 @@ public:
     // Basic conversions.
     JS_EXPORT_PRIVATE JSValue toPrimitive(JSGlobalObject*, PreferredPrimitiveType) const;
     bool toBoolean(JSGlobalObject*) const;
-    TriState pureToBoolean() const;
+    inline TriState pureToBoolean() const;
     JS_EXPORT_PRIVATE double toNumber(JSGlobalObject*) const;
     JSObject* toObject(JSGlobalObject*) const;
 
@@ -210,8 +212,8 @@ public:
     JS_EXPORT_PRIVATE static bool deleteProperty(JSCell*, JSGlobalObject*, PropertyName);
     static bool deletePropertyByIndex(JSCell*, JSGlobalObject*, unsigned propertyName);
 
-    static bool canUseFastGetOwnProperty(const Structure&);
-    JSValue fastGetOwnProperty(VM&, Structure&, PropertyName);
+    static inline bool canUseFastGetOwnProperty(const Structure&);
+    inline JSValue fastGetOwnProperty(VM&, Structure&, PropertyName);
 
     // The recommended idiom for using cellState() is to switch on it or perform an == comparison on it
     // directly. We deliberately avoid helpers for this, because we want transparency about how the various
@@ -301,10 +303,10 @@ private:
 
 class JSCellLock : public JSCell {
 public:
-    void lock();
-    bool tryLock();
-    void unlock();
-    bool isLocked() const;
+    inline void lock();
+    inline bool tryLock();
+    inline void unlock();
+    inline bool isLocked() const;
 private:
     JS_EXPORT_PRIVATE void lockSlow();
     JS_EXPORT_PRIVATE void unlockSlow();

--- a/Source/JavaScriptCore/runtime/JSCellInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCellInlines.h
@@ -131,31 +131,6 @@ inline void JSCell::finishCreation(VM& vm, Structure* structure, CreatingEarlyCe
     ASSERT(m_structureID || !vm.structureStructure);
 }
 
-inline JSType JSCell::type() const
-{
-    return m_type;
-}
-
-inline IndexingType JSCell::indexingTypeAndMisc() const
-{
-    return m_indexingTypeAndMisc;
-}
-
-inline IndexingType JSCell::indexingType() const
-{
-    return indexingTypeAndMisc() & AllWritableArrayTypes;
-}
-
-inline IndexingType JSCell::indexingMode() const
-{
-    return indexingTypeAndMisc() & AllArrayTypes;
-}
-
-ALWAYS_INLINE Structure* JSCell::structure() const
-{
-    return m_structureID.decode();
-}
-
 template<typename Visitor>
 void JSCell::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
@@ -228,41 +203,6 @@ void* tryAllocateCell(VM& vm, GCDeferralContext* deferralContext, size_t size)
     return tryAllocateCellHelper<T, AllocationFailureMode::ReturnNull>(vm, size, deferralContext);
 }
 
-inline bool JSCell::isObject() const
-{
-    return TypeInfo::isObject(m_type);
-}
-
-inline bool JSCell::isString() const
-{
-    return m_type == StringType;
-}
-
-inline bool JSCell::isHeapBigInt() const
-{
-    return m_type == HeapBigIntType;
-}
-
-inline bool JSCell::isSymbol() const
-{
-    return m_type == SymbolType;
-}
-
-inline bool JSCell::isGetterSetter() const
-{
-    return m_type == GetterSetterType;
-}
-
-inline bool JSCell::isCustomGetterSetter() const
-{
-    return m_type == CustomGetterSetterType;
-}
-
-inline bool JSCell::isProxy() const
-{
-    return m_type == GlobalProxyType || m_type == ProxyObjectType;
-}
-
 // FIXME: Consider making getCallData concurrency-safe once NPAPI support is removed.
 // https://bugs.webkit.org/show_bug.cgi?id=215801
 template<Concurrency concurrency>
@@ -308,11 +248,6 @@ ALWAYS_INLINE bool JSCell::isConstructor()
     auto result = isConstructorWithConcurrency<Concurrency::MainThread>();
     ASSERT(result != TriState::Indeterminate);
     return result == TriState::True;
-}
-
-inline bool JSCell::isAPIValueWrapper() const
-{
-    return m_type == APIValueWrapperType;
 }
 
 ALWAYS_INLINE void JSCell::setStructure(VM& vm, Structure* structure)

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h
@@ -45,7 +45,7 @@ void JSGenericTypedArrayViewPrototype<ViewClass>::finishCreation(
 {
     Base::finishCreation(vm);
     
-    ASSERT(inherits(info()));
+    ASSERT(inheritsSlow(info()));
 
     putDirectWithoutTransition(vm, vm.propertyNames->BYTES_PER_ELEMENT, jsNumber(ViewClass::elementSize), PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly | PropertyAttribute::DontDelete);
 

--- a/Source/JavaScriptCore/runtime/JSObject.h
+++ b/Source/JavaScriptCore/runtime/JSObject.h
@@ -1335,7 +1335,7 @@ inline void JSObject::setStructure(VM& vm, Structure* structure)
 inline JSObject* asObject(JSCell* cell)
 {
     ASSERT(cell);
-    ASSERT(cell->isObject());
+    ASSERT(cell->isObjectSlow());
     return jsCast<JSObject*>(cell);
 }
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -957,6 +957,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     bindings/js/JSShadowRealmGlobalScopeBase.h
     bindings/js/JSStyleSheetCustom.h
     bindings/js/JSValueInWrappedObject.h
+    bindings/js/JSValueInWrappedObjectInlines.h
     bindings/js/JSWindowProxy.h
     bindings/js/ModuleScriptLoader.h
     bindings/js/ReadableStreamDefaultController.h

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -47,6 +47,7 @@
 #include "VideoFrame.h"
 #include "WebCodecsVideoFrame.h"
 #include "WebGPUDevice.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/MallocSpan.h>
 

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
@@ -48,6 +48,8 @@
 #include "PasteboardCustomData.h"
 #include "SharedBuffer.h"
 #include "markup.h"
+#include <JavaScriptCore/HeapCellInlines.h>
+#include <JavaScriptCore/JSCJSValueCellInlines.h>
 #include <wtf/Function.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
+++ b/Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp
@@ -38,6 +38,7 @@
 #include "JSDOMConvertInterface.h"
 #include "JSDOMConvertNullable.h"
 #include "JSDigitalCredential.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "LocalFrame.h"
 #include "Navigator.h"
 #include "Page.h"

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp
@@ -54,6 +54,8 @@
 #include "SecurityOriginData.h"
 #include "Settings.h"
 #include "SharedBuffer.h"
+#include <JavaScriptCore/HeapCellInlines.h>
+#include <JavaScriptCore/StrongInlines.h>
 #include <wtf/HashCountedSet.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.cpp
@@ -34,6 +34,7 @@
 #include "JSMediaKeyStatusMap.h"
 #include "MediaKeySession.h"
 #include "SharedBuffer.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
 #include <ranges>
 #include <wtf/StdLibExtras.h>
 

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.h
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.h
@@ -33,7 +33,6 @@
 #include "BufferSource.h"
 #include "CDMKeyID.h"
 #include "MediaKeyStatus.h"
-#include <JavaScriptCore/JSCJSValueInlines.h>
 #include <wtf/RefCounted.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp
@@ -40,6 +40,7 @@
 #include "JSMediaKeys.h"
 #include "MediaKeys.h"
 #include "MediaKeysRequirement.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp
+++ b/Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp
@@ -39,6 +39,7 @@
 #include "JSMediaKeySystemAccess.h"
 #include "Logging.h"
 #include "MediaKeySystemRequest.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace WTF {

--- a/Source/WebCore/Modules/fetch/FetchBodySource.h
+++ b/Source/WebCore/Modules/fetch/FetchBodySource.h
@@ -36,6 +36,7 @@ class ArrayBuffer;
 namespace WebCore {
 
 class DOMPromise;
+class Exception;
 class FetchBodyOwner;
 class ReadableByteStreamController;
 

--- a/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
+++ b/Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
@@ -34,6 +34,7 @@
 #include "JSDOMConvertInterface.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSFetchResponse.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "LocalDOMWindow.h"
 #include "UserGestureIndicator.h"
 #include "WorkerGlobalScope.h"

--- a/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
+++ b/Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp
@@ -38,6 +38,7 @@
 #include "JSDOMConvertStrings.h"
 #include "JSDOMPromiseDeferred.h"
 #include "Settings.h"
+#include <JavaScriptCore/JSString.h>
 #include <wtf/CompletionHandler.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -43,6 +43,7 @@
 #include "JSDOMConvertNullable.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSDigitalCredential.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "Page.h"
 #include "SecurityOriginData.h"
 #include <JavaScriptCore/JSObject.h>

--- a/Source/WebCore/Modules/indexeddb/IDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBCursor.cpp
@@ -35,6 +35,7 @@
 #include "IDBObjectStore.h"
 #include "IDBRequest.h"
 #include "IDBTransaction.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "Logging.h"
 #include "ScriptExecutionContext.h"
 #include "ScriptWrappableInlines.h"

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
@@ -43,6 +43,7 @@
 #include "JSDOMConvertIndexedDB.h"
 #include "JSDOMConvertNumbers.h"
 #include "JSDOMConvertSequences.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "Logging.h"
 #include "ScriptExecutionContext.h"
 #include "ThreadSafeDataBuffer.h"

--- a/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
+++ b/Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp
@@ -42,6 +42,7 @@
 #include "PlatformMediaEngineConfigurationFactory.h"
 #include "Settings.h"
 #include "WebRTCProvider.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <wtf/Logger.h>
 #include <wtf/SortedArrayMap.h>
 

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -49,6 +49,7 @@
 #include "HTMLElement.h"
 #include "HTMLMediaElement.h"
 #include "HTMLVideoElement.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "LocalDOMWindow.h"
 #include "LocalizedStrings.h"
 #include "Logging.h"

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp
@@ -38,6 +38,7 @@
 #include "OffscreenCanvas.h"
 #include "ReadableStream.h"
 #include "SVGImageElement.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <wtf/Scope.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -293,7 +294,6 @@ void MediaStreamTrackProcessor::Source::doCancel(JSC::JSValue)
     m_isCancelled = true;
     Ref { m_processor.get() }->stopObserving();
 }
-
 
 Ref<MediaStreamTrackProcessor::TrackObserverWrapper> MediaStreamTrackProcessor::TrackObserverWrapper::create(ScriptExecutionContext& context, MediaStreamTrackProcessor& processor, MediaStreamTrackHandle& handle)
 {

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -69,6 +69,7 @@
 #include "RTCSessionDescription.h"
 #include "RTCSessionDescriptionInit.h"
 #include "Settings.h"
+#include <JavaScriptCore/StrongInlines.h>
 #include <algorithm>
 #include <wtf/MainThread.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
@@ -36,6 +36,7 @@
 #include "RTCRtpScriptTransformer.h"
 #include "RTCRtpTransformBackend.h"
 #include "Worker.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/WeakPtr.h>
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
@@ -36,6 +36,7 @@
 #include "RTCEncodedStreamProducer.h"
 #include "ScriptExecutionContextInlines.h"
 #include "WorkerThread.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
+++ b/Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp
@@ -35,7 +35,7 @@
 #include "VideoFrame.h"
 #include "WritableStream.h"
 #include "WritableStreamSink.h"
-
+#include <JavaScriptCore/JSCellInlines.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -82,6 +82,7 @@
 #include "ScriptController.h"
 #include "Settings.h"
 #include <JavaScriptCore/ConsoleTypes.h>
+#include <JavaScriptCore/HeapInlines.h>
 #include <wtf/Seconds.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/URL.h>

--- a/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(PAYMENT_REQUEST)
 
+#include "JSValueInWrappedObjectInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp
@@ -30,6 +30,7 @@
 
 #include "Document.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "NotImplemented.h"
 #include "PaymentComplete.h"
 #include "PaymentCompleteDetails.h"

--- a/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
+++ b/Source/WebCore/Modules/paymentrequest/PaymentResponse.h
@@ -34,6 +34,7 @@
 #include "ExceptionOr.h"
 #include "JSValueInWrappedObject.h"
 #include "PaymentAddress.h"
+#include <JavaScriptCore/Strong.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -53,6 +53,7 @@
 #include "WorkerGlobalScope.h"
 #include "WorkerLoaderProxy.h"
 #include "WorkerThread.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <optional>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/TypeCasts.h>

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp
@@ -34,6 +34,7 @@
 #include "Exception.h"
 #include "JSDOMPromiseDeferred.h"
 #include "WakeLockManager.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
@@ -35,6 +35,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "JSReadableByteStreamController.h"
 #include "JSReadableStreamReadResult.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "ReadableStream.h"
 #include "ReadableStreamBYOBReader.h"
 #include "ReadableStreamBYOBRequest.h"

--- a/Source/WebCore/Modules/streams/ReadableStreamSource.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamSource.cpp
@@ -82,13 +82,18 @@ void ReadableStreamSource::pullFinished()
     setInactive();
 }
 
-void ReadableStreamSource::cancelFinished(std::optional<Exception>&& exception)
+void ReadableStreamSource::cancelFinished()
 {
     ASSERT(m_promise);
-    if (exception)
-        m_promise->reject(WTF::move(*exception));
-    else
-        m_promise->resolve();
+    m_promise->resolve();
+    m_promise = nullptr;
+    setInactive();
+}
+
+void ReadableStreamSource::cancelFinished(Exception&& exception)
+{
+    ASSERT(m_promise);
+    m_promise->reject(WTF::move(exception));
     m_promise = nullptr;
     setInactive();
 }

--- a/Source/WebCore/Modules/streams/ReadableStreamSource.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamSource.h
@@ -35,6 +35,8 @@
 
 namespace WebCore {
 
+class Exception;
+
 class ReadableStreamSource : public AbstractRefCounted {
 public:
     WEBCORE_EXPORT ReadableStreamSource();
@@ -55,7 +57,8 @@ protected:
 
     void startFinished();
     void pullFinished();
-    void cancelFinished(std::optional<Exception>&& = { });
+    void cancelFinished();
+    void cancelFinished(Exception&&);
     void cancelFinishedWithError(JSC::JSValue);
     WEBCORE_EXPORT void clean();
 

--- a/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
@@ -33,11 +33,13 @@
 #include "InternalWritableStreamWriter.h"
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "ReadableStream.h"
 #include "ReadableStreamDefaultReader.h"
 #include "ScriptExecutionContextInlines.h"
 #include "StreamPipeOptions.h"
 #include "WritableStream.h"
+#include <JavaScriptCore/StrongInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -33,13 +33,15 @@
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSReadableStreamReadResult.h"
-#include "JSValueInWrappedObject.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "ReadableByteStreamController.h"
 #include "ReadableStream.h"
 #include "ReadableStreamBYOBReader.h"
 #include "ReadableStreamBYOBRequest.h"
 #include "ReadableStreamDefaultReader.h"
 #include "ScriptExecutionContextInlines.h"
+#include <JavaScriptCore/JSGlobalObjectInlines.h>
+#include <JavaScriptCore/MarkedVector.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/streams/StreamTransferUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTransferUtilities.cpp
@@ -36,6 +36,7 @@
 #include "StructuredSerializeOptions.h"
 #include "WritableStream.h"
 #include "WritableStreamSink.h"
+#include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/streams/TransformStream.cpp
+++ b/Source/WebCore/Modules/streams/TransformStream.cpp
@@ -30,6 +30,7 @@
 #include "JSDOMConvertSequences.h"
 #include "JSReadableStream.h"
 #include "JSTransformStream.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "JSWritableStream.h"
 #include "MessagePort.h"
 #include "StreamTransferUtilities.h"

--- a/Source/WebCore/Modules/streams/WritableStreamSink.cpp
+++ b/Source/WebCore/Modules/streams/WritableStreamSink.cpp
@@ -31,6 +31,7 @@
 #include "JSWritableStreamDefaultController.h"
 #include "JSWritableStreamSink.h"
 #include "WebCoreJSClientData.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/IdentifierInlines.h>
 #include <JavaScriptCore/JSObjectInlines.h>

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp
@@ -31,14 +31,18 @@
 #include "URLPatternCanonical.h"
 #include "URLPatternParser.h"
 #include "URLPatternResult.h"
-#include <JavaScriptCore/JSCJSValue.h>
+#include <JavaScriptCore/JSCJSValueInlines.h>
+#include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/RegExpObject.h>
+#include <JavaScriptCore/StrongInlines.h>
 #include <ranges>
 
 namespace WebCore {
 using namespace JSC;
 namespace URLPatternUtilities {
+
+URLPatternComponent::URLPatternComponent() = default;
 
 URLPatternComponent::URLPatternComponent(String&& patternString, JSC::Strong<JSC::RegExp>&& regex, Vector<String>&& groupNameList, bool hasRegexpGroupsFromPartsList)
     : m_patternString(WTF::move(patternString))

--- a/Source/WebCore/Modules/url-pattern/URLPatternComponent.h
+++ b/Source/WebCore/Modules/url-pattern/URLPatternComponent.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #include <JavaScriptCore/Strong.h>
-#include <JavaScriptCore/StrongInlines.h>
 
 namespace JSC {
 class RegExp;
@@ -52,7 +51,7 @@ public:
     bool matchSpecialSchemeProtocol(ScriptExecutionContext&) const;
     JSC::JSValue componentExec(ScriptExecutionContext&, StringView) const;
     URLPatternComponentResult createComponentMatchResult(JSC::JSGlobalObject*, String&& input, const JSC::JSValue& execResult) const;
-    URLPatternComponent() = default;
+    URLPatternComponent();
 
 private:
     URLPatternComponent(String&&, JSC::Strong<JSC::RegExp>&&, Vector<String>&&, bool);

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -44,6 +44,7 @@
 #include "WorkerGlobalScope.h"
 #include "WorkerLoaderProxy.h"
 #include "WorkerThread.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/RunLoop.h>
 #include <wtf/text/MakeString.h>

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -37,6 +37,7 @@
 #include "AudioFileReader.h"
 #include "AudioUtilities.h"
 #include "ExceptionOr.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "ScriptWrappableInlines.h"
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/JSCInlines.h>

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.h
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.h
@@ -34,12 +34,13 @@
 #include "ScriptWrappable.h"
 #include <JavaScriptCore/Forward.h>
 #include <JavaScriptCore/TypedArrayAdaptersForwardDeclarations.h>
+#include <wtf/FixedVector.h>
 #include <wtf/Lock.h>
-#include <wtf/Vector.h>
 
 namespace WebCore {
 
 class AudioBus;
+class JSDOMGlobalObject;
 class WebCoreOpaqueRoot;
 template<typename> class ExceptionOr;
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
@@ -37,10 +37,14 @@
 #include "AudioWorkletProcessorConstructionData.h"
 #include "JSCallbackData.h"
 #include "JSDOMExceptionHandling.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "MessagePort.h"
 #include "ScriptWrappableInlines.h"
 #include "WebCoreOpaqueRoot.h"
+#include <JavaScriptCore/JSArray.h>
+#include <JavaScriptCore/JSGlobalObjectInlines.h>
 #include <JavaScriptCore/JSTypedArrays.h>
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <wtf/GetPtr.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -42,7 +42,6 @@
 #include "WebCodecsEncodedAudioChunk.h"
 #include "WebCodecsErrorCallback.h"
 #include "WebCodecsUtilities.h"
-
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/Modules/webtransport/DatagramByteSource.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramByteSource.cpp
@@ -32,6 +32,7 @@
 #include "ReadableStream.h"
 #include "ReadableStreamBYOBRequest.h"
 #include <JavaScriptCore/ArrayBuffer.h>
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <wtf/StdLibExtras.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webtransport/DatagramByteSource.h
+++ b/Source/WebCore/Modules/webtransport/DatagramByteSource.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "DatagramSource.h"
+#include <wtf/RefCounted.h>
 
 namespace JSC {
 class ArrayBuffer;

--- a/Source/WebCore/Modules/webtransport/DatagramSource.cpp
+++ b/Source/WebCore/Modules/webtransport/DatagramSource.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "DatagramSource.h"
 
+#include "Exception.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <wtf/StdLibExtras.h>
 

--- a/Source/WebCore/Modules/webtransport/DatagramSource.h
+++ b/Source/WebCore/Modules/webtransport/DatagramSource.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "Exception.h"
 #include "ReadableStreamSource.h"
 #include <wtf/AbstractRefCounted.h>
 
@@ -36,7 +37,6 @@ class JSValue;
 namespace WebCore {
 
 class WebTransport;
-class Exception;
 
 class DatagramSource : public AbstractRefCounted {
 public:

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp
@@ -33,6 +33,8 @@
 #include "WebTransport.h"
 #include "WebTransportError.h"
 #include "WebTransportSession.h"
+#include <JavaScriptCore/HeapCellInlines.h>
+#include <JavaScriptCore/JSCellInlines.h>
 #include <wtf/Scope.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webxr/WebXRRigidTransform.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRRigidTransform.cpp
@@ -30,6 +30,7 @@
 
 #include "DOMPointReadOnly.h"
 #include "ExceptionOr.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "ScriptWrappableInlines.h"
 #include "TransformationMatrix.h"
 #include <JavaScriptCore/TypedArrayInlines.h>

--- a/Source/WebCore/Modules/webxr/WebXRView.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRView.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR)
 
+#include "JSValueInWrappedObjectInlines.h"
 #include "WebXRFrame.h"
 #include "WebXRRigidTransform.h"
 #include <JavaScriptCore/TypedArrayInlines.h>

--- a/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -1,3 +1,4 @@
+CommandLineAPIModuleSourceBuiltins.h
 Modules/WebGPU/Implementation/WebGPUAdapterImpl.cpp
 Modules/WebGPU/Implementation/WebGPUBindGroupImpl.cpp
 Modules/WebGPU/Implementation/WebGPUBufferImpl.cpp
@@ -23,6 +24,10 @@ Modules/WebGPU/Implementation/WebGPUXRBindingImpl.cpp
 Modules/WebGPU/Implementation/WebGPUXRSubImageImpl.cpp
 Modules/notifications/NotificationController.h
 Modules/webdatabase/DatabaseThread.h
+ReadableStreamInternalsBuiltins.h
+StreamInternalsBuiltins.h
+TransformStreamInternalsBuiltins.h
+WritableStreamInternalsBuiltins.h
 accessibility/AccessibilityObject.cpp
 bindings/js/GarbageCollectionController.cpp
 bindings/js/JSLocationCustom.cpp

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -695,7 +695,9 @@ bindings/js/JSDOMBindingSecurity.cpp
 bindings/js/JSDOMBuiltinConstructorBase.cpp
 bindings/js/JSDOMConstructorBase.cpp
 bindings/js/JSDOMConstructorWithDocument.cpp
+bindings/js/JSDOMConvertAny.cpp
 bindings/js/JSDOMConvertBoolean.cpp
+bindings/js/JSDOMConvertBufferSource.cpp
 bindings/js/JSDOMConvertDate.cpp
 bindings/js/JSDOMConvertNumbers.cpp
 bindings/js/JSDOMConvertStrings.cpp

--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -29,7 +29,6 @@
 #include "AnimationEffect.h"
 #include "AnimationPlaybackEvent.h"
 #include "AnimationTimeline.h"
-#include "ContainerNodeInlines.h"
 #include "CSSAnimationEvent.h"
 #include "CSSSerializationContext.h"
 #include "CSSStyleProperties.h"
@@ -39,6 +38,7 @@
 #include "CSSValuePool.h"
 #include "Chrome.h"
 #include "ChromeClient.h"
+#include "ContainerNodeInlines.h"
 #include "ContextDestructionObserverInlines.h"
 #include "DOMPromiseProxy.h"
 #include "DocumentPage.h"
@@ -62,6 +62,7 @@
 #include "StyledElement.h"
 #include "WebAnimationTypes.h"
 #include "WebAnimationUtilities.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>

--- a/Source/WebCore/bindings/js/CommonVM.cpp
+++ b/Source/WebCore/bindings/js/CommonVM.cpp
@@ -34,6 +34,7 @@
 #include "WebCoreJSClientData.h"
 #include <JavaScriptCore/EdenGCActivityCallback.h>
 #include <JavaScriptCore/FullGCActivityCallback.h>
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/MachineStackMarker.h>
 #include <JavaScriptCore/VM.h>

--- a/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
+++ b/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
@@ -53,6 +53,7 @@
 #include "WebCoreJSClientData.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/DateInstance.h>
+#include <JavaScriptCore/JSObjectInlines.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/StrongInlines.h>
 #include <wtf/AutodrainedPool.h>

--- a/Source/WebCore/bindings/js/InternalWritableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStream.cpp
@@ -29,6 +29,7 @@
 #include "Exception.h"
 #include "JSDOMExceptionHandling.h"
 #include "WebCoreJSClientData.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/JSArrayBufferViewInlines.h>
 #include <JavaScriptCore/JSObjectInlines.h>
 

--- a/Source/WebCore/bindings/js/JSAbortSignalCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAbortSignalCustom.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "JSAbortSignal.h"
 
+#include "JSValueInWrappedObjectInlines.h"
 #include "WebCoreOpaqueRootInlines.h"
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSAudioWorkletProcessorCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAudioWorkletProcessorCustom.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "JSAudioWorkletProcessor.h"
 
+#include "JSValueInWrappedObjectInlines.h"
+
 #if ENABLE(WEB_AUDIO)
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSCallbackData.cpp
+++ b/Source/WebCore/bindings/js/JSCallbackData.cpp
@@ -31,14 +31,57 @@
 
 #include "Document.h"
 #include "JSDOMBinding.h"
+#include "JSDOMGlobalObject.h"
 #include "JSExecState.h"
 #include "JSExecStateInstrumentation.h"
 #include <JavaScriptCore/Exception.h>
+#include <JavaScriptCore/HeapCellInlines.h>
+#include <JavaScriptCore/JSObjectInlines.h>
+#include <JavaScriptCore/WeakInlines.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
 
 namespace WebCore {
 using namespace JSC;
+
+JSCallbackData::JSCallbackData(JSC::JSObject* callback, JSDOMGlobalObject* globalObject, void* owner)
+    : m_globalObject(globalObject)
+    , m_callback(callback, &m_weakOwner, owner)
+{
+}
+
+JSCallbackData::~JSCallbackData()
+{
+#if !PLATFORM(IOS_FAMILY)
+    ASSERT(m_thread.ptr() == &Thread::currentSingleton());
+#endif
+}
+
+JSDOMGlobalObject* JSCallbackData::globalObject()
+{
+    return m_globalObject.get();
+}
+
+JSC::JSObject* JSCallbackData::callback()
+{
+    return m_callback.get();
+}
+
+JSC::JSValue JSCallbackData::invokeCallback(JSC::JSValue thisValue, JSC::MarkedArgumentBuffer& args, CallbackType callbackType, JSC::PropertyName functionName, NakedPtr<JSC::Exception>& returnedException)
+{
+    auto* globalObject = this->globalObject();
+    if (!globalObject)
+        return { };
+
+    return JSCallbackData::invokeCallback(*globalObject, callback(), thisValue, args, callbackType, functionName, returnedException);
+}
+
+bool JSCallbackData::WeakOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* owner, JSC::AbstractSlotVisitor& visitor, ASCIILiteral* reason)
+{
+    if (reason) [[unlikely]]
+        *reason = "Callback owner is an opaque root"_s;
+    return visitor.containsOpaqueRoot(owner);
+}
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(JSCallbackData);
 

--- a/Source/WebCore/bindings/js/JSCallbackData.h
+++ b/Source/WebCore/bindings/js/JSCallbackData.h
@@ -28,15 +28,22 @@
 
 #pragma once
 
-#include "JSDOMBinding.h"
 #include "ScriptExecutionContext.h"
-#include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Weak.h>
-#include <JavaScriptCore/WeakInlines.h>
+#include <wtf/NakedPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/Threading.h>
 
+namespace JSC {
+class JSObject;
+class JSValue;
+template<size_t> class MarkedArgumentBufferWithSize;
+using MarkedArgumentBuffer = MarkedArgumentBufferWithSize<8>;
+}
+
 namespace WebCore {
+
+class JSDOMGlobalObject;
 
 template<typename ImplementationClass> struct JSDOMCallbackConverterTraits;
 
@@ -44,50 +51,28 @@ template<typename ImplementationClass> struct JSDOMCallbackConverterTraits;
 // JSObject on the wrong thread without synchronization would corrupt the heap
 // (and synchronization would be slow).
 
-class JSCallbackData {
+class WEBCORE_EXPORT JSCallbackData {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(JSCallbackData, WEBCORE_EXPORT);
 public:
     enum class CallbackType { Function, Object, FunctionOrObject };
 
-    JSCallbackData(JSC::JSObject* callback, JSDOMGlobalObject* globalObject, void* owner)
-        : m_globalObject(globalObject)
-        , m_callback(callback, &m_weakOwner, owner)
-    {
-    }
+    JSCallbackData(JSC::JSObject* callback, JSDOMGlobalObject*, void* owner);
+    ~JSCallbackData();
 
-    ~JSCallbackData()
-    {
-#if !PLATFORM(IOS_FAMILY)
-        ASSERT(m_thread.ptr() == &Thread::currentSingleton());
-#endif
-    }
-
-    JSDOMGlobalObject* globalObject() { return m_globalObject.get(); }
-    JSC::JSObject* callback() { return m_callback.get(); }
+    JSDOMGlobalObject* globalObject();
+    JSC::JSObject* callback();
 
     template<typename Visitor> void visitJSFunctionInGCThread(Visitor&);
 
-    WEBCORE_EXPORT static JSC::JSValue invokeCallback(JSDOMGlobalObject&, JSC::JSObject* callback, JSC::JSValue thisValue, JSC::MarkedArgumentBuffer&, CallbackType, JSC::PropertyName functionName, NakedPtr<JSC::Exception>& returnedException);
+    static JSC::JSValue invokeCallback(JSDOMGlobalObject&, JSC::JSObject* callback, JSC::JSValue thisValue, JSC::MarkedArgumentBuffer&, CallbackType, JSC::PropertyName functionName, NakedPtr<JSC::Exception>& returnedException);
 
-    JSC::JSValue invokeCallback(JSC::JSValue thisValue, JSC::MarkedArgumentBuffer& args, CallbackType callbackType, JSC::PropertyName functionName, NakedPtr<JSC::Exception>& returnedException)
-    {
-        auto* globalObject = this->globalObject();
-        if (!globalObject)
-            return { };
-
-        return JSCallbackData::invokeCallback(*globalObject, callback(), thisValue, args, callbackType, functionName, returnedException);
-    }
+    JSC::JSValue invokeCallback(JSC::JSValue thisValue, JSC::MarkedArgumentBuffer&, CallbackType, JSC::PropertyName functionName, NakedPtr<JSC::Exception>&);
 
 private:
     JSC::Weak<JSDOMGlobalObject> m_globalObject;
 
-    class WeakOwner : public JSC::WeakHandleOwner {
-        bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* owner, JSC::AbstractSlotVisitor& visitor, ASCIILiteral* reason) override
-        {
-            if (reason) [[unlikely]]
-                *reason = "Callback owner is an opaque root"_s;
-            return visitor.containsOpaqueRoot(owner);
-        }
+    class WEBCORE_EXPORT WeakOwner : public JSC::WeakHandleOwner {
+        bool isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown>, void* owner, JSC::AbstractSlotVisitor&, ASCIILiteral*) override;
     };
     WeakOwner m_weakOwner;
     JSC::Weak<JSC::JSObject> m_callback;

--- a/Source/WebCore/bindings/js/JSCustomEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCustomEventCustom.cpp
@@ -28,6 +28,7 @@
 
 #include "CustomEvent.h"
 #include "DOMWrapperWorld.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/Structure.h>

--- a/Source/WebCore/bindings/js/JSDOMAsyncIterator.h
+++ b/Source/WebCore/bindings/js/JSDOMAsyncIterator.h
@@ -558,7 +558,7 @@ template<typename JSWrapper, typename IteratorTraits>
 void JSDOMAsyncIteratorPrototype<JSWrapper, IteratorTraits>::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
     Base::finishCreation(vm);
-    ASSERT(inherits(info()));
+    ASSERT(inheritsSlow(info()));
 
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->next, next, 0, 0, JSC::ImplementationVisibility::Public);
     addReturnMethodIfNeeded<typename DOMWrapped::Iterator>(vm, globalObject);

--- a/Source/WebCore/bindings/js/JSDOMBinding.h
+++ b/Source/WebCore/bindings/js/JSDOMBinding.h
@@ -24,21 +24,3 @@
 #pragma once
 
 // FIXME: Remove this header.
-
-#include <JavaScriptCore/AuxiliaryBarrierInlines.h>
-#include <JavaScriptCore/HeapInlines.h>
-#include <JavaScriptCore/JSArray.h>
-#include <JavaScriptCore/JSCJSValueInlines.h>
-#include <JavaScriptCore/JSCellInlines.h>
-#include <JavaScriptCore/JSObjectInlines.h>
-#include <JavaScriptCore/Lookup.h>
-#include <JavaScriptCore/ObjectConstructor.h>
-#include <JavaScriptCore/SlotVisitorInlines.h>
-#include <JavaScriptCore/StructureInlines.h>
-#include <JavaScriptCore/WriteBarrier.h>
-#include <WebCore/ExceptionOr.h>
-#include <WebCore/JSDOMWrapperCache.h>
-#include <cstddef>
-#include <wtf/Forward.h>
-#include <wtf/GetPtr.h>
-#include <wtf/Vector.h>

--- a/Source/WebCore/bindings/js/JSDOMBuiltinConstructor.h
+++ b/Source/WebCore/bindings/js/JSDOMBuiltinConstructor.h
@@ -22,6 +22,8 @@
 #include "JSDOMBuiltinConstructorBase.h"
 #include "JSDOMExceptionHandling.h"
 #include "JSDOMWrapperCache.h"
+#include <JavaScriptCore/ArgList.h>
+#include <JavaScriptCore/JSFunction.h>
 
 namespace WebCore {
 
@@ -72,7 +74,7 @@ template<typename JSClass> inline JSC::Structure* JSDOMBuiltinConstructor<JSClas
 template<typename JSClass> inline void JSDOMBuiltinConstructor<JSClass>::finishCreation(JSC::VM& vm, JSDOMGlobalObject& globalObject)
 {
     Base::finishCreation(vm);
-    ASSERT(inherits(info()));
+    ASSERT(inheritsSlow(info()));
     setInitializeFunction(vm, *JSC::JSFunction::create(vm, &globalObject, initializeExecutable(vm), &globalObject));
     initializeProperties(vm, globalObject);
 }

--- a/Source/WebCore/bindings/js/JSDOMBuiltinConstructorBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMBuiltinConstructorBase.cpp
@@ -23,6 +23,7 @@
 #include "JSDOMBuiltinConstructorBase.h"
 
 #include "WebCoreJSClientData.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/JSCInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSDOMConstructor.h
+++ b/Source/WebCore/bindings/js/JSDOMConstructor.h
@@ -67,7 +67,7 @@ template<typename JSClass> inline JSC::Structure* JSDOMConstructor<JSClass>::cre
 template<typename JSClass> inline void JSDOMConstructor<JSClass>::finishCreation(JSC::VM& vm, JSDOMGlobalObject& globalObject)
 {
     Base::finishCreation(vm);
-    ASSERT(inherits(info()));
+    ASSERT(inheritsSlow(info()));
     initializeProperties(vm, globalObject);
 }
 

--- a/Source/WebCore/bindings/js/JSDOMConstructorBase.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConstructorBase.cpp
@@ -23,6 +23,7 @@
 #include "JSDOMConstructor.h"
 
 #include "WebCoreJSClientData.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/JSCInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSDOMConstructorNotCallable.h
+++ b/Source/WebCore/bindings/js/JSDOMConstructorNotCallable.h
@@ -80,7 +80,7 @@ template<typename JSClass> inline JSC::Structure* JSDOMConstructorNotCallable<JS
 template<typename JSClass> inline void JSDOMConstructorNotCallable<JSClass>::finishCreation(JSC::VM& vm, JSDOMGlobalObject& globalObject)
 {
     Base::finishCreation(vm);
-    ASSERT(inherits(info()));
+    ASSERT(inheritsSlow(info()));
     initializeProperties(vm, globalObject);
 }
 

--- a/Source/WebCore/bindings/js/JSDOMConvertAny.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertAny.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSDOMConvertAny.h"
+
+#include "JSValueInWrappedObjectInlines.h"
+#include <JavaScriptCore/StrongInlines.h>
+
+namespace WebCore {
+
+JSC::JSValue JSConverter<IDLAny>::convert(const JSValueInWrappedObject& value)
+{
+    return value.getValue();
+}
+
+auto VariadicConverter<IDLAny>::convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value) -> std::optional<Item>
+{
+    return Item { JSC::getVM(&lexicalGlobalObject), value };
+}
+
+}

--- a/Source/WebCore/bindings/js/JSDOMConvertAny.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertAny.h
@@ -59,19 +59,13 @@ template<> struct JSConverter<IDLAny> {
         return value.get();
     }
 
-    static JSC::JSValue convert(const JSValueInWrappedObject& value)
-    {
-        return value.getValue();
-    }
+    static JSC::JSValue convert(const JSValueInWrappedObject&);
 };
 
 template<> struct VariadicConverter<IDLAny> {
     using Item = JSC::Strong<JSC::Unknown>;
 
-    static std::optional<Item> convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
-    {
-        return Item { JSC::getVM(&lexicalGlobalObject), value };
-    }
+    static std::optional<Item> convert(JSC::JSGlobalObject&, JSC::JSValue);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSDOMConvertBufferSource.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertBufferSource.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "JSDOMConvertBufferSource.h"
+
+namespace WebCore {
+
+RefPtr<JSC::Int8Array> toPossiblySharedInt8Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Int8Adaptor>(vm, value); }
+RefPtr<JSC::Int16Array> toPossiblySharedInt16Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Int16Adaptor>(vm, value); }
+RefPtr<JSC::Int32Array> toPossiblySharedInt32Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Int32Adaptor>(vm, value); }
+RefPtr<JSC::Uint8Array> toPossiblySharedUint8Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Uint8Adaptor>(vm, value); }
+RefPtr<JSC::Uint8ClampedArray> toPossiblySharedUint8ClampedArray(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Uint8ClampedAdaptor>(vm, value); }
+RefPtr<JSC::Uint16Array> toPossiblySharedUint16Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Uint16Adaptor>(vm, value); }
+RefPtr<JSC::Uint32Array> toPossiblySharedUint32Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Uint32Adaptor>(vm, value); }
+RefPtr<JSC::Float16Array> toPossiblySharedFloat16Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Float16Adaptor>(vm, value); }
+RefPtr<JSC::Float32Array> toPossiblySharedFloat32Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Float32Adaptor>(vm, value); }
+RefPtr<JSC::Float64Array> toPossiblySharedFloat64Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Float64Adaptor>(vm, value); }
+RefPtr<JSC::BigInt64Array> toPossiblySharedBigInt64Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::BigInt64Adaptor>(vm, value); }
+RefPtr<JSC::BigUint64Array> toPossiblySharedBigUint64Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::BigUint64Adaptor>(vm, value); }
+
+RefPtr<JSC::Int8Array> toUnsharedInt8Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Int8Adaptor>(vm, value); }
+RefPtr<JSC::Int16Array> toUnsharedInt16Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Int16Adaptor>(vm, value); }
+RefPtr<JSC::Int32Array> toUnsharedInt32Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Int32Adaptor>(vm, value); }
+RefPtr<JSC::Uint8Array> toUnsharedUint8Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Uint8Adaptor>(vm, value); }
+RefPtr<JSC::Uint8ClampedArray> toUnsharedUint8ClampedArray(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Uint8ClampedAdaptor>(vm, value); }
+RefPtr<JSC::Uint16Array> toUnsharedUint16Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Uint16Adaptor>(vm, value); }
+RefPtr<JSC::Uint32Array> toUnsharedUint32Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Uint32Adaptor>(vm, value); }
+RefPtr<JSC::Float16Array> toUnsharedFloat16Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Float16Adaptor>(vm, value); }
+RefPtr<JSC::Float32Array> toUnsharedFloat32Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Float32Adaptor>(vm, value); }
+RefPtr<JSC::Float64Array> toUnsharedFloat64Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Float64Adaptor>(vm, value); }
+RefPtr<JSC::BigInt64Array> toUnsharedBigInt64Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::BigInt64Adaptor>(vm, value); }
+RefPtr<JSC::BigUint64Array> toUnsharedBigUint64Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::BigUint64Adaptor>(vm, value); }
+
+JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, JSC::ArrayBuffer& buffer)
+{
+    if (auto result = getCachedWrapper(globalObject->world(), buffer))
+        return result;
+
+    // The JSArrayBuffer::create function will register the wrapper in finishCreation.
+    return JSC::JSArrayBuffer::create(JSC::getVM(lexicalGlobalObject), globalObject->arrayBufferStructure(buffer.sharingMode()), &buffer);
+}
+
+}

--- a/Source/WebCore/bindings/js/JSDOMConvertBufferSource.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertBufferSource.h
@@ -25,8 +25,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/JSCInlines.h>
-#include <JavaScriptCore/JSGenericTypedArrayViewInlines.h>
 #include <JavaScriptCore/JSTypedArrays.h>
 #include <WebCore/BufferSource.h>
 #include <WebCore/IDLTypes.h>
@@ -48,40 +46,33 @@ struct IDLFloat64Array : IDLTypedArray<JSC::Float64Array> { };
 struct IDLBigInt64Array : IDLTypedArray<JSC::BigInt64Array> { };
 struct IDLBigUint64Array : IDLTypedArray<JSC::BigUint64Array> { };
 
-inline RefPtr<JSC::Int8Array> toPossiblySharedInt8Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Int8Adaptor>(vm, value); }
-inline RefPtr<JSC::Int16Array> toPossiblySharedInt16Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Int16Adaptor>(vm, value); }
-inline RefPtr<JSC::Int32Array> toPossiblySharedInt32Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Int32Adaptor>(vm, value); }
-inline RefPtr<JSC::Uint8Array> toPossiblySharedUint8Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Uint8Adaptor>(vm, value); }
-inline RefPtr<JSC::Uint8ClampedArray> toPossiblySharedUint8ClampedArray(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Uint8ClampedAdaptor>(vm, value); }
-inline RefPtr<JSC::Uint16Array> toPossiblySharedUint16Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Uint16Adaptor>(vm, value); }
-inline RefPtr<JSC::Uint32Array> toPossiblySharedUint32Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Uint32Adaptor>(vm, value); }
-inline RefPtr<JSC::Float16Array> toPossiblySharedFloat16Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Float16Adaptor>(vm, value); }
-inline RefPtr<JSC::Float32Array> toPossiblySharedFloat32Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Float32Adaptor>(vm, value); }
-inline RefPtr<JSC::Float64Array> toPossiblySharedFloat64Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::Float64Adaptor>(vm, value); }
-inline RefPtr<JSC::BigInt64Array> toPossiblySharedBigInt64Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::BigInt64Adaptor>(vm, value); }
-inline RefPtr<JSC::BigUint64Array> toPossiblySharedBigUint64Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toPossiblySharedNativeTypedView<JSC::BigUint64Adaptor>(vm, value); }
+WEBCORE_EXPORT RefPtr<JSC::Int8Array> toPossiblySharedInt8Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Int16Array> toPossiblySharedInt16Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Int32Array> toPossiblySharedInt32Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Uint8Array> toPossiblySharedUint8Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Uint8ClampedArray> toPossiblySharedUint8ClampedArray(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Uint16Array> toPossiblySharedUint16Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Uint32Array> toPossiblySharedUint32Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Float16Array> toPossiblySharedFloat16Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Float32Array> toPossiblySharedFloat32Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Float64Array> toPossiblySharedFloat64Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::BigInt64Array> toPossiblySharedBigInt64Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::BigUint64Array> toPossiblySharedBigUint64Array(JSC::VM&, JSC::JSValue);
 
-inline RefPtr<JSC::Int8Array> toUnsharedInt8Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Int8Adaptor>(vm, value); }
-inline RefPtr<JSC::Int16Array> toUnsharedInt16Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Int16Adaptor>(vm, value); }
-inline RefPtr<JSC::Int32Array> toUnsharedInt32Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Int32Adaptor>(vm, value); }
-inline RefPtr<JSC::Uint8Array> toUnsharedUint8Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Uint8Adaptor>(vm, value); }
-inline RefPtr<JSC::Uint8ClampedArray> toUnsharedUint8ClampedArray(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Uint8ClampedAdaptor>(vm, value); }
-inline RefPtr<JSC::Uint16Array> toUnsharedUint16Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Uint16Adaptor>(vm, value); }
-inline RefPtr<JSC::Uint32Array> toUnsharedUint32Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Uint32Adaptor>(vm, value); }
-inline RefPtr<JSC::Float16Array> toUnsharedFloat16Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Float16Adaptor>(vm, value); }
-inline RefPtr<JSC::Float32Array> toUnsharedFloat32Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Float32Adaptor>(vm, value); }
-inline RefPtr<JSC::Float64Array> toUnsharedFloat64Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::Float64Adaptor>(vm, value); }
-inline RefPtr<JSC::BigInt64Array> toUnsharedBigInt64Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::BigInt64Adaptor>(vm, value); }
-inline RefPtr<JSC::BigUint64Array> toUnsharedBigUint64Array(JSC::VM& vm, JSC::JSValue value) { return JSC::toUnsharedNativeTypedView<JSC::BigUint64Adaptor>(vm, value); }
+WEBCORE_EXPORT RefPtr<JSC::Int8Array> toUnsharedInt8Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Int16Array> toUnsharedInt16Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Int32Array> toUnsharedInt32Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Uint8Array> toUnsharedUint8Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Uint8ClampedArray> toUnsharedUint8ClampedArray(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Uint16Array> toUnsharedUint16Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Uint32Array> toUnsharedUint32Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Float16Array> toUnsharedFloat16Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Float32Array> toUnsharedFloat32Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::Float64Array> toUnsharedFloat64Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::BigInt64Array> toUnsharedBigInt64Array(JSC::VM&, JSC::JSValue);
+WEBCORE_EXPORT RefPtr<JSC::BigUint64Array> toUnsharedBigUint64Array(JSC::VM&, JSC::JSValue);
 
-inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, JSC::ArrayBuffer& buffer)
-{
-    if (auto result = getCachedWrapper(globalObject->world(), buffer))
-        return result;
-
-    // The JSArrayBuffer::create function will register the wrapper in finishCreation.
-    return JSC::JSArrayBuffer::create(JSC::getVM(lexicalGlobalObject), globalObject->arrayBufferStructure(buffer.sharingMode()), &buffer);
-}
+WEBCORE_EXPORT JSC::JSValue toJS(JSC::JSGlobalObject*, JSDOMGlobalObject*, JSC::ArrayBuffer&);
 
 inline JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSC::JSGlobalObject* globalObject, JSC::ArrayBufferView& view)
 {

--- a/Source/WebCore/bindings/js/JSDOMConvertNumbers.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertNumbers.cpp
@@ -419,4 +419,20 @@ template<> ConversionResult<IDLUnsignedLongLong> convertToInteger<IDLUnsignedLon
     return n;
 }
 
+JSC::JSValue JSConverter<IDLDouble>::convert(Type value)
+{
+    ASSERT(!std::isnan(value));
+    return JSC::jsNumber(value);
+}
+
+JSC::JSValue JSConverter<IDLUnrestrictedDouble>::convert(Type value)
+{
+    return JSC::jsNumber(JSC::purifyNaN(value));
+}
+
+JSC::JSValue JSConverter<IDLUnrestrictedDouble>::convert(const MediaTime& value)
+{
+    return JSC::jsNumber(JSC::purifyNaN(value.toDouble()));
+}
+
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSDOMConvertNumbers.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertNumbers.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/PureNaN.h>
 #include <WebCore/IDLTypes.h>
 #include <WebCore/JSDOMConvertBase.h>
@@ -265,11 +264,7 @@ template<> struct JSConverter<IDLDouble> {
     static constexpr bool needsState = false;
     static constexpr bool needsGlobalObject = false;
 
-    static JSC::JSValue convert(Type value)
-    {
-        ASSERT(!std::isnan(value));
-        return JSC::jsNumber(value);
-    }
+    WEBCORE_EXPORT static JSC::JSValue convert(Type);
 };
 
 template<> struct Converter<IDLUnrestrictedDouble> : DefaultConverter<IDLUnrestrictedDouble> {
@@ -299,16 +294,10 @@ template<> struct JSConverter<IDLUnrestrictedDouble> {
     static constexpr bool needsState = false;
     static constexpr bool needsGlobalObject = false;
 
-    static JSC::JSValue convert(Type value)
-    {
-        return JSC::jsNumber(JSC::purifyNaN(value));
-    }
+    WEBCORE_EXPORT static JSC::JSValue convert(Type);
 
     // Add overload for MediaTime.
-    static JSC::JSValue convert(const MediaTime& value)
-    {
-        return JSC::jsNumber(JSC::purifyNaN(value.toDouble()));
-    }
+    WEBCORE_EXPORT static JSC::JSValue convert(const MediaTime&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSDOMConvertPromise.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertPromise.h
@@ -40,7 +40,7 @@ template<typename T> struct Converter<IDLPromise<T>> : DefaultConverter<IDLPromi
     template<typename ExceptionThrower = DefaultExceptionThrower>
     static Result convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, ExceptionThrower&& exceptionThrower = ExceptionThrower())
     {
-        JSC::VM& vm = JSC::getVM(&lexicalGlobalObject);
+        auto& vm = lexicalGlobalObject.vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
         auto* globalObject = JSC::jsDynamicCast<JSDOMGlobalObject*>(&lexicalGlobalObject);
         RELEASE_ASSERT(globalObject);

--- a/Source/WebCore/bindings/js/JSDOMConvertScheduledAction.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertScheduledAction.h
@@ -37,7 +37,7 @@ template<> struct Converter<IDLScheduledAction> : DefaultConverter<IDLScheduledA
 
     static Result convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value, JSDOMGlobalObject& globalObject, const String& sink)
     {
-        JSC::VM& vm = JSC::getVM(&lexicalGlobalObject);
+        auto& vm = lexicalGlobalObject.vm();
         auto scope = DECLARE_THROW_SCOPE(vm);
 
         if (!value.isCallable()) {

--- a/Source/WebCore/bindings/js/JSDOMConvertStrings.cpp
+++ b/Source/WebCore/bindings/js/JSDOMConvertStrings.cpp
@@ -33,6 +33,18 @@
 namespace WebCore {
 using namespace JSC;
 
+auto Converter<IDLDOMString>::convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value) -> Result
+{
+    auto& vm = lexicalGlobalObject.vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto string = value.toWTFString(&lexicalGlobalObject);
+
+    RETURN_IF_EXCEPTION(scope, Result::exception());
+
+    return Result { WTF::move(string) };
+}
+
 String identifierToString(JSGlobalObject& lexicalGlobalObject, const Identifier& identifier)
 {
     if (identifier.isSymbol()) [[unlikely]] {

--- a/Source/WebCore/bindings/js/JSDOMConvertStrings.h
+++ b/Source/WebCore/bindings/js/JSDOMConvertStrings.h
@@ -66,17 +66,7 @@ inline AtomString propertyNameToAtomString(JSC::PropertyName propertyName)
 template<> struct Converter<IDLDOMString> : DefaultConverter<IDLDOMString> {
     using Result = ConversionResult<IDLDOMString>;
 
-    static Result convert(JSC::JSGlobalObject& lexicalGlobalObject, JSC::JSValue value)
-    {
-        auto& vm = lexicalGlobalObject.vm();
-        auto scope = DECLARE_THROW_SCOPE(vm);
-
-        auto string = value.toWTFString(&lexicalGlobalObject);
-
-        RETURN_IF_EXCEPTION(scope, Result::exception());
-
-        return Result { WTF::move(string) };
-    }
+    WEBCORE_EXPORT static Result convert(JSC::JSGlobalObject&, JSC::JSValue);
 };
 
 template<> struct JSConverter<IDLDOMString> {

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -28,14 +28,12 @@
 
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/WeakGCMap.h>
-#if ENABLE(WEBASSEMBLY)
-#include <JavaScriptCore/WebAssemblyCompileOptions.h>
-#endif
 #include <wtf/Compiler.h>
 #include <wtf/Forward.h>
 
 namespace JSC {
 
+class WebAssemblyCompileOptions;
 enum class JSPromiseRejectionOperation : unsigned;
 
 }

--- a/Source/WebCore/bindings/js/JSDOMIterator.h
+++ b/Source/WebCore/bindings/js/JSDOMIterator.h
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/JSIteratorPrototype.h>
 #include <JavaScriptCore/PropertySlot.h>
 #include <WebCore/JSDOMConvert.h>
+#include <WebCore/ScriptExecutionContext.h>
 #include <type_traits>
 
 namespace WebCore {
@@ -276,7 +277,7 @@ template<typename JSWrapper, typename IteratorTraits>
 void JSDOMIteratorPrototype<JSWrapper, IteratorTraits>::finishCreation(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
     Base::finishCreation(vm);
-    ASSERT(inherits(info()));
+    ASSERT(inheritsSlow(info()));
 
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->next, next, 0, 0, JSC::ImplementationVisibility::Public);
     JSC_TO_STRING_TAG_WITHOUT_TRANSITION();

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
@@ -42,7 +42,7 @@ enum class RejectAsHandled : bool { No, Yes };
 
 #define DEFERRED_PROMISE_HANDLE_AND_RETURN_IF_EXCEPTION(scope, globalObject) do { \
         if (scope.exception()) [[unlikely]] { \
-            handleUncaughtException(scope, *jsCast<JSDOMGlobalObject*>(globalObject)); \
+            handleUncaughtException(scope, *globalObject); \
             return; \
         } \
     } while (false)
@@ -76,7 +76,7 @@ public:
 
         ASSERT(deferred());
         ASSERT(globalObject());
-        JSC::JSGlobalObject* lexicalGlobalObject = globalObject();
+        auto* lexicalGlobalObject = globalObject();
         auto& vm = lexicalGlobalObject->vm();
         JSC::JSLockHolder locker(vm);
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
@@ -93,7 +93,7 @@ public:
 
         ASSERT(deferred());
         ASSERT(globalObject());
-        JSC::JSGlobalObject* lexicalGlobalObject = globalObject();
+        auto* lexicalGlobalObject = globalObject();
         JSC::JSLockHolder locker(lexicalGlobalObject);
         resolve(*lexicalGlobalObject, resolution);
     }
@@ -105,7 +105,7 @@ public:
 
         ASSERT(deferred());
         ASSERT(globalObject());
-        JSC::JSGlobalObject* lexicalGlobalObject = globalObject();
+        auto* lexicalGlobalObject = globalObject();
         JSC::JSLockHolder locker(lexicalGlobalObject);
         resolve(*lexicalGlobalObject, JSC::jsUndefined());
     }
@@ -118,7 +118,7 @@ public:
 
         ASSERT(deferred());
         ASSERT(globalObject());
-        JSC::JSGlobalObject* lexicalGlobalObject = globalObject();
+        auto* lexicalGlobalObject = globalObject();
         auto& vm = lexicalGlobalObject->vm();
         JSC::JSLockHolder locker(vm);
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
@@ -152,7 +152,7 @@ public:
 
         ASSERT(deferred());
         ASSERT(globalObject());
-        JSC::JSGlobalObject* lexicalGlobalObject = globalObject();
+        auto* lexicalGlobalObject = globalObject();
         auto& vm = lexicalGlobalObject->vm();
         JSC::JSLockHolder locker(vm);
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.h
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.h
@@ -22,7 +22,6 @@
 #include <JavaScriptCore/AuxiliaryBarrierInlines.h>
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/JSArray.h>
-#include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/JSCellInlines.h>
 #include <JavaScriptCore/JSObjectInlines.h>
 #include <JavaScriptCore/Lookup.h>

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -52,6 +52,7 @@
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <JavaScriptCore/GlobalObjectMethodTable.h>
 #include <JavaScriptCore/HeapAnalyzer.h>
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/InternalFunction.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSFunction.h>

--- a/Source/WebCore/bindings/js/JSDOMWrapper.h
+++ b/Source/WebCore/bindings/js/JSDOMWrapper.h
@@ -22,12 +22,15 @@
 #pragma once
 
 #include <JavaScriptCore/JSDestructibleObject.h>
-#include <JavaScriptCore/StructureInlines.h>
 #include <WebCore/JSDOMGlobalObject.h>
 #include <WebCore/NodeType.h>
 #include <wtf/Compiler.h>
 #include <wtf/SignedPtr.h>
 #include <wtf/StdLibExtras.h>
+
+namespace JSC {
+class Structure;
+}
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSErrorEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSErrorEventCustom.cpp
@@ -28,7 +28,7 @@
 #include "JSErrorEvent.h"
 
 #include "JSDOMGlobalObject.h"
-#include "JSValueInWrappedObject.h"
+#include "JSValueInWrappedObjectInlines.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/Source/WebCore/bindings/js/JSEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSEventListener.cpp
@@ -41,6 +41,7 @@
 #include "WorkerGlobalScope.h"
 #include <JavaScriptCore/ExceptionHelpers.h>
 #include <JavaScriptCore/JSLock.h>
+#include <JavaScriptCore/SlotVisitorInlines.h>
 #include <JavaScriptCore/VMEntryScopeInlines.h>
 #include <JavaScriptCore/Watchdog.h>
 #include <wtf/Ref.h>

--- a/Source/WebCore/bindings/js/JSEventListener.h
+++ b/Source/WebCore/bindings/js/JSEventListener.h
@@ -26,7 +26,6 @@
 #include <WebCore/LocalDOMWindow.h>
 #include <WebCore/NodeDocument.h>
 #include "WebCoreJSClientData.h"
-#include <JavaScriptCore/StrongInlines.h>
 #include <JavaScriptCore/Weak.h>
 #include <JavaScriptCore/WeakInlines.h>
 #include <wtf/Ref.h>

--- a/Source/WebCore/bindings/js/JSExtendableMessageEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSExtendableMessageEventCustom.cpp
@@ -32,6 +32,7 @@
 #include "JSDOMConvertSequences.h"
 #include "JSDOMConvertStrings.h"
 #include "JSMessagePort.h"
+#include "JSValueInWrappedObjectInlines.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLElementCustom.cpp
@@ -33,6 +33,7 @@
 #include "HTMLFormElement.h"
 #include "JSCustomElementInterface.h"
 #include "JSDOMConstructorBase.h"
+#include "JSDOMWrapperCache.h"
 #include "JSHTMLElementWrapperFactory.h"
 #include "JSNodeCustom.h"
 #include "LocalDOMWindow.h"

--- a/Source/WebCore/bindings/js/JSHistoryCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHistoryCustom.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "JSHistory.h"
 
+#include "JSValueInWrappedObjectInlines.h"
 #include "SerializedScriptValue.h"
 #include <JavaScriptCore/JSCInlines.h>
 

--- a/Source/WebCore/bindings/js/JSIDBCursorCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBCursorCustom.cpp
@@ -29,6 +29,7 @@
 #include "IDBBindingUtilities.h"
 #include "JSDOMBinding.h"
 #include "JSIDBCursorWithValue.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "WebCoreOpaqueRootInlines.h"
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSIDBCursorWithValueCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBCursorWithValueCustom.cpp
@@ -28,6 +28,7 @@
 
 #include "IDBBindingUtilities.h"
 #include "IDBCursorWithValue.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include <JavaScriptCore/JSCInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSIDBRecordCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBRecordCustom.cpp
@@ -44,7 +44,7 @@ JSC::JSValue JSIDBRecord::primaryKey(JSC::JSGlobalObject& lexicalGlobalObject) c
 JSC::JSValue JSIDBRecord::value(JSC::JSGlobalObject& lexicalGlobalObject) const
 {
     auto result = deserializeIDBValueWithKeyInjection(lexicalGlobalObject, wrapped().value(), wrapped().primaryKey(), wrapped().keyPath());
-    return result ? result.value() : jsNull();
+    return result ? result.value() : JSC::jsNull();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSIDBRequestCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBRequestCustom.cpp
@@ -35,6 +35,7 @@
 #include "JSIDBCursor.h"
 #include "JSIDBDatabase.h"
 #include "JSIDBRecord.h"
+#include "JSValueInWrappedObjectInlines.h"
 
 namespace WebCore {
 using namespace JSC;

--- a/Source/WebCore/bindings/js/JSMediaControlsHostCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMediaControlsHostCustom.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "JSMediaControlsHost.h"
 
+#include "JSValueInWrappedObjectInlines.h"
+
 #if ENABLE(VIDEO)
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSMessageEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMessageEventCustom.cpp
@@ -40,6 +40,7 @@
 #include "JSDOMConvertStrings.h"
 #include "JSEventTarget.h"
 #include "JSMessagePort.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include <JavaScriptCore/JSArray.h>
 #include <JavaScriptCore/JSArrayBuffer.h>
 

--- a/Source/WebCore/bindings/js/JSNavigateEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNavigateEventCustom.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "JSNavigateEvent.h"
 
+#include "JSValueInWrappedObjectInlines.h"
+
 namespace WebCore {
 
 template<typename Visitor>

--- a/Source/WebCore/bindings/js/JSNavigatorCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNavigatorCustom.cpp
@@ -29,7 +29,9 @@
 #include "WebCoreJSBuiltinInternals.h"
 #include "WebCoreJSClientData.h"
 #include "WebCoreOpaqueRootInlines.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/JSCJSValue.h>
+#include <JavaScriptCore/JSObjectInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSNodeCustom.h
+++ b/Source/WebCore/bindings/js/JSNodeCustom.h
@@ -29,6 +29,7 @@
 #include <WebCore/JSDOMBinding.h>
 #include <WebCore/JSNode.h>
 #include <WebCore/NodeInlines.h>
+#include <WebCore/ScriptWrappableInlines.h>
 #include <WebCore/WebCoreOpaqueRoot.h>
 
 namespace JSC {

--- a/Source/WebCore/bindings/js/JSNodeListCustom.h
+++ b/Source/WebCore/bindings/js/JSNodeListCustom.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/JSDOMBinding.h>
+#include <WebCore/JSDOMWrapperCache.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSObservableArray.cpp
+++ b/Source/WebCore/bindings/js/JSObservableArray.cpp
@@ -223,6 +223,11 @@ bool JSObservableArray::defineOwnProperty(JSObject* object, JSGlobalObject* glob
     RELEASE_AND_RETURN(scope, Base::defineOwnProperty(object, globalObject, propertyName, descriptor, throwException));
 }
 
+Structure* JSObservableArray::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
+{
+    return Structure::create(vm, globalObject, prototype, TypeInfo(DerivedArrayType, StructureFlags), info(), NonArray);
+}
+
 JSC::GCClient::IsoSubspace* JSObservableArray::subspaceForImpl(JSC::VM& vm)
 {
     return &downcast<JSVMClientData>(vm.clientData)->observableArraySpace();

--- a/Source/WebCore/bindings/js/JSObservableArray.h
+++ b/Source/WebCore/bindings/js/JSObservableArray.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "JSDOMBinding.h"
+#include "JSDOMWrapperCache.h"
 #include <JavaScriptCore/ArrayPrototype.h>
 
 namespace JSC {
@@ -88,10 +88,7 @@ public:
         return globalObject.arrayPrototype();
     }
 
-    static Structure* createStructure(VM& vm, JSGlobalObject* globalObject, JSValue prototype)
-    {
-        return Structure::create(vm, globalObject, prototype, TypeInfo(DerivedArrayType, StructureFlags), info(), NonArray);
-    }
+    static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
 private:
     JSObservableArray(VM&, Structure*);

--- a/Source/WebCore/bindings/js/JSPaymentMethodChangeEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPaymentMethodChangeEventCustom.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "JSPaymentMethodChangeEvent.h"
 
+#include "JSValueInWrappedObjectInlines.h"
+
 #if ENABLE(PAYMENT_REQUEST)
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSPaymentResponseCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPaymentResponseCustom.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "JSPaymentResponse.h"
 
+#include "JSValueInWrappedObjectInlines.h"
+
 #if ENABLE(PAYMENT_REQUEST)
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSPopStateEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPopStateEventCustom.cpp
@@ -33,7 +33,7 @@
 #include "JSPopStateEvent.h"
 
 #include "JSHistory.h"
-#include "JSValueInWrappedObject.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
 

--- a/Source/WebCore/bindings/js/JSPromiseRejectionEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPromiseRejectionEventCustom.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "JSPromiseRejectionEvent.h"
 
+#include "JSValueInWrappedObjectInlines.h"
 #include "PromiseRejectionEvent.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>

--- a/Source/WebCore/bindings/js/JSTrackCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTrackCustom.cpp
@@ -30,6 +30,7 @@
 #include "JSTrackCustom.h"
 
 #include "JSAudioTrack.h"
+#include "JSDOMWrapperCache.h"
 #include "JSTextTrack.h"
 #include "JSVideoTrack.h"
 

--- a/Source/WebCore/bindings/js/JSValueInWrappedObject.h
+++ b/Source/WebCore/bindings/js/JSValueInWrappedObject.h
@@ -24,13 +24,20 @@
 
 #pragma once
 
-#include <JavaScriptCore/JSCJSValueInlines.h>
+#include <JavaScriptCore/JSCJSValue.h>
 #include <JavaScriptCore/SlotVisitor.h>
-#include <JavaScriptCore/WeakInlines.h>
-#include <WebCore/DOMWrapperWorld.h>
-#include <WebCore/JSDOMWrapper.h>
+#include <JavaScriptCore/Weak.h>
+#include <wtf/WeakPtr.h>
+
+namespace JSC {
+class JSGlobalObject;
+class ThrowScope;
+}
 
 namespace WebCore {
+
+class DOMWrapperWorld;
+class JSDOMObject;
 
 // This class includes a lot of subtle GC related things, and changing this class can easily cause GC crashes.
 // Any changes to this class must be reviewed by JavaScriptCore reviewers too.
@@ -40,31 +47,32 @@ class JSValueInWrappedObject {
     WTF_MAKE_NONMOVABLE(JSValueInWrappedObject);
 public:
     JSValueInWrappedObject() = default;
-    JSValueInWrappedObject(JSC::JSGlobalObject&, JSC::JSValue);
-    JSValueInWrappedObject(RefPtr<DOMWrapperWorld>&&, JSC::JSValue);
+    inline JSValueInWrappedObject(JSC::JSGlobalObject&, JSC::JSValue); // Defined in JSValueInWrappedObjectInlines.h
+    inline JSValueInWrappedObject(RefPtr<DOMWrapperWorld>&&, JSC::JSValue); // Defined in JSValueInWrappedObjectInlines.h
 
-    explicit operator bool() const;
-    template<typename Visitor> void visitInGCThread(Visitor&) const;
-    void clear();
+    inline explicit operator bool() const; // Defined in JSValueInWrappedObjectInlines.h
+    template<typename Visitor> inline void visitInGCThread(Visitor&) const; // Defined in JSValueInWrappedObjectInlines.h
+
+    inline void clear(); // Defined in JSValueInWrappedObjectInlines.h
 
     // If you expect the value you store to be returned by getValue and not cleared under you, you *MUST* use set not setWeakly.
     // The owner parameter is typically the wrapper of the DOM node this class is embedded into but can be any GCed object that
     // will visit this JSValueInWrappedObject via visitAdditionalChildrenInGCThread/isReachableFromOpaqueRoots.
-    void set(JSC::JSGlobalObject&, const JSC::JSCell* owner, JSC::JSValue);
-    void set(RefPtr<DOMWrapperWorld>&&, JSC::VM&, const JSC::JSCell* owner, JSC::JSValue);
+    inline void set(JSC::JSGlobalObject&, const JSC::JSCell* owner, JSC::JSValue); // Defined in JSValueInWrappedObjectInlines.h
+    inline void set(RefPtr<DOMWrapperWorld>&&, JSC::VM&, const JSC::JSCell* owner, JSC::JSValue); // Defined in JSValueInWrappedObjectInlines.h
     // Only use this if you actually expect this value to be weakly held. If you call visitInGCThread on this value *DONT* set using setWeakly
     // use set instead. The GC might or might not keep your value around in that case.
-    void setWeakly(JSC::JSGlobalObject&, JSC::JSValue);
-    void setWeakly(RefPtr<DOMWrapperWorld>&&, JSC::JSValue);
-    JSC::JSValue getValue(JSC::JSValue nullValue = JSC::jsUndefined()) const;
+    inline void setWeakly(JSC::JSGlobalObject&, JSC::JSValue); // Defined in JSValueInWrappedObjectInlines.h
+    inline void setWeakly(RefPtr<DOMWrapperWorld>&&, JSC::JSValue); // Defined in JSValueInWrappedObjectInlines.h
+    inline JSC::JSValue getValue(JSC::JSValue nullValue = JSC::jsUndefined()) const; // Defined in JSValueInWrappedObjectInlines.h
 
-    RefPtr<DOMWrapperWorld> world() const;
-    bool isWorldCompatible(JSC::JSGlobalObject& lexicalGlobalObject) const;
+    inline RefPtr<DOMWrapperWorld> world() const; // Defined in JSValueInWrappedObjectInlines.h
+    inline bool isWorldCompatible(JSC::JSGlobalObject& lexicalGlobalObject) const; // Defined in JSValueInWrappedObjectInlines.h
 
 private:
-    void setValueInternal(JSC::JSValue);
-    void setWorld(JSC::JSGlobalObject&);
-    void setWorld(RefPtr<DOMWrapperWorld>&&);
+    inline void setValueInternal(JSC::JSValue); // Defined in JSValueInWrappedObjectInlines.h
+    inline void setWorld(JSC::JSGlobalObject&); // Defined in JSValueInWrappedObjectInlines.h
+    inline void setWorld(RefPtr<DOMWrapperWorld>&&); // Defined in JSValueInWrappedObjectInlines.h
 
     // Keep in mind that all of these fields are accessed concurrently without lock from concurrent GC thread.
     JSC::JSValue m_nonCell { };
@@ -72,124 +80,6 @@ private:
     SingleThreadWeakPtr<DOMWrapperWorld> m_world;
 };
 
-JSC::JSValue cachedPropertyValue(JSC::ThrowScope&, JSC::JSGlobalObject&, const JSDOMObject& owner, JSValueInWrappedObject& cacheSlot, const auto&);
-
-inline JSValueInWrappedObject::JSValueInWrappedObject(JSC::JSGlobalObject& globalObject, JSC::JSValue value)
-{
-    setWeakly(globalObject, value);
-}
-
-inline JSValueInWrappedObject::JSValueInWrappedObject(RefPtr<DOMWrapperWorld>&& world, JSC::JSValue value)
-{
-    setWeakly(WTF::move(world), value);
-}
-
-inline JSC::JSValue JSValueInWrappedObject::getValue(JSC::JSValue nullValue) const
-{
-    if (m_nonCell)
-        return m_nonCell;
-    return m_cell ? m_cell.get() : nullValue;
-}
-
-inline JSValueInWrappedObject::operator bool() const
-{
-    return m_nonCell || m_cell;
-}
-
-template<typename Visitor>
-inline void JSValueInWrappedObject::visitInGCThread(Visitor& visitor) const
-{
-    visitor.append(m_cell);
-}
-
-template void JSValueInWrappedObject::visitInGCThread(JSC::AbstractSlotVisitor&) const;
-template void JSValueInWrappedObject::visitInGCThread(JSC::SlotVisitor&) const;
-
-inline void JSValueInWrappedObject::setValueInternal(JSC::JSValue value)
-{
-    m_world= nullptr;
-    if (!value.isCell()) {
-        m_nonCell = value;
-        m_cell.clear();
-        return;
-    }
-    m_nonCell = { };
-    JSC::Weak weak { value.asCell() };
-    WTF::storeStoreFence();
-    m_cell = WTF::move(weak);
-}
-
-inline void JSValueInWrappedObject::setWorld(JSC::JSGlobalObject& globalObject)
-{
-    m_world = &currentWorld(globalObject);
-}
-
-inline void JSValueInWrappedObject::setWorld(RefPtr<DOMWrapperWorld>&& world)
-{
-    m_world = WTF::move(world);
-}
-
-inline void JSValueInWrappedObject::setWeakly(JSC::JSGlobalObject& globalObject, JSC::JSValue value)
-{
-    setValueInternal(value);
-    setWorld(globalObject);
-}
-
-inline void JSValueInWrappedObject::setWeakly(RefPtr<DOMWrapperWorld>&& world, JSC::JSValue value)
-{
-    setValueInternal(value);
-    setWorld(WTF::move(world));
-}
-
-inline void JSValueInWrappedObject::set(JSC::JSGlobalObject& globalObject, const JSC::JSCell* owner, JSC::JSValue value)
-{
-    setValueInternal(value);
-    globalObject.vm().writeBarrier(owner, value);
-    setWorld(globalObject);
-}
-
-inline void JSValueInWrappedObject::set(RefPtr<DOMWrapperWorld>&& world, JSC::VM& vm, const JSC::JSCell* owner, JSC::JSValue value)
-{
-    setValueInternal(value);
-    vm.writeBarrier(owner, value);
-    setWorld(WTF::move(world));
-}
-
-inline RefPtr<DOMWrapperWorld> JSValueInWrappedObject::world() const
-{
-    return m_world.get();
-}
-
-inline void JSValueInWrappedObject::clear()
-{
-    m_nonCell = { };
-    m_cell.clear();
-    m_world = nullptr;
-}
-
-inline bool JSValueInWrappedObject::isWorldCompatible(JSC::JSGlobalObject& lexicalGlobalObject) const
-{
-    JSC::JSValue value = getValue();
-    if (!value.isObject())
-        return true;
-
-    auto* world = m_world.get();
-    if (!world)
-        return false;
-    return world == &currentWorld(lexicalGlobalObject);
-}
-
-inline JSC::JSValue cachedPropertyValue(JSC::ThrowScope& throwScope, JSC::JSGlobalObject& lexicalGlobalObject, const JSDOMObject& owner, JSValueInWrappedObject& cachedValue, const auto& function)
-{
-    if (cachedValue && cachedValue.isWorldCompatible(lexicalGlobalObject))
-        return cachedValue.getValue();
-
-    auto value = function(throwScope);
-    RETURN_IF_EXCEPTION(throwScope, { });
-
-    cachedValue.set(lexicalGlobalObject, &owner, cloneAcrossWorlds(lexicalGlobalObject, owner, value));
-    ASSERT(cachedValue.isWorldCompatible(lexicalGlobalObject));
-    return cachedValue.getValue();
-}
+inline JSC::JSValue cachedPropertyValue(JSC::ThrowScope&, JSC::JSGlobalObject&, const JSDOMObject& owner, JSValueInWrappedObject& cacheSlot, const auto&);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSValueInWrappedObjectInlines.h
+++ b/Source/WebCore/bindings/js/JSValueInWrappedObjectInlines.h
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2018-2024 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/HeapCellInlines.h>
+#include <JavaScriptCore/JSCJSValueCellInlines.h>
+#include <JavaScriptCore/SlotVisitorInlines.h>
+#include <JavaScriptCore/WeakInlines.h>
+#include <WebCore/DOMWrapperWorld.h>
+#include <WebCore/JSDOMWrapper.h>
+#include <WebCore/JSValueInWrappedObject.h>
+
+namespace WebCore {
+
+inline JSValueInWrappedObject::JSValueInWrappedObject(JSC::JSGlobalObject& globalObject, JSC::JSValue value)
+{
+    setWeakly(globalObject, value);
+}
+
+inline JSValueInWrappedObject::JSValueInWrappedObject(RefPtr<DOMWrapperWorld>&& world, JSC::JSValue value)
+{
+    setWeakly(WTF::move(world), value);
+}
+
+inline JSC::JSValue JSValueInWrappedObject::getValue(JSC::JSValue nullValue) const
+{
+    if (m_nonCell)
+        return m_nonCell;
+    return m_cell ? m_cell.get() : nullValue;
+}
+
+inline JSValueInWrappedObject::operator bool() const
+{
+    return m_nonCell || m_cell;
+}
+
+template<typename Visitor>
+inline void JSValueInWrappedObject::visitInGCThread(Visitor& visitor) const
+{
+    visitor.append(m_cell);
+}
+
+template void JSValueInWrappedObject::visitInGCThread(JSC::AbstractSlotVisitor&) const;
+template void JSValueInWrappedObject::visitInGCThread(JSC::SlotVisitor&) const;
+
+inline void JSValueInWrappedObject::setValueInternal(JSC::JSValue value)
+{
+    m_world = nullptr;
+    if (!value.isCell()) {
+        m_nonCell = value;
+        m_cell.clear();
+        return;
+    }
+    m_nonCell = { };
+    JSC::Weak weak { value.asCell() };
+    WTF::storeStoreFence();
+    m_cell = WTF::move(weak);
+}
+
+inline void JSValueInWrappedObject::setWorld(JSC::JSGlobalObject& globalObject)
+{
+    m_world = &currentWorld(globalObject);
+}
+
+inline void JSValueInWrappedObject::setWorld(RefPtr<DOMWrapperWorld>&& world)
+{
+    m_world = WTF::move(world);
+}
+
+inline void JSValueInWrappedObject::setWeakly(JSC::JSGlobalObject& globalObject, JSC::JSValue value)
+{
+    setValueInternal(value);
+    setWorld(globalObject);
+}
+
+inline void JSValueInWrappedObject::setWeakly(RefPtr<DOMWrapperWorld>&& world, JSC::JSValue value)
+{
+    setValueInternal(value);
+    setWorld(WTF::move(world));
+}
+
+inline void JSValueInWrappedObject::set(JSC::JSGlobalObject& globalObject, const JSC::JSCell* owner, JSC::JSValue value)
+{
+    setValueInternal(value);
+    globalObject.vm().writeBarrier(owner, value);
+    setWorld(globalObject);
+}
+
+inline void JSValueInWrappedObject::set(RefPtr<DOMWrapperWorld>&& world, JSC::VM& vm, const JSC::JSCell* owner, JSC::JSValue value)
+{
+    setValueInternal(value);
+    vm.writeBarrier(owner, value);
+    setWorld(WTF::move(world));
+}
+
+inline void JSValueInWrappedObject::clear()
+{
+    m_nonCell = { };
+    m_cell.clear();
+    m_world = nullptr;
+}
+
+inline RefPtr<DOMWrapperWorld> JSValueInWrappedObject::world() const
+{
+    return m_world.get();
+}
+
+inline bool JSValueInWrappedObject::isWorldCompatible(JSC::JSGlobalObject& lexicalGlobalObject) const
+{
+    JSC::JSValue value = getValue();
+    if (!value.isObject())
+        return true;
+
+    if (RefPtr world = m_world.get())
+        return world == &currentWorld(lexicalGlobalObject);
+    return false;
+}
+
+inline JSC::JSValue cachedPropertyValue(JSC::ThrowScope& throwScope, JSC::JSGlobalObject& lexicalGlobalObject, const JSDOMObject& owner, JSValueInWrappedObject& cachedValue, const auto& function)
+{
+    if (cachedValue && cachedValue.isWorldCompatible(lexicalGlobalObject))
+        return cachedValue.getValue();
+
+    auto value = function(throwScope);
+    RETURN_IF_EXCEPTION(throwScope, { });
+
+    cachedValue.set(lexicalGlobalObject, &owner, cloneAcrossWorlds(lexicalGlobalObject, owner, value));
+    ASSERT(cachedValue.isWorldCompatible(lexicalGlobalObject));
+    return cachedValue.getValue();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/bindings/js/JSWebXRRigidTransformCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebXRRigidTransformCustom.cpp
@@ -29,6 +29,7 @@
 #include "JSWebXRRigidTransform.h"
 
 #include "JSDOMConvertBufferSource.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "WebXRRigidTransform.h"
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/JSWebXRViewCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebXRViewCustom.cpp
@@ -29,6 +29,7 @@
 #include "JSWebXRView.h"
 
 #include "JSDOMConvertBufferSource.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "WebXRView.h"
 
 namespace WebCore {

--- a/Source/WebCore/bindings/js/ReadableStreamDefaultController.cpp
+++ b/Source/WebCore/bindings/js/ReadableStreamDefaultController.cpp
@@ -31,9 +31,12 @@
 #include "config.h"
 #include "ReadableStreamDefaultController.h"
 
+#include "JSDOMConvertBufferSource.h"
 #include "WebCoreJSClientData.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/IdentifierInlines.h>
+#include <JavaScriptCore/JSGenericTypedArrayViewInlines.h>
 #include <JavaScriptCore/JSObjectInlines.h>
 #include <JavaScriptCore/TopExceptionScope.h>
 

--- a/Source/WebCore/bindings/js/ReadableStreamDefaultController.h
+++ b/Source/WebCore/bindings/js/ReadableStreamDefaultController.h
@@ -31,12 +31,11 @@
 
 #include "JSReadableStreamDefaultController.h"
 #include <JavaScriptCore/JSCJSValue.h>
-#include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/TypedArrays.h>
-#include <WebCore/JSDOMConvertBufferSource.h>
 
 namespace WebCore {
 
+class Exception;
 class ReadableStreamSource;
 
 class ReadableStreamDefaultController {

--- a/Source/WebCore/bindings/js/ScheduledAction.h
+++ b/Source/WebCore/bindings/js/ScheduledAction.h
@@ -19,9 +19,10 @@
 
 #pragma once
 
+#include <JavaScriptCore/SourceTaintedOrigin.h>
 #include <JavaScriptCore/Strong.h>
-#include <JavaScriptCore/StrongInlines.h>
 #include <memory>
+#include <wtf/FixedVector.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -68,6 +68,7 @@
 #include <JavaScriptCore/BuiltinNames.h>
 #include <JavaScriptCore/Debugger.h>
 #include <JavaScriptCore/Heap.h>
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/ImportMap.h>
 #include <JavaScriptCore/InitializeThreading.h>
 #include <JavaScriptCore/JSFunction.h>

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -55,6 +55,7 @@
 #include <JavaScriptCore/AbstractModuleRecord.h>
 #include <JavaScriptCore/BuiltinNames.h>
 #include <JavaScriptCore/Completion.h>
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/ImportMap.h>
 #include <JavaScriptCore/JSInternalPromise.h>
 #include <JavaScriptCore/JSNativeStdFunction.h>

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -85,6 +85,7 @@
 #include <JavaScriptCore/ErrorInstance.h>
 #include <JavaScriptCore/Exception.h>
 #include <JavaScriptCore/ExceptionHelpers.h>
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/IterationKind.h>
 #include <JavaScriptCore/JSArrayBuffer.h>
 #include <JavaScriptCore/JSArrayBufferView.h>

--- a/Source/WebCore/bindings/js/WebCoreOpaqueRootInlines.h
+++ b/Source/WebCore/bindings/js/WebCoreOpaqueRootInlines.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/AbstractSlotVisitorInlines.h>
 #include <WebCore/JSNodeCustomInlines.h>
 #include <WebCore/WebCoreOpaqueRoot.h>
 

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -3656,20 +3656,7 @@ sub GenerateHeader
     }
 
     # Structure ID
-    push(@headerContent, "    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)\n");
-    push(@headerContent, "    {\n");
-    my $indexingModeIncludingHistory = InstanceOverridesGetOwnPropertySlot($interface) ? "JSC::MayHaveIndexedAccessors" : "JSC::NonArray";
-    if (IsDOMGlobalObject($interface)) {
-        push(@headerContent, "        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), $indexingModeIncludingHistory);\n");
-    } elsif ($codeGenerator->InheritsInterface($interface, "Node")) {
-        my $type = GetJSTypeForNode($interface);
-        push(@headerContent, "        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::JSType($type), StructureFlags), info(), $indexingModeIncludingHistory);\n");
-    } elsif ($codeGenerator->InheritsInterface($interface, "Event")) {
-        push(@headerContent, "        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::JSType(JSEventType), StructureFlags), info(), $indexingModeIncludingHistory);\n");
-    } else {
-        push(@headerContent, "        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), $indexingModeIncludingHistory);\n");
-    }
-    push(@headerContent, "    }\n\n");
+    push(@headerContent, "    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);\n");
 
     if ($codeGenerator->InheritsInterface($interface, "HTMLElement")) {
         push(@headerContent, "    JSC::JSScope* pushEventHandlerScope(JSC::JSGlobalObject*, JSC::JSScope*) const;\n\n");
@@ -5521,6 +5508,22 @@ sub GenerateImplementation
         push(@implContent, "\n");
     }
 
+    AddToImplIncludes("<JavaScriptCore/StructureInlines.h>");
+    push(@implContent, "JSC::Structure* ${className}::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)\n");
+    push(@implContent, "{\n");
+    my $indexingModeIncludingHistory = InstanceOverridesGetOwnPropertySlot($interface) ? "JSC::MayHaveIndexedAccessors" : "JSC::NonArray";
+    if (IsDOMGlobalObject($interface)) {
+        push(@implContent, "    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), $indexingModeIncludingHistory);\n");
+    } elsif ($codeGenerator->InheritsInterface($interface, "Node")) {
+        my $type = GetJSTypeForNode($interface);
+        push(@implContent, "    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::JSType($type), StructureFlags), info(), $indexingModeIncludingHistory);\n");
+    } elsif ($codeGenerator->InheritsInterface($interface, "Event")) {
+        push(@implContent, "    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::JSType(JSEventType), StructureFlags), info(), $indexingModeIncludingHistory);\n");
+    } else {
+        push(@implContent, "    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), $indexingModeIncludingHistory);\n");
+    }
+    push(@implContent, "}\n\n");
+
     unless (ShouldUseGlobalObjectPrototype($interface) || ShouldUseOrdinaryObjectPrototype($interface)) {
         push(@implContent, "JSObject* ${className}::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)\n");
         push(@implContent, "{\n");
@@ -5890,6 +5893,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 END
 
+        AddToImplIncludes("JSDOMWrapperCache.h");
         push(@implContent, "JSC::JSValue toJSNewlyCreated(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<$implType>&& impl)\n");
         push(@implContent, "{\n");
         if ($implType =~ /Document$/) {
@@ -5930,6 +5934,7 @@ END
     verifyVTable<$implType>(impl.ptr());
 #endif
 END
+        AddToImplIncludes("JSDOMWrapperCache.h");
         push(@implContent, "    return createWrapper<${implType}>(globalObject, WTF::move(impl));\n");
         push(@implContent, "}\n\n");
 
@@ -7496,6 +7501,8 @@ sub GenerateCallbackImplementationOperationBody
     push(@$contentRef, "    auto& lexicalGlobalObject = globalObject;\n");
 
     push(@$contentRef, "    JSValue thisValue = ${thisValue};\n");
+
+    $includesRef->{"<JavaScriptCore/MarkedVector.h>"} = 1;
     push(@$contentRef, "    MarkedArgumentBuffer args;\n");
 
     foreach my $argument (@{$operation->arguments}) {
@@ -7569,8 +7576,10 @@ sub GenerateCallbackImplementationContent
     my $visibleName = $codeGenerator->GetVisibleInterfaceName($interfaceOrCallback);
     my $className = "JS${name}";
 
-    $includesRef->{"ScriptExecutionContext.h"} = 1;
     $includesRef->{"ContextDestructionObserverInlines.h"} = 1;
+    $includesRef->{"JSDOMGlobalObject.h"} = 1;
+    $includesRef->{"ScriptExecutionContext.h"} = 1;
+    $includesRef->{"<JavaScriptCore/JSCellInlines.h>"} = 1;
 
     # We already validated GenerateIsReachable when generating the header file.
     my $ownerObject = $generateIsReachable ? "globalObject->scriptExecutionContext()" : "this";

--- a/Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.cpp
@@ -51,6 +51,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -203,6 +204,11 @@ void JSDOMWindow::finishCreation(VM& vm, JSWindowProxy* proxy)
 
     if (((scriptExecutionContext && scriptExecutionContext->isSecureContext()) && TestEnabledForContext::enabledForContext(*jsCast<JSDOMGlobalObject*>(realm())->scriptExecutionContext())))
         putDirectCustomAccessor(vm, builtinNames(vm).TestEnabledForContextPublicName(), CustomGetterSetter::create(vm, jsDOMWindow_TestEnabledForContextConstructor, nullptr), attributesForStructure(static_cast<unsigned>(JSC::PropertyAttribute::DontEnum)));
+}
+
+JSC::Structure* JSDOMWindow::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
 }
 
 JSValue JSDOMWindow::getConstructor(VM& vm, const JSGlobalObject* globalObject)

--- a/Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSDedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSDedicatedWorkerGlobalScope.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -127,6 +128,11 @@ void JSDedicatedWorkerGlobalScope::finishCreation(VM& vm, JSGlobalProxy* proxy)
 
 }
 #endif
+
+JSC::Structure* JSDedicatedWorkerGlobalScope::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSValue JSDedicatedWorkerGlobalScope::getConstructor(VM& vm, const JSGlobalObject* globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSDedicatedWorkerGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSDedicatedWorkerGlobalScope.h
@@ -41,11 +41,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedStar.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedStar.cpp
@@ -41,6 +41,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -153,6 +154,11 @@ JSExposedStar::JSExposedStar(Structure* structure, JSDOMGlobalObject& globalObje
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, ExposedStar>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSExposedStar::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSExposedStar::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedStar.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedStar.h
@@ -45,11 +45,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.cpp
@@ -43,6 +43,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <type_traits>
 #include <wtf/GetPtr.h>
@@ -206,6 +207,11 @@ JSExposedToWorkerAndWindow::JSExposedToWorkerAndWindow(Structure* structure, JSD
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, ExposedToWorkerAndWindow>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSExposedToWorkerAndWindow::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSExposedToWorkerAndWindow::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.h
@@ -45,11 +45,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSPaintWorkletGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSPaintWorkletGlobalScope.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -128,6 +129,11 @@ void JSPaintWorkletGlobalScope::finishCreation(VM& vm, JSGlobalProxy* proxy)
 
 }
 #endif
+
+JSC::Structure* JSPaintWorkletGlobalScope::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSValue JSPaintWorkletGlobalScope::getConstructor(VM& vm, const JSGlobalObject* globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSPaintWorkletGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSPaintWorkletGlobalScope.h
@@ -41,11 +41,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSServiceWorkerGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSServiceWorkerGlobalScope.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -127,6 +128,11 @@ void JSServiceWorkerGlobalScope::finishCreation(VM& vm, JSGlobalProxy* proxy)
 
 }
 #endif
+
+JSC::Structure* JSServiceWorkerGlobalScope::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSValue JSServiceWorkerGlobalScope::getConstructor(VM& vm, const JSGlobalObject* globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSServiceWorkerGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSServiceWorkerGlobalScope.h
@@ -41,11 +41,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSShadowRealmGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSShadowRealmGlobalScope.cpp
@@ -42,6 +42,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/ObjectPrototype.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -104,6 +105,11 @@ void JSShadowRealmGlobalScope::finishCreation(VM& vm, JSGlobalProxy* proxy)
 
     if (jsCast<JSDOMGlobalObject*>(realm())->scriptExecutionContext()->settingsValues().webAPIsInShadowRealmEnabled)
         putDirectCustomAccessor(vm, builtinNames(vm).ExposedStarPublicName(), CustomGetterSetter::create(vm, jsShadowRealmGlobalScope_ExposedStarConstructor, nullptr), attributesForStructure(static_cast<unsigned>(JSC::PropertyAttribute::DontEnum)));
+}
+
+JSC::Structure* JSShadowRealmGlobalScope::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
 }
 
 JSValue JSShadowRealmGlobalScope::getConstructor(VM& vm, const JSGlobalObject* globalObject)

--- a/Source/WebCore/bindings/scripts/test/JS/JSShadowRealmGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSShadowRealmGlobalScope.h
@@ -42,11 +42,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSSharedWorkerGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSSharedWorkerGlobalScope.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -128,6 +129,11 @@ void JSSharedWorkerGlobalScope::finishCreation(VM& vm, JSGlobalProxy* proxy)
 
 }
 #endif
+
+JSC::Structure* JSSharedWorkerGlobalScope::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSValue JSSharedWorkerGlobalScope::getConstructor(VM& vm, const JSGlobalObject* globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSSharedWorkerGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSSharedWorkerGlobalScope.h
@@ -41,11 +41,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.cpp
@@ -43,6 +43,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -136,6 +137,11 @@ JSTestAsyncIterable::JSTestAsyncIterable(Structure* structure, JSDOMGlobalObject
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestAsyncIterable>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestAsyncIterable::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestAsyncIterable::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterableWithoutFlags.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterableWithoutFlags.cpp
@@ -42,6 +42,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -135,6 +136,11 @@ JSTestAsyncIterableWithoutFlags::JSTestAsyncIterableWithoutFlags(Structure* stru
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestAsyncIterableWithoutFlags>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestAsyncIterableWithoutFlags::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestAsyncIterableWithoutFlags::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterableWithoutFlags.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterableWithoutFlags.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.cpp
@@ -43,6 +43,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -140,6 +141,11 @@ JSTestAsyncKeyValueIterable::JSTestAsyncKeyValueIterable(Structure* structure, J
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestAsyncKeyValueIterable>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestAsyncKeyValueIterable::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestAsyncKeyValueIterable::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.cpp
@@ -48,6 +48,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -160,6 +161,11 @@ JSTestCEReactions::JSTestCEReactions(Structure* structure, JSDOMGlobalObject& gl
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestCEReactions>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestCEReactions::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestCEReactions::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.cpp
@@ -41,6 +41,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -139,6 +140,11 @@ JSTestCEReactionsStringifier::JSTestCEReactionsStringifier(Structure* structure,
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestCEReactionsStringifier>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestCEReactionsStringifier::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestCEReactionsStringifier::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.cpp
@@ -53,6 +53,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -181,6 +182,11 @@ JSTestCallTracer::JSTestCallTracer(Structure* structure, JSDOMGlobalObject& glob
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestCallTracer>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestCallTracer::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestCallTracer::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
@@ -25,7 +25,10 @@
 #include "JSDOMConvertNumbers.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMExceptionHandling.h"
+#include "JSDOMGlobalObject.h"
 #include "ScriptExecutionContext.h"
+#include <JavaScriptCore/JSCellInlines.h>
+#include <JavaScriptCore/MarkedVector.h>
 
 
 namespace WebCore {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
@@ -25,7 +25,10 @@
 #include "JSDOMConvertNumbers.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMExceptionHandling.h"
+#include "JSDOMGlobalObject.h"
 #include "ScriptExecutionContext.h"
+#include <JavaScriptCore/JSCellInlines.h>
+#include <JavaScriptCore/MarkedVector.h>
 
 
 namespace WebCore {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
@@ -30,6 +30,8 @@
 #include "JSTestNode.h"
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/JSArray.h>
+#include <JavaScriptCore/JSCellInlines.h>
+#include <JavaScriptCore/MarkedVector.h>
 
 
 namespace WebCore {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
@@ -30,6 +30,8 @@
 #include "JSDOMGlobalObject.h"
 #include "ScriptExecutionContext.h"
 #include <JavaScriptCore/JSArray.h>
+#include <JavaScriptCore/JSCellInlines.h>
+#include <JavaScriptCore/MarkedVector.h>
 
 
 namespace WebCore {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
@@ -24,7 +24,10 @@
 #include "ContextDestructionObserverInlines.h"
 #include "JSDOMConvertStrings.h"
 #include "JSDOMExceptionHandling.h"
+#include "JSDOMGlobalObject.h"
 #include "ScriptExecutionContext.h"
+#include <JavaScriptCore/JSCellInlines.h>
+#include <JavaScriptCore/MarkedVector.h>
 
 
 namespace WebCore {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -47,7 +47,9 @@
 #include "SerializedScriptValue.h"
 #include <JavaScriptCore/FunctionPrototype.h>
 #include <JavaScriptCore/JSCInlines.h>
+#include <JavaScriptCore/JSCellInlines.h>
 #include <JavaScriptCore/JSString.h>
+#include <JavaScriptCore/MarkedVector.h>
 #include <type_traits>
 #include <wtf/IsIncreasing.h>
 #include <wtf/NeverDestroyed.h>

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
@@ -31,6 +31,8 @@
 #include "JSTestCallbackFunction.h"
 #include "JSTestDictionary.h"
 #include "ScriptExecutionContext.h"
+#include <JavaScriptCore/JSCellInlines.h>
+#include <JavaScriptCore/MarkedVector.h>
 #include <wtf/Variant.h>
 
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.cpp
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -130,6 +131,11 @@ JSTestClassWithJSBuiltinConstructor::JSTestClassWithJSBuiltinConstructor(Structu
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestClassWithJSBuiltinConstructor>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestClassWithJSBuiltinConstructor::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestClassWithJSBuiltinConstructor::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditional.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditional.cpp
@@ -38,6 +38,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -233,6 +234,11 @@ JSTestConditional::JSTestConditional(Structure* structure, JSDOMGlobalObject& gl
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestConditional>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestConditional::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestConditional::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditional.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditional.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.cpp
@@ -42,6 +42,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -459,6 +460,11 @@ JSTestConditionalIncludes::JSTestConditionalIncludes(Structure* structure, JSDOM
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestConditionalIncludes>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestConditionalIncludes::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestConditionalIncludes::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.cpp
@@ -45,6 +45,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -211,6 +212,11 @@ void JSTestConditionallyReadWrite::finishCreation(VM& vm)
     ASSERT(inherits(info()));
 
     putDirectCustomAccessor(vm, builtinNames(vm).enabledConditionallyReadWriteBySettingAttributeUnforgeablePrivatePrivateName(), CustomGetterSetter::create(vm, jsTestConditionallyReadWrite_enabledConditionallyReadWriteBySettingAttributeUnforgeablePrivate, nullptr), attributesForStructure(JSC::PropertyAttribute::DontDelete | JSC::PropertyAttribute::ReadOnly));
+}
+
+JSC::Structure* JSTestConditionallyReadWrite::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
 }
 
 JSObject* JSTestConditionallyReadWrite::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.cpp
@@ -52,6 +52,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -578,6 +579,11 @@ const ClassInfo JSTestDOMJIT::s_info = { "TestDOMJIT"_s, &Base::s_info, nullptr,
 JSTestDOMJIT::JSTestDOMJIT(Structure* structure, JSDOMGlobalObject& globalObject, Ref<TestDOMJIT>&& impl)
     : JSNode(structure, globalObject, WTF::move(impl))
 {
+}
+
+JSC::Structure* JSTestDOMJIT::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::JSType(JSNodeType), StructureFlags), info(), JSC::NonArray);
 }
 
 JSObject* JSTestDOMJIT::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::JSType(JSNodeType), StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.cpp
@@ -58,6 +58,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -227,6 +228,11 @@ JSTestDefaultToJSON::JSTestDefaultToJSON(Structure* structure, JSDOMGlobalObject
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestDefaultToJSON>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestDefaultToJSON::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestDefaultToJSON::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.cpp
@@ -44,6 +44,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -159,6 +160,11 @@ JSTestDefaultToJSONFilteredByExposed::JSTestDefaultToJSONFilteredByExposed(Struc
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestDefaultToJSONFilteredByExposed>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestDefaultToJSONFilteredByExposed::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestDefaultToJSONFilteredByExposed::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONIndirectInheritance.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONIndirectInheritance.cpp
@@ -36,6 +36,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -122,6 +123,11 @@ JSTestDefaultToJSONIndirectInheritance::JSTestDefaultToJSONIndirectInheritance(S
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestDefaultToJSONIndirectInheritance>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestDefaultToJSONIndirectInheritance::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestDefaultToJSONIndirectInheritance::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONIndirectInheritance.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONIndirectInheritance.h
@@ -43,11 +43,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.cpp
@@ -53,6 +53,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -153,6 +154,11 @@ JSTestDefaultToJSONInherit::JSTestDefaultToJSONInherit(Structure* structure, JSD
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestDefaultToJSONInherit>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestDefaultToJSONInherit::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestDefaultToJSONInherit::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.h
@@ -43,11 +43,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInheritFinal.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInheritFinal.cpp
@@ -53,6 +53,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -156,6 +157,11 @@ JSTestDefaultToJSONInheritFinal::JSTestDefaultToJSONInheritFinal(Structure* stru
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestDefaultToJSONInheritFinal>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestDefaultToJSONInheritFinal::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestDefaultToJSONInheritFinal::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInheritFinal.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInheritFinal.h
@@ -43,11 +43,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -136,6 +137,11 @@ JSTestDelegateToSharedSyntheticAttribute::JSTestDelegateToSharedSyntheticAttribu
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestDelegateToSharedSyntheticAttribute>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestDelegateToSharedSyntheticAttribute::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestDelegateToSharedSyntheticAttribute::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.cpp
@@ -47,6 +47,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -157,6 +158,11 @@ JSTestDomainSecurity::JSTestDomainSecurity(Structure* structure, JSDOMGlobalObje
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestDomainSecurity>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestDomainSecurity::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestDomainSecurity::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.cpp
@@ -44,6 +44,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -258,6 +259,11 @@ void JSTestEnabledBySetting::finishCreation(VM& vm)
         putDirectCustomAccessor(vm, builtinNames(vm).TestSubObjEnabledBySettingPrivatePublicPublicName(), CustomGetterSetter::create(vm, jsTestEnabledBySetting_TestSubObjEnabledBySettingPrivatePublicConstructor, nullptr), attributesForStructure(static_cast<unsigned>(JSC::PropertyAttribute::DontEnum)));
         putDirectCustomAccessor(vm, builtinNames(vm).TestSubObjEnabledBySettingPrivatePublicPrivateName(), CustomGetterSetter::create(vm, jsTestEnabledBySetting_TestSubObjEnabledBySettingPrivatePublicConstructor, nullptr), attributesForStructure(static_cast<unsigned>(JSC::PropertyAttribute::DontEnum)));
     }
+}
+
+JSC::Structure* JSTestEnabledBySetting::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
 }
 
 JSObject* JSTestEnabledBySetting::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.cpp
@@ -41,6 +41,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -137,6 +138,11 @@ void JSTestEnabledForContext::finishCreation(VM& vm)
 
     if ((downcast<Document>(jsCast<JSDOMGlobalObject*>(realm())->scriptExecutionContext())->settingsValues().testSettingEnabled && TestSubObjEnabledForContext::enabledForContext(*jsCast<JSDOMGlobalObject*>(realm())->scriptExecutionContext())))
         putDirectCustomAccessor(vm, builtinNames(vm).TestSubObjEnabledForContextPublicName(), CustomGetterSetter::create(vm, jsTestEnabledForContext_TestSubObjEnabledForContextConstructor, nullptr), attributesForStructure(static_cast<unsigned>(JSC::PropertyAttribute::DontEnum)));
+}
+
+JSC::Structure* JSTestEnabledForContext::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
 }
 
 JSObject* JSTestEnabledForContext::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp
@@ -42,6 +42,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <type_traits>
 #include <wtf/GetPtr.h>
@@ -276,6 +277,11 @@ JSTestEventConstructor::JSTestEventConstructor(Structure* structure, JSDOMGlobal
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestEventConstructor>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestEventConstructor::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::JSType(JSEventType), StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestEventConstructor::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::JSType(JSEventType), StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.cpp
@@ -44,6 +44,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -135,6 +136,11 @@ JSTestEventTarget::JSTestEventTarget(Structure* structure, JSDOMGlobalObject& gl
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestEventTarget>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestEventTarget::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestEventTarget::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.h
@@ -55,11 +55,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestException.cpp
@@ -39,6 +39,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -128,6 +129,11 @@ JSTestException::JSTestException(Structure* structure, JSDOMGlobalObject& global
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestException>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestException::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestException::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestException.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestException.h
@@ -45,11 +45,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -129,6 +130,11 @@ JSTestGenerateAddOpaqueRoot::JSTestGenerateAddOpaqueRoot(Structure* structure, J
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestGenerateAddOpaqueRoot>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestGenerateAddOpaqueRoot::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestGenerateAddOpaqueRoot::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -139,6 +140,11 @@ JSTestGenerateIsReachable::JSTestGenerateIsReachable(Structure* structure, JSDOM
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestGenerateIsReachable>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestGenerateIsReachable::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestGenerateIsReachable::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.cpp
@@ -115,6 +115,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -721,6 +722,11 @@ void JSTestGlobalObject::finishCreation(VM& vm)
     if ((jsCast<JSDOMGlobalObject*>(realm())->scriptExecutionContext()->isSecureContext() && DeprecatedGlobalSettings::testFeatureEnabled()))
         putDirectNativeFunction(vm, this, builtinNames(vm).testFeatureGetSecretBooleanPublicName(), 0, jsTestGlobalObjectInstanceFunction_testFeatureGetSecretBoolean, ImplementationVisibility::Public, NoIntrinsic, attributesForStructure(static_cast<unsigned>(JSC::PropertyAttribute::Function)));
 #endif
+}
+
+JSC::Structure* JSTestGlobalObject::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
 }
 
 JSValue JSTestGlobalObject::getConstructor(VM& vm, const JSGlobalObject* globalObject)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -127,6 +128,11 @@ JSTestIndexedSetterNoIdentifier::JSTestIndexedSetterNoIdentifier(Structure* stru
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestIndexedSetterNoIdentifier>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestIndexedSetterNoIdentifier::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestIndexedSetterNoIdentifier::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -127,6 +128,11 @@ JSTestIndexedSetterThrowingException::JSTestIndexedSetterThrowingException(Struc
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestIndexedSetterThrowingException>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestIndexedSetterThrowingException::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestIndexedSetterThrowingException::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.cpp
@@ -44,6 +44,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -136,6 +137,11 @@ JSTestIndexedSetterWithIdentifier::JSTestIndexedSetterWithIdentifier(Structure* 
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestIndexedSetterWithIdentifier>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestIndexedSetterWithIdentifier::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestIndexedSetterWithIdentifier::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp
@@ -54,6 +54,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -491,6 +492,11 @@ JSTestInterface::JSTestInterface(Structure* structure, JSDOMGlobalObject& global
 }
 
 static_assert(std::is_base_of<ActiveDOMObject, TestInterface>::value, "Interface is marked as [ActiveDOMObject] but implementation class does not subclass ActiveDOMObject.");
+
+JSC::Structure* JSTestInterface::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestInterface::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterface.h
@@ -48,11 +48,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.cpp
@@ -39,6 +39,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -128,6 +129,11 @@ JSTestInterfaceLeadingUnderscore::JSTestInterfaceLeadingUnderscore(Structure* st
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestInterfaceLeadingUnderscore>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestInterfaceLeadingUnderscore::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestInterfaceLeadingUnderscore::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.cpp
@@ -42,6 +42,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -141,6 +142,11 @@ JSTestIterable::JSTestIterable(Structure* structure, JSDOMGlobalObject& globalOb
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestIterable>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestIterable::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestIterable::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestIterable.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestJSBuiltinConstructor.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestJSBuiltinConstructor.cpp
@@ -36,6 +36,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -134,6 +135,11 @@ const ClassInfo JSTestJSBuiltinConstructor::s_info = { "TestJSBuiltinConstructor
 
 JSTestJSBuiltinConstructor::JSTestJSBuiltinConstructor(Structure* structure, JSDOMGlobalObject& globalObject)
     : JSDOMObject(structure, globalObject) { }
+
+JSC::Structure* JSTestJSBuiltinConstructor::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestJSBuiltinConstructor::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestJSBuiltinConstructor.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestJSBuiltinConstructor.h
@@ -41,11 +41,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.cpp
@@ -42,6 +42,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -184,6 +185,11 @@ JSTestLegacyFactoryFunction::JSTestLegacyFactoryFunction(Structure* structure, J
 }
 
 static_assert(std::is_base_of<ActiveDOMObject, TestLegacyFactoryFunction>::value, "Interface is marked as [ActiveDOMObject] but implementation class does not subclass ActiveDOMObject.");
+
+JSC::Structure* JSTestLegacyFactoryFunction::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestLegacyFactoryFunction::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     static JSC::JSValue getLegacyFactoryFunction(JSC::VM&, JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.cpp
@@ -45,6 +45,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -134,6 +135,11 @@ JSTestLegacyNoInterfaceObject::JSTestLegacyNoInterfaceObject(Structure* structur
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestLegacyNoInterfaceObject>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestLegacyNoInterfaceObject::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestLegacyNoInterfaceObject::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.h
@@ -46,11 +46,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {
         if constexpr (mode == JSC::SubspaceAccess::Concurrently)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.cpp
@@ -44,6 +44,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -136,6 +137,11 @@ JSTestLegacyOverrideBuiltIns::JSTestLegacyOverrideBuiltIns(Structure* structure,
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestLegacyOverrideBuiltIns>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestLegacyOverrideBuiltIns::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestLegacyOverrideBuiltIns::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.cpp
@@ -43,6 +43,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -154,6 +155,11 @@ JSTestMapLike::JSTestMapLike(Structure* structure, JSDOMGlobalObject& globalObje
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestMapLike>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestMapLike::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestMapLike::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.cpp
@@ -46,6 +46,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -158,6 +159,11 @@ JSTestMapLikeWithOverriddenOperations::JSTestMapLikeWithOverriddenOperations(Str
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestMapLikeWithOverriddenOperations>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestMapLikeWithOverriddenOperations::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestMapLikeWithOverriddenOperations::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.cpp
@@ -41,6 +41,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -128,6 +129,11 @@ JSTestNamedAndIndexedSetterNoIdentifier::JSTestNamedAndIndexedSetterNoIdentifier
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedAndIndexedSetterNoIdentifier>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedAndIndexedSetterNoIdentifier::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedAndIndexedSetterNoIdentifier::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.cpp
@@ -41,6 +41,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -128,6 +129,11 @@ JSTestNamedAndIndexedSetterThrowingException::JSTestNamedAndIndexedSetterThrowin
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedAndIndexedSetterThrowingException>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedAndIndexedSetterThrowingException::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedAndIndexedSetterThrowingException::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.cpp
@@ -45,6 +45,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -139,6 +140,11 @@ JSTestNamedAndIndexedSetterWithIdentifier::JSTestNamedAndIndexedSetterWithIdenti
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedAndIndexedSetterWithIdentifier>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedAndIndexedSetterWithIdentifier::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedAndIndexedSetterWithIdentifier::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -127,6 +128,11 @@ JSTestNamedDeleterNoIdentifier::JSTestNamedDeleterNoIdentifier(Structure* struct
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedDeleterNoIdentifier>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedDeleterNoIdentifier::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedDeleterNoIdentifier::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -127,6 +128,11 @@ JSTestNamedDeleterThrowingException::JSTestNamedDeleterThrowingException(Structu
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedDeleterThrowingException>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedDeleterThrowingException::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedDeleterThrowingException::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.cpp
@@ -43,6 +43,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -135,6 +136,11 @@ JSTestNamedDeleterWithIdentifier::JSTestNamedDeleterWithIdentifier(Structure* st
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedDeleterWithIdentifier>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedDeleterWithIdentifier::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedDeleterWithIdentifier::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.cpp
@@ -41,6 +41,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -128,6 +129,11 @@ JSTestNamedDeleterWithIndexedGetter::JSTestNamedDeleterWithIndexedGetter(Structu
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedDeleterWithIndexedGetter>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedDeleterWithIndexedGetter::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedDeleterWithIndexedGetter::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -127,6 +128,11 @@ JSTestNamedGetterCallWith::JSTestNamedGetterCallWith(Structure* structure, JSDOM
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedGetterCallWith>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedGetterCallWith::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedGetterCallWith::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -127,6 +128,11 @@ JSTestNamedGetterNoIdentifier::JSTestNamedGetterNoIdentifier(Structure* structur
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedGetterNoIdentifier>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedGetterNoIdentifier::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedGetterNoIdentifier::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.cpp
@@ -41,6 +41,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -133,6 +134,11 @@ JSTestNamedGetterWithIdentifier::JSTestNamedGetterWithIdentifier(Structure* stru
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedGetterWithIdentifier>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedGetterWithIdentifier::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedGetterWithIdentifier::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -127,6 +128,11 @@ JSTestNamedSetterNoIdentifier::JSTestNamedSetterNoIdentifier(Structure* structur
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedSetterNoIdentifier>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedSetterNoIdentifier::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedSetterNoIdentifier::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -127,6 +128,11 @@ JSTestNamedSetterThrowingException::JSTestNamedSetterThrowingException(Structure
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedSetterThrowingException>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedSetterThrowingException::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedSetterThrowingException::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.cpp
@@ -43,6 +43,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -135,6 +136,11 @@ JSTestNamedSetterWithIdentifier::JSTestNamedSetterWithIdentifier(Structure* stru
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedSetterWithIdentifier>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedSetterWithIdentifier::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedSetterWithIdentifier::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.cpp
@@ -45,6 +45,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -139,6 +140,11 @@ JSTestNamedSetterWithIndexedGetter::JSTestNamedSetterWithIndexedGetter(Structure
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedSetterWithIndexedGetter>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedSetterWithIndexedGetter::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedSetterWithIndexedGetter::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.cpp
@@ -45,6 +45,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -139,6 +140,11 @@ JSTestNamedSetterWithIndexedGetterAndSetter::JSTestNamedSetterWithIndexedGetterA
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedSetterWithIndexedGetterAndSetter>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedSetterWithIndexedGetterAndSetter::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedSetterWithIndexedGetterAndSetter::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -127,6 +128,11 @@ JSTestNamedSetterWithLegacyOverrideBuiltIns::JSTestNamedSetterWithLegacyOverride
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedSetterWithLegacyOverrideBuiltIns>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedSetterWithLegacyOverrideBuiltIns::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedSetterWithLegacyOverrideBuiltIns::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.cpp
@@ -44,6 +44,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -153,6 +154,11 @@ JSTestNamedSetterWithLegacyUnforgeableProperties::JSTestNamedSetterWithLegacyUnf
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedSetterWithLegacyUnforgeableProperties>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedSetterWithLegacyUnforgeableProperties::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedSetterWithLegacyUnforgeableProperties::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.cpp
@@ -44,6 +44,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -153,6 +154,11 @@ JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns::JSTes
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.h
@@ -53,11 +53,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceConst.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceConst.cpp
@@ -35,6 +35,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/ObjectPrototype.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -75,6 +76,11 @@ JSTestNamespaceConst::JSTestNamespaceConst(Structure* structure, JSDOMGlobalObje
     : JSDOMObject(structure, globalObject) { }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamespaceConst>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamespaceConst::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSValue JSTestNamespaceConst::getConstructor(VM& vm, const JSGlobalObject* globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceConst.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceConst.h
@@ -39,11 +39,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceObject.cpp
@@ -47,6 +47,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/ObjectPrototype.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -137,6 +138,11 @@ JSTestNamespaceObject::JSTestNamespaceObject(Structure* structure, JSDOMGlobalOb
     : JSDOMObject(structure, globalObject) { }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestNamespaceObject>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestNamespaceObject::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSValue JSTestNamespaceObject::getConstructor(VM& vm, const JSGlobalObject* globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceObject.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceObject.h
@@ -39,11 +39,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp
@@ -53,6 +53,7 @@
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -240,6 +241,11 @@ const ClassInfo JSTestNode::s_info = { "TestNode"_s, &Base::s_info, nullptr, nul
 JSTestNode::JSTestNode(Structure* structure, JSDOMGlobalObject& globalObject, Ref<TestNode>&& impl)
     : JSNode(structure, globalObject, WTF::move(impl))
 {
+}
+
+JSC::Structure* JSTestNode::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::JSType(JSNodeType), StructureFlags), info(), JSC::NonArray);
 }
 
 JSObject* JSTestNode::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestNode.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestNode.h
@@ -43,11 +43,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::JSType(JSNodeType), StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -103,6 +103,7 @@
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <JavaScriptCore/PropertyNameArray.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <type_traits>
 #include <wtf/GetPtr.h>
@@ -3466,6 +3467,11 @@ JSTestObj::JSTestObj(Structure* structure, JSDOMGlobalObject& globalObject, Ref<
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestObj>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestObj::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestObj::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.h
@@ -55,11 +55,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     mutable JSC::WriteBarrier<JSC::Unknown> m_cachedAttribute1;
     mutable JSC::WriteBarrier<JSC::Unknown> m_cachedAttribute2;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.cpp
@@ -41,6 +41,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -152,6 +153,11 @@ JSTestOperationConditional::JSTestOperationConditional(Structure* structure, JSD
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestOperationConditional>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestOperationConditional::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestOperationConditional::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.h
@@ -46,11 +46,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.cpp
@@ -44,6 +44,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -264,6 +265,11 @@ JSTestOverloadedConstructors::JSTestOverloadedConstructors(Structure* structure,
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestOverloadedConstructors>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestOverloadedConstructors::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestOverloadedConstructors::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.cpp
@@ -43,6 +43,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -199,6 +200,11 @@ JSTestOverloadedConstructorsWithSequence::JSTestOverloadedConstructorsWithSequen
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestOverloadedConstructorsWithSequence>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestOverloadedConstructorsWithSequence::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestOverloadedConstructorsWithSequence::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.cpp
@@ -39,6 +39,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -126,6 +127,11 @@ JSTestPluginInterface::JSTestPluginInterface(Structure* structure, JSDOMGlobalOb
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestPluginInterface>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestPluginInterface::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
+}
 
 JSObject* JSTestPluginInterface::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.h
@@ -52,11 +52,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::MayHaveIndexedAccessors);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp
@@ -45,6 +45,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <type_traits>
 #include <wtf/GetPtr.h>
@@ -269,6 +270,11 @@ JSTestPromiseRejectionEvent::JSTestPromiseRejectionEvent(Structure* structure, J
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestPromiseRejectionEvent>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestPromiseRejectionEvent::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::JSType(JSEventType), StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestPromiseRejectionEvent::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::JSType(JSEventType), StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.cpp
@@ -43,6 +43,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -148,6 +149,11 @@ JSTestReadOnlyMapLike::JSTestReadOnlyMapLike(Structure* structure, JSDOMGlobalOb
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestReadOnlyMapLike>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestReadOnlyMapLike::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestReadOnlyMapLike::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.cpp
@@ -43,6 +43,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -146,6 +147,11 @@ JSTestReadOnlySetLike::JSTestReadOnlySetLike(Structure* structure, JSDOMGlobalOb
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestReadOnlySetLike>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestReadOnlySetLike::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestReadOnlySetLike::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.cpp
@@ -37,6 +37,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -131,6 +132,11 @@ void JSTestReportExtraMemoryCost::finishCreation(VM& vm)
     ASSERT(inherits(info()));
 
     vm.heap.reportExtraMemoryAllocated(this, wrapped().memoryCost());
+}
+
+JSC::Structure* JSTestReportExtraMemoryCost::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
 }
 
 JSObject* JSTestReportExtraMemoryCost::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.h
@@ -45,11 +45,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestScheduledAction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestScheduledAction.cpp
@@ -42,6 +42,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -134,6 +135,11 @@ JSTestScheduledAction::JSTestScheduledAction(Structure* structure, JSDOMGlobalOb
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestScheduledAction>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestScheduledAction::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestScheduledAction::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestScheduledAction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestScheduledAction.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.cpp
@@ -51,6 +51,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -157,6 +158,11 @@ JSTestSerializedScriptValueInterface::JSTestSerializedScriptValueInterface(Struc
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestSerializedScriptValueInterface>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestSerializedScriptValueInterface::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestSerializedScriptValueInterface::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.h
@@ -46,11 +46,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     mutable JSC::WriteBarrier<JSC::Unknown> m_cachedValue;
     mutable JSC::WriteBarrier<JSC::Unknown> m_cachedReadonlyValue;

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.cpp
@@ -43,6 +43,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -152,6 +153,11 @@ JSTestSetLike::JSTestSetLike(Structure* structure, JSDOMGlobalObject& globalObje
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestSetLike>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestSetLike::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestSetLike::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.cpp
@@ -46,6 +46,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -156,6 +157,11 @@ JSTestSetLikeWithOverriddenOperations::JSTestSetLikeWithOverriddenOperations(Str
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestSetLikeWithOverriddenOperations>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestSetLikeWithOverriddenOperations::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestSetLikeWithOverriddenOperations::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.cpp
@@ -39,6 +39,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -131,6 +132,11 @@ JSTestStringifier::JSTestStringifier(Structure* structure, JSDOMGlobalObject& gl
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestStringifier>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestStringifier::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestStringifier::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.cpp
@@ -39,6 +39,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -131,6 +132,11 @@ JSTestStringifierAnonymousOperation::JSTestStringifierAnonymousOperation(Structu
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestStringifierAnonymousOperation>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestStringifierAnonymousOperation::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestStringifierAnonymousOperation::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.cpp
@@ -39,6 +39,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -133,6 +134,11 @@ JSTestStringifierNamedOperation::JSTestStringifierNamedOperation(Structure* stru
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestStringifierNamedOperation>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestStringifierNamedOperation::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestStringifierNamedOperation::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.cpp
@@ -39,6 +39,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -133,6 +134,11 @@ JSTestStringifierOperationImplementedAs::JSTestStringifierOperationImplementedAs
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestStringifierOperationImplementedAs>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestStringifierOperationImplementedAs::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestStringifierOperationImplementedAs::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.cpp
@@ -39,6 +39,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -131,6 +132,11 @@ JSTestStringifierOperationNamedToString::JSTestStringifierOperationNamedToString
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestStringifierOperationNamedToString>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestStringifierOperationNamedToString::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestStringifierOperationNamedToString::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -134,6 +135,11 @@ JSTestStringifierReadOnlyAttribute::JSTestStringifierReadOnlyAttribute(Structure
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestStringifierReadOnlyAttribute>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestStringifierReadOnlyAttribute::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestStringifierReadOnlyAttribute::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.cpp
@@ -40,6 +40,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -135,6 +136,11 @@ JSTestStringifierReadWriteAttribute::JSTestStringifierReadWriteAttribute(Structu
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestStringifierReadWriteAttribute>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestStringifierReadWriteAttribute::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestStringifierReadWriteAttribute::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.cpp
@@ -37,6 +37,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -124,6 +125,11 @@ JSTestTaggedWrapper::JSTestTaggedWrapper(Structure* structure, JSDOMGlobalObject
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestTaggedWrapper>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestTaggedWrapper::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestTaggedWrapper::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.h
@@ -45,11 +45,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.cpp
@@ -60,6 +60,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -251,6 +252,11 @@ JSTestTypedefs::JSTestTypedefs(Structure* structure, JSDOMGlobalObject& globalOb
 }
 
 static_assert(!std::is_base_of<ActiveDOMObject, TestTypedefs>::value, "Interface is not marked as [ActiveDOMObject] even though implementation class subclasses ActiveDOMObject.");
+
+JSC::Structure* JSTestTypedefs::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSTestTypedefs::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.h
@@ -44,11 +44,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::ObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
@@ -38,6 +38,8 @@
 #include "JSTestNode.h"
 #include "ScriptExecutionContext.h"
 #include "SerializedScriptValue.h"
+#include <JavaScriptCore/JSCellInlines.h>
+#include <JavaScriptCore/MarkedVector.h>
 
 
 namespace WebCore {

--- a/Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.cpp
@@ -44,6 +44,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -152,6 +153,11 @@ void JSWorkerGlobalScope::finishCreation(VM& vm, JSGlobalProxy* proxy)
 
 }
 #endif
+
+JSC::Structure* JSWorkerGlobalScope::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSWorkerGlobalScope::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.h
@@ -45,11 +45,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.cpp
@@ -39,6 +39,7 @@
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSDestructibleObjectHeapCellType.h>
 #include <JavaScriptCore/SlotVisitorMacros.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <JavaScriptCore/SubspaceInlines.h>
 #include <wtf/GetPtr.h>
 #include <wtf/PointerPreparations.h>
@@ -122,6 +123,11 @@ void JSWorkletGlobalScope::finishCreation(VM& vm, JSGlobalProxy* proxy)
 
 }
 #endif
+
+JSC::Structure* JSWorkletGlobalScope::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
+{
+    return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
+}
 
 JSObject* JSWorkletGlobalScope::createPrototype(VM& vm, JSDOMGlobalObject& globalObject)
 {

--- a/Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.h
@@ -45,11 +45,7 @@ public:
 
     DECLARE_INFO;
 
-    static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
-    {
-        return JSC::Structure::create(vm, globalObject, prototype, JSC::TypeInfo(JSC::GlobalObjectType, StructureFlags), info(), JSC::NonArray);
-    }
-
+    static JSC::Structure* createStructure(JSC::VM&, JSC::JSGlobalObject*, JSC::JSValue);
     static JSC::JSValue getConstructor(JSC::VM&, const JSC::JSGlobalObject*);
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
     {

--- a/Source/WebCore/bridge/objc/objc_runtime.h
+++ b/Source/WebCore/bridge/objc/objc_runtime.h
@@ -27,8 +27,11 @@
 
 #include "BridgeJSC.h"
 #include "JSDOMBinding.h"
+#include "JSDOMWrapperCache.h"
 #include "objc_header.h"
+#include <JavaScriptCore/JSDestructibleObject.h>
 #include <JavaScriptCore/JSGlobalObject.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/RetainPtr.h>
 
 namespace JSC::Bindings {

--- a/Source/WebCore/bridge/runtime_array.h
+++ b/Source/WebCore/bridge/runtime_array.h
@@ -27,8 +27,9 @@
 #define RUNTIME_ARRAY_H_
 
 #include "BridgeJSC.h"
-#include "JSDOMBinding.h"
+#include "JSDOMWrapperCache.h"
 #include <JavaScriptCore/ArrayPrototype.h>
+#include <JavaScriptCore/JSGlobalObject.h>
 
 namespace JSC {
     

--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -73,6 +73,8 @@
 #include "Settings.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <JavaScriptCore/JSONObject.h>
+#include <JavaScriptCore/JSObjectInlines.h>
+#include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/ObjectConstructor.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/css/CSSStyleSheetObservableArray.cpp
+++ b/Source/WebCore/css/CSSStyleSheetObservableArray.cpp
@@ -31,6 +31,7 @@
 #include "JSDOMConvertInterface.h"
 #include "ShadowRoot.h"
 #include "TreeScope.h"
+#include <JavaScriptCore/JSGlobalObjectInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/AbortController.cpp
+++ b/Source/WebCore/dom/AbortController.cpp
@@ -28,6 +28,7 @@
 
 #include "AbortSignal.h"
 #include "JSAbortController.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "ScriptWrappableInlines.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/dom/AbortSignal.cpp
+++ b/Source/WebCore/dom/AbortSignal.cpp
@@ -34,6 +34,7 @@
 #include "EventNames.h"
 #include "EventTargetInlines.h"
 #include "JSDOMException.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "ScriptExecutionContext.h"
 #include "ScriptWrappableInlines.h"
 #include "WebCoreOpaqueRoot.h"

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -38,6 +38,7 @@
 namespace WebCore {
 
 class AbortAlgorithm;
+class JSDOMGlobalObject;
 class ScriptExecutionContext;
 class WebCoreOpaqueRoot;
 

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -39,6 +39,7 @@
 #include "WorkerGlobalScope.h"
 #include "WorkerLoaderProxy.h"
 #include "WorkerThread.h"
+#include <JavaScriptCore/TopExceptionScope.h>
 #include <wtf/CallbackAggregator.h>
 #include <wtf/HashMap.h>
 #include <wtf/Identified.h>

--- a/Source/WebCore/dom/CollectionIndexCache.cpp
+++ b/Source/WebCore/dom/CollectionIndexCache.cpp
@@ -29,6 +29,7 @@
 #include "CommonVM.h"
 #include "JSDOMBinding.h"
 #include "LocalDOMWindow.h"
+#include <JavaScriptCore/HeapInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/CustomEvent.cpp
+++ b/Source/WebCore/dom/CustomEvent.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "CustomEvent.h"
 
+#include "JSValueInWrappedObjectInlines.h"
 #include "ScriptWrappableInlines.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/dom/ErrorEvent.cpp
+++ b/Source/WebCore/dom/ErrorEvent.cpp
@@ -33,6 +33,7 @@
 #include "ErrorEvent.h"
 
 #include "EventNames.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/StrongInlines.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -48,6 +48,8 @@
 #include "ScriptController.h"
 #include "ScriptDisallowedScope.h"
 #include "Settings.h"
+#include <JavaScriptCore/HeapCellInlines.h>
+#include <JavaScriptCore/JSCJSValueCellInlines.h>
 #include <wtf/MainThread.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Ref.h>

--- a/Source/WebCore/dom/InternalObserverEvery.cpp
+++ b/Source/WebCore/dom/InternalObserverEvery.cpp
@@ -32,6 +32,7 @@
 #include "InternalObserver.h"
 #include "JSDOMConvertBoolean.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "Observable.h"
 #include "PredicateCallback.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/dom/InternalObserverFind.cpp
+++ b/Source/WebCore/dom/InternalObserverFind.cpp
@@ -33,6 +33,7 @@
 #include "InternalObserver.h"
 #include "JSDOMConvertAny.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "Observable.h"
 #include "PredicateCallback.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/dom/InternalObserverFirst.cpp
+++ b/Source/WebCore/dom/InternalObserverFirst.cpp
@@ -32,6 +32,7 @@
 #include "InternalObserver.h"
 #include "JSDOMConvertAny.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "Observable.h"
 #include "ScriptExecutionContext.h"
 #include "SubscribeOptions.h"

--- a/Source/WebCore/dom/InternalObserverForEach.cpp
+++ b/Source/WebCore/dom/InternalObserverForEach.cpp
@@ -30,6 +30,7 @@
 #include "ContextDestructionObserverInlines.h"
 #include "InternalObserver.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "Observable.h"
 #include "ScriptExecutionContext.h"
 #include "SubscribeOptions.h"

--- a/Source/WebCore/dom/InternalObserverLast.cpp
+++ b/Source/WebCore/dom/InternalObserverLast.cpp
@@ -33,7 +33,7 @@
 #include "InternalObserver.h"
 #include "JSDOMConvertAny.h"
 #include "JSDOMPromiseDeferred.h"
-#include "JSValueInWrappedObject.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "Observable.h"
 #include "ScriptExecutionContext.h"
 #include "SubscribeOptions.h"

--- a/Source/WebCore/dom/InternalObserverReduce.cpp
+++ b/Source/WebCore/dom/InternalObserverReduce.cpp
@@ -33,7 +33,7 @@
 #include "InternalObserver.h"
 #include "JSDOMConvertAny.h"
 #include "JSDOMPromiseDeferred.h"
-#include "JSValueInWrappedObject.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "Observable.h"
 #include "ReducerCallback.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/dom/InternalObserverSome.cpp
+++ b/Source/WebCore/dom/InternalObserverSome.cpp
@@ -33,6 +33,7 @@
 #include "JSDOMConvertAny.h"
 #include "JSDOMConvertBoolean.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "Observable.h"
 #include "PredicateCallback.h"
 #include "ScriptExecutionContext.h"

--- a/Source/WebCore/dom/MapperCallback.h
+++ b/Source/WebCore/dom/MapperCallback.h
@@ -29,6 +29,10 @@
 #include "CallbackResult.h"
 #include <wtf/RefCounted.h>
 
+namespace JSC {
+class JSValue;
+}
+
 namespace WebCore {
 
 class MapperCallback : public RefCounted<MapperCallback>, public ActiveDOMCallback {

--- a/Source/WebCore/dom/MessageEvent.cpp
+++ b/Source/WebCore/dom/MessageEvent.cpp
@@ -31,6 +31,7 @@
 #include "Blob.h"
 #include "EventNames.h"
 #include "JSMessageEvent.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "SecurityOrigin.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/dom/MutationRecord.cpp
+++ b/Source/WebCore/dom/MutationRecord.cpp
@@ -36,6 +36,7 @@
 #include "JSNode.h"
 #include "StaticNodeList.h"
 #include "WebCoreOpaqueRootInlines.h"
+#include <JavaScriptCore/AbstractSlotVisitorInlines.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StdLibExtras.h>
 

--- a/Source/WebCore/dom/ObservableInspectorAbortCallback.h
+++ b/Source/WebCore/dom/ObservableInspectorAbortCallback.h
@@ -29,6 +29,10 @@
 #include "CallbackResult.h"
 #include <wtf/RefCounted.h>
 
+namespace JSC {
+class JSValue;
+}
+
 namespace WebCore {
 
 class ObservableInspectorAbortCallback : public RefCounted<ObservableInspectorAbortCallback>, public ActiveDOMCallback {

--- a/Source/WebCore/dom/PopStateEvent.cpp
+++ b/Source/WebCore/dom/PopStateEvent.cpp
@@ -29,6 +29,7 @@
 
 #include "EventNames.h"
 #include "History.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include <JavaScriptCore/JSCInlines.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/dom/PredicateCallback.h
+++ b/Source/WebCore/dom/PredicateCallback.h
@@ -29,6 +29,10 @@
 #include "CallbackResult.h"
 #include <wtf/RefCounted.h>
 
+namespace JSC {
+class JSValue;
+}
+
 namespace WebCore {
 
 class PredicateCallback : public RefCounted<PredicateCallback>, public ActiveDOMCallback {

--- a/Source/WebCore/dom/PromiseRejectionEvent.cpp
+++ b/Source/WebCore/dom/PromiseRejectionEvent.cpp
@@ -28,6 +28,7 @@
 
 #include "DOMWrapperWorld.h"
 #include "JSDOMPromise.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include <JavaScriptCore/HeapInlines.h>
 #include <JavaScriptCore/StrongInlines.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -54,6 +54,7 @@
 #include "VisibleUnits.h"
 #include "WebCoreOpaqueRootInlines.h"
 #include "markup.h"
+#include <JavaScriptCore/AbstractSlotVisitorInlines.h>
 #include <stdio.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/CString.h>

--- a/Source/WebCore/dom/ReducerCallback.h
+++ b/Source/WebCore/dom/ReducerCallback.h
@@ -29,6 +29,10 @@
 #include "CallbackResult.h"
 #include <wtf/RefCounted.h>
 
+namespace JSC {
+class JSValue;
+}
+
 namespace WebCore {
 
 class ReducerCallback : public RefCounted<ReducerCallback>, public ActiveDOMCallback {

--- a/Source/WebCore/dom/StaticRange.cpp
+++ b/Source/WebCore/dom/StaticRange.cpp
@@ -29,6 +29,7 @@
 #include "ContainerNodeInlines.h"
 #include "JSNode.h"
 #include "WebCoreOpaqueRootInlines.h"
+#include <JavaScriptCore/AbstractSlotVisitorInlines.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/dom/Subscriber.cpp
+++ b/Source/WebCore/dom/Subscriber.cpp
@@ -30,6 +30,7 @@
 #include "Document.h"
 #include "InternalObserver.h"
 #include "JSDOMExceptionHandling.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "ScriptWrappableInlines.h"
 #include "SubscriberCallback.h"
 #include "SubscriptionObserverCallback.h"

--- a/Source/WebCore/dom/SubscriptionObserverCallback.h
+++ b/Source/WebCore/dom/SubscriptionObserverCallback.h
@@ -29,6 +29,10 @@
 #include "CallbackResult.h"
 #include <wtf/RefCounted.h>
 
+namespace JSC {
+class JSValue;
+}
+
 namespace WebCore {
 
 class SubscriptionObserverCallback : public RefCounted<SubscriptionObserverCallback>, public ActiveDOMCallback {

--- a/Source/WebCore/dom/VisitorCallback.h
+++ b/Source/WebCore/dom/VisitorCallback.h
@@ -29,6 +29,10 @@
 #include "CallbackResult.h"
 #include <wtf/RefCounted.h>
 
+namespace JSC {
+class JSValue;
+}
+
 namespace WebCore {
 
 class VisitorCallback : public RefCounted<VisitorCallback>, public ActiveDOMCallback {

--- a/Source/WebCore/dom/make_event_factory.pl
+++ b/Source/WebCore/dom/make_event_factory.pl
@@ -90,6 +90,7 @@ sub generateImplementation()
     print F "#include \"${namespace}Headers.h\"\n";
     print F "\n";
     print F "#include \"JSDOMGlobalObject.h\"\n";
+    print F "#include \"JSDOMWrapperCache.h\"\n";
     print F "#include <JavaScriptCore/StructureInlines.h>\n";
     print F "\n";
     print F "namespace WebCore {\n";

--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -1954,6 +1954,7 @@ sub printWrapperFactoryCppFile
 
 #include "DeprecatedGlobalSettings.h"
 #include "Document.h"
+#include "JSDOMWrapperCache.h"
 #include "NodeName.h"
 #include "Settings.h"
 #include <wtf/NeverDestroyed.h>
@@ -1963,8 +1964,6 @@ END
     printConditionalElementIncludes($F, 1);
 
     print F <<END;
-
-using namespace JSC;
 
 namespace WebCore {
 

--- a/Source/WebCore/domjit/JSDocumentDOMJIT.cpp
+++ b/Source/WebCore/domjit/JSDocumentDOMJIT.cpp
@@ -35,6 +35,7 @@
 #include "JSDOMWrapper.h"
 #include "JSElement.h"
 #include "JSHTMLElement.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/Snippet.h>
 #include <JavaScriptCore/SnippetParams.h>
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -83,6 +83,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "JSHTMLMediaElement.h"
 #include "JSMediaControlsHost.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "LoadableTextTrack.h"
 #include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -37,6 +37,7 @@
 #include "Image.h"
 #include "ImageBitmap.h"
 #include "InspectorInstrumentation.h"
+#include <JavaScriptCore/HeapInlines.h>
 #include "OriginAccessPatterns.h"
 #include "PixelFormat.h"
 #include "SVGImageElement.h"

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -59,6 +59,7 @@
 #include "JSCanvasRenderingContext2D.h"
 #include "JSCanvasTextAlign.h"
 #include "JSCanvasTextBaseline.h"
+#include "JSDOMWrapperCache.h"
 #include "JSExecState.h"
 #include "JSImageBitmapRenderingContext.h"
 #include "JSImageSmoothingQuality.h"

--- a/Source/WebCore/inspector/WebInjectedScriptHost.cpp
+++ b/Source/WebCore/inspector/WebInjectedScriptHost.cpp
@@ -37,6 +37,7 @@
 #include "JSNodeList.h"
 #include "JSWorker.h"
 #include "Worker.h"
+#include <JavaScriptCore/ObjectConstructor.h>
 
 #if ENABLE(PAYMENT_REQUEST)
 #include "JSPaymentRequest.h"

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -51,6 +51,7 @@
 #include "CrossOriginAccessControl.h"
 #include "CrossOriginEmbedderPolicy.h"
 #include "DNS.h"
+#include "DOMWrapperWorld.h"
 #include "DatabaseManager.h"
 #include "DiagnosticLoggingClient.h"
 #include "DiagnosticLoggingKeys.h"

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -58,6 +58,7 @@
 #include "RenderImage.h"
 #include "RenderSVGImage.h"
 #include "Settings.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Scope.h>
 #include <wtf/text/MakeString.h>

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -36,6 +36,7 @@
 #include "HistoryItem.h"
 #include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "Logging.h"
 #include "Navigation.h"
 #include "NavigationScheduler.h"

--- a/Source/WebCore/page/NavigateEvent.cpp
+++ b/Source/WebCore/page/NavigateEvent.cpp
@@ -35,6 +35,7 @@
 #include "ExceptionCode.h"
 #include "HTMLBodyElement.h"
 #include "HistoryController.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "LocalFrameInlines.h"
 #include "LocalFrameView.h"
 #include "Navigation.h"
@@ -105,6 +106,11 @@ ExceptionOr<void> NavigateEvent::sharedChecks(Document& document)
         return Exception { ExceptionCode::InvalidStateError, "Event was already canceled"_s };
 
     return { };
+}
+
+JSC::JSValue NavigateEvent::info()
+{
+    return m_info.getValue();
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-intercept

--- a/Source/WebCore/page/NavigateEvent.h
+++ b/Source/WebCore/page/NavigateEvent.h
@@ -101,7 +101,7 @@ public:
     AbortSignal& signal() { return m_signal; }
     DOMFormData* formData() { return m_formData.get(); }
     String downloadRequest() { return m_downloadRequest; }
-    JSC::JSValue info() { return m_info.getValue(); }
+    JSC::JSValue info();
     JSValueInWrappedObject& infoWrapper() LIFETIME_BOUND { return m_info; }
     Element* sourceElement() { return m_sourceElement.get(); }
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -54,6 +54,7 @@
 #include "JSDOMPromise.h"
 #include "JSDOMPromiseDeferred.h"
 #include "JSNavigationHistoryEntry.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "Logging.h"
 #include "MessagePort.h"
 #include "NavigateEvent.h"
@@ -68,6 +69,8 @@
 #include "SerializedScriptValue.h"
 #include "ShouldTreatAsContinuingLoad.h"
 #include "UserGestureIndicator.h"
+#include <JavaScriptCore/JSGlobalObjectInlines.h>
+#include <JavaScriptCore/StrongInlines.h>
 #include <optional>
 #include <wtf/Assertions.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -40,6 +40,7 @@
 #include "Page.h"
 #include "Settings.h"
 #include "VisibilityState.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/UserMessageHandler.cpp
+++ b/Source/WebCore/page/UserMessageHandler.cpp
@@ -32,6 +32,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "LocalFrame.h"
 #include "SerializedScriptValue.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/JSCJSValue.h>
 
 namespace WebCore {

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -36,6 +36,7 @@
 #include "ContentSecurityPolicySource.h"
 #include "ContentSecurityPolicySourceList.h"
 #include "DOMStringList.h"
+#include "DOMWrapperWorld.h"
 #include "DocumentLoader.h"
 #include "DocumentPage.h"
 #include "EventNames.h"
@@ -57,6 +58,7 @@
 #include "SubresourceIntegrity.h"
 #include "ViolationReportType.h"
 #include "WorkerGlobalScope.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/ScriptCallStack.h>
 #include <JavaScriptCore/ScriptCallStackFactory.h>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -32,6 +32,7 @@
 #include "CommonVM.h"
 #include "ComposedTreeIterator.h"
 #include "ContainerNodeInlines.h"
+#include "DOMWrapperWorld.h"
 #include "DocumentPage.h"
 #include "DocumentSecurityOrigin.h"
 #include "DocumentView.h"

--- a/Source/WebCore/testing/EventTargetForTesting.cpp
+++ b/Source/WebCore/testing/EventTargetForTesting.cpp
@@ -30,6 +30,9 @@
 #include "CustomEvent.h"
 #include "MessageForTesting.h"
 #include "MessageTargetForTesting.h"
+#include <JavaScriptCore/HeapInlines.h>
+#include <JavaScriptCore/JSCellInlines.h>
+#include <JavaScriptCore/JSString.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/testing/GCObservation.h
+++ b/Source/WebCore/testing/GCObservation.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Weak.h>
 #include <wtf/RefCounted.h>

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -278,6 +278,7 @@
 #include "XMLHttpRequest.h"
 #include <JavaScriptCore/CodeBlock.h>
 #include <JavaScriptCore/FunctionExecutable.h>
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/InspectorAgentBase.h>
 #include <JavaScriptCore/InspectorFrontendChannel.h>
 #include <JavaScriptCore/JSCInlines.h>

--- a/Source/WebCore/testing/ServiceWorkerInternals.cpp
+++ b/Source/WebCore/testing/ServiceWorkerInternals.cpp
@@ -39,6 +39,7 @@
 #include "ServiceWorkerClient.h"
 #include "ServiceWorkerGlobalScope.h"
 #include "ServiceWorkerRegistration.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <wtf/ProcessID.h>
 
 namespace WebCore {

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -33,6 +33,7 @@
 #include "DOMPointReadOnly.h"
 #include "JSDOMPromiseDeferred.h"
 #include "WebFakeXRInputController.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/testing/WebXRTest.cpp
+++ b/Source/WebCore/testing/WebXRTest.cpp
@@ -37,6 +37,7 @@
 #include "UserGestureIndicator.h"
 #include "WebXRSystem.h"
 #include "XRSessionMode.h"
+#include <JavaScriptCore/JSCJSValueInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/workers/service/ExtendableMessageEvent.cpp
+++ b/Source/WebCore/workers/service/ExtendableMessageEvent.cpp
@@ -30,6 +30,7 @@
 #include "EventNames.h"
 #include "JSDOMConvertInterface.h"
 #include "JSExtendableMessageEvent.h"
+#include "JSValueInWrappedObjectInlines.h"
 #include "SecurityOrigin.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
@@ -51,6 +51,7 @@
 #include "ServiceWorkerTypes.h"
 #include "WebCoreOpaqueRoot.h"
 #include "WorkerGlobalScope.h"
+#include <JavaScriptCore/HeapCellInlines.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
@@ -32,6 +32,7 @@
 #include "WebExtensionAPIRuntime.h"
 #include "WebFrame.h"
 #include "WebPage.h"
+#include <JavaScriptCore/JSClassRef.h>
 #include <JavaScriptCore/JSObjectRef.h>
 #include <JavaScriptCore/JSWeakObjectMapRefPrivate.h>
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDOMWindow.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/gtk/DOM/WebKitDOMDOMWindow.cpp
@@ -23,6 +23,7 @@
 #include <WebCore/CSSImportRule.h>
 #include "DOMObjectCache.h"
 #include <WebCore/DOMException.h>
+#include <WebCore/DOMWrapperWorld.h>
 #include <WebCore/Document.h>
 #include "GObjectEventListener.h"
 #include <JavaScriptCore/APICast.h>

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -72,6 +72,7 @@
 #include <WebCore/CertificateInfo.h>
 #include <WebCore/Chrome.h>
 #include <WebCore/ContextMenuController.h>
+#include <WebCore/DOMWrapperWorld.h>
 #include <WebCore/DocumentInlines.h>
 #include <WebCore/DocumentLoader.h>
 #include <WebCore/DocumentPage.h>

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -200,6 +200,7 @@
 #include <WebCore/CrossOriginEmbedderPolicy.h>
 #include <WebCore/CrossOriginOpenerPolicy.h>
 #include <WebCore/DOMPasteAccess.h>
+#include <WebCore/DOMWrapperWorld.h>
 #include <WebCore/DataTransfer.h>
 #include <WebCore/DatabaseManager.h>
 #include <WebCore/DeprecatedGlobalSettings.h>

--- a/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
@@ -86,6 +86,7 @@
 #import <WebCore/TreeWalker.h>
 #import <WebCore/VisibilityState.h>
 #import <WebCore/WebScriptObjectPrivate.h>
+#import <WebCore/WindowProxy.h>
 #import <WebCore/XPathExpression.h>
 #import <WebCore/XPathNSResolver.h>
 #import <WebCore/XPathResult.h>

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLFrameElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLFrameElement.mm
@@ -37,6 +37,7 @@
 #import <WebCore/LocalDOMWindow.h>
 #import <WebCore/ThreadCheck.h>
 #import <WebCore/WebScriptObjectPrivate.h>
+#import <WebCore/WindowProxy.h>
 #import <wtf/GetPtr.h>
 #import <wtf/URL.h>
 

--- a/Source/WebKitLegacy/mac/DOM/DOMHTMLIFrameElement.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTMLIFrameElement.mm
@@ -36,6 +36,7 @@
 #import <WebCore/LocalDOMWindow.h>
 #import <WebCore/ThreadCheck.h>
 #import <WebCore/WebScriptObjectPrivate.h>
+#import <WebCore/WindowProxy.h>
 #import <wtf/GetPtr.h>
 #import <wtf/URL.h>
 

--- a/Source/WebKitLegacy/mac/DOM/DOMInternal.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMInternal.mm
@@ -26,6 +26,7 @@
 #import "DOMInternal.h"
 
 #import "DOMNodeInternal.h"
+#import <WebCore/DOMWrapperWorld.h>
 #import <WebCore/Document.h>
 #import <WebCore/FrameDestructionObserverInlines.h>
 #import <WebCore/JSNode.h>

--- a/Source/WebKitLegacy/mac/DOM/DOMUtility.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMUtility.mm
@@ -47,6 +47,7 @@
 #import "DOMTreeWalkerInternal.h"
 #import "DOMXPathExpressionInternal.h"
 #import "DOMXPathResultInternal.h"
+#import <JavaScriptCore/HeapCellInlines.h>
 #import <WebCore/JSCSSRule.h>
 #import <WebCore/JSCSSRuleList.h>
 #import <WebCore/JSCSSStyleDeclaration.h>

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -83,6 +83,7 @@
 #import <WebCore/Chrome.h>
 #import <WebCore/ContainerNodeInlines.h>
 #import <WebCore/DNS.h>
+#import <WebCore/DOMWrapperWorld.h>
 #import <WebCore/DocumentLoader.h>
 #import <WebCore/DocumentPage.h>
 #import <WebCore/DocumentView.h>

--- a/Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm
@@ -25,6 +25,7 @@
 #import "WebScriptWorld.h"
 
 #import "WebScriptWorldInternal.h"
+#import <WebCore/DOMWrapperWorld.h>
 #import <WebCore/JSDOMBinding.h>
 #import <WebCore/ScriptController.h>
 #import <JavaScriptCore/APICast.h>


### PR DESCRIPTION
#### f7dca525f768cd9862f2752c7b567deae852a2d5
<pre>
[Build Speed] Remove JSCJSValueInlines.h from JSValueInWrappedObject.h and other WebCore binding headers
<a href="https://rdar.apple.com/172254660">rdar://172254660</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309650">https://bugs.webkit.org/show_bug.cgi?id=309650</a>

Reviewed by Ryosuke Niwa and BJ Burg.

JSCJSValueInlines.h was the 2nd most expensive header in the build, included
320 times at an average cost of 1268ms each. This patch removes it from
JSValueInWrappedObject.h (by creating JSValueInWrappedObjectInlines.h) and
from ~13 other binding headers (JSDOMBinding.h, JSDOMWrapper.h,
JSDOMGlobalObject.h, JSDOMGuardedObject.h, JSEventListener.h, etc.),
replacing them with lighter includes and forward declarations. The bindings
code generator is also updated to emit the necessary includes in generated
.cpp files.

After this change JSCJSValueInlines.h drops to 14th most expensive, included
279 times at 570ms average. Frontend parsing time is reduced by ~150 seconds.

* Source/JavaScriptCore/API/JSCallbackObjectFunctions.h:
(JSC::JSCallbackObject&lt;Parent&gt;::asCallbackObject):
* Source/JavaScriptCore/heap/GCAssertions.h:
* Source/JavaScriptCore/heap/Strong.h:
* Source/JavaScriptCore/heap/StrongInlines.h:
(JSC::=):
* Source/JavaScriptCore/runtime/JSArray.h:
(JSC::JSArray::tryCreate): Deleted.
(JSC::JSArray::create): Deleted.
* Source/JavaScriptCore/runtime/JSArrayInlines.h:
(JSC::JSArray::tryCreate):
(JSC::JSArray::create):
* Source/JavaScriptCore/runtime/JSCJSValue.h:
* Source/JavaScriptCore/runtime/JSCell.cpp:
(JSC::JSCell::isObjectSlow const):
(JSC::JSCell::inheritsSlow const):
* Source/JavaScriptCore/runtime/JSCell.h:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeInlines.h:
(JSC::JSGenericTypedArrayViewPrototype&lt;ViewClass&gt;::finishCreation):
* Source/JavaScriptCore/runtime/JSObject.h:
(JSC::asObject):
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
* Source/WebCore/Modules/credentialmanagement/CredentialsContainer.cpp:
* Source/WebCore/Modules/encryptedmedia/MediaKeySession.cpp:
* Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.cpp:
* Source/WebCore/Modules/encryptedmedia/MediaKeyStatusMap.h:
* Source/WebCore/Modules/encryptedmedia/MediaKeySystemAccess.cpp:
* Source/WebCore/Modules/encryptedmedia/NavigatorEME.cpp:
* Source/WebCore/Modules/fetch/FetchBodySource.h:
* Source/WebCore/Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp:
* Source/WebCore/Modules/gamepad/GamepadHapticActuator.cpp:
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
* Source/WebCore/Modules/indexeddb/IDBCursor.cpp:
* Source/WebCore/Modules/indexeddb/IDBRequest.cpp:
* Source/WebCore/Modules/mediacapabilities/MediaCapabilities.cpp:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
* Source/WebCore/Modules/mediastream/MediaStreamTrackProcessor.cpp:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp:
* Source/WebCore/Modules/mediastream/VideoTrackGenerator.cpp:
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
* Source/WebCore/Modules/paymentrequest/PaymentMethodChangeEvent.cpp:
* Source/WebCore/Modules/paymentrequest/PaymentResponse.cpp:
* Source/WebCore/Modules/paymentrequest/PaymentResponse.h:
* Source/WebCore/Modules/permissions/Permissions.cpp:
* Source/WebCore/Modules/screen-wake-lock/WakeLockSentinel.cpp:
* Source/WebCore/Modules/streams/ReadableByteStreamController.cpp:
* Source/WebCore/Modules/streams/ReadableStreamSource.cpp:
(WebCore::ReadableStreamSource::cancelFinished):
* Source/WebCore/Modules/streams/ReadableStreamSource.h:
(WebCore::ReadableStreamSource::cancelFinished): Deleted.
* Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp:
* Source/WebCore/Modules/streams/StreamTeeUtilities.cpp:
* Source/WebCore/Modules/streams/StreamTransferUtilities.cpp:
* Source/WebCore/Modules/streams/TransformStream.cpp:
* Source/WebCore/Modules/url-pattern/URLPatternComponent.cpp:
* Source/WebCore/Modules/url-pattern/URLPatternComponent.h:
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
* Source/WebCore/Modules/webaudio/AudioBuffer.h:
* Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
* Source/WebCore/Modules/webtransport/DatagramByteSource.cpp:
* Source/WebCore/Modules/webtransport/DatagramByteSource.h:
* Source/WebCore/Modules/webtransport/DatagramSource.cpp:
* Source/WebCore/Modules/webtransport/DatagramSource.h:
* Source/WebCore/Modules/webtransport/WebTransportReceiveStreamSource.cpp:
* Source/WebCore/Modules/webxr/WebXRRigidTransform.cpp:
* Source/WebCore/Modules/webxr/WebXRView.cpp:
* Source/WebCore/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/WebAnimation.cpp:
* Source/WebCore/bindings/js/IDBBindingUtilities.cpp:
* Source/WebCore/bindings/js/JSAbortSignalCustom.cpp:
* Source/WebCore/bindings/js/JSAudioWorkletProcessorCustom.cpp:
* Source/WebCore/bindings/js/JSCallbackData.cpp:
(WebCore::JSCallbackData::JSCallbackData):
(WebCore::JSCallbackData::~JSCallbackData):
(WebCore::JSCallbackData::globalObject):
(WebCore::JSCallbackData::callback):
(WebCore::JSCallbackData::invokeCallback):
(WebCore::JSCallbackData::WeakOwner::isReachableFromOpaqueRoots):
* Source/WebCore/bindings/js/JSCallbackData.h:
(WebCore::JSCallbackData::JSCallbackData): Deleted.
(WebCore::JSCallbackData::~JSCallbackData): Deleted.
(WebCore::JSCallbackData::globalObject): Deleted.
(WebCore::JSCallbackData::callback): Deleted.
(WebCore::JSCallbackData::invokeCallback): Deleted.
* Source/WebCore/bindings/js/JSCustomEventCustom.cpp:
* Source/WebCore/bindings/js/JSDOMAsyncIterator.h:
(WebCore::IteratorTraits&gt;::finishCreation):
* Source/WebCore/bindings/js/JSDOMBinding.h:
* Source/WebCore/bindings/js/JSDOMBuiltinConstructor.h:
(WebCore::JSDOMBuiltinConstructor&lt;JSClass&gt;::finishCreation):
* Source/WebCore/bindings/js/JSDOMConstructor.h:
(WebCore::JSDOMConstructor&lt;JSClass&gt;::finishCreation):
* Source/WebCore/bindings/js/JSDOMConstructorNotCallable.h:
(WebCore::JSDOMConstructorNotCallable&lt;JSClass&gt;::finishCreation):
* Source/WebCore/bindings/js/JSDOMConvertAny.cpp: Copied from Source/WebCore/bindings/js/JSNavigateEventCustom.cpp.
(WebCore::JSConverter&lt;IDLAny&gt;::convert):
(WebCore::VariadicConverter&lt;IDLAny&gt;::convert):
* Source/WebCore/bindings/js/JSDOMConvertAny.h:
(WebCore::VariadicConverter&lt;IDLAny&gt;::convert): Deleted.
* Source/WebCore/bindings/js/JSDOMConvertBufferSource.cpp: Added.
(WebCore::toPossiblySharedInt8Array):
(WebCore::toPossiblySharedInt16Array):
(WebCore::toPossiblySharedInt32Array):
(WebCore::toPossiblySharedUint8Array):
(WebCore::toPossiblySharedUint8ClampedArray):
(WebCore::toPossiblySharedUint16Array):
(WebCore::toPossiblySharedUint32Array):
(WebCore::toPossiblySharedFloat16Array):
(WebCore::toPossiblySharedFloat32Array):
(WebCore::toPossiblySharedFloat64Array):
(WebCore::toPossiblySharedBigInt64Array):
(WebCore::toPossiblySharedBigUint64Array):
(WebCore::toUnsharedInt8Array):
(WebCore::toUnsharedInt16Array):
(WebCore::toUnsharedInt32Array):
(WebCore::toUnsharedUint8Array):
(WebCore::toUnsharedUint8ClampedArray):
(WebCore::toUnsharedUint16Array):
(WebCore::toUnsharedUint32Array):
(WebCore::toUnsharedFloat16Array):
(WebCore::toUnsharedFloat32Array):
(WebCore::toUnsharedFloat64Array):
(WebCore::toUnsharedBigInt64Array):
(WebCore::toUnsharedBigUint64Array):
(WebCore::toJS):
* Source/WebCore/bindings/js/JSDOMConvertBufferSource.h:
(WebCore::toPossiblySharedInt8Array): Deleted.
(WebCore::toPossiblySharedInt16Array): Deleted.
(WebCore::toPossiblySharedInt32Array): Deleted.
(WebCore::toPossiblySharedUint8Array): Deleted.
(WebCore::toPossiblySharedUint8ClampedArray): Deleted.
(WebCore::toPossiblySharedUint16Array): Deleted.
(WebCore::toPossiblySharedUint32Array): Deleted.
(WebCore::toPossiblySharedFloat16Array): Deleted.
(WebCore::toPossiblySharedFloat32Array): Deleted.
(WebCore::toPossiblySharedFloat64Array): Deleted.
(WebCore::toPossiblySharedBigInt64Array): Deleted.
(WebCore::toPossiblySharedBigUint64Array): Deleted.
(WebCore::toUnsharedInt8Array): Deleted.
(WebCore::toUnsharedInt16Array): Deleted.
(WebCore::toUnsharedInt32Array): Deleted.
(WebCore::toUnsharedUint8Array): Deleted.
(WebCore::toUnsharedUint8ClampedArray): Deleted.
(WebCore::toUnsharedUint16Array): Deleted.
(WebCore::toUnsharedUint32Array): Deleted.
(WebCore::toUnsharedFloat16Array): Deleted.
(WebCore::toUnsharedFloat32Array): Deleted.
(WebCore::toUnsharedFloat64Array): Deleted.
(WebCore::toUnsharedBigInt64Array): Deleted.
(WebCore::toUnsharedBigUint64Array): Deleted.
* Source/WebCore/bindings/js/JSDOMConvertNumbers.cpp:
(WebCore::JSConverter&lt;IDLDouble&gt;::convert):
(WebCore::JSConverter&lt;IDLUnrestrictedDouble&gt;::convert):
* Source/WebCore/bindings/js/JSDOMConvertNumbers.h:
(WebCore::JSConverter&lt;IDLDouble&gt;::convert): Deleted.
(WebCore::JSConverter&lt;IDLUnrestrictedDouble&gt;::convert): Deleted.
* Source/WebCore/bindings/js/JSDOMConvertPromise.h:
(WebCore::Converter&lt;IDLPromise&lt;T&gt;&gt;::convert):
* Source/WebCore/bindings/js/JSDOMConvertScheduledAction.h:
(WebCore::Converter&lt;IDLScheduledAction&gt;::convert):
* Source/WebCore/bindings/js/JSDOMConvertStrings.cpp:
(WebCore::Converter&lt;IDLDOMString&gt;::convert):
* Source/WebCore/bindings/js/JSDOMConvertStrings.h:
(WebCore::Converter&lt;IDLDOMString&gt;::convert): Deleted.
* Source/WebCore/bindings/js/JSDOMGlobalObject.h:
* Source/WebCore/bindings/js/JSDOMIterator.h:
(WebCore::IteratorTraits&gt;::finishCreation):
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
(WebCore::DeferredPromise::resolve):
(WebCore::DeferredPromise::resolveWithJSValue):
(WebCore::DeferredPromise::resolveWithNewlyCreated):
(WebCore::DeferredPromise::reject):
* Source/WebCore/bindings/js/JSDOMWindowBase.h:
* Source/WebCore/bindings/js/JSDOMWrapper.h:
* Source/WebCore/bindings/js/JSErrorEventCustom.cpp:
* Source/WebCore/bindings/js/JSEventListener.h:
* Source/WebCore/bindings/js/JSExtendableMessageEventCustom.cpp:
* Source/WebCore/bindings/js/JSHTMLElementCustom.cpp:
* Source/WebCore/bindings/js/JSHistoryCustom.cpp:
* Source/WebCore/bindings/js/JSIDBCursorCustom.cpp:
* Source/WebCore/bindings/js/JSIDBCursorWithValueCustom.cpp:
* Source/WebCore/bindings/js/JSIDBRecordCustom.cpp:
(WebCore::JSIDBRecord::value const):
* Source/WebCore/bindings/js/JSIDBRequestCustom.cpp:
* Source/WebCore/bindings/js/JSMediaControlsHostCustom.cpp:
* Source/WebCore/bindings/js/JSMessageEventCustom.cpp:
* Source/WebCore/bindings/js/JSNavigateEventCustom.cpp:
* Source/WebCore/bindings/js/JSNavigatorCustom.cpp:
* Source/WebCore/bindings/js/JSNodeCustom.h:
* Source/WebCore/bindings/js/JSNodeListCustom.h:
* Source/WebCore/bindings/js/JSObservableArray.cpp:
(JSC::JSObservableArray::createStructure):
* Source/WebCore/bindings/js/JSObservableArray.h:
* Source/WebCore/bindings/js/JSPaymentMethodChangeEventCustom.cpp:
* Source/WebCore/bindings/js/JSPaymentResponseCustom.cpp:
* Source/WebCore/bindings/js/JSPopStateEventCustom.cpp:
* Source/WebCore/bindings/js/JSPromiseRejectionEventCustom.cpp:
* Source/WebCore/bindings/js/JSTrackCustom.cpp:
* Source/WebCore/bindings/js/JSValueInWrappedObject.h:
(WebCore::JSValueInWrappedObject::JSValueInWrappedObject): Deleted.
(WebCore::JSValueInWrappedObject::getValue const): Deleted.
(WebCore::JSValueInWrappedObject::operator bool const): Deleted.
(WebCore::JSValueInWrappedObject::visitInGCThread const): Deleted.
(WebCore::JSValueInWrappedObject::setValueInternal): Deleted.
(WebCore::JSValueInWrappedObject::setWorld): Deleted.
(WebCore::JSValueInWrappedObject::setWeakly): Deleted.
(WebCore::JSValueInWrappedObject::set): Deleted.
(WebCore::JSValueInWrappedObject::world const): Deleted.
(WebCore::JSValueInWrappedObject::clear): Deleted.
(WebCore::JSValueInWrappedObject::isWorldCompatible const): Deleted.
(WebCore::cachedPropertyValue): Deleted.
* Source/WebCore/bindings/js/JSValueInWrappedObjectInlines.h: Copied from Source/WebCore/bindings/js/JSValueInWrappedObject.h.
(WebCore::JSValueInWrappedObject::JSValueInWrappedObject):
(WebCore::JSValueInWrappedObject::getValue const):
(WebCore::JSValueInWrappedObject::operator bool const):
(WebCore::JSValueInWrappedObject::visitInGCThread const):
(WebCore::JSValueInWrappedObject::setValueInternal):
(WebCore::JSValueInWrappedObject::setWorld):
(WebCore::JSValueInWrappedObject::setWeakly):
(WebCore::JSValueInWrappedObject::set):
(WebCore::JSValueInWrappedObject::clear):
(WebCore::JSValueInWrappedObject::world const):
(WebCore::JSValueInWrappedObject::isWorldCompatible const):
(WebCore::cachedPropertyValue):
* Source/WebCore/bindings/js/JSWebXRRigidTransformCustom.cpp:
* Source/WebCore/bindings/js/JSWebXRViewCustom.cpp:
* Source/WebCore/bindings/js/ReadableStreamDefaultController.cpp:
* Source/WebCore/bindings/js/ReadableStreamDefaultController.h:
* Source/WebCore/bindings/js/ScheduledAction.h:
* Source/WebCore/bindings/js/WebCoreOpaqueRootInlines.h:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateHeader):
(GenerateImplementation):
(GenerateCallbackImplementationOperationBody):
(GenerateCallbackImplementationContent):
* Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.cpp:
(WebCore::JSDOMWindow::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSDOMWindow.h:
(WebCore::JSDOMWindow::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSDedicatedWorkerGlobalScope.cpp:
(WebCore::JSDedicatedWorkerGlobalScope::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSDedicatedWorkerGlobalScope.h:
(WebCore::JSDedicatedWorkerGlobalScope::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSExposedStar.cpp:
(WebCore::JSExposedStar::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSExposedStar.h:
(WebCore::JSExposedStar::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.cpp:
(WebCore::JSExposedToWorkerAndWindow::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSExposedToWorkerAndWindow.h:
(WebCore::JSExposedToWorkerAndWindow::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSPaintWorkletGlobalScope.cpp:
(WebCore::JSPaintWorkletGlobalScope::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSPaintWorkletGlobalScope.h:
(WebCore::JSPaintWorkletGlobalScope::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSServiceWorkerGlobalScope.cpp:
(WebCore::JSServiceWorkerGlobalScope::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSServiceWorkerGlobalScope.h:
(WebCore::JSServiceWorkerGlobalScope::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSShadowRealmGlobalScope.cpp:
(WebCore::JSShadowRealmGlobalScope::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSShadowRealmGlobalScope.h:
(WebCore::JSShadowRealmGlobalScope::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSSharedWorkerGlobalScope.cpp:
(WebCore::JSSharedWorkerGlobalScope::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSSharedWorkerGlobalScope.h:
(WebCore::JSSharedWorkerGlobalScope::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.cpp:
(WebCore::JSTestAsyncIterable::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterable.h:
(WebCore::JSTestAsyncIterable::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterableWithoutFlags.cpp:
(WebCore::JSTestAsyncIterableWithoutFlags::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestAsyncIterableWithoutFlags.h:
(WebCore::JSTestAsyncIterableWithoutFlags::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.cpp:
(WebCore::JSTestAsyncKeyValueIterable::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestAsyncKeyValueIterable.h:
(WebCore::JSTestAsyncKeyValueIterable::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.cpp:
(WebCore::JSTestCEReactions::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestCEReactions.h:
(WebCore::JSTestCEReactions::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.cpp:
(WebCore::JSTestCEReactionsStringifier::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestCEReactionsStringifier.h:
(WebCore::JSTestCEReactionsStringifier::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.cpp:
(WebCore::JSTestCallTracer::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallTracer.h:
(WebCore::JSTestCallTracer::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.cpp:
(WebCore::JSTestClassWithJSBuiltinConstructor::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestClassWithJSBuiltinConstructor.h:
(WebCore::JSTestClassWithJSBuiltinConstructor::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestConditional.cpp:
(WebCore::JSTestConditional::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestConditional.h:
(WebCore::JSTestConditional::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.cpp:
(WebCore::JSTestConditionalIncludes::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestConditionalIncludes.h:
(WebCore::JSTestConditionalIncludes::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.cpp:
(WebCore::JSTestConditionallyReadWrite::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestConditionallyReadWrite.h:
(WebCore::JSTestConditionallyReadWrite::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.cpp:
(WebCore::JSTestDOMJIT::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestDOMJIT.h:
(WebCore::JSTestDOMJIT::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.cpp:
(WebCore::JSTestDefaultToJSON::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSON.h:
(WebCore::JSTestDefaultToJSON::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.cpp:
(WebCore::JSTestDefaultToJSONFilteredByExposed::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONFilteredByExposed.h:
(WebCore::JSTestDefaultToJSONFilteredByExposed::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONIndirectInheritance.cpp:
(WebCore::JSTestDefaultToJSONIndirectInheritance::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONIndirectInheritance.h:
(WebCore::JSTestDefaultToJSONIndirectInheritance::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.cpp:
(WebCore::JSTestDefaultToJSONInherit::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInherit.h:
(WebCore::JSTestDefaultToJSONInherit::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInheritFinal.cpp:
(WebCore::JSTestDefaultToJSONInheritFinal::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONInheritFinal.h:
(WebCore::JSTestDefaultToJSONInheritFinal::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.cpp:
(WebCore::JSTestDelegateToSharedSyntheticAttribute::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestDelegateToSharedSyntheticAttribute.h:
(WebCore::JSTestDelegateToSharedSyntheticAttribute::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.cpp:
(WebCore::JSTestDomainSecurity::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestDomainSecurity.h:
(WebCore::JSTestDomainSecurity::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.cpp:
(WebCore::JSTestEnabledBySetting::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestEnabledBySetting.h:
(WebCore::JSTestEnabledBySetting::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.cpp:
(WebCore::JSTestEnabledForContext::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestEnabledForContext.h:
(WebCore::JSTestEnabledForContext::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.cpp:
(WebCore::JSTestEventConstructor::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestEventConstructor.h:
(WebCore::JSTestEventConstructor::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.cpp:
(WebCore::JSTestEventTarget::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestEventTarget.h:
(WebCore::JSTestEventTarget::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestException.cpp:
(WebCore::JSTestException::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestException.h:
(WebCore::JSTestException::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.cpp:
(WebCore::JSTestGenerateAddOpaqueRoot::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestGenerateAddOpaqueRoot.h:
(WebCore::JSTestGenerateAddOpaqueRoot::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.cpp:
(WebCore::JSTestGenerateIsReachable::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestGenerateIsReachable.h:
(WebCore::JSTestGenerateIsReachable::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.cpp:
(WebCore::JSTestGlobalObject::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestGlobalObject.h:
(WebCore::JSTestGlobalObject::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.cpp:
(WebCore::JSTestIndexedSetterNoIdentifier::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterNoIdentifier.h:
(WebCore::JSTestIndexedSetterNoIdentifier::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.cpp:
(WebCore::JSTestIndexedSetterThrowingException::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterThrowingException.h:
(WebCore::JSTestIndexedSetterThrowingException::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.cpp:
(WebCore::JSTestIndexedSetterWithIdentifier::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestIndexedSetterWithIdentifier.h:
(WebCore::JSTestIndexedSetterWithIdentifier::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestInterface.cpp:
(WebCore::JSTestInterface::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestInterface.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.cpp:
(WebCore::JSTestInterfaceLeadingUnderscore::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestInterfaceLeadingUnderscore.h:
(WebCore::JSTestInterfaceLeadingUnderscore::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestIterable.cpp:
(WebCore::JSTestIterable::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestIterable.h:
(WebCore::JSTestIterable::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestJSBuiltinConstructor.cpp:
(WebCore::JSTestJSBuiltinConstructor::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestJSBuiltinConstructor.h:
(WebCore::JSTestJSBuiltinConstructor::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.cpp:
(WebCore::JSTestLegacyFactoryFunction::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestLegacyFactoryFunction.h:
(WebCore::JSTestLegacyFactoryFunction::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.cpp:
(WebCore::JSTestLegacyNoInterfaceObject::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestLegacyNoInterfaceObject.h:
(WebCore::JSTestLegacyNoInterfaceObject::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.cpp:
(WebCore::JSTestLegacyOverrideBuiltIns::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestLegacyOverrideBuiltIns.h:
(WebCore::JSTestLegacyOverrideBuiltIns::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.cpp:
(WebCore::JSTestMapLike::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestMapLike.h:
(WebCore::JSTestMapLike::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.cpp:
(WebCore::JSTestMapLikeWithOverriddenOperations::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestMapLikeWithOverriddenOperations.h:
(WebCore::JSTestMapLikeWithOverriddenOperations::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.cpp:
(WebCore::JSTestNamedAndIndexedSetterNoIdentifier::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterNoIdentifier.h:
(WebCore::JSTestNamedAndIndexedSetterNoIdentifier::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.cpp:
(WebCore::JSTestNamedAndIndexedSetterThrowingException::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterThrowingException.h:
(WebCore::JSTestNamedAndIndexedSetterThrowingException::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.cpp:
(WebCore::JSTestNamedAndIndexedSetterWithIdentifier::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedAndIndexedSetterWithIdentifier.h:
(WebCore::JSTestNamedAndIndexedSetterWithIdentifier::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.cpp:
(WebCore::JSTestNamedDeleterNoIdentifier::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterNoIdentifier.h:
(WebCore::JSTestNamedDeleterNoIdentifier::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.cpp:
(WebCore::JSTestNamedDeleterThrowingException::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterThrowingException.h:
(WebCore::JSTestNamedDeleterThrowingException::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.cpp:
(WebCore::JSTestNamedDeleterWithIdentifier::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIdentifier.h:
(WebCore::JSTestNamedDeleterWithIdentifier::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.cpp:
(WebCore::JSTestNamedDeleterWithIndexedGetter::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedDeleterWithIndexedGetter.h:
(WebCore::JSTestNamedDeleterWithIndexedGetter::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.cpp:
(WebCore::JSTestNamedGetterCallWith::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterCallWith.h:
(WebCore::JSTestNamedGetterCallWith::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.cpp:
(WebCore::JSTestNamedGetterNoIdentifier::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterNoIdentifier.h:
(WebCore::JSTestNamedGetterNoIdentifier::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.cpp:
(WebCore::JSTestNamedGetterWithIdentifier::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedGetterWithIdentifier.h:
(WebCore::JSTestNamedGetterWithIdentifier::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.cpp:
(WebCore::JSTestNamedSetterNoIdentifier::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterNoIdentifier.h:
(WebCore::JSTestNamedSetterNoIdentifier::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.cpp:
(WebCore::JSTestNamedSetterThrowingException::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterThrowingException.h:
(WebCore::JSTestNamedSetterThrowingException::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.cpp:
(WebCore::JSTestNamedSetterWithIdentifier::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIdentifier.h:
(WebCore::JSTestNamedSetterWithIdentifier::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.cpp:
(WebCore::JSTestNamedSetterWithIndexedGetter::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetter.h:
(WebCore::JSTestNamedSetterWithIndexedGetter::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.cpp:
(WebCore::JSTestNamedSetterWithIndexedGetterAndSetter::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithIndexedGetterAndSetter.h:
(WebCore::JSTestNamedSetterWithIndexedGetterAndSetter::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.cpp:
(WebCore::JSTestNamedSetterWithLegacyOverrideBuiltIns::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyOverrideBuiltIns.h:
(WebCore::JSTestNamedSetterWithLegacyOverrideBuiltIns::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.cpp:
(WebCore::JSTestNamedSetterWithLegacyUnforgeableProperties::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeableProperties.h:
(WebCore::JSTestNamedSetterWithLegacyUnforgeableProperties::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.cpp:
(WebCore::JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns.h:
(WebCore::JSTestNamedSetterWithLegacyUnforgeablePropertiesAndLegacyOverrideBuiltIns::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceConst.cpp:
(WebCore::JSTestNamespaceConst::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceConst.h:
(WebCore::JSTestNamespaceConst::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceObject.cpp:
(WebCore::JSTestNamespaceObject::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNamespaceObject.h:
(WebCore::JSTestNamespaceObject::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestNode.cpp:
(WebCore::JSTestNode::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestNode.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
(WebCore::JSTestObj::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.h:
(WebCore::JSTestObj::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.cpp:
(WebCore::JSTestOperationConditional::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestOperationConditional.h:
(WebCore::JSTestOperationConditional::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.cpp:
(WebCore::JSTestOverloadedConstructors::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructors.h:
(WebCore::JSTestOverloadedConstructors::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.cpp:
(WebCore::JSTestOverloadedConstructorsWithSequence::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestOverloadedConstructorsWithSequence.h:
(WebCore::JSTestOverloadedConstructorsWithSequence::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.cpp:
(WebCore::JSTestPluginInterface::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestPluginInterface.h:
(WebCore::JSTestPluginInterface::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.cpp:
(WebCore::JSTestPromiseRejectionEvent::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestPromiseRejectionEvent.h:
(WebCore::JSTestPromiseRejectionEvent::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.cpp:
(WebCore::JSTestReadOnlyMapLike::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlyMapLike.h:
(WebCore::JSTestReadOnlyMapLike::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.cpp:
(WebCore::JSTestReadOnlySetLike::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestReadOnlySetLike.h:
(WebCore::JSTestReadOnlySetLike::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.cpp:
(WebCore::JSTestReportExtraMemoryCost::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestReportExtraMemoryCost.h:
(WebCore::JSTestReportExtraMemoryCost::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestScheduledAction.cpp:
(WebCore::JSTestScheduledAction::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestScheduledAction.h:
(WebCore::JSTestScheduledAction::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.cpp:
(WebCore::JSTestSerializedScriptValueInterface::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestSerializedScriptValueInterface.h:
(WebCore::JSTestSerializedScriptValueInterface::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.cpp:
(WebCore::JSTestSetLike::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestSetLike.h:
(WebCore::JSTestSetLike::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.cpp:
(WebCore::JSTestSetLikeWithOverriddenOperations::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestSetLikeWithOverriddenOperations.h:
(WebCore::JSTestSetLikeWithOverriddenOperations::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.cpp:
(WebCore::JSTestStringifier::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifier.h:
(WebCore::JSTestStringifier::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.cpp:
(WebCore::JSTestStringifierAnonymousOperation::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierAnonymousOperation.h:
(WebCore::JSTestStringifierAnonymousOperation::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.cpp:
(WebCore::JSTestStringifierNamedOperation::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierNamedOperation.h:
(WebCore::JSTestStringifierNamedOperation::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.cpp:
(WebCore::JSTestStringifierOperationImplementedAs::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationImplementedAs.h:
(WebCore::JSTestStringifierOperationImplementedAs::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.cpp:
(WebCore::JSTestStringifierOperationNamedToString::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierOperationNamedToString.h:
(WebCore::JSTestStringifierOperationNamedToString::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.cpp:
(WebCore::JSTestStringifierReadOnlyAttribute::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadOnlyAttribute.h:
(WebCore::JSTestStringifierReadOnlyAttribute::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.cpp:
(WebCore::JSTestStringifierReadWriteAttribute::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestStringifierReadWriteAttribute.h:
(WebCore::JSTestStringifierReadWriteAttribute::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.cpp:
(WebCore::JSTestTaggedWrapper::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestTaggedWrapper.h:
(WebCore::JSTestTaggedWrapper::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.cpp:
(WebCore::JSTestTypedefs::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSTestTypedefs.h:
(WebCore::JSTestTypedefs::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp:
* Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.cpp:
(WebCore::JSWorkerGlobalScope::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSWorkerGlobalScope.h:
(WebCore::JSWorkerGlobalScope::createStructure): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.cpp:
(WebCore::JSWorkletGlobalScope::createStructure):
* Source/WebCore/bindings/scripts/test/JS/JSWorkletGlobalScope.h:
(WebCore::JSWorkletGlobalScope::createStructure): Deleted.
* Source/WebCore/bridge/objc/objc_runtime.h:
* Source/WebCore/bridge/runtime_array.h:
* Source/WebCore/crypto/SubtleCrypto.cpp:
* Source/WebCore/css/CSSStyleSheetObservableArray.cpp:
* Source/WebCore/dom/AbortController.cpp:
* Source/WebCore/dom/AbortSignal.cpp:
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/dom/BroadcastChannel.cpp:
* Source/WebCore/dom/CollectionIndexCache.cpp:
* Source/WebCore/dom/CustomEvent.cpp:
* Source/WebCore/dom/ErrorEvent.cpp:
* Source/WebCore/dom/EventTarget.cpp:
* Source/WebCore/dom/InternalObserverEvery.cpp:
* Source/WebCore/dom/InternalObserverFind.cpp:
* Source/WebCore/dom/InternalObserverFirst.cpp:
* Source/WebCore/dom/InternalObserverForEach.cpp:
* Source/WebCore/dom/InternalObserverLast.cpp:
* Source/WebCore/dom/InternalObserverReduce.cpp:
* Source/WebCore/dom/InternalObserverSome.cpp:
* Source/WebCore/dom/MapperCallback.h:
* Source/WebCore/dom/MessageEvent.cpp:
* Source/WebCore/dom/MutationRecord.cpp:
* Source/WebCore/dom/ObservableInspectorAbortCallback.h:
* Source/WebCore/dom/PopStateEvent.cpp:
* Source/WebCore/dom/PredicateCallback.h:
* Source/WebCore/dom/PromiseRejectionEvent.cpp:
* Source/WebCore/dom/Range.cpp:
* Source/WebCore/dom/ReducerCallback.h:
* Source/WebCore/dom/StaticRange.cpp:
* Source/WebCore/dom/Subscriber.cpp:
* Source/WebCore/dom/SubscriptionObserverCallback.h:
* Source/WebCore/dom/VisitorCallback.h:
* Source/WebCore/dom/make_event_factory.pl:
(generateImplementation):
* Source/WebCore/dom/make_names.pl:
(printWrapperFactoryCppFile):
* Source/WebCore/domjit/JSDocumentDOMJIT.cpp:
* Source/WebCore/html/HTMLMediaElement.cpp:
* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
* Source/WebCore/inspector/InspectorCanvas.cpp:
* Source/WebCore/inspector/WebInjectedScriptHost.cpp:
* Source/WebCore/loader/FrameLoader.cpp:
* Source/WebCore/loader/ImageLoader.cpp:
* Source/WebCore/page/History.cpp:
* Source/WebCore/page/NavigateEvent.cpp:
(WebCore::NavigateEvent::info):
* Source/WebCore/page/NavigateEvent.h:
* Source/WebCore/page/Navigation.cpp:
* Source/WebCore/page/ScreenOrientation.cpp:
* Source/WebCore/page/UserMessageHandler.cpp:
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
* Source/WebCore/testing/EventTargetForTesting.cpp:
* Source/WebCore/testing/GCObservation.h:
* Source/WebCore/testing/ServiceWorkerInternals.cpp:
* Source/WebCore/testing/WebFakeXRDevice.cpp:
* Source/WebCore/testing/WebXRTest.cpp:
* Source/WebCore/workers/service/ExtendableMessageEvent.cpp:
* Source/WebCore/workers/service/ServiceWorkerRegistration.cpp:
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
* Source/WebKitLegacy/mac/DOM/DOMDocument.mm:
* Source/WebKitLegacy/mac/DOM/DOMHTMLFrameElement.mm:
* Source/WebKitLegacy/mac/DOM/DOMHTMLIFrameElement.mm:
* Source/WebKitLegacy/mac/DOM/DOMInternal.mm:
* Source/WebKitLegacy/mac/DOM/DOMUtility.mm:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
* Source/WebKitLegacy/mac/WebView/WebScriptWorld.mm:

Canonical link: <a href="https://commits.webkit.org/310756@main">https://commits.webkit.org/310756@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3b2fa87b3f7fd79821017659e20442c414eff61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154759 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108229 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27867 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119715 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84650 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138990 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100408 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21089 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19107 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11345 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146809 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165993 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15590 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9237 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18443 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127817 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27563 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127957 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34739 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27487 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138627 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84192 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22854 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15421 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186493 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27179 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91281 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47801 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26757 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26988 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26830 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->