### PR TITLE
pointer-event-button-and-buttons is constantly timing out

### DIFF
--- a/LayoutTests/pointerevents/ios/pointer-event-button-and-buttons.html
+++ b/LayoutTests/pointerevents/ios/pointer-event-button-and-buttons.html
@@ -23,13 +23,14 @@ target_test({ width: "200px", height: "200px" }, (target, test) => {
         one.end()
     ]).then(() => {
         eventTracker.assertMatchesEvents([
-            { type: "pointerover", button: 0, buttons: 1 },
-            { type: "pointerenter", button: 0, buttons: 1 },
+            { type: "pointerover", button: -1, buttons: 1 },
+            { type: "pointerenter", button: -1, buttons: 1 },
             { type: "pointerdown", button: 0, buttons: 1 },
             { type: "pointermove", button: -1, buttons: 1 },
+            { type: "pointermove", button: -1, buttons: 1 },
             { type: "pointerup", button: 0, buttons: 0 },
-            { type: "pointerout", button: 0, buttons: 0 },
-            { type: "pointerleave", button: 0, buttons: 0 },
+            { type: "pointerout", button: -1, buttons: 0 },
+            { type: "pointerleave", button: -1, buttons: 0 },
         ]);
         test.done();
     });


### PR DESCRIPTION
#### 76791cd00d336e1ac7c4105e2fa45908f7fce00e
<pre>
pointer-event-button-and-buttons is constantly timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=309709">https://bugs.webkit.org/show_bug.cgi?id=309709</a>
<a href="https://rdar.apple.com/122591319">rdar://122591319</a>

Reviewed by Wenson Hsieh and Abrar Rahman Protyasha.

This test was timing out because the assert in EventTracker.assertMatchesEvents
was failing, which caused test.done() never to be called.

The assert was failing because the button attribute of the pointer events were
wrong and there was an extra pointermove event.

The test was expecting incorrect and stale values for the button attribute, which
was addressed here: <a href="https://commits.webkit.org/268459@main.">https://commits.webkit.org/268459@main.</a>

I believe the extra pointermove event is just the result of some timing changing.
I looked at the spec and it doesn&apos;t seem like the amount of pointermove events
fired is deterministic.

* LayoutTests/pointerevents/ios/pointer-event-button-and-buttons.html:

Canonical link: <a href="https://commits.webkit.org/309120@main">https://commits.webkit.org/309120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e312b8c2376931e8d64cebc31db5b31f6af078e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158124 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102854 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a455b648-1592-4d1c-9cd6-845f35be29f1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115241 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81966 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7db05c36-9065-4de5-9492-315808545801) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95987 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02931c8b-e630-4829-8cd1-13e59455daab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16486 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5967 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12029 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160601 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123277 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18423 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123491 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33575 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21950 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133821 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78164 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18702 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10572 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21548 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21279 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21432 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21336 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->