### PR TITLE
texImage2D with HTMLCanvasElement source returns empty texture after source is composited

### DIFF
--- a/LayoutTests/fast/canvas/webgl/teximage2d-webgl-canvas-after-compositing-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/teximage2d-webgl-canvas-after-compositing-expected.txt
@@ -1,0 +1,13 @@
+Test texImage2D from a WebGL canvas after the source has been composited. See https://bugs.webkit.org/show_bug.cgi?id=290436.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS getError was expected value: NO_ERROR : Should be no errors from source setup.
+PASS getError was expected value: NO_ERROR : texImage2D from source canvas
+PASS getError was expected value: NO_ERROR : drawQuad
+PASS Canvas should be red after copying from composited source
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/canvas/webgl/teximage2d-webgl-canvas-after-compositing.html
+++ b/LayoutTests/fast/canvas/webgl/teximage2d-webgl-canvas-after-compositing.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>texImage2D from WebGL canvas after compositing</title>
+<script src="../../../resources/js-test.js"></script>
+<script src="resources/webgl-test.js"></script>
+<script src="resources/webgl-test-utils.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="source" width="16" height="16"></canvas>
+<canvas id="target" width="16" height="16"></canvas>
+<script>
+description("Test texImage2D from a WebGL canvas after the source has been composited. See https://bugs.webkit.org/show_bug.cgi?id=290436.");
+
+if (window.initNonKhronosFramework)
+    window.initNonKhronosFramework(true);
+
+var wtu = WebGLTestUtils;
+
+// Create the source context first and render red.
+var glSource = wtu.create3DContext("source");
+glSource.clearColor(1.0, 0.0, 0.0, 1.0);
+glSource.clear(glSource.COLOR_BUFFER_BIT);
+
+glErrorShouldBe(glSource, glSource.NO_ERROR, "Should be no errors from source setup.");
+
+// Wait for the source canvas to be composited, then create the target context
+// and copy. After compositing, the drawing buffer is cleared (preserveDrawingBuffer
+// is false by default), so the copy must read from the display buffer.
+requestAnimationFrame(function() {
+    requestAnimationFrame(function() {
+        runTest();
+    });
+});
+
+function runTest() {
+    var glTarget = wtu.create3DContext("target");
+    var program = wtu.setupTexturedQuad(glTarget);
+
+    glTarget.disable(glTarget.BLEND);
+    glTarget.disable(glTarget.DEPTH_TEST);
+
+    var tex = glTarget.createTexture();
+    glTarget.bindTexture(glTarget.TEXTURE_2D, tex);
+    glTarget.texParameteri(glTarget.TEXTURE_2D, glTarget.TEXTURE_WRAP_S, glTarget.CLAMP_TO_EDGE);
+    glTarget.texParameteri(glTarget.TEXTURE_2D, glTarget.TEXTURE_WRAP_T, glTarget.CLAMP_TO_EDGE);
+    glTarget.texParameteri(glTarget.TEXTURE_2D, glTarget.TEXTURE_MIN_FILTER, glTarget.NEAREST);
+    glTarget.texParameteri(glTarget.TEXTURE_2D, glTarget.TEXTURE_MAG_FILTER, glTarget.NEAREST);
+
+    // This is the call that fails without the fix: the source drawing buffer has
+    // been cleared after compositing, but the display buffer still has red.
+    glTarget.texImage2D(glTarget.TEXTURE_2D, 0, glTarget.RGBA, glTarget.RGBA, glTarget.UNSIGNED_BYTE, glSource.canvas);
+    glErrorShouldBe(glTarget, glTarget.NO_ERROR, "texImage2D from source canvas");
+
+    wtu.drawQuad(glTarget);
+    glErrorShouldBe(glTarget, glTarget.NO_ERROR, "drawQuad");
+
+    wtu.checkCanvas(glTarget, [255, 0, 0, 255], "Canvas should be red after copying from composited source");
+
+    debug("");
+    finishTest();
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -3349,9 +3349,31 @@ ExceptionOr<void> WebGLRenderingContextBase::texImageSource(TexImageFunctionID f
 
     if (RefPtr imageData = source.getImageData()) {
         texImageSourceHelper(functionID, target, level, internalformat, border, format, type, xoffset, yoffset, zoffset, sourceImageRect, depth, unpackImageHeight, TexImageSource(imageData.releaseNonNull()));
-    } else if (RefPtr image = source.copiedImage()) {
-        texImageImpl(functionID, target, level, internalformat, xoffset, yoffset, zoffset, format, type, *image, GraphicsContextGL::DOMSource::Canvas, m_unpackFlipY, m_unpackPremultiplyAlpha, false, sourceImageRect, depth, unpackImageHeight);
+        return { };
     }
+
+    // When the source is a WebGL canvas whose drawing buffer has been composited and
+    // cleared (preserveDrawingBuffer is false by default), copiedImage() would return an
+    // empty image because it reads the drawing buffer which clearIfComposited() clears.
+    // In this case, read from the display buffer which holds the last composited content.
+    // This only applies to texImage2D; other consumers like drawImage() are expected to
+    // see the cleared drawing buffer per the WebGL spec.
+    // See https://bugs.webkit.org/show_bug.cgi?id=290436.
+    if (RefPtr sourceContext = dynamicDowncast<WebGLRenderingContextBase>(source.renderingContext())) {
+        if (!sourceContext->compositingResultsNeedUpdating()) {
+            RefPtr buffer = sourceContext->surfaceBufferToImageBuffer(SurfaceBuffer::DisplayBuffer);
+            if (buffer) {
+                if (RefPtr image = buffer->copyNativeImage()) {
+                    auto bufferImage = BitmapImage::create(image.releaseNonNull());
+                    texImageImpl(functionID, target, level, internalformat, xoffset, yoffset, zoffset, format, type, bufferImage.get(), GraphicsContextGL::DOMSource::Canvas, m_unpackFlipY, m_unpackPremultiplyAlpha, false, sourceImageRect, depth, unpackImageHeight);
+                }
+            }
+            return { };
+        }
+    }
+
+    if (RefPtr image = source.copiedImage())
+        texImageImpl(functionID, target, level, internalformat, xoffset, yoffset, zoffset, format, type, *image, GraphicsContextGL::DOMSource::Canvas, m_unpackFlipY, m_unpackPremultiplyAlpha, false, sourceImageRect, depth, unpackImageHeight);
     return { };
 }
 


### PR DESCRIPTION
#### 1eb54b4ffc6c557897614e6c3e78b2ecf1af2f03
<pre>
texImage2D with HTMLCanvasElement source returns empty texture after source is composited
<a href="https://bugs.webkit.org/show_bug.cgi?id=290436">https://bugs.webkit.org/show_bug.cgi?id=290436</a>

Move the display buffer fallback from texImageSource into surfaceBufferToImageBuffer
so all consumers (texImage2D, drawImage, toDataURL, copiedImage) uniformly get the
last composited content when the drawing buffer has been cleared.

Co-Authored-By: Claude Opus 4.6 &lt;noreply@anthropic.com&gt;
</pre>
----------------------------------------------------------------------
#### 6e9a3423403fb4732ff1c4e5846e5e5769656e28
<pre>
texImage2D with HTMLCanvasElement source returns empty texture after source is composited
<a href="https://bugs.webkit.org/show_bug.cgi?id=290436">https://bugs.webkit.org/show_bug.cgi?id=290436</a>

Reviewed by NOBODY (OOPS!).

After compositing, prepareForDisplay() swaps the drawing buffer and marks it
dirty. When texImage2D copies from a WebGL canvas source, copiedImage() reads
the drawing buffer via surfaceBufferToImageBuffer(DrawingBuffer), where
clearIfComposited() clears it to (0,0,0,0), producing an empty texture.

Fix by detecting in texImageSource(HTMLCanvasElement&amp;) when the source is a
WebGL canvas whose drawing buffer has been composited and contains no new
content, and reading from the display buffer instead. This is scoped to
texImage2D only; other consumers like drawImage() continue to see the cleared
drawing buffer per the WebGL spec for preserveDrawingBuffer=false.

Test: fast/canvas/webgl/teximage2d-webgl-canvas-after-compositing.html

* LayoutTests/fast/canvas/webgl/teximage2d-webgl-canvas-after-compositing-expected.txt: Added.
* LayoutTests/fast/canvas/webgl/teximage2d-webgl-canvas-after-compositing.html: Added.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageSource): Read from the display buffer when the source WebGL canvas has been composited and has no new rendering.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1eb54b4ffc6c557897614e6c3e78b2ecf1af2f03

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22373 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158357 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103086 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151527 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22360 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115438 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82065 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152614 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17571 "Found 2 new test failures: webgl/1.0.x/conformance/context/context-attribute-preserve-drawing-buffer.html webgl/2.0.y/conformance/context/context-attribute-preserve-drawing-buffer.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134298 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96180 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16668 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14578 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6202 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126276 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12229 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160835 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3833 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13770 "Found 2 new test failures: webgl/1.0.x/conformance/context/context-attribute-preserve-drawing-buffer.html webgl/2.0.y/conformance/context/context-attribute-preserve-drawing-buffer.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123470 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22175 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18619 "Found 2 new test failures: webgl/1.0.x/conformance/context/context-attribute-preserve-drawing-buffer.html webgl/2.0.y/conformance/context/context-attribute-preserve-drawing-buffer.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123677 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22182 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134021 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78407 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18859 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10773 "Found 2 new test failures: webgl/1.0.x/conformance/context/context-attribute-preserve-drawing-buffer.html webgl/2.0.y/conformance/context/context-attribute-preserve-drawing-buffer.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21783 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85603 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21513 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21665 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21570 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->