### PR TITLE
Fix outside list-marker painting with relative-positioned block links

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-covered-by-relpos-block-link-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-covered-by-relpos-block-link-expected.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: outside marker covered by relatively positioned block link</title>
+<link rel="author" title="Jason Leo" href="mailto:m.jason.liu@outlook.com">
+<style>
+body {
+  background: white;
+  font: 16px/1.4 sans-serif;
+}
+
+ul {
+  list-style-position: outside;
+  padding-inline-start: 40px;
+}
+
+.hide-marker::marker {
+  color: transparent;
+}
+
+.LinkContainer {
+  width: 290px;
+}
+
+.faqviewmore {
+    background-color: #efefef;
+    display: block;
+    left: -22px;
+    padding-left: 22px;
+    position: relative;
+}
+</style>
+
+<div class="LinkContainer">
+  <ul>
+    <li><a href="#">Why doesn't my map print?</a></li>
+    <li class="hide-marker"><a class="faqviewmore" href="#">View more questions</a></li>
+  </ul>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-covered-by-relpos-block-link-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-covered-by-relpos-block-link-ref.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference: outside marker covered by relatively positioned block link</title>
+<link rel="author" title="Jason Leo" href="mailto:m.jason.liu@outlook.com">
+<style>
+body {
+  background: white;
+  font: 16px/1.4 sans-serif;
+}
+
+ul {
+  list-style-position: outside;
+  padding-inline-start: 40px;
+}
+
+.hide-marker::marker {
+  color: transparent;
+}
+
+.LinkContainer {
+  width: 290px;
+}
+
+.faqviewmore {
+    background-color: #efefef;
+    display: block;
+    left: -22px;
+    padding-left: 22px;
+    position: relative;
+}
+</style>
+
+<div class="LinkContainer">
+  <ul>
+    <li><a href="#">Why doesn't my map print?</a></li>
+    <li class="hide-marker"><a class="faqviewmore" href="#">View more questions</a></li>
+  </ul>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-covered-by-relpos-block-link.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-covered-by-relpos-block-link.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Lists: outside marker covered by relatively positioned block link</title>
+<link rel="author" title="CGQAQ" href="mailto:cgqaq@chromium.org">
+<link rel="help" href="https://www.w3.org/TR/CSS22/generate.html#lists">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=18289">
+<link rel="match" href="outside-marker-covered-by-relpos-block-link-ref.html">
+<meta name="assert" content="An outside list marker must not remain visibly painted when a relatively positioned display:block link extends into the marker area and paints over it.">
+<style>
+body {
+  background: white;
+  font: 16px/1.4 sans-serif;
+}
+
+ul {
+  list-style-position: outside;
+  padding-inline-start: 40px;
+}
+
+.LinkContainer {
+  width: 290px;
+}
+
+.faqviewmore {
+    background-color: #efefef;
+    display: block;
+    left: -22px;
+    padding-left: 22px;
+    position: relative;
+}
+</style>
+
+<div class="LinkContainer">
+  <ul>
+    <li><a href="#">Why doesn't my map print?</a></li>
+    <li><a class="faqviewmore" href="#">View more questions</a></li>
+  </ul>
+</div>

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -93,6 +93,18 @@ bool isHTMLListElement(const Node& node)
     return isAnyOf<HTMLUListElement, HTMLOListElement>(node);
 }
 
+static LayoutPoint paintOffsetForMarkerFromAssociatedListItem(const RenderListMarker& marker, const RenderListItem& listItem, const LayoutPoint& listItemPaintOffset)
+{
+    auto markerParentPaintOffset = listItemPaintOffset;
+    for (auto* ancestor = marker.parent(); ancestor && ancestor != &listItem; ancestor = ancestor->parent()) {
+        auto* box = dynamicDowncast<RenderBox>(*ancestor);
+        if (!box)
+            break;
+        markerParentPaintOffset.moveBy(box->location());
+    }
+    return markerParentPaintOffset;
+}
+
 // Returns the enclosing list with respect to the DOM order.
 static Element* enclosingList(const RenderListItem& listItem)
 {
@@ -283,6 +295,9 @@ void RenderListItem::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
         return;
 
     RenderBlockFlow::paint(paintInfo, paintOffset);
+
+    if (auto* marker = markerRenderer(); marker && marker->shouldPaintInAssociatedListItemLayer())
+        marker->paintFromAssociatedListItemLayer(paintInfo, paintOffsetForMarkerFromAssociatedListItem(*marker, *this, paintOffset));
 }
 
 String RenderListItem::markerTextWithoutSuffix() const

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -43,6 +43,7 @@
 #include "StyleListStyleType.h"
 #include "StyleScope.h"
 #include "TextUtil.h"
+#include <wtf/Assertions.h>
 #include <wtf/StackStats.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
@@ -82,6 +83,33 @@ RenderListMarker::RenderListMarker(RenderListItem& listItem, RenderStyle&& style
 
 // Do not add any code in below destructor. Add it to willBeDestroyed() instead.
 RenderListMarker::~RenderListMarker() = default;
+
+bool RenderListMarker::shouldPaintInAssociatedListItemLayer() const
+{
+    if (isInside())
+        return false;
+
+    auto* associatedListItem = listItem();
+    if (!associatedListItem) {
+        ASSERT_NOT_REACHED("Marker must have an associated list item");
+        return false;
+    }
+
+    for (auto* ancestor = parent(); ancestor && ancestor != associatedListItem; ancestor = ancestor->parent()) {
+        if (!ancestor->hasSelfPaintingLayer())
+            continue;
+        if (ancestor->isRenderFragmentedFlow())
+            return false;
+        return ancestor->isPositioned();
+    }
+
+    return false;
+}
+
+void RenderListMarker::paintFromAssociatedListItemLayer(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
+{
+    paint(paintInfo, paintOffset);
+}
 
 void RenderListMarker::willBeDestroyed()
 {
@@ -192,6 +220,9 @@ void RenderListMarker::paintDisclosureMarker(GraphicsContext& context, const Flo
 void RenderListMarker::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 {
     if (paintInfo.phase != PaintPhase::Foreground && paintInfo.phase != PaintPhase::Accessibility)
+        return;
+
+    if (shouldPaintInAssociatedListItemLayer() && paintInfo.enclosingSelfPaintingLayer() == enclosingLayer())
         return;
 
     if (style().usedVisibility() != Visibility::Visible)

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -64,6 +64,7 @@ public:
 
     bool NODELETE isInside() const;
     bool isDisclosureMarker() const;
+    bool shouldPaintInAssociatedListItemLayer() const;
 
     void updateInlineMarginsAndContent();
 
@@ -71,6 +72,7 @@ public:
 
     LayoutUnit lineLogicalOffsetForListItem() const { return m_lineLogicalOffsetForListItem; }
     const RenderListItem* NODELETE listItem() const;
+    void paintFromAssociatedListItemLayer(PaintInfo&, const LayoutPoint&);
 
     std::pair<float, float> layoutBounds() const { return m_layoutBounds; }
 


### PR DESCRIPTION
#### d184010b1c5533e37b700e227571b73183af02aa
<pre>
Fix outside list-marker painting with relative-positioned block links
<a href="https://bugs.webkit.org/show_bug.cgi?id=18289">https://bugs.webkit.org/show_bug.cgi?id=18289</a>

Reviewed by Alan Baradlay.

Outside list markers can end up structurally nested under descendant renderers that paint in a different self-painting layer from the associated RenderListItem. For the reported case, a relatively positioned display:block link with a negative offset paints its background over the marker’s visual area, but the marker was still painted from the descendant painting path, so the bullet showed through.

Fix:
The change keeps layout behavior unchanged and only adjusts painting:
 - detect outside markers that need to be painted from the associated list-item layer
 - skip painting those markers in the descendant self-painting-layer pass
 - explicitly paint them from the associated list-item layer instead
 - preserve the correct visual position by computing the paint offset from the marker’s ancestor chain

This restores the expected paint order:
 - the list item paints the outside marker
 - the relatively positioned link paints afterward
 - the link background correctly covers the marker area

Tests: fast/lists/outside-marker-covered-by-relpos-block-link-render-tree.html
       imported/w3c/web-platform-tests/css/css-lists/outside-marker-covered-by-relpos-block-link-ref.html
       imported/w3c/web-platform-tests/css/css-lists/outside-marker-covered-by-relpos-block-link.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-covered-by-relpos-block-link-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-covered-by-relpos-block-link-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-lists/outside-marker-covered-by-relpos-block-link.html: Added.
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::paintOffsetForMarkerFromAssociatedListItem):
(WebCore::RenderListItem::paint):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::shouldPaintInAssociatedListItemLayer const):
(WebCore::RenderListMarker::paintFromAssociatedListItemLayer):
(WebCore::RenderListMarker::paint):
* Source/WebCore/rendering/RenderListMarker.h:

Canonical link: <a href="https://commits.webkit.org/309188@main">https://commits.webkit.org/309188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99e595d7a665f34ac4efdd5897321deca0520a9f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22474 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158460 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103187 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151628 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22924 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22564 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115519 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82112 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134381 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96260 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16742 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14662 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6306 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126350 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12312 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160937 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123542 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22276 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123748 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33620 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134105 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78508 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18921 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10856 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21884 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85704 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21614 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21766 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21671 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->