### PR TITLE
[AutoFill Debugging] Prefer case-sensitive matches before falling back to case-insensitive search

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1579,16 +1579,24 @@ static std::optional<SimpleRange> searchForText(Node& node, const String& search
         return std::nullopt;
 
     auto searchRange = makeRangeSelectingNodeContents(node);
-    auto foundRange = findPlainText(searchRange, searchText, {
+    auto caseSensitiveRange = findPlainText(searchRange, searchText, {
+        FindOption::DoNotRevealSelection,
+        FindOption::DoNotSetSelection,
+    });
+
+    if (!caseSensitiveRange.collapsed())
+        return { WTF::move(caseSensitiveRange) };
+
+    auto caseInsensitiveRange = findPlainText(searchRange, searchText, {
         FindOption::DoNotRevealSelection,
         FindOption::DoNotSetSelection,
         FindOption::CaseInsensitive,
     });
 
-    if (foundRange.collapsed())
-        return { };
+    if (!caseInsensitiveRange.collapsed())
+        return { WTF::move(caseInsensitiveRange) };
 
-    return { WTF::move(foundRange) };
+    return { };
 }
 
 static String invalidNodeIdentifierDescription(std::optional<NodeIdentifier>&& identifier)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
@@ -571,9 +571,10 @@ TEST(TextExtractionTests, NodesToSkip)
     }()];
 
     NSArray<NSString *> *lines = [debugText componentsSeparatedByString:@"\n"];
-    EXPECT_EQ([lines count], 2u);
+    EXPECT_EQ([lines count], 3u);
     EXPECT_WK_STREQ("Test", lines[0]);
-    EXPECT_WK_STREQ("0", lines[1]);
+    EXPECT_WK_STREQ("subject SUBJECT", lines[1]);
+    EXPECT_WK_STREQ("0", lines[2]);
 }
 
 TEST(TextExtractionTests, RequestJSHandleForNodeIdentifier)
@@ -616,6 +617,46 @@ TEST(TextExtractionTests, RequestJSHandleForNodeIdentifier)
     }()];
 
     EXPECT_WK_STREQ(debugTextForBody.get(), @"root,'“The quick brown fox jumped over the lazy dog”'");
+}
+
+TEST(TextExtractionTests, RequestJSHandleForNodeIdentifierCaseSensitive)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:^{
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration preferences] _setTextExtractionEnabled:YES];
+        return configuration.autorelease();
+    }()]);
+
+    [webView synchronouslyLoadTestPageNamed:@"debug-text-extraction"];
+
+    RetainPtr extractionResult = [webView synchronouslyExtractDebugTextResult:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setIncludeRects:NO];
+        [configuration setIncludeURLs:NO];
+        return configuration.autorelease();
+    }()];
+
+    RetainPtr debugTextForLowercase = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setIncludeRects:NO];
+        [configuration setIncludeURLs:NO];
+        [configuration setNodeIdentifierInclusion:_WKTextExtractionNodeIdentifierInclusionNone];
+        [configuration setTargetNode:[extractionResult jsHandleForNodeIdentifier:nil searchText:@"subject"]];
+        return configuration.autorelease();
+    }()];
+
+    EXPECT_WK_STREQ(debugTextForLowercase.get(), @"root\n\taria-label='Lowercase','subject'");
+
+    RetainPtr debugTextForUppercase = [webView synchronouslyGetDebugText:^{
+        RetainPtr configuration = adoptNS([_WKTextExtractionConfiguration new]);
+        [configuration setIncludeRects:NO];
+        [configuration setIncludeURLs:NO];
+        [configuration setNodeIdentifierInclusion:_WKTextExtractionNodeIdentifierInclusionNone];
+        [configuration setTargetNode:[extractionResult jsHandleForNodeIdentifier:nil searchText:@"SUBJECT"]];
+        return configuration.autorelease();
+    }()];
+
+    EXPECT_WK_STREQ(debugTextForUppercase.get(), @"root\n\taria-label='Uppercase','SUBJECT'");
 }
 
 TEST(TextExtractionTests, RequestContainerJSHandleForNodeIdentifier)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/debug-text-extraction.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/debug-text-extraction.html
@@ -22,6 +22,10 @@
         <h3 aria-label="Heading">Subject</h3>
         <p>“The quick brown fox jumped over the lazy dog”</p>
     </div>
+    <div aria-label="Case sensitivity test">
+        <span aria-label="Lowercase">subject</span>
+        <span aria-label="Uppercase">SUBJECT</span>
+    </div>
     <h1 class="click-count">0</h1>
     <h4 aria-label="Top secret">Here’s to the crazy ones. The misfits. The rebels. The troublemakers. The round pegs in the square holes. The ones who see things differently. They’re not fond of rules. And they have no respect for the status quo. You can quote them, disagree with them, glorify or vilify them. About the only thing you can’t do is ignore them. Because they change things. They push the human race forward. And while some may see them as the crazy ones, we see genius. Because the people who are crazy enough to think they can change the world, are the ones who do.</h4>
     <script>


### PR DESCRIPTION
#### 37b7ce74854deba90d950e45470b44311cb57af4
<pre>
[AutoFill Debugging] Prefer case-sensitive matches before falling back to case-insensitive search
<a href="https://bugs.webkit.org/show_bug.cgi?id=309680">https://bugs.webkit.org/show_bug.cgi?id=309680</a>
<a href="https://rdar.apple.com/172283407">rdar://172283407</a>

Reviewed by Aditya Keerthi.

Adjust `TextExtraction::searchForText`, such that it prefers exact, case-sensitive text matches in
the DOM before falling back to a case-insensitive search.

Tests: TextExtractionTests.RequestJSHandleForNodeIdentifierCaseSensitive

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::searchForText):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, RequestJSHandleForNodeIdentifierCaseSensitive)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/debug-text-extraction.html:

Canonical link: <a href="https://commits.webkit.org/309074@main">https://commits.webkit.org/309074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/487c75bf1c53a1bd84c8293c23fed61455342037

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149368 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22081 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158068 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115184 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152328 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134032 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95931 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5911 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160546 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13500 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123222 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21884 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123439 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33545 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21892 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133764 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78110 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/18668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10510 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21494 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85307 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21225 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21374 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->