### PR TITLE
REGRESSION(297346@main): Cookie dialog on hillsprofeeding.com is misplaced

### DIFF
--- a/LayoutTests/compositing/layer-creation/sticky-overlap-extent-expected.txt
+++ b/LayoutTests/compositing/layer-creation/sticky-overlap-extent-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 2000.00)
       (contentsOpaque 1)
-      (children 41
+      (children 33
         (GraphicsLayer
           (preserves3D 1)
           (children 1
@@ -95,26 +95,6 @@
           (contentsOpaque 1)
         )
         (GraphicsLayer
-          (position 0.00 1600.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 0.00 1700.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 0.00 1800.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 0.00 1900.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
           (position 100.00 0.00)
           (bounds 50.00 50.00)
           (contentsOpaque 1)
@@ -191,26 +171,6 @@
         )
         (GraphicsLayer
           (position 100.00 1500.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 100.00 1600.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 100.00 1700.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 100.00 1800.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 100.00 1900.00)
           (bounds 50.00 50.00)
           (contentsOpaque 1)
         )

--- a/LayoutTests/fast/multicol/fixed-inside-columns-with-sticky-sibling-expected.html
+++ b/LayoutTests/fast/multicol/fixed-inside-columns-with-sticky-sibling-expected.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body { margin: 0; }
+
+    .flex-column {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .sticky-header {
+        top: 0;
+        height: 50px;
+        background: blue;
+        z-index: 100;
+    }
+
+    .columns {
+        padding-left: 40px;
+        column-count: 2;
+        column-gap: 24px;
+    }
+
+    .list-item {
+        display: list-item;
+    }
+
+    .consent-bar {
+        position: relative;
+        width: 100%;
+        z-index: 999999;
+    }
+
+    .dialog {
+        position: fixed;
+        top: 100px;
+        left: 0;
+        right: 0;
+        max-width: 500px;
+        width: auto;
+        margin: 0 auto;
+        height: 50px;
+        border: 2px solid black;
+        background: white;
+    }
+</style>
+</head>
+<body>
+    <div class="flex-column">
+        <div class="sticky-header"></div>
+        <footer>
+            <div>
+                <div class="columns">
+                    <div class="list-item">Item</div>
+                    <div class="list-item">
+                        <div class="consent-bar">
+                            <div class="dialog">content</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </footer>
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/multicol/fixed-inside-columns-with-sticky-sibling.html
+++ b/LayoutTests/fast/multicol/fixed-inside-columns-with-sticky-sibling.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body { margin: 0; }
+
+    .flex-column {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .sticky-header {
+        position: sticky;
+        top: 0;
+        height: 50px;
+        background: blue;
+        z-index: 100;
+    }
+
+    .columns {
+        padding-left: 40px;
+        column-count: 2;
+        column-gap: 24px;
+    }
+
+    .list-item {
+        display: list-item;
+    }
+
+    .consent-bar {
+        position: relative;
+        width: 100%;
+        z-index: 999999;
+    }
+
+    .dialog {
+        position: fixed;
+        top: 100px;
+        left: 0;
+        right: 0;
+        max-width: 500px;
+        width: auto;
+        margin: 0 auto;
+        height: 50px;
+        border: 2px solid black;
+        background: white;
+    }
+</style>
+</head>
+<body>
+    <div class="flex-column">
+        <div class="sticky-header"></div>
+        <footer>
+            <div>
+                <div class="columns">
+                    <div class="list-item">Item</div>
+                    <div class="list-item">
+                        <div class="consent-bar">
+                            <div class="dialog">content</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </footer>
+    </div>
+</body>
+</html>

--- a/LayoutTests/platform/mac-sequoia-wk2/compositing/layer-creation/sticky-overlap-extent-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/compositing/layer-creation/sticky-overlap-extent-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 2000.00)
       (contentsOpaque 1)
-      (children 41
+      (children 33
         (GraphicsLayer
           (preserves3D 1)
           (children 1
@@ -95,26 +95,6 @@
           (contentsOpaque 1)
         )
         (GraphicsLayer
-          (position 0.00 1600.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 0.00 1700.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 0.00 1800.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 0.00 1900.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
           (position 100.00 0.00)
           (bounds 50.00 50.00)
           (contentsOpaque 1)
@@ -191,26 +171,6 @@
         )
         (GraphicsLayer
           (position 100.00 1500.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 100.00 1600.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 100.00 1700.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 100.00 1800.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 100.00 1900.00)
           (bounds 50.00 50.00)
           (contentsOpaque 1)
         )

--- a/LayoutTests/platform/mac-sonoma-wk2/compositing/layer-creation/sticky-overlap-extent-expected.txt
+++ b/LayoutTests/platform/mac-sonoma-wk2/compositing/layer-creation/sticky-overlap-extent-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 2000.00)
       (contentsOpaque 1)
-      (children 41
+      (children 33
         (GraphicsLayer
           (preserves3D 1)
           (children 1
@@ -95,26 +95,6 @@
           (contentsOpaque 1)
         )
         (GraphicsLayer
-          (position 0.00 1600.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 0.00 1700.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 0.00 1800.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 0.00 1900.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
           (position 100.00 0.00)
           (bounds 50.00 50.00)
           (contentsOpaque 1)
@@ -191,26 +171,6 @@
         )
         (GraphicsLayer
           (position 100.00 1500.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 100.00 1600.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 100.00 1700.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 100.00 1800.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 100.00 1900.00)
           (bounds 50.00 50.00)
           (contentsOpaque 1)
         )

--- a/LayoutTests/platform/mac-wk2/compositing/layer-creation/sticky-overlap-extent-expected.txt
+++ b/LayoutTests/platform/mac-wk2/compositing/layer-creation/sticky-overlap-extent-expected.txt
@@ -5,7 +5,7 @@
     (GraphicsLayer
       (bounds 800.00 2000.00)
       (contentsOpaque 1)
-      (children 41
+      (children 33
         (GraphicsLayer
           (bounds 785.00 585.00)
           (children 1
@@ -100,26 +100,6 @@
           (contentsOpaque 1)
         )
         (GraphicsLayer
-          (position 0.00 1600.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 0.00 1700.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 0.00 1800.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 0.00 1900.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
           (position 100.00 0.00)
           (bounds 50.00 50.00)
           (contentsOpaque 1)
@@ -196,26 +176,6 @@
         )
         (GraphicsLayer
           (position 100.00 1500.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 100.00 1600.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 100.00 1700.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 100.00 1800.00)
-          (bounds 50.00 50.00)
-          (contentsOpaque 1)
-        )
-        (GraphicsLayer
-          (position 100.00 1900.00)
           (bounds 50.00 50.00)
           (contentsOpaque 1)
         )

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -2589,18 +2589,6 @@ void RenderLayerCompositor::computeExtent(const LayerOverlapMap& overlapMap, con
         extent.extentComputed = true;
     });
 
-    RenderLayerModelObject& renderer = layer.renderer();
-    if (renderer.isStickilyPositioned()) {
-        // Use rectangle that represents union of all possible sticky element positions,
-        // because it could be moved around without re-computing overlap.
-        auto const& box = downcast<RenderBoxModelObject>(renderer);
-        StickyPositionViewportConstraints constraints;
-        auto constrainingRectForStickyPosition = box.constrainingRectForStickyPosition();
-        box.computeStickyPositionConstraints(constraints, constrainingRectForStickyPosition);
-        extent.bounds = LayoutRect(constraints.computeStickyExtent());
-        return;
-    }
-
     LayoutRect layerBounds;
     if (extent.hasTransformAnimation)
         extent.animationCausesExtentUncertainty = !layer.getOverlapBoundsIncludingChildrenAccountingForTransformAnimations(layerBounds);
@@ -2615,7 +2603,19 @@ void RenderLayerCompositor::computeExtent(const LayerOverlapMap& overlapMap, con
     if (extent.bounds.isEmpty())
         extent.bounds.setSize(LayoutSize(1, 1));
 
-    if (renderer.isFixedPositioned() && renderer.container() == &m_renderView) {
+    auto& renderer = layer.renderer();
+    if (renderer.isStickilyPositioned()) {
+        // Use rectangle that represents union of all possible sticky element positions,
+        // because it could be moved around without re-computing overlap.
+        auto scrollInflated = m_renderView.frameView().fixedScrollableAreaBoundsInflatedForScrolling(extent.bounds);
+        auto& box = downcast<RenderBoxModelObject>(renderer);
+        StickyPositionViewportConstraints constraints;
+        auto constrainingRect = box.constrainingRectForStickyPosition();
+        box.computeStickyPositionConstraints(constraints, constrainingRect);
+        auto stickyBounds = LayoutRect(constraints.computeStickyExtent());
+        scrollInflated.intersect(stickyBounds);
+        extent.bounds = scrollInflated;
+    } else if (renderer.isFixedPositioned() && renderer.container() == &m_renderView) {
         // Because fixed elements get moved around without re-computing overlap, we have to compute an overlap
         // rect that covers all the locations that the fixed element could move to.
         extent.bounds = m_renderView.frameView().fixedScrollableAreaBoundsInflatedForScrolling(extent.bounds);


### PR DESCRIPTION
#### f149f1d42c54f54255042637f8889dfd9de64084
<pre>
REGRESSION(297346@main): Cookie dialog on hillsprofeeding.com is misplaced
<a href="https://bugs.webkit.org/show_bug.cgi?id=309729">https://bugs.webkit.org/show_bug.cgi?id=309729</a>
<a href="https://rdar.apple.com/171393860">rdar://171393860</a>

Reviewed by Simon Fraser.

The sticky overlap extent added in 297346@main used computeStickyExtent which covers the full
containing block range regardless of whether the page scrolls. This caused false overlap, forcing
multicol content to composite. It also returned early, skipping the normal overlapBounds()
computation.

Intersect the scroll-range inflation with the sticky extent so the result is bounded by both how far
the page can scroll and how far the element can travel in the containing block.

Test: fast/multicol/fixed-inside-columns-with-sticky-sibling.html
* LayoutTests/compositing/layer-creation/sticky-overlap-extent-expected.txt:
* LayoutTests/fast/multicol/fixed-inside-columns-with-sticky-sibling-expected.html: Added.
* LayoutTests/fast/multicol/fixed-inside-columns-with-sticky-sibling.html: Added.
* LayoutTests/platform/mac-sequoia-wk2/compositing/layer-creation/sticky-overlap-extent-expected.txt:
* LayoutTests/platform/mac-sonoma-wk2/compositing/layer-creation/sticky-overlap-extent-expected.txt:
* LayoutTests/platform/mac-wk2/compositing/layer-creation/sticky-overlap-extent-expected.txt:
Update these test expectations to account for the tighter extent.

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::computeExtent const):

Canonical link: <a href="https://commits.webkit.org/309147@main">https://commits.webkit.org/309147@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43ddd6aa810c021407a83a94aae393c110911ce7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15796 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158202 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102932 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9cbb47f8-c122-45e4-a059-f9ee88a4c7a9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115308 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81998 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9df8255b-ff40-42af-958f-e2608ea2ac41) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152460 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134160 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96049 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16541 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14444 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6046 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12092 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160679 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3674 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13632 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123346 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18486 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123551 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133884 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78242 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23036 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18761 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10635 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21628 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85449 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21359 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21511 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21416 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->