### PR TITLE
[JSC] Use fjcvtzs for fast double -> int32_t conversion

### DIFF
--- a/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValueInlines.h
@@ -64,8 +64,8 @@ inline JSValue jsNumber(const MediaTime& t)
 
 inline JSValue::JSValue(double d)
 {
-    if (canBeStrictInt32(d)) {
-        *this = JSValue(static_cast<int32_t>(d));
+    if (auto int32Value = tryConvertToStrictInt32(d)) {
+        *this = JSValue(int32Value.value());
         return;
     }
     *this = JSValue(EncodeAsDouble, d);

--- a/Source/JavaScriptCore/runtime/JSStringJoiner.h
+++ b/Source/JavaScriptCore/runtime/JSStringJoiner.h
@@ -216,8 +216,8 @@ ALWAYS_INLINE void JSStringJoiner::appendNumber(VM& vm, int32_t value)
 
 ALWAYS_INLINE void JSStringJoiner::appendNumber(VM& vm, double value)
 {
-    if (canBeStrictInt32(value))
-        appendNumber(vm, static_cast<int32_t>(value));
+    if (auto int32Value = tryConvertToStrictInt32(value))
+        appendNumber(vm, int32Value.value());
     else
         append8Bit(vm.numericStrings.add(value));
 }

--- a/Source/JavaScriptCore/runtime/MathCommon.h
+++ b/Source/JavaScriptCore/runtime/MathCommon.h
@@ -240,12 +240,27 @@ inline std::optional<double> safeReciprocalForDivByConst(double constant)
     return reciprocal;
 }
 
-ALWAYS_INLINE bool canBeStrictInt32(double value)
+ALWAYS_INLINE std::optional<int32_t> tryConvertToStrictInt32(double value)
 {
+#if HAVE(FJCVTZS_INSTRUCTION)
+    int32_t result;
+    bool isExact;
+    __asm__(
+        "fjcvtzs %w0, %d2"
+        : "=r" (result), "=@cceq" (isExact)
+        : "w" (value)
+        : "cc");
+    if (isExact)
+        return value;
+    return std::nullopt;
+#else
     if (std::isinf(value) || std::isnan(value))
-        return false;
+        return std::nullopt;
     const int32_t asInt32 = static_cast<int32_t>(value);
-    return !(asInt32 != value || (!asInt32 && std::signbit(value))); // true for -0.0
+    if (!(asInt32 != value || (!asInt32 && std::signbit(value)))) // true for -0.0
+        return asInt32;
+    return std::nullopt;
+#endif
 }
 
 ALWAYS_INLINE bool canBeInt32(double value)

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -554,10 +554,11 @@ inline size_t sizeOfType(TypeKind kind)
 
 inline JSValue internalizeExternref(JSValue value)
 {
-    if (value.isDouble() && JSC::canBeStrictInt32(value.asDouble())) {
-        int32_t int32Value = JSC::toInt32(value.asDouble());
-        if (int32Value <= Wasm::maxI31ref && int32Value >= Wasm::minI31ref)
-            return jsNumber(int32Value);
+    if (value.isDouble()) {
+        if (auto int32Value = JSC::tryConvertToStrictInt32(value.asDouble())) {
+            if (int32Value.value() <= Wasm::maxI31ref && int32Value.value() >= Wasm::minI31ref)
+                return jsNumber(int32Value.value());
+        }
     }
 
     return value;


### PR DESCRIPTION
#### 30b7ac169e4c173dfc74ce6dcc7177246dddfe2c
<pre>
[JSC] Use fjcvtzs for fast double -&gt; int32_t conversion
<a href="https://bugs.webkit.org/show_bug.cgi?id=309721">https://bugs.webkit.org/show_bug.cgi?id=309721</a>
<a href="https://rdar.apple.com/172318348">rdar://172318348</a>

Reviewed by NOBODY (OOPS!).

WIP, probably we have similar code in JIT too.

* Source/JavaScriptCore/runtime/JSCJSValueInlines.h:
(JSC::JSValue::JSValue):
* Source/JavaScriptCore/runtime/JSStringJoiner.h:
(JSC::JSStringJoiner::appendNumber):
* Source/JavaScriptCore/runtime/MathCommon.h:
(JSC::tryConvertToStrictInt32):
(JSC::canBeStrictInt32): Deleted.
* Source/JavaScriptCore/wasm/WasmFormat.h:
(JSC::Wasm::internalizeExternref):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30b7ac169e4c173dfc74ce6dcc7177246dddfe2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149578 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158281 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103010 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22222 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115390 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82043 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134238 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96131 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16621 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14522 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6125 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141553 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126229 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160757 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10372 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3755 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13711 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123419 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18563 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123628 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133962 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78320 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18806 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10713 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181007 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21706 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85527 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46370 "Found 1 new JSC stress test failure: Too many failures: 5674 jsc tests failed (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21437 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21589 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21494 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->