### PR TITLE
Style: split isStretch() from isIntrinsic()

### DIFF
--- a/Source/WebCore/layout/layouttree/LayoutElementBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutElementBox.cpp
@@ -186,12 +186,12 @@ void ElementBox::destroyChildren()
 
 bool ElementBox::hasIntrinsicWidth() const
 {
-    return (m_replacedData && m_replacedData->intrinsicSize) || style().logicalWidth().isIntrinsic();
+    return (m_replacedData && m_replacedData->intrinsicSize) || style().logicalWidth().isIntrinsicOrStretch();
 }
 
 bool ElementBox::hasIntrinsicHeight() const
 {
-    return (m_replacedData && m_replacedData->intrinsicSize) || style().logicalHeight().isIntrinsic();
+    return (m_replacedData && m_replacedData->intrinsicSize) || style().logicalHeight().isIntrinsicOrStretch();
 }
 
 bool ElementBox::hasIntrinsicRatio() const

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3077,7 +3077,7 @@ std::optional<LayoutUnit> RenderBlock::availableLogicalHeightForPercentageComput
         // However, intrinsic heights (fit-content, min-content, max-content) are
         // content-dependent and should be treated as indefinite for percentage
         // resolution of children, since the actual height is not yet determined.
-        auto heightIsIntrinsic = style.logicalHeight().isIntrinsic() || style.logicalHeight().isLegacyIntrinsic();
+        auto heightIsIntrinsic = style.logicalHeight().isIntrinsicOrStretch() || style.logicalHeight().isIntrinsicKeyword() || style.logicalHeight().isMinIntrinsic();
         auto hasNonIntrinsicSpecifiedHeight = !style.logicalHeight().isAuto() && !heightIsIntrinsic;
         auto hasDefiniteHeightFromInsets = !style.logicalTop().isAuto() && !style.logicalBottom().isAuto() && style.logicalHeight().isAuto();
         auto isOutOfFlowPositionedWithSpecifiedHeight = isOutOfFlowPositioned() && (hasNonIntrinsicSpecifiedHeight || hasDefiniteHeightFromInsets);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -755,10 +755,10 @@ LayoutUnit RenderBox::constrainLogicalWidthByMinMax(LayoutUnit logicalWidth, Lay
 {
     auto& styleToUse = style();
     auto computedMaxWidth = LayoutUnit::max();
-    if (!styleToUse.logicalMaxWidth().isNone() && (allowIntrinsic == AllowIntrinsic::Yes || !styleToUse.logicalMaxWidth().isIntrinsic()))
+    if (!styleToUse.logicalMaxWidth().isNone() && (allowIntrinsic == AllowIntrinsic::Yes || !styleToUse.logicalMaxWidth().isIntrinsicOrStretch()))
         computedMaxWidth = computeLogicalWidthUsing(styleToUse.logicalMaxWidth(), availableWidth, cb);
 
-    if (allowIntrinsic == AllowIntrinsic::No && styleToUse.logicalMinWidth().isIntrinsic())
+    if (allowIntrinsic == AllowIntrinsic::No && styleToUse.logicalMinWidth().isIntrinsicOrStretch())
         return std::min(logicalWidth, computedMaxWidth);
 
     auto logicalMinWidth = styleToUse.logicalMinWidth();
@@ -2930,7 +2930,7 @@ LayoutUnit RenderBox::computeIntrinsicLogicalWidthUsing(CSS::Keyword::FitContent
 
 template<typename SizeType> LayoutUnit RenderBox::computeIntrinsicLogicalWidthUsingGeneric(const SizeType& logicalWidth, LayoutUnit availableLogicalWidth, LayoutUnit borderAndPadding) const
 {
-    if (logicalWidth.isFillAvailable())
+    if (logicalWidth.isStretch())
         return computeIntrinsicLogicalWidthUsing(CSS::Keyword::WebkitFillAvailable { }, availableLogicalWidth, borderAndPadding);
     if (logicalWidth.isMinIntrinsic())
         return computeIntrinsicLogicalWidthUsing(CSS::Keyword::MinContent { }, availableLogicalWidth, borderAndPadding);
@@ -2977,7 +2977,7 @@ template<typename SizeType> LayoutUnit RenderBox::computeLogicalWidthUsingGeneri
         return adjustBorderBoxLogicalWidthForBoxSizing(Style::evaluate<LayoutUnit>(logicalWidth, availableLogicalWidth, style().usedZoomForLength()));
     }
 
-    if (logicalWidth.isIntrinsic() || logicalWidth.isMinIntrinsic())
+    if (logicalWidth.isIntrinsicOrStretch() || logicalWidth.isMinIntrinsic())
         return computeIntrinsicLogicalWidthUsing(logicalWidth, availableLogicalWidth, borderAndPaddingLogicalWidth());
 
     LayoutUnit marginStart;
@@ -4094,7 +4094,7 @@ void RenderBox::computeOutOfFlowPositionedLogicalWidth(LogicalExtentComputedValu
 
     // Clamp by min-width.
     auto usedMinWidth = LayoutUnit::min();
-    if (auto& logicalMinWidth = styleToUse.logicalMinWidth(); !logicalMinWidth.isKnownZero() || logicalMinWidth.isIntrinsic())
+    if (auto& logicalMinWidth = styleToUse.logicalMinWidth(); !logicalMinWidth.isKnownZero())
         usedMinWidth = computeOutOfFlowPositionedLogicalWidthUsing(logicalMinWidth, inlineConstraints);
     if (transferredMinSize > usedMinWidth)
         usedMinWidth = computeOutOfFlowPositionedLogicalWidthUsing(Style::MinimumSize { Style::MinimumSize::Fixed { transferredMinSize } }, inlineConstraints);
@@ -4218,15 +4218,15 @@ void RenderBox::computeOutOfFlowPositionedLogicalHeight(LogicalExtentComputedVal
     LayoutUnit computedHeight = computedValues.extent;
     LayoutUnit usedHeight = computeOutOfFlowPositionedLogicalHeightUsing(styleToUse.logicalHeight(), computedHeight, blockConstraints);
 
-    // Clamp by max height.
+    // Clamp by max-height.
     if (auto logicalMaxHeight = styleToUse.logicalMaxHeight(); !logicalMaxHeight.isNone()) {
         auto usedMaxHeight = computeOutOfFlowPositionedLogicalHeightUsing(logicalMaxHeight, computedHeight, blockConstraints);
         if (usedHeight > usedMaxHeight)
             usedHeight = usedMaxHeight;
     }
 
-    // Clamp by min height.
-    if (auto& logicalMinHeight = styleToUse.logicalMinHeight(); logicalMinHeight.isAuto() || !logicalMinHeight.isKnownZero() || logicalMinHeight.isIntrinsic()) {
+    // Clamp by min-height.
+    if (auto& logicalMinHeight = styleToUse.logicalMinHeight(); logicalMinHeight.isAuto() || !logicalMinHeight.isKnownZero()) {
         auto usedMinHeight = computeOutOfFlowPositionedLogicalHeightUsing(logicalMinHeight, computedHeight, blockConstraints);
         if (usedHeight < usedMinHeight)
             usedHeight = usedMinHeight;
@@ -4270,7 +4270,7 @@ LayoutUnit RenderBox::computeOutOfFlowPositionedLogicalHeightUsing(const Style::
     bool logicalHeightIsAuto = logicalHeight.isAuto() && !fromAspectRatio;
 
     if (!logicalHeightIsAuto) {
-        if (logicalHeight.isIntrinsic())
+        if (logicalHeight.isIntrinsicOrStretch())
             return adjustContentBoxLogicalHeightForBoxSizing(computeIntrinsicLogicalContentHeightUsing(logicalHeight, contentLogicalHeight, blockConstraints.bordersPlusPadding()).value_or(0_lu));
         if (fromAspectRatio) {
             auto resolvedLogicalHeight = blockSizeFromAspectRatio(horizontalBorderAndPaddingExtent(), verticalBorderAndPaddingExtent(), style().logicalAspectRatio(), style().boxSizingForAspectRatio(), logicalWidth(), style().aspectRatio(), isRenderReplaced());
@@ -4303,7 +4303,7 @@ LayoutUnit RenderBox::computeOutOfFlowPositionedLogicalHeightUsing(const Style::
             logicalHeight = 0_css_px;
     }
 
-    if (logicalHeight.isIntrinsic())
+    if (logicalHeight.isIntrinsicOrStretch())
         return adjustContentBoxLogicalHeightForBoxSizing(computeIntrinsicLogicalContentHeightUsing(logicalHeight, contentLogicalHeight, blockConstraints.bordersPlusPadding()).value_or(0_lu));
     return adjustContentBoxLogicalHeightForBoxSizing(Style::evaluate<LayoutUnit>(logicalHeight, blockConstraints.containingSize(), style().usedZoomForLength()));
 }
@@ -4316,7 +4316,7 @@ LayoutUnit RenderBox::computeOutOfFlowPositionedLogicalHeightUsing(const Style::
     if (isRenderTable())
         return contentLogicalHeight;
 
-    if (logicalHeight.isIntrinsic())
+    if (logicalHeight.isIntrinsicOrStretch())
         return adjustContentBoxLogicalHeightForBoxSizing(computeIntrinsicLogicalContentHeightUsing(logicalHeight, contentLogicalHeight, blockConstraints.bordersPlusPadding()).value_or(0_lu));
     return adjustContentBoxLogicalHeightForBoxSizing(Style::evaluate<LayoutUnit>(logicalHeight, blockConstraints.containingSize(), style().usedZoomForLength()));
 }
@@ -5000,7 +5000,7 @@ bool RenderBox::shouldComputeLogicalHeightFromAspectRatio() const
         return false;
 
     auto h = style().logicalHeight();
-    return (h.isAuto()) || h.isIntrinsic() || (!isOutOfFlowPositioned() && h.isPercentOrCalculated() && !percentageLogicalHeightIsResolvable());
+    return (h.isAuto()) || h.isIntrinsicOrStretch() || (!isOutOfFlowPositioned() && h.isPercentOrCalculated() && !percentageLogicalHeightIsResolvable());
 }
 
 bool RenderBox::shouldComputeLogicalWidthFromAspectRatio() const

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -1232,7 +1232,7 @@ template<typename SizeType> bool RenderFlexibleBox::flexItemMainSizeIsDefinite(c
         if (size.isContent())
             return false;
     }
-    if (!mainAxisIsFlexItemInlineAxis(flexItem) && (size.isIntrinsic() || size.isIntrinsicKeyword()))
+    if (!mainAxisIsFlexItemInlineAxis(flexItem) && (size.isIntrinsicOrStretch() || size.isIntrinsicKeyword()))
         return false;
     if (size.isPercentOrCalculated())
         return canComputePercentageFlexBasis(flexItem, size, UpdatePercentageHeightDescendants::No);
@@ -1719,12 +1719,12 @@ std::pair<LayoutUnit, LayoutUnit> RenderFlexibleBox::computeFlexItemMinMaxSizes(
 {
     auto max = maxMainSizeLengthForFlexItem(flexItem);
     std::optional<LayoutUnit> maxExtent = std::nullopt;
-    if (max.isSpecified() || max.isIntrinsic())
+    if (max.isSpecified() || max.isIntrinsicOrStretch())
         maxExtent = computeMainAxisExtentForFlexItem(flexItem, max);
 
     auto min = minMainSizeLengthForFlexItem(flexItem);
     // Intrinsic sizes in child's block axis are handled by the min-size:auto code path.
-    if (min.isSpecified() || (min.isIntrinsic() && mainAxisIsFlexItemInlineAxis(flexItem))) {
+    if (min.isSpecified() || (min.isIntrinsicOrStretch() && mainAxisIsFlexItemInlineAxis(flexItem))) {
         auto minExtent = computeMainAxisExtentForFlexItem(flexItem, min).value_or(0_lu);
         // We must never return a min size smaller than the min preferred size for tables.
         if (flexItem.isRenderTable() && mainAxisIsFlexItemInlineAxis(flexItem))
@@ -2316,7 +2316,7 @@ bool RenderFlexibleBox::flexItemHasIntrinsicMainAxisSize(const RenderBox& flexIt
     // which has some side effects like calling addPercentHeightDescendant() for example so it is not possible to skip
     // the call for example by moving it to the end of the conditional expression. This is error-prone and we should
     // refactor computePercentageLogicalHeight() at some point so that it only computes stuff without those side effects.
-    if (!flexItemMainSizeIsDefinite(flexItem, flexBasis) || minSize.isIntrinsic() || maxSize.isIntrinsic())
+    if (!flexItemMainSizeIsDefinite(flexItem, flexBasis) || minSize.isIntrinsicOrStretch() || maxSize.isIntrinsicOrStretch())
         return true;
 
     if (shouldApplyMinSizeAutoForFlexItem(flexItem))

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -417,7 +417,7 @@ bool RenderReplaced::hasReplacedLogicalHeight() const
     if (style().logicalHeight().isPercentOrCalculated())
         return !hasAutoHeightOrContainingBlockWithAutoHeight();
 
-    if (style().logicalHeight().isIntrinsic())
+    if (style().logicalHeight().isIntrinsicOrStretch())
         return !style().aspectRatio().hasRatio();
 
     return false;
@@ -429,7 +429,7 @@ bool RenderReplaced::setNeedsLayoutIfNeededAfterIntrinsicSizeChange()
 
     // If the actual area occupied by the image has changed and it is not constrained by style then a layout is required.
     bool imageSizeIsConstrained = style().logicalWidth().isSpecified() && style().logicalHeight().isSpecified()
-        && !style().logicalMinWidth().isIntrinsic() && !style().logicalMaxWidth().isIntrinsic()
+        && !style().logicalMinWidth().isIntrinsicOrStretch() && !style().logicalMaxWidth().isIntrinsicOrStretch()
         && !hasAutoHeightOrContainingBlockWithAutoHeight(UpdatePercentageHeightDescendants::No);
 
     // FIXME: We only need to recompute the containing block's preferred size
@@ -714,7 +714,7 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ShouldComputePreferred sh
     auto& style = this->style();
     if (style.logicalWidth().isSpecified())
         return computeReplacedLogicalWidthRespectingMinMaxWidth(computeReplacedLogicalWidthUsing(style.logicalWidth()), shouldComputePreferred);
-    if (style.logicalWidth().isIntrinsic())
+    if (style.logicalWidth().isIntrinsicOrStretch())
         return computeReplacedLogicalWidthRespectingMinMaxWidth(computeReplacedLogicalWidthUsing(style.logicalWidth()), shouldComputePreferred);
 
     RenderBox* contentRenderer = embeddedContentBox();
@@ -783,7 +783,7 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ShouldComputePreferred sh
                 if (isOutOfFlowPositioned() && !style.logicalLeft().isAuto() && !style.logicalRight().isAuto()) {
                     // Still respect min-width, but ignore max-width if it's an intrinsic keyword.
                     auto& logicalMinWidth = style.logicalMinWidth();
-                    auto minLogicalWidth = logicalMinWidth.isIntrinsic() ? 0_lu : computeReplacedLogicalWidthUsing(logicalMinWidth);
+                    auto minLogicalWidth = logicalMinWidth.isIntrinsicOrStretch() ? 0_lu : computeReplacedLogicalWidthUsing(logicalMinWidth);
                     return std::max(minLogicalWidth, constrainedLogicalWidth);
                 }
 

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -304,7 +304,7 @@ void RenderTable::updateLogicalWidth()
     auto& styleLogicalWidth = style().logicalWidth();
     if (auto overridingLogicalWidth = this->overridingBorderBoxLogicalWidth())
         setLogicalWidth(*overridingLogicalWidth);
-    else if ((styleLogicalWidth.isSpecified() && styleLogicalWidth.isPossiblyPositive()) || styleLogicalWidth.isIntrinsic())
+    else if ((styleLogicalWidth.isSpecified() && styleLogicalWidth.isPossiblyPositive()) || styleLogicalWidth.isIntrinsicOrStretch())
         setLogicalWidth(convertStyleLogicalWidthToComputedWidth(styleLogicalWidth, containerWidthInInlineDirection));
     else {
         // Subtract out any fixed margins from our available width for auto width tables.
@@ -331,7 +331,7 @@ void RenderTable::updateLogicalWidth()
 
     // Ensure we aren't bigger than our max-width style.
     auto& styleMaxLogicalWidth = style().logicalMaxWidth();
-    if (styleMaxLogicalWidth.isSpecified() || styleMaxLogicalWidth.isIntrinsic()) {
+    if (styleMaxLogicalWidth.isSpecified() || styleMaxLogicalWidth.isIntrinsicOrStretch()) {
         LayoutUnit computedMaxLogicalWidth = convertStyleLogicalWidthToComputedWidth(styleMaxLogicalWidth, availableLogicalWidth);
         setLogicalWidth(std::min(logicalWidth(), computedMaxLogicalWidth));
     }
@@ -341,7 +341,7 @@ void RenderTable::updateLogicalWidth()
 
     // Ensure we aren't smaller than our min-width style.
     auto& styleMinLogicalWidth = style().logicalMinWidth();
-    if (styleMinLogicalWidth.isSpecified() || styleMinLogicalWidth.isIntrinsic()) {
+    if (styleMinLogicalWidth.isSpecified() || styleMinLogicalWidth.isIntrinsicOrStretch()) {
         LayoutUnit computedMinLogicalWidth = convertStyleLogicalWidthToComputedWidth(styleMinLogicalWidth, availableLogicalWidth);
         setLogicalWidth(std::max(logicalWidth(), computedMinLogicalWidth));
     }
@@ -370,7 +370,7 @@ void RenderTable::updateLogicalWidth()
 
 template<typename SizeType> LayoutUnit RenderTable::convertStyleLogicalWidthToComputedWidth(const SizeType& styleLogicalWidth, LayoutUnit availableWidth)
 {
-    if (styleLogicalWidth.isIntrinsic())
+    if (styleLogicalWidth.isIntrinsicOrStretch())
         return computeIntrinsicLogicalWidthUsing(styleLogicalWidth, availableWidth, bordersPaddingAndSpacingInRowDirection());
 
     // HTML tables' width styles already include borders and padding, but CSS tables' width styles do not.
@@ -397,7 +397,7 @@ template<typename SizeType> LayoutUnit RenderTable::convertStyleLogicalHeightToC
         return LayoutUnit(fixedStyleLogicalHeight->resolveZoom(style().usedZoomForLength()) - borders);
     } else if (styleLogicalHeight.isPercentOrCalculated())
         return computePercentageLogicalHeight(styleLogicalHeight).value_or(0);
-    else if (styleLogicalHeight.isIntrinsic())
+    else if (styleLogicalHeight.isIntrinsicOrStretch())
         return computeIntrinsicLogicalContentHeightUsing(styleLogicalHeight, logicalHeight() - borderAndPadding, borderAndPadding).value_or(0);
     else
         ASSERT_NOT_REACHED();
@@ -616,7 +616,7 @@ void RenderTable::layout()
         LayoutUnit computedLogicalHeight;
 
         auto& logicalHeightLength = style().logicalHeight();
-        if (logicalHeightLength.isIntrinsic() || (logicalHeightLength.isSpecified() && logicalHeightLength.isPossiblyPositive()))
+        if (logicalHeightLength.isIntrinsicOrStretch() || (logicalHeightLength.isSpecified() && logicalHeightLength.isPossiblyPositive()))
             computedLogicalHeight = convertStyleLogicalHeightToComputedHeight(logicalHeightLength);
 
         if (auto overridingLogicalHeight = this->overridingBorderBoxLogicalHeight())
@@ -624,7 +624,7 @@ void RenderTable::layout()
 
         if (!shouldIgnoreLogicalMinMaxHeightSizes()) {
             auto& logicalMaxHeightLength = style().logicalMaxHeight();
-            if (logicalMaxHeightLength.isFillAvailable() || logicalMaxHeightLength.isSpecified()) {
+            if (logicalMaxHeightLength.isStretch() || logicalMaxHeightLength.isSpecified()) {
                 LayoutUnit computedMaxLogicalHeight = convertStyleLogicalHeightToComputedHeight(logicalMaxHeightLength);
                 computedLogicalHeight = std::min(computedLogicalHeight, computedMaxLogicalHeight);
             }
@@ -632,7 +632,7 @@ void RenderTable::layout()
             auto logicalMinHeightLength = style().logicalMinHeight();
             if (logicalMinHeightLength.isMinContent() || logicalMinHeightLength.isMaxContent() || logicalMinHeightLength.isFitContent())
                 logicalMinHeightLength = CSS::Keyword::Auto { };
-            if (logicalMinHeightLength.isIntrinsic() || logicalMinHeightLength.isSpecified()) {
+            if (logicalMinHeightLength.isIntrinsicOrStretch() || logicalMinHeightLength.isSpecified()) {
                 LayoutUnit computedMinLogicalHeight = convertStyleLogicalHeightToComputedHeight(logicalMinHeightLength);
                 computedLogicalHeight = std::max(computedLogicalHeight, computedMinLogicalHeight);
             }

--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -930,7 +930,7 @@ inline bool RenderStyle::isFixedTableLayout() const
     return tableLayout() == TableLayoutType::Fixed 
         && (logicalWidth().isSpecified() 
             || logicalWidth().isFitContent() 
-            || logicalWidth().isFillAvailable() 
+            || logicalWidth().isStretch()
             || logicalWidth().isMinContent());
 }
 

--- a/Source/WebCore/style/values/flexbox/StyleFlexBasis.h
+++ b/Source/WebCore/style/values/flexbox/StyleFlexBasis.h
@@ -44,7 +44,7 @@ struct FlexBasis : LengthWrapperBase<LengthPercentage<CSS::NonnegativeUnzoomed>,
     ALWAYS_INLINE bool isMinContent() const { return holdsAlternative<CSS::Keyword::MinContent>(); }
     ALWAYS_INLINE bool isMaxContent() const { return holdsAlternative<CSS::Keyword::MaxContent>(); }
     ALWAYS_INLINE bool isFitContent() const { return holdsAlternative<CSS::Keyword::FitContent>(); }
-    ALWAYS_INLINE bool isFillAvailable() const { return holdsAlternative<CSS::Keyword::WebkitFillAvailable>(); }
+    ALWAYS_INLINE bool isStretch() const { return holdsAlternative<CSS::Keyword::WebkitFillAvailable>(); }
     ALWAYS_INLINE bool isIntrinsicKeyword() const { return holdsAlternative<CSS::Keyword::Intrinsic>(); }
     ALWAYS_INLINE bool isMinIntrinsic() const { return holdsAlternative<CSS::Keyword::MinIntrinsic>(); }
 
@@ -52,20 +52,12 @@ struct FlexBasis : LengthWrapperBase<LengthPercentage<CSS::NonnegativeUnzoomed>,
     {
         return holdsAlternative<CSS::Keyword::MinContent>()
             || holdsAlternative<CSS::Keyword::MaxContent>()
-            || holdsAlternative<CSS::Keyword::WebkitFillAvailable>()
             || holdsAlternative<CSS::Keyword::FitContent>();
     }
-    ALWAYS_INLINE bool isLegacyIntrinsic() const
-    {
-        return holdsAlternative<CSS::Keyword::Intrinsic>()
-            || holdsAlternative<CSS::Keyword::MinIntrinsic>();
-    }
+    ALWAYS_INLINE bool isIntrinsicOrStretch() const { return isIntrinsic() || isStretch(); }
     ALWAYS_INLINE bool isSizingKeywordOrAuto() const // Excludes isContent().
     {
-        return holdsAlternative<CSS::Keyword::MinContent>()
-            || holdsAlternative<CSS::Keyword::MaxContent>()
-            || holdsAlternative<CSS::Keyword::WebkitFillAvailable>()
-            || holdsAlternative<CSS::Keyword::FitContent>()
+        return isIntrinsicOrStretch()
             || holdsAlternative<CSS::Keyword::Intrinsic>()
             || holdsAlternative<CSS::Keyword::MinIntrinsic>()
             || holdsAlternative<CSS::Keyword::Auto>();

--- a/Source/WebCore/style/values/sizing/StyleMaximumSize.h
+++ b/Source/WebCore/style/values/sizing/StyleMaximumSize.h
@@ -55,7 +55,7 @@ struct MaximumSize : LengthWrapperBase<LengthPercentage<CSS::NonnegativeUnzoomed
     ALWAYS_INLINE bool isMinContent() const { return holdsAlternative<CSS::Keyword::MinContent>(); }
     ALWAYS_INLINE bool isMaxContent() const { return holdsAlternative<CSS::Keyword::MaxContent>(); }
     ALWAYS_INLINE bool isFitContent() const { return holdsAlternative<CSS::Keyword::FitContent>(); }
-    ALWAYS_INLINE bool isFillAvailable() const { return holdsAlternative<CSS::Keyword::WebkitFillAvailable>(); }
+    ALWAYS_INLINE bool isStretch() const { return holdsAlternative<CSS::Keyword::WebkitFillAvailable>(); }
     ALWAYS_INLINE bool isIntrinsicKeyword() const { return holdsAlternative<CSS::Keyword::Intrinsic>(); }
     ALWAYS_INLINE bool isMinIntrinsic() const { return holdsAlternative<CSS::Keyword::MinIntrinsic>(); }
 
@@ -63,20 +63,12 @@ struct MaximumSize : LengthWrapperBase<LengthPercentage<CSS::NonnegativeUnzoomed
     {
         return holdsAlternative<CSS::Keyword::MinContent>()
             || holdsAlternative<CSS::Keyword::MaxContent>()
-            || holdsAlternative<CSS::Keyword::WebkitFillAvailable>()
             || holdsAlternative<CSS::Keyword::FitContent>();
     }
-    ALWAYS_INLINE bool isLegacyIntrinsic() const
-    {
-        return holdsAlternative<CSS::Keyword::Intrinsic>()
-            || holdsAlternative<CSS::Keyword::MinIntrinsic>();
-    }
+    ALWAYS_INLINE bool isIntrinsicOrStretch() const { return isIntrinsic() || isStretch(); }
     ALWAYS_INLINE bool isSizingKeyword() const // Excludes isNone().
     {
-        return holdsAlternative<CSS::Keyword::MinContent>()
-            || holdsAlternative<CSS::Keyword::MaxContent>()
-            || holdsAlternative<CSS::Keyword::WebkitFillAvailable>()
-            || holdsAlternative<CSS::Keyword::FitContent>()
+        return isIntrinsicOrStretch()
             || holdsAlternative<CSS::Keyword::Intrinsic>()
             || holdsAlternative<CSS::Keyword::MinIntrinsic>();
     }

--- a/Source/WebCore/style/values/sizing/StyleMinimumSize.h
+++ b/Source/WebCore/style/values/sizing/StyleMinimumSize.h
@@ -57,7 +57,7 @@ struct MinimumSize : LengthWrapperBase<LengthPercentage<CSS::NonnegativeUnzoomed
     ALWAYS_INLINE bool isMinContent() const { return holdsAlternative<CSS::Keyword::MinContent>(); }
     ALWAYS_INLINE bool isMaxContent() const { return holdsAlternative<CSS::Keyword::MaxContent>(); }
     ALWAYS_INLINE bool isFitContent() const { return holdsAlternative<CSS::Keyword::FitContent>(); }
-    ALWAYS_INLINE bool isFillAvailable() const { return holdsAlternative<CSS::Keyword::WebkitFillAvailable>(); }
+    ALWAYS_INLINE bool isStretch() const { return holdsAlternative<CSS::Keyword::WebkitFillAvailable>(); }
     ALWAYS_INLINE bool isIntrinsicKeyword() const { return holdsAlternative<CSS::Keyword::Intrinsic>(); }
     ALWAYS_INLINE bool isMinIntrinsic() const { return holdsAlternative<CSS::Keyword::MinIntrinsic>(); }
 
@@ -65,20 +65,12 @@ struct MinimumSize : LengthWrapperBase<LengthPercentage<CSS::NonnegativeUnzoomed
     {
         return holdsAlternative<CSS::Keyword::MinContent>()
             || holdsAlternative<CSS::Keyword::MaxContent>()
-            || holdsAlternative<CSS::Keyword::WebkitFillAvailable>()
             || holdsAlternative<CSS::Keyword::FitContent>();
     }
-    ALWAYS_INLINE bool isLegacyIntrinsic() const
-    {
-        return holdsAlternative<CSS::Keyword::Intrinsic>()
-            || holdsAlternative<CSS::Keyword::MinIntrinsic>();
-    }
+    ALWAYS_INLINE bool isIntrinsicOrStretch() const { return isIntrinsic() || isStretch(); }
     ALWAYS_INLINE bool isSizingKeywordOrAuto() const
     {
-        return holdsAlternative<CSS::Keyword::MinContent>()
-            || holdsAlternative<CSS::Keyword::MaxContent>()
-            || holdsAlternative<CSS::Keyword::WebkitFillAvailable>()
-            || holdsAlternative<CSS::Keyword::FitContent>()
+        return isIntrinsicOrStretch()
             || holdsAlternative<CSS::Keyword::Intrinsic>()
             || holdsAlternative<CSS::Keyword::MinIntrinsic>()
             || holdsAlternative<CSS::Keyword::Auto>();

--- a/Source/WebCore/style/values/sizing/StylePreferredSize.h
+++ b/Source/WebCore/style/values/sizing/StylePreferredSize.h
@@ -64,7 +64,7 @@ struct PreferredSize : LengthWrapperBase<LengthPercentage<CSS::NonnegativeUnzoom
     ALWAYS_INLINE bool isMinContent() const { return holdsAlternative<CSS::Keyword::MinContent>(); }
     ALWAYS_INLINE bool isMaxContent() const { return holdsAlternative<CSS::Keyword::MaxContent>(); }
     ALWAYS_INLINE bool isFitContent() const { return holdsAlternative<CSS::Keyword::FitContent>(); }
-    ALWAYS_INLINE bool isFillAvailable() const { return holdsAlternative<CSS::Keyword::WebkitFillAvailable>(); }
+    ALWAYS_INLINE bool isStretch() const { return holdsAlternative<CSS::Keyword::WebkitFillAvailable>(); }
     ALWAYS_INLINE bool isIntrinsicKeyword() const { return holdsAlternative<CSS::Keyword::Intrinsic>(); }
     ALWAYS_INLINE bool isMinIntrinsic() const { return holdsAlternative<CSS::Keyword::MinIntrinsic>(); }
 
@@ -72,20 +72,12 @@ struct PreferredSize : LengthWrapperBase<LengthPercentage<CSS::NonnegativeUnzoom
     {
         return holdsAlternative<CSS::Keyword::MinContent>()
             || holdsAlternative<CSS::Keyword::MaxContent>()
-            || holdsAlternative<CSS::Keyword::WebkitFillAvailable>()
             || holdsAlternative<CSS::Keyword::FitContent>();
     }
-    ALWAYS_INLINE bool isLegacyIntrinsic() const
-    {
-        return holdsAlternative<CSS::Keyword::Intrinsic>()
-            || holdsAlternative<CSS::Keyword::MinIntrinsic>();
-    }
+    ALWAYS_INLINE bool isIntrinsicOrStretch() const { return isIntrinsic() || isStretch(); }
     ALWAYS_INLINE bool isSizingKeywordOrAuto() const
     {
-        return holdsAlternative<CSS::Keyword::MinContent>()
-            || holdsAlternative<CSS::Keyword::MaxContent>()
-            || holdsAlternative<CSS::Keyword::WebkitFillAvailable>()
-            || holdsAlternative<CSS::Keyword::FitContent>()
+        return isIntrinsicOrStretch()
             || holdsAlternative<CSS::Keyword::Intrinsic>()
             || holdsAlternative<CSS::Keyword::MinIntrinsic>()
             || holdsAlternative<CSS::Keyword::Auto>();


### PR DESCRIPTION
#### 9415fc43f62b99743e4fc0cbabcb28abbe939e74
<pre>
Style: split isStretch() from isIntrinsic()
<a href="https://bugs.webkit.org/show_bug.cgi?id=309686">https://bugs.webkit.org/show_bug.cgi?id=309686</a>

Reviewed by Elika Etemad.

This is a purely mechanical change to ease review and blame for
subsequent changes.

-webkit-fill-available is not an intrinsic size and should not be
classified as such.

The following changes are made:

- isFillAvailable() is renamed to isStretch() as that is what it will
  eventually become.
- isIntrinsic() has isStretch() removed.
- isIntrinsicOrStretch() takes over the old definition of isIntrinsic()
  and for now that is what all callers are switched to, to keep this a
  mechanical change.
- In RenderBox we remove two isIntrinsic() checks that are redundant
  with !isKnownZero(). (We keep a leading isAuto() check that is also
  redundant, but possibly cheaper.)
- We inline isLegacyIntrinsic() into its one caller in
  RenderBlock::availableLogicalHeightForPercentageComputation() so we
  can get rid of it.

This results in awkward code such as ElementBox::hasIntrinsicWidth()
containing an isIntrinsicOrStretch() check, but it seems better to be
explicit about such errors in the interim than try to address them as
part of this change.

Canonical link: <a href="https://commits.webkit.org/309146@main">https://commits.webkit.org/309146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83ff49808521f5cc7c1fc90fdf70e791c351d225

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22274 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158263 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102988 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ed82ea9d-e945-4b00-a0e6-bd8012c56bed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151429 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22176 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115366 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5a0b3f9f-7fa0-4b51-a39e-dfae5231e4f9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17500 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134240 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96107 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df3fd572-5b13-4719-b62c-0161e403d088) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16597 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14498 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6103 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126205 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160735 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3732 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123394 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123604 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133938 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78298 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23035 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18789 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10689 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21684 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85505 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21415 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21567 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21472 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->