### PR TITLE
SVGTransformList::concatenate() should returns std::optional<AffineTransform> if m_items.isEmpty()

### DIFF
--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -394,7 +394,7 @@ void RenderLayerModelObject::mapLocalToSVGContainer(const RenderLayerModelObject
 
 void RenderLayerModelObject::applySVGTransform(TransformationMatrix& transform, const SVGGraphicsElement& graphicsElement, const RenderStyle& style, const FloatRect& boundingBox, const std::optional<AffineTransform>& preApplySVGTransformMatrix, const std::optional<AffineTransform>& postApplySVGTransformMatrix, OptionSet<Style::TransformResolverOption> options) const
 {
-    auto svgTransform = graphicsElement.transform().concatenate();
+    auto svgTransform = graphicsElement.transform().concatenate().value_or(identity);
     auto* supplementalTransform = graphicsElement.supplementalTransform(); // SMIL <animateMotion>
 
     // This check does not use style.hasTransformRelatedProperty() on purpose -- we only want to know if either the 'transform' property, an

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -172,9 +172,10 @@ AffineTransform SVGGraphicsElement::animatedLocalTransform() const
 {
     // LBSE handles transforms via RenderLayer, no need to handle CSS transforms here.
     if (document().settings().layerBasedSVGEngineEnabled()) {
-        if (m_supplementalTransform)
-            return *m_supplementalTransform * transform().concatenate();
-        return protect(transform())->concatenate();
+        auto concatenatedTransform = protect(transform())->concatenate();
+        if (concatenatedTransform && m_supplementalTransform)
+            return *m_supplementalTransform * *concatenatedTransform;
+        return m_supplementalTransform ? *m_supplementalTransform : concatenatedTransform.value_or(identity);
     }
 
     AffineTransform matrix;
@@ -197,7 +198,7 @@ AffineTransform SVGGraphicsElement::animatedLocalTransform() const
     if (!hasSpecifiedTransform && style && !transform().isEmpty()) {
         auto t = Style::TransformResolver::computeTransformOrigin(*style, renderer->transformReferenceBoxRect()).xy();
         matrix.translate(t);
-        matrix *= transform().concatenate();
+        matrix *= *transform().concatenate();
         matrix.translate(-t.x(), -t.y());
     }
 

--- a/Source/WebCore/svg/SVGGraphicsElement.h
+++ b/Source/WebCore/svg/SVGGraphicsElement.h
@@ -58,7 +58,7 @@ public:
     AffineTransform* ensureSupplementalTransform() override;
     AffineTransform* supplementalTransform() const LIFETIME_BOUND override { return m_supplementalTransform.get(); }
 
-    virtual bool hasTransformRelatedAttributes() const { return !transform().concatenate().isIdentity() || m_supplementalTransform; }
+    virtual bool hasTransformRelatedAttributes() const { return (!transform().isEmpty() && !transform().concatenate()->isIdentity()) || m_supplementalTransform; }
 
     Ref<SVGRect> getBBoxForBindings();
     virtual FloatRect getBBox(StyleUpdateStrategy = AllowStyleUpdate);

--- a/Source/WebCore/svg/SVGLinearGradientElement.cpp
+++ b/Source/WebCore/svg/SVGLinearGradientElement.cpp
@@ -119,7 +119,7 @@ static void setGradientAttributes(SVGGradientElement& element, LinearGradientAtt
         attributes.setGradientUnits(element.gradientUnits());
 
     if (!attributes.hasGradientTransform() && element.hasAttribute(SVGNames::gradientTransformAttr))
-        attributes.setGradientTransform(element.gradientTransform().concatenate());
+        attributes.setGradientTransform(element.gradientTransform().concatenate().value_or(identity));
 
     if (!attributes.hasStops())
         attributes.setStops(element.buildStops());

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -186,7 +186,7 @@ void SVGPatternElement::collectPatternAttributes(PatternAttributes& attributes) 
         attributes.setPatternContentUnits(patternContentUnits());
 
     if (!attributes.hasPatternTransform() && hasAttribute(SVGNames::patternTransformAttr))
-        attributes.setPatternTransform(patternTransform().concatenate());
+        attributes.setPatternTransform(patternTransform().concatenate().value_or(identity));
 
     if (!attributes.hasPatternContentElement() && childElementCount())
         attributes.setPatternContentElement(this);
@@ -194,7 +194,7 @@ void SVGPatternElement::collectPatternAttributes(PatternAttributes& attributes) 
 
 AffineTransform SVGPatternElement::localCoordinateSpaceTransform(CTMScope) const
 {
-    return protect(patternTransform())->concatenate();
+    return protect(patternTransform())->concatenate().value_or(identity);
 }
 
 }

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -126,7 +126,7 @@ static void setGradientAttributes(SVGGradientElement& element, RadialGradientAtt
         attributes.setGradientUnits(element.gradientUnits());
 
     if (!attributes.hasGradientTransform() && element.hasAttribute(SVGNames::gradientTransformAttr))
-        attributes.setGradientTransform(element.gradientTransform().concatenate());
+        attributes.setGradientTransform(element.gradientTransform().concatenate().value_or(identity));
 
     if (!attributes.hasStops())
         attributes.setStops(element.buildStops());

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -716,7 +716,7 @@ AffineTransform SVGSVGElement::viewBoxToViewTransform(float viewWidth, float vie
 
     RefPtr viewSpec = m_viewSpec;
     AffineTransform transform = SVGFitToViewBox::viewBoxToViewTransform(currentViewBoxRect(), viewSpec->preserveAspectRatio(), viewWidth, viewHeight);
-    transform *= protect(viewSpec->transform())->concatenate();
+    transform *= protect(viewSpec->transform())->concatenate().value_or(identity);
     return transform;
 }
 

--- a/Source/WebCore/svg/SVGTransformList.cpp
+++ b/Source/WebCore/svg/SVGTransformList.cpp
@@ -102,7 +102,7 @@ ExceptionOr<RefPtr<SVGTransform>> SVGTransformList::consolidate()
     if (m_items.size() == 1)
         return RefPtr { at(0).ptr() };
 
-    auto newItem = SVGTransform::create(concatenate());
+    auto newItem = SVGTransform::create(*concatenate());
     clearItems();
 
     auto item = append(WTF::move(newItem));
@@ -110,8 +110,10 @@ ExceptionOr<RefPtr<SVGTransform>> SVGTransformList::consolidate()
     return RefPtr { item.ptr() };
 }
 
-AffineTransform SVGTransformList::concatenate() const
+std::optional<AffineTransform> SVGTransformList::concatenate() const
 {
+    if (m_items.isEmpty())
+        return std::nullopt;
     AffineTransform result;
     for (auto& transform : m_items)
         result *= transform->matrix().value();

--- a/Source/WebCore/svg/SVGTransformList.h
+++ b/Source/WebCore/svg/SVGTransformList.h
@@ -57,7 +57,7 @@ public:
     }
 
     ExceptionOr<RefPtr<SVGTransform>> consolidate();
-    AffineTransform concatenate() const;
+    std::optional<AffineTransform> concatenate() const;
 
     void parse(StringView);
     String valueAsString() const override;


### PR DESCRIPTION
#### 59258d66c145b84b4feaf4c0c533b333dbefaf8a
<pre>
SVGTransformList::concatenate() should returns std::optional&lt;AffineTransform&gt; if m_items.isEmpty()
<a href="https://bugs.webkit.org/show_bug.cgi?id=309642">https://bugs.webkit.org/show_bug.cgi?id=309642</a>
<a href="https://rdar.apple.com/172252666">rdar://172252666</a>

Reviewed by Said Abou-Hallawa.

Change SVGTransformList::concatenate() to return
std::optional&lt;AffineTransform&gt;, returning std::nullopt when the list
is empty. This makes the empty case explicit and distinguishes &quot;no
transform&quot; from an &quot;identity transform&quot;.

Call sites are updated with .value_or(AffineTransform()) to preserve
existing behaviour. The follow-up in <a href="https://github.com/WebKit/WebKit/pull/58833">https://github.com/WebKit/WebKit/pull/58833</a>
will use the optional to simplify each call site properly.

* Source/WebCore/rendering/RenderLayerModelObject.cpp:
(WebCore::RenderLayerModelObject::applySVGTransform const):
* Source/WebCore/svg/SVGGraphicsElement.cpp:
(WebCore::SVGGraphicsElement::animatedLocalTransform const):
* Source/WebCore/svg/SVGGraphicsElement.h:
(WebCore::SVGGraphicsElement::hasTransformRelatedAttributes const):
* Source/WebCore/svg/SVGLinearGradientElement.cpp:
(WebCore::setGradientAttributes):
* Source/WebCore/svg/SVGPatternElement.cpp:
(WebCore::SVGPatternElement::collectPatternAttributes const):
(WebCore::SVGPatternElement::localCoordinateSpaceTransform const):
* Source/WebCore/svg/SVGRadialGradientElement.cpp:
(WebCore::setGradientAttributes):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::viewBoxToViewTransform const):

Canonical link: <a href="https://commits.webkit.org/309953@main">https://commits.webkit.org/309953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64e3aaffe5ba4d5f63667a05b4053c163c4a22f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/152070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/18453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160813 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/105527 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25158 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117470 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/83320 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/155030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19652 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/136505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98184 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/43fabeb0-6df1-4978-9111-b76bb5ecea2c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18730 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16681 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8647 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/14391 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163279 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/6425 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/125497 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24650 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20729 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125673 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/136187 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81233 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23352 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20683 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12964 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24268 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/88553 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23959 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/24119 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/24020 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->