### PR TITLE
[macOS] CSS scrollbars may be cut off, scrollbar corner rect may be sized incorrectly

### DIFF
--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -759,8 +759,14 @@ void ScrollView::updateScrollbars(const ScrollPosition& desiredPosition)
         IntRect oldRect(m_horizontalScrollbar->frameRect());
 
         auto scrollerHalfHeight = m_horizontalScrollbar->height() / 2.f;
-        auto leftOffset = std::max(0.f, cornerRadii.bottomLeft().width() - scrollerHalfHeight);
-        auto rightOffset = std::max(0.f, cornerRadii.bottomRight().width() - scrollerHalfHeight);
+        auto scrollCornerWidth = m_verticalScrollbar ? static_cast<float>(m_verticalScrollbar->occupiedWidth()) : 0.f;
+        auto leftOffset = std::max(0.f, cornerRadii.bottomLeft().width() - (shouldPlaceVerticalScrollbarOnLeft() ? scrollCornerWidth : 0.f));
+        auto rightOffset = std::max(0.f, cornerRadii.bottomRight().width() - (shouldPlaceVerticalScrollbarOnLeft() ? 0.f : scrollCornerWidth));
+
+        if (!m_horizontalScrollbar->isCustomScrollbar()) {
+            leftOffset = std::max(0.f, leftOffset - scrollerHalfHeight);
+            rightOffset = std::max(0.f, rightOffset - scrollerHalfHeight);
+        }
 
         leftOffset = std::max(leftOffset, contentInsets.left());
         rightOffset = std::max(rightOffset, contentInsets.right());
@@ -799,8 +805,14 @@ void ScrollView::updateScrollbars(const ScrollPosition& desiredPosition)
         auto upperCornerRadius = isRTL ? cornerRadii.topLeft().height() : cornerRadii.topRight().height();
         auto lowerCornerRadius = isRTL ? cornerRadii.bottomLeft().height() : cornerRadii.bottomRight().height();
 
-        auto topOffset = std::max(0.f, upperCornerRadius - scrollerHalfWidth);
-        auto bottomOffset = std::max(0.f, lowerCornerRadius - scrollerHalfWidth);
+        auto topOffset = std::max(0.f, upperCornerRadius);
+        auto scrollCornerHeight = m_horizontalScrollbar ? static_cast<float>(m_horizontalScrollbar->occupiedHeight()) : 0.f;
+        auto bottomOffset = std::max(0.f, lowerCornerRadius - scrollCornerHeight);
+
+        if (!m_verticalScrollbar->isCustomScrollbar()) {
+            topOffset = std::max(0.f, topOffset - scrollerHalfWidth);
+            bottomOffset = std::max(0.f, bottomOffset - scrollerHalfWidth);
+        }
 
         topOffset = std::max(topOffset, contentInsets.top());
         bottomOffset = std::max(bottomOffset, contentInsets.bottom());
@@ -1370,24 +1382,14 @@ IntRect ScrollView::scrollCornerRect() const
     if (hasOverlayScrollbars())
         return cornerRect;
 
-    auto obscuredContentInsets = this->obscuredContentInsets();
-    int widthTrackedByScrollbar = width() - obscuredContentInsets.left() - obscuredContentInsets.right();
-    int heightTrackedByScrollbar = height() - obscuredContentInsets.top() - obscuredContentInsets.bottom();
+    if (!m_horizontalScrollbar || !m_verticalScrollbar)
+        return cornerRect;
 
-    if (m_horizontalScrollbar && widthTrackedByScrollbar > m_horizontalScrollbar->width()) {
-        // FIXME: This may need to account for non-zero left or right content insets.
-        cornerRect.unite(IntRect(shouldPlaceVerticalScrollbarOnLeft() ? 0 : m_horizontalScrollbar->width(),
-            height() - m_horizontalScrollbar->height(),
-            width() - m_horizontalScrollbar->width(),
-            m_horizontalScrollbar->height()));
-    }
-
-    if (m_verticalScrollbar && heightTrackedByScrollbar > m_verticalScrollbar->height()) {
-        cornerRect.unite(IntRect(shouldPlaceVerticalScrollbarOnLeft() ? 0 : width() - m_verticalScrollbar->width(),
-            m_verticalScrollbar->height() + obscuredContentInsets.top(),
-            m_verticalScrollbar->width(),
-            heightTrackedByScrollbar - m_verticalScrollbar->height()));
-    }
+    cornerRect = IntRect(
+        m_verticalScrollbar->x(),
+        m_horizontalScrollbar->y(),
+        m_verticalScrollbar->width(),
+        m_horizontalScrollbar->height());
 
     return cornerRect;
 }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3552,6 +3552,15 @@ ExceptionOr<Ref<DOMRect>> Internals::verticalScrollbarFrameRect(Node* node) cons
     return DOMRect::create();
 }
 
+ExceptionOr<Ref<DOMRect>> Internals::scrollCornerRect(Node* node) const
+{
+    auto areaOrException = scrollableAreaForNode(node);
+    if (areaOrException.hasException())
+        return areaOrException.releaseException();
+
+    return DOMRect::create(areaOrException.returnValue()->scrollCornerRect());
+}
+
 ExceptionOr<Internals::ScrollingNodeID> Internals::scrollingNodeIDForNode(Node* node)
 {
     auto areaOrException = scrollableAreaForNode(node);

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -581,6 +581,7 @@ public:
     ExceptionOr<uint64_t> verticalScrollbarLayerID(Node*) const;
     ExceptionOr<Ref<DOMRect>> horizontalScrollbarFrameRect(Node*) const;
     ExceptionOr<Ref<DOMRect>> verticalScrollbarFrameRect(Node*) const;
+    ExceptionOr<Ref<DOMRect>> scrollCornerRect(Node*) const;
 
     ExceptionOr<String> scrollbarsControllerTypeForNode(Node*) const;
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -811,6 +811,7 @@ enum ContentsFormat {
     unsigned long long verticalScrollbarLayerID(optional Node? node = null);
     DOMRect horizontalScrollbarFrameRect(optional Node? node = null);
     DOMRect verticalScrollbarFrameRect(optional Node? node = null);
+    DOMRect scrollCornerRect(optional Node? node = null);
 
     ScrollingNodeID scrollingNodeIDForNode(optional Node? node = null);
 

--- a/Tools/TestWebKitAPI/Tests/mac/ScrollbarTests.mm
+++ b/Tools/TestWebKitAPI/Tests/mac/ScrollbarTests.mm
@@ -488,6 +488,275 @@ TEST(ScrollbarTests, HorizontalScrollbarYPositionAccountsForObscuredContentInset
     [webView setObscuredContentInsets:NSEdgeInsetsMake(0, 0, 0, 0)];
 }
 
+static std::optional<CGRect> scrollCornerRectForWebView(TestWKWebView *webView)
+{
+    RetainPtr script = @"(() => { "
+        "const rect = internals.scrollCornerRect(); "
+        "if (!rect) return null; "
+        "return { x: rect.x, y: rect.y, width: rect.width, height: rect.height }; "
+        "})()";
+
+    id result = [webView objectByEvaluatingJavaScript:script.get()];
+    if (RetainPtr<NSDictionary> dictionary = result) {
+        return CGRectMake(
+            [[dictionary objectForKey:@"x"] doubleValue],
+            [[dictionary objectForKey:@"y"] doubleValue],
+            [[dictionary objectForKey:@"width"] doubleValue],
+            [[dictionary objectForKey:@"height"] doubleValue]
+        );
+    }
+
+    return std::nullopt;
+}
+
+static constexpr NSString *customScrollbarStyle = @(R"(
+    ::-webkit-scrollbar { width: 10px; }
+    ::-webkit-scrollbar:horizontal { height: 18px; }
+    ::-webkit-scrollbar-track { background: gray; }
+    ::-webkit-scrollbar-thumb { background: yellow; }
+    ::-webkit-scrollbar-corner { background: red; }
+    )");
+
+static NSString *customScrollbarHTMLWithDimensions(NSString *bodyStyle)
+{
+    return [NSString stringWithFormat:@"<style>%@</style><body style='%@'></body>", customScrollbarStyle, bodyStyle];
+}
+
+static NSString *customScrollbarHTMLWithBothScrollbars()
+{
+    return customScrollbarHTMLWithDimensions(@"width: 2000px; height: 2000px;");
+}
+
+TEST(ScrollbarTests, CustomScrollbarSizesNoCornerRadii)
+{
+    RetainPtr webView = scrollbarAvoidanceTestWebView();
+
+    [webView synchronouslyLoadHTMLString:customScrollbarHTMLWithBothScrollbars()];
+    [webView stringByEvaluatingJavaScript:@"internals.setUsesOverlayScrollbars(false)"];
+    [webView waitForNextPresentationUpdate];
+
+    auto frameWidth = [webView frame].size.width;
+    auto frameHeight = [webView frame].size.height;
+
+    auto verticalRect = scrollbarFrameRect(webView.get(), ScrollbarType::Vertical);
+    ASSERT_TRUE(verticalRect);
+    EXPECT_EQ(verticalRect->size.width, 10);
+    EXPECT_EQ(verticalRect->origin.x, frameWidth - 10);
+    EXPECT_EQ(verticalRect->origin.y, 0);
+    EXPECT_EQ(verticalRect->size.height, frameHeight - 18);
+
+    auto horizontalRect = scrollbarFrameRect(webView.get(), ScrollbarType::Horizontal);
+    ASSERT_TRUE(horizontalRect);
+    EXPECT_EQ(horizontalRect->size.height, 18);
+    EXPECT_EQ(horizontalRect->origin.x, 0);
+    EXPECT_EQ(horizontalRect->origin.y, frameHeight - 18);
+    EXPECT_EQ(horizontalRect->size.width, frameWidth - 10);
+}
+
+TEST(ScrollbarTests, CustomScrollbarScrollCornerRectNoCornerRadii)
+{
+    RetainPtr webView = scrollbarAvoidanceTestWebView();
+
+    [webView synchronouslyLoadHTMLString:customScrollbarHTMLWithBothScrollbars()];
+    [webView stringByEvaluatingJavaScript:@"internals.setUsesOverlayScrollbars(false)"];
+    [webView waitForNextPresentationUpdate];
+
+    auto frameWidth = [webView frame].size.width;
+    auto frameHeight = [webView frame].size.height;
+
+    auto cornerRect = scrollCornerRectForWebView(webView.get());
+    ASSERT_TRUE(cornerRect);
+    EXPECT_EQ(cornerRect->origin.x, frameWidth - 10);
+    EXPECT_EQ(cornerRect->origin.y, frameHeight - 18);
+    EXPECT_EQ(cornerRect->size.width, 10);
+    EXPECT_EQ(cornerRect->size.height, 18);
+}
+
+TEST(ScrollbarTests, CustomScrollbarScrollCornerRectWithObscuredContentInsets)
+{
+    RetainPtr webView = scrollbarAvoidanceTestWebView();
+
+    [webView synchronouslyLoadHTMLString:customScrollbarHTMLWithBothScrollbars()];
+    [webView stringByEvaluatingJavaScript:@"internals.setUsesOverlayScrollbars(false)"];
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(0, 0, 15, 20)];
+    [webView waitForNextPresentationUpdate];
+
+    auto frameWidth = [webView frame].size.width;
+    auto frameHeight = [webView frame].size.height;
+
+    auto verticalRect = scrollbarFrameRect(webView.get(), ScrollbarType::Vertical);
+    ASSERT_TRUE(verticalRect);
+    EXPECT_EQ(verticalRect->origin.x, frameWidth - 10 - 20);
+
+    auto horizontalRect = scrollbarFrameRect(webView.get(), ScrollbarType::Horizontal);
+    ASSERT_TRUE(horizontalRect);
+    EXPECT_EQ(horizontalRect->origin.y, frameHeight - 18 - 15);
+
+    auto cornerRect = scrollCornerRectForWebView(webView.get());
+    ASSERT_TRUE(cornerRect);
+    EXPECT_EQ(cornerRect->origin.x, frameWidth - 10 - 20);
+    EXPECT_EQ(cornerRect->origin.y, frameHeight - 18 - 15);
+    EXPECT_EQ(cornerRect->size.width, 10);
+    EXPECT_EQ(cornerRect->size.height, 18);
+
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(0, 0, 0, 0)];
+}
+
+TEST(ScrollbarTests, CustomScrollbarCornerRadiusAvoidanceAccountsForScrollCorner)
+{
+    RetainPtr webView = scrollbarAvoidanceTestWebView();
+    RetainPtr window = scrollbarAvoidanceTestWindow();
+    RetainPtr container = adoptNS([[ContainerView alloc] initWithFrame:NSMakeRect(0, 0, 500, 400)]);
+
+    [[window contentView] addSubview:container.get()];
+
+    WebCore::CornerRadii radii { 30 };
+    [container setCustomCornerRadius:radii];
+    [container addSubview:webView.get()];
+
+    [webView synchronouslyLoadHTMLString:customScrollbarHTMLWithBothScrollbars()];
+    [webView stringByEvaluatingJavaScript:@"internals.setUsesOverlayScrollbars(false)"];
+    [webView waitForNextPresentationUpdate];
+
+    auto frameWidth = [webView frame].size.width;
+    auto frameHeight = [webView frame].size.height;
+
+    auto verticalRect = scrollbarFrameRect(webView.get(), ScrollbarType::Vertical);
+    ASSERT_TRUE(verticalRect);
+    auto horizontalRect = scrollbarFrameRect(webView.get(), ScrollbarType::Horizontal);
+    ASSERT_TRUE(horizontalRect);
+
+    auto cornerRadius = 30.0;
+    auto verticalScrollbarWidth = verticalRect->size.width;
+    auto horizontalScrollbarHeight = horizontalRect->size.height;
+
+    auto expectedBottomOffset = std::max(0.0, cornerRadius - horizontalScrollbarHeight);
+    auto expectedTopOffset = cornerRadius;
+    auto expectedVerticalHeight = frameHeight - horizontalScrollbarHeight - expectedTopOffset - expectedBottomOffset;
+
+    EXPECT_NEAR(verticalRect->origin.y, expectedTopOffset, 0.5);
+    EXPECT_NEAR(verticalRect->size.height, expectedVerticalHeight, 0.5);
+
+    auto expectedRightOffset = std::max(0.0, cornerRadius - verticalScrollbarWidth);
+    auto expectedLeftOffset = cornerRadius;
+    auto expectedHorizontalWidth = frameWidth - verticalScrollbarWidth - expectedLeftOffset - expectedRightOffset;
+
+    EXPECT_NEAR(horizontalRect->origin.x, expectedLeftOffset, 0.5);
+    EXPECT_NEAR(horizontalRect->size.width, expectedHorizontalWidth, 0.5);
+
+    auto cornerRect = scrollCornerRectForWebView(webView.get());
+    ASSERT_TRUE(cornerRect);
+    EXPECT_NEAR(cornerRect->origin.x, verticalRect->origin.x, 0.5);
+    EXPECT_NEAR(cornerRect->origin.y, horizontalRect->origin.y, 0.5);
+    EXPECT_NEAR(cornerRect->size.width, verticalScrollbarWidth, 0.5);
+    EXPECT_NEAR(cornerRect->size.height, horizontalScrollbarHeight, 0.5);
+}
+
+TEST(ScrollbarTests, CustomScrollbarCornerRadiusAvoidanceWithObscuredContentInsetsAndScrollCorner)
+{
+    RetainPtr webView = scrollbarAvoidanceTestWebView();
+    RetainPtr window = scrollbarAvoidanceTestWindow();
+    RetainPtr container = adoptNS([[ContainerView alloc] initWithFrame:NSMakeRect(0, 0, 500, 400)]);
+
+    [[window contentView] addSubview:container.get()];
+
+    WebCore::CornerRadii radii { 30 };
+    [container setCustomCornerRadius:radii];
+    [container addSubview:webView.get()];
+
+    [webView synchronouslyLoadHTMLString:customScrollbarHTMLWithBothScrollbars()];
+    [webView stringByEvaluatingJavaScript:@"internals.setUsesOverlayScrollbars(false)"];
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(5, 5, 10, 8)];
+    [webView waitForNextPresentationUpdate];
+
+    auto frameWidth = [webView frame].size.width;
+    auto frameHeight = [webView frame].size.height;
+
+    auto verticalRect = scrollbarFrameRect(webView.get(), ScrollbarType::Vertical);
+    ASSERT_TRUE(verticalRect);
+    auto horizontalRect = scrollbarFrameRect(webView.get(), ScrollbarType::Horizontal);
+    ASSERT_TRUE(horizontalRect);
+
+    auto cornerRadius = 30.0;
+    auto verticalScrollbarWidth = 10.0;
+    auto horizontalScrollbarHeight = 18.0;
+
+    auto expectedTopOffset = std::max(cornerRadius, 5.0);
+    auto expectedBottomOffset = std::max(std::max(0.0, cornerRadius - horizontalScrollbarHeight), 10.0);
+    auto expectedVerticalHeight = frameHeight - horizontalScrollbarHeight - expectedTopOffset - expectedBottomOffset;
+
+    EXPECT_NEAR(verticalRect->origin.y, expectedTopOffset, 0.5);
+    EXPECT_NEAR(verticalRect->size.height, expectedVerticalHeight, 0.5);
+    EXPECT_NEAR(verticalRect->origin.x, frameWidth - verticalScrollbarWidth - 8, 0.5);
+
+    auto expectedLeftOffset = std::max(cornerRadius, 5.0);
+    auto expectedRightOffset = std::max(std::max(0.0, cornerRadius - verticalScrollbarWidth), 8.0);
+    auto expectedHorizontalWidth = frameWidth - verticalScrollbarWidth - expectedLeftOffset - expectedRightOffset;
+
+    EXPECT_NEAR(horizontalRect->origin.x, expectedLeftOffset, 0.5);
+    EXPECT_NEAR(horizontalRect->size.width, expectedHorizontalWidth, 0.5);
+    EXPECT_NEAR(horizontalRect->origin.y, frameHeight - horizontalScrollbarHeight - 10, 0.5);
+
+    auto cornerRect = scrollCornerRectForWebView(webView.get());
+    ASSERT_TRUE(cornerRect);
+    EXPECT_NEAR(cornerRect->origin.x, verticalRect->origin.x, 0.5);
+    EXPECT_NEAR(cornerRect->origin.y, horizontalRect->origin.y, 0.5);
+    EXPECT_NEAR(cornerRect->size.width, verticalScrollbarWidth, 0.5);
+    EXPECT_NEAR(cornerRect->size.height, horizontalScrollbarHeight, 0.5);
+
+    [webView setObscuredContentInsets:NSEdgeInsetsMake(0, 0, 0, 0)];
+}
+
+TEST(ScrollbarTests, CustomScrollbarScrollCornerSmallCornerRadius)
+{
+    RetainPtr webView = scrollbarAvoidanceTestWebView();
+    RetainPtr window = scrollbarAvoidanceTestWindow();
+    RetainPtr container = adoptNS([[ContainerView alloc] initWithFrame:NSMakeRect(0, 0, 500, 400)]);
+
+    [[window contentView] addSubview:container.get()];
+
+    WebCore::CornerRadii radii { 8 };
+    [container setCustomCornerRadius:radii];
+    [container addSubview:webView.get()];
+
+    [webView synchronouslyLoadHTMLString:customScrollbarHTMLWithBothScrollbars()];
+    [webView stringByEvaluatingJavaScript:@"internals.setUsesOverlayScrollbars(false)"];
+    [webView waitForNextPresentationUpdate];
+
+    auto frameWidth = [webView frame].size.width;
+    auto frameHeight = [webView frame].size.height;
+
+    auto verticalRect = scrollbarFrameRect(webView.get(), ScrollbarType::Vertical);
+    ASSERT_TRUE(verticalRect);
+    auto horizontalRect = scrollbarFrameRect(webView.get(), ScrollbarType::Horizontal);
+    ASSERT_TRUE(horizontalRect);
+
+    auto cornerRadius = 8.0;
+    auto verticalScrollbarWidth = 10.0;
+    auto horizontalScrollbarHeight = 18.0;
+
+    auto expectedTopOffset = cornerRadius;
+    auto expectedBottomOffset = 0.0;
+    auto expectedVerticalHeight = frameHeight - horizontalScrollbarHeight - expectedTopOffset - expectedBottomOffset;
+
+    EXPECT_NEAR(verticalRect->origin.y, expectedTopOffset, 0.5);
+    EXPECT_NEAR(verticalRect->size.height, expectedVerticalHeight, 0.5);
+
+    auto expectedLeftOffset = cornerRadius;
+    auto expectedRightOffset = 0.0;
+    auto expectedHorizontalWidth = frameWidth - verticalScrollbarWidth - expectedLeftOffset - expectedRightOffset;
+
+    EXPECT_NEAR(horizontalRect->origin.x, expectedLeftOffset, 0.5);
+    EXPECT_NEAR(horizontalRect->size.width, expectedHorizontalWidth, 0.5);
+
+    auto cornerRect = scrollCornerRectForWebView(webView.get());
+    ASSERT_TRUE(cornerRect);
+    EXPECT_NEAR(cornerRect->origin.x, verticalRect->origin.x, 0.5);
+    EXPECT_NEAR(cornerRect->origin.y, horizontalRect->origin.y, 0.5);
+    EXPECT_NEAR(cornerRect->size.width, verticalScrollbarWidth, 0.5);
+    EXPECT_NEAR(cornerRect->size.height, horizontalScrollbarHeight, 0.5);
+}
+
 #endif // HAVE(NSVIEW_CORNER_CONFIGURATION)
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 3a24edb712c909d7883a9f670435121bf326480c
<pre>
[macOS] CSS scrollbars may be cut off, scrollbar corner rect may be sized incorrectly
<a href="https://bugs.webkit.org/show_bug.cgi?id=309753">https://bugs.webkit.org/show_bug.cgi?id=309753</a>
<a href="https://rdar.apple.com/168566468">rdar://168566468</a>

Reviewed by Aditya Keerthi.

In 306039@main we introduced a mechanism to inset scrollbars based on the size
of the window&apos;s corner radii in order to prevent them from being partially
obscured. While it worked well for non-custom scrollbars, it introduced a new
issue which caused the scrollbar corner rect to increase in size as the window&apos;s
corner radii increased.

To fix this, the scroll corner rect is now computed directly from the scrollbars&apos;
already-positioned frame rects. The previous implementation independently computed
two rects based on the tracked dimensions and united them, which produced an
oversized result after corner-radius avoidance changed the scrollbar lengths. This
also naturally handles obscured content insets and RTL placement since the scrollbar
frame rects already account for those. This fixes not only the size of the corner
rect, but also fixes an additional bug in which the scroll corner was obscured by
obscured content insets.

For the custom scrollbars themselves, we no longer reduce the inset by half of the
length of the scrollbar cap because we have no guarantee that the scrollbar has
a round cap. We also factor in the size of the scroll corner rect when determining
insets so that the scrollbar insets are not unnecessarily large. For example, if
a scroll corner of height 16px is displaying and the window corner radius is 26px,
we only need to inset the vertical scrollbar 10px further.

Test: Tools/TestWebKitAPI/Tests/mac/ScrollbarTests.mm

* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::updateScrollbars):
(WebCore::ScrollView::scrollCornerRect const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::scrollCornerRect const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Tools/TestWebKitAPI/Tests/mac/ScrollbarTests.mm:
(TestWebKitAPI::scrollCornerRectForWebView):
(TestWebKitAPI::=):
(TestWebKitAPI::customScrollbarHTMLWithDimensions):
(TestWebKitAPI::customScrollbarHTMLWithBothScrollbars):
(TestWebKitAPI::TEST(ScrollbarTests, CustomScrollbarSizesNoCornerRadii)):
(TestWebKitAPI::TEST(ScrollbarTests, CustomScrollbarScrollCornerRectNoCornerRadii)):
(TestWebKitAPI::TEST(ScrollbarTests, CustomScrollbarScrollCornerRectWithObscuredContentInsets)):
(TestWebKitAPI::TEST(ScrollbarTests, CustomScrollbarCornerRadiusAvoidanceAccountsForScrollCorner)):
(TestWebKitAPI::TEST(ScrollbarTests, CustomScrollbarCornerRadiusAvoidanceWithObscuredContentInsetsAndScrollCorner)):
(TestWebKitAPI::TEST(ScrollbarTests, CustomScrollbarScrollCornerSmallCornerRadius)):

Canonical link: <a href="https://commits.webkit.org/309119@main">https://commits.webkit.org/309119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5084b0e9f2359edb8b03e74702cfea54aba7787f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158231 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151402 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115338 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b6866b9-30c9-400b-8cbf-5b57bb7f2735) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17476 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134190 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96079 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6076 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160708 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3704 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13662 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123370 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123580 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33574 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133914 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78271 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18764 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10665 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21657 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85478 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21388 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21540 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21445 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->