### PR TITLE
Sync `moving-between-documents` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: script
+  files: '**'

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/before-prepare-iframe-parse-error-external-module-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/before-prepare-iframe-parse-error-external-module-expected.txt
@@ -3,6 +3,6 @@
 PASS Sanity check around top-level Window
 PASS Eval: Move parse-error external module script to iframe before-prepare
 PASS <script> load: Move parse-error external module script to iframe before-prepare
-FAIL <script> error: Move parse-error external module script to iframe before-prepare assert_unreached: Script error evennt fired unexpectedly Reached unreachable code
-PASS window error: Move parse-error external module script to iframe before-prepare
+PASS <script> error: Move parse-error external module script to iframe before-prepare
+FAIL window error: Move parse-error external module script to iframe before-prepare assert_unreached: Window error event shouldn't fired on destination window Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/before-prepare-iframe-parse-error-inline-module-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/before-prepare-iframe-parse-error-inline-module-expected.txt
@@ -3,6 +3,6 @@
 PASS Sanity check around top-level Window
 PASS Eval: Move parse-error inline module script to iframe before-prepare
 PASS <script> load: Move parse-error inline module script to iframe before-prepare
-FAIL <script> error: Move parse-error inline module script to iframe before-prepare assert_unreached: Script error evennt fired unexpectedly Reached unreachable code
-PASS window error: Move parse-error inline module script to iframe before-prepare
+PASS <script> error: Move parse-error inline module script to iframe before-prepare
+FAIL window error: Move parse-error inline module script to iframe before-prepare assert_unreached: Window error event shouldn't fired on destination window Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/before-prepare-iframe-success-inline-module-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/before-prepare-iframe-success-inline-module-expected.txt
@@ -2,7 +2,7 @@
 
 PASS Sanity check around top-level Window
 FAIL Eval: Move success inline module script to iframe before-prepare assert_false: The script must not have executed in destination window expected false got "executed"
-FAIL <script> load: Move success inline module script to iframe before-prepare assert_unreached: Script load event fired unexpectedly Reached unreachable code
+PASS <script> load: Move success inline module script to iframe before-prepare
 PASS <script> error: Move success inline module script to iframe before-prepare
 PASS window error: Move success inline module script to iframe before-prepare
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/delay-load-event-1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/delay-load-event-1.html
@@ -3,8 +3,10 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="helper.js"></script>
+
 <body>
 <script>
 runDelayEventTest('Script elements (parser-blocking)');
 </script>
+
 <script id="to-be-moved" src="../../resources/throw.js?pipe=trickle(d3)"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/delay-load-event-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/delay-load-event-2.html
@@ -3,6 +3,7 @@
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="helper.js"></script>
+
 <body>
 <script>
 runDelayEventTest('Script elements (async)');

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/delay-load-event-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/delay-load-event-iframe.html
@@ -2,4 +2,3 @@
 <meta charset="utf-8">
 <body onload="parent.onloadIframe()">
 <script src="../../resources/throw.js?pipe=trickle(d2)"></script>
-</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/helper.js
@@ -1,14 +1,14 @@
 function runDelayEventTest(description) {
-  const t = async_test(description +
+  const t_original = async_test(description +
       ' still delay the load event in the original Document after move');
   const t_new = async_test(description +
       ' does not delay the load event in the new Document after move');
-  const start_time = performance.now();
   const iframe = document.createElement('iframe');
   iframe.setAttribute('src', 'delay-load-event-iframe.html');
+  const start_time = performance.now();
   document.body.appendChild(iframe);
 
-  window.onload = t.step_func_done(() => {
+  window.onload = t_original.step_func_done(() => {
     // The `#to-be-moved` script should delay the load event until it is loaded
     // (i.e. 3 seconds), not just until it is moved out to another Document
     // (i.e. 1 second). Here we expect the delay should be at least 2 seconds,
@@ -20,11 +20,11 @@ function runDelayEventTest(description) {
   window.onloadIframe = t_new.step_func_done(() => {
     // The iframe's load event is fired after 2 seconds of its subresource
     // loading, and shouldn't wait for the `#to-be-moved` script.
-    assert_less_than(performance.now() - start_time, 2500,
+    assert_less_than(performance.now() - start_time, 3000,
         'Load event should not be delayed until moved script is loaded');
   });
 
-  t.step_timeout(() => {
+  t_original.step_timeout(() => {
     const script = document.querySelector('#to-be-moved');
     iframe.contentDocument.body.appendChild(script);
   }, 1000);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/w3c-import.log
@@ -15,6 +15,7 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/README.md
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/after-prepare-createHTMLDocument-fetch-error-external-classic.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/after-prepare-createHTMLDocument-fetch-error-external-module.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/after-prepare-createHTMLDocument-parse-error-external-classic.html


### PR DESCRIPTION
#### 49a19d4d4b4e62cb67b16f2decc6db7af08bd2bf
<pre>
Sync `moving-between-documents` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=309733">https://bugs.webkit.org/show_bug.cgi?id=309733</a>
<a href="https://rdar.apple.com/172324306">rdar://172324306</a>

Reviewed by Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/84dd573da13cf45272052c3663936cec59650ade">https://github.com/web-platform-tests/wpt/commit/84dd573da13cf45272052c3663936cec59650ade</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/before-prepare-iframe-parse-error-external-module-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/before-prepare-iframe-parse-error-inline-module-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/before-prepare-iframe-success-inline-module-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/delay-load-event-1.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/delay-load-event-2.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/delay-load-event-iframe.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/helper.js:
(runDelayEventTest):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/309134@main">https://commits.webkit.org/309134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c95cacb6ddb3a8fd8449dcd7ef915e677d621e0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158175 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102905 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9e6d1f6-24ed-4fac-8339-6398fc011bc9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115279 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81988 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8598bfc9-329e-4cb9-932f-bcb9b5bbda0c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17421 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134126 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96023 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f16403a7-0df4-4855-b3ae-8e5856e7e117) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16517 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14417 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6018 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160652 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13598 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123312 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21994 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123525 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33584 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133851 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78215 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18725 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10602 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21601 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21332 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21484 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21389 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->