### PR TITLE
[threaded-animations] Safari 26.4 crashes loading https://business.southwest.com/apple

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/empty-filter-animation-crash-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/empty-filter-animation-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if this does not crash.

--- a/LayoutTests/webanimations/threaded-animations/empty-filter-animation-crash.html
+++ b/LayoutTests/webanimations/threaded-animations/empty-filter-animation-crash.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<style>
+
+@keyframes empty-filter {
+    from { transform: none } 
+    to { filter: none }
+}
+
+html {
+    height: 2000px;
+}
+
+div {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+
+    animation: empty-filter auto;
+    animation-timeline: scroll();
+}
+
+</style>
+
+<div>PASS if this does not crash.</div>
+
+<script src="threaded-animations-utils.js"></script>
+<script>
+
+(async function () {
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+
+    // Wait for the initial layer tree commit.
+    await threadedAnimationsCommit();
+    // Wait another frame.
+    await new Promise(requestAnimationFrame);
+
+    window.testRunner?.notifyDone();
+})();
+
+</script>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
@@ -121,14 +121,16 @@ void RemoteAnimationStack::initEffectsFromMainThread(PlatformLayer *layer)
 
     auto computedValues = computeValues();
 
+    // While m_affectedLayerProperties may contain LayerProperty::Filter, in practice
+    // we could be in a situation where all `filter` values for this animation stack
+    // are `none`. In that case, longestFilterList() will return nullptr, so we can
+    // use this alone to determine whether this stack interpolates `filter`.
     auto* canonicalFilters = longestFilterList();
 
     auto numberOfPresentationModifiers = [&]() {
         size_t count = 0;
-        if (m_affectedLayerProperties.contains(LayerProperty::Filter)) {
-            ASSERT(canonicalFilters);
+        if (canonicalFilters)
             count += WebCore::PlatformCAFilters::presentationModifierCount(*canonicalFilters);
-        }
         if (m_affectedLayerProperties.contains(LayerProperty::Opacity))
             count++;
         if (m_affectedLayerProperties.contains(LayerProperty::Transform))
@@ -138,8 +140,8 @@ void RemoteAnimationStack::initEffectsFromMainThread(PlatformLayer *layer)
 
     m_presentationModifierGroup = [CAPresentationModifierGroup groupWithCapacity:numberOfPresentationModifiers];
 
-    if (m_affectedLayerProperties.contains(LayerProperty::Filter)) {
-        WebCore::PlatformCAFilters::presentationModifiers(computedValues.filter, longestFilterList(), m_filterPresentationModifiers, m_presentationModifierGroup);
+    if (canonicalFilters) {
+        WebCore::PlatformCAFilters::presentationModifiers(computedValues.filter, canonicalFilters, m_filterPresentationModifiers, m_presentationModifierGroup);
         for (auto& filterPresentationModifier : m_filterPresentationModifiers)
             [layer addPresentationModifier:filterPresentationModifier.second.get()];
     }


### PR DESCRIPTION
#### cf8d02e5b70c57695f28e314c608786389ab08ab
<pre>
[threaded-animations] Safari 26.4 crashes loading <a href="https://business.southwest.com/apple">https://business.southwest.com/apple</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309655">https://bugs.webkit.org/show_bug.cgi?id=309655</a>
<a href="https://rdar.apple.com/170883110">rdar://170883110</a>

Reviewed by Alan Baradlay.

The assumption that because `filter` is in the list of animated properties we are guaranteed
to have non-empty filter values to work with is incorrect as an animation can provide a keyframe
rule such as this one on this Southwest page:

```
@keyframes planeIn {
    from {
        translate: -50px 50px;
    }
    to {
        -webkit-filter: none;
                filter: none;
        opacity: 1;
        scale: 1;
        translate: 0 0;
    }
}

```

We fix this by removing the incorrect assertion and instead check whether `longestFilterList()`
returned a non-null `FilterOperations` pointer to determine whether filters are indeed animated.

Note that a keyframe rule like this one would still crash:

```
@keyframes empty-filter {
    to { filter: none }
}
```

Indeed, in this case we would create an empty set of presentation modifiers which would trigger
an exception. This likely isn&apos;t a very common case, so we&apos;re fixing the known issue in this simple
patch and will tackle this more involved issue in bug 309656.

Test: webanimations/threaded-animations/empty-filter-animation-crash.html

* LayoutTests/webanimations/threaded-animations/empty-filter-animation-crash-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/empty-filter-animation-crash.html: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm:
(WebKit::RemoteAnimationStack::initEffectsFromMainThread):

Canonical link: <a href="https://commits.webkit.org/309053@main">https://commits.webkit.org/309053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d73913ab7dc2a92d87bbe37f5b10afc7a0cf357

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158000 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f2b0c3e-89cf-4650-8be5-0bf1afef1372) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115124 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133963 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95872 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5849 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125983 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160483 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123165 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21822 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18296 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123382 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21830 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133696 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78030 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22991 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18612 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10442 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21432 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85245 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21163 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21312 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21220 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->