### PR TITLE
Parsing multipart form data should check that the boundary is followed by CRLF or "--"

### DIFF
--- a/LayoutTests/http/wpt/fetch/resources/wrong-form-data.py
+++ b/LayoutTests/http/wpt/fetch/resources/wrong-form-data.py
@@ -1,0 +1,11 @@
+from wptserve.utils import isomorphic_decode
+
+
+def main(request, response):
+    value = request.GET.first(b"value", b"")
+    body = b"--boundary" + value + b"--boundary--\r\n"
+    headers = [(b"Content-Type", b"multipart/form-data; boundary=boundary"),
+               (b"Cache-Control", b"no-cache"),
+               (b"Pragma", b"no-cache")]
+
+    return 200, headers, body

--- a/LayoutTests/http/wpt/fetch/wrong-form-data-expected.txt
+++ b/LayoutTests/http/wpt/fetch/wrong-form-data-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Validate buggy form data - empty
+PASS Validate buggy form data - cr
+PASS Validate buggy form data - cr_
+PASS Validate buggy form data - dashes
+

--- a/LayoutTests/http/wpt/fetch/wrong-form-data.html
+++ b/LayoutTests/http/wpt/fetch/wrong-form-data.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="help" href="https://fetch.spec.whatwg.org/#request">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <script>
+const urlsToCheck = [
+    ["empty", ""],
+    ["cr", "?value=%0A"],
+    ["cr_", "?value=%0A_"],
+    ["dashes", "?value=-%20-"]
+];
+
+urlsToCheck.forEach(url => {
+    promise_test(async t => {
+    const response = await fetch("resources/wrong-form-data.py" + url[1]);
+    await promise_rejects_js(t, TypeError, response.formData());
+    }, "Validate buggy form data - " + url[0]);
+});
+    </script>
+  </body>
+</html>

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -208,12 +208,22 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
         size_t currentBoundaryIndex = find(data, boundary.span());
         if (currentBoundaryIndex == notFound)
             return nullptr;
+
         skip(data, currentBoundaryIndex + boundaryLength);
+        if (spanHasPrefix(data, "--\r\n"_span))
+            return form;
+        if (!spanHasPrefix(data, "\r\n"_span))
+            return nullptr;
+
         size_t nextBoundaryIndex;
         while ((nextBoundaryIndex = find(data, boundary.span())) != notFound) {
             parseMultipartPart(data.first(nextBoundaryIndex - oneNewLine.length()), form.get());
             currentBoundaryIndex = nextBoundaryIndex;
             skip(data, nextBoundaryIndex + boundaryLength);
+            if (spanHasPrefix(data, "--\r\n"_span))
+                return form;
+            if (!spanHasPrefix(data, "\r\n"_span))
+                return nullptr;
         }
     } else if (mimeType && equalLettersIgnoringASCIICase(mimeType->type, "application"_s) && equalLettersIgnoringASCIICase(mimeType->subtype, "x-www-form-urlencoded"_s)) {
         auto dataString = String::fromUTF8(data);


### PR DESCRIPTION
#### ff70c312f1bb9b293ae92c92fdbd864c4f0d0dff
<pre>
Parsing multipart form data should check that the boundary is followed by CRLF or &quot;--&quot;
<a href="https://rdar.apple.com/172038722">rdar://172038722</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309676">https://bugs.webkit.org/show_bug.cgi?id=309676</a>

Reviewed by Chris Dumez.

We make sure that the parser checks that next two bytes after the boundary are either &apos;--&apos; or crlf.
Otherwise, we bail out and form data parsing fails.
Covered by added test.

Canonical link: <a href="https://commits.webkit.org/309130@main">https://commits.webkit.org/309130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c41e0caf9d4319d5f211bc535574660339903413

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158262 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2685d31-0bd8-4182-9704-dbf2f5c12987) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115365 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a21f40d7-5bd5-4bf5-a0f2-560f110b9ff5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134216 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96106 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4bc11613-99ae-4c20-87dd-65c0eb3b3b10) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6107 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12148 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160739 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123396 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22081 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123606 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33581 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133940 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78302 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18787 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10691 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21688 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85509 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21419 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21571 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21476 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->