### PR TITLE
[JSC] Fix FTL BigInt operations for comparisons

### DIFF
--- a/JSTests/stress/big-int-call-side-effect.js
+++ b/JSTests/stress/big-int-call-side-effect.js
@@ -1,0 +1,20 @@
+//@ runDefault("--thresholdForFTLOptimizeAfterWarmUp=0", "--osrExitCountForReoptimization=15", "--useConcurrentJIT=0")
+
+function main() {
+  function v1(v2, v3) {}
+  function v4(v5, v6, v7, v8, v9) {
+    flashHeapAccess(0.1);
+    for (let v14 = 0; v14 < 100; v14++) {
+      const v15 = {};
+      switch (v5) {
+      case v15:
+      case v7:
+      case `number${-547391.1881778344}boolean${v1}E${v5}icKGfbgqm5`:
+      }
+    }
+  }
+  for (let v20 = 0; v20 < 100; v20++) {
+    const v21 = v4?.(-2147483647n);
+  }
+}
+main();

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -12440,8 +12440,7 @@ IGNORE_CLANG_WARNINGS_END
 
             LBasicBlock lastNext = m_out.appendTo(notTriviallyEqualCase, continuation);
 
-            ValueFromBlock slowResult = m_out.anchor(m_out.notZero64(
-                m_out.callWithoutSideEffects(Int64, operationCompareHeapBigIntEq, left, right)));
+            ValueFromBlock slowResult = m_out.anchor(m_out.notZero64(vmCall(Int64, operationCompareHeapBigIntEq, left, right)));
             m_out.jump(continuation);
 
             m_out.appendTo(continuation, lastNext);
@@ -19385,19 +19384,19 @@ IGNORE_CLANG_WARNINGS_END
             LValue result;
             switch (m_node->op()) {
             case CompareLess:
-                result = m_out.callWithoutSideEffects(Int64, operationCompareHeapBigIntLess, left, right);
+                result = vmCall(Int64, operationCompareHeapBigIntLess, left, right);
                 break;
             case CompareLessEq:
-                result = m_out.callWithoutSideEffects(Int64, operationCompareHeapBigIntLessEq, left, right);
+                result = vmCall(Int64, operationCompareHeapBigIntLessEq, left, right);
                 break;
             case CompareGreater:
-                result = m_out.callWithoutSideEffects(Int64, operationCompareHeapBigIntGreater, left, right);
+                result = vmCall(Int64, operationCompareHeapBigIntGreater, left, right);
                 break;
             case CompareGreaterEq:
-                result = m_out.callWithoutSideEffects(Int64, operationCompareHeapBigIntGreaterEq, left, right);
+                result = vmCall(Int64, operationCompareHeapBigIntGreaterEq, left, right);
                 break;
             case CompareEq:
-                result = m_out.callWithoutSideEffects(Int64, operationCompareHeapBigIntEq, left, right);
+                result = vmCall(Int64, operationCompareHeapBigIntEq, left, right);
                 break;
             default:
                 RELEASE_ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### dc46995eb9ed6f2af8e2c8d95414df91fe79cddf
<pre>
[JSC] Fix FTL BigInt operations for comparisons
<a href="https://bugs.webkit.org/show_bug.cgi?id=309712">https://bugs.webkit.org/show_bug.cgi?id=309712</a>
<a href="https://rdar.apple.com/171518842">rdar://171518842</a>

Reviewed by Yijia Huang.

callWithoutSideEffects should be used only when it is pure operation and
it is not load-dependent. HeapBigInt speculation requirement means that
this function call is load-dependent: we need to check and load the
cell&apos;s type before calling operation. Otherwise, this call can be
hoisted randomly before the check.

Test: JSTests/stress/big-int-call-side-effect.js

* JSTests/stress/big-int-call-side-effect.js: Added.
(main.v1):
(main.v4):
(main):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/309099@main">https://commits.webkit.org/309099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53fb6396cbce9817de5ca63f001ab1354898770d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15710 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158128 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115244 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17396 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/134098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95990 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db5acf41-c186-41a6-8e27-e49e18bbd3da) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5971 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141413 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12031 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160605 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10217 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123280 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123494 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/21954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133823 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23013 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10574 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180855 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21552 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85386 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46342 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; jscore-tests (cancelled)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21283 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/21436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21340 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->