### PR TITLE
[JSC] IntervalSet should be non-copyable but still moveable

### DIFF
--- a/Source/WTF/wtf/IndexMap.h
+++ b/Source/WTF/wtf/IndexMap.h
@@ -44,6 +44,14 @@ public:
     IndexMap(const IndexMap&) = default;
     IndexMap& operator=(const IndexMap&) = default;
     
+    // Constrained to non-copyable types so that POD types always use the variadic constructor below,
+    // which zero-initializes via fill (unlike Vector::grow).
+    explicit IndexMap(size_t size)
+        requires (!std::is_copy_constructible_v<Value>)
+    {
+        m_vector.grow(size);
+    }
+
     template<typename... Args>
     explicit IndexMap(size_t size, Args&&... args)
         : m_vector(size, Value(std::forward<Args>(args)...))

--- a/Source/WTF/wtf/IntervalSet.h
+++ b/Source/WTF/wtf/IntervalSet.h
@@ -47,6 +47,7 @@ namespace WTF {
 template<typename T, typename Value, size_t cacheLinesPerNode = 1>
     requires std::is_trivially_destructible_v<T> && std::is_trivially_destructible_v<Value>
 class IntervalSet {
+    WTF_MAKE_NONCOPYABLE(IntervalSet);
 public:
     using Interval = Range<T>;
 
@@ -74,6 +75,42 @@ public:
     static_assert(innerOrder >= 2, "cacheLinesPerNode parameter too small: InnerNode order must be at least 2 for a valid B+ tree");
 
     IntervalSet() = default;
+
+    IntervalSet(IntervalSet&& other)
+        : m_root(other.m_root)
+        , m_rootInterval(other.m_rootInterval)
+        , m_height(other.m_height)
+#if ASSERT_ENABLED
+        , assertOnlyNumNodes(other.assertOnlyNumNodes)
+#endif
+    {
+        other.m_root = { };
+        other.m_rootInterval = { };
+        other.m_height = 0;
+#if ASSERT_ENABLED
+        other.assertOnlyNumNodes = 0;
+#endif
+    }
+
+    IntervalSet& operator=(IntervalSet&& other)
+    {
+        if (this != &other) {
+            freeAllNodes();
+            m_root = other.m_root;
+            m_rootInterval = other.m_rootInterval;
+            m_height = other.m_height;
+#if ASSERT_ENABLED
+            assertOnlyNumNodes = other.assertOnlyNumNodes;
+#endif
+            other.m_root = { };
+            other.m_rootInterval = { };
+            other.m_height = 0;
+#if ASSERT_ENABLED
+            other.assertOnlyNumNodes = 0;
+#endif
+        }
+        return *this;
+    }
 
     ~IntervalSet()
     {

--- a/Tools/TestWebKitAPI/Tests/WTF/IntervalSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/IntervalSet.cpp
@@ -534,4 +534,104 @@ TEST(WTF_IntervalSet, EraseLastItemWithInnerNodes)
     EXPECT_EQ(result->second, 999);
 }
 
+TEST(WTF_IntervalSet, MoveConstructor)
+{
+    IntervalSet<Point, Value> original;
+    original.insert({ 10, 20 }, 1);
+    original.insert({ 30, 40 }, 2);
+    original.insert({ 50, 60 }, 3);
+
+    IntervalSet<Point, Value> moved(WTF::move(original));
+
+    // Moved-to set should have all intervals
+    EXPECT_FALSE(moved.isEmpty());
+    auto result = moved.find({ 10, 20 });
+    EXPECT_TRUE(result);
+    EXPECT_EQ(result->first, Interval(10, 20));
+    EXPECT_EQ(result->second, 1);
+    EXPECT_TRUE(moved.hasOverlap({ 30, 40 }));
+    EXPECT_TRUE(moved.hasOverlap({ 50, 60 }));
+
+    // Moved-from set should be empty and reusable
+    EXPECT_TRUE(original.isEmpty());
+    EXPECT_FALSE(original.hasOverlap({ 10, 20 }));
+    EXPECT_FALSE(original.find({ 10, 20 }));
+    original.insert({ 70, 80 }, 7);
+    EXPECT_TRUE(original.hasOverlap({ 70, 80 }));
+}
+
+TEST(WTF_IntervalSet, MoveAssignment)
+{
+    IntervalSet<Point, Value> original;
+    original.insert({ 10, 20 }, 1);
+    original.insert({ 30, 40 }, 2);
+
+    IntervalSet<Point, Value> destination;
+    destination.insert({ 100, 200 }, 99);
+
+    destination = WTF::move(original);
+
+    // Destination should have original's intervals
+    EXPECT_FALSE(destination.isEmpty());
+    auto result = destination.find({ 10, 20 });
+    EXPECT_TRUE(result);
+    EXPECT_EQ(result->second, 1);
+    EXPECT_TRUE(destination.hasOverlap({ 30, 40 }));
+
+    // Old destination content should be gone
+    EXPECT_FALSE(destination.hasOverlap({ 100, 200 }));
+
+    // Moved-from set should be empty and reusable
+    EXPECT_TRUE(original.isEmpty());
+    original.insert({ 70, 80 }, 7);
+    EXPECT_TRUE(original.hasOverlap({ 70, 80 }));
+}
+
+TEST(WTF_IntervalSet, MoveConstructorEmpty)
+{
+    IntervalSet<Point, Value> original;
+    IntervalSet<Point, Value> moved(WTF::move(original));
+
+    EXPECT_TRUE(moved.isEmpty());
+    EXPECT_TRUE(original.isEmpty());
+    original.insert({ 10, 20 }, 1);
+    EXPECT_TRUE(original.hasOverlap({ 10, 20 }));
+}
+
+TEST(WTF_IntervalSet, MoveAssignmentEmpty)
+{
+    IntervalSet<Point, Value> original;
+    IntervalSet<Point, Value> destination;
+    destination.insert({ 10, 20 }, 1);
+
+    destination = WTF::move(original);
+
+    EXPECT_TRUE(destination.isEmpty());
+    EXPECT_TRUE(original.isEmpty());
+    original.insert({ 10, 20 }, 1);
+    EXPECT_TRUE(original.hasOverlap({ 10, 20 }));
+}
+
+TEST(WTF_IntervalSet, MoveConstructorSourceDestructed)
+{
+    IntervalSet<Point, Value> moved;
+    {
+        IntervalSet<Point, Value> original;
+        original.insert({ 10, 20 }, 1);
+        original.insert({ 30, 40 }, 2);
+        original.insert({ 50, 60 }, 3);
+        moved = WTF::move(original);
+        // original is destructed here — nodes should not be freed
+    }
+
+    // Verify moved set is still valid after source destruction
+    EXPECT_FALSE(moved.isEmpty());
+    auto result = moved.find({ 10, 20 });
+    EXPECT_TRUE(result);
+    EXPECT_EQ(result->first, Interval(10, 20));
+    EXPECT_EQ(result->second, 1);
+    EXPECT_TRUE(moved.hasOverlap({ 30, 40 }));
+    EXPECT_TRUE(moved.hasOverlap({ 50, 60 }));
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 949ac090a94a20f34427f44601243734e3f86768
<pre>
[JSC] IntervalSet should be non-copyable but still moveable
<a href="https://bugs.webkit.org/show_bug.cgi?id=309720">https://bugs.webkit.org/show_bug.cgi?id=309720</a>
<a href="https://rdar.apple.com/172317692">rdar://172317692</a>

Reviewed by Yusuke Suzuki.

IntervalSet should be non-copyable since the nodes need to have
a single owner. There was one place that was using copy construction,
IndexMap, but it was safe because it would only copy empty (initial value)
IntervalSets.

But now, IndexMap doesn&apos;t have access to a copy constructor and so it
needs a constructor that uses default construction. But this constructor
is not equivalent for POD since Vector::grow() does not zero-fill while
the original constructor does. So the new constructor is restricted to
avoid POD.

Test: Tools/TestWebKitAPI/Tests/WTF/IntervalSet.cpp
* Source/WTF/wtf/IndexMap.h:
(WTF::IndexMap::requires):
* Source/WTF/wtf/IntervalSet.h:
(WTF::IntervalSet::IntervalSet):
(WTF::IntervalSet::operator=):
* Tools/TestWebKitAPI/Tests/WTF/IntervalSet.cpp:
(TestWebKitAPI::TEST(WTF_IntervalSet, MoveConstructor)):
(TestWebKitAPI::TEST(WTF_IntervalSet, MoveAssignment)):
(TestWebKitAPI::TEST(WTF_IntervalSet, MoveConstructorEmpty)):
(TestWebKitAPI::TEST(WTF_IntervalSet, MoveAssignmentEmpty)):
(TestWebKitAPI::TEST(WTF_IntervalSet, MoveConstructorSourceDestructed)):

Canonical link: <a href="https://commits.webkit.org/309110@main">https://commits.webkit.org/309110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5f70f40931a7d787908ee2b10811d5cb78b8ce1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158151 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8136f645-7dc8-481d-a6aa-a5efffb4580f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115260 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c42da9c0-e9dc-4c48-8ca3-0907ab5cb020) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17405 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96004 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d68d86d8-3d98-4362-b7df-3bfaa4d47de0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16501 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5994 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141424 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126110 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12043 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160628 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10243 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3622 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123295 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123508 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33566 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133835 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78191 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18710 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10586 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/180878 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21577 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85398 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46347 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21308 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21459 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21365 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->