### PR TITLE
[GLIB] WebProcess critical assertion during D-Bus RequestName completion on process shutdown

### DIFF
--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
@@ -82,12 +82,38 @@ void AccessibilityAtspi::didConnect(GRefPtr<GDBusConnection>&& connection)
     }
 
     RELEASE_ASSERT(g_dbus_is_name(m_busName.utf8().data()));
-    g_bus_own_name_on_connection(m_connection.get(), m_busName.utf8().data(), G_BUS_NAME_OWNER_FLAGS_DO_NOT_QUEUE,
+    m_nameOwnerId = g_bus_own_name_on_connection(m_connection.get(), m_busName.utf8().data(), G_BUS_NAME_OWNER_FLAGS_DO_NOT_QUEUE,
         [](GDBusConnection*, const char*, gpointer userData) {
             auto& atspi = *static_cast<AccessibilityAtspi*>(userData);
             atspi.didOwnName();
         },
         nullptr, this, nullptr);
+}
+
+void AccessibilityAtspi::disconnect()
+{
+    m_isConnecting = false;
+
+    m_cacheUpdateTimer.stop();
+    m_cacheClearTimer.stop();
+    m_cacheUpdateList.clear();
+
+    for (auto& pending : std::exchange(m_pendingRootRegistrations, { }))
+        pending.completionHandler({ });
+
+    if (auto id = std::exchange(m_nameOwnerId, 0))
+        g_bus_unown_name(id);
+
+    if (auto registry = std::exchange(m_registry, nullptr))
+        g_signal_handlers_disconnect_by_data(registry.get(), this);
+
+    if (auto connection = std::exchange(m_connection, nullptr)) {
+        for (auto id : m_clients.values())
+            g_dbus_connection_signal_unsubscribe(connection.get(), id);
+        m_clients.clear();
+
+        g_dbus_connection_close_sync(connection.get(), nullptr, nullptr);
+    }
 }
 
 void AccessibilityAtspi::didOwnName()

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.h
@@ -54,6 +54,7 @@ public:
     void deref() const { }
 
     void connect(const String&, const String&);
+    WEBCORE_EXPORT void disconnect();
 
     const char* uniqueName() const;
     GVariant* nullReference() const;
@@ -136,6 +137,7 @@ private:
 
     String m_busName;
     bool m_isConnecting { false };
+    unsigned m_nameOwnerId { 0 };
     GRefPtr<GDBusConnection> m_connection;
     GRefPtr<GDBusProxy> m_registry;
     Vector<PendingRootRegistration> m_pendingRootRegistrations;

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -112,6 +112,10 @@ void WebProcess::stopRunLoop()
     if (auto* display = PlatformDisplay::sharedDisplayIfExists())
         display->clearGLContexts();
 
+#if USE(ATSPI)
+    AccessibilityAtspi::singleton().disconnect();
+#endif
+
     AuxiliaryProcess::stopRunLoop();
 }
 


### PR DESCRIPTION
#### 57438b0e69831fedd7851825b33b09a0917c9b74
<pre>
[GLIB] WebProcess critical assertion during D-Bus RequestName completion on process shutdown
<a href="https://bugs.webkit.org/show_bug.cgi?id=309693">https://bugs.webkit.org/show_bug.cgi?id=309693</a>

Reviewed by Claudio Saavedra.

While rare, there&apos;s a chance that the WebProcess exits while the
AccessibilityAtspi dbus name callbacks are still in flight. If we don&apos;t
close them gracefully, we risk critical errors when the reply arrives.
This is likely related to 284894@main, which added the support for
well-known bus name to AccessibilityAtspi.

This happens, for example, in some WebDriver tests that quickly open and
close browsing contexts. A run with release asserts is reporting almost
30 crashes.

This commit addresses this issue by adding a graceful cleanup path to
AccessibilityAtspi.

* Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp:
(WebCore::AccessibilityAtspi::didConnect):
(WebCore::AccessibilityAtspi::disconnect):
* Source/WebCore/accessibility/atspi/AccessibilityAtspi.h:
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::stopRunLoop):

Canonical link: <a href="https://commits.webkit.org/309174@main">https://commits.webkit.org/309174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fd797fcab8825a69e73bacb7aff36f77a833854

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22443 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158428 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22893 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115495 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17617 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134351 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96236 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6274 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160906 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123522 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22245 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18674 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123728 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33609 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22252 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134075 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78477 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18895 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10826 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21853 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85673 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21583 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21735 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21640 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->