### PR TITLE
Crash in TreeScopeOrderedMap::getElementById via ReferencedSVGResources::~ReferencedSVGResources

### DIFF
--- a/LayoutTests/svg/custom/referenced-svg-resources-crash-on-slot-removal-expected.txt
+++ b/LayoutTests/svg/custom/referenced-svg-resources-crash-on-slot-removal-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+

--- a/LayoutTests/svg/custom/referenced-svg-resources-crash-on-slot-removal.html
+++ b/LayoutTests/svg/custom/referenced-svg-resources-crash-on-slot-removal.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This test passes if it does not crash.</p>
+<div id="outer-host"></div>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+const outerHost = document.getElementById("outer-host");
+const outerShadow = outerHost.attachShadow({ mode: "open" });
+
+outerShadow.innerHTML = `
+    <div id="inner-host">
+        <div id="svg-defs" slot="s">
+            <svg>
+                <defs>
+                    <clipPath id="clip"><rect width="50" height="50"/></clipPath>
+                </defs>
+            </svg>
+        </div>
+        <div id="svg-user" slot="s">
+            <svg>
+                <rect width="100" height="100" style="clip-path: url(#clip);"/>
+            </svg>
+        </div>
+    </div>
+`;
+
+const innerHost = outerShadow.getElementById("inner-host");
+const innerShadow = innerHost.attachShadow({ mode: "open" });
+innerShadow.innerHTML = '<slot name="s"></slot>';
+
+document.body.offsetHeight;
+
+outerShadow.getElementById("svg-defs").remove();
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -108,9 +108,8 @@ ReferencedSVGResources::ReferencedSVGResources(RenderElement& renderer)
 
 ReferencedSVGResources::~ReferencedSVGResources()
 {
-    Ref treeScope = m_renderer->treeScopeForSVGReferences();
     for (auto& targetID : copyToVector(m_elementClients.keys()))
-        removeClientForTarget(treeScope, targetID);
+        removeClientForTarget(targetID);
 }
 
 void ReferencedSVGResources::addClientForTarget(SVGElement& targetElement, const AtomString& targetID)
@@ -118,16 +117,15 @@ void ReferencedSVGResources::addClientForTarget(SVGElement& targetElement, const
     m_elementClients.ensure(targetID, [&] {
         auto client = makeUnique<CSSSVGResourceElementClient>(m_renderer);
         targetElement.addReferencingCSSClient(*client);
-        return client;
+        return ClientEntry { WTF::move(client), targetElement };
     });
 }
 
-void ReferencedSVGResources::removeClientForTarget(TreeScope& treeScope, const AtomString& targetID)
+void ReferencedSVGResources::removeClientForTarget(const AtomString& targetID)
 {
-    auto client = m_elementClients.take(targetID);
-
-    if (RefPtr targetElement = dynamicDowncast<SVGElement>(treeScope.getElementById(targetID)))
-        targetElement->removeReferencingCSSClient(*client);
+    auto entry = m_elementClients.take(targetID);
+    if (RefPtr targetElement = entry.targetElement)
+        targetElement->removeReferencingCSSClient(protect(*entry.client));
 }
 
 ReferencedSVGResources::SVGElementIdentifierAndTagPairs ReferencedSVGResources::referencedSVGResourceIDs(const RenderStyle& style, const Document& document)
@@ -214,7 +212,7 @@ void ReferencedSVGResources::updateReferencedResources(TreeScope& treeScope, con
     }
 
     for (auto& targetID : oldKeys)
-        removeClientForTarget(treeScope, targetID);
+        removeClientForTarget(targetID);
 }
 
 bool ReferencedSVGResources::addReferencedSVGResourceIfNeeded(SVGElement& targetElement, const AtomString& targetID)

--- a/Source/WebCore/rendering/ReferencedSVGResources.h
+++ b/Source/WebCore/rendering/ReferencedSVGResources.h
@@ -28,6 +28,7 @@
 #include "SVGNames.h"
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/AtomStringHash.h>
 
@@ -86,10 +87,14 @@ private:
     static RefPtr<SVGElement> elementForResourceIDs(TreeScope&, const AtomString& resourceID, const SVGQualifiedNames& tagNames);
 
     void addClientForTarget(SVGElement& targetElement, const AtomString&);
-    void removeClientForTarget(TreeScope&, const AtomString&);
+    void removeClientForTarget(const AtomString&);
 
     const CheckedRef<RenderElement> m_renderer;
-    MemoryCompactRobinHoodHashMap<AtomString, std::unique_ptr<CSSSVGResourceElementClient>> m_elementClients;
+    struct ClientEntry {
+        std::unique_ptr<CSSSVGResourceElementClient> client;
+        WeakPtr<SVGElement, WeakPtrImplWithEventTargetData> targetElement;
+    };
+    MemoryCompactRobinHoodHashMap<AtomString, ClientEntry> m_elementClients;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 11b230b2d6219835d9b777684f305f7b7c632612
<pre>
Crash in TreeScopeOrderedMap::getElementById via ReferencedSVGResources::~ReferencedSVGResources
<a href="https://bugs.webkit.org/show_bug.cgi?id=309749">https://bugs.webkit.org/show_bug.cgi?id=309749</a>
&lt;<a href="https://rdar.apple.com/172309380">rdar://172309380</a>&gt;

Reviewed by Chris Dumez.

The crash was caused by ReferencedSVGResources&apos;s destructor calling getElementById to find an element
with ID during Element::removedFromAncestor. Because TreeScopeOrderedMap relies on removedFromAncestor
to update its internal states, it&apos;s not safe to call TreeScopeOrderedMap&apos;s member functions such as
getElementById before we finish calling removedFromAncestor on a removed subtree.

Fixed the bug by eliminating this use of TreeScopeOrderedMap::getElementById. Instead of looking up
a client element with an ID in ReferencedSVGResources::removeClientForTarget, keep a weak reference to
the client element in m_elementClients.

The analysis and test co-authored with Claude AI.

Test: svg/custom/referenced-svg-resources-crash-on-slot-removal.html

* LayoutTests/svg/custom/referenced-svg-resources-crash-on-slot-removal-expected.txt: Added.
* LayoutTests/svg/custom/referenced-svg-resources-crash-on-slot-removal.html: Added.
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::ReferencedSVGResources::~ReferencedSVGResources):
(WebCore::ReferencedSVGResources::addClientForTarget):
(WebCore::ReferencedSVGResources::removeClientForTarget):
(WebCore::ReferencedSVGResources::updateReferencedResources):
* Source/WebCore/rendering/ReferencedSVGResources.h:

Canonical link: <a href="https://commits.webkit.org/309133@main">https://commits.webkit.org/309133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d69d02c62c8c33ac18cf315a44af880c829f90e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158246 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22161 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115352 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/214cc438-7c47-4866-abb5-510480bff752) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134199 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96093 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c5ccda1-e046-4c29-a239-f1bd43dd2cdd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16583 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6091 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126191 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160723 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3720 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13672 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123384 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18528 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123594 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22072 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133923 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78286 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23027 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18775 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10674 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21672 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85493 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21403 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21555 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21460 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->