### PR TITLE
[run-webkit-tests] Extend --test-list to support inline TestExpectations syntax.

### DIFF
--- a/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py
@@ -59,11 +59,14 @@ class LayoutTestFinder(object):
         self._options = options
         self._filesystem = self._port.host.filesystem
         self.LAYOUT_TESTS_DIRECTORY = 'LayoutTests'
+        self._test_list_expectations = []
 
     def find_tests(self, options, args, device_type=None, with_expectations=False):
         paths = self._strip_test_dir_prefixes(args)
         if options and options.test_list:
-            paths += self._strip_test_dir_prefixes(self._read_test_names_from_file(options.test_list, self._port.TEST_PATH_SEPARATOR))
+            test_names, expectations = self._read_test_names_from_file(options.test_list, self._port.TEST_PATH_SEPARATOR)
+            paths += self._strip_test_dir_prefixes(test_names)
+            self._test_list_expectations = expectations
         tests = self.find_tests_by_path(paths, device_type=device_type, with_expectations=with_expectations)
         return (paths, tests)
 
@@ -76,7 +79,8 @@ class LayoutTestFinder(object):
         """
         paths = self._strip_test_dir_prefixes(args)
         if options and options.test_list:
-            paths += self._strip_test_dir_prefixes(self._read_test_names_from_file(options.test_list, self._port.TEST_PATH_SEPARATOR))
+            test_names, _ = self._read_test_names_from_file(options.test_list, self._port.TEST_PATH_SEPARATOR)
+            paths += self._strip_test_dir_prefixes(test_names)
 
         layout_tests_dir = self._port.layout_tests_dir()
         paths = [p for p in paths
@@ -152,24 +156,48 @@ class LayoutTestFinder(object):
     def _read_test_names_from_file(self, filenames, test_path_separator):
         fs = self._filesystem
         tests = []
+        expectations = []
         for filename in filenames:
             if test_path_separator != fs.sep:
                 filename = filename.replace(test_path_separator, fs.sep)
             file_contents = fs.read_text_file(filename).split('\n')
-            for line in file_contents:
-                line = self._strip_comments(line)
-                if line:
-                    tests.append(line)
-        return tests
+            for line_number, line in enumerate(file_contents, 1):
+                content = self._strip_test_list_comments(line)
+                if not content:
+                    continue
+
+                if '[' in content:
+                    # Line has inline expectations (TestExpectations syntax)
+                    expectations.append((filename, line_number, content))
+                    test_name = content[:content.index('[')].strip()
+                    if test_name:
+                        tests.append(test_name)
+                else:
+                    tests.append(content)
+        return tests, expectations
+
+    def get_test_list_expectations(self):
+        return self._test_list_expectations
+
+    def get_test_list_skip_paths(self):
+        skip_paths = set()
+        for _filename, _line_number, raw_line in self._test_list_expectations:
+            match = re.search(r'\[([^\]]+)\]', raw_line)
+            if match and 'SKIP' in match.group(1).upper().split():
+                test_name = raw_line[:raw_line.index('[')].strip()
+                if test_name:
+                    skip_paths.add(test_name)
+        return skip_paths
 
     @staticmethod
-    def _strip_comments(line):
-        commentIndex = line.find('//')
-        if commentIndex == -1:
-            commentIndex = len(line)
-
-        line = re.sub(r'\s+', ' ', line[:commentIndex].strip())
-        if line == '':
-            return None
-        else:
-            return line
+    def _strip_test_list_comments(line):
+        # Strip // comments by finding the position and truncating.
+        comment_index = line.find('//')
+        if comment_index != -1:
+            line = line[:comment_index]
+        # Strip # comments.
+        comment_index = line.find('#')
+        if comment_index != -1:
+            line = line[:comment_index]
+        line = re.sub(r'\s+', ' ', line.strip())
+        return line if line else None

--- a/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
+++ b/Tools/Scripts/webkitpy/layout_tests/controllers/manager.py
@@ -128,6 +128,7 @@ class Manager(object):
             self._printer.write_update(u'Parsing expectations {}...'.format(for_device_type))
             self._expectations[device_type] = test_expectations.TestExpectations(self._port, test_names, force_expectations_pass=self._options.force, device_type=device_type)
             self._expectations[device_type].parse_all_expectations()
+            self._expectations[device_type].add_test_list_expectations(self._finder.get_test_list_expectations())
 
             tests_to_run = self._tests_to_run(tests, device_type=device_type)
             tests_to_run_by_device[device_type] = [test for test in tests_to_run if test not in aggregate_tests_to_run]
@@ -334,11 +335,13 @@ class Manager(object):
             skipped_tests_by_path[test.test_path].add(test)
 
         # If a test is marked skipped, but was explicitly requested, run it anyways.
+        # However, tests explicitly marked [ Skip ] in a --test-list file should stay skipped.
         if self._options.skipped != 'always':
+            test_list_skip_paths = self._finder.get_test_list_skip_paths()
             _, explicitly_specified_tests = self._finder.find_tests_for_specified_files(self._options, args)
             for test in explicitly_specified_tests:
                 path = test.test_path
-                if path in skipped_tests_by_path:
+                if path in skipped_tests_by_path and path not in test_list_skip_paths:
                     skipped_tests = skipped_tests_by_path[path]
                     tests_to_run_by_device[device_type_list[0]].extend(skipped_tests)
                     aggregate_tests_to_run |= skipped_tests

--- a/Tools/Scripts/webkitpy/layout_tests/models/test_expectations.py
+++ b/Tools/Scripts/webkitpy/layout_tests/models/test_expectations.py
@@ -1219,6 +1219,20 @@ class TestExpectations(object):
             expectation_line = self._parser.expectation_for_skipped_test(test_name)
             self._model.add_expectation_line(expectation_line, in_skipped=True)
 
+    def add_test_list_expectations(self, test_list_expectations):
+        # type: (List[Tuple[str, int, str]]) -> None
+        if not test_list_expectations:
+            return
+
+        expectation_lines = []
+        for filename, line_number, raw_line in test_list_expectations:
+            exp_line = TestExpectationParser._tokenize_line(filename, raw_line, line_number)
+            self._parser._parse_line(exp_line)
+            expectation_lines.append(exp_line)
+
+        self._add_expectations(expectation_lines)
+        self._expectations += expectation_lines
+
     @staticmethod
     def list_to_string(
         expectation_lines,  # type: Iterable[TestExpectationLine]

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
@@ -495,6 +495,77 @@ class RunTest(unittest.TestCase, StreamTestingMixin):
         tests_run = get_tests_run(['--test-list=%s' % filename], host=host)
         self.assertEqual(['passes/text.html'], tests_run)
 
+    def test_test_list_with_skip_expectation(self):
+        host = MockHost()
+        filename = '/tmp/foo.txt'
+        host.filesystem.write_text_file(filename, 'passes/text.html [ Skip ]\npasses/image.html')
+        tests_run = get_tests_run(['--test-list=%s' % filename], host=host)
+        self.assertEqual(['passes/image.html'], tests_run)
+
+    def test_test_list_with_hash_comments(self):
+        host = MockHost()
+        filename = '/tmp/foo.txt'
+        host.filesystem.write_text_file(filename, '# this is a comment\npasses/text.html\n# another comment')
+        tests_run = get_tests_run(['--test-list=%s' % filename], host=host)
+        self.assertEqual(['passes/text.html'], tests_run)
+
+    def test_test_list_with_mixed_content(self):
+        host = MockHost()
+        filename = '/tmp/foo.txt'
+        host.filesystem.write_text_file(filename,
+                                        '# comment line\n'
+                                        'passes/text.html\n'
+                                        '// legacy comment\n'
+                                        'passes/image.html [ Failure ]\n'
+                                        '\n'
+                                        'passes/error.html\n')
+        tests_run = get_tests_run(['--test-list=%s' % filename], host=host)
+        self.assertIn('passes/text.html', tests_run)
+        self.assertIn('passes/image.html', tests_run)
+        self.assertIn('passes/error.html', tests_run)
+
+    def test_test_list_with_slow_expectation(self):
+        host = MockHost()
+        filename = '/tmp/foo.txt'
+        host.filesystem.write_text_file(filename, 'passes/text.html [ Slow ]')
+        results = get_test_results(['--test-list=%s' % filename], host=host)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].test_name, 'passes/text.html')
+        self.assertTrue(results[0].test_input.is_slow)
+
+    def test_test_list_with_failure_expectation(self):
+        host = MockHost()
+        filename = '/tmp/foo.txt'
+        host.filesystem.write_text_file(filename, 'failures/unexpected/text.html [ Failure ]')
+        details, _, _ = logging_run(['--test-list=%s' % filename], tests_included=True, host=host)
+        self.assertNotIn('failures/unexpected/text.html', details.initial_results.unexpected_results_by_name)
+
+    def test_test_list_with_double_slash_comments(self):
+        host = MockHost()
+        filename = '/tmp/foo.txt'
+        host.filesystem.write_text_file(filename, '// this is a legacy comment\npasses/text.html // inline comment')
+        tests_run = get_tests_run(['--test-list=%s' % filename], host=host)
+        self.assertEqual(['passes/text.html'], tests_run)
+
+    def test_test_list_skip_not_overridden(self):
+        # Tests marked [ Skip ] in the test-list should stay skipped,
+        # even though being in the test-list makes them "explicitly specified".
+        host = MockHost()
+        filename = '/tmp/foo.txt'
+        host.filesystem.write_text_file(filename, 'passes/text.html [ Skip ]\npasses/image.html')
+        tests_run = get_tests_run(['--test-list=%s' % filename], host=host)
+        self.assertNotIn('passes/text.html', tests_run)
+        self.assertIn('passes/image.html', tests_run)
+
+    def test_test_list_unskip_with_pass(self):
+        # A test marked [ Skip ] in TestExpectations can be un-skipped
+        # by marking it [ Pass ] in the test-list file.
+        host = MockHost()
+        filename = '/tmp/foo.txt'
+        host.filesystem.write_text_file(filename, 'passes/skipped/skip.html [ Pass ]')
+        tests_run = get_tests_run(['--test-list=%s' % filename], host=host)
+        self.assertIn('passes/skipped/skip.html', tests_run)
+
     def test_missing_and_unexpected_results(self):
         # Test that we update expectations in place. If the expectation
         # is missing, update the expected generic location.


### PR DESCRIPTION
#### cb97940984aef5babb9025633eb65d32a76100cb
<pre>
[run-webkit-tests] Extend --test-list to support inline TestExpectations syntax.
<a href="https://bugs.webkit.org/show_bug.cgi?id=309696">https://bugs.webkit.org/show_bug.cgi?id=309696</a>
<a href="https://rdar.apple.com/172301315">rdar://172301315</a>

Reviewed by Jonathan Bedard.

The `--test-list` option for `run-webkit-tests` accepts a text file listing test paths to
run. Currently, the file format only supports plain test paths (one per line) with `//`
comments. There is no way to annotate individual tests with expectations.

This change extends the `--test-list` file format to support inline expectations using the
standard TestExpectations bracket syntax:

```
fast/dom/test1.html

fast/dom/test2.html [ Skip ]
fast/dom/test3.html [ Slow ]
fast/dom/test4.html [ Pass Failure ]
```

The full TestExpectations syntax is supported (Skip, Slow, Failure, Timeout, Crash, Pass,
etc.). Both `#` and `//` comments are supported.

**Behavior:**

- **`test.html`** (plain path) — Include the test in the run, keep existing expectations
  from TestExpectations files. If the test is marked Skip in TestExpectations, it is
  un-skipped (existing behavior, unchanged).
- **`test.html [ Pass ]`** — Include and explicitly override the expectation to Pass,
  regardless of what TestExpectations files say.
- **`test.html [ Skip ]`** — Include in the test set but skip it. This Skip is honored
  and not overridden by the explicit-specification logic.
- **`test.html [ Slow ]`** — Include with extended timeout.
- **`test.html [ Failure ]`** — Include and expect failure. A failure result will not be
  reported as unexpected.

Inline expectations from `--test-list` files are injected with highest priority, overriding
expectations from all other sources (generic TestExpectations, platform-specific, overrides,
and Skipped files). This means a test marked `[ Skip ]` in the standard TestExpectations
can be un-skipped by listing it in the test-list as a plain path or with `[ Pass ]`.
Conversely, tests marked `[ Skip ]` in the test-list file stay skipped.

Plain paths without brackets do not alter expectations — they only control which tests are
included in the run. This is consistent with the existing `--test-list` behavior.

**Motivation:**

When investigating specific sets of tests (e.g., triaging failures, running a curated
subset for a feature area), it is useful to annotate individual tests in the list file
itself rather than editing the global TestExpectations files. This avoids polluting the
shared expectations and allows ad-hoc, per-session control over test behavior.

* Tools/Scripts/webkitpy/layout_tests/controllers/layout_test_finder_legacy.py:
(LayoutTestFinder.__init__):
(LayoutTestFinder._read_test_names_from_file):
(LayoutTestFinder.get_test_list_expectations):
(LayoutTestFinder):
(LayoutTestFinder.get_test_list_skip_paths):
(LayoutTestFinder._strip_comments):
(LayoutTestFinder._strip_hash_and_whitespace):
* Tools/Scripts/webkitpy/layout_tests/controllers/manager.py:
(Manager._collect_tests):
(Manager.run):
* Tools/Scripts/webkitpy/layout_tests/models/test_expectations.py:
(TestExpectations.add_test_list_expectations):
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py:
(RunTest.test_test_list_with_skip_expectation):
(RunTest):
(RunTest.test_test_list_with_hash_comments):
(RunTest.test_test_list_with_mixed_content):
(RunTest.test_test_list_with_slow_expectation):
(RunTest.test_test_list_with_failure_expectation):
(RunTest.test_test_list_with_double_slash_comments):
(RunTest.test_test_list_skip_not_overridden):
(RunTest.test_test_list_unskip_with_pass):

Canonical link: <a href="https://commits.webkit.org/309087@main">https://commits.webkit.org/309087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f706197ead1b5dc8333610418039c5808df1c492

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158103 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b575d12-364f-4887-91ee-4b44d9203860) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21993 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115220 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/598c1d67-f0b5-4485-bb40-3b51894c49df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95966 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8d166ca9-2442-4ae6-bb88-ee8adf53b5b1) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/148723 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5946 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160580 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123257 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21918 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18390 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123474 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33554 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133793 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/18696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10539 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21528 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21259 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/21409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21316 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->