### PR TITLE
[css-grid] Update grid-shorthands-style-format test for shortest-form serialization

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1664,7 +1664,6 @@ imported/w3c/web-platform-tests/css/css-flexbox/flexbox-flex-wrap-flexing-003.ht
 imported/w3c/web-platform-tests/css/css-flexbox/multiline-shrink-to-fit.html [ ImageOnlyFailure ]
 
 # grid layout tests
-webkit.org/b/149890 fast/css-grid-layout/grid-shorthands-style-format.html [ Failure ]
 webkit.org/b/191508 fast/css-grid-layout/crash-large-positions.html [ Skip ]
 
 webkit.org/b/231021 imported/w3c/web-platform-tests/css/css-grid/grid-with-dynamic-img.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/css-grid-layout/grid-shorthands-style-format-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/grid-shorthands-style-format-expected.txt
@@ -2,28 +2,29 @@ Test that the format of grid shorthands style uses slashes as expected
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
+
 Test grid-column shorthand
-PASS item.style.gridColumn is "1 / auto"
+PASS item.style.gridColumn is "1"
 PASS item.style.gridColumn is "1 / 3"
 PASS item.style.gridColumn is "1 / span 2"
 PASS item.style.gridColumn is "foo / bar"
 PASS item.style.gridColumn is "foo / span bar"
 PASS item.style.gridColumn is "2 foo / span 3 bar"
 Test grid-row shorthand
-PASS item.style.gridRow is "1 / auto"
+PASS item.style.gridRow is "1"
 PASS item.style.gridRow is "1 / 3"
 PASS item.style.gridRow is "1 / span 2"
 PASS item.style.gridRow is "foo / bar"
 PASS item.style.gridRow is "foo / span bar"
 PASS item.style.gridRow is "2 foo / span 3 bar"
 Test grid-area shorthand
-PASS item.style.gridArea is "1 / auto / auto / auto"
-PASS item.style.gridArea is "1 / 3 / auto / auto"
-PASS item.style.gridArea is "1 / span 2 / auto / auto"
-PASS item.style.gridArea is "foo / foo / foo / foo"
-PASS item.style.gridArea is "foo / bar / foo / bar"
-PASS item.style.gridArea is "2 foo / span 3 bar / auto / auto"
-PASS item.style.gridArea is "1 / 2 / 3 / auto"
+PASS item.style.gridArea is "1"
+PASS item.style.gridArea is "1 / 3"
+PASS item.style.gridArea is "1 / span 2"
+PASS item.style.gridArea is "foo"
+PASS item.style.gridArea is "foo / bar"
+PASS item.style.gridArea is "2 foo / span 3 bar"
+PASS item.style.gridArea is "1 / 2 / 3"
 PASS item.style.gridArea is "1 / 3 / 2 / 4"
 PASS item.style.gridArea is "1 / span 2 / 1 / span 2"
 PASS item.style.gridArea is "foo / bar / baz / qux"

--- a/LayoutTests/fast/css-grid-layout/grid-shorthands-style-format.html
+++ b/LayoutTests/fast/css-grid-layout/grid-shorthands-style-format.html
@@ -11,7 +11,7 @@
 
     debug("Test grid-column shorthand");
     item.style.gridColumn = "1";
-    shouldBeEqualToString("item.style.gridColumn", "1 / auto");
+    shouldBeEqualToString("item.style.gridColumn", "1");
     item.style.gridColumn = "1 / 3";
     shouldBeEqualToString("item.style.gridColumn", "1 / 3");
     item.style.gridColumn = "1 / span 2";
@@ -25,7 +25,7 @@
 
     debug("Test grid-row shorthand");
     item.style.gridRow = "1";
-    shouldBeEqualToString("item.style.gridRow", "1 / auto");
+    shouldBeEqualToString("item.style.gridRow", "1");
     item.style.gridRow = "1 / 3";
     shouldBeEqualToString("item.style.gridRow", "1 / 3");
     item.style.gridRow = "1 / span 2";
@@ -39,19 +39,19 @@
 
     debug("Test grid-area shorthand");
     item.style.gridArea = "1";
-    shouldBeEqualToString("item.style.gridArea", "1 / auto / auto / auto");
+    shouldBeEqualToString("item.style.gridArea", "1");
     item.style.gridArea = "1 / 3";
-    shouldBeEqualToString("item.style.gridArea", "1 / 3 / auto / auto");
+    shouldBeEqualToString("item.style.gridArea", "1 / 3");
     item.style.gridArea = "1 / span 2";
-    shouldBeEqualToString("item.style.gridArea", "1 / span 2 / auto / auto");
+    shouldBeEqualToString("item.style.gridArea", "1 / span 2");
     item.style.gridArea = "foo / foo";
-    shouldBeEqualToString("item.style.gridArea", "foo / foo / foo / foo");
+    shouldBeEqualToString("item.style.gridArea", "foo");
     item.style.gridArea = "foo / bar";
-    shouldBeEqualToString("item.style.gridArea", "foo / bar / foo / bar");
+    shouldBeEqualToString("item.style.gridArea", "foo / bar");
     item.style.gridArea = "2 foo / span 3 bar";
-    shouldBeEqualToString("item.style.gridArea", "2 foo / span 3 bar / auto / auto");
+    shouldBeEqualToString("item.style.gridArea", "2 foo / span 3 bar");
     item.style.gridArea = "1 / 2 / 3";
-    shouldBeEqualToString("item.style.gridArea", "1 / 2 / 3 / auto");
+    shouldBeEqualToString("item.style.gridArea", "1 / 2 / 3");
     item.style.gridArea = "1 / 3 / 2 / 4";
     shouldBeEqualToString("item.style.gridArea", "1 / 3 / 2 / 4");
     item.style.gridArea = "1 / span 2 / 1 / span 2";


### PR DESCRIPTION
#### de9f188d4061818c9b43d27e8292dba0a11f1f43
<pre>
[css-grid] Update grid-shorthands-style-format test for shortest-form serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=309713">https://bugs.webkit.org/show_bug.cgi?id=309713</a>
<a href="https://rdar.apple.com/172310714">rdar://172310714</a>

Reviewed by Elika Etemad.

Grid shorthand properties now serialize in shortest form.
Update the test expectations to match and remove the Failure entry from TestExpectations.

* LayoutTests/TestExpectations:
* LayoutTests/fast/css-grid-layout/grid-shorthands-style-format-expected.txt:
* LayoutTests/fast/css-grid-layout/grid-shorthands-style-format.html:

Canonical link: <a href="https://commits.webkit.org/309111@main">https://commits.webkit.org/309111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44880d097d3a0daaf1101570d5deeecd8d9cc39a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149429 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158131 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102861 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22020 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115247 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd453d01-1a25-4f29-89a7-e48e5e744de7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152389 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17401 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95992 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16497 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14382 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5974 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12027 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160608 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13557 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123282 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123496 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33570 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21957 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133819 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78171 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18704 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10567 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21561 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21286 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21439 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21343 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->