### PR TITLE
[threaded-animations] animating empty filter yields `<CAPresentationModifierGroup: 0x8a6523d50>: cannot create group with 0 capacity` exception

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/empty-filter-single-property-animation-crash-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/empty-filter-single-property-animation-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if this does not crash.

--- a/LayoutTests/webanimations/threaded-animations/empty-filter-single-property-animation-crash.html
+++ b/LayoutTests/webanimations/threaded-animations/empty-filter-single-property-animation-crash.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<style>
+
+@keyframes empty-filter {
+    to { filter: none }
+}
+
+div {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+    animation: empty-filter 1s;
+}
+
+</style>
+
+<div>PASS if this does not crash.</div>
+
+<script src="threaded-animations-utils.js"></script>
+<script>
+
+(async function () {
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+
+    // Wait for the initial layer tree commit.
+    await threadedAnimationsCommit();
+    // Wait another frame.
+    await new Promise(requestAnimationFrame);
+
+    window.testRunner?.notifyDone();
+})();
+
+</script>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
@@ -127,6 +127,12 @@ void RemoteAnimationStack::initEffectsFromMainThread(PlatformLayer *layer)
     // use this alone to determine whether this stack interpolates `filter`.
     auto* canonicalFilters = longestFilterList();
 
+    // FIXME: If we're only animating a filter property and we haven't found a filter, then
+    // we won't have anything to animate. Ideally, we wouldn't end up in this state where we
+    // have a no-op animation stack. See https://bugs.webkit.org/show_bug.cgi?id=309658.
+    if (!canonicalFilters && m_affectedLayerProperties.containsOnly({ LayerProperty::Filter }))
+        return;
+
     auto numberOfPresentationModifiers = [&]() {
         size_t count = 0;
         if (canonicalFilters)
@@ -164,7 +170,8 @@ void RemoteAnimationStack::initEffectsFromMainThread(PlatformLayer *layer)
 
 void RemoteAnimationStack::applyEffects() const
 {
-    ASSERT(m_presentationModifierGroup);
+    if (!m_presentationModifierGroup)
+        return;
 
     auto computedValues = computeValues();
 
@@ -216,7 +223,8 @@ WebCore::AcceleratedEffectValues RemoteAnimationStack::computeValues() const
 void RemoteAnimationStack::clear(PlatformLayer *layer)
 {
 #if PLATFORM(MAC)
-    ASSERT(m_presentationModifierGroup);
+    if (!m_presentationModifierGroup)
+        return;
 
     for (auto& filterPresentationModifier : m_filterPresentationModifiers)
         [layer removePresentationModifier:filterPresentationModifier.second.get()];


### PR DESCRIPTION
#### a988e4921ecf818ab550d4c4ce95a0e81577d3fc
<pre>
[threaded-animations] animating empty filter yields `&lt;CAPresentationModifierGroup: 0x8a6523d50&gt;: cannot create group with 0 capacity` exception
<a href="https://bugs.webkit.org/show_bug.cgi?id=309656">https://bugs.webkit.org/show_bug.cgi?id=309656</a>
<a href="https://rdar.apple.com/172263428">rdar://172263428</a>

Reviewed by Simon Fraser.

Ensure we don&apos;t create empty `CAPresentationModifierGroup` in the case where we have an empty `filter` animation.
Other properties aren&apos;t affected because they will always yield a value, even though it&apos;s a no-op value, but filters
do not work that way.

Test: webanimations/threaded-animations/empty-filter-single-property-animation-crash.html

* LayoutTests/webanimations/threaded-animations/empty-filter-single-property-animation-crash-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/empty-filter-single-property-animation-crash.html: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm:
(WebKit::RemoteAnimationStack::initEffectsFromMainThread):
(WebKit::RemoteAnimationStack::applyEffects const):
(WebKit::RemoteAnimationStack::clear):

Canonical link: <a href="https://commits.webkit.org/309058@main">https://commits.webkit.org/309058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d22741acbf10b13c2a4cd4e606b1d2f1b711fbc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149315 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158010 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21906 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115131 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17286 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95879 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16385 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14266 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5858 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11920 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160492 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3486 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13448 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123175 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18305 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123391 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21839 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133712 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78041 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22995 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18623 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10458 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21441 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85254 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21172 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21321 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21229 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->