### PR TITLE
Expose RTCRtpTransceiver stopping state

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-removeTrack.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-removeTrack.https-expected.txt
@@ -11,6 +11,6 @@ PASS Calling removeTrack with currentDirection sendrecv should set direction to 
 PASS Calling removeTrack with currentDirection sendonly should set direction to inactive
 PASS Calling removeTrack with currentDirection recvonly should not change direction
 PASS Calling removeTrack with currentDirection inactive should not change direction
-FAIL Calling removeTrack on a stopped transceiver should be a no-op assert_equals: expected object "[object MediaStreamTrack]" but got null
+PASS Calling removeTrack on a stopped transceiver should be a no-op
 PASS Calling removeTrack on a null track should have no effect
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-transceivers.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-transceivers.https-expected.txt
@@ -39,7 +39,7 @@ PASS addTransceiver('audio'): transceiver.stopped is false
 PASS addTrack reuses reusable transceivers
 PASS addTransceiver does not reuse reusable transceivers
 PASS Can setup two-way call using a single transceiver
-FAIL Closing the PC stops the transceivers assert_equals: expected "stopped" but got "inactive"
+PASS Closing the PC stops the transceivers
 PASS Changing transceiver direction to 'sendrecv' makes ontrack fire
 PASS transceiver.sender.track does not revert to an old state
 PASS transceiver.direction does not revert to an old state

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-stop-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-stop-expected.txt
@@ -7,5 +7,5 @@ PASS A stopped inactive transceiver should generate an inactive m-section in the
 PASS If a transceiver is stopped locally, setting a locally generated answer should still work
 PASS If a transceiver is stopped remotely, setting a locally generated answer should still work
 PASS If a transceiver is stopped, transceivers, senders and receivers should disappear after offer/answer
-FAIL If a transceiver is stopped, transceivers should end up in state stopped assert_equals: expected "stopped" but got "inactive"
+PASS If a transceiver is stopped, transceivers should end up in state stopped
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-stopping.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-stopping.https-expected.txt
@@ -1,18 +1,18 @@
 
-FAIL [audio] Locally stopped transceiver goes from stopping to stopped assert_equals: direction after stop() expected "stopped" but got "inactive"
+PASS [audio] Locally stopped transceiver goes from stopping to stopped
 PASS [audio] Locally stopping a transceiver ends the track
 FAIL [audio] Remotely stopping a transceiver ends the track assert_equals: expected "live" but got "ended"
-FAIL [audio] Remotely stopped transceiver goes directly to stopped assert_equals: direction during negotiation expected "stopped" but got "inactive"
+PASS [audio] Remotely stopped transceiver goes directly to stopped
 PASS [audio] Rollback when transceiver is not removed does not end track
 FAIL [audio] Rollback when removing transceiver does end the track assert_equals: expected "live" but got "ended"
-FAIL [audio] Rollback when removing transceiver makes it stopped assert_equals: currentDirection indicate stopped expected "stopped" but got "inactive"
+PASS [audio] Rollback when removing transceiver makes it stopped
 PASS [audio] Glare when transceiver is not removed does not end track
-FAIL [video] Locally stopped transceiver goes from stopping to stopped assert_equals: direction after stop() expected "stopped" but got "inactive"
+PASS [video] Locally stopped transceiver goes from stopping to stopped
 PASS [video] Locally stopping a transceiver ends the track
 FAIL [video] Remotely stopping a transceiver ends the track assert_equals: expected "live" but got "ended"
-FAIL [video] Remotely stopped transceiver goes directly to stopped assert_equals: direction during negotiation expected "stopped" but got "inactive"
+PASS [video] Remotely stopped transceiver goes directly to stopped
 PASS [video] Rollback when transceiver is not removed does not end track
 FAIL [video] Rollback when removing transceiver does end the track assert_equals: expected "live" but got "ended"
-FAIL [video] Rollback when removing transceiver makes it stopped assert_equals: currentDirection indicate stopped expected "stopped" but got "inactive"
+PASS [video] Rollback when removing transceiver makes it stopped
 PASS [video] Glare when transceiver is not removed does not end track
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver.https-expected.txt
@@ -9,7 +9,7 @@ PASS checkAddTransceiverBadKind
 PASS checkNoMidOffer
 PASS checkNoMidAnswer
 PASS checkSetDirection
-FAIL checkCurrentDirection assert_equals: expected "[{currentDirection:\"stopped\"}]" but got "[{currentDirection:\"inactive\"}]"
+PASS checkCurrentDirection
 PASS checkSendrecvWithNoSendTrack
 PASS checkSendrecvWithTracklessStream
 PASS checkAddTransceiverNoTrackDoesntPair
@@ -21,17 +21,17 @@ PASS checkReplaceTrackNullDoesntPreventPairing
 PASS checkRemoveAndReadd
 PASS checkAddTrackExistingTransceiverThenRemove
 PASS checkRemoveTrackNegotiation
-FAIL checkStop assert_equals: expected "[{currentDirection:\"sendrecv\",direction:\"stopped\",receiver:{track:{kind:\"audio\",readyState:\"ended\"}},sender:{track:{kind:\"audio\"}}}]" but got "[{currentDirection:\"sendrecv\",direction:\"inactive\",receiver:{track:{kind:\"audio\",readyState:\"ended\"}},sender:{track:null}}]"
-FAIL checkStopAfterCreateOffer assert_equals: expected "[{currentDirection:\"sendrecv\",direction:\"stopped\"}]" but got "[{currentDirection:\"sendrecv\",direction:\"inactive\"}]"
-FAIL checkStopAfterSetLocalOffer assert_equals: expected "[{currentDirection:\"sendrecv\",direction:\"stopped\"}]" but got "[{currentDirection:\"sendrecv\",direction:\"inactive\"}]"
-FAIL checkStopAfterSetRemoteOffer assert_equals: expected "stopped" but got "inactive"
-FAIL checkStopAfterCreateAnswer assert_equals: expected "[{currentDirection:null,direction:\"stopped\"}]" but got "[{currentDirection:null,direction:\"inactive\"}]"
-FAIL checkStopAfterSetLocalAnswer assert_equals: expected "[{currentDirection:\"sendrecv\",direction:\"stopped\"}]" but got "[{currentDirection:\"sendrecv\",direction:\"inactive\"}]"
+PASS checkStop
+PASS checkStopAfterCreateOffer
+PASS checkStopAfterSetLocalOffer
+PASS checkStopAfterSetRemoteOffer
+PASS checkStopAfterCreateAnswer
+PASS checkStopAfterSetLocalAnswer
 PASS checkStopAfterClose
-FAIL checkLocalRollback assert_equals: expected "[{direction:\"stopped\"}]" but got "[{direction:\"inactive\"}]"
+PASS checkLocalRollback
 PASS checkRollbackAndSetRemoteOfferWithDifferentType
-FAIL checkRemoteRollback assert_equals: expected "{currentDirection:\"stopped\",mid:null}" but got "{currentDirection:\"inactive\",mid:null}"
-FAIL checkMsectionReuse assert_equals: expected "stopped" but got "inactive"
+PASS checkRemoteRollback
+PASS checkMsectionReuse
 PASS checkStopAfterCreateOfferWithReusedMsection
 PASS checkAddIceCandidateToStoppedTransceiver
 PASS checkBundleTagRejected

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
@@ -97,7 +97,6 @@ void RTCRtpSender::stop()
         m_transform->detachFromSender(*this);
 
     m_trackId = { };
-    m_track = nullptr;
     m_isStopped = true;
 }
 
@@ -202,7 +201,7 @@ std::optional<RTCRtpCapabilities> RTCRtpSender::getCapabilities(ScriptExecutionC
 
 RTCDTMFSender* RTCRtpSender::dtmf()
 {
-    if (!m_dtmfSender && m_connection && m_connection->scriptExecutionContext() && !isStopped() && m_trackKind == "audio"_s)
+    if (!m_dtmfSender && m_connection && m_connection->scriptExecutionContext() && m_trackKind == "audio"_s)
         m_dtmfSender = RTCDTMFSender::create(*protect(m_connection->scriptExecutionContext()), *this, m_backend->createDTMFBackend());
 
     return m_dtmfSender.get();

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.cpp
@@ -69,9 +69,16 @@ std::optional<RTCRtpTransceiverDirection> RTCRtpTransceiver::currentDirection() 
     return m_backend->currentDirection();
 }
 
-void RTCRtpTransceiver::setDirection(RTCRtpTransceiverDirection direction)
+ExceptionOr<void> RTCRtpTransceiver::setDirection(RTCRtpTransceiverDirection direction)
 {
+    if (m_isStopping)
+        return Exception { ExceptionCode::InvalidStateError, "RTCRtpTransceiver has been stopped"_s };
+
+    if (direction == RTCRtpTransceiverDirection::Stopped && this->direction() != RTCRtpTransceiverDirection::Stopped)
+        return Exception { ExceptionCode::TypeError, "RTCRtpTransceiver direction is stopped"_s };
+
     m_backend->setDirection(direction);
+    return { };
 }
 
 void RTCRtpTransceiver::setConnection(RTCPeerConnection& connection)
@@ -85,10 +92,10 @@ ExceptionOr<void> RTCRtpTransceiver::stop()
     if (!m_connection || m_connection->isClosed())
         return Exception { ExceptionCode::InvalidStateError, "RTCPeerConnection is closed"_s };
 
-    if (m_stopped)
+    if (m_isStopping)
         return { };
 
-    m_stopped = true;
+    m_isStopping = true;
     m_receiver->stop();
     m_sender->stop();
     m_backend->stop();

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.h
@@ -55,7 +55,7 @@ public:
 
     RTCRtpTransceiverDirection direction() const;
     std::optional<RTCRtpTransceiverDirection> currentDirection() const;
-    void setDirection(RTCRtpTransceiverDirection);
+    ExceptionOr<void> setDirection(RTCRtpTransceiverDirection);
     String mid() const;
 
     RTCRtpSender& sender() { return m_sender.get(); }
@@ -74,7 +74,7 @@ public:
 private:
     RTCRtpTransceiver(Ref<RTCRtpSender>&&, Ref<RTCRtpReceiver>&&, UniqueRef<RTCRtpTransceiverBackend>&&);
 
-    bool m_stopped { false };
+    bool m_isStopping { false };
     std::optional<RTCRtpTransceiverDirection> m_firedDirection;
 
     const Ref<RTCRtpSender> m_sender;

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiver.idl
@@ -29,8 +29,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-typedef RTCRtpTransceiverDirection RtpTransceiverDirection;
-
 [
     Conditional=WEB_RTC,
     EnabledBySetting=PeerConnectionEnabled,
@@ -40,7 +38,7 @@ typedef RTCRtpTransceiverDirection RtpTransceiverDirection;
     [SameObject] readonly attribute RTCRtpSender sender;
     [SameObject] readonly attribute RTCRtpReceiver receiver;
     readonly attribute boolean stopped;
-    attribute RtpTransceiverDirection direction;
+    attribute RTCRtpTransceiverDirection direction;
     readonly attribute RTCRtpTransceiverDirection? currentDirection;
     undefined stop();
     undefined setCodecPreferences(sequence<RTCRtpCodecCapability> codecs);

--- a/Source/WebCore/Modules/mediastream/RTCRtpTransceiverDirection.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpTransceiverDirection.idl
@@ -30,5 +30,6 @@
     "sendrecv",
     "sendonly",
     "recvonly",
-    "inactive"
+    "inactive",
+    "stopped"
 };

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.h
@@ -116,6 +116,7 @@ inline GstWebRTCRTPTransceiverDirection fromRTCRtpTransceiverDirection(RTCRtpTra
 {
     switch (direction) {
     case RTCRtpTransceiverDirection::Inactive:
+    case RTCRtpTransceiverDirection::Stopped:
         return GST_WEBRTC_RTP_TRANSCEIVER_DIRECTION_INACTIVE;
     case RTCRtpTransceiverDirection::Sendonly:
         return GST_WEBRTC_RTP_TRANSCEIVER_DIRECTION_SENDONLY;

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCUtils.cpp
@@ -313,8 +313,9 @@ RTCRtpTransceiverDirection toRTCRtpTransceiverDirection(webrtc::RtpTransceiverDi
     case webrtc::RtpTransceiverDirection::kRecvOnly:
         return RTCRtpTransceiverDirection::Recvonly;
     case webrtc::RtpTransceiverDirection::kInactive:
-    case webrtc::RtpTransceiverDirection::kStopped:
         return RTCRtpTransceiverDirection::Inactive;
+    case webrtc::RtpTransceiverDirection::kStopped:
+        return RTCRtpTransceiverDirection::Stopped;
     };
 
     RELEASE_ASSERT_NOT_REACHED();
@@ -331,6 +332,8 @@ webrtc::RtpTransceiverDirection fromRTCRtpTransceiverDirection(RTCRtpTransceiver
         return webrtc::RtpTransceiverDirection::kRecvOnly;
     case RTCRtpTransceiverDirection::Inactive:
         return webrtc::RtpTransceiverDirection::kInactive;
+    case RTCRtpTransceiverDirection::Stopped:
+        return webrtc::RtpTransceiverDirection::kStopped;
     };
 
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/mediastream/RTCRtpTransceiverDirection.h
+++ b/Source/WebCore/platform/mediastream/RTCRtpTransceiverDirection.h
@@ -35,7 +35,8 @@ enum class RTCRtpTransceiverDirection {
     Sendrecv,
     Sendonly,
     Recvonly,
-    Inactive
+    Inactive,
+    Stopped
 };
 
 String convertEnumerationToString(RTCRtpTransceiverDirection); // in JSRTCRtpTransceiverDirection.h


### PR DESCRIPTION
#### 6687f908cc14371ac8631b38dfc2d3329416ef41
<pre>
Expose RTCRtpTransceiver stopping state
<a href="https://bugs.webkit.org/show_bug.cgi?id=309667">https://bugs.webkit.org/show_bug.cgi?id=309667</a>
<a href="https://rdar.apple.com/172275276">rdar://172275276</a>

Reviewed by Philippe Normand.

As per spec, we expose a new state named stopped to web pages.
We update the conversion routines with libwebrtc to no longer use inactive.

To fully pass WPT tests, we do a few changes to RTCRtpSender (we keep the track non null when transceiver gets stopped, and we always create a dtmf even if transceiver is stopped).
Covered by rebased WPT tests.

Canonical link: <a href="https://commits.webkit.org/309123@main">https://commits.webkit.org/309123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08d3033ef9b513bab32bbbc2f98c1e9db93fea1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22047 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158034 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102765 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c1ac769f-b3f2-4d7d-b27b-798e0aa78784) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115152 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81932 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cedcdadb-b1e7-4647-84b5-11379bfeb755) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133999 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95900 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c75f8eac-759e-4212-92f5-242c1fafa76d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16408 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14285 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5877 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126008 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160512 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3505 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13468 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123195 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18324 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123411 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33580 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21858 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133732 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78075 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18643 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10478 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21460 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85273 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21191 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21340 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21248 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->