### PR TITLE
[bmalloc] Reroute BASSERT to libpas asserts when available

### DIFF
--- a/Source/bmalloc/bmalloc/BAssert.h
+++ b/Source/bmalloc/bmalloc/BAssert.h
@@ -80,9 +80,6 @@
         BCRASH(); \
 } while (0)
 
-#define RELEASE_BASSERT(x) BASSERT_IMPL(x)
-#define RELEASE_BASSERT_NOT_REACHED() BCRASH()
-
 #if BUSE(OS_LOG)
 #define BMALLOC_LOGGING_PREFIX "bmalloc: "
 #define BLOG_ERROR(format, ...) os_log_error(OS_LOG_DEFAULT, BMALLOC_LOGGING_PREFIX format, __VA_ARGS__)
@@ -103,7 +100,20 @@
 
 #define BUNUSED(x) ((void)x)
 
+#if BUSE(LIBPAS)
+
+#include "pas_utils.h"
+
+#define BASSERT(x) PAS_TESTING_ASSERT(x)
+#define RELEASE_BASSERT(x) PAS_ASSERT(x)
+#define RELEASE_BASSERT_NOT_REACHED() PAS_ASSERT_NOT_REACHED()
+
+#else // !BUSE(LIBPAS)
+
 // ===== Release build =====
+
+#define RELEASE_BASSERT(x) BASSERT_IMPL(x)
+#define RELEASE_BASSERT_NOT_REACHED() BCRASH()
 
 #if defined(NDEBUG)
 
@@ -123,3 +133,5 @@
 #define IF_DEBUG(x) (x)
 
 #endif // !defined(NDEBUG)
+
+#endif // BUSE(LIBPAS)

--- a/Source/bmalloc/bmalloc/CompactAllocationMode.h
+++ b/Source/bmalloc/bmalloc/CompactAllocationMode.h
@@ -57,6 +57,7 @@ BINLINE constexpr pas_allocation_mode asPasAllocationMode(CompactAllocationMode 
         return pas_always_compact_allocation_mode;
     }
     RELEASE_BASSERT_NOT_REACHED();
+    return pas_non_compact_allocation_mode;
 }
 
 #endif

--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
@@ -68,6 +68,7 @@
 
 typedef uint64_t Slot;
 
+PAS_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN;
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -75,6 +76,7 @@ extern Slot g_config[];
 #ifdef __cplusplus
 }
 #endif
+PAS_ALLOW_UNSAFE_BUFFER_USAGE_END;
 
 #define PAS_MTE_ENABLE_FLAG 0
 #define PAS_MTE_MODE_BITS 1

--- a/Source/bmalloc/libpas/src/libpas/pas_utils.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_utils.h
@@ -231,6 +231,9 @@ PAS_API PAS_NO_RETURN PAS_NEVER_INLINE void pas_reallocation_did_fail(const char
                                                                       size_t old_size,
                                                                       size_t new_size);
 
+PAS_IGNORE_WARNINGS_BEGIN("missing-noreturn")
+PAS_IGNORE_WARNINGS_BEGIN("return-type")
+
 #if PAS_OS(DARWIN) && PAS_VA_OPT_SUPPORTED
 
 #define PAS_VA_COUNT6(x, ...) + 1
@@ -278,15 +281,11 @@ static PAS_ALWAYS_INLINE PAS_NO_RETURN void pas_assertion_failed(
 PAS_API PAS_NO_RETURN PAS_NEVER_INLINE void pas_assertion_failed_no_inline(const char* filename, int line, const char* function, const char* expression);
 PAS_API PAS_NO_RETURN PAS_NEVER_INLINE void pas_assertion_failed_no_inline_with_extra_detail(const char* filename, int line, const char* function, const char* expression, uint64_t extra);
 
-PAS_IGNORE_WARNINGS_BEGIN("missing-noreturn")
-
 static PAS_ALWAYS_INLINE void pas_assertion_failed_noreturn_silencer(
     const char* filename, int line, const char* function, const char* expression)
 {
     pas_assertion_failed(filename, line, function, expression);
 }
-
-PAS_IGNORE_WARNINGS_END
 
 #if PAS_OS(DARWIN) && PAS_VA_OPT_SUPPORTED
 
@@ -315,8 +314,6 @@ PAS_NEVER_INLINE void pas_report_assertion_failed(
 #define PAS_REPORT_ASSERTION_FAILED(filename, line, function, expression) \
     PAS_UNUSED_ASSERTION_FAILED_ARGS(filename, line, function, expression)
 #endif
-
-PAS_IGNORE_WARNINGS_BEGIN("missing-noreturn")
 
 static PAS_ALWAYS_INLINE void pas_assertion_failed_noreturn_silencer1(
     const char* filename, int line, const char* function, const char* expression, uint64_t misc1)
@@ -359,8 +356,6 @@ static PAS_ALWAYS_INLINE void pas_assertion_failed_noreturn_silencer6(
     PAS_REPORT_ASSERTION_FAILED(filename, line, function, expression);
     pas_crash_with_info_impl6((uint64_t)line, misc1, misc2, misc3, misc4, misc5, misc6);
 }
-
-PAS_IGNORE_WARNINGS_END
 
 /* The count argument will always be computed with PAS_VA_NUM_ARGS in the client.
    Hence, it is always a constant, and the following cascade of if statements will
@@ -485,6 +480,9 @@ PAS_IGNORE_WARNINGS_END
     } while (0)
 
 #define PAS_ASSERT_NOT_REACHED(...) PAS_ASSERT(!"Should not be reached", __VA_ARGS__)
+
+PAS_IGNORE_WARNINGS_END
+PAS_IGNORE_WARNINGS_END
 
 static inline bool pas_is_power_of_2(uintptr_t value)
 {


### PR DESCRIPTION
#### 736a08b1bbf553a10c02b604107318f0ee3d25c0
<pre>
[bmalloc] Reroute BASSERT to libpas asserts when available
<a href="https://bugs.webkit.org/show_bug.cgi?id=309694">https://bugs.webkit.org/show_bug.cgi?id=309694</a>
<a href="https://rdar.apple.com/171019019">rdar://171019019</a>

Reviewed by Keith Miller.

This gives us the benefit of extra information like the line-number of a
crash without incurring further code-duplication between the different
sub-projects.

Canonical link: <a href="https://commits.webkit.org/309224@main">https://commits.webkit.org/309224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10aff2d5043079a4f6b3d4b40cd12be248c5721c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149735 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158448 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103167 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9625cc5-838e-466e-bd6f-d2b09b354971) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22904 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115522 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82109 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c41088f2-cf1f-45f7-b8f4-2f3871ab817b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17641 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134380 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96257 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74fd74f5-76fd-4b5b-b26c-630bfa24f7ed) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16737 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14651 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6286 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141711 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126345 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160917 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10529 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13853 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123544 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22256 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123743 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33643 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134104 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78488 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18909 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10855 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181164 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21864 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46394 "Build was cancelled. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21594 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21746 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21651 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->