### PR TITLE
[JSC] Implement `await using` syntax from Explicit Resource Management proposal

### DIFF
--- a/JSTests/stress/await-using-declaration-basic.js
+++ b/JSTests/stress/await-using-declaration-basic.js
@@ -1,0 +1,113 @@
+//@ requireOptions("--useExplicitResourceManagement=true")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}, expected: ${String(expected)}`);
+}
+
+async function test() {
+    var order = [];
+    {
+        await using a = {
+            [Symbol.asyncDispose]() {
+                order.push("dispose-a");
+                return Promise.resolve();
+            }
+        };
+        order.push("body");
+    }
+    order.push("after");
+    shouldBe(order.join(","), "body,dispose-a,after");
+}
+
+async function testReverseOrder() {
+    var order = [];
+    {
+        await using a = { [Symbol.asyncDispose]() { order.push("a"); } };
+        await using b = { [Symbol.asyncDispose]() { order.push("b"); } };
+        await using c = { [Symbol.asyncDispose]() { order.push("c"); } };
+    }
+    shouldBe(order.join(","), "c,b,a");
+}
+
+async function testNull() {
+    var order = [];
+    var wasSync = true;
+    var promise = (async function() {
+        {
+            order.push("before");
+            await using x = null;
+            order.push("after-decl");
+        }
+        order.push("after-block");
+        shouldBe(wasSync, false);
+    })();
+    wasSync = false;
+    await promise;
+    shouldBe(order.join(","), "before,after-decl,after-block");
+}
+
+async function testMixed() {
+    var order = [];
+    {
+        await using a = { [Symbol.asyncDispose]() { order.push("async-a"); } };
+        using b = { [Symbol.dispose]() { order.push("sync-b"); } };
+        order.push("body");
+    }
+    shouldBe(order.join(","), "body,sync-b,async-a");
+}
+
+async function testSyncFallback() {
+    var calledAsync = false;
+    var calledSync = false;
+    {
+        await using a = {
+            [Symbol.dispose]() { calledSync = true; }
+        };
+    }
+    shouldBe(calledAsync, false);
+    shouldBe(calledSync, true);
+}
+
+async function testAsyncDisposeReturnValueAwaited() {
+    var resolved = false;
+    {
+        await using a = {
+            [Symbol.asyncDispose]() {
+                return new Promise(resolve => {
+                    Promise.resolve().then(() => {
+                        resolved = true;
+                        resolve();
+                    });
+                });
+            }
+        };
+    }
+    shouldBe(resolved, true);
+}
+
+async function testNotEvaluatedNoAwait() {
+    var wasSync = true;
+    var promise = (async function() {
+        outer: {
+            if (true) break outer;
+            await using x = null;
+        }
+        shouldBe(wasSync, true);
+    })();
+    wasSync = false;
+    await promise;
+}
+
+async function main() {
+    await test();
+    await testReverseOrder();
+    await testNull();
+    await testMixed();
+    await testSyncFallback();
+    await testAsyncDisposeReturnValueAwaited();
+    await testNotEvaluatedNoAwait();
+}
+
+main().then(() => {}, e => { print("FAIL: " + e); throw e; });
+drainMicrotasks();

--- a/JSTests/stress/await-using-declaration-error.js
+++ b/JSTests/stress/await-using-declaration-error.js
@@ -1,0 +1,124 @@
+//@ requireOptions("--useExplicitResourceManagement=true")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}, expected: ${String(expected)}`);
+}
+
+function shouldThrowAsync(func, errorCheck) {
+    let caught = null;
+    func().then(() => {}, e => { caught = e; });
+    drainMicrotasks();
+    if (!caught)
+        throw new Error("did not throw");
+    if (errorCheck && !errorCheck(caught))
+        throw new Error("wrong error: " + caught);
+}
+
+shouldThrowAsync(async function() {
+    await using a = 42;
+}, e => e instanceof TypeError);
+
+shouldThrowAsync(async function() {
+    await using a = {};
+}, e => e instanceof TypeError);
+
+shouldThrowAsync(async function() {
+    await using a = { [Symbol.asyncDispose]: 42 };
+}, e => e instanceof TypeError);
+
+async function testDisposeThrows() {
+    let caught;
+    try {
+        await using a = {
+            [Symbol.asyncDispose]() { throw new Error("dispose error"); }
+        };
+    } catch (e) {
+        caught = e;
+    }
+    shouldBe(caught instanceof Error, true);
+    shouldBe(caught.message, "dispose error");
+}
+
+async function testDisposeRejects() {
+    let caught;
+    try {
+        await using a = {
+            [Symbol.asyncDispose]() { return Promise.reject(new Error("reject error")); }
+        };
+    } catch (e) {
+        caught = e;
+    }
+    shouldBe(caught instanceof Error, true);
+    shouldBe(caught.message, "reject error");
+}
+
+async function testSuppressedError() {
+    let caught;
+    try {
+        await using a = { [Symbol.asyncDispose]() { throw new Error("a"); } };
+        await using b = { [Symbol.asyncDispose]() { throw new Error("b"); } };
+    } catch (e) {
+        caught = e;
+    }
+    shouldBe(caught instanceof SuppressedError, true);
+    shouldBe(caught.error.message, "a");
+    shouldBe(caught.suppressed.message, "b");
+}
+
+async function testBodyThrowThenDisposeThrow() {
+    let caught;
+    try {
+        await using a = { [Symbol.asyncDispose]() { throw new Error("dispose"); } };
+        throw new Error("body");
+    } catch (e) {
+        caught = e;
+    }
+    shouldBe(caught instanceof SuppressedError, true);
+    shouldBe(caught.error.message, "dispose");
+    shouldBe(caught.suppressed.message, "body");
+}
+
+async function testSyncFallbackThrows() {
+    let caught;
+    try {
+        await using a = {
+            [Symbol.dispose]() { throw new Error("sync dispose"); }
+        };
+    } catch (e) {
+        caught = e;
+    }
+    shouldBe(caught instanceof Error, true);
+    shouldBe(caught.message, "sync dispose");
+}
+
+async function testMethodLookupThrowNoAwait() {
+    var order = [];
+    async function inner() {
+        order.push("start");
+        try {
+            await using x = { [Symbol.asyncDispose]: 42 };
+            order.push("unreachable");
+        } catch (e) {
+            order.push("caught:" + e.constructor.name);
+        }
+        order.push("end");
+    }
+    var p = inner();
+    order.push("after-call");
+    await p;
+    shouldBe(order.join(","), "start,caught:TypeError,end,after-call");
+}
+
+
+async function main() {
+    await testDisposeThrows();
+    await testDisposeRejects();
+    await testSuppressedError();
+    await testBodyThrowThenDisposeThrow();
+    await testSyncFallbackThrows();
+    await testMethodLookupThrowNoAwait();
+}
+
+main().then(() => {}, e => { print("FAIL: " + e); $vm.abort(); });
+drainMicrotasks();

--- a/JSTests/stress/await-using-declaration-for-of.js
+++ b/JSTests/stress/await-using-declaration-for-of.js
@@ -1,0 +1,79 @@
+//@ requireOptions("--useExplicitResourceManagement=true")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}, expected: ${String(expected)}`);
+}
+
+async function testForOf() {
+    var order = [];
+    var resources = [
+        { id: "a", [Symbol.asyncDispose]() { order.push("dispose-a"); } },
+        { id: "b", [Symbol.asyncDispose]() { order.push("dispose-b"); } },
+        { id: "c", [Symbol.asyncDispose]() { order.push("dispose-c"); } },
+    ];
+    for (await using r of resources) {
+        order.push("body-" + r.id);
+    }
+    shouldBe(order.join(","), "body-a,dispose-a,body-b,dispose-b,body-c,dispose-c");
+}
+
+async function testForAwaitOf() {
+    var order = [];
+    var asyncIterable = {
+        [Symbol.asyncIterator]() {
+            var i = 0;
+            return {
+                next() {
+                    if (i < 2) {
+                        var id = String.fromCharCode(97 + i);
+                        i++;
+                        return Promise.resolve({ value: { id, [Symbol.asyncDispose]() { order.push("dispose-" + id); } }, done: false });
+                    }
+                    return Promise.resolve({ value: undefined, done: true });
+                }
+            };
+        }
+    };
+    for await (await using r of asyncIterable) {
+        order.push("body-" + r.id);
+    }
+    shouldBe(order.join(","), "body-a,dispose-a,body-b,dispose-b");
+}
+
+async function testForOfContinue() {
+    var order = [];
+    var resources = [
+        { id: "a", [Symbol.asyncDispose]() { order.push("dispose-a"); } },
+        { id: "b", [Symbol.asyncDispose]() { order.push("dispose-b"); } },
+    ];
+    for (await using r of resources) {
+        order.push("pre-" + r.id);
+        if (r.id === "a") continue;
+        order.push("post-" + r.id);
+    }
+    shouldBe(order.join(","), "pre-a,dispose-a,pre-b,post-b,dispose-b");
+}
+
+async function testForOfBreak() {
+    var order = [];
+    var resources = [
+        { id: "a", [Symbol.asyncDispose]() { order.push("dispose-a"); } },
+        { id: "b", [Symbol.asyncDispose]() { order.push("dispose-b"); } },
+    ];
+    for (await using r of resources) {
+        order.push("body-" + r.id);
+        if (r.id === "a") break;
+    }
+    shouldBe(order.join(","), "body-a,dispose-a");
+}
+
+async function main() {
+    await testForOf();
+    await testForAwaitOf();
+    await testForOfContinue();
+    await testForOfBreak();
+}
+
+main().then(() => {}, e => { print("FAIL: " + e); $vm.abort(); });
+drainMicrotasks();

--- a/JSTests/stress/await-using-declaration-generator.js
+++ b/JSTests/stress/await-using-declaration-generator.js
@@ -1,0 +1,63 @@
+//@ requireOptions("--useExplicitResourceManagement=true")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}, expected: ${String(expected)}`);
+}
+
+async function testAsyncGenerator() {
+    var order = [];
+    async function* gen() {
+        await using a = { [Symbol.asyncDispose]() { order.push("dispose-a"); } };
+        yield 1;
+        yield 2;
+        order.push("body-end");
+    }
+    var iter = gen();
+    shouldBe((await iter.next()).value, 1);
+    shouldBe((await iter.next()).value, 2);
+    shouldBe((await iter.next()).done, true);
+    shouldBe(order.join(","), "body-end,dispose-a");
+}
+
+async function testAsyncGeneratorReturn() {
+    var order = [];
+    async function* gen() {
+        await using a = { [Symbol.asyncDispose]() { order.push("dispose-a"); } };
+        yield 1;
+        order.push("never");
+    }
+    var iter = gen();
+    shouldBe((await iter.next()).value, 1);
+    shouldBe((await iter.return(42)).value, 42);
+    shouldBe(order.join(","), "dispose-a");
+}
+
+async function testAsyncGeneratorNestedBlocks() {
+    var order = [];
+    async function* gen() {
+        {
+            await using a = { [Symbol.asyncDispose]() { order.push("dispose-a"); } };
+            {
+                await using b = { [Symbol.asyncDispose]() { order.push("dispose-b"); } };
+                yield 1;
+            }
+            order.push("between");
+        }
+        yield 2;
+    }
+    var iter = gen();
+    shouldBe((await iter.next()).value, 1);
+    shouldBe((await iter.next()).value, 2);
+    shouldBe((await iter.next()).done, true);
+    shouldBe(order.join(","), "dispose-b,between,dispose-a");
+}
+
+async function main() {
+    await testAsyncGenerator();
+    await testAsyncGeneratorReturn();
+    await testAsyncGeneratorNestedBlocks();
+}
+
+main().then(() => {}, e => { print("FAIL: " + e); $vm.abort(); });
+drainMicrotasks();

--- a/JSTests/stress/await-using-declaration-mixed.js
+++ b/JSTests/stress/await-using-declaration-mixed.js
@@ -1,0 +1,79 @@
+//@ requireOptions("--useExplicitResourceManagement=true")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${String(actual)}, expected: ${String(expected)}`);
+}
+
+async function testSyncThenAsync() {
+    var order = [];
+    {
+        using a = { [Symbol.dispose]() { order.push("sync-a"); } };
+        await using b = { [Symbol.asyncDispose]() { order.push("async-b"); } };
+        order.push("body");
+    }
+    shouldBe(order.join(","), "body,async-b,sync-a");
+}
+
+async function testAsyncThenSync() {
+    var order = [];
+    {
+        await using a = { [Symbol.asyncDispose]() { order.push("async-a"); } };
+        using b = { [Symbol.dispose]() { order.push("sync-b"); } };
+        order.push("body");
+    }
+    shouldBe(order.join(","), "body,sync-b,async-a");
+}
+
+async function testInterleaved() {
+    var order = [];
+    {
+        using a = { [Symbol.dispose]() { order.push("sync-a"); } };
+        await using b = { [Symbol.asyncDispose]() { order.push("async-b"); } };
+        using c = { [Symbol.dispose]() { order.push("sync-c"); } };
+        await using d = { [Symbol.asyncDispose]() { order.push("async-d"); } };
+        order.push("body");
+    }
+    shouldBe(order.join(","), "body,async-d,sync-c,async-b,sync-a");
+}
+
+async function testMixedWithNullAwaitUsing() {
+    var order = [];
+    var wasSync = true;
+    var p = (async function() {
+        {
+            using a = { [Symbol.dispose]() { order.push("sync-a"); } };
+            await using b = null;
+            order.push("body");
+        }
+        shouldBe(wasSync, false);
+        order.push("after");
+    })();
+    wasSync = false;
+    await p;
+    shouldBe(order.join(","), "body,sync-a,after");
+}
+
+async function testMixedSuppressedError() {
+    var caught;
+    try {
+        using a = { [Symbol.dispose]() { throw new Error("sync"); } };
+        await using b = { [Symbol.asyncDispose]() { return Promise.reject(new Error("async")); } };
+    } catch (e) {
+        caught = e;
+    }
+    shouldBe(caught instanceof SuppressedError, true);
+    shouldBe(caught.error.message, "sync");
+    shouldBe(caught.suppressed.message, "async");
+}
+
+async function main() {
+    await testSyncThenAsync();
+    await testAsyncThenSync();
+    await testInterleaved();
+    await testMixedWithNullAwaitUsing();
+    await testMixedSuppressedError();
+}
+
+main().then(() => {}, e => { print("FAIL: " + e); $vm.abort(); });
+drainMicrotasks();

--- a/JSTests/stress/await-using-declaration-syntax-errors.js
+++ b/JSTests/stress/await-using-declaration-syntax-errors.js
@@ -1,0 +1,63 @@
+//@ requireOptions("--useExplicitResourceManagement=true")
+
+function shouldThrowSyntaxError(code) {
+    var threw = false;
+    try {
+        eval(code);
+    } catch (e) {
+        if (!(e instanceof SyntaxError))
+            throw new Error(`wrong error type: ${e.constructor.name}: ${e.message}`);
+        threw = true;
+    }
+    if (!threw)
+        throw new Error(`did not throw: ${code}`);
+}
+
+function shouldNotThrowSyntaxError(code) {
+    try {
+        eval(code);
+    } catch (e) {
+        if (e instanceof SyntaxError)
+            throw new Error(`unexpected SyntaxError: ${e.message}: ${code}`);
+    }
+}
+
+shouldThrowSyntaxError(`await using x = null;`);
+shouldThrowSyntaxError(`function f() { await using x = null; }`);
+shouldThrowSyntaxError(`function* f() { await using x = null; }`);
+shouldThrowSyntaxError(`() => { await using x = null; }`);
+
+// `await [no LT] using` constraint: with a line break, `await` becomes an AwaitExpression
+// whose operand is `using` (an identifier expression), and the rest is a separate statement.
+// This is not a SyntaxError — the following should parse but run as distinct statements.
+{
+    let calledDispose = false;
+    let using = { [Symbol.dispose]() { calledDispose = true; } };
+    (async function() {
+        let x;
+        await
+        using
+        x = null;
+        if (x !== null) throw new Error("line break: x should be null");
+    })();
+    drainMicrotasks();
+    if (calledDispose) throw new Error("line break: should not have called dispose");
+}
+
+shouldThrowSyntaxError(`async function f() { await using [a] = null; }`);
+shouldThrowSyntaxError(`async function f() { await using {a} = null; }`);
+
+shouldThrowSyntaxError(`async function f() { await using x; }`);
+
+shouldThrowSyntaxError(`async function f() { for (await using x in obj) {} }`);
+shouldThrowSyntaxError(`async function f() { for (await using x; ; ) {} }`);
+
+shouldThrowSyntaxError(`async function f() { switch (1) { case 1: await using x = null; } }`);
+
+shouldNotThrowSyntaxError(`async function f() { await using x = null; }`);
+shouldNotThrowSyntaxError(`async function* f() { await using x = null; }`);
+shouldNotThrowSyntaxError(`async function f() { { await using x = null; } }`);
+shouldNotThrowSyntaxError(`async function f() { for (await using x of []) {} }`);
+shouldNotThrowSyntaxError(`async function f() { for await (await using x of []) {} }`);
+shouldNotThrowSyntaxError(`async function f() { switch (1) { case 1: { await using x = null; } } }`);
+shouldNotThrowSyntaxError(`async function f() { await using a = null, b = null; }`);

--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -42,9 +42,6 @@ skip:
     - test/staging/JSON
     - test/staging/Temporal
     - test/staging/sm/Temporal
-    # Explicit Resource Management
-    - test/staging/explicit-resource-management
-    - test/language/statements/await-using
   files:
     # https://github.com/claudepache/es-legacy-function-reflection
     - test/built-ins/ThrowTypeError/unique-per-realm-function-proto.js

--- a/Source/JavaScriptCore/builtins/DisposableStackPrototype.js
+++ b/Source/JavaScriptCore/builtins/DisposableStackPrototype.js
@@ -23,30 +23,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://tc39.es/proposal-explicit-resource-management/#sec-getdisposemethod
-@linkTimeConstant
-function getAsyncDisposableMethod(value)
-{
-    'use strict';
-
-    var method = value.@@asyncDispose;
-
-    if (!@isCallable(method))
-        @throwTypeError("@@asyncDispose must be callable");
-
-    if (@isUndefinedOrNull(method))
-        return @undefined;
-
-    return () => {
-        try {
-            method.@call(value);
-        } catch (e) {
-            return @promiseReject(@Promise, e);
-        }
-        return @promiseResolve(@Promise, @undefined);
-    };
-}
-
 // https://tc39.es/proposal-explicit-resource-management/#sec-createdisposableresource
 @linkTimeConstant
 function createDisposableResource(value, isAsync /* , method */)
@@ -60,13 +36,10 @@ function createDisposableResource(value, isAsync /* , method */)
         else {
             if (!@isObject(value))
                 @throwTypeError("Disposable value must be an object");
-            if (isAsync) {
-                method = @getAsyncDisposableMethod(value);
-                if (method === @undefined)
-                    @throwTypeError("@@asyncDispose must not be an undefined");
-            } else {
+            if (isAsync)
+                method = @getAsyncDisposeMethod(value);
+            else
                 method = @getDisposeMethod(value);
-            }
         }
     } else {
         method = @argument(2);
@@ -99,6 +72,40 @@ function getDisposeMethod(value)
         @throwTypeError("@@dispose must not be undefined or null");
     if (!@isCallable(method))
         @throwTypeError("@@dispose must be callable");
+    return method;
+}
+
+// https://tc39.es/proposal-explicit-resource-management/#sec-getdisposemethod (async-dispose hint)
+@linkTimeConstant
+function getAsyncDisposeMethod(value)
+{
+    'use strict';
+
+    if (@isUndefinedOrNull(value))
+        return @undefined;
+    if (!@isObject(value))
+        @throwTypeError("Disposable value must be an object, null, or undefined");
+
+    var method = value.@@asyncDispose;
+    if (@isUndefinedOrNull(method)) {
+        method = value.@@dispose;
+        if (@isUndefinedOrNull(method))
+            @throwTypeError("@@asyncDispose and @@dispose must not be undefined or null");
+        if (!@isCallable(method))
+            @throwTypeError("@@dispose must be callable");
+        var syncMethod = method;
+        var receiver = value;
+        return function () {
+            try {
+                syncMethod.@call(receiver);
+            } catch (e) {
+                return @promiseReject(@Promise, e);
+            }
+            return @promiseResolve(@Promise, @undefined);
+        };
+    }
+    if (!@isCallable(method))
+        @throwTypeError("@@asyncDispose must be callable");
     return method;
 }
 

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp
@@ -4638,33 +4638,50 @@ void BytecodeGenerator::emitTryWithFinallyThatDoesNotShadowException(FinallyCont
     }
 }
 
-void BytecodeGenerator::emitPrepareDisposable(RegisterID* value, const JSTextPosition& divot)
+void BytecodeGenerator::emitPrepareDisposable(RegisterID* value, const JSTextPosition& divot, bool isAsync)
 {
     auto& usingScope = currentUsingScope();
     ASSERT(usingScope.nextSlot < usingScope.slots.size());
     auto& slot = usingScope.slots[usingScope.nextSlot++];
+    slot.isAsync = isAsync;
     move(slot.value.get(), value);
 
-    RefPtr<RegisterID> getDisposeMethodFunc = moveLinkTimeConstant(nullptr, LinkTimeConstant::getDisposeMethod);
+    RefPtr<RegisterID> getDisposeMethodFunc = moveLinkTimeConstant(nullptr, isAsync ? LinkTimeConstant::getAsyncDisposeMethod : LinkTimeConstant::getDisposeMethod);
     CallArguments args(*this, nullptr, 1);
     emitLoad(args.thisRegister(), jsUndefined());
     move(args.argumentRegister(0), value);
     emitCall(slot.method.get(), getDisposeMethodFunc.get(), NoExpectedFunction, args, divot, divot, divot, DebuggableCall::No);
+
+    // Mark reached only after method lookup succeeds; if the above call threw, reached stays
+    // false so the finally block skips this slot entirely (spec: no resource record is added).
+    if (isAsync) {
+        ASSERT(usingScope.hasAwaitUsing);
+        ASSERT(slot.reached);
+        emitLoad(slot.reached.get(), jsBoolean(true));
+    }
 }
 
-void BytecodeGenerator::emitUsingBodyScope(unsigned usingCount, const ScopedLambda<void(BytecodeGenerator&)>& emitBody)
+void BytecodeGenerator::emitUsingBodyScope(unsigned usingCount, bool hasAwaitUsing, const ScopedLambda<void(BytecodeGenerator&)>& emitBody)
 {
+    ASSERT(!hasAwaitUsing || isAsyncFunctionParseMode(parseMode()) || isModuleParseMode(parseMode()));
+
     // Pre-allocate slots and initialize method registers to undefined BEFORE the try block.
     // This ensures that if an initializer throws, the method register has a known value (undefined)
     // so the finally block can safely check it.
     m_usingScopeStack.append(UsingScope { });
     auto& usingScope = currentUsingScope();
+    usingScope.hasAwaitUsing = hasAwaitUsing;
     for (unsigned i = 0; i < usingCount; i++) {
         RefPtr<RegisterID> valueCopy = newTemporary();
         RefPtr<RegisterID> method = newTemporary();
+        RefPtr<RegisterID> reached;
         emitLoad(valueCopy.get(), jsUndefined());
         emitLoad(method.get(), jsUndefined());
-        usingScope.slots.append({ valueCopy, method });
+        if (hasAwaitUsing) {
+            reached = newTemporary();
+            emitLoad(reached.get(), jsBoolean(false));
+        }
+        usingScope.slots.append({ valueCopy, method, reached, false });
     }
 
     RefPtr<RegisterID> thrownValue = newTemporary();
@@ -4705,51 +4722,138 @@ void BytecodeGenerator::emitUsingBodyScope(unsigned usingCount, const ScopedLamb
 
         JSTextPosition divot(m_scopeNode->firstLine(), m_scopeNode->startOffset(), m_scopeNode->lineStartOffset());
 
+        // Async disposal state (per DisposeResources spec): needsAwait / hasAwaited.
+        // Only allocated when this scope contains at least one await using declaration.
+        RefPtr<RegisterID> needsAwait;
+        RefPtr<RegisterID> hasAwaited;
+        if (hasAwaitUsing) {
+            needsAwait = newTemporary();
+            hasAwaited = newTemporary();
+            emitLoad(needsAwait.get(), jsBoolean(false));
+            emitLoad(hasAwaited.get(), jsBoolean(false));
+        }
+
+        // Shared temporaries for the catch handler (one pair is enough across all slots).
+        RefPtr<RegisterID> caughtException = newTemporary();
+        RefPtr<RegisterID> caughtValue = newTemporary();
+        RefPtr<RegisterID> createSuppressedErrorFunc = newTemporary();
+
+        auto emitSuppressedErrorCatch = [&](TryData* trySlotData, Label& catchLabel) {
+            emitLabel(catchLabel);
+            emitOutOfLineExceptionHandler(caughtException.get(), caughtValue.get(), nullptr, trySlotData);
+
+            Ref<Label> afterCatch = newLabel();
+            Ref<Label> firstError = newLabel();
+            emitJumpIfFalse(hasError.get(), firstError.get());
+
+            moveLinkTimeConstant(createSuppressedErrorFunc.get(), LinkTimeConstant::createSuppressedError);
+            CallArguments seArgs(*this, nullptr, 2);
+            emitLoad(seArgs.thisRegister(), jsUndefined());
+            move(seArgs.argumentRegister(0), caughtValue.get());
+            move(seArgs.argumentRegister(1), pendingError.get());
+            emitCall(pendingError.get(), createSuppressedErrorFunc.get(), NoExpectedFunction, seArgs, divot, divot, divot, DebuggableCall::No);
+            emitJump(afterCatch.get());
+
+            emitLabel(firstError.get());
+            move(pendingError.get(), caughtValue.get());
+            emitLoad(hasError.get(), jsBoolean(true));
+
+            emitLabel(afterCatch.get());
+            emitLoad(disposeThrew.get(), jsBoolean(true));
+        };
+
+        auto emitAwaitUndefined = [&]() {
+            RefPtr<RegisterID> tmp = newTemporary();
+            emitLoad(tmp.get(), jsUndefined());
+            emitAwait(tmp.get(), tmp.get(), divot);
+        };
+
         // Dispose each resource in reverse declaration order.
+        // Track whether we've processed an async slot so far: needsAwait can only become
+        // true after an async slot's null-value case, so Step 3.d before the first async
+        // slot in disposal order is always dead and can be elided at compile time.
+        bool sawAsyncSlotInDisposalOrder = false;
         for (auto& slot : usingScope.slots | std::views::reverse) {
             Ref<Label> skipSlot = newLabel();
-            emitJumpIfTrue(emitIsUndefined(newTemporary(), slot.method.get()), skipSlot.get());
 
-            Ref<Label> catchLabel = newLabel();
-            Ref<Label> trySlotStart = newEmittedLabel();
-            TryData* trySlotData = pushTry(trySlotStart.get(), catchLabel.get(), HandlerType::SynthesizedCatch);
+            if (slot.isAsync) {
+                sawAsyncSlotInDisposalOrder = true;
+                // Async disposal slot.
+                // If the declaration was never reached (reached == false), skip entirely
+                // without setting needsAwait; the spec only adds a resource record on evaluation.
+                emitJumpIfFalse(slot.reached.get(), skipSlot.get());
 
-            CallArguments disposeArgs(*this, nullptr, 0);
-            move(disposeArgs.thisRegister(), slot.value.get());
-            emitCallIgnoreResult(newTemporary(), slot.method.get(), NoExpectedFunction, disposeArgs, divot, divot, divot, DebuggableCall::No);
+                Ref<Label> methodDefined = newLabel();
+                emitJumpIfFalse(emitIsUndefined(newTemporary(), slot.method.get()), methodDefined.get());
 
-            Ref<Label> trySlotEnd = newEmittedLabel();
-            popTry(trySlotData, trySlotEnd.get());
-            emitJump(skipSlot.get());
+                // method is undefined (await using x = null/undefined).
+                // Per DisposeResources step 3.f: set needsAwait to true, no call.
+                emitLoad(needsAwait.get(), jsBoolean(true));
+                emitJump(skipSlot.get());
 
-            // catch (e): Build SuppressedError chain if needed.
-            {
-                emitLabel(catchLabel.get());
-                RefPtr<RegisterID> caughtException = newTemporary();
-                RefPtr<RegisterID> caughtValue = newTemporary();
-                emitOutOfLineExceptionHandler(caughtException.get(), caughtValue.get(), nullptr, trySlotData);
+                // method is defined: call it and Await the result.
+                emitLabel(methodDefined.get());
+                Ref<Label> catchLabel = newLabel();
+                Ref<Label> trySlotStart = newEmittedLabel();
+                TryData* trySlotData = pushTry(trySlotStart.get(), catchLabel.get(), HandlerType::SynthesizedCatch);
 
-                Ref<Label> afterCatch = newLabel();
-                Ref<Label> firstError = newLabel();
-                emitJumpIfFalse(hasError.get(), firstError.get());
+                RefPtr<RegisterID> result = newTemporary();
+                CallArguments disposeArgs(*this, nullptr, 0);
+                move(disposeArgs.thisRegister(), slot.value.get());
+                emitCall(result.get(), slot.method.get(), NoExpectedFunction, disposeArgs, divot, divot, divot, DebuggableCall::No);
 
-                RefPtr<RegisterID> createSuppressedErrorFunc = moveLinkTimeConstant(nullptr, LinkTimeConstant::createSuppressedError);
-                CallArguments seArgs(*this, nullptr, 2);
-                emitLoad(seArgs.thisRegister(), jsUndefined());
-                move(seArgs.argumentRegister(0), caughtValue.get());
-                move(seArgs.argumentRegister(1), pendingError.get());
-                emitCall(pendingError.get(), createSuppressedErrorFunc.get(), NoExpectedFunction, seArgs, divot, divot, divot, DebuggableCall::No);
-                emitJump(afterCatch.get());
+                // Set hasAwaited before Await: emitAwait throws on rejection, but a rejected
+                // Await still implies a microtask boundary has occurred.
+                emitLoad(hasAwaited.get(), jsBoolean(true));
+                emitAwait(result.get(), result.get(), divot);
 
-                emitLabel(firstError.get());
-                move(pendingError.get(), caughtValue.get());
-                emitLoad(hasError.get(), jsBoolean(true));
+                Ref<Label> trySlotEnd = newEmittedLabel();
+                popTry(trySlotData, trySlotEnd.get());
+                emitJump(skipSlot.get());
 
-                emitLabel(afterCatch.get());
-                emitLoad(disposeThrew.get(), jsBoolean(true));
+                emitSuppressedErrorCatch(trySlotData, catchLabel.get());
+            } else {
+                // Sync disposal slot.
+                // Per DisposeResources step 3.d: if needsAwait && !hasAwaited, Await(undefined) first.
+                // Only emit if an async slot was already processed (otherwise needsAwait is provably false).
+                if (sawAsyncSlotInDisposalOrder) {
+                    Ref<Label> skipAwaitCheck = newLabel();
+                    emitJumpIfFalse(needsAwait.get(), skipAwaitCheck.get());
+                    emitJumpIfTrue(hasAwaited.get(), skipAwaitCheck.get());
+                    emitAwaitUndefined();
+                    emitLoad(needsAwait.get(), jsBoolean(false));
+                    emitLabel(skipAwaitCheck.get());
+                }
+
+                emitJumpIfTrue(emitIsUndefined(newTemporary(), slot.method.get()), skipSlot.get());
+
+                Ref<Label> catchLabel = newLabel();
+                Ref<Label> trySlotStart = newEmittedLabel();
+                TryData* trySlotData = pushTry(trySlotStart.get(), catchLabel.get(), HandlerType::SynthesizedCatch);
+
+                CallArguments disposeArgs(*this, nullptr, 0);
+                move(disposeArgs.thisRegister(), slot.value.get());
+                emitCallIgnoreResult(newTemporary(), slot.method.get(), NoExpectedFunction, disposeArgs, divot, divot, divot, DebuggableCall::No);
+
+                Ref<Label> trySlotEnd = newEmittedLabel();
+                popTry(trySlotData, trySlotEnd.get());
+                emitJump(skipSlot.get());
+
+                emitSuppressedErrorCatch(trySlotData, catchLabel.get());
             }
 
             emitLabel(skipSlot.get());
+        }
+
+        // Per DisposeResources step 6: trailing Await(undefined) if needsAwait && !hasAwaited.
+        // If the first-declared slot is sync, its Step 3.d (above) already consumed any pending
+        // needsAwait, so this trailing check is provably dead and elided.
+        if (hasAwaitUsing && usingScope.slots[0].isAsync) {
+            Ref<Label> skipFinalAwait = newLabel();
+            emitJumpIfFalse(needsAwait.get(), skipFinalAwait.get());
+            emitJumpIfTrue(hasAwaited.get(), skipFinalAwait.get());
+            emitAwaitUndefined();
+            emitLabel(skipFinalAwait.get());
         }
 
         // If any dispose threw, throw the pending error (which may be a SuppressedError chain).
@@ -4769,10 +4873,10 @@ void BytecodeGenerator::emitUsingBodyScope(unsigned usingCount, const ScopedLamb
     m_usingScopeStack.removeLast();
 }
 
-void BytecodeGenerator::emitBodyWithUsingIfNeeded(unsigned usingCount, const ScopedLambda<void(BytecodeGenerator&)>& emitBody)
+void BytecodeGenerator::emitBodyWithUsingIfNeeded(unsigned usingCount, bool hasAwaitUsing, const ScopedLambda<void(BytecodeGenerator&)>& emitBody)
 {
     if (usingCount)
-        emitUsingBodyScope(usingCount, emitBody);
+        emitUsingBodyScope(usingCount, hasAwaitUsing, emitBody);
     else
         emitBody(*this);
 }

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -330,11 +330,14 @@ namespace JSC {
     struct UsingSlot {
         RefPtr<RegisterID> value;
         RefPtr<RegisterID> method;
+        RefPtr<RegisterID> reached;
+        bool isAsync { false };
     };
 
     struct UsingScope {
         Vector<UsingSlot> slots;
         unsigned nextSlot { 0 };
+        bool hasAwaitUsing { false };
     };
 
     struct JSGeneratorTraits {
@@ -880,9 +883,9 @@ namespace JSC {
 
         // Explicit Resource Management: using declarations
         UsingScope& currentUsingScope() { ASSERT(!m_usingScopeStack.isEmpty()); return m_usingScopeStack.last(); }
-        void emitPrepareDisposable(RegisterID* value, const JSTextPosition& divot);
-        void emitUsingBodyScope(unsigned usingCount, const ScopedLambda<void(BytecodeGenerator&)>& emitBody);
-        void emitBodyWithUsingIfNeeded(unsigned usingCount, const ScopedLambda<void(BytecodeGenerator&)>& emitBody);
+        void emitPrepareDisposable(RegisterID* value, const JSTextPosition& divot, bool isAsync = false);
+        void emitUsingBodyScope(unsigned usingCount, bool hasAwaitUsing, const ScopedLambda<void(BytecodeGenerator&)>& emitBody);
+        void emitBodyWithUsingIfNeeded(unsigned usingCount, bool hasAwaitUsing, const ScopedLambda<void(BytecodeGenerator&)>& emitBody);
 
         void emitGenericEnumeration(ThrowableExpressionData* enumerationNode, ExpressionNode* subjectNode, const ScopedLambda<void(BytecodeGenerator&, RegisterID*)>& callBack, ForOfNode* = nullptr, RegisterID* forLoopSymbolTable = nullptr);
         void emitEnumeration(ThrowableExpressionData* enumerationNode, ExpressionNode* subjectNode, const ScopedLambda<void(BytecodeGenerator&, RegisterID*)>& callBack, ForOfNode* = nullptr, RegisterID* forLoopSymbolTable = nullptr);

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -4125,6 +4125,7 @@ static InitializationMode initializationModeForAssignmentContext(AssignmentConte
         return InitializationMode::Initialization;
     case AssignmentContext::ConstDeclarationStatement:
     case AssignmentContext::UsingDeclarationStatement:
+    case AssignmentContext::AwaitUsingDeclarationStatement:
         return InitializationMode::ConstInitialization;
     case AssignmentContext::AssignmentExpression:
         return InitializationMode::NotInitialization;
@@ -4134,10 +4135,15 @@ static InitializationMode initializationModeForAssignmentContext(AssignmentConte
     return InitializationMode::NotInitialization;
 }
 
+static inline bool isUsingOrAwaitUsingAssignmentContext(AssignmentContext context)
+{
+    return context == AssignmentContext::UsingDeclarationStatement || context == AssignmentContext::AwaitUsingDeclarationStatement;
+}
+
 RegisterID* AssignResolveNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 {
     Variable var = generator.variable(m_ident);
-    bool isReadOnly = var.isReadOnly() && m_assignmentContext != AssignmentContext::ConstDeclarationStatement && m_assignmentContext != AssignmentContext::UsingDeclarationStatement;
+    bool isReadOnly = var.isReadOnly() && m_assignmentContext != AssignmentContext::ConstDeclarationStatement && !isUsingOrAwaitUsingAssignmentContext(m_assignmentContext);
     JSTextPosition newDivot = divotStart() + m_ident.length();
     if (RegisterID* local = var.local()) {
         RegisterID* result = nullptr;
@@ -4170,10 +4176,10 @@ RegisterID* AssignResolveNode::emitBytecode(BytecodeGenerator& generator, Regist
             result = generator.move(dst, right);
         }
 
-        if (m_assignmentContext == AssignmentContext::UsingDeclarationStatement)
-            generator.emitPrepareDisposable(local, divotStart());
+        if (isUsingOrAwaitUsingAssignmentContext(m_assignmentContext))
+            generator.emitPrepareDisposable(local, divotStart(), m_assignmentContext == AssignmentContext::AwaitUsingDeclarationStatement);
 
-        if (m_assignmentContext == AssignmentContext::DeclarationStatement || m_assignmentContext == AssignmentContext::ConstDeclarationStatement || m_assignmentContext == AssignmentContext::UsingDeclarationStatement)
+        if (m_assignmentContext != AssignmentContext::AssignmentExpression)
             generator.liftTDZCheckIfPossible(var);
         return result;
     }
@@ -4200,10 +4206,10 @@ RegisterID* AssignResolveNode::emitBytecode(BytecodeGenerator& generator, Regist
         generator.emitProfileType(result.get(), var, divotStart(), divotEnd());
     }
 
-    if (m_assignmentContext == AssignmentContext::UsingDeclarationStatement)
-        generator.emitPrepareDisposable(result.get(), divotStart());
+    if (isUsingOrAwaitUsingAssignmentContext(m_assignmentContext))
+        generator.emitPrepareDisposable(result.get(), divotStart(), m_assignmentContext == AssignmentContext::AwaitUsingDeclarationStatement);
 
-    if (m_assignmentContext == AssignmentContext::DeclarationStatement || m_assignmentContext == AssignmentContext::ConstDeclarationStatement || m_assignmentContext == AssignmentContext::UsingDeclarationStatement)
+    if (m_assignmentContext != AssignmentContext::AssignmentExpression)
         generator.liftTDZCheckIfPossible(var);
     return returnResult;
 }
@@ -4426,7 +4432,7 @@ void BlockNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
         return;
     generator.pushLexicalScope(this, BytecodeGenerator::ScopeType::LetConstScope, BytecodeGenerator::TDZCheckOptimization::Optimize, BytecodeGenerator::NestedScopeType::IsNested);
 
-    generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(),
+    generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(), hasAwaitUsingDeclaration(),
         scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
             m_statements->emitBytecode(generator, dst);
         })
@@ -4677,7 +4683,7 @@ void ForNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
         generator.emitLabel(loopEnd.get());
     };
 
-    generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(),
+    generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(), hasAwaitUsingDeclaration(),
         scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
             emitLoopBody(generator);
         })
@@ -4873,7 +4879,8 @@ void ForOfNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
     RegisterID* forLoopSymbolTable = nullptr;
     generator.pushLexicalScope(this, BytecodeGenerator::ScopeType::LetConstScope, BytecodeGenerator::TDZCheckOptimization::Optimize, BytecodeGenerator::NestedScopeType::IsNested, &forLoopSymbolTable);
     bool isUsingDeclaration = hasUsingDeclaration();
-    auto extractor = scopedLambda<void(BytecodeGenerator&, RegisterID*)>([this, dst, isUsingDeclaration](BytecodeGenerator& generator, RegisterID* value)
+    bool isAwaitUsingDeclaration = hasAwaitUsingDeclaration();
+    auto extractor = scopedLambda<void(BytecodeGenerator&, RegisterID*)>([this, dst, isUsingDeclaration, isAwaitUsingDeclaration](BytecodeGenerator& generator, RegisterID* value)
     {
         auto emitBody = [&](BytecodeGenerator& generator) {
             if (m_lexpr->isResolveNode()) {
@@ -4894,7 +4901,7 @@ void ForOfNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
                 }
                 generator.emitProfileType(value, var, m_lexpr->position(), m_lexpr->position() + ident.length());
                 if (isUsingDeclaration)
-                    generator.emitPrepareDisposable(value, divotStart());
+                    generator.emitPrepareDisposable(value, divotStart(), isAwaitUsingDeclaration);
             } else if (m_lexpr->isDotAccessorNode()) {
                 DotAccessorNode* assignNode = static_cast<DotAccessorNode*>(m_lexpr);
                 RefPtr<RegisterID> base = generator.emitNode(assignNode->base());
@@ -4922,7 +4929,7 @@ void ForOfNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
             generator.emitNode(dst, m_statement);
         };
 
-        generator.emitBodyWithUsingIfNeeded(isUsingDeclaration ? 1 : 0,
+        generator.emitBodyWithUsingIfNeeded(isUsingDeclaration ? 1 : 0, isAwaitUsingDeclaration,
             scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
                 emitBody(generator);
             })
@@ -5212,7 +5219,7 @@ void SwitchNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 
     generator.pushLexicalScope(this, BytecodeGenerator::ScopeType::LetConstScope, BytecodeGenerator::TDZCheckOptimization::DoNotOptimize, BytecodeGenerator::NestedScopeType::IsNested);
 
-    generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(),
+    generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(), hasAwaitUsingDeclaration(),
         scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
             m_block->emitBytecodeForBlock(generator, r0.get(), dst);
         })
@@ -5408,7 +5415,7 @@ static void emitProgramNodeBytecode(BytecodeGenerator& generator, ScopeNode& sco
     generator.emitLoad(dstRegister.get(), jsUndefined());
     generator.emitProfileControlFlow(scopeNode.startStartOffset());
 
-    generator.emitBodyWithUsingIfNeeded(scopeNode.usingDeclarationCount(),
+    generator.emitBodyWithUsingIfNeeded(scopeNode.usingDeclarationCount(), scopeNode.hasAwaitUsingDeclaration(),
         scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
             scopeNode.emitStatementsBytecode(generator, dstRegister.get());
         })
@@ -5441,7 +5448,7 @@ void EvalNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
     RefPtr<RegisterID> dstRegister = generator.newTemporary();
     generator.emitLoad(dstRegister.get(), jsUndefined());
 
-    generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(),
+    generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(), hasAwaitUsingDeclaration(),
         scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
             emitStatementsBytecode(generator, dstRegister.get());
         })
@@ -5540,7 +5547,7 @@ void FunctionNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
             Ref<Label> catchLabel = generator.newLabel();
             Ref<Label> tryStartLabel = generator.newEmittedLabel();
             TryData* tryData = generator.pushTry(tryStartLabel.get(), catchLabel.get(), HandlerType::Catch);
-            generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(),
+            generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(), hasAwaitUsingDeclaration(),
                 scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
                     emitStatementsBytecode(generator, generator.ignoredResult());
                 })
@@ -5710,7 +5717,7 @@ void FunctionNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
 
     case SourceParseMode::AsyncArrowFunctionBodyMode:
     case SourceParseMode::AsyncFunctionBodyMode: {
-        generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(),
+        generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(), hasAwaitUsingDeclaration(),
             scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
                 emitStatementsBytecode(generator, generator.ignoredResult());
             })
@@ -5721,7 +5728,7 @@ void FunctionNode::emitBytecode(BytecodeGenerator& generator, RegisterID*)
     }
 
     default: {
-        generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(),
+        generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(), hasAwaitUsingDeclaration(),
             scopedLambda<void(BytecodeGenerator&)>([&](BytecodeGenerator& generator) {
                 emitStatementsBytecode(generator, generator.ignoredResult());
             })
@@ -6444,7 +6451,7 @@ void BindingNode::finishDirectBindingAssignment(BytecodeGenerator& generator) co
 void BindingNode::bindValue(BytecodeGenerator& generator, RegisterID* value) const
 {
     Variable var = generator.variable(m_boundProperty);
-    bool isReadOnly = var.isReadOnly() && m_bindingContext != AssignmentContext::ConstDeclarationStatement && m_bindingContext != AssignmentContext::UsingDeclarationStatement;
+    bool isReadOnly = var.isReadOnly() && m_bindingContext != AssignmentContext::ConstDeclarationStatement && !isUsingOrAwaitUsingAssignmentContext(m_bindingContext);
     if (RegisterID* local = var.local()) {
         if (m_bindingContext == AssignmentContext::AssignmentExpression)
             generator.emitTDZCheckIfNecessary(var, local, nullptr);
@@ -6454,9 +6461,9 @@ void BindingNode::bindValue(BytecodeGenerator& generator, RegisterID* value) con
         }
         generator.move(local, value);
         generator.emitProfileType(local, var, divotStart(), divotEnd());
-        if (m_bindingContext == AssignmentContext::UsingDeclarationStatement)
-            generator.emitPrepareDisposable(local, divotStart());
-        if (m_bindingContext == AssignmentContext::DeclarationStatement || m_bindingContext == AssignmentContext::ConstDeclarationStatement || m_bindingContext == AssignmentContext::UsingDeclarationStatement)
+        if (isUsingOrAwaitUsingAssignmentContext(m_bindingContext))
+            generator.emitPrepareDisposable(local, divotStart(), m_bindingContext == AssignmentContext::AwaitUsingDeclarationStatement);
+        if (m_bindingContext != AssignmentContext::AssignmentExpression)
             generator.liftTDZCheckIfPossible(var);
         return;
     }
@@ -6472,9 +6479,9 @@ void BindingNode::bindValue(BytecodeGenerator& generator, RegisterID* value) con
     }
     generator.emitPutToScope(scope.get(), var, value, generator.ecmaMode().isStrict() ? ThrowIfNotFound : DoNotThrowIfNotFound, initializationModeForAssignmentContext(m_bindingContext));
     generator.emitProfileType(value, var, divotStart(), divotEnd());
-    if (m_bindingContext == AssignmentContext::UsingDeclarationStatement)
-        generator.emitPrepareDisposable(value, divotStart());
-    if (m_bindingContext == AssignmentContext::DeclarationStatement || m_bindingContext == AssignmentContext::ConstDeclarationStatement || m_bindingContext == AssignmentContext::UsingDeclarationStatement)
+    if (isUsingOrAwaitUsingAssignmentContext(m_bindingContext))
+        generator.emitPrepareDisposable(value, divotStart(), m_bindingContext == AssignmentContext::AwaitUsingDeclarationStatement);
+    if (m_bindingContext != AssignmentContext::AssignmentExpression)
         generator.liftTDZCheckIfPossible(var);
     return;
 }

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -388,6 +388,8 @@ public:
             metadata->setEcmaName(ident);
         } else if (rhs->isClassExprNode())
             static_cast<ClassExprNode*>(rhs)->setEcmaName(ident);
+        if (assignmentContext == AssignmentContext::AwaitUsingDeclarationStatement)
+            usesAwait();
         AssignResolveNode* node = new (m_parserArena) AssignResolveNode(location, ident, rhs, assignmentContext);
         setExceptionLocation(node, start, divot, end);
         return node;
@@ -1067,6 +1069,8 @@ public:
 
     BindingPattern createBindingLocation(const JSTokenLocation&, const Identifier& boundProperty, const JSTextPosition& start, const JSTextPosition& end, AssignmentContext context)
     {
+        if (context == AssignmentContext::AwaitUsingDeclarationStatement)
+            usesAwait();
         return new (m_parserArena) BindingNode(boundProperty, start, end, context);
     }
 

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -103,6 +103,7 @@ namespace JSC {
         DeclarationStatement,
         ConstDeclarationStatement,
         UsingDeclarationStatement,
+        AwaitUsingDeclarationStatement,
         AssignmentExpression
     };
 
@@ -283,6 +284,7 @@ namespace JSC {
         FunctionStack& functionStack() LIFETIME_BOUND { return m_functionStack; }
 
         bool hasUsingDeclaration() const { return m_lexicalVariables.hasUsingDeclaration(); }
+        bool hasAwaitUsingDeclaration() const { return m_lexicalVariables.hasAwaitUsingDeclaration(); }
         unsigned usingDeclarationCount() const { return m_lexicalVariables.usingDeclarationCount(); }
 
     protected:

--- a/Source/JavaScriptCore/parser/Parser.cpp
+++ b/Source/JavaScriptCore/parser/Parser.cpp
@@ -819,6 +819,30 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatementList
         }
         [[fallthrough]];
     case AWAIT:
+        if (Options::useExplicitResourceManagement()
+            && match(AWAIT)
+            && !m_parserState.classFieldInitMasksAsync
+            && (currentFunctionScope()->isAsyncFunctionBoundary() || isModuleParseMode(sourceParseMode()))) [[unlikely]] {
+            SavePoint savePoint = createSavePoint(context);
+            next();
+            if (!m_lexer->hasLineTerminatorBeforeToken()
+                && match(IDENT)
+                && *m_token.m_data.ident == m_vm.propertyNames->usingIdentifier
+                && !m_token.m_data.escaped) {
+                next();
+                if (!m_lexer->hasLineTerminatorBeforeToken() && matchSpecIdentifier()) {
+                    restoreSavePoint(context, savePoint);
+                    semanticFailIfTrue(currentScope()->isGlobalCode() && !currentScope()->isModuleCode() && m_statementDepth == 1, "'await using' declaration is not allowed at the top level of a script or eval");
+                    semanticFailIfTrue(m_insideSwitchCaseBody, "'await using' declaration is not allowed directly in a switch case or default clause");
+                    currentFunctionScope()->setUsesAwait();
+                    result = parseVariableDeclaration(context, DeclarationType::AwaitUsingDeclaration);
+                    shouldSetPauseLocation = true;
+                    break;
+                }
+            }
+            restoreSavePoint(context, savePoint);
+        }
+        [[fallthrough]];
     case YIELD: {
         if (currentScope()->isStaticBlock()) [[unlikely]] {
             failIfTrue(match(YIELD), "Cannot use 'yield' within static block");
@@ -853,7 +877,9 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseStatementList
 template <typename LexerType>
 template <class TreeBuilder> TreeStatement Parser<LexerType>::parseVariableDeclaration(TreeBuilder& context, DeclarationType declarationType, ExportType exportType)
 {
-    ASSERT(match(VAR) || match(LET) || match(CONSTTOKEN) || (declarationType == DeclarationType::UsingDeclaration && match(IDENT)));
+    ASSERT(match(VAR) || match(LET) || match(CONSTTOKEN)
+        || (declarationType == DeclarationType::UsingDeclaration && match(IDENT))
+        || (declarationType == DeclarationType::AwaitUsingDeclaration && match(AWAIT)));
     JSTokenLocation location(tokenLocation());
     int start = tokenLine();
     int end = 0;
@@ -920,19 +946,23 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseWhileStatemen
 template <typename LexerType>
 template <class TreeBuilder> TreeExpression Parser<LexerType>::parseVariableDeclarationList(TreeBuilder& context, int& declarations, TreeDestructuringPattern& lastPattern, TreeExpression& lastInitializer, JSTextPosition& identStart, JSTextPosition& initStart, JSTextPosition& initEnd, VarDeclarationListContext declarationListContext, DeclarationType declarationType, ExportType exportType, bool& forLoopConstDoesNotHaveInitializer)
 {
-    ASSERT(declarationType == DeclarationType::LetDeclaration || declarationType == DeclarationType::VarDeclaration || declarationType == DeclarationType::ConstDeclaration || declarationType == DeclarationType::UsingDeclaration);
+    ASSERT(declarationType == DeclarationType::LetDeclaration || declarationType == DeclarationType::VarDeclaration || declarationType == DeclarationType::ConstDeclaration || declarationType == DeclarationType::UsingDeclaration || declarationType == DeclarationType::AwaitUsingDeclaration);
     TreeExpression head = 0;
     JSTokenLocation headLocation;
     TreeExpression tail = 0;
     const Identifier* lastIdent;
     JSToken lastIdentToken;
     AssignmentContext assignmentContext = assignmentContextFromDeclarationType(declarationType);
-    bool isUsingDeclaration = declarationType == DeclarationType::UsingDeclaration;
+    bool isUsingDeclaration = declarationType == DeclarationType::UsingDeclaration || declarationType == DeclarationType::AwaitUsingDeclaration;
     do {
         lastPattern = TreeDestructuringPattern(0);
         lastIdent = nullptr;
         JSTokenLocation location(tokenLocation());
         next();
+        if (!head && declarationType == DeclarationType::AwaitUsingDeclaration) {
+            ASSERT(match(IDENT) && *m_token.m_data.ident == m_vm.propertyNames->usingIdentifier);
+            next();
+        }
         if (head) {
             // Move the location of subsequent declarations after the comma.
             location = tokenLocation();
@@ -949,7 +979,7 @@ template <class TreeBuilder> TreeExpression Parser<LexerType>::parseVariableDecl
         }
         if (matchSpecIdentifier()) {
             semanticFailIfTrue(currentScope()->isStaticBlock() && isArgumentsIdentifier(), "Cannot use 'arguments' as an identifier in static block");
-            failIfTrue(isPossiblyEscapedLet(m_token) && (declarationType == DeclarationType::LetDeclaration || declarationType == DeclarationType::ConstDeclaration || declarationType == DeclarationType::UsingDeclaration),
+            failIfTrue(isPossiblyEscapedLet(m_token) && (declarationType == DeclarationType::LetDeclaration || declarationType == DeclarationType::ConstDeclaration || isUsingDeclaration),
                 "Cannot use 'let' as an identifier name for a LexicalDeclaration");
             semanticFailIfTrue(isDisallowedIdentifierAwait(m_token), "Cannot use 'await' as a ", declarationTypeToVariableKind(declarationType), " ", disallowedIdentifierAwaitReason());
             JSTextPosition varStart = tokenStartPosition();
@@ -1474,6 +1504,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseForStatement(
     bool isLetDeclaration = match(LET);
     bool isConstDeclaration = match(CONSTTOKEN);
     bool isUsingDeclaration = false;
+    bool isAwaitUsingDeclaration = false;
     if (Options::useExplicitResourceManagement() && match(IDENT)
         && *m_token.m_data.ident == m_vm.propertyNames->usingIdentifier
         && !m_token.m_data.escaped) {
@@ -1493,26 +1524,46 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseForStatement(
                 isUsingDeclaration = true;
         }
         restoreSavePoint(context, savePoint);
+    } else if (Options::useExplicitResourceManagement() && match(AWAIT)
+        && !m_parserState.classFieldInitMasksAsync
+        && (currentFunctionScope()->isAsyncFunctionBoundary() || isModuleParseMode(sourceParseMode()))) {
+        SavePoint savePoint = createSavePoint(context);
+        next();
+        if (!m_lexer->hasLineTerminatorBeforeToken()
+            && match(IDENT)
+            && *m_token.m_data.ident == m_vm.propertyNames->usingIdentifier
+            && !m_token.m_data.escaped) {
+            next();
+            // Note: unlike sync `using`, there is no [lookahead != `of`] constraint for `await using`,
+            // so `for (await using of of expr)` binds `of` as an identifier.
+            if (!m_lexer->hasLineTerminatorBeforeToken() && matchSpecIdentifier())
+                isAwaitUsingDeclaration = true;
+        }
+        restoreSavePoint(context, savePoint);
+        if (isAwaitUsingDeclaration)
+            currentFunctionScope()->setUsesAwait();
     }
+    bool isAnyUsingDeclaration = isUsingDeclaration || isAwaitUsingDeclaration;
+    bool isLexicalDeclaration = isLetDeclaration || isConstDeclaration || isAnyUsingDeclaration;
     bool forLoopConstDoesNotHaveInitializer = false;
     bool forLoopinitializerContainsClosure = false;
 
     AutoCleanupLexicalScope lexicalScope;
 
     auto popLexicalScopeIfNecessary = [&]() -> VariableEnvironment {
-        if (isLetDeclaration || isConstDeclaration || isUsingDeclaration) {
+        if (isLexicalDeclaration) {
             auto [lexicalVariables, functionDeclarations] = popScope(lexicalScope, TreeBuilder::NeedsFreeVariableInfo);
             return lexicalVariables;
         }
         return { };
     };
 
-    if (isVarDeclaration || isLetDeclaration || isConstDeclaration || isUsingDeclaration) {
+    if (isVarDeclaration || isLexicalDeclaration) {
         /*
          for (var/let/const/using IDENT in/of expression) statement
          for (var/let/const varDeclarationList; expressionOpt; expressionOpt)
          */
-        if (isLetDeclaration || isConstDeclaration || isUsingDeclaration) {
+        if (isLexicalDeclaration) {
             Scope* newScope = pushScope();
             newScope->setIsLexicalScope();
             newScope->preventVarDeclarations();
@@ -1533,6 +1584,8 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseForStatement(
             declarationType = DeclarationType::ConstDeclaration;
         else if (isUsingDeclaration)
             declarationType = DeclarationType::UsingDeclaration;
+        else if (isAwaitUsingDeclaration)
+            declarationType = DeclarationType::AwaitUsingDeclaration;
         else
             RELEASE_ASSERT_NOT_REACHED();
         unsigned candidateCountBeforeInitializer = currentScope()->closedVariableCandidates().size();
@@ -1555,7 +1608,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseForStatement(
             isOfEnumeration = true;
             next();
         } else {
-            failIfTrue(isUsingDeclaration, "Cannot use 'using' declaration in for-in loop");
+            failIfTrue(isAnyUsingDeclaration, "Cannot use 'using' declaration in for-in loop");
             failIfFalse(!isAwaitFor, "Expected 'of' in for-await syntax");
             next();
         }
@@ -1620,7 +1673,7 @@ template <class TreeBuilder> TreeStatement Parser<LexerType>::parseForStatement(
         next();
         TreeExpression condition = 0;
         failIfTrue(forLoopConstDoesNotHaveInitializer && isConstDeclaration, "const variables in for loops must have initializers");
-        failIfTrue(forLoopConstDoesNotHaveInitializer && isUsingDeclaration, "'using' declaration requires an initializer");
+        failIfTrue(forLoopConstDoesNotHaveInitializer && isAnyUsingDeclaration, "'using' declaration requires an initializer");
         
         if (!match(SEMICOLON)) {
             condition = parseExpression(context);

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -91,6 +91,7 @@ enum class DeclarationType {
     LetDeclaration,
     ConstDeclaration,
     UsingDeclaration,
+    AwaitUsingDeclaration,
 };
 
 enum class DeclarationImportType {
@@ -456,7 +457,7 @@ public:
     DeclarationStacks::FunctionStack takeFunctionDeclarations() { return WTF::move(m_functionDeclarations); }
     
 
-    DeclarationResultMask declareLexicalVariable(const Identifier* ident, bool isConstant, DeclarationImportType importType = DeclarationImportType::NotImported, bool isUsing = false)
+    DeclarationResultMask declareLexicalVariable(const Identifier* ident, bool isConstant, DeclarationImportType importType = DeclarationImportType::NotImported, bool isUsing = false, bool isAwaitUsing = false)
     {
         ASSERT(m_allowsLexicalDeclarations);
         DeclarationResultMask result = DeclarationResult::Valid;
@@ -469,6 +470,8 @@ public:
             addResult.iterator->value.setIsLet();
         if (isUsing)
             addResult.iterator->value.setIsUsing();
+        if (isAwaitUsing)
+            m_lexicalVariables.setHasAwaitUsingDeclaration();
 
         if (importType == DeclarationImportType::Imported)
             addResult.iterator->value.setIsImported();
@@ -1166,6 +1169,7 @@ private:
         case DeclarationType::ConstDeclaration:
             return DestructuringKind::DestructureToConst;
         case DeclarationType::UsingDeclaration:
+        case DeclarationType::AwaitUsingDeclaration:
             RELEASE_ASSERT_NOT_REACHED();
             return DestructuringKind::DestructureToVariables;
         }
@@ -1183,6 +1187,7 @@ private:
         case DeclarationType::ConstDeclaration:
             return "lexical variable name";
         case DeclarationType::UsingDeclaration:
+        case DeclarationType::AwaitUsingDeclaration:
             return "using variable name";
         }
         RELEASE_ASSERT_NOT_REACHED();
@@ -1196,6 +1201,8 @@ private:
             return AssignmentContext::ConstDeclarationStatement;
         case DeclarationType::UsingDeclaration:
             return AssignmentContext::UsingDeclarationStatement;
+        case DeclarationType::AwaitUsingDeclaration:
+            return AssignmentContext::AwaitUsingDeclarationStatement;
         default:
             return AssignmentContext::DeclarationStatement;
         }
@@ -1382,7 +1389,7 @@ private:
         if (type == DeclarationType::VarDeclaration)
             return declareHoistedVariable(ident);
 
-        ASSERT(type == DeclarationType::LetDeclaration || type == DeclarationType::ConstDeclaration || type == DeclarationType::UsingDeclaration);
+        ASSERT(type == DeclarationType::LetDeclaration || type == DeclarationType::ConstDeclaration || type == DeclarationType::UsingDeclaration || type == DeclarationType::AwaitUsingDeclaration);
         // Lexical variables declared at a top level scope that shadow arguments or vars are not allowed.
         if (!m_lexer->isReparsingFunction() && m_statementDepth == 1 && (hasDeclaredParameter(*ident) || hasDeclaredVariable(*ident)))
             return DeclarationResult::InvalidDuplicateDeclaration;
@@ -1391,8 +1398,9 @@ private:
         if (scope->isCatchBlockScope() && scope->containingScope()->hasLexicallyDeclaredVariable(*ident))
             return DeclarationResult::InvalidDuplicateDeclaration;
 
-        bool isUsing = type == DeclarationType::UsingDeclaration;
-        return scope->declareLexicalVariable(ident, type == DeclarationType::ConstDeclaration || isUsing, importType, isUsing);
+        bool isAwaitUsing = type == DeclarationType::AwaitUsingDeclaration;
+        bool isUsing = type == DeclarationType::UsingDeclaration || isAwaitUsing;
+        return scope->declareLexicalVariable(ident, type == DeclarationType::ConstDeclaration || isUsing, importType, isUsing, isAwaitUsing);
     }
 
     std::pair<DeclarationResultMask, Scope*> declareFunction(const Identifier* ident)

--- a/Source/JavaScriptCore/parser/VariableEnvironment.cpp
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.cpp
@@ -98,7 +98,8 @@ bool VariableEnvironment::captures(UniquedStringImpl* identifier) const
 void VariableEnvironment::swap(VariableEnvironment& other)
 {
     m_map.swap(other.m_map);
-    m_isEverythingCaptured = other.m_isEverythingCaptured;
+    std::swap(m_isEverythingCaptured, other.m_isEverythingCaptured);
+    std::swap(m_hasAwaitUsingDeclaration, other.m_hasAwaitUsingDeclaration);
     m_rareData.swap(other.m_rareData);
 }
 

--- a/Source/JavaScriptCore/parser/VariableEnvironment.h
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.h
@@ -154,12 +154,14 @@ public:
     VariableEnvironment(VariableEnvironment&& other)
         : m_map(WTF::move(other.m_map))
         , m_isEverythingCaptured(other.m_isEverythingCaptured)
+        , m_hasAwaitUsingDeclaration(other.m_hasAwaitUsingDeclaration)
         , m_rareData(WTF::move(other.m_rareData))
     {
     }
     VariableEnvironment(const VariableEnvironment& other)
         : m_map(other.m_map)
         , m_isEverythingCaptured(other.m_isEverythingCaptured)
+        , m_hasAwaitUsingDeclaration(other.m_hasAwaitUsingDeclaration)
         , m_rareData(other.m_rareData ? WTF::makeUnique<VariableEnvironment::RareData>(*other.m_rareData) : nullptr)
     {
     }
@@ -214,6 +216,8 @@ public:
         }
         return count;
     }
+    bool hasAwaitUsingDeclaration() const { return m_hasAwaitUsingDeclaration; }
+    void setHasAwaitUsingDeclaration() { m_hasAwaitUsingDeclaration = true; }
     bool isEmpty() const { return !m_map.size() && !privateNamesSize(); }
 
     using PrivateNamesRange = WTF::IteratorRange<PrivateNameEnvironment::iterator>;
@@ -339,6 +343,7 @@ private:
 
     Map m_map;
     bool m_isEverythingCaptured { false };
+    bool m_hasAwaitUsingDeclaration { false };
 
     PrivateNameEntry& getOrAddPrivateName(UniquedStringImpl* impl)
     {

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -1072,6 +1072,7 @@ public:
     void encode(Encoder& encoder, const VariableEnvironment& env)
     {
         m_isEverythingCaptured = env.m_isEverythingCaptured;
+        m_hasAwaitUsingDeclaration = env.m_hasAwaitUsingDeclaration;
         m_map.encode(encoder, env.m_map);
         m_rareData.encode(encoder, env.m_rareData.get());
     }
@@ -1079,6 +1080,7 @@ public:
     void decode(Decoder& decoder, VariableEnvironment& env) const
     {
         env.m_isEverythingCaptured = m_isEverythingCaptured;
+        env.m_hasAwaitUsingDeclaration = m_hasAwaitUsingDeclaration;
         m_map.decode(decoder, env.m_map);
         if (!m_rareData.isEmpty()) {
             env.m_rareData = WTF::makeUnique<VariableEnvironment::RareData>();
@@ -1088,6 +1090,7 @@ public:
 
 private:
     bool m_isEverythingCaptured;
+    bool m_hasAwaitUsingDeclaration;
     CachedHashMap<CachedRefPtr<CachedUniquedStringImpl, UniquedStringImpl, WTF::PackedPtrTraits<UniquedStringImpl>>, VariableEnvironmentEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>, VariableEnvironmentEntryHashTraits> m_map;
     CachedPtr<CachedVariableEnvironmentRareData> m_rareData;
 };


### PR DESCRIPTION
#### 92e52221d299ee0a0aa4359f476eb82d0c975e00
<pre>
[JSC] Implement `await using` syntax from Explicit Resource Management proposal
<a href="https://bugs.webkit.org/show_bug.cgi?id=309673">https://bugs.webkit.org/show_bug.cgi?id=309673</a>

Reviewed by Yusuke Suzuki.

This patch implements `await using` declarations from the Explicit Resource
Management proposal, completing the syntax-level support for the proposal
alongside the previously landed synchronous `using` declarations.

An `await using` declaration invokes the @@asyncDispose method of a resource
when the enclosing scope is exited, awaiting the result. If @@asyncDispose is
absent, it falls back to @@dispose wrapped in a promise-returning closure per
the spec&apos;s GetDisposeMethod(V, async-dispose).

This patch extends the parser and bytecode compiler. No new bytecodes are
introduced; the existing op_yield / Generatorification machinery handles the
suspend points.

** Parser **

The parser recognizes `await [no LineTerminator here] using [no LineTerminator
here] BindingList` in contexts where `await` is a keyword: async functions,
async generators, and the top level of modules. Both no-LineTerminator
constraints are checked via two-token lookahead with savepoint restore. Like
sync `using`, it is a SyntaxError at script/eval top level and directly inside
switch case/default clauses; destructuring patterns are disallowed.

`await using` also appears in for-of heads, both `for (await using x of ...)`
and `for await (await using x of ...)`. Unlike sync `using`, the lookahead
permits `for (await using of of ...)` where the first `of` is a binding name.

Crucially, when an `await using` is seen, the parser calls setUsesAwait() on
the current function scope. Without this, the isAsyncFunctionWithoutAwait
optimization would inline the body into the wrapper, leaving no generator
register for emitAwait to use.

A separate boolean m_hasAwaitUsingDeclaration is added to VariableEnvironment
(rather than a new Traits bit, as uint16_t m_bits is already full) so the
bytecode generator can determine whether any slot in a given scope is async.

** Bytecode Compiler **

The UsingSlot structure gains two fields: a `reached` boolean register and an
`isAsync` compile-time flag. Unlike sync `using`, where `method == undefined`
alone suffices to skip a slot (covering both &quot;not reached&quot; and &quot;null value&quot;),
async requires distinguishing the two because `await using x = null` must still
produce exactly one Await(undefined) at disposal time, per the spec&apos;s
needsAwait/hasAwaited protocol.

The reached register is set to true only after @getAsyncDisposeMethod returns
successfully; if the method lookup throws, the slot is treated as never
reached, avoiding a spurious Await(undefined) before propagating the error.

The finally block maintains two runtime registers, needsAwait and hasAwaited,
mirroring DisposeResources steps 3-6. These ensure multiple null `await using`
declarations produce at most one Await(undefined). A compile-time cursor tracks
whether any async slot has been encountered yet in disposal order; Step 3.d
checks and the trailing Step 6 check are elided where statically unreachable,
reducing unnecessary yield points.

For a scope mixing sync and async:

  {
    using a = resource1;       // sync
    await using b = resource2; // async
  }

The generated disposal sequence is:

  // slot[1] (async, disposed first): call b[@@asyncDispose], await result
  //   - if method undefined (null value): needsAwait = true
  //   - if call succeeds: hasAwaited = true; await result
  // slot[0] (sync):
  //   - Step 3.d: if needsAwait &amp;&amp; !hasAwaited, Await(undefined)
  //   - call a[@@dispose]
  // trailing: elided (slot[0] is sync)

** Built-in **

A new link-time constant @getAsyncDisposeMethod implements GetDisposeMethod
with async-dispose hint: it tries @@asyncDispose first, then falls back to
@@dispose wrapped in a closure that calls the sync method, discards its return
value, and resolves to undefined (or rejects on throw). This replaces the
previous @getAsyncDisposableMethod, which lacked the fallback.

Tests: JSTests/stress/await-using-declaration-basic.js
       JSTests/stress/await-using-declaration-error.js
       JSTests/stress/await-using-declaration-for-of.js
       JSTests/stress/await-using-declaration-generator.js
       JSTests/stress/await-using-declaration-mixed.js
       JSTests/stress/await-using-declaration-syntax-errors.js

* JSTests/stress/await-using-declaration-basic.js: Added.
(shouldBe):
(async test):
(async testReverseOrder):
(async testNull.promise):
(async testMixed):
(async testSyncFallback):
(async testAsyncDisposeReturnValueAwaited):
(async testNotEvaluatedNoAwait.promise):
(async main):
* JSTests/stress/await-using-declaration-error.js: Added.
(shouldBe):
(async await):
(async testDisposeThrows):
(async testDisposeRejects):
(async testSuppressedError):
(async testBodyThrowThenDisposeThrow):
(async testSyncFallbackThrows):
(async testMethodLookupThrowNoAwait.async inner):
(async main):
* JSTests/stress/await-using-declaration-for-of.js: Added.
(shouldBe):
(async testForOf):
(async testForAwaitOf):
(async testForOfContinue):
(async testForOfBreak):
(async main):
(main.then):
* JSTests/stress/await-using-declaration-generator.js: Added.
(shouldBe):
(async testAsyncGenerator.async gen):
(async testAsyncGeneratorReturn.async gen):
(async testAsyncGeneratorNestedBlocks.async gen):
(async main):
* JSTests/stress/await-using-declaration-mixed.js: Added.
(shouldBe):
(async testSyncThenAsync):
(async testAsyncThenSync):
(async testInterleaved):
(async testMixedWithNullAwaitUsing.p):
(async testMixedSuppressedError):
(async main):
* JSTests/stress/await-using-declaration-syntax-errors.js: Added.
(shouldThrowSyntaxError):
(shouldThrowSyntaxError.f):
(async shouldThrowSyntaxError):
(async shouldNotThrowSyntaxError):
* JSTests/test262/config.yaml:
* Source/JavaScriptCore/builtins/DisposableStackPrototype.js:
(linkTimeConstant.createDisposableResource):
(linkTimeConstant.getAsyncDisposeMethod):
(linkTimeConstant.getAsyncDisposableMethod): Deleted.
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.cpp:
(JSC::BytecodeGenerator::emitPrepareDisposable):
(JSC::BytecodeGenerator::emitUsingBodyScope):
(JSC::BytecodeGenerator::emitBodyWithUsingIfNeeded):
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::initializationModeForAssignmentContext):
(JSC::isUsingOrAwaitUsingAssignmentContext):
(JSC::AssignResolveNode::emitBytecode):
(JSC::BlockNode::emitBytecode):
(JSC::ForNode::emitBytecode):
(JSC::ForOfNode::emitBytecode):
(JSC::SwitchNode::emitBytecode):
(JSC::emitProgramNodeBytecode):
(JSC::EvalNode::emitBytecode):
(JSC::FunctionNode::emitBytecode):
(JSC::BindingNode::bindValue const):
* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::createAssignResolve):
(JSC::ASTBuilder::createBindingLocation):
* Source/JavaScriptCore/parser/Nodes.h:
(JSC::VariableEnvironmentNode::hasAwaitUsingDeclaration const):
* Source/JavaScriptCore/parser/Parser.cpp:
(JSC::Parser&lt;LexerType&gt;::parseStatementListItem):
(JSC::Parser&lt;LexerType&gt;::parseVariableDeclaration):
(JSC::Parser&lt;LexerType&gt;::parseVariableDeclarationList):
(JSC::Parser&lt;LexerType&gt;::parseForStatement):
* Source/JavaScriptCore/parser/Parser.h:
(JSC::Scope::declareLexicalVariable):
* Source/JavaScriptCore/parser/VariableEnvironment.cpp:
(JSC::VariableEnvironment::swap):
* Source/JavaScriptCore/parser/VariableEnvironment.h:
(JSC::VariableEnvironment::VariableEnvironment):
(JSC::VariableEnvironment::hasAwaitUsingDeclaration const):
(JSC::VariableEnvironment::setHasAwaitUsingDeclaration):
* Source/JavaScriptCore/runtime/CachedTypes.cpp:
(JSC::CachedVariableEnvironment::encode):
(JSC::CachedVariableEnvironment::decode const):

Canonical link: <a href="https://commits.webkit.org/309389@main">https://commits.webkit.org/309389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/86e61b38eda4499bf8cc773b0d8eaf30c4e3aee1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22073 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158059 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102792 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115178 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81944 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152320 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95925 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16434 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14311 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5903 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141330 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160538 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10151 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3531 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13495 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123218 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123435 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33759 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21884 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133759 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78102 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18670 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10505 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180789 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21486 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85299 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46323 "Build was cancelled. Recent messages:") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21217 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21366 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->