### PR TITLE
REGRESSION(308928@main): imported/w3c/web-platform-tests/fullscreen/rendering/backdrop-object.html is [ Pass Timeout ImageOnlyFailure ] recently

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -8334,8 +8334,6 @@ imported/w3c/web-platform-tests/editing/other/insertparagraph-in-child-of-head.t
 
 webkit.org/b/288546 imported/w3c/web-platform-tests/fullscreen/api/element-ready-allowed.html [ Pass Failure ]
 
-webkit.org/b/309619 imported/w3c/web-platform-tests/fullscreen/rendering/backdrop-object.html [ Pass ImageOnlyFailure Timeout ]
-
 # Tests that timed out
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-from-click.html [ Skip ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-push-navigation-hidden-document.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/backdrop-object.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/backdrop-object.html
@@ -10,20 +10,23 @@
 object::backdrop {
   background: blue;
 }
+object {
+  object-position: 0 0;
+}
 </style>
 <object width="200" type="image/svg+xml"></object>
 
 <script>
 const object = document.querySelector("object");
 
-Promise.all([
-  new Promise((resolve) => {
-    object.addEventListener("load", resolve);
-    object.data = "/images/100px-green-rect.svg";
-  }),
-  new Promise((resolve) => {
-    document.addEventListener("fullscreenchange", resolve);
-    test_driver.bless('fullscreen', () => object.requestFullscreen());
-  }),
-]).then(() => document.documentElement.classList.remove('reftest-wait'));
+document.addEventListener("fullscreenchange", async () => {
+  // Await fullscreen animation. It seems to always be done within 3 frames.
+  await new Promise(requestAnimationFrame);
+  await new Promise(requestAnimationFrame);
+  await new Promise(requestAnimationFrame);
+  document.documentElement.classList.remove('reftest-wait');
+});
+
+object.onload = () => test_driver.bless('fullscreen', () => object.requestFullscreen());
+object.data = "/images/100px-green-rect.svg";
 </script>


### PR DESCRIPTION
#### 57e7069c334d84599ccb9e922eefb36bb36ff688
<pre>
REGRESSION(308928@main): imported/w3c/web-platform-tests/fullscreen/rendering/backdrop-object.html is [ Pass Timeout ImageOnlyFailure ] recently
<a href="https://bugs.webkit.org/show_bug.cgi?id=309619">https://bugs.webkit.org/show_bug.cgi?id=309619</a>

Reviewed by Antoine Quint.

test_driver.bless creates a button and clicks on it so there is user
activation. However, this button can get shifted due to the &lt;object&gt;
element in play leading to it getting missed. (This part wasn&apos;t a
problem before because the click was fully synchronous. But that&apos;s no
longer the case.)

An additional problem is that the fullscreen animation might not have
finished by the time we hit fullscreenchange so we need a couple of
additional frames before confirming the final rendering.

(The object-position change came from upstream.)

Upstream:

    <a href="https://github.com/web-platform-tests/wpt/pull/58434">https://github.com/web-platform-tests/wpt/pull/58434</a>

Canonical link: <a href="https://commits.webkit.org/309132@main">https://commits.webkit.org/309132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1cf4befe65006375e99d1a094760d1ac7c96f85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22302 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/15881 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158287 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103016 "Build is in progress. Recent messages:") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22232 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/115388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/103016 "Build is in progress. Recent messages:") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152544 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/17526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/134242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/96129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6131 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/12173 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/160763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3761 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/13714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/160763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22105 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/18567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/160763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/22112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/133965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78327 "Failed to checkout and rebase branch from PR 60375") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23026 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/10716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21712 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21443 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21595 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21500 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->