### PR TITLE
AX: AXObjectCache::onPopoverToggled can resolve relations downstream of element removal, which causes a release assert

### DIFF
--- a/LayoutTests/accessibility/popover-remove-controller-then-popover-crash-expected.txt
+++ b/LayoutTests/accessibility/popover-remove-controller-then-popover-crash-expected.txt
@@ -1,0 +1,9 @@
+This test ensures we don't crash when a popover controller is removed from the DOM and the popover is immediately removed afterwards.
+
+PASS: Popover is open.
+PASS: No crash after removing a popover controller and then the popover.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/popover-remove-controller-then-popover-crash.html
+++ b/LayoutTests/accessibility/popover-remove-controller-then-popover-crash.html
@@ -1,0 +1,60 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="test-content">
+    <button type="button" id="controller1" commandfor="mypopover" command="toggle-popover">Controller 1</button>
+    <button type="button" id="controller2" commandfor="mypopover" command="show-popover">Controller 2</button>
+    <div id="extra" aria-controls="mypopover" role="button">Extra controller</div>
+
+    <span id="popover-label">Popover Label</span>
+    <div id="mypopover" popover aria-labelledby="popover-label">Popover content</div>
+</div>
+
+<script>
+var output = "This test ensures we don't crash when a popover controller is removed from the DOM and the popover is immediately removed afterwards.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    // Step 1: Touch the accessibility tree to ensure AX objects exist for everything.
+    touchAccessibilityTree(accessibilityController.rootElement);
+
+    setTimeout(async () => {
+        // Show the popover so that hiding it (via removal) triggers onPopoverToggle.
+        document.getElementById("mypopover").showPopover();
+        await waitFor(() => {
+            return document.getElementById("mypopover").matches(":popover-open");
+        });
+        output += "PASS: Popover is open.\n";
+
+        // Step 2: Remove one of the controllers and dirty the aria-labelledby
+        // relationship at the same time. This modifies the DOM tree and the tree
+        // scope's ID-to-element ordered map while relations are still cached.
+        document.getElementById("controller1").remove();
+        document.getElementById("popover-label").id = "popover-label-changed";
+
+        // Step 3: Immediately remove the popover. This triggers hidePopoverInternal
+        // during removedFromAncestor, which calls onPopoverToggle -> controllers() ->
+        // relatedObjectIDsFor -> updateRelationsForTree. The relation update walks the
+        // tree and resolves ID-based attributes (aria-controls, commandfor,
+        // aria-labelledby, etc.) via getElementById. The tree scope's ordered map can
+        // be inconsistent at this point, which previously caused a crash.
+        document.getElementById("mypopover").remove();
+
+        // Step 4: Touch the accessibility tree again to verify no crash.
+        touchAccessibilityTree(accessibilityController.rootElement);
+
+        output += "PASS: No crash after removing a popover controller and then the popover.\n";
+        debug(output);
+        document.getElementById("test-content").style.display = "none";
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2129,9 +2129,14 @@ void AXObjectCache::onPopoverToggle(const HTMLElement& popover)
     RefPtr axPopover = get(const_cast<HTMLElement*>(&popover));
     if (!axPopover)
         return;
-    // There may be multiple elements with popovertarget attributes that point at |popover|.
-    for (const auto& invoker : axPopover->controllers())
-        postNotification(dynamicDowncast<AccessibilityObject>(invoker.get()), protect(document()).get(), AXNotification::ExpandedChanged);
+
+    // Updating the accessibility tree and sending notifications in response to a toggled
+    // popover requires accessing the popover's controllers(), which could resolve relations
+    // at a time that's not safe (i.e. if this function is called downstream of an element
+    // removal). Defer this handling to a time we know it's safe.
+    m_deferredToggledPopovers.append(axPopover.releaseNonNull());
+    if (!m_performCacheUpdateTimer.isActive())
+        m_performCacheUpdateTimer.startOneShot(0_s);
 }
 
 void AXObjectCache::deferMenuListValueChange(Element* element)
@@ -5101,6 +5106,10 @@ void AXObjectCache::performDeferredCacheUpdate(ForceLayout forceLayout)
         handleDeferredNotification(notificationData);
     m_deferredNotifications.clear();
 
+    for (auto& toggledPopover : m_deferredToggledPopovers)
+        handleDeferredPopoverToggle(toggledPopover);
+    m_deferredToggledPopovers.clear();
+
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     if (m_deferredRegenerateIsolatedTree) {
         if (auto tree = AXIsolatedTree::treeForFrameID(m_frameID)) {
@@ -5130,6 +5139,13 @@ void AXObjectCache::performDeferredCacheUpdate(ForceLayout forceLayout)
 #endif
 
     platformPerformDeferredCacheUpdate();
+}
+
+void AXObjectCache::handleDeferredPopoverToggle(AccessibilityObject& axPopover)
+{
+    // There may be multiple elements with popovertarget or commandfor attributes that point at this popover.
+    for (const auto& invoker : axPopover.controllers())
+        postNotification(&downcast<AccessibilityObject>(invoker.get()), document(), AXNotification::ExpandedChanged);
 }
 
 void AXObjectCache::handleDeferredNotification(const DeferredNotificationData& data)

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -890,6 +890,7 @@ private:
     void handleRowspanChanged(AccessibilityNodeObject&);
 #endif
     void handleDeferredNotification(const DeferredNotificationData&);
+    void handleDeferredPopoverToggle(AccessibilityObject&);
 
     // aria-modal or modal <dialog> related
     bool isModalElement(Element&) const;
@@ -1039,6 +1040,7 @@ private:
     Vector<WeakPtr<Document, WeakPtrImplWithEventTargetData>> m_deferredDocumentsWithNewRenderTrees;
 #endif
     Vector<DeferredNotificationData> m_deferredNotifications;
+    Vector<Ref<AccessibilityObject>> m_deferredToggledPopovers;
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     Timer m_buildIsolatedTreeTimer;


### PR DESCRIPTION
#### 219958859919aca05ee6b9e4dd8a67f773187225
<pre>
AX: AXObjectCache::onPopoverToggled can resolve relations downstream of element removal, which causes a release assert
<a href="https://bugs.webkit.org/show_bug.cgi?id=309716">https://bugs.webkit.org/show_bug.cgi?id=309716</a>
<a href="https://rdar.apple.com/172255285">rdar://172255285</a>

Reviewed by Joshua Hoffman.

Calling controllers() from onPopoverToggle during element removal
can trigger updateRelationsForTree, which resolves ID-based attributes via
getElementById while the tree scope&apos;s ordered map is in an inconsistent
state, causing a crash. Defer the work to performDeferredCacheUpdate
when the DOM is stable.

* LayoutTests/accessibility/popover-remove-controller-then-popover-crash-expected.txt: Added.
* LayoutTests/accessibility/popover-remove-controller-then-popover-crash.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::onPopoverToggle):
(WebCore::AXObjectCache::performDeferredCacheUpdate):
(WebCore::AXObjectCache::handleDeferredPopoverToggle):
* Source/WebCore/accessibility/AXObjectCache.h:

Canonical link: <a href="https://commits.webkit.org/309115@main">https://commits.webkit.org/309115@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06fdad64c1a626910b2196eb52b1706dab5ba412

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149471 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22189 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158173 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/58967bb7-c24d-4067-9133-02789bcd255b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151344 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115278 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f68d89d0-7b18-4721-b73a-eedfc791324a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96022 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/77b9879b-7ed8-4f08-af3a-43d014c673bd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16523 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6016 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126132 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160650 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3644 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123313 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123526 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33572 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21999 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133855 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78213 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18730 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10606 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21599 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85420 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21330 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21482 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21387 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->