### PR TITLE
imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-requestsubmit.html is a flaky text failure.

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2447,8 +2447,6 @@ webkit.org/b/307088 [ Tahoe Release ] webgl/webgl-and-dom-in-gpup.html [ ImageOn
 
 webkit.org/b/307196 http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html [ Pass Failure ]
 
-webkit.org/b/307351 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-requestsubmit.html [ Pass Failure ]
-
 webkit.org/b/307377 [ Tahoe Release arm64 ] compositing/webgl/update-composited-canvas-layer.html [ ImageOnlyFailure Pass ]
 
 webkit.orb/b/309833 fast/scrolling/mac/scrollend-event-user-scroll-basic.html [ Failure Pass ]

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -735,10 +735,15 @@ void NavigationScheduler::scheduleFormSubmission(Ref<FormSubmission>&& submissio
     // FIXME: Do we need special handling for form submissions where the URL is the same
     // as the current one except for the fragment part? See scheduleLocationChange above.
 
-    // Handle a location change of a page with no document as a special case.
-    // This may happen when a frame changes the location of another frame.
+    // If the current document hasn't finished loading, or if we're still on the
+    // initial empty document (before any real document has been committed), mark
+    // this navigation as during load so that schedule() will synchronously abort
+    // the current load. This prevents the current document's load event from
+    // racing with the scheduled navigation, and also ensures that
+    // redirectScheduledDuringLoad() returns true in didOpenURL() so a concurrent
+    // navigation (e.g., from window.open) doesn't cancel this form submission.
     RefPtr localFrame = dynamicDowncast<LocalFrame>(m_frame.get());
-    bool duringLoad = localFrame && !localFrame->loader().stateMachine().committedFirstRealDocumentLoad();
+    bool duringLoad = localFrame && (!localFrame->loader().isComplete() || !localFrame->loader().stateMachine().committedFirstRealDocumentLoad());
 
     // If this is a child frame and the form submission was triggered by a script, lock the back/forward list
     // to match IE and Opera.
@@ -848,9 +853,11 @@ void NavigationScheduler::schedule(std::unique_ptr<ScheduledNavigation> redirect
     RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get());
 
     // If a redirect was scheduled during a load, then stop the current load.
-    // Otherwise when the current load transitions from a provisional to a 
-    // committed state, pending redirects may be cancelled. 
-    if (redirect->wasDuringLoad()) {
+    // Otherwise when the current load transitions from a provisional to a
+    // committed state, pending redirects may be cancelled.
+    // Only do this when the navigation targets the current frame — navigations
+    // to new windows (e.g., target=_blank) should not abort the current load.
+    if (redirect->wasDuringLoad() && redirect->targetIsCurrentFrame()) {
         if (localFrame) {
             if (RefPtr provisionalDocumentLoader = localFrame->loader().provisionalDocumentLoader())
                 provisionalDocumentLoader->stopLoading();


### PR DESCRIPTION
#### 94abc6b8f69e64cc9eabcb628c5fee25b4c3e93e
<pre>
imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-requestsubmit.html is a flaky text failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307351">https://bugs.webkit.org/show_bug.cgi?id=307351</a>
<a href="https://rdar.apple.com/169977453">rdar://169977453</a>

Reviewed by Basuke Suzuki.

Navigations initiated during document loading (e.g., form.requestSubmit(),
location.assign() called during parsing) can race with the current
document&apos;s load event. This is because NavigationScheduler::scheduleFormSubmission()
uses !stateMachine().committedFirstRealDocumentLoad() to determine if a
navigation is happening &quot;during load.&quot; This check only returns true when
the frame is still on its initial empty document — by the time a script
runs in the actual document being loaded, the first real document has
already been committed, so the check returns false.

When duringLoad is false, the schedule() method skips the synchronous
abort of the current document load, and instead just starts a 0-delay
timer for the new navigation. This creates a race between the current
document&apos;s load event and the timer, causing flaky test failures where
the load event fires before the scheduled navigation starts.

To address the issue, change the duringLoad check in
scheduleFormSubmission() to also include `!loader().isComplete()`. This
correctly identifies any navigation scheduled while the current document
is still loading, ensuring schedule() synchronously aborts the current
load and prevents the load event from racing with the new navigation.

The original `!committedFirstRealDocumentLoad()` check is preserved
alongside the new `!isComplete()` check (combined with ||) because it
serves a different purpose: when a popup is created via window.open(url),
the initial empty document is already complete (isComplete() returns true)
but committedFirstRealDocumentLoad() is still false. A form.submit()
in this state must be marked as duringLoad so that
redirectScheduledDuringLoad() returns true in didOpenURL(). Otherwise,
when the window.open navigation&apos;s async policy check completes and
didOpenURL() is called, it would cancel the pending form submission,
causing the popup to navigate to the window.open URL instead of the
form&apos;s action URL.

Also add a targetIsCurrentFrame() check to the wasDuringLoad condition
in schedule(). When a form submission targets a new window (e.g.,
target=_blank), the submission is scheduled on the submitter&apos;s frame but
should not abort the submitter&apos;s current load — only form submissions
that navigate the current frame should do so.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::NavigationScheduler::scheduleFormSubmission):
(WebCore::NavigationScheduler::schedule):

Canonical link: <a href="https://commits.webkit.org/309254@main">https://commits.webkit.org/309254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dbf8d32819ae2be4d5330ab30b1b16d96da78eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16178 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158581 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103307 "") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0171f366-e0c6-409f-9bbc-b138ebb9fd74) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151748 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22697 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115612 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/103307 "") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/272325bc-1b16-4ef1-9f83-81b3d3cd18da) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17737 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134492 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96351 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16834 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14760 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6428 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126441 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12423 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161057 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4141 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13965 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123628 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123832 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33661 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22403 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134216 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78628 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18992 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10968 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22004 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85824 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21734 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21886 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21791 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->