### PR TITLE
getUserMedia media streams should present audio tracks before video tracks

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2752,7 +2752,6 @@ http/wpt/mediarecorder/pause-recording.html [ Slow ]
 http/wpt/mediarecorder/pause-recording-2.html [ Pass Failure ]
 
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html [ Slow ]
-imported/w3c/web-platform-tests/webrtc/protocol/split.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-relay-canvas.https.html [ Failure ]
 imported/w3c/web-platform-tests/webrtc/protocol/h264-profile-levels.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-encodings.html [ Pass Failure ]

--- a/LayoutTests/fast/mediastream/MediaStreamConstructor-expected.txt
+++ b/LayoutTests/fast/mediastream/MediaStreamConstructor-expected.txt
@@ -6,6 +6,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS Got local stream.
 PASS localStream.getAudioTracks().length is 1
 PASS localStream.getVideoTracks().length is 1
+PASS localStream.getTracks().length is 2
+PASS localStream.getTracks()[0].kind is "audio"
+PASS localStream.getTracks()[1].kind is "video"
 PASS typeof MediaStream === 'function' is true
 PASS checkIdAttribute(localStream.id) is true
 PASS new MediaStream(document) threw exception TypeError: Type error.

--- a/LayoutTests/fast/mediastream/MediaStreamConstructor.html
+++ b/LayoutTests/fast/mediastream/MediaStreamConstructor.html
@@ -47,6 +47,10 @@
                 shouldBe('localStream.getAudioTracks().length', '1');
                 shouldBe('localStream.getVideoTracks().length', '1');
 
+                shouldBe('localStream.getTracks().length', '2');
+                shouldBe('localStream.getTracks()[0].kind', '"audio"');
+                shouldBe('localStream.getTracks()[1].kind', '"video"');
+
                 shouldBeTrue("typeof MediaStream === 'function'");
                 shouldBeTrue('checkIdAttribute(localStream.id)');
                 testConstructor(localStream);

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/protocol/split.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/protocol/split.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Connect audio and video to two independent PeerConnections assert_equals: expected "connected" but got "connecting"
+PASS Connect audio and video to two independent PeerConnections
 

--- a/Source/WebCore/Modules/mediastream/MediaStream.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStream.cpp
@@ -59,9 +59,20 @@ Ref<MediaStream> MediaStream::create(Document& document, MediaStream& stream)
     return mediaStream;
 }
 
-Ref<MediaStream> MediaStream::create(Document& document, const Vector<Ref<MediaStreamTrack>>& tracks)
+Ref<MediaStream> MediaStream::create(Document& document, Vector<Ref<MediaStreamTrack>>&& tracks, CheckDuplicate checkDuplicate)
 {
-    auto mediaStream = adoptRef(*new MediaStream(document, tracks));
+    if (checkDuplicate == CheckDuplicate::Yes) {
+        HashSet<MediaStreamTrack*> existingTracks;
+        Vector<size_t> tracksToRemove;
+        for (size_t counter = 0; counter < tracks.size(); ++counter) {
+            if (!existingTracks.add(tracks[counter].ptr()).isNewEntry)
+                tracksToRemove.append(counter);
+        }
+        for (auto iterator = tracksToRemove.rbegin(); iterator != tracksToRemove.rend(); ++iterator)
+            tracks.removeAt(*iterator);
+    }
+
+    auto mediaStream = adoptRef(*new MediaStream(document, WTF::move(tracks)));
     mediaStream->suspendIfNeeded();
     return mediaStream;
 }
@@ -78,17 +89,16 @@ static inline MediaStreamTrackPrivateVector createTrackPrivateVector(const Vecto
     return map(tracks, [](auto& track) { return Ref { track->privateTrack() }; });
 }
 
-MediaStream::MediaStream(Document& document, const Vector<Ref<MediaStreamTrack>>& tracks)
+MediaStream::MediaStream(Document& document, Vector<Ref<MediaStreamTrack>>&& tracks)
     : ActiveDOMObject(document)
     , m_private(MediaStreamPrivate::create(document.logger(), createTrackPrivateVector(tracks)))
+    , m_tracks(WTF::move(tracks))
 {
     // This constructor preserves MediaStreamTrack instances and must be used by calls originating
     // from the JavaScript MediaStream constructor.
 
-    for (auto& track : tracks) {
+    for (Ref track : m_tracks)
         track->setMediaStreamId(id());
-        m_trackMap.add(track->id(), track);
-    }
 
     setIsActive(m_private->active());
     m_private->addObserver(*this);
@@ -104,7 +114,7 @@ MediaStream::MediaStream(Document& document, Ref<MediaStreamPrivate>&& streamPri
     for (auto& trackPrivate : m_private->tracks()) {
         auto track = MediaStreamTrack::create(document, trackPrivate.get());
         track->setMediaStreamId(id());
-        m_trackMap.add(trackPrivate->id(), WTF::move(track));
+        m_tracks.append(WTF::move(track));
     }
 
     setIsActive(m_private->active());
@@ -132,12 +142,12 @@ RefPtr<MediaStream> MediaStream::clone()
         return nullptr;
 
     Vector<Ref<MediaStreamTrack>> clonedTracks;
-    clonedTracks.reserveInitialCapacity(m_trackMap.size());
-    for (auto& track : m_trackMap.values()) {
+    clonedTracks.reserveInitialCapacity(m_tracks.size());
+    for (Ref track : m_tracks) {
         if (auto clone = track->clone())
             clonedTracks.append(clone.releaseNonNull());
     }
-    return MediaStream::create(*document, WTF::move(clonedTracks));
+    return MediaStream::create(*document, WTF::move(clonedTracks), CheckDuplicate::No);
 }
 
 void MediaStream::addTrack(MediaStreamTrack& track)
@@ -161,16 +171,18 @@ void MediaStream::removeTrack(MediaStreamTrack& track)
 
 MediaStreamTrack* MediaStream::getTrackById(String id)
 {
-    auto iterator = m_trackMap.find(id);
-    if (iterator != m_trackMap.end())
-        return iterator->value.ptr();
+    auto position = m_tracks.findIf([&](auto& track) {
+        return track->id() == id;
+    });
+    if (position == notFound)
+        return nullptr;
 
-    return nullptr;
+    return m_tracks[position].ptr();
 }
 
 MediaStreamTrack* MediaStream::getFirstAudioTrack() const
 {
-    for (auto& track : m_trackMap.values()) {
+    for (auto& track : m_tracks) {
         if (track->isAudio())
             return track.ptr();
     }
@@ -179,7 +191,7 @@ MediaStreamTrack* MediaStream::getFirstAudioTrack() const
 
 MediaStreamTrack* MediaStream::getFirstVideoTrack() const
 {
-    for (auto& track : m_trackMap.values()) {
+    for (auto& track : m_tracks) {
         if (track->isVideo())
             return track.ptr();
     }
@@ -188,21 +200,27 @@ MediaStreamTrack* MediaStream::getFirstVideoTrack() const
 
 MediaStreamTrackVector MediaStream::getAudioTracks() const
 {
-    return filteredTracks([] (auto& track) mutable {
-        return track.isAudio();
-    });
+    MediaStreamTrackVector tracks;
+    for (Ref track : m_tracks) {
+        if (track->isAudio())
+            tracks.append(WTF::move(track));
+    }
+    return tracks;
 }
 
 MediaStreamTrackVector MediaStream::getVideoTracks() const
 {
-    return filteredTracks([] (auto& track) mutable {
-        return track.isVideo();
-    });
+    MediaStreamTrackVector tracks;
+    for (Ref track : m_tracks) {
+        if (track->isVideo())
+            tracks.append(WTF::move(track));
+    }
+    return tracks;
 }
 
 MediaStreamTrackVector MediaStream::getTracks() const
 {
-    return copyToVector(m_trackMap.values());
+    return m_tracks;
 }
 
 void MediaStream::activeStatusChanged()
@@ -244,18 +262,23 @@ void MediaStream::addTrackFromPlatform(Ref<MediaStreamTrack>&& track)
     dispatchEvent(MediaStreamTrackEvent::create(eventNames().addtrackEvent, Event::CanBubble::No, Event::IsCancelable::No, WTF::move(track)));
 }
 
-void MediaStream::internalAddTrack(Ref<MediaStreamTrack>&& trackToAdd)
+void MediaStream::internalAddTrack(Ref<MediaStreamTrack>&& track)
 {
-    ASSERT(!m_trackMap.contains(trackToAdd->id()));
-    m_trackMap.add(trackToAdd->id(), WTF::move(trackToAdd));
+    ASSERT(!getTrackById(track->id()));
+    m_tracks.append(WTF::move(track));
     updateActiveState();
 }
 
 RefPtr<MediaStreamTrack> MediaStream::internalTakeTrack(const String& trackId)
 {
-    auto track = m_trackMap.take(trackId);
-    if (track)
-        updateActiveState();
+    auto position = m_tracks.findIf([&](auto& track) {
+        return track->id() == trackId;
+    });
+    if (position == notFound)
+        return nullptr;
+
+    RefPtr track = m_tracks[position].get();
+    m_tracks.removeAt(position);
 
     return track;
 }
@@ -331,7 +354,7 @@ MediaProducerMediaStateFlags MediaStream::mediaState() const
     if (!m_isActive || !document() || !document()->page())
         return state;
 
-    for (const auto& track : m_trackMap.values())
+    for (Ref track : m_tracks)
         state.add(track->mediaState());
 
     return state;
@@ -358,7 +381,7 @@ void MediaStream::characteristicsChanged()
 void MediaStream::updateActiveState()
 {
     bool active = false;
-    for (auto& track : m_trackMap.values()) {
+    for (Ref track : m_tracks) {
         if (!track->ended()) {
             active = true;
             break;
@@ -369,17 +392,6 @@ void MediaStream::updateActiveState()
         return;
 
     setIsActive(active);
-}
-
-MediaStreamTrackVector MediaStream::filteredTracks(NOESCAPE const Function<bool(const MediaStreamTrack&)>& filter) const
-{
-    MediaStreamTrackVector tracks;
-    for (auto& track : m_trackMap.values()) {
-        if (filter(track))
-            tracks.append(track);
-    }
-
-    return tracks;
 }
 
 Document* MediaStream::document() const

--- a/Source/WebCore/Modules/mediastream/MediaStream.h
+++ b/Source/WebCore/Modules/mediastream/MediaStream.h
@@ -65,7 +65,8 @@ public:
 
     static Ref<MediaStream> create(Document&);
     static Ref<MediaStream> create(Document&, MediaStream&);
-    static Ref<MediaStream> create(Document&, const Vector<Ref<MediaStreamTrack>>&);
+    enum class CheckDuplicate : bool { No, Yes };
+    static Ref<MediaStream> create(Document&, Vector<Ref<MediaStreamTrack>>&&, CheckDuplicate = CheckDuplicate::Yes);
 
     enum class AllowEventTracks : bool { No, Yes };
     static Ref<MediaStream> create(Document&, Ref<MediaStreamPrivate>&&, AllowEventTracks = AllowEventTracks::No);
@@ -91,7 +92,7 @@ public:
     bool active() const { return m_isActive; }
     bool muted() const { return m_private->muted(); }
 
-    template<typename Function> bool hasMatchingTrack(Function&& function) const { return std::ranges::any_of(m_trackMap.values(), std::forward<Function>(function)); }
+    template<typename Function> bool hasMatchingTrack(Function&& function) const { return std::ranges::any_of(m_tracks, std::forward<Function>(function)); }
 
     MediaStreamPrivate& privateStream() { return m_private.get(); }
 
@@ -112,7 +113,7 @@ public:
     void allowEventTracksForTesting() { m_allowEventTracks = AllowEventTracks::Yes; }
 
 protected:
-    MediaStream(Document&, const Vector<Ref<MediaStreamTrack>>&);
+    MediaStream(Document&, Vector<Ref<MediaStreamTrack>>&&);
     MediaStream(Document&, Ref<MediaStreamPrivate>&&, AllowEventTracks = AllowEventTracks::No);
 
 #if !RELEASE_LOG_DISABLED
@@ -149,14 +150,12 @@ private:
     void setIsActive(bool);
     void statusDidChange();
 
-    MediaStreamTrackVector filteredTracks(NOESCAPE const Function<bool(const MediaStreamTrack&)>&) const;
-
     Document* NODELETE document() const;
     RefPtr<MediaSessionManagerInterface> mediaSessionManager() const;
 
     const Ref<MediaStreamPrivate> m_private;
 
-    MemoryCompactRobinHoodHashMap<String, Ref<MediaStreamTrack>> m_trackMap;
+    Vector<Ref<MediaStreamTrack>> m_tracks;
 
     MediaProducerMediaStateFlags m_state;
 

--- a/Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp
@@ -62,11 +62,12 @@ Ref<MediaStreamPrivate> MediaStreamPrivate::create(Ref<const Logger>&& logger, R
     if (videoSource)
         tracks.append(MediaStreamTrackPrivate::create(logger.copyRef(), videoSource.releaseNonNull()));
 
-    return MediaStreamPrivate::create(WTF::move(logger), tracks);
+    return MediaStreamPrivate::create(WTF::move(logger), WTF::move(tracks));
 }
 
-MediaStreamPrivate::MediaStreamPrivate(Ref<const Logger>&& logger, const MediaStreamTrackPrivateVector& tracks, String&& id)
+MediaStreamPrivate::MediaStreamPrivate(Ref<const Logger>&& logger, MediaStreamTrackPrivateVector&& tracks, String&& id)
     : m_id(WTF::move(id))
+    , m_tracks(tracks)
 #if !RELEASE_LOG_DISABLED
     , m_logger(WTF::move(logger))
     , m_logIdentifier(uniqueLogIdentifier())
@@ -75,17 +76,21 @@ MediaStreamPrivate::MediaStreamPrivate(Ref<const Logger>&& logger, const MediaSt
     UNUSED_PARAM(logger);
     ASSERT(!m_id.isEmpty());
 
-    for (Ref track : tracks) {
+#if ASSERT_ENABLED
+    HashSet<MediaStreamTrackPrivate*> trackSet;
+#endif
+    for (Ref track : m_tracks) {
+        ASSERT(trackSet.add(track.ptr()).isNewEntry);
         track->addObserver(*this);
-        m_trackSet.add(track->id(), track);
     }
+
     m_isActive = computeActiveState();
     updateActiveVideoTrack();
 }
 
 MediaStreamPrivate::~MediaStreamPrivate()
 {
-    for (Ref track : m_trackSet.values())
+    for (Ref track : m_tracks)
         track->removeObserver(*this);
 }
 
@@ -110,24 +115,24 @@ void MediaStreamPrivate::forEachObserver(NOESCAPE const Function<void(MediaStrea
 
 MediaStreamTrackPrivateVector MediaStreamPrivate::tracks() const
 {
-    return copyToVector(m_trackSet.values());
+    return m_tracks;
 }
 
 void MediaStreamPrivate::forEachTrack(NOESCAPE const Function<void(const MediaStreamTrackPrivate&)>& callback) const
 {
-    for (Ref track : m_trackSet.values())
+    for (Ref track : m_tracks)
         callback(track.get());
 }
 
 void MediaStreamPrivate::forEachTrack(NOESCAPE const Function<void(MediaStreamTrackPrivate&)>& callback)
 {
-    for (Ref track : m_trackSet.values())
+    for (Ref track : m_tracks)
         callback(track.get());
 }
 
 bool MediaStreamPrivate::computeActiveState()
 {
-    return std::ranges::any_of(m_trackSet, [](auto& track) { return !track.value->ended(); });
+    return std::ranges::any_of(m_tracks, [](auto& track) { return !track->ended(); });
 }
 
 void MediaStreamPrivate::updateActiveState()
@@ -149,14 +154,15 @@ void MediaStreamPrivate::updateActiveState()
 
 void MediaStreamPrivate::addTrack(Ref<MediaStreamTrackPrivate>&& track)
 {
-    if (m_trackSet.contains(track->id()))
+    bool isAlreadyAdded = std::ranges::any_of(m_tracks, [&](auto& current) { return current->id() == track->id(); });
+    if (isAlreadyAdded)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, track->logIdentifier());
 
     Ref trackRef = track.get();
     track->addObserver(*this);
-    m_trackSet.add(track->id(), WTF::move(track));
+    m_tracks.append(WTF::move(track));
 
     forEachObserver([&trackRef](auto& observer) {
         observer.didAddTrack(trackRef);
@@ -168,7 +174,10 @@ void MediaStreamPrivate::addTrack(Ref<MediaStreamTrackPrivate>&& track)
 
 void MediaStreamPrivate::removeTrack(MediaStreamTrackPrivate& track)
 {
-    if (!m_trackSet.remove(track.id()))
+    bool hasTrack = m_tracks.removeFirstMatching([&](auto& current) {
+        return current->id() == track.id();
+    });
+    if (!hasTrack)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, track.logIdentifier());
@@ -185,20 +194,20 @@ void MediaStreamPrivate::removeTrack(MediaStreamTrackPrivate& track)
 void MediaStreamPrivate::startProducingData()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    for (Ref track : m_trackSet.values())
+    for (Ref track : m_tracks)
         track->startProducingData();
 }
 
 void MediaStreamPrivate::stopProducingData()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    for (Ref track : m_trackSet.values())
+    for (Ref track : m_tracks)
         track->stopProducingData();
 }
 
 bool MediaStreamPrivate::isProducingData() const
 {
-    for (Ref track : m_trackSet.values()) {
+    for (Ref track : m_tracks) {
         if (track->isProducingData())
             return true;
     }
@@ -207,7 +216,7 @@ bool MediaStreamPrivate::isProducingData() const
 
 bool MediaStreamPrivate::hasVideo() const
 {
-    for (Ref track : m_trackSet.values()) {
+    for (Ref track : m_tracks) {
         if (track->isVideo() && track->isActive())
             return true;
     }
@@ -216,7 +225,7 @@ bool MediaStreamPrivate::hasVideo() const
 
 bool MediaStreamPrivate::hasAudio() const
 {
-    for (Ref track : m_trackSet.values()) {
+    for (Ref track : m_tracks) {
         if (track->isAudio() && track->isActive())
             return true;
     }
@@ -225,7 +234,7 @@ bool MediaStreamPrivate::hasAudio() const
 
 bool MediaStreamPrivate::muted() const
 {
-    for (Ref track : m_trackSet.values()) {
+    for (Ref track : m_tracks) {
         if (!track->muted() && !track->ended())
             return false;
     }
@@ -247,7 +256,7 @@ IntSize MediaStreamPrivate::intrinsicSize() const
 void MediaStreamPrivate::updateActiveVideoTrack()
 {
     m_activeVideoTrack = nullptr;
-    for (Ref track : m_trackSet.values()) {
+    for (Ref track : m_tracks) {
         if (!track->ended() && track->isVideo()) {
             m_activeVideoTrack = track.ptr();
             break;
@@ -312,7 +321,7 @@ void MediaStreamPrivate::trackEnded(MediaStreamTrackPrivate& track)
 
 void MediaStreamPrivate::monitorOrientation(OrientationNotifier& notifier)
 {
-    for (Ref track : m_trackSet.values()) {
+    for (Ref track : m_tracks) {
         if (track->isCaptureTrack() && track->deviceType() == CaptureDevice::DeviceType::Camera)
             protect(track->source())->monitorOrientation(notifier);
     }

--- a/Source/WebCore/platform/mediastream/MediaStreamPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamPrivate.h
@@ -72,7 +72,7 @@ class MediaStreamPrivate final
 public:
     static Ref<MediaStreamPrivate> create(Ref<const Logger>&&, Ref<RealtimeMediaSource>&&);
     static Ref<MediaStreamPrivate> create(Ref<const Logger>&&, RefPtr<RealtimeMediaSource>&& audioSource, RefPtr<RealtimeMediaSource>&& videoSource);
-    static Ref<MediaStreamPrivate> create(Ref<const Logger>&& logger, const MediaStreamTrackPrivateVector& tracks, String&& id = createVersion4UUIDString()) { return adoptRef(*new MediaStreamPrivate(WTF::move(logger), tracks, WTF::move(id))); }
+    static Ref<MediaStreamPrivate> create(Ref<const Logger>&& logger, MediaStreamTrackPrivateVector&& tracks, String&& id = createVersion4UUIDString()) { return adoptRef(*new MediaStreamPrivate(WTF::move(logger), WTF::move(tracks), WTF::move(id))); }
 
     WEBCORE_EXPORT virtual ~MediaStreamPrivate();
 
@@ -85,7 +85,7 @@ public:
     String id() const { return m_id; }
 
     MediaStreamTrackPrivateVector tracks() const;
-    bool hasTracks() const { return !m_trackSet.isEmpty(); }
+    bool hasTracks() const { return !m_tracks.isEmpty(); }
     void forEachTrack(NOESCAPE const Function<void(const MediaStreamTrackPrivate&)>&) const;
     void forEachTrack(NOESCAPE const Function<void(MediaStreamTrackPrivate&)>&);
     MediaStreamTrackPrivate* activeVideoTrack() { return m_activeVideoTrack.get(); }
@@ -114,7 +114,7 @@ public:
 #endif
 
 private:
-    MediaStreamPrivate(Ref<const Logger>&&, const MediaStreamTrackPrivateVector&, String&&);
+    MediaStreamPrivate(Ref<const Logger>&&, MediaStreamTrackPrivateVector&&, String&&);
 
     // MediaStreamTrackPrivateObserver
     void trackStarted(MediaStreamTrackPrivate&) override;
@@ -137,7 +137,7 @@ private:
     WeakHashSet<MediaStreamPrivateObserver> m_observers;
     String m_id;
     WeakPtr<MediaStreamTrackPrivate> m_activeVideoTrack;
-    MemoryCompactRobinHoodHashMap<String, Ref<MediaStreamTrackPrivate>> m_trackSet;
+    Vector<Ref<MediaStreamTrackPrivate>> m_tracks;
     bool m_isActive { false };
 #if !RELEASE_LOG_DISABLED
     const Ref<const Logger> m_logger;


### PR DESCRIPTION
#### d45a59ea60e013f1c7a6b144f45b0f72d4a49478
<pre>
getUserMedia media streams should present audio tracks before video tracks
<a href="https://rdar.apple.com/172204931">rdar://172204931</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309584">https://bugs.webkit.org/show_bug.cgi?id=309584</a>

Reviewed by Eric Carlson.

Web sites, like WPT webrtc/protocol/split.https.html, often do call RTCPeerConnection.addTrack with the order of MediaStream.getTracks.
This has an effect on the order of transceiver and on the SDP.
Chrome and Firefox always start with audio track then video track for getUserMedia.
WebKit was not doing this as it was relying on a map of tracks.

We change to a Vector of tracks, which ensures that getUserMedia audio track will happen before video track.
Covered by rebased WPT test and updated layout test.

Canonical link: <a href="https://commits.webkit.org/309128@main">https://commits.webkit.org/309128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d03a544e6960a5e1b3ede922e576e5b5c756dfe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149302 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22015 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157995 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102733 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf87b25a-14fe-45f6-859a-f6288f9299c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151175 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22469 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21893 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115120 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81919 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4633f9b-f708-4e9c-a708-e2e26e4d96e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95868 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16bdb264-4437-434c-9066-0d4620ec64b0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16372 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14252 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5845 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160479 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3473 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123162 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21818 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123379 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33582 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133701 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78026 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18610 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10447 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21428 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85241 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21159 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21308 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21216 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->