### PR TITLE
REGRESSION (298613@main): Number inputs fail to display localized numbers

### DIFF
--- a/LayoutTests/fast/forms/number/number-l10n-input-visible-text-expected.txt
+++ b/LayoutTests/fast/forms/number/number-l10n-input-visible-text-expected.txt
@@ -1,0 +1,56 @@
+This test verifies that number inputs display the localized decimal separator in the visible text while maintaining the correct DOM value.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+German locale (comma decimal separator)
+Typing a localized decimal number using comma separator:
+PASS document.execCommand("InsertText", false, "5,6"); deInput.value is "5.6"
+PASS getVisibleText(deInput) is "5,6"
+
+Typing a number with a period (also accepted as decimal in German):
+PASS document.execCommand("InsertText", false, "5.6"); deInput.value is "5.6"
+PASS getVisibleText(deInput) is "5.6"
+
+Typing a negative decimal number:
+PASS document.execCommand("InsertText", false, "-3,14"); deInput.value is "-3.14"
+PASS getVisibleText(deInput) is "-3,14"
+
+Verifying duplicate decimal separator is rejected:
+PASS document.execCommand("InsertText", false, "1,2,3"); deInput.value is "1.23"
+PASS getVisibleText(deInput) is "1,23"
+
+Setting value attribute displays localized:
+PASS getVisibleText(deInput) is "7,89"
+
+French locale (comma decimal separator)
+PASS document.execCommand("InsertText", false, "1,234"); frInput.value is "1.234"
+PASS getVisibleText(frInput) is "1,234"
+
+English US locale (period decimal separator)
+PASS document.execCommand("InsertText", false, "5.6"); enInput.value is "5.6"
+PASS getVisibleText(enInput) is "5.6"
+
+Duplicate decimal separator rejected in English:
+PASS document.execCommand("InsertText", false, "1.2.3"); enInput.value is "1.23"
+PASS getVisibleText(enInput) is "1.23"
+
+Pasting number with comma group separators in German (period decimal):
+PASS document.execCommand("InsertText", false, "1,327,489.05"); deInput.value is "1327489.05"
+PASS getVisibleText(deInput) is "1327489.05"
+
+Pasting number with period group separators in German (comma decimal):
+PASS document.execCommand("InsertText", false, "1.327.489,05"); deInput.value is "1327489.05"
+PASS getVisibleText(deInput) is "1327489,05"
+
+Pasting number with comma group separators in English (period decimal):
+PASS document.execCommand("InsertText", false, "1,327,489.05"); enInput.value is "1327489.05"
+PASS getVisibleText(enInput) is "1327489.05"
+
+Pasting number with period group separators in English (treated as multiple decimals):
+PASS document.execCommand("InsertText", false, "1.327.489,05"); enInput.value is "1.32748905"
+PASS getVisibleText(enInput) is "1.32748905"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/number/number-l10n-input-visible-text.html
+++ b/LayoutTests/fast/forms/number/number-l10n-input-visible-text.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<script>
+    description('This test verifies that number inputs display the localized decimal separator in the visible text while maintaining the correct DOM value.');
+    if (window.internals)
+        internals.settings.setLangAttributeAwareFormControlUIEnabled(true);
+    else
+        debug('Requires WebKitTestRunner.');
+</script>
+<!-- German: 1.234,56 (period group separator, comma decimal separator) -->
+<input id="input-de" lang="de-de" type="number">
+<!-- French: 1 234,56 (space group separator, comma decimal separator) -->
+<input id="input-fr" lang="fr-fr" type="number">
+<!-- English US: 1,234.56 (comma group separator, period decimal separator) -->
+<input id="input-en" lang="en-us" type="number">
+<script>
+    function getVisibleText(input) {
+        var shadow = internals.shadowRoot(input);
+        return shadow.querySelector('div[contenteditable]').innerText;
+    }
+
+    debug('German locale (comma decimal separator)');
+    var deInput = document.getElementById('input-de');
+    deInput.focus();
+
+    debug('Typing a localized decimal number using comma separator:');
+    shouldBeEqualToString('document.execCommand("InsertText", false, "5,6"); deInput.value', '5.6');
+    shouldBeEqualToString('getVisibleText(deInput)', '5,6');
+    deInput.value = '';
+
+    debug('');
+    debug('Typing a number with a period (also accepted as decimal in German):');
+    shouldBeEqualToString('document.execCommand("InsertText", false, "5.6"); deInput.value', '5.6');
+    shouldBeEqualToString('getVisibleText(deInput)', '5.6');
+    deInput.value = '';
+
+    debug('');
+    debug('Typing a negative decimal number:');
+    shouldBeEqualToString('document.execCommand("InsertText", false, "-3,14"); deInput.value', '-3.14');
+    shouldBeEqualToString('getVisibleText(deInput)', '-3,14');
+    deInput.value = '';
+
+    debug('');
+    debug('Verifying duplicate decimal separator is rejected:');
+    shouldBeEqualToString('document.execCommand("InsertText", false, "1,2,3"); deInput.value', '1.23');
+    shouldBeEqualToString('getVisibleText(deInput)', '1,23');
+    deInput.value = '';
+
+    debug('');
+    debug('Setting value attribute displays localized:');
+    deInput.value = '7.89';
+    shouldBeEqualToString('getVisibleText(deInput)', '7,89');
+    deInput.value = '';
+
+    debug('');
+    debug('French locale (comma decimal separator)');
+    var frInput = document.getElementById('input-fr');
+    frInput.focus();
+
+    shouldBeEqualToString('document.execCommand("InsertText", false, "1,234"); frInput.value', '1.234');
+    shouldBeEqualToString('getVisibleText(frInput)', '1,234');
+    frInput.value = '';
+
+    debug('');
+    debug('English US locale (period decimal separator)');
+    var enInput = document.getElementById('input-en');
+    enInput.focus();
+
+    shouldBeEqualToString('document.execCommand("InsertText", false, "5.6"); enInput.value', '5.6');
+    shouldBeEqualToString('getVisibleText(enInput)', '5.6');
+    enInput.value = '';
+
+    debug('');
+    debug('Duplicate decimal separator rejected in English:');
+    shouldBeEqualToString('document.execCommand("InsertText", false, "1.2.3"); enInput.value', '1.23');
+    shouldBeEqualToString('getVisibleText(enInput)', '1.23');
+    enInput.value = '';
+
+    debug('');
+    debug('Pasting number with comma group separators in German (period decimal):');
+    deInput.focus();
+    shouldBeEqualToString('document.execCommand("InsertText", false, "1,327,489.05"); deInput.value', '1327489.05');
+    shouldBeEqualToString('getVisibleText(deInput)', '1327489.05');
+    deInput.value = '';
+
+    debug('');
+    debug('Pasting number with period group separators in German (comma decimal):');
+    shouldBeEqualToString('document.execCommand("InsertText", false, "1.327.489,05"); deInput.value', '1327489.05');
+    shouldBeEqualToString('getVisibleText(deInput)', '1327489,05');
+    deInput.value = '';
+
+    debug('');
+    debug('Pasting number with comma group separators in English (period decimal):');
+    enInput.focus();
+    shouldBeEqualToString('document.execCommand("InsertText", false, "1,327,489.05"); enInput.value', '1327489.05');
+    shouldBeEqualToString('getVisibleText(enInput)', '1327489.05');
+    enInput.value = '';
+
+    debug('');
+    debug('Pasting number with period group separators in English (treated as multiple decimals):');
+    shouldBeEqualToString('document.execCommand("InsertText", false, "1.327.489,05"); enInput.value', '1.32748905');
+    shouldBeEqualToString('getVisibleText(enInput)', '1.32748905');
+    enInput.value = '';
+</script>
+</body>

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -400,25 +400,56 @@ void NumberInputType::handleBeforeTextInsertedEvent(BeforeTextInsertedEvent& eve
     auto normalizedText = normalizeFullWidthNumberChars(event.text()).get();
     LOG(Editing, "normalizeFullWidthNumberChars() -> [%s]", normalizedText.utf8().data());
 
-    auto localizedText = protect(protect(element())->locale())->convertFromLocalizedNumber(normalizedText);
+    ASSERT(element());
+    Ref element = *this->element();
+    CheckedRef locale = element->locale();
+    auto& localizedSeparator = locale->localizedDecimalSeparator();
+
+    String updatedEventText;
+    bool displayedTextUsesNonPeriodDecimalSeparator = false;
+
+    if (localizedSeparator == "."_s) {
+        const auto localizedText = locale->convertFromLocalizedNumber(normalizedText);
+        updatedEventText = stripInvalidNumberCharacters(localizedText).get();
+    } else {
+        // In some locales where the decimal separator is not typically a period,
+        // a period may still be used as the decimal separator in certain contexts.
+        // For this reason, we allow both. If both are present in the inserted text,
+        // use whichever comes last since the first instances may be group separators.
+        const auto lastPeriodPosition = normalizedText.reverseFind('.');
+        const auto lastLocalizedSeparatorPosition = normalizedText.reverseFind(localizedSeparator);
+
+        displayedTextUsesNonPeriodDecimalSeparator = lastLocalizedSeparatorPosition != notFound
+            && (lastPeriodPosition == notFound || lastLocalizedSeparatorPosition > lastPeriodPosition);
+
+        if (displayedTextUsesNonPeriodDecimalSeparator) {
+            const auto withoutPeriods = makeStringByReplacingAll(normalizedText, "."_s, emptyString());
+            updatedEventText = makeStringByReplacingAll(withoutPeriods, localizedSeparator, "."_s);
+        } else
+            updatedEventText = makeStringByReplacingAll(normalizedText, localizedSeparator, emptyString());
+    }
 
     // If the cleaned up text doesn't match input text, don't insert partial input
     // since it could be an incorrect paste.
-    auto updatedEventText = stripInvalidNumberCharacters(localizedText).get();
+    updatedEventText = stripInvalidNumberCharacters(updatedEventText).get();
     LOG(Editing, "stripInvalidNumberCharacters() -> [%s]", updatedEventText.utf8().data());
 
     // Get left and right of cursor
-    ASSERT(element());
-    Ref element = *this->element();
-
     auto originalValue = element->innerTextValue();
     auto selectionStart = element->selectionStart();
     auto selectionEnd = element->selectionEnd();
 
+    // The inner text value may contain either '.' or the localized decimal
+    // separator. Replace the localized separator with '.' so validation
+    // works correctly for all locales.
     auto leftHalf = originalValue.substring(0, selectionStart);
+    auto rightHalf = originalValue.substring(selectionEnd);
+    if (localizedSeparator != "."_s) {
+        leftHalf = makeStringByReplacingAll(leftHalf, localizedSeparator, "."_s);
+        rightHalf = makeStringByReplacingAll(rightHalf, localizedSeparator, "."_s);
+    }
     LOG(Editing, "leftHalf after length=%u", leftHalf.length());
 
-    auto rightHalf = originalValue.substring(selectionEnd);
     LOG(Editing, "rightHalf after length=%u", rightHalf.length());
 
     // Process 1 char at a time
@@ -531,7 +562,8 @@ void NumberInputType::handleBeforeTextInsertedEvent(BeforeTextInsertedEvent& eve
         finalEventText.append(character);
     }
     LOG(Editing, "finalEventText: [%s]", finalEventText.toString().utf8().data());
-    event.setText(finalEventText.toString());
+    const auto displayedText = displayedTextUsesNonPeriodDecimalSeparator ? locale->localizeNumberCharacters(finalEventText.toString()) : finalEventText.toString();
+    event.setText(displayedText);
 }
 
 String NumberInputType::localizeValue(const String& proposedValue) const

--- a/Source/WebCore/platform/text/PlatformLocale.cpp
+++ b/Source/WebCore/platform/text/PlatformLocale.cpp
@@ -372,4 +372,24 @@ const String& Locale::localizedDecimalSeparator()
     return m_decimalSymbols[DecimalSeparatorIndex];
 }
 
+String Locale::localizeNumberCharacters(const String& input)
+{
+    initializeLocaleData();
+    if (!m_hasLocaleData || input.isEmpty())
+        return input;
+
+    StringBuilder builder;
+    builder.reserveCapacity(input.length());
+    for (unsigned i = 0; i < input.length(); ++i) {
+        auto character = input[i];
+        if (character >= '0' && character <= '9')
+            builder.append(m_decimalSymbols[character - '0']);
+        else if (character == '.')
+            builder.append(m_decimalSymbols[DecimalSeparatorIndex]);
+        else
+            builder.append(character);
+    }
+    return builder.toString();
+}
+
 }

--- a/Source/WebCore/platform/text/PlatformLocale.h
+++ b/Source/WebCore/platform/text/PlatformLocale.h
@@ -123,6 +123,12 @@ public:
 
     const String& localizedDecimalSeparator();
 
+    // Converts digit and decimal separator characters to their localized
+    // equivalents, passing through all other characters unchanged. Unlike
+    // convertToLocalizedNumber, this handles partial input (e.g. containing
+    // 'e', '+') and does not add sign prefixes or suffixes.
+    String localizeNumberCharacters(const String&);
+
     enum FormatType { FormatTypeUnspecified, FormatTypeShort, FormatTypeMedium };
 
     // Serializes the specified date into a formatted date string to


### PR DESCRIPTION
#### 84c60475975224f44a23c1de430edd7721a998a1
<pre>
REGRESSION (298613@main): Number inputs fail to display localized numbers
<a href="https://bugs.webkit.org/show_bug.cgi?id=309725">https://bugs.webkit.org/show_bug.cgi?id=309725</a>
<a href="https://rdar.apple.com/172112320">rdar://172112320</a>

Reviewed by Wenson Hsieh, Aditya Keerthi, and Abrar Rahman Protyasha.

Before 298613@main, any text could be entered inside number inputs. If it
was a valid number, we would convert it according to the user&apos;s locale
into a standardized number format specified by the HTML spec.

Starting in 298613@main, characters can only be entered into number inputs
if they would not cause the value to become invalid. If the user&apos;s number
format uses commas instead of decimals as the decimal separator, and the
user types a number with a comma such as &quot;1,2&quot;, we would correctly update
the value of the input to &quot;1.2&quot;, but we would also display &quot;1.2&quot; instead of
displaying the localized number.

Now, if the user&apos;s locale indicates a non-period decimal separator, we allow
either the localized separator or a period to be entered AND displayed as the
separator (since using a period may still be desirable in certain contexts
such as mathematics).

In the presence of two potential separators, we use whatever comes last since
the first separators may indicate group separators rather than decimal separators.

Test: fast/forms/number/number-l10n-input-visible-text.html

* LayoutTests/fast/forms/number/number-l10n-input-visible-text-expected.txt: Added.
* LayoutTests/fast/forms/number/number-l10n-input-visible-text.html: Added.
* Source/WebCore/html/NumberInputType.cpp:
(WebCore::NumberInputType::handleBeforeTextInsertedEvent):
* Source/WebCore/platform/text/PlatformLocale.cpp:
(WebCore::Locale::localizeNumberCharacters):
* Source/WebCore/platform/text/PlatformLocale.h:

Canonical link: <a href="https://commits.webkit.org/309366@main">https://commits.webkit.org/309366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac4065d2e0c334d2c19e9a5f7de3b8a47687561c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159163 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b1dff5f-4a44-4e81-a7f1-5d038439fbcf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23630 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23336 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116078 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22ee775f-c67a-4788-8f49-b131ee023e16) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153401 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18202 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134957 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96806 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec63af08-779f-476a-9d67-095f7137ce5f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15232 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7011 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12881 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161637 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4757 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14434 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124076 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124274 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22988 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134676 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79368 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23123 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19388 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11433 "Found 1 new test failure: fast/attachment/mac/wide-attachment-image-controls-basic.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22602 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86401 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22315 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22467 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22369 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->