### PR TITLE
REGRESSION (301965@main): List items that span multiple lines have incorrect margins when zoomed in/out

### DIFF
--- a/LayoutTests/fast/lists/list-marker-margin-multiline-zoomed-expected.html
+++ b/LayoutTests/fast/lists/list-marker-margin-multiline-zoomed-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<style>
+
+body {
+    --scale: 1;
+}
+
+ul {
+    margin: 0;
+    font-size: calc(1rem * var(--scale));
+    padding-inline-start: calc(40px * var(--scale));
+    width: calc(200px * var(--scale));
+}
+
+.zoom {
+    --scale: 2;
+}
+
+</style>
+
+<div>
+    <ul>
+        <li>This is a long list item that wraps to multiple lines at this width</li>
+    </ul>
+</div>
+
+<div>
+    <ul class="zoom">
+        <li>This is a long list item that wraps to multiple lines at this width</li>
+    </ul>
+</div>

--- a/LayoutTests/fast/lists/list-marker-margin-multiline-zoomed.html
+++ b/LayoutTests/fast/lists/list-marker-margin-multiline-zoomed.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<style>
+
+ul {
+    margin: 0;
+    padding-inline-start: 40px;
+    width: 200px;
+}
+
+.zoom {
+    zoom: 2;
+}
+
+</style>
+
+<div>
+    <ul>
+        <li>This is a long list item that wraps to multiple lines at this width</li>
+    </ul>
+</div>
+
+<div>
+    <ul class="zoom">
+        <li>This is a long list item that wraps to multiple lines at this width</li>
+    </ul>
+</div>

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -468,8 +468,10 @@ void RenderListMarker::updateInlineMargins()
     };
 
     auto [marginStart, marginEnd] = isInside() ? marginsForInsideMarker() : marginsForOutsideMarker();
-    mutableStyle().setMarginStart(Style::MarginEdge::Fixed { marginStart });
-    mutableStyle().setMarginEnd(Style::MarginEdge::Fixed { marginEnd });
+    auto zoom = style().usedZoomForLength().value;
+
+    mutableStyle().setMarginStart(Style::MarginEdge::Fixed { marginStart / zoom });
+    mutableStyle().setMarginEnd(Style::MarginEdge::Fixed { marginEnd / zoom });
 }
 
 bool RenderListMarker::isInside() const


### PR DESCRIPTION
#### 4b403c87f5538086968e387222fbca8c45058a1b
<pre>
REGRESSION (301965@main): List items that span multiple lines have incorrect margins when zoomed in/out
<a href="https://bugs.webkit.org/show_bug.cgi?id=309757">https://bugs.webkit.org/show_bug.cgi?id=309757</a>
<a href="https://rdar.apple.com/172312498">rdar://172312498</a>

Reviewed by Alan Baradlay.

Margin values computed in `RenderListMarker::updateInlineMargins` are based on
font metrics which are already zoomed. Since `MarginEdge` stores unzoomed
values, and zoom is applied at resolution time via `resolveZoom`, margins get
zoomed twice.

Fix by dividing out the zoom factor to avoid double-zooming.

* LayoutTests/fast/lists/list-marker-margin-multiline-zoomed-expected.html: Added.
* LayoutTests/fast/lists/list-marker-margin-multiline-zoomed.html: Added.
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::updateInlineMargins):

Canonical link: <a href="https://commits.webkit.org/309152@main">https://commits.webkit.org/309152@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbe1bcbfa52bc22b2e2569c5fab5567f3e443f2a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158236 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102966 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e17ff2a-8774-46d2-bf6c-1f4401c064c3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151407 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22703 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115342 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82014 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/73975034-be9f-419c-a83a-1605770892a6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17480 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134219 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96083 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9aeca5d0-9646-4361-9e39-fa6e11fcc1af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16577 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14477 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6081 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126185 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12151 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160713 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3710 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123374 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22055 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123584 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22062 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133943 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78276 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23040 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18772 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10694 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21662 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85483 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21393 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21545 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21450 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->