### PR TITLE
fast/viewport/ios/viewport-fit-auto-safe-area-inset-change.html does not pass on iPad

### DIFF
--- a/LayoutTests/fast/viewport/ios/viewport-fit-auto-safe-area-inset-change-expected.txt
+++ b/LayoutTests/fast/viewport/ios/viewport-fit-auto-safe-area-inset-change-expected.txt
@@ -4,13 +4,13 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 Initial width, using viewport-fit: cover
-PASS document.body.clientWidth is 374
+PASS document.body.clientWidth is viewportWidth
 
 Set safe area, but still using viewport-fit: cover
-PASS document.body.clientWidth is 374
+PASS document.body.clientWidth is viewportWidth
 
 Change to viewport-fit: auto
-PASS document.body.clientWidth is 334
+PASS document.body.clientWidth is viewportWidth - leftAndRightSafeAreaInsets
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/viewport/ios/viewport-fit-auto-safe-area-inset-change.html
+++ b/LayoutTests/fast/viewport/ios/viewport-fit-auto-safe-area-inset-change.html
@@ -12,12 +12,15 @@ jsTestIsAsync = true;
 addEventListener("load", async () => {
     description("Tests that changing the value of viewport-fit affects the size of the viewport.");
 
+    // Body margins are 8px left and 8px right.
+    viewportWidth = screen.width - 16;
+
     debug("Initial width, using viewport-fit: cover");
-    shouldBe("document.body.clientWidth", "374");
+    shouldBe("document.body.clientWidth", "viewportWidth");
 
     debug("\nSet safe area, but still using viewport-fit: cover");
     await UIHelper.setSafeAreaInsets(0, 20, 0, 20);
-    shouldBe("document.body.clientWidth", "374");
+    shouldBe("document.body.clientWidth", "viewportWidth");
 
     debug("\nChange to viewport-fit: auto");
     let viewportMeta = document.querySelector('meta[name="viewport"]');
@@ -25,7 +28,8 @@ addEventListener("load", async () => {
 
     await UIHelper.ensurePresentationUpdate();
 
-    shouldBe("document.body.clientWidth", "334");
+    leftAndRightSafeAreaInsets = 40;
+    shouldBe("document.body.clientWidth", "viewportWidth - leftAndRightSafeAreaInsets");
 
     debug("");
     finishJSTest();

--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -166,7 +166,6 @@ scrollingcoordinator/ios/fixed-scrolling-with-keyboard.html [ Skip ]
 webkit.org/b/307451 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional.html [ Pass Failure ]
 
 # webkit.org/b/307469 4x fast/viewport/iOS tests are constant text failures on iPad
-fast/viewport/ios/viewport-fit-auto-safe-area-inset-change.html [ Failure ]
 fast/viewport/ios/shrink-to-fit-content-large-constant-width.html [ Failure ]
 
 webkit.org/b/307488 media/volume-activate-audio-session.html [ Failure ]


### PR DESCRIPTION
#### c79b6db1c2ecbc01c1fa36cfe33f794e050eb5ed
<pre>
fast/viewport/ios/viewport-fit-auto-safe-area-inset-change.html does not pass on iPad
<a href="https://bugs.webkit.org/show_bug.cgi?id=309593">https://bugs.webkit.org/show_bug.cgi?id=309593</a>
<a href="https://rdar.apple.com/172214570">rdar://172214570</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

This test was originally hardcoded for iPhone screen sizes.
To fix this, update this test to be screen size agnostic.

Ungarden the TestExpctations for this test.

* LayoutTests/fast/viewport/ios/viewport-fit-auto-safe-area-inset-change-expected.txt:
* LayoutTests/fast/viewport/ios/viewport-fit-auto-safe-area-inset-change.html:
* LayoutTests/platform/ipad/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/309379@main">https://commits.webkit.org/309379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95be32ae03740db72d2e25a6d90fbdeb699d72d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150438 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159160 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103872 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/57fcb054-3ed9-4f03-b982-b90f6be7c42a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116076 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82473 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134954 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96804 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e0a7410d-3b8f-4a15-bf8f-52b994c1453e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17280 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15231 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7008 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126895 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161634 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124073 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22998 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19278 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124271 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33750 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22985 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134673 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79365 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19389 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11430 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22599 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22312 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22464 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22366 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->