### PR TITLE
WebModelPlayer animations always loop

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -696,6 +696,7 @@ NS_SWIFT_SENDABLE
 - (void)loadModelFrom:(NSURL *)url;
 - (void)loadModel:(NSData *)data;
 - (void)update:(double)deltaTime;
+- (void)setLoop:(BOOL)loop;
 - (void)requestCompleted:(NSObject *)request;
 - (void)setCallbacksWithModelUpdatedCallback:(void (^)(WKBridgeUpdateMesh *))modelUpdatedCallback textureUpdatedCallback:(void (^)(WKBridgeUpdateTexture *))textureUpdatedCallback materialUpdatedCallback:(void (^)(WKBridgeUpdateMaterial *))materialUpdatedCallback;
 

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -902,6 +902,8 @@ final class USDModelLoader: _Proto_UsdStageSession_v1.Delegate {
     fileprivate var endTime: TimeInterval = 1
     @nonobjc
     fileprivate var timeCodePerSecond: TimeInterval = 1
+    @nonobjc
+    fileprivate var loop: Bool = false
 
     init(objcInstance: WKBridgeModelLoader) {
         objcLoader = objcInstance
@@ -997,7 +999,7 @@ final class USDModelLoader: _Proto_UsdStageSession_v1.Delegate {
 
     func update(deltaTime: TimeInterval) {
         let newTime = currentTime() + deltaTime
-        time = startTime + fmod(newTime, max(duration(), 1))
+        time = startTime + (loop ? fmod(newTime, max(duration(), 1)) : min(newTime, duration()))
         usdLoader.update(time: time * timeCodePerSecond)
     }
 }
@@ -1051,6 +1053,11 @@ extension WKBridgeModelLoader {
     @objc
     func update(_ deltaTime: Double) {
         self.loader?.update(deltaTime: deltaTime)
+    }
+
+    @objc
+    func setLoop(_ loop: Bool) {
+        self.loader?.loop = loop
     }
 
     @objc
@@ -1516,6 +1523,10 @@ extension WKBridgeModelLoader {
 
     @objc
     func update(_ deltaTime: Double) {
+    }
+
+    @objc
+    func setLoop(_ loop: Bool) {
     }
 
     @objc

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -533,10 +533,12 @@ void WebModelPlayer::update()
     simulate(elapsedTime);
 
     auto timeDelta = paused() ? 0.f : (m_playbackRate * elapsedTime);
-    if (!m_isLooping && [m_modelLoader currentTime] > [m_modelLoader duration])
-        timeDelta = 0.f;
 
     [m_modelLoader update:timeDelta];
+
+    if (!m_isLooping && !paused() && [m_modelLoader currentTime] >= [m_modelLoader duration])
+        m_pauseState = PauseState::Paused;
+
     if (m_didFinishLoading) {
         if (RefPtr currentModel = m_currentModel)
             currentModel->render();
@@ -565,6 +567,8 @@ bool WebModelPlayer::supportsTransform(WebCore::TransformationMatrix transformat
 void WebModelPlayer::play(bool playing)
 {
     if (RefPtr model = m_currentModel) {
+        if (playing && !m_isLooping && [m_modelLoader currentTime] >= [m_modelLoader duration])
+            [m_modelLoader setCurrentTime:0];
         model->play(playing);
         m_pauseState = playing ? PauseState::Playing : PauseState::Paused;
     }
@@ -576,6 +580,7 @@ void WebModelPlayer::setLoop(bool loop)
         return;
 
     m_isLooping = loop;
+    [m_modelLoader setLoop:loop];
 }
 
 void WebModelPlayer::setAutoplay(bool autoplay)


### PR DESCRIPTION
#### ac51296daaebed5e41c728bb17eb440186a1aa7f
<pre>
WebModelPlayer animations always loop
<a href="https://bugs.webkit.org/show_bug.cgi?id=309691">https://bugs.webkit.org/show_bug.cgi?id=309691</a>
&lt;<a href="https://rdar.apple.com/172281131">rdar://172281131</a>&gt;

Reviewed by Mike Wyrzykowski.

Wire the loop property and add a bit more state management for
animations.

* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(USDModelLoader.loop):
(USDModelLoader.update(_:)):
Update the animation time based on the `loop` value.
(WKBridgeModelLoader.setLoop(_:)):
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::update):
Make sure we update the pause state ourselves when the animation
finishes (and we&apos;re not looping).
(WebKit::WebModelPlayer::play):
Make sure we can play the animation multiple times.
(WebKit::WebModelPlayer::setLoop):

Canonical link: <a href="https://commits.webkit.org/309162@main">https://commits.webkit.org/309162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c96870082dc2efb05507a4bd2e667521a7abda0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158350 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103079 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115433 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c5a7e0b-ce82-425f-8a6d-2a19960e79ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152607 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96175 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d61303f9-353f-43ed-806d-5ac25289933f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16665 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14574 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6195 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126273 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160828 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3826 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123465 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123672 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33597 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22175 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134017 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78400 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18851 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10769 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21776 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85596 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21506 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21658 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21563 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->