### PR TITLE
Glyph clipping at line start on fractional device pixel positions

### DIFF
--- a/LayoutTests/fast/text/subpixel-position-glyph-clipping-expected.html
+++ b/LayoutTests/fast/text/subpixel-position-glyph-clipping-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+div {
+    position: absolute;
+    left: 7px;
+    font-family: ui-monospace;
+    font-size: 48px;
+}
+</style>
+<div>d</div>

--- a/LayoutTests/fast/text/subpixel-position-glyph-clipping-overflow-clip-expected.html
+++ b/LayoutTests/fast/text/subpixel-position-glyph-clipping-overflow-clip-expected.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+.container {
+    position: absolute;
+    left: 7px;
+    width: 200px;
+    height: 100px;
+    overflow: clip;
+}
+.container > div {
+    font-family: ui-monospace;
+    font-size: 48px;
+}
+</style>
+<div class="container"><div>d</div></div>

--- a/LayoutTests/fast/text/subpixel-position-glyph-clipping-overflow-clip.html
+++ b/LayoutTests/fast/text/subpixel-position-glyph-clipping-overflow-clip.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+.container {
+    position: absolute;
+    left: 6.99px;
+    width: 200px;
+    height: 100px;
+    overflow: clip;
+}
+.container > div {
+    font-family: ui-monospace;
+    font-size: 48px;
+}
+</style>
+<div class="container"><div>d</div></div>

--- a/LayoutTests/fast/text/subpixel-position-glyph-clipping.html
+++ b/LayoutTests/fast/text/subpixel-position-glyph-clipping.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+div {
+    position: absolute;
+    left: 6.99px;
+    font-family: ui-monospace;
+    font-size: 48px;
+}
+</style>
+<div>d</div>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp
@@ -44,13 +44,13 @@ namespace LayoutIntegration {
 
 InlineContentPainter::InlineContentPainter(PaintInfo& paintInfo, const LayoutPoint& paintOffset, const RenderInline* inlineBoxWithLayer, const InlineContent& inlineContent, const RenderBlockFlow& root)
     : m_paintInfo(paintInfo)
-    , m_paintOffset(paintOffset)
+    , m_paintOffset(LayoutPoint(roundPointToDevicePixels(paintOffset, protect(root)->document().deviceScaleFactor())))
     , m_inlineBoxWithLayer(inlineBoxWithLayer)
     , m_inlineContent(inlineContent)
     , m_root(root)
 {
     m_damageRect = m_paintInfo.rect;
-    m_damageRect.moveBy(-m_paintOffset);
+    m_damageRect.moveBy(-paintOffset);
 }
 
 void InlineContentPainter::paintEllipsis(size_t lineIndex)

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
@@ -64,6 +64,7 @@ private:
     const RenderBlock& NODELETE root() const;
 
     PaintInfo& m_paintInfo;
+    // FIXME: (webkit.org/b/309800) This should maybe be a FloatPoint to indicate paint-ready geometry.
     const LayoutPoint m_paintOffset;
     LayoutRect m_damageRect;
     const RenderInline* m_inlineBoxWithLayer { nullptr };


### PR DESCRIPTION
#### 2f1d0ec6225eaaf0b17dc334f1545f28c8a81864
<pre>
Glyph clipping at line start on fractional device pixel positions
<a href="https://bugs.webkit.org/show_bug.cgi?id=309731">https://bugs.webkit.org/show_bug.cgi?id=309731</a>
<a href="https://rdar.apple.com/172323599">rdar://172323599</a>

Reviewed by NOBODY (OOPS!).

When inline content starts at a fractional device pixel position,
subpixel quantization can clip the left edge of the first glyph.

* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp:
(WebCore::LayoutIntegration::InlineContentPainter::InlineContentPainter):
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h:
* LayoutTests/fast/text/subpixel-position-glyph-clipping.html: Added.
* LayoutTests/fast/text/subpixel-position-glyph-clipping-expected.html: Added.
* LayoutTests/fast/text/subpixel-position-glyph-clipping-overflow-clip.html: Added.
* LayoutTests/fast/text/subpixel-position-glyph-clipping-overflow-clip-expected.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f1d0ec6225eaaf0b17dc334f1545f28c8a81864

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149670 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158373 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103102 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c629890b-3cf5-46ed-9a0f-b0bba29e3eb7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151543 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22384 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115451 "Found 11 new test failures: fast/block/positioning/offsetLeft-offsetTop-multicolumn.html fast/frames/hidpi-position-iframe-on-device-pixel.html fast/sub-pixel/float-wrap-with-subpixel-top.html imported/w3c/web-platform-tests/compat/webkit-box-rtl-flex.html imported/w3c/web-platform-tests/css/css-flexbox/fieldset-baseline-alignment.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-baseline-align-self-baseline-horiz-001.html imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-pixel-rounding.html imported/w3c/web-platform-tests/css/css-writing-modes/block-flow-direction-srl-065.xht imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-038.html imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-046.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82070 "2 flakes 39 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152630 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17588 "Found 4 new test failures: fast/dynamic/out-of-flow-counter-do-not-update.html fast/sub-pixel/float-wrap-with-subpixel-top.html mathml/non-core/fenced.html mathml/presentation/tokenElements-mathvariant.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134310 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96194 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16685 "Found 40 new test failures: imported/w3c/web-platform-tests/css/CSS2/box-display/display-005.xht imported/w3c/web-platform-tests/css/CSS2/box-display/display-006.xht imported/w3c/web-platform-tests/css/CSS2/box-display/display-007.xht imported/w3c/web-platform-tests/css/CSS2/box-display/display-014.xht imported/w3c/web-platform-tests/css/CSS2/linebox/vertical-align-baseline-006.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-009.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-010.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-011.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-012.xht imported/w3c/web-platform-tests/css/CSS2/tables/table-anonymous-objects-197.xht ... (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14591 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6218 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126293 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160851 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3850 "Found 1 new failure in layout/integration/inline/LayoutIntegrationInlineContentPainter.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13782 "Found 60 new test failures: compositing/style-change/perspective-origin-change.html css3/filters/identity-filters.html fast/css/is-specificity-3.html fast/dynamic/out-of-flow-counter-do-not-update.html fast/flexbox/flexbox-fail-to-select-same-line.html fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment.html fast/frames/hidpi-position-iframe-on-device-pixel.html fast/images/mac/play-pause-individual-animation-context-menu-items.html fast/inline/hidpi-select-inline-on-subpixel-position.html fast/misc/selection-gap-between-flex-items.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123484 "Found 12 new test failures: fast/block/positioning/offsetLeft-offsetTop-multicolumn.html fast/frames/hidpi-position-iframe-on-device-pixel.html fast/sub-pixel/float-wrap-with-subpixel-top.html imported/w3c/web-platform-tests/compat/webkit-box-rtl-flex.html imported/w3c/web-platform-tests/css/css-flexbox/fieldset-baseline-alignment.html imported/w3c/web-platform-tests/css/css-flexbox/flexbox-baseline-align-self-baseline-horiz-001.html imported/w3c/web-platform-tests/css/css-position/sticky/position-sticky-table-pixel-rounding.html imported/w3c/web-platform-tests/css/css-writing-modes/block-flow-direction-srl-065.xht imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-034.html imported/w3c/web-platform-tests/css/css-writing-modes/wm-propagation-body-038.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22191 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18632 "Found 60 new test failures: css3/filters/identity-filters.html fast/dynamic/out-of-flow-counter-do-not-update.html fast/flexbox/flexbox-fail-to-select-same-line.html fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment.html fast/forms/select/select-show-picker.html fast/frames/hidpi-position-iframe-on-device-pixel.html fast/inline/hidpi-select-inline-on-subpixel-position.html fast/misc/selection-gap-between-flex-items.html fast/sub-pixel/float-wrap-with-subpixel-top.html fast/text/image-alt-text-bidi-2.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123691 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22198 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134033 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78423 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18863 "Found 3 new test failures: interaction-region/content-hint.html interaction-region/icon-masking.html interaction-region/svg-luminance.html (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10785 "Found 60 new test failures: compositing/hidpi-composited-container-and-graphics-layer-gap-changes.html compositing/patterns/direct-pattern-compositing.html css3/filters/identity-filters.html css3/flexbox/flex-item-margin-top-no-crash.html fast/dynamic/out-of-flow-counter-do-not-update.html fast/flexbox/flexbox-fail-to-select-same-line.html fast/forms/auto-fill-button/input-strong-password-viewable-baseline-alignment.html fast/frames/hidpi-position-iframe-on-device-pixel.html fast/inline/hidpi-select-inline-on-subpixel-position.html fast/misc/selection-gap-between-flex-items.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21799 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85619 "Failed to build and analyze WebKit") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21529 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21681 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21586 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->