### PR TITLE
[JSC] Add ArrayIsArray intrinsic for Array.isArray

### DIFF
--- a/JSTests/stress/array-is-array-intrinsic.js
+++ b/JSTests/stress/array-is-array-intrinsic.js
@@ -1,0 +1,152 @@
+function assert(cond, msg) {
+    if (!cond) throw new Error(msg ?? "assertion failed");
+}
+
+// ---- Correctness: spec edge cases ----
+
+// Non-cell primitives
+assert(Array.isArray(undefined) === false, "undefined");
+assert(Array.isArray(null) === false, "null");
+assert(Array.isArray(true) === false, "true");
+assert(Array.isArray(false) === false, "false");
+assert(Array.isArray(0) === false, "0");
+assert(Array.isArray(-0) === false, "-0");
+assert(Array.isArray(NaN) === false, "NaN");
+assert(Array.isArray(Infinity) === false, "Infinity");
+assert(Array.isArray(1.5) === false, "1.5");
+assert(Array.isArray(42n) === false, "BigInt");
+
+// Cell non-arrays
+assert(Array.isArray("string") === false, "string");
+assert(Array.isArray({}) === false, "plain object");
+assert(Array.isArray(function () { }) === false, "function");
+assert(Array.isArray(/regex/) === false, "regexp");
+assert(Array.isArray(new Map()) === false, "Map");
+assert(Array.isArray(new Set()) === false, "Set");
+assert(Array.isArray(Symbol()) === false, "Symbol");
+
+// Arrays
+assert(Array.isArray([]) === true, "empty array");
+assert(Array.isArray([1, 2, 3]) === true, "array literal");
+assert(Array.isArray(new Array(5)) === true, "new Array");
+
+// Derived arrays (subclasses — DerivedArrayType)
+class MyArray extends Array { }
+assert(Array.isArray(new MyArray()) === true, "derived array");
+assert(Array.isArray(new MyArray(3)) === true, "derived array with size");
+
+// Zero-argument call -> false (spec: arg is undefined)
+assert(Array.isArray() === false, "no args");
+
+// Proxy wrapping an array -> true (spec: IsArray recurses through proxy)
+const proxiedArray = new Proxy([], {});
+assert(Array.isArray(proxiedArray) === true, "Proxy(array)");
+
+// Proxy wrapping a non-array -> false
+const proxiedObj = new Proxy({}, {});
+assert(Array.isArray(proxiedObj) === false, "Proxy(object)");
+
+// Nested proxy -> true (spec recurses)
+const doubleProxied = new Proxy(new Proxy([], {}), {});
+assert(Array.isArray(doubleProxied) === true, "Proxy(Proxy(array))");
+
+// Revoked proxy -> throws TypeError
+const { proxy: revokedProxy, revoke } = Proxy.revocable([], {});
+revoke();
+let threw = false;
+try { Array.isArray(revokedProxy); } catch (e) { threw = e instanceof TypeError; }
+assert(threw, "revoked proxy must throw TypeError");
+
+// ---- Tier tests ----
+// Each function is called enough times to force up through the tiers.
+// Mixing non-cell and cell inputs in the same hot function was the bug trigger.
+
+// LLInt / Baseline (no DFG)
+function testMixedNoDFG(v) {
+    return Array.isArray(v);
+}
+noDFG(testMixedNoDFG);
+noFTL(testMixedNoDFG);
+
+for (let i = 0; i < 1000; i++) {
+    assert(testMixedNoDFG(undefined) === false);
+    assert(testMixedNoDFG([]) === true);
+    assert(testMixedNoDFG(null) === false);
+    assert(testMixedNoDFG(true) === false);
+    assert(testMixedNoDFG({}) === false);
+}
+
+// DFG (no FTL): mixed types must not cause BadType exits / jettisons
+function testMixedDFG(v) {
+    return Array.isArray(v);
+}
+noFTL(testMixedDFG);
+
+const mixed = [undefined, [], null, false, {}, new MyArray(), 42, "str", new Proxy([], {})];
+for (let i = 0; i < 10000; i++) {
+    const result = testMixedDFG(mixed[i % mixed.length]);
+    assert(typeof result === "boolean", `DFG: expected boolean for input index ${i % mixed.length}`);
+}
+
+// DFG: known-array input — abstract interpreter should fold to constant true
+function testKnownArray(arr) {
+    return Array.isArray(arr);
+}
+noFTL(testKnownArray);
+noInline(testKnownArray);
+
+for (let i = 0; i < 10000; i++) {
+    assert(testKnownArray([1, 2, 3]) === true, "DFG constant fold: known array");
+}
+
+// DFG: known non-cell — abstract interpreter should fold to constant false
+function testKnownNonCell(x) {
+    return Array.isArray(x);
+}
+noFTL(testKnownNonCell);
+noInline(testKnownNonCell);
+
+for (let i = 0; i < 10000; i++) {
+    assert(testKnownNonCell(i) === false, "DFG constant fold: known number");
+}
+
+// FTL: hot mixed-type loop — must compile stably without exits
+function testFTLMixed(v) {
+    return Array.isArray(v);
+}
+noInline(testFTLMixed);
+
+const ftlInputs = [[], new MyArray(), null, undefined, false, {}, 0, "s"];
+for (let i = 0; i < 200000; i++) {
+    testFTLMixed(ftlInputs[i & 7]);
+}
+assert(testFTLMixed([]) === true, "FTL: array");
+assert(testFTLMixed(new MyArray()) === true, "FTL: derived array");
+assert(testFTLMixed(null) === false, "FTL: null");
+assert(testFTLMixed(undefined) === false, "FTL: undefined");
+assert(testFTLMixed({}) === false, "FTL: plain object");
+
+// FTL: known-array constant folding in hot path
+function testFTLKnownArray(arr) {
+    return Array.isArray(arr);
+}
+noInline(testFTLKnownArray);
+
+const arrInput = [1];
+for (let i = 0; i < 200000; i++) {
+    assert(testFTLKnownArray(arrInput) === true, "FTL constant fold: known array");
+}
+
+// FTL: proxy slow path reachable at FTL tier
+function testFTLProxy(v) {
+    return Array.isArray(v);
+}
+noInline(testFTLProxy);
+
+const proxyArr = new Proxy([], {});
+for (let i = 0; i < 200000; i++) {
+    // Warm with arrays (fast path), occasionally hit the proxy slow path
+    testFTLProxy(i % 100 === 0 ? proxyArr : []);
+}
+assert(testFTLProxy(proxyArr) === true, "FTL proxy slow path returns true");
+assert(testFTLProxy(new Proxy({}, {})) === false, "FTL proxy slow path returns false");

--- a/Source/JavaScriptCore/builtins/ArrayConstructor.js
+++ b/Source/JavaScriptCore/builtins/ArrayConstructor.js
@@ -95,17 +95,6 @@ function from(items /*, mapFn, thisArg */)
     return result;
 }
 
-function isArray(array)
-{
-    "use strict";
-
-    if (@isJSArray(array) || @isDerivedArray(array))
-        return true;
-    if (!@isProxyObject(array))
-        return false;
-    return @isArraySlow(array);
-}
-
 @linkTimeConstant
 @visibility=PrivateRecursive
 async function defaultAsyncFromAsyncIterator(iterator, mapFn, thisArg)

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -144,6 +144,7 @@ namespace JSC {
     macro(hasInstanceBoundFunction) \
     macro(instanceOf) \
     macro(isArraySlow) \
+    macro(isArray) \
     macro(sameValue) \
     macro(regExpCreate) \
     macro(isRegExp) \

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2071,6 +2071,42 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
+    case ArrayIsArray: {
+        AbstractValue& child = forNode(node->child1());
+        if (JSValue v = child.value()) {
+            if (!v.isCell()) {
+                didFoldClobberWorld();
+                setConstant(node, jsBoolean(false));
+                break;
+            }
+            JSType type = v.asCell()->type();
+            if (type == ArrayType || type == DerivedArrayType) {
+                didFoldClobberWorld();
+                setConstant(node, jsBoolean(true));
+                break;
+            }
+            if (type != ProxyObjectType) {
+                didFoldClobberWorld();
+                setConstant(node, jsBoolean(false));
+                break;
+            }
+        } else {
+            if (!(child.m_type & (SpecArray | SpecDerivedArray | SpecProxyObject))) {
+                didFoldClobberWorld();
+                setConstant(node, jsBoolean(false));
+                break;
+            }
+            if (!(child.m_type & ~(SpecArray | SpecDerivedArray))) {
+                didFoldClobberWorld();
+                setConstant(node, jsBoolean(true));
+                break;
+            }
+        }
+        clobberWorld();
+        setNonCellTypeForNode(node, SpecBoolean);
+        break;
+    }
+
     case NumberIsNaN: {
         AbstractValue& child = forNode(node->child1());
         if (JSValue value = child.value()) {

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -2919,6 +2919,15 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case ArrayIsArrayIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            setResult(addToGraph(ArrayIsArray, get(virtualRegisterForArgumentIncludingThis(1, registerOffset))));
+            return CallOptimizationResult::Inlined;
+        }
+
         case AtomicsAddIntrinsic:
         case AtomicsAndIntrinsic:
         case AtomicsCompareExchangeIntrinsic:

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -678,7 +678,11 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         read(MiscFields);
         def(HeapLocation(IsConstructorLoc, MiscFields, node->child1()), LazyNode(node));
         return;
-        
+
+    case ArrayIsArray:
+        clobberTop();
+        return;
+
     case MatchStructure:
         read(JSCell_structureID);
         return;

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -491,6 +491,7 @@ bool doesGC(Graph& graph, Node* node)
     case PromiseReject:
     case PromiseThen:
     case PerformPromiseThen:
+    case ArrayIsArray:
 #else // not ASSERT_ENABLED
     // See comment at the top for why the default for all nodes should be to
     // return true.

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2751,6 +2751,11 @@ private:
             break;
         }
 
+        case ArrayIsArray: {
+            fixEdge<UntypedUse>(node->child1());
+            break;
+        }
+
         case HasStructureWithFlags: {
             fixEdge<KnownCellUse>(node->child1());
             break;

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -458,6 +458,7 @@ namespace JSC { namespace DFG {
     macro(MatchStructure, NodeMustGenerate | NodeResultBoolean) \
     \
     macro(IsCellWithType, NodeResultBoolean) \
+    macro(ArrayIsArray, NodeMustGenerate | NodeResultBoolean) \
     macro(IsEmpty, NodeResultBoolean) \
     macro(IsEmptyStorage, NodeResultBoolean) \
     macro(HasStructureWithFlags, NodeResultBoolean) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -28,6 +28,7 @@
 
 
 #include "ArrayPrototypeInlines.h"
+#include "ArrayConstructor.h"
 #include "ButterflyInlines.h"
 #include "CacheableIdentifierInlines.h"
 #include "ClonedArguments.h"
@@ -2646,6 +2647,18 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationIsConstructor, size_t, (JSGlobalObjec
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     OPERATION_RETURN(scope, JSValue::decode(value).isConstructor());
+}
+
+JSC_DEFINE_JIT_OPERATION(operationArrayIsArray, size_t, (JSGlobalObject* globalObject, EncodedJSValue encodedValue))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue value = JSValue::decode(encodedValue);
+    ASSERT(value.isCell() && value.asCell()->type() == ProxyObjectType);
+    OPERATION_RETURN(scope, isArraySlow(globalObject, jsCast<ProxyObject*>(value.asCell())));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationTypeOfObject, JSCell*, (JSGlobalObject* globalObject, JSCell* object))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -262,6 +262,7 @@ JSC_DECLARE_JIT_OPERATION(operationTypeOfIsObject, size_t, (JSGlobalObject*, JSC
 JSC_DECLARE_JIT_OPERATION(operationTypeOfIsFunction, size_t, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationObjectIsCallable, size_t, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationIsConstructor, size_t, (JSGlobalObject*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationArrayIsArray, size_t, (JSGlobalObject*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationTypeOfObject, JSCell*, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationAllocateSimplePropertyStorageWithInitialCapacity, Butterfly*, (VM*));
 JSC_DECLARE_JIT_OPERATION(operationAllocateSimplePropertyStorage, Butterfly*, (VM*, size_t newSize));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1293,6 +1293,7 @@ private:
         case IsConstructor:
         case IsCellWithType:
         case IsTypedArrayView:
+        case ArrayIsArray:
         case HasStructureWithFlags:
         case MatchStructure: {
             setPrediction(SpecBoolean);

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -281,6 +281,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case IsConstructor:
     case IsCellWithType:
     case IsTypedArrayView:
+    case ArrayIsArray:
     case HasStructureWithFlags:
     case TypeOf:
     case ToBoolean:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -5016,6 +5016,43 @@ void SpeculativeJIT::compileIsTypedArrayView(Node* node)
     blessedBooleanResult(resultGPR, node);
 }
 
+void SpeculativeJIT::compileArrayIsArray(Node* node)
+{
+    // Array.isArray(value):
+    //   if value is not a cell -> false
+    //   if cell type == ArrayType || DerivedArrayType -> true
+    //   if cell type == ProxyObjectType -> call isArraySlow (slow path, may throw)
+    //   else -> false
+    JSValueOperand value(this, node->child1());
+    GPRTemporary result(this);
+
+    JSValueRegs valueRegs = value.jsValueRegs();
+    GPRReg resultGPR = result.gpr();
+
+    Jump isNotCell = branchIfNotCell(valueRegs);
+
+    // Load the JSType byte into resultGPR, then bias by ArrayType for unsigned range checks.
+    // After sub: 0 -> ArrayType, 1 -> DerivedArrayType (-> true), ProxyObjectType-ArrayType -> slow path, else -> false.
+    static_assert(DerivedArrayType == ArrayType + 1, "ArrayType and DerivedArrayType must be consecutive");
+    static_assert(ProxyObjectType > DerivedArrayType, "ProxyObjectType must be above DerivedArrayType");
+    load8(Address(valueRegs.payloadGPR(), JSCell::typeInfoTypeOffset()), resultGPR);
+    sub32(TrustedImm32(ArrayType), resultGPR);
+    Jump isArrayOrDerived = branch32(BelowOrEqual, resultGPR, TrustedImm32(DerivedArrayType - ArrayType));
+    Jump isProxy = branch32(Equal, resultGPR, TrustedImm32(ProxyObjectType - ArrayType));
+
+    isNotCell.link(this);
+    move(TrustedImm32(0), resultGPR);
+    Jump done = jump();
+
+    isArrayOrDerived.link(this);
+    move(TrustedImm32(1), resultGPR);
+
+    addSlowPathGenerator(slowPathCall(isProxy, this, operationArrayIsArray, resultGPR, LinkableConstant::globalObject(*this, node), valueRegs));
+
+    done.link(this);
+    unblessedBooleanResult(resultGPR, node);
+}
+
 void SpeculativeJIT::compileHasStructureWithFlags(Node* node)
 {
     SpeculateCellOperand object(this, node->child1());

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -756,6 +756,7 @@ public:
 
     void compileIsCellWithType(Node*);
     void compileIsTypedArrayView(Node*);
+    void compileArrayIsArray(Node*);
 
     void emitCall(Node*);
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3866,6 +3866,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case ArrayIsArray: {
+        compileArrayIsArray(node);
+        break;
+    }
+
     case TypeOf: {
         compileTypeOf(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -5605,6 +5605,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case ArrayIsArray: {
+        compileArrayIsArray(node);
+        break;
+    }
+
     case TypeOf: {
         compileTypeOf(node);
         break;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -322,6 +322,7 @@ inline CapabilityLevel canCompile(Node* node)
     case IsCallable:
     case IsConstructor:
     case IsTypedArrayView:
+    case ArrayIsArray:
     case CheckTypeInfoFlags:
     case HasStructureWithFlags:
     case OverridesHasInstance:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1612,6 +1612,9 @@ private:
         case IsCellWithType:
             compileIsCellWithType();
             break;
+        case ArrayIsArray:
+            compileArrayIsArray();
+            break;
         case MapHash:
             compileMapHash();
             break;
@@ -15095,6 +15098,56 @@ IGNORE_CLANG_WARNINGS_END
             ASSERT(m_node->child1().useKind() == CellUse);
             setBoolean(isCellWithType(lowCell(m_node->child1()), m_node->queriedType(), m_node->speculatedTypeForQuery(), provenType(m_node->child1())));
         }
+    }
+
+    void compileArrayIsArray()
+    {
+        // Array.isArray(value):
+        //   non-cell -> false
+        //   ArrayType | DerivedArrayType -> true
+        //   ProxyObjectType -> slow path (may throw on revoked proxy)
+        //   other cell -> false
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+
+        LValue value = lowJSValue(m_node->child1());
+
+        LBasicBlock isCellCase = m_out.newBlock();
+        LBasicBlock checkProxyBlock = m_out.newBlock();
+        LBasicBlock slowPathBlock = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        ValueFromBlock notCellResult = m_out.anchor(m_out.booleanFalse);
+        m_out.branch(isCell(value, provenType(m_node->child1())), usually(isCellCase), rarely(continuation));
+
+        LBasicBlock lastNext = m_out.appendTo(isCellCase, checkProxyBlock);
+        // Bias by ArrayType so a single unsigned range check covers both ArrayType and DerivedArrayType.
+        // adjustedType = typeInfo - ArrayType:
+        //   0 -> ArrayType, 1 -> DerivedArrayType (true), ProxyObjectType-ArrayType -> slow path, else -> false.
+        static_assert(DerivedArrayType == ArrayType + 1, "ArrayType and DerivedArrayType must be consecutive");
+        static_assert(ProxyObjectType > DerivedArrayType, "ProxyObjectType must be above DerivedArrayType");
+        LValue adjustedType = m_out.sub(m_out.load8ZeroExt32(value, m_heaps.JSCell_typeInfoType), m_out.constInt32(ArrayType));
+        ValueFromBlock arrayResult = m_out.anchor(m_out.booleanTrue);
+        m_out.branch(m_out.belowOrEqual(adjustedType, m_out.constInt32(DerivedArrayType - ArrayType)),
+            usually(continuation), unsure(checkProxyBlock));
+
+        m_out.appendTo(checkProxyBlock, slowPathBlock);
+        ValueFromBlock otherCellResult = m_out.anchor(m_out.booleanFalse);
+        m_out.branch(m_out.equal(adjustedType, m_out.constInt32(ProxyObjectType - ArrayType)),
+            rarely(slowPathBlock), usually(continuation));
+
+        m_out.appendTo(slowPathBlock, continuation);
+        VM& vm = this->vm();
+        LValue slowResultValue = lazySlowPath(
+            [=, &vm] (const Vector<Location>& locations) -> RefPtr<LazySlowPath::Generator> {
+                return createLazyCallGenerator(vm,
+                    operationArrayIsArray, locations[0].directGPR(),
+                    CCallHelpers::TrustedImmPtr(globalObject), locations[1].directGPR());
+            }, value);
+        ValueFromBlock slowResult = m_out.anchor(m_out.notNull(slowResultValue));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        setBoolean(m_out.phi(Int32, notCellResult, arrayResult, otherCellResult, slowResult));
     }
 
     void compileIsObject()

--- a/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
@@ -68,7 +68,7 @@ void ArrayConstructor::finishCreation(VM& vm, JSGlobalObject* globalObject, Arra
     putDirectWithoutTransition(vm, vm.propertyNames->prototype, arrayPrototype, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
     putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->speciesSymbol, globalObject->arraySpeciesGetterSetter(), PropertyAttribute::Accessor | PropertyAttribute::ReadOnly | PropertyAttribute::DontEnum);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->of, arrayConstructorOf, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public, ArrayConstructorOfIntrinsic);
-    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->isArray, arrayConstructorIsArrayCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->isArray, arrayConstructorIsArray, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, ArrayIsArrayIntrinsic);
 
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().fromPrivateName(), arrayConstructorFromCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
     JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().fromAsyncPublicName(), arrayConstructorFromAsyncCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
@@ -111,6 +111,15 @@ JSC_DEFINE_HOST_FUNCTION(callArrayConstructor, (JSGlobalObject* globalObject, Ca
 {
     ArgList args(callFrame);
     return JSValue::encode(constructArrayWithSizeQuirk(globalObject, args, JSValue()));
+}
+
+JSC_DEFINE_HOST_FUNCTION(arrayConstructorIsArray, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    bool result = isArray(globalObject, callFrame->argument(0));
+    RETURN_IF_EXCEPTION(scope, { });
+    return JSValue::encode(jsBoolean(result));
 }
 
 static ALWAYS_INLINE bool isArraySlowInline(JSGlobalObject* globalObject, ProxyObject* proxy)

--- a/Source/JavaScriptCore/runtime/ArrayConstructor.h
+++ b/Source/JavaScriptCore/runtime/ArrayConstructor.h
@@ -56,6 +56,7 @@ STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(ArrayConstructor, InternalFunction);
 
 JSArray* constructArrayWithSizeQuirk(JSGlobalObject*, ArrayAllocationProfile*, JSValue length, JSValue prototype = JSValue());
 
+JSC_DECLARE_HOST_FUNCTION(arrayConstructorIsArray);
 JSC_DECLARE_HOST_FUNCTION(arrayConstructorPrivateFromFastWithoutMapFn);
 JSC_DECLARE_HOST_FUNCTION(arrayConstructorPrivateFuncIsArraySlow);
 bool isArraySlow(JSGlobalObject*, ProxyObject* argument);

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -62,6 +62,7 @@ namespace JSC {
     macro(ArrayKeysIntrinsic) \
     macro(ArrayEntriesIntrinsic) \
     macro(ArrayConstructorOfIntrinsic) \
+    macro(ArrayIsArrayIntrinsic) \
     macro(AsyncIteratorIntrinsic) \
     macro(BooleanConstructorIntrinsic) \
     macro(CharCodeAtIntrinsic) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1811,7 +1811,9 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpPrototypeSymbolMatch)].set(vm, this, m_regExpPrototype->getDirect(vm, vm.propertyNames->matchSymbol).asCell());
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::regExpPrototypeSymbolReplace)].set(vm, this, m_regExpPrototype->getDirect(vm, vm.propertyNames->replaceSymbol).asCell());
 
-    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isArray)].set(vm, this, arrayConstructor->getDirect(vm, vm.propertyNames->isArray).asCell());
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isArray)].initLater([] (const Initializer<JSCell>& init) {
+        init.set(JSFunction::create(init.vm, jsCast<JSGlobalObject*>(init.owner), 1, "isArray"_s, arrayConstructorIsArray, ImplementationVisibility::Public, ArrayIsArrayIntrinsic));
+    });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::callFunction)].set(vm, this, callFunction);
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::applyFunction)].set(vm, this, applyFunction);
 


### PR DESCRIPTION
#### b7c903516b25148b30e3ed279df67988a38ae8a9
<pre>
[JSC] Add ArrayIsArray intrinsic for Array.isArray
<a href="https://rdar.apple.com/172330191">rdar://172330191</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309738">https://bugs.webkit.org/show_bug.cgi?id=309738</a>

Reviewed by Yusuke Suzuki.

Array.isArray was a JS builtin using IsCellWithType(CellUse), which caused
TypeCheckHoistingPhase to hoist a cell check to function entry. Non-cell
inputs (undefined, null, booleans) triggered BadType OSR exits and DFG
jettisons.

Replace the builtin with a C++ host function + ArrayIsArray DFG/FTL node
using UntypedUse, bypassing type-check hoisting. The node handles all ES
spec cases inline: non-cell -&gt; false, ArrayType/DerivedArrayType -&gt; true,
ProxyObjectType -&gt; isArraySlow slow path, other cells -&gt; false. The abstract
interpreter constant-folds the node when the input type is known.

Test: JSTests/stress/array-is-array-intrinsic.js
Canonical link: <a href="https://commits.webkit.org/309209@main">https://commits.webkit.org/309209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc984895116d33d7c93c41061809daedfe3603ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149749 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158454 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103181 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa97be02-18ba-43fd-ab5e-55eaa11aca93) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22918 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115520 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82110 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11bb0c32-b85e-4bc8-af2e-8aa69ac801a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17650 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134386 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96261 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16746 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14661 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6300 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141725 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12317 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160931 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10543 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13859 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123545 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18703 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123750 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33633 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22277 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134110 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78502 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18912 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10861 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181178 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21878 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85698 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46400 "Build was cancelled. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21608 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21760 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21665 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->