### PR TITLE
REGRESSION(300617@main): [macOS iOS] imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.sharedworker.html is flaky failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8277,8 +8277,6 @@ webkit.org/b/299567 editing/text-iterator/hidden-textarea-selection-quirk.html [
 
 webkit.org/b/299501 http/tests/site-isolation/focus-tab-navigation-activeElement.html [ Pass Failure ]
 
-webkit.org/b/300137 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.sharedworker.html [ Pass Failure ]
-
 webkit.org/b/300946 http/tests/site-isolation/key-events.html [ Pass Failure ]
 
 # https://bugs.webkit.org/show_bug.cgi?id=301131 [ iOS 26 ] 6x tests (layout-tests) are constant text failures 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -870,8 +870,6 @@ imported/w3c/web-platform-tests/storage-access-api/storage-access-beyond-cookies
 http/tests/storageAccess/deny-with-prompt-does-not-preserve-gesture.html [ Skip ]
 http/tests/storageAccess/deny-with-prompt-under-general-third-party-cookie-blocking-with-partitioned-cookies.https.html [ Skip ]
 
-[ x86_64 ] imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.sharedworker.html [ Pass Failure ]
-
 # rdar://140222322 (Supposed to pass on 2025 OSes (Sequoia-aligned) xx.4+, but failing on debug)
 http/tests/storageAccess/grant-with-prompt-under-general-third-party-cookie-blocking-with-partitioned-cookies.https.html [ Skip ]
 http/tests/resourceLoadStatistics/only-partitioned-third-party-cookies.https.html [ Skip ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2413,8 +2413,6 @@ webkit.org/b/299322 imported/w3c/web-platform-tests/uievents/mouse/mouse_boundar
 
 [ x86_64 ] imported/w3c/web-platform-tests/svg/fonts/font-size-adjust-scale-text.svg [ Failure Pass ]
 
-webkit.org/b/300137 imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.sharedworker.html [ Pass Failure ]
-
 webkit.org/b/300337 fast/images/imagebitmap-memory.html [ Pass ImageOnlyFailure ]
 
 # webkit.org/b/300715

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5166,6 +5166,15 @@ void Page::setupForRemoteWorker(const URL& scriptURL, const SecurityOriginData& 
     if (auto policy = parseReferrerPolicy(referrerPolicy, ReferrerPolicySource::HTTPHeader))
         document->setReferrerPolicy(*policy);
 
+    // Mark the synthetic document's load event as finished so that the
+    // CachedResourceLoader's m_validatedURLs optimization (which avoids
+    // re-fetching resources during initial page load) does not apply. Without
+    // this, worker module fetches to the same URL with different import
+    // attributes (e.g. JSON vs JavaScript) can incorrectly reuse a cached
+    // response from the MemoryCache, because m_validatedURLs bypasses all
+    // freshness and revalidation checks.
+    document->dispatchWindowLoadEvent();
+
     localMainFrame->setDocument(WTF::move(document));
 }
 


### PR DESCRIPTION
#### a6e683bb5a797d976b15e5481c96473562080d55
<pre>
REGRESSION(300617@main): [macOS iOS] imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/json-module/repeated-imports.any.sharedworker.html is flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=300137">https://bugs.webkit.org/show_bug.cgi?id=300137</a>
<a href="https://rdar.apple.com/161922656">rdar://161922656</a>

Reviewed by Basuke Suzuki.

The test repeated-imports.any.sharedworker.html was flaky because the
second import() call to the same URL (but without { type: &quot;json&quot; }) was
sometimes served a cached text/json response from the first import
instead of making a fresh network request to get the application/javascript
response.

It could happen because:
Worker module imports go through WorkerScriptLoader → ThreadableLoader →
DocumentThreadableLoader → CachedResourceLoader::requestRawResource().
Both the JSON and JavaScript imports create CachedRawResource objects
with the same resource type, so WebKit&apos;s MemoryCache type-mismatch check
(which protects the Document/Window path, where CachedScript::JSON vs
CachedScript::Script are differentiated) does not apply.

SharedWorkers proxy their network requests through a synthetic Document
created in Page::setupForRemoteWorker(). This synthetic page never
dispatches its window load event, so document-&gt;loadEventFinished() is
permanently false.

In CachedResourceLoader::determineRevalidationPolicy(), there is an
optimization at line 1545:
```
if (document() &amp;&amp; !document()-&gt;loadEventFinished() &amp;&amp; m_validatedURLs.contains(existingResource-&gt;url()))
    return Use;
```

This is designed to avoid redundantly re-fetching the same resource
during initial page load. But for the SharedWorker&apos;s synthetic page,
loadEventFinished() is always false and m_validatedURLs is never
cleared, so this optimization applies permanently. After the first
import caches the URL, the second import hits this check and returns
Use, bypassing all freshness and revalidation checks. The stale
text/json response is served for what should be a JavaScript import.

The flakiness (rather than consistent failure) is because
MemoryCache::pruneSoon() is scheduled after the first import&apos;s client is
removed. If the prune timer fires and evicts the resource before the
second import arrives, the cache misses and a fresh request succeeds. If
not, the cached response is reused and the test fails.

DedicatedWorker is unaffected because it proxies through the parent
page&apos;s Document, whose load event fires normally, so the m_validatedURLs
check is bypassed.
The Window path is unaffected because it uses CachedScript with distinct
JSON/Script types that trigger a type-mismatch reload.

To address the problem:
Call document-&gt;dispatchWindowLoadEvent() on the synthetic page in
Page::setupForRemoteWorker() before attaching it to the frame. This sets
m_loadEventFinished = true and calls documentDidFinishLoadEvent() (which
clears m_validatedURLs), preventing the optimization from
inappropriately applying to worker resource loads. The event dispatch
itself is a no-op since the synthetic page has no listeners.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setupForRemoteWorker):

Canonical link: <a href="https://commits.webkit.org/309170@main">https://commits.webkit.org/309170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5322d899d673c35bbe9c0ab113d2fd497c6f45c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22017 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157997 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102735 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8cbfd2fb-ec40-4b0a-a408-f85386830fb1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115122 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81921 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a361308d-b6e3-4917-bb64-6a09b767799b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133972 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95870 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2995200-db9d-4987-a7cb-4732fddf17e0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16374 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14255 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5847 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125974 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11913 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160481 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3475 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123164 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123381 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33605 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133705 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78028 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18622 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10451 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21430 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85243 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21161 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21310 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21218 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->