### PR TITLE
Regression: `media_fragment_seek.html` seems to fail on STP 238 but passes on Safari 26.3

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1221,8 +1221,6 @@ webkit.org/b/221487 imported/w3c/web-platform-tests/server-timing/server_timing_
 
 webkit.org/b/221011 fast/selectors/selection-window-inactive-text-shadow.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/223014 imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/media_fragment_seek.html [ Pass Failure ]
-
 webkit.org/b/223131 [ Debug ] imported/w3c/web-platform-tests/wasm/webapi/instantiateStreaming-bad-imports.any.worker.html [ Pass Failure ]
 
 webkit.org/b/229832 imported/w3c/web-platform-tests/beacon/beacon-redirect.https.window.html [ Pass Failure ]

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -343,7 +343,7 @@ private:
 
     FloatSize m_naturalSize;
     MediaTime m_currentTime;
-    MediaTime m_duration;
+    MediaTime m_duration { MediaTime::indefiniteTime() };
     double m_rate { 1 };
 
     bool isEnabledVideoTrackID(TrackID) const;

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -682,6 +682,7 @@ void MediaPlayerPrivateWebM::updateBufferedFromTrackBuffers(bool ended)
 
 void MediaPlayerPrivateWebM::updateDurationFromTrackBuffers()
 {
+    ASSERT(m_loadFinished);
     MediaTime highestEndTime = MediaTime::zeroTime();
     for (auto& pair : m_trackBufferMap) {
         auto& trackBuffer = pair.second;
@@ -844,6 +845,9 @@ void MediaPlayerPrivateWebM::setDuration(MediaTime duration)
     m_duration = WTF::move(duration);
     if (RefPtr player = m_player.get())
         player->durationChanged();
+
+    if (m_readyState < MediaPlayerReadyState::HaveMetadata)
+        return;
 
     monitorReadyState();
 }
@@ -1290,12 +1294,10 @@ void MediaPlayerPrivateWebM::didParseInitializationData(InitializationSegment&& 
         }
     }
 
-    setReadyState(MediaPlayer::ReadyState::HaveMetadata);
-
     if (segment.duration.isValid())
         setDuration(WTF::move(segment.duration));
-    else
-        setDuration(MediaTime::positiveInfiniteTime());
+
+    setReadyState(MediaPlayer::ReadyState::HaveMetadata);
 }
 
 void MediaPlayerPrivateWebM::didProvideMediaDataForTrackId(Ref<MediaSampleAVFObjC>&& sample, TrackID trackId, const String& mediaType)


### PR DESCRIPTION
#### b34e82c05a9094c1fa45122f847628dcec7746d6
<pre>
Regression: `media_fragment_seek.html` seems to fail on STP 238 but passes on Safari 26.3
<a href="https://bugs.webkit.org/show_bug.cgi?id=309217">https://bugs.webkit.org/show_bug.cgi?id=309217</a>
<a href="https://rdar.apple.com/171917063">rdar://171917063</a>

Reviewed by Eric Carlson.

In 303424@main we changed to set the duration only after changing the readyState.
readyState should be set to HAVE_METADATA once the duration has been determined.

Fly-by: Don&apos;t set duration to infiniteTime if duration wasn&apos;t set in the metadata, but default to NaN.

Re-enabled test. Covered by the existing tests. wpt.live has a more recent
version that default to webm. We&apos;ll update the wpt in a follow-up change.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::updateDurationFromTrackBuffers):
(WebCore::MediaPlayerPrivateWebM::setDuration):
(WebCore::MediaPlayerPrivateWebM::didParseInitializationData):

Canonical link: <a href="https://commits.webkit.org/309089@main">https://commits.webkit.org/309089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1da37df27af981d33ab006a0ec0a7d1eaa99395e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158016 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102751 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1f48679-5cad-408a-b152-dea63bd7ddd7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151193 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115140 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81924 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4e9f122-445a-47ed-91c2-03a41c1f48de) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17291 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95885 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b1c56603-869d-4681-9d8b-f61ffeafbca3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16390 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14270 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5863 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125990 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11924 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160497 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3491 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13452 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123180 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21836 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123396 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33555 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133716 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78049 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18629 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10462 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21446 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85259 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21177 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21326 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21234 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->