### PR TITLE
<model> should be HDR by default

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -76,7 +76,7 @@ class Renderer {
             configuration: .init(
                 output: .init(colorPixelFormat: colorPixelFormat),
                 rasterSampleCount: rasterSampleCount,
-                enableTonemap: true,
+                enableTonemap: false,
                 enableColorMatch: colorSpace != nil,
                 hasTransparentContent: false
             ),

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -315,7 +315,7 @@ extension WKBridgeUSDConfiguration {
     @objc(createMaterialCompiler:)
     func createMaterialCompiler() async {
         do {
-            try await self.appRenderer.createMaterialCompiler(colorPixelFormat: .bgra8Unorm_srgb, rasterSampleCount: 4)
+            try await self.appRenderer.createMaterialCompiler(colorPixelFormat: .rgba16Float, rasterSampleCount: 4)
         } catch {
             fatalError("Exception creating renderer \(error)")
         }

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
@@ -568,7 +568,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebMesh);
 WebMesh::WebMesh(const WebModelCreateMeshDescriptor& descriptor)
 {
     id<MTLDevice> device = MTLCreateSystemDefaultDevice();
-    MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatBGRA8Unorm_sRGB width:descriptor.width height:descriptor.height mipmapped:NO];
+    MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatRGBA16Float width:descriptor.width height:descriptor.height mipmapped:NO];
     m_textures = [NSMutableArray array];
     for (RetainPtr ioSurface : descriptor.ioSurfaces)
         [m_textures addObject:[device newTextureWithDescriptor:textureDescriptor iosurface:ioSurface.get() plane:0]];

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -273,7 +273,7 @@ void RemoteGPU::paintNativeImageToImageBuffer(WebCore::NativeImage& nativeImage,
 #if ENABLE(GPU_PROCESS_MODEL)
 static Vector<UniqueRef<WebCore::IOSurface>> createIOSurfaces(unsigned width, unsigned height)
 {
-    const auto colorFormat = WebCore::IOSurface::Format::BGRA;
+    const auto colorFormat = WebCore::IOSurface::Format::RGBA16F;
     const auto colorSpace = WebCore::DestinationColorSpace::LinearDisplayP3();
 
     Vector<UniqueRef<WebCore::IOSurface>> ioSurfaces;

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -117,7 +117,11 @@ private:
     WTF::MachSendRight m_displayBuffer;
     const float m_contentsScale;
     bool m_isOpaque;
+#if ENABLE(PIXEL_FORMAT_RGBA16F)
+    WebCore::ContentsFormat m_contentsFormat { WebCore::ContentsFormat::RGBA16F };
+#else
     WebCore::ContentsFormat m_contentsFormat { WebCore::ContentsFormat::RGBA8 };
+#endif
 };
 
 Ref<WebModelPlayer> WebModelPlayer::create(WebCore::Page& page, WebCore::ModelPlayerClient& client)


### PR DESCRIPTION
#### eb34b379a3bb93fb9c154a8aa1630efb807a0c8c
<pre>
&lt;model&gt; should be HDR by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=309748">https://bugs.webkit.org/show_bug.cgi?id=309748</a>
<a href="https://rdar.apple.com/172338408">rdar://172338408</a>

Reviewed by Etienne Segonzac.

Patch largely from Etienne Segonzac, I just added one line in WebKitMesh.mm

Use rgba16Float instead of bgra8unorm_srgb as environment map highlights
look a lot better when initial colors don&apos;t get clamped to 8bpc.

* Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift:
(Renderer.createMaterialCompiler(_:rasterSampleCount:colorSpace:)):
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(WKBridgeUSDConfiguration.createMaterialCompiler):
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm:
(WebKit::WebMesh::WebMesh):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::createIOSurfaces):
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:

Canonical link: <a href="https://commits.webkit.org/309274@main">https://commits.webkit.org/309274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/855a159585c671a13b4d6d77d70b5650a53c71b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102946 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f433c049-9b73-40bc-bbb6-6d72e92cda8d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22683 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115323 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82004 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/955a3dd1-17da-4261-9358-132f2a6299bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96064 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/70e227a2-2049-4131-8beb-8391774d9bd5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16566 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14456 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6060 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126174 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160693 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3689 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13647 "Found 1 new test failure: fast/attachment/mac/wide-attachment-image-controls-basic.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123356 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18498 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123566 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33675 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78256 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18748 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10650 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21642 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85463 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21373 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21525 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21430 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->