### PR TITLE
discord.com: copy paste post with emojis into gmail.com are not display correctly

### DIFF
--- a/LayoutTests/editing/pasteboard/copy-emoji-img-with-svg-source-expected.txt
+++ b/LayoutTests/editing/pasteboard/copy-emoji-img-with-svg-source-expected.txt
@@ -1,0 +1,14 @@
+This tests that emoji img elements with SVG sources are replaced with their Unicode alt text during copy serialization. This ensures clipboard HTML uses native Unicode emoji instead of external SVG references that may fail to load cross-origin.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.clipboardData.getData("text/html").includes("😌") is true
+PASS event.clipboardData.getData("text/html").includes("emoji.svg") is false
+PASS event.clipboardData.getData("text/html").includes("Hello") is true
+PASS event.clipboardData.getData("text/html").includes("world") is true
+PASS event.clipboardData.getData("text/plain").includes("😌") is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/pasteboard/copy-emoji-img-with-svg-source.html
+++ b/LayoutTests/editing/pasteboard/copy-emoji-img-with-svg-source.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="source">Hello <img class="emoji" alt="&#x1F60C;" src="/assets/emoji.svg"> world</div>
+<div id="destination" contenteditable></div>
+<pre id="output"></pre>
+</body>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+description(`This tests that emoji img elements with SVG sources are replaced with their Unicode alt text during copy serialization. This ensures clipboard HTML uses native Unicode emoji instead of external SVG references that may fail to load cross-origin.`);
+
+jsTestIsAsync = true;
+getSelection().setBaseAndExtent(source, 0, source, source.childNodes.length);
+
+destination.addEventListener("paste", () => {
+    // Emoji img should be replaced with its Unicode alt text in clipboard HTML.
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("\u{1F60C}")');
+
+    // The img tag and SVG reference should not be in the clipboard HTML.
+    shouldBeFalse('event.clipboardData.getData("text/html").includes("emoji.svg")');
+
+    // Surrounding text should be preserved.
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("Hello")');
+    shouldBeTrue('event.clipboardData.getData("text/html").includes("world")');
+
+    // Plain text should also contain the emoji.
+    shouldBeTrue('event.clipboardData.getData("text/plain").includes("\u{1F60C}")');
+
+    source.style.display = "none";
+    destination.style.display = "none";
+    finishJSTest();
+});
+
+if (window.testRunner) {
+    if (window.internals)
+        internals.settings.setCustomPasteboardDataEnabled(true);
+    testRunner.execCommand("Copy");
+    destination.focus();
+    testRunner.execCommand("Paste");
+} else {
+    source.addEventListener("copy", () => {
+        setTimeout(() => destination.focus(), 0);
+    });
+}
+
+</script>
+</html>

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -101,6 +101,7 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/URL.h>
 #include <wtf/URLParser.h>
+#include <wtf/text/CharacterProperties.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -340,6 +341,46 @@ auto UserSelectNoneStateCache::computeState(Node& targetNode) -> State
 static String directionAttributeAndValue(TextDirection direction)
 {
     return makeString("dir=\""_s, direction == TextDirection::LTR ? "ltr"_s : "rtl"_s, '"');
+}
+
+// Used to identify <img> elements that represent emoji and can be replaced with their Unicode alt text.
+static bool containsOnlyEmoji(StringView text)
+{
+    if (text.isEmpty())
+        return false;
+
+    bool hasEmoji = false;
+    for (auto codePoint : text.codePoints()) {
+        if (isEmojiWithPresentationByDefault(codePoint)) {
+            hasEmoji = true;
+            continue;
+        }
+
+        if (isEmojiRegionalIndicator(codePoint)) {
+            hasEmoji = true;
+            continue;
+        }
+
+        // Non-Latin1 emoji characters (e.g., those needing VS16 for emoji presentation).
+        if (!isLatin1(codePoint) && u_hasBinaryProperty(codePoint, UCHAR_EMOJI)) {
+            hasEmoji = true;
+            continue;
+        }
+
+        // Emoji sequence components: ZWJ, VS16, skin tone modifiers, keycap bases, tag characters.
+        if (u_hasBinaryProperty(codePoint, UCHAR_EMOJI_COMPONENT))
+            continue;
+
+        // Combining Enclosing Keycap completes a keycap emoji sequence.
+        if (codePoint == 0x20E3) {
+            hasEmoji = true;
+            continue;
+        }
+
+        return false;
+    }
+
+    return hasEmoji;
 }
 
 enum class MSOListMode : bool { Preserve, DoNotPreserve };
@@ -852,6 +893,17 @@ RefPtr<Node> StyledMarkupAccumulator::traverseNodesForSerialization(Node& startN
 
         if (m_ignoresUserSelectNone && userSelectNoneStateCache.nodeOnlyContainsUserSelectNone(node))
             return false;
+
+        if (shouldEmit) {
+            if (RefPtr imgElement = dynamicDowncast<HTMLImageElement>(node)) {
+                auto& alt = imgElement->attributeWithoutSynchronization(altAttr);
+                auto& src = imgElement->attributeWithoutSynchronization(srcAttr);
+                if (!alt.isEmpty() && src.endsWithIgnoringASCIICase(".svg"_s) && containsOnlyEmoji(alt)) {
+                    append(alt);
+                    return false;
+                }
+            }
+        }
 
         ++depth;
         if (shouldEmit)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -307,6 +307,55 @@ TEST(CopyHTML, CopySelectedTextInTextDocument)
     TestWebKitAPI::Util::run(&doneLoading);
     EXPECT_WK_STREQ(expectedString.get(), [copiedText string]);
 #endif
+}
+
+TEST(CopyHTML, EmojiImgWithSVGSourceReplacedWithAltText)
+{
+    auto webView = createWebViewWithCustomPasteboardDataEnabled();
+    [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
+        "<body>"
+        "<div id='copy'>Hello <img class='emoji' alt='\U0001F60C' src='/assets/emoji.svg'> world</div>"
+        "<script>getSelection().selectAllChildren(copy);</script>"
+        "</body>"];
+    [webView copy:nil];
+    [webView waitForNextPresentationUpdate];
+
+    NSString *copiedMarkup = readHTMLStringFromPasteboard();
+    EXPECT_TRUE([copiedMarkup containsString:@"\U0001F60C"]);
+    EXPECT_TRUE([copiedMarkup containsString:@"Hello"]);
+    EXPECT_TRUE([copiedMarkup containsString:@"world"]);
+    EXPECT_FALSE([copiedMarkup containsString:@"<img"]);
+    EXPECT_FALSE([copiedMarkup containsString:@".svg"]);
+}
+
+TEST(CopyHTML, NonEmojiImgWithSVGSourcePreserved)
+{
+    auto webView = createWebViewWithCustomPasteboardDataEnabled();
+    [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
+        "<body>"
+        "<div id='copy'>Hello <img alt='a logo' src='/assets/logo.svg'> world</div>"
+        "<script>getSelection().selectAllChildren(copy);</script>"
+        "</body>"];
+    [webView copy:nil];
+    [webView waitForNextPresentationUpdate];
+
+    NSString *copiedMarkup = readHTMLStringFromPasteboard();
+    EXPECT_TRUE([copiedMarkup containsString:@"<img"]);
+}
+
+TEST(CopyHTML, EmojiImgWithNonSVGSourcePreserved)
+{
+    auto webView = createWebViewWithCustomPasteboardDataEnabled();
+    [webView synchronouslyLoadHTMLString:@"<!DOCTYPE html>"
+        "<body>"
+        "<div id='copy'>Hello <img alt='\U0001F60C' src='/assets/emoji.png'> world</div>"
+        "<script>getSelection().selectAllChildren(copy);</script>"
+        "</body>"];
+    [webView copy:nil];
+    [webView waitForNextPresentationUpdate];
+
+    NSString *copiedMarkup = readHTMLStringFromPasteboard();
+    EXPECT_TRUE([copiedMarkup containsString:@"<img"]);
 }
 
 #endif // PLATFORM(COCOA)


### PR DESCRIPTION
#### 6c20a290578699c2828d10eef0e625cd9f0e88b5
<pre>
discord.com: copy paste post with emojis into gmail.com are not display correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=309683">https://bugs.webkit.org/show_bug.cgi?id=309683</a>
<a href="https://rdar.apple.com/162708499">rdar://162708499</a>

Reviewed by Ryosuke Niwa.

Previously, emoji SVG images were serialized as &lt;img&gt;
tags in the HTML clipboard. That required the paste target
to fetch the SVG from source origin.
Cross-origin resource policies (CORP) block these requests,
so the images were broken when pasted into Gmail.

In the case of just emoji with no surrounding text, it
was already working before this fix because it goes through
the writeImageToPasteboard() path instead, which puts the
direct raw image data on the clipboard.

Discord already puts the real emoji character in the alt
attribute, so the fix was checking &lt;img&gt;s with SVG sources
and emoji-only alt text during copy, and writing the Unicode
character directly into clipboard HTML.

Tests: editing/pasteboard/copy-emoji-img-with-svg-source.html
       Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm

* LayoutTests/editing/pasteboard/copy-emoji-img-with-svg-source-expected.txt: Added.
* LayoutTests/editing/pasteboard/copy-emoji-img-with-svg-source.html: Added.
* Source/WebCore/editing/markup.cpp:
(WebCore::containsOnlyEmoji):
(WebCore::StyledMarkupAccumulator::traverseNodesForSerialization):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/CopyHTML.mm:
(TEST(CopyHTML, EmojiImgWithSVGSourceReplacedWithAltText)):
(TEST(CopyHTML, NonEmojiImgWithSVGSourcePreserved)):
(TEST(CopyHTML, EmojiImgWithNonSVGSourcePreserved)):

Canonical link: <a href="https://commits.webkit.org/309176@main">https://commits.webkit.org/309176@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bd42a19c50e26d1d390e08fc105781b9058f68a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22418 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15998 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158402 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103131 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151572 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22868 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115473 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17601 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134336 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96214 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16698 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14615 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6247 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126306 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12267 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160881 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3892 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13809 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123502 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22220 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123708 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33611 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22227 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134060 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78452 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18881 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10811 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21828 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85648 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21558 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21710 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21615 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->