### PR TITLE
[DRAFT] Reset scroll tracking state after back/forward cache restore to fix scroll pocket color

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -522,6 +522,16 @@ void LocalFrameView::didRestoreFromBackForwardCache()
     // When restoring from back/forward cache, the main frame stays in place while subframes get swapped in.
     // We update the scrollable area set to ensure that scrolling data structures get invalidated.
     updateScrollableAreaSet();
+
+    // Reset scroll tracking state for the main frame so that fixed container edge
+    // sampling is not blocked by stale state from the previous navigation entry.
+    // Page::didCommitLoad() clears the cached fixed container edges, and
+    // Page::updateFixedContainerEdges() skips top edge sampling when
+    // wasEverScrolledExplicitlyByUserBelowTopEdge() returns true.
+    if (m_frame->isMainFrame()) {
+        m_wasEverScrolledExplicitlyByUser = false;
+        m_wasEverScrolledExplicitlyByUserBelowTopEdge = false;
+    }
 }
 
 void LocalFrameView::willDestroyRenderTree()


### PR DESCRIPTION
#### 6371df1ecff564c7468231efd98f824187bbf723
<pre>
Reset scroll tracking state after back/forward cache restore to fix scroll pocket color
<a href="https://bugs.webkit.org/show_bug.cgi?id=305546">https://bugs.webkit.org/show_bug.cgi?id=305546</a>
<a href="https://rdar.apple.com/168340980">rdar://168340980</a>

Reviewed by NOBODY (OOPS!).

After restoring from the back/forward cache, the status bar color extension
view disappears and is replaced by a shadow. This happens because
Page::didCommitLoad() clears m_fixedContainerEdgesAndElements before
CachedPage::restore() runs, while the restored FrameView retains its
m_wasEverScrolledExplicitlyByUserBelowTopEdge=true flag from the cached
state. When updateFixedContainerEdges() later evaluates canSampleTopEdge,
the stale flag prevents resampling on platforms where
topContentInsetBackgroundCanChangeAfterScrolling is disabled (iPad/macOS).

Fix by resetting scroll tracking flags after BFCache restore so the top
edge can be resampled on the next layer tree commit. This matches the
&quot;new page load&quot; semantics that didCommitLoad establishes for other state.

* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::restore): Call resetScrollTrackingAfterBackForwardCacheRestore
on the main frame view after opening the cached frame.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::resetScrollTrackingAfterBackForwardCacheRestore): Added.
Resets m_wasEverScrolledExplicitlyByUser and
m_wasEverScrolledExplicitlyByUserBelowTopEdge.
* Source/WebCore/page/LocalFrameView.h: Add declaration.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6371df1ecff564c7468231efd98f824187bbf723

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149394 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158095 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102826 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95442cbe-bc4a-4071-9d91-d55d564920d9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22561 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115214 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81957 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1219073d-0999-4415-b16f-15fcc0a813b1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95960 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8bda9558-abc7-489b-a2fe-12ae8b125079) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16452 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14352 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5937 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126072 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160572 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3565 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13526 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123250 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123467 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21918 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133789 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78136 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18686 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10535 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21520 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85333 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21251 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21401 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21308 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->