### PR TITLE
Setting model.currentTime doesn't work with the WebModelPlayer

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -691,6 +691,7 @@ NS_SWIFT_SENDABLE
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 
 - (double)currentTime;
+- (void)setCurrentTime:(double)newTime;
 - (double)duration;
 - (void)loadModelFrom:(NSURL *)url;
 - (void)loadModel:(NSData *)data;

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -944,9 +944,7 @@ final class USDModelLoader: _Proto_UsdStageSession_v1.Delegate {
     func loadModel(from url: Foundation.URL) {
         do {
             let stage = try UsdStage(contentsOf: url)
-            self.timeCodePerSecond = stage.timeCodesPerSecond
-            self.startTime = stage.startTimeCode
-            self.endTime = stage.endTimeCode
+            self.setupTimes(from: stage)
             self.usdLoader.loadStage(stage)
         } catch {
             fatalError(error.localizedDescription)
@@ -962,34 +960,38 @@ final class USDModelLoader: _Proto_UsdStageSession_v1.Delegate {
                 logError("model data is corrupted")
                 return
             }
-            self.timeCodePerSecond = stage.timeCodesPerSecond
-            self.startTime = stage.startTimeCode
-            self.endTime = stage.endTimeCode
+            self.setupTimes(from: stage)
             self.usdLoader.loadStage(stage)
         } catch {
             fatalError(error.localizedDescription)
         }
     }
 
-    func duration() -> Double {
-        if timeCodePerSecond > 0 {
-            return (endTime - startTime) / timeCodePerSecond
-        }
+    func setupTimes(from stage: UsdStage) {
+        timeCodePerSecond = stage.timeCodesPerSecond > 0 ? stage.timeCodesPerSecond : 1
+        startTime = stage.startTimeCode / timeCodePerSecond
+        endTime = stage.endTimeCode / timeCodePerSecond
+    }
 
-        return 0.0
+    func duration() -> Double {
+        endTime - startTime
     }
 
     func currentTime() -> Double {
         time - startTime
     }
 
+    func setCurrentTime(_ newTime: Double) {
+        time = startTime + newTime
+    }
+
     func loadModel(from data: Data) {
     }
 
     func update(deltaTime: TimeInterval) {
-        usdLoader.update(time: time)
-
-        time = fmod(deltaTime * self.timeCodePerSecond + time - startTime, max(endTime - startTime, 1)) + startTime
+        let newTime = currentTime() + deltaTime
+        time = startTime + fmod(newTime, max(duration(), 1))
+        usdLoader.update(time: time * timeCodePerSecond)
     }
 }
 
@@ -1063,6 +1065,11 @@ extension WKBridgeModelLoader {
             return 0.0
         }
         return loader.currentTime()
+    }
+
+    @objc
+    func setCurrentTime(_ newTime: Double) {
+        loader?.setCurrentTime(newTime)
     }
 
     fileprivate func updateMesh(webRequest: WKBridgeUpdateMesh) {
@@ -1516,6 +1523,10 @@ extension WKBridgeModelLoader {
     @objc
     func currentTime() -> Double {
         0.0
+    }
+
+    @objc
+    func setCurrentTime(_ newTime: Double) {
     }
 }
 #endif

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.h
@@ -105,6 +105,8 @@ private:
     void setLoop(bool) final;
     void setPaused(bool, CompletionHandler<void(bool succeeded)>&&) final;
     bool paused() const final;
+    Seconds currentTime() const final;
+    void setCurrentTime(Seconds, CompletionHandler<void()>&&) final;
     void play(bool);
     void simulate(float elapsedTime);
     double duration() const final;

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -598,6 +598,18 @@ bool WebModelPlayer::paused() const
     return m_pauseState != PauseState::Playing;
 }
 
+Seconds WebModelPlayer::currentTime() const
+{
+    return Seconds([m_modelLoader currentTime]);
+}
+
+void WebModelPlayer::setCurrentTime(Seconds currentTime, CompletionHandler<void()>&& completion)
+{
+    double clamped = std::clamp(currentTime.seconds(), 0.0, duration());
+    [m_modelLoader setCurrentTime:clamped];
+    completion();
+}
+
 std::optional<WebCore::TransformationMatrix> WebModelPlayer::entityTransform() const
 {
 #if PLATFORM(COCOA)


### PR DESCRIPTION
#### a798a7d546e6bd5e2ba721d3ddf8fa64af9369cb
<pre>
Setting model.currentTime doesn&apos;t work with the WebModelPlayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=309677">https://bugs.webkit.org/show_bug.cgi?id=309677</a>
&lt;<a href="https://rdar.apple.com/172279090">rdar://172279090</a>&gt;

Reviewed by Mike Wyrzykowski.

Add the missing plumbing so that setting the `currentTime` attribute
on a model properly updates the `USDModel`.

* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(USDModelLoader.loadModel(from:)):
(USDModelLoader.loadModel(_:)):
(USDModelLoader.setupTimes(from:)):
(USDModelLoader.duration):
(USDModelLoader.setCurrentTime(_:)):
(USDModelLoader.update(_:)):
(WKBridgeModelLoader.setCurrentTime(_:)):
Clarify animation timing management:
- startTime, endTime, deltaTime all use wall clock values
- the timeCodePerSecond is only applied at the usdLoader boundary

* Source/WebKit/WebProcess/Model/WebModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::currentTime const):
(WebKit::WebModelPlayer::setCurrentTime):
Like in ModelProcessModelPlayer, clamp the currentTime value before
sending it forward.

Canonical link: <a href="https://commits.webkit.org/309098@main">https://commits.webkit.org/309098@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d3186cda454604455ebb05c501a1f8a11333cb9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149374 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158077 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de616f86-356c-40f6-9393-2eb4f8de7fa5) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21965 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115194 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/017f2a65-78c3-42eb-838e-acd0a57a2728) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95940 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6af7f7d4-9eeb-4125-8793-6f559a352125) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16438 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14331 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5917 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126039 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160552 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3545 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123229 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18360 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123446 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33562 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21898 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133778 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78116 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18669 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10524 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21500 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85313 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21231 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21380 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21288 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->