### PR TITLE
[JSC] Allow quick DFG/FTL tier-up recovery after reinstall

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2853,19 +2853,20 @@ bool CodeBlock::shouldReoptimizeFromLoopNow()
 
 void CodeBlock::didInstallDFGCode()
 {
+#if PLATFORM(MAC)
+    // Always reset — allows quick tier-up recovery after reinstall.
+    // Enable this only on macOS due to perf regression on iOS.
+    unlinkedCodeBlock()->setQuickDFGTierUp(TriState::True);
+#else
+    // Restore old one-shot behavior — once failed, stays disabled.
     if (!unlinkedCodeBlock()->hasQuickDFGTierUpUpdated())
         unlinkedCodeBlock()->setQuickDFGTierUp(TriState::True);
+#endif
 }
 
 void CodeBlock::didDFGJettison(Profiler::JettisonReason reason)
 {
-    if (!Profiler::isSpeculationFailure(reason))
-        return;
-
-    // Only mark as failed if code was already installed and ran (flag = True).
-    // If jettison happens during compilation (flag = Indeterminate), leave it
-    // unchanged - this was environmental (OOM, GC pressure), not a code quality issue.
-    if (unlinkedCodeBlock()->hasQuickDFGTierUpUpdated())
+    if (Profiler::isSpeculationFailure(reason))
         unlinkedCodeBlock()->setQuickDFGTierUp(TriState::False);
 }
 
@@ -2877,25 +2878,18 @@ void CodeBlock::didFailDFGCompilation()
 #if ENABLE(FTL_JIT)
 void CodeBlock::didInstallFTLCode()
 {
-    if (!unlinkedCodeBlock()->hasQuickFTLTierUpUpdated() && unlinkedCodeBlock()->isQuickDFGTierUp())
-        unlinkedCodeBlock()->setQuickFTLTierUp(WTF::TriState::True);
+    unlinkedCodeBlock()->setQuickFTLTierUp(true);
 }
 
 void CodeBlock::didFTLJettison(Profiler::JettisonReason reason)
 {
-    if (!Profiler::isSpeculationFailure(reason))
-        return;
-
-    // Only mark as failed if code was already installed and ran (flag = True).
-    // If jettison happens during compilation (flag = Indeterminate), leave it
-    // unchanged - this was environmental (OOM, GC pressure), not a code quality issue.
-    if (unlinkedCodeBlock()->hasQuickFTLTierUpUpdated())
-        unlinkedCodeBlock()->setQuickFTLTierUp(WTF::TriState::False);
+    if (Profiler::isSpeculationFailure(reason))
+        unlinkedCodeBlock()->setQuickFTLTierUp(false);
 }
 
 void CodeBlock::didFailFTLCompilation()
 {
-    unlinkedCodeBlock()->setQuickFTLTierUp(WTF::TriState::False);
+    unlinkedCodeBlock()->setQuickFTLTierUp(false);
 }
 #endif
 

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -180,10 +180,8 @@ public:
     void setQuickDFGTierUp(TriState state) { m_quickDFGTierUp = state; }
     TriState quickDFGTierUp() const { return m_quickDFGTierUp; }
 
-    bool hasQuickFTLTierUpUpdated() const { return m_quickFTLTierUp != TriState::Indeterminate; }
-    bool isQuickFTLTierUp() const { return m_quickFTLTierUp == TriState::True; }
-    void setQuickFTLTierUp(TriState state) { m_quickFTLTierUp = state; }
-    TriState quickFTLTierUp() const { return m_quickFTLTierUp; }
+    bool isQuickFTLTierUp() const { return m_quickFTLTierUp; }
+    void setQuickFTLTierUp(bool value) { m_quickFTLTierUp = value; }
 
     // Special registers
     void setThisRegister(VirtualRegister thisRegister) { m_thisRegister = thisRegister; }
@@ -440,7 +438,7 @@ private:
     bool m_hasCheckpoints : 1;
     LexicallyScopedFeatures m_lexicallyScopedFeatures : bitWidthOfLexicallyScopedFeatures { 0 };
     TriState m_quickDFGTierUp : 2 { TriState::Indeterminate };
-    TriState m_quickFTLTierUp : 2 { TriState::Indeterminate };
+    bool m_quickFTLTierUp : 1 { false };
 
 public:
     ConcurrentJSLock m_lock;


### PR DESCRIPTION
#### f92b82d07c51c38c2cd46d9f7420f54f1901c695
<pre>
[JSC] Allow quick DFG/FTL tier-up recovery after reinstall
<a href="https://bugs.webkit.org/show_bug.cgi?id=309687">https://bugs.webkit.org/show_bug.cgi?id=309687</a>
<a href="https://rdar.apple.com/172290040">rdar://172290040</a>

Reviewed by Dan Hecht.

Quick tier-up reduces the optimization threshold for functions that have
previously run JIT code successfully, letting them re-tier faster after
jettison.

Previously didInstallDFGCode() and didInstallFTLCode() were one-shot:
once the flag was cleared by a jettison, subsequent reinstalls could not
recover it. This patch allows recovery on reinstall.

A jettison is a profiling event — the speculation failure reveals type
information that baseline JIT captures, and a re-compile against those
richer profiles is likely more stable. Penalizing it permanently was
counterproductive.

Canonical link: <a href="https://commits.webkit.org/309230@main">https://commits.webkit.org/309230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f05e49d93e2808b318b8b4d4690687486142c3af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150005 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/22731 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/16324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/158716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/23178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/22854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/158716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152965 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/23178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/16324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/158716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/23178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/16324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/6562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141988 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/23178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/16324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/161190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10803 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/16324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/161190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/22532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/22854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/161190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33646 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/22537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/16324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/16324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/181436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/22137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/85965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/181436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/21867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/22019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/21925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->