### PR TITLE
Message port rework [testing - do not review]

### DIFF
--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -194,6 +194,16 @@ TransferredMessagePort MessagePort::disentangle()
     m_entangled = false;
 
     Ref context = *scriptExecutionContext();
+
+    // Flush any messages that were taken from the provider but not yet dispatched
+    // back to the provider, so they follow the port to its new destination.
+    if (!m_pendingDispatchMessages.isEmpty()) {
+        Vector<MessageWithMessagePorts> messages;
+        while (!m_pendingDispatchMessages.isEmpty())
+            messages.append(m_pendingDispatchMessages.takeFirst());
+        protect(MessagePortChannelProvider::fromContext(context))->returnUndeliveredMessages(m_identifier, WTF::move(messages));
+    }
+
     protect(MessagePortChannelProvider::fromContext(context))->messagePortDisentangled(m_identifier);
 
     // We can't receive any messages or generate any events after this, so remove ourselves from the list of active ports.
@@ -275,32 +285,58 @@ void MessagePort::dispatchMessages()
             return;
 
         ASSERT(context->isContextThread());
-        auto* globalObject = context->globalObject();
-        Ref vm = globalObject->vm();
-        auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-
         RefPtr workerGlobalScope = dynamicDowncast<WorkerGlobalScope>(*context);
-        for (auto& message : messages) {
+
+        // Append taken messages to the per-port pending buffer. Event-dispatch tasks
+        // pop from this buffer, so messages that haven't been dispatched yet can be
+        // returned to the provider if the port is transferred (disentangle).
+        auto& pending = pendingActivity->object().m_pendingDispatchMessages;
+        for (auto& message : messages)
+            pending.append(WTF::move(message));
+
+        size_t messageCount = pending.size();
+        for (size_t i = 0; i < messageCount; ++i) {
             // close() in Worker onmessage handler should prevent next message from dispatching.
             if (workerGlobalScope && workerGlobalScope->isClosing())
                 return;
 
             if (pendingActivity->object().m_messageHandler) {
+                auto* globalObject = context->globalObject();
+                if (!globalObject)
+                    return;
+                Ref vm = globalObject->vm();
+                auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+                auto message = pending.takeFirst();
                 ASSERT(message.transferredPorts.isEmpty());
                 pendingActivity->object().m_messageHandler(*JSC::jsCast<JSDOMGlobalObject*>(globalObject), message.message.releaseNonNull().get());
+                if (scope.exception()) [[unlikely]] {
+                    RELEASE_ASSERT(vm->hasPendingTerminationException());
+                    return;
+                }
                 continue;
             }
 
-            auto ports = MessagePort::entanglePorts(*context, WTF::move(message.transferredPorts));
-            auto event = MessageEvent::create(*globalObject, message.message.releaseNonNull(), { }, { }, { }, WTF::move(ports));
-            if (scope.exception()) [[unlikely]] {
-                // Currently, we assume that the only way we can get here is if we have a termination.
-                RELEASE_ASSERT(vm->hasPendingTerminationException());
-                return;
-            }
-
             // Per specification, each MessagePort object has a task source called the port message queue.
-            queueTaskKeepingObjectAlive(pendingActivity->object(), TaskSource::PostedMessageQueue, [event = WTF::move(event)](auto& port) {
+            queueTaskKeepingObjectAlive(pendingActivity->object(), TaskSource::PostedMessageQueue, [](auto& port) {
+                if (port.m_pendingDispatchMessages.isEmpty())
+                    return;
+
+                RefPtr context = port.scriptExecutionContext();
+                if (!context || !context->globalObject())
+                    return;
+
+                auto* globalObject = context->globalObject();
+                Ref vm = globalObject->vm();
+                auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
+
+                auto message = port.m_pendingDispatchMessages.takeFirst();
+                auto ports = MessagePort::entanglePorts(*context, WTF::move(message.transferredPorts));
+                auto event = MessageEvent::create(*globalObject, message.message.releaseNonNull(), { }, { }, { }, WTF::move(ports));
+                if (scope.exception()) [[unlikely]] {
+                    RELEASE_ASSERT(vm->hasPendingTerminationException());
+                    return;
+                }
+
                 port.dispatchEvent(event.event);
             });
         }

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -32,6 +32,7 @@
 #include <WebCore/MessagePortChannel.h>
 #include <WebCore/MessagePortIdentifier.h>
 #include <WebCore/MessageWithMessagePorts.h>
+#include <wtf/Deque.h>
 #include <wtf/WeakPtr.h>
 
 namespace JSC {
@@ -130,6 +131,8 @@ private:
     MessagePortIdentifier m_remoteIdentifier;
 
     MessageHandler m_messageHandler;
+
+    Deque<MessageWithMessagePorts> m_pendingDispatchMessages;
 };
 
 WebCoreOpaqueRoot NODELETE root(MessagePort*);

--- a/Source/WebCore/dom/messageports/MessagePortChannelProvider.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProvider.h
@@ -53,6 +53,11 @@ public:
     virtual void takeAllMessagesForPort(const MessagePortIdentifier&, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&) = 0;
 
     virtual void postMessageToRemote(MessageWithMessagePorts&&, const MessagePortIdentifier& remoteTarget) = 0;
+
+    // Called when a port is transferred and has pending messages that were already
+    // taken from the provider but not yet dispatched. Returns them so they can be
+    // flushed to the Network process along with the port.
+    virtual void returnUndeliveredMessages(const MessagePortIdentifier&, Vector<MessageWithMessagePorts>&&) { }
 };
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
@@ -72,6 +72,7 @@ void WebMessagePortChannelProvider::createNewMessagePortChannel(const MessagePor
 void WebMessagePortChannelProvider::entangleLocalPortInThisProcessToRemote(const MessagePortIdentifier& local, const MessagePortIdentifier& remote)
 {
     m_inProcessPortMessages.add(local, Vector<MessageWithMessagePorts> { });
+    m_portsPendingSync.add(local);
 
     protect(networkProcessConnection())->send(Messages::NetworkConnectionToWebProcess::EntangleLocalPortInThisProcessToRemote { local, remote }, 0);
 }
@@ -91,21 +92,34 @@ void WebMessagePortChannelProvider::messagePortSentToRemote(const WebCore::Messa
 void WebMessagePortChannelProvider::messagePortClosed(const MessagePortIdentifier& port)
 {
     m_inProcessPortMessages.remove(port);
+    m_portsPendingSync.remove(port);
     protect(networkProcessConnection())->send(Messages::NetworkConnectionToWebProcess::MessagePortClosed { port }, 0);
 }
 
 void WebMessagePortChannelProvider::takeAllMessagesForPort(const MessagePortIdentifier& port, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&& completionHandler)
 {
+    // Fast path: port is local and not pending sync — zero IPC.
+    if (!m_portsPendingSync.contains(port)) {
+        auto iterator = m_inProcessPortMessages.find(port);
+        if (iterator != m_inProcessPortMessages.end()) {
+            auto messages = std::exchange(iterator->value, { });
+            completionHandler(WTF::move(messages), [] { });
+            return;
+        }
+    }
+
+    // IPC path: pending sync (need to fetch pre-transfer messages) or port not in local map.
     protect(networkProcessConnection())->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::TakeAllMessagesForPort { port }, [completionHandler = WTF::move(completionHandler), port](Vector<WebCore::MessageWithMessagePorts>&& messages, std::optional<MessageBatchIdentifier> messageBatchIdentifier) mutable {
         if (!messageBatchIdentifier)
-            return completionHandler({ }, [] { }); // IPC failure.
+            return completionHandler({ }, [] { });
 
-        auto& inProcessPortMessages = WebMessagePortChannelProvider::singleton().m_inProcessPortMessages;
-        auto iterator = inProcessPortMessages.find(port);
-        if (iterator != inProcessPortMessages.end()) {
-            auto pendingMessages = std::exchange(iterator->value, { });
-            messages.appendVector(WTF::move(pendingMessages));
-        }
+        auto& provider = WebMessagePortChannelProvider::singleton();
+        provider.m_portsPendingSync.remove(port);
+
+        auto iterator = provider.m_inProcessPortMessages.find(port);
+        if (iterator != provider.m_inProcessPortMessages.end())
+            messages.appendVector(std::exchange(iterator->value, { }));
+
         completionHandler(WTF::move(messages), [messageBatchIdentifier] {
             protect(networkProcessConnection())->send(Messages::NetworkConnectionToWebProcess::DidDeliverMessagePortMessages { *messageBatchIdentifier }, 0);
         });
@@ -125,6 +139,20 @@ void WebMessagePortChannelProvider::postMessageToRemote(MessageWithMessagePorts&
         messagePortSentToRemote(port.first);
 
     protect(networkProcessConnection())->send(Messages::NetworkConnectionToWebProcess::PostMessageToRemote { message, remoteTarget }, 0);
+}
+
+void WebMessagePortChannelProvider::returnUndeliveredMessages(const MessagePortIdentifier& port, Vector<MessageWithMessagePorts>&& messages)
+{
+    if (messages.isEmpty())
+        return;
+
+    auto& buffer = m_inProcessPortMessages.ensure(port, [] {
+        return Vector<MessageWithMessagePorts> { };
+    }).iterator->value;
+
+    // Prepend: these are older messages that should be delivered before any new ones.
+    messages.appendVector(WTF::move(buffer));
+    buffer = WTF::move(messages);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.h
@@ -53,8 +53,10 @@ private:
     void messagePortClosed(const WebCore::MessagePortIdentifier& local) final;
     void takeAllMessagesForPort(const WebCore::MessagePortIdentifier&, CompletionHandler<void(Vector<WebCore::MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&) final;
     void postMessageToRemote(WebCore::MessageWithMessagePorts&&, const WebCore::MessagePortIdentifier& remoteTarget) final;
+    void returnUndeliveredMessages(const WebCore::MessagePortIdentifier&, Vector<WebCore::MessageWithMessagePorts>&&) final;
 
     HashMap<WebCore::MessagePortIdentifier, Vector<WebCore::MessageWithMessagePorts>> m_inProcessPortMessages;
+    HashSet<WebCore::MessagePortIdentifier> m_portsPendingSync;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 6816a43a80641d80f04362d93c48feee096bd8c8
<pre>
For testing - do not review
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6816a43a80641d80f04362d93c48feee096bd8c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158221 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102951 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151392 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22118 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115330 "Failure limit exceed. At least found 497 new test failures: fast/parser/empty-text-resource.html http/tests/workers/service/basic-messageport.html http/wpt/mediastream/getUserMedia-odd-size.html http/wpt/service-workers/claim-worker-fetch-without-nesting.https.html http/wpt/service-workers/navigation-iframe-site.https.html http/wpt/service-workers/service-worker-spinning-push.https.html http/wpt/service-workers/service-worker-spinning-pushsubscriptionchange.https.html http/wpt/service-workers/serviceworker-in-sharedworker.https.html http/wpt/service-workers/use-element.https.html http/wpt/shared-workers/connect-event-ordering.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82008 "10 flakes 15 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152479 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17463 "Found 6 new test failures: http/wpt/service-workers/form-data-upload.html http/wpt/service-workers/navigation-iframe-site.https.html http/wpt/service-workers/service-worker-iframe-preload.https.html http/wpt/service-workers/service-worker-preload-when-not-activated.https.html http/wpt/service-workers/serviceworker-in-sharedworker.https.html http/wpt/service-workers/use-element.https.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134177 "Found 1 new API test failure: TestWebKitAPI.ServiceWorkers.LockdownModeInSharedWorkerProcess (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96071 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16560 "Found 60 new test failures: imported/w3c/web-platform-tests/IndexedDB/bindings-inject-keys-bypass.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/bindings-inject-values-bypass.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/idbcursor_advance_index.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/idbcursor_advance_objectstore.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/idbcursor_continue_index.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/idbcursor_continue_objectstore.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/idbcursor_delete_index.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/idbdatabase_deleteObjectStore.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/idbdatabase_transaction.any.sharedworker.html imported/w3c/web-platform-tests/IndexedDB/idbfactory-databases-opaque-origin.html ... (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14462 "Found 1 new API test failure: TestWebKitAPI.ServiceWorkers.LockdownModeInSharedWorkerProcess (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6065 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126168 "Found 1 new API test failure: TestWebKitAPI.ServiceWorkers.LockdownModeInSharedWorkerProcess (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160698 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3694 "Found 2 new failures in dom/MessagePort.cpp") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13649 "Found 60 new test failures: http/tests/performance/performance-resource-timing-cross-origin-media.html http/tests/workers/service/basic-messageport.html http/wpt/service-workers/claim-worker-fetch-without-nesting.https.html http/wpt/service-workers/controlled-sharedworker.https.html http/wpt/service-workers/form-data-upload.html http/wpt/service-workers/navigation-iframe-site.https.html http/wpt/service-workers/service-worker-iframe-preload.https.html http/wpt/service-workers/service-worker-preload-when-not-activated.https.html http/wpt/service-workers/service-worker-spinning-push.https.html http/wpt/service-workers/service-worker-spinning-pushsubscriptionchange.https.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123361 "Failure limit exceed. At least found 497 new test failures: fullscreen/full-screen-enter-while-exiting.html http/tests/permissions/permission-status-onchange-event-shared-worker.html http/wpt/service-workers/claim-worker-fetch-without-nesting.https.html http/wpt/service-workers/navigation-iframe-site.https.html http/wpt/service-workers/service-worker-spinning-push.https.html http/wpt/service-workers/service-worker-spinning-pushsubscriptionchange.https.html http/wpt/service-workers/serviceworker-in-sharedworker.https.html http/wpt/service-workers/use-element.https.html http/wpt/shared-workers/connect-event-ordering.html http/wpt/shared-workers/relaunch-after-close.html ... (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22040 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18504 "Found 60 new test failures: fast/forms/select/select-show-picker.html fast/parser/entity-comment-in-title.html http/tests/workers/service/basic-messageport.html http/wpt/service-workers/claim-worker-fetch-without-nesting.https.html http/wpt/service-workers/controlled-sharedworker.https.html http/wpt/service-workers/form-data-upload.html http/wpt/service-workers/navigation-iframe-site.https.html http/wpt/service-workers/service-worker-iframe-preload.https.html http/wpt/service-workers/service-worker-preload-when-not-activated.https.html http/wpt/service-workers/service-worker-spinning-push.https.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123571 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133901 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78261 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18758 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10652 "Found 60 new test failures: compositing/reflections/repaint-with-reflection.html css3/blending/background-blend-mode-svg.html css3/filters/backdrop/backdrop-filter-nested.html css3/filters/backdrop/backdrop-filter-with-reflection-add-backdrop.html css3/filters/clipping-overflow-scroll-with-pixel-moving-effect-on-parent.html css3/masking/clip-path-border-radius-padding-box-001.html fast/forms/datalist/data-list-search-input-with-appearance-none.html fast/multicol/newmulticol/compare-with-old-impl/before-child-anonymous-column-block.html fast/shapes/shape-outside-floats/shape-outside-dynamic-shape-margin.html http/tests/webgpu/webgpu/api/operation/render_pipeline/sample_mask.html ... (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21647 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85468 "Found 2 new failures in dom/MessagePort.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21378 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21530 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->