### PR TITLE
[Site Isolation] about-url-host.html is failing

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -109,6 +109,7 @@
 #include <WebCore/ProcessWarming.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/ResourceRequest.h>
+#include <WebCore/SecurityPolicy.h>
 #include <WebCore/Site.h>
 #include <algorithm>
 #include <pal/SessionID.h>
@@ -2352,7 +2353,16 @@ std::tuple<Ref<WebProcessProxy>, RefPtr<SuspendedPageProxy>, ASCIILiteral> WebPr
             return { createNewProcess(), nullptr, "Process swap because this is a first navigation in a DOM popup without opener"_s };
     }
 
-    if (navigation.treatAsSameOriginNavigation())
+    const bool treatAsSameOriginNavigation = [&targetURL, &navigation, &siteIsolationEnabled] {
+        if (siteIsolationEnabled
+            && targetURL.protocolIsAbout()
+            && !SecurityPolicy::shouldInheritSecurityOriginFromOwner(targetURL))
+            return false;
+
+        return navigation.treatAsSameOriginNavigation();
+    }();
+
+    if (treatAsSameOriginNavigation)
         return { WTF::move(sourceProcess), nullptr, "The treatAsSameOriginNavigation flag is set"_s };
 
     URL sourceURL;


### PR DESCRIPTION
#### fb9f3322fb79a3da8d5bb2703981d65bf48b6a28
<pre>
[Site Isolation] about-url-host.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=309690">https://bugs.webkit.org/show_bug.cgi?id=309690</a>
<a href="https://rdar.apple.com/172290988">rdar://172290988</a>

Reviewed by Sihui Liu.

With site isolation enabled, this test crashes when opening an iframe with the
URL &quot;about://example.org&quot;.

We hit this assert in WebProcessProxy::didStartUsingProcessForSiteIsolation:

ASSERT(m_site ? (m_site.value().isEmpty() || m_site.value() == *site) ...

because m_site is not equal to site.

WebProcessPool::processForNavigationInternal chooses to load the iframe in the
same web process being used by the main frame because treatAsSameOriginNavigation
is true (since the iframe&apos;s URL is &quot;about:*&quot;).

In the continueWithProcessForNavigation callback, since the iframe&apos;s Site is
not empty and not equal to the main frame&apos;s Site(http, localhost), we call
BrowsingContextGroup::ensureProcessForSite. When creating the FrameProcess,
we call WebProcessProxy::didStartUsingProcessForSiteIsolation where we hit the
assertion because the process&apos; Site(http, localhost) doesn&apos;t match the site of
the iframe Site(about, example.org).

Our issue is that we are incorrectly trying to load &quot;about://example.org&quot; in
the same web process as the main frame.

According to the spec
(<a href="https://html.spec.whatwg.org/multipage/document-sequences.html#determining-the-origin)">https://html.spec.whatwg.org/multipage/document-sequences.html#determining-the-origin)</a>,
about:blank and about:srcdoc can inherit the security properties of their parent
origin. So they should be put in the same web process as the parent. But other
&quot;about:*&quot; URLS don&apos;t inherit the parent&apos;s security context, so they should be
put in their own web process.

In order to force a process change, if the the navigation was marked as
treatAsSameOriginNavigation, but the URL is &quot;about:*&quot; and should not inherit the
security properties of its parent, we don&apos;t actually treat it as a same origin
navigation.

Note that this does not happen with site isolation off. With just PSON enabled,
if the main frame navigates to &quot;about://example.org&quot;, we do not swap processes
(again because treatAsSameOriginNavigation is true). In order to maintain the
shipping behavior, we only do the swap with site isolation enabled.

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigationInternal):

Canonical link: <a href="https://commits.webkit.org/309359@main">https://commits.webkit.org/309359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfe521701e03a173fd005705b851f8707161a808

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158829 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103551 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115803 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82260 "3 flakes 1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f593120-33bf-4e42-8809-067901aba39b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96532 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c39a69bd-a6a8-4142-99b9-cd9230cfcd9f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17016 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14966 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6674 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126631 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161302 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4393 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14154 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123807 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22677 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124008 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134397 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78893 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23121 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19134 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11154 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22277 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86077 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21991 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22143 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22045 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->