### PR TITLE
font: property serializes incorrectly in Web Inspector

### DIFF
--- a/LayoutTests/inspector/css/font-shorthand-property-value-expected.txt
+++ b/LayoutTests/inspector/css/font-shorthand-property-value-expected.txt
@@ -1,0 +1,37 @@
+Testing that the font shorthand property value is serialized correctly in the Web Inspector.
+
+
+== Running test suite: FontShorthandPropertyValue
+-- Running test case: FontShorthandPropertyValue.SerializedCorrectly
+Property name: font
+Property value: 12px sans-serif
+PASS: Property name should be 'font'.
+PASS: Property value should contain '12px'.
+PASS: Property value should contain 'sans-serif'.
+PASS: Property value should not contain newlines.
+
+-- Running test case: FontShorthandPropertyValue.BoldItalic
+Property name: font
+Property value: italic bold 16px serif
+PASS: Property name should be 'font'.
+PASS: Property value should contain 'bold'.
+PASS: Property value should contain 'italic'.
+PASS: Property value should contain '16px'.
+PASS: Property value should contain 'serif'.
+
+-- Running test case: FontShorthandPropertyValue.WithLineHeight
+Property name: font
+Property value: 14px / 1.5 monospace
+PASS: Property name should be 'font'.
+PASS: Property value should contain '14px'.
+PASS: Property value should contain '1.5'.
+PASS: Property value should contain 'monospace'.
+
+-- Running test case: FontShorthandPropertyValue.NormalValuesNotExpanded
+Property name: font
+Property value: 16px fantasy
+PASS: Property name should be 'font'.
+PASS: Property value should not have redundant 'normal' values (got: '16px fantasy').
+PASS: Property value should contain '16px'.
+PASS: Property value should contain 'fantasy'.
+

--- a/LayoutTests/inspector/css/font-shorthand-property-value.html
+++ b/LayoutTests/inspector/css/font-shorthand-property-value.html
@@ -1,0 +1,165 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("FontShorthandPropertyValue");
+
+    function getNodeStyles(selector) {
+        return new Promise((resolve, reject) => {
+            WI.domManager.requestDocument((documentNode) => {
+                documentNode.querySelector(selector, (contentNodeId) => {
+                    if (!contentNodeId) {
+                        InspectorTest.fail("DOM node not found.");
+                        reject();
+                        return;
+                    }
+
+                    let domNode = WI.domManager.nodeForId(contentNodeId);
+                    let nodeStyles = WI.cssManager.stylesForNode(domNode);
+
+                    if (nodeStyles.needsRefresh) {
+                        nodeStyles.singleFireEventListener(WI.DOMNodeStyles.Event.Refreshed, (event) => {
+                            resolve(nodeStyles);
+                        });
+                    } else
+                        resolve(nodeStyles);
+                });
+            });
+        });
+    }
+
+    suite.addTestCase({
+        name: "FontShorthandPropertyValue.SerializedCorrectly",
+        description: "Test that the font shorthand property value is serialized correctly in the inspector.",
+        async test() {
+            let nodeStyles = await getNodeStyles("#font-shorthand");
+
+            for (let rule of nodeStyles.matchedRules) {
+                if (rule.selectorText !== "#font-shorthand")
+                    continue;
+
+                let fontProperty = rule.style.propertyForName("font");
+                InspectorTest.assert(fontProperty, "Should find a 'font' property.");
+
+                InspectorTest.log("Property name: " + fontProperty.name);
+                InspectorTest.log("Property value: " + fontProperty.value);
+
+                InspectorTest.expectEqual(fontProperty.name, "font", "Property name should be 'font'.");
+                InspectorTest.expectThat(fontProperty.value.includes("12px"), "Property value should contain '12px'.");
+                InspectorTest.expectThat(fontProperty.value.includes("sans-serif"), "Property value should contain 'sans-serif'.");
+
+                // The value should be the properly serialized form, not contain raw subproperties.
+                InspectorTest.expectFalse(fontProperty.value.includes("\n"), "Property value should not contain newlines.");
+            }
+        }
+    });
+
+    suite.addTestCase({
+        name: "FontShorthandPropertyValue.BoldItalic",
+        description: "Test that the font shorthand with bold and italic is serialized correctly.",
+        async test() {
+            let nodeStyles = await getNodeStyles("#font-bold-italic");
+
+            for (let rule of nodeStyles.matchedRules) {
+                if (rule.selectorText !== "#font-bold-italic")
+                    continue;
+
+                let fontProperty = rule.style.propertyForName("font");
+                InspectorTest.assert(fontProperty, "Should find a 'font' property.");
+
+                InspectorTest.log("Property name: " + fontProperty.name);
+                InspectorTest.log("Property value: " + fontProperty.value);
+
+                InspectorTest.expectEqual(fontProperty.name, "font", "Property name should be 'font'.");
+                InspectorTest.expectThat(fontProperty.value.includes("bold"), "Property value should contain 'bold'.");
+                InspectorTest.expectThat(fontProperty.value.includes("italic"), "Property value should contain 'italic'.");
+                InspectorTest.expectThat(fontProperty.value.includes("16px"), "Property value should contain '16px'.");
+                InspectorTest.expectThat(fontProperty.value.includes("serif"), "Property value should contain 'serif'.");
+            }
+        }
+    });
+
+    suite.addTestCase({
+        name: "FontShorthandPropertyValue.WithLineHeight",
+        description: "Test that the font shorthand with line-height is serialized correctly.",
+        async test() {
+            let nodeStyles = await getNodeStyles("#font-line-height");
+
+            for (let rule of nodeStyles.matchedRules) {
+                if (rule.selectorText !== "#font-line-height")
+                    continue;
+
+                let fontProperty = rule.style.propertyForName("font");
+                InspectorTest.assert(fontProperty, "Should find a 'font' property.");
+
+                InspectorTest.log("Property name: " + fontProperty.name);
+                InspectorTest.log("Property value: " + fontProperty.value);
+
+                InspectorTest.expectEqual(fontProperty.name, "font", "Property name should be 'font'.");
+                InspectorTest.expectThat(fontProperty.value.includes("14px"), "Property value should contain '14px'.");
+                InspectorTest.expectThat(fontProperty.value.includes("1.5"), "Property value should contain '1.5'.");
+                InspectorTest.expectThat(fontProperty.value.includes("monospace"), "Property value should contain 'monospace'.");
+            }
+        }
+    });
+
+    suite.addTestCase({
+        name: "FontShorthandPropertyValue.NormalValuesNotExpanded",
+        description: "Test that the font shorthand does not serialize as 'normal normal normal ...' (Bug 15379).",
+        async test() {
+            let nodeStyles = await getNodeStyles("#font-normal-values");
+
+            for (let rule of nodeStyles.matchedRules) {
+                if (rule.selectorText !== "#font-normal-values")
+                    continue;
+
+                let fontProperty = rule.style.propertyForName("font");
+                InspectorTest.assert(fontProperty, "Should find a 'font' property.");
+
+                InspectorTest.log("Property name: " + fontProperty.name);
+                InspectorTest.log("Property value: " + fontProperty.value);
+
+                InspectorTest.expectEqual(fontProperty.name, "font", "Property name should be 'font'.");
+
+                // Before the fix, this would serialize as "normal normal normal 16px / normal fantasy"
+                // with redundant 'normal' values. The properly serialized form omits default 'normal' values.
+                let normalCount = (fontProperty.value.match(/normal/g) || []).length;
+                InspectorTest.expectLessThanOrEqual(normalCount, 1, "Property value should not have redundant 'normal' values (got: '" + fontProperty.value + "').");
+                InspectorTest.expectThat(fontProperty.value.includes("16px"), "Property value should contain '16px'.");
+                InspectorTest.expectThat(fontProperty.value.includes("fantasy"), "Property value should contain 'fantasy'.");
+            }
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Testing that the font shorthand property value is serialized correctly in the Web Inspector.</p>
+
+    <style>
+    #font-shorthand {
+        font: 12px sans-serif;
+    }
+
+    #font-bold-italic {
+        font: italic bold 16px serif;
+    }
+
+    #font-line-height {
+        font: 14px / 1.5 monospace;
+    }
+
+    #font-normal-values {
+        font: normal normal normal 16px / normal fantasy;
+    }
+    </style>
+    <div id="font-shorthand"></div>
+    <div id="font-bold-italic"></div>
+    <div id="font-line-height"></div>
+    <div id="font-normal-values"></div>
+</body>
+</html>

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -840,6 +840,22 @@ Vector<InspectorStyleProperty> InspectorStyle::collectProperties(bool includeAll
     return result;
 }
 
+std::optional<String> InspectorStyle::serializedTextForProperty(const CSSPropertySourceData& sourceData) const
+{
+    if (!sourceData.parsedOk || sourceData.disabled)
+        return std::nullopt;
+
+    auto propertyID = cssPropertyID(sourceData.name);
+    if (propertyID != CSSPropertyFont)
+        return std::nullopt;
+
+    auto serializedValue = m_style->getPropertyValue(sourceData.name);
+    if (serializedValue.isEmpty())
+        return std::nullopt;
+
+    return serializedValue;
+}
+
 Ref<Inspector::Protocol::CSS::CSSStyle> InspectorStyle::styleWithProperties()
 {
     auto properties = collectProperties(false);
@@ -860,9 +876,11 @@ Ref<Inspector::Protocol::CSS::CSSStyle> InspectorStyle::styleWithProperties()
 
         auto status = styleProperty.disabled ? Inspector::Protocol::CSS::CSSPropertyStatus::Disabled : Inspector::Protocol::CSS::CSSPropertyStatus::Active;
 
+        auto propertyValue = serializedTextForProperty(propertyEntry).value_or(propertyEntry.value);
+
         auto property = Inspector::Protocol::CSS::CSSProperty::create()
             .setName(lowercasePropertyName(name))
-            .setValue(propertyEntry.value)
+            .setValue(propertyValue)
             .release();
 
         propertiesObject->addItem(property.copyRef());

--- a/Source/WebCore/inspector/InspectorStyleSheet.h
+++ b/Source/WebCore/inspector/InspectorStyleSheet.h
@@ -29,6 +29,7 @@
 #include "CSSStyleDeclaration.h"
 #include "Settings.h"
 #include <JavaScriptCore/InspectorProtocolObjects.h>
+#include <optional>
 #include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/JSONValues.h>
@@ -140,6 +141,7 @@ private:
 
     Vector<InspectorStyleProperty> collectProperties(bool includeAll);
     Ref<Inspector::Protocol::CSS::CSSStyle> styleWithProperties();
+    std::optional<String> serializedTextForProperty(const CSSPropertySourceData&) const;
     RefPtr<CSSRuleSourceData> extractSourceData() const;
     String shorthandValue(const String& shorthandProperty) const;
     String shorthandPriority(const String& shorthandProperty) const;


### PR DESCRIPTION
#### 44da4af8db1de6f0c792fdd65b71ae67d6978162
<pre>
font: property serializes incorrectly in Web Inspector
<a href="https://bugs.webkit.org/show_bug.cgi?id=15379">https://bugs.webkit.org/show_bug.cgi?id=15379</a>

Reviewed by NOBODY (OOPS!).

When the Web Inspector displays the `font` shorthand property, it previously
showed the raw source text which could contain redundant default values like
&quot;normal normal normal 16px / normal fantasy&quot;. This is because the raw text
from the style declaration was used directly without proper serialization.

The fix adds `serializedTextForProperty()` which, for the `font` shorthand,
uses `getPropertyValue()` to obtain the properly serialized value. This
produces the canonical compact form (e.g. &quot;16px fantasy&quot;) that omits default
`normal` values, matching what `getPropertyValue(&quot;font&quot;)` returns per the
CSSOM specification.

* LayoutTests/inspector/css/font-shorthand-property-value-expected.txt: Added.
* LayoutTests/inspector/css/font-shorthand-property-value.html: Added.
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::InspectorStyle::collectProperties):
(WebCore::InspectorStyle::serializedTextForProperty const):
* Source/WebCore/inspector/InspectorStyleSheet.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44da4af8db1de6f0c792fdd65b71ae67d6978162

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158869 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103590 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115839 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82295 "3 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17953 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134714 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96570 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17053 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15002 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6713 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126668 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12638 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161341 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4432 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14190 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123843 "Found 2 new test failures: inspector/css/modify-inline-style.html media/media-vp8-webm-seek-to-start.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19049 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124044 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22703 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134433 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78990 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19172 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11190 "Found 1 new test failure: inspector/css/modify-inline-style.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22316 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86116 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22030 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22182 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22084 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->