### PR TITLE
[iOS] Unable to select AirPlay route prior to playing a video

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -205,7 +205,11 @@ void MediaSessionManagerCocoa::updateSessionState()
     if (mode == AudioSession::Mode::Default && category == AudioSession::CategoryType::PlayAndRecord)
         mode = AudioSession::Mode::VideoChat;
 
+#if HAVE(AVROUTING_FRAMEWORK)
+    RouteSharingPolicy policy = RouteSharingPolicy::LongFormAudio;
+#else
     RouteSharingPolicy policy = (category == AudioSession::CategoryType::MediaPlayback) ? RouteSharingPolicy::LongFormAudio : RouteSharingPolicy::Default;
+#endif
 
     ALWAYS_LOG(LOGIDENTIFIER, "setting category = ", category, ", mode = ", mode, ", policy = ", policy, ", previous category = ", m_previousCategory);
 

--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -308,3 +308,11 @@ selectors = [
     { name = "_lookToScrollGroupName", class = "UIScrollView" },
 ]
 requires = ["PLATFORM_VISION"]
+
+[[staging]]
+request = "rdar://171222829"
+selectors = [
+    { name = "setPresentingAppBundleID:", class = "?" },
+    { name = "setPresentingAppProcessIdentifier:", class = "?" },
+]
+requires = ["ENABLE_AIRPLAY_PICKER", "ENABLE_WIRELESS_PLAYBACK_MEDIA_PLAYER"]

--- a/Source/WebKit/UIProcess/ios/forms/WKAirPlayRoutePicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKAirPlayRoutePicker.mm
@@ -81,11 +81,12 @@ typedef NSInteger WKAirPlayRoutePickerRouteSharingPolicy;
     __block RetainPtr<MPAVRoutingController> routingController = adoptNS([allocMPAVRoutingControllerInstance() initWithName:@"WebKit - HTML media element showing AirPlay route picker"]);
     [routingController setDiscoveryMode:MPRouteDiscoveryModeDetailed];
 
-    RetainPtr<MPMediaControlsConfiguration> configuration;
-    if ([getMPMediaControlsConfigurationClassSingleton() instancesRespondToSelector:@selector(setSortByIsVideoRoute:)]) {
-        configuration = adoptNS([allocMPMediaControlsConfigurationInstance() init]);
-        configuration.get().sortByIsVideoRoute = hasVideo;
-    }
+    RetainPtr configuration = adoptNS([allocMPMediaControlsConfigurationInstance() init]);
+    [configuration setSortByIsVideoRoute:hasVideo];
+#if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
+    [configuration setPresentingAppProcessIdentifier:getCurrentProcessID()];
+    [configuration setPresentingAppBundleID:applicationBundleIdentifier().createNSString().get()];
+#endif
     _actionSheet = adoptNS([allocMPMediaControlsViewControllerInstance() initWithConfiguration:configuration.get()]);
 
     if ([_actionSheet respondsToSelector:@selector(setOverrideRouteSharingPolicy:routingContextUID:)])


### PR DESCRIPTION
#### 43b9e770e01396b4c8f0b29030f3c058853bc6db
<pre>
[iOS] Unable to select AirPlay route prior to playing a video
<a href="https://bugs.webkit.org/show_bug.cgi?id=309711">https://bugs.webkit.org/show_bug.cgi?id=309711</a>
<a href="https://rdar.apple.com/170356272">rdar://170356272</a>

Reviewed by Jer Noble and Eric Carlson.

Updated MediaSessionManagerCocoa to use a long-form route sharing policy unconditionally so that
users can configure an AirPlay route prior to starting audible media playback. Updated
WKAirPlayRoutePicker to configure its MPMediaControlsViewController such that it can find WebKit&apos;s
audio session in the GPU process.

* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateSessionState):
* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/UIProcess/ios/forms/WKAirPlayRoutePicker.mm:
(-[WKAirPlayRoutePicker showFromView:routeSharingPolicy:routingContextUID:hasVideo:]):

Canonical link: <a href="https://commits.webkit.org/309371@main">https://commits.webkit.org/309371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7cdebcb37f5cfe7f88f06e0d70a3987c8c28b5eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150432 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159154 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103866 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca925236-838d-4320-b3f3-ee76b5b2e6b7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152305 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116070 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82471 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6dc7ead5-3d47-47a9-bf76-1f279ae3c4c3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18183 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96798 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ccf94129-1014-4d91-8d1e-15d4119f9d2f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17282 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15227 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7002 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126897 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12871 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161628 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4748 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14424 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124069 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19274 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124267 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33745 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22979 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134666 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79359 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19384 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11423 "Found 1 new test failure: fast/attachment/mac/wide-attachment-image-controls-basic.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22593 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86392 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22306 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22458 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22360 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->