### PR TITLE
[JSC] Implement SIMD Shuffle reduction

### DIFF
--- a/JSTests/wasm/stress/simd-canonical-shuffle.js
+++ b/JSTests/wasm/stress/simd-canonical-shuffle.js
@@ -1,0 +1,180 @@
+//@ requireOptions("--useWasmSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Comprehensive test for binary shuffle canonical pattern recognition.
+// These patterns should be lowered to UZP1/UZP2/ZIP1/ZIP2/TRN1/TRN2/REV instructions.
+
+async function test() {
+    let wat = `(module
+      (memory (export "mem") 1)
+
+      ;; UZP1.4S binary: {a[0],a[2],b[0],b[2]}
+      (func (export "uzp1_4s") (param i32 i32 i32)
+        (v128.store (local.get 2)
+          (i8x16.shuffle 0 1 2 3 8 9 10 11 16 17 18 19 24 25 26 27
+            (v128.load (local.get 0)) (v128.load (local.get 1)))))
+
+      ;; UZP2.4S binary: {a[1],a[3],b[1],b[3]}
+      (func (export "uzp2_4s") (param i32 i32 i32)
+        (v128.store (local.get 2)
+          (i8x16.shuffle 4 5 6 7 12 13 14 15 20 21 22 23 28 29 30 31
+            (v128.load (local.get 0)) (v128.load (local.get 1)))))
+
+      ;; ZIP1.4S binary: {a[0],b[0],a[1],b[1]}
+      (func (export "zip1_4s") (param i32 i32 i32)
+        (v128.store (local.get 2)
+          (i8x16.shuffle 0 1 2 3 16 17 18 19 4 5 6 7 20 21 22 23
+            (v128.load (local.get 0)) (v128.load (local.get 1)))))
+
+      ;; ZIP2.4S binary: {a[2],b[2],a[3],b[3]}
+      (func (export "zip2_4s") (param i32 i32 i32)
+        (v128.store (local.get 2)
+          (i8x16.shuffle 8 9 10 11 24 25 26 27 12 13 14 15 28 29 30 31
+            (v128.load (local.get 0)) (v128.load (local.get 1)))))
+
+      ;; TRN1.4S binary: {a[0],b[0],a[2],b[2]}
+      (func (export "trn1_4s") (param i32 i32 i32)
+        (v128.store (local.get 2)
+          (i8x16.shuffle 0 1 2 3 16 17 18 19 8 9 10 11 24 25 26 27
+            (v128.load (local.get 0)) (v128.load (local.get 1)))))
+
+      ;; TRN2.4S binary: {a[1],b[1],a[3],b[3]}
+      (func (export "trn2_4s") (param i32 i32 i32)
+        (v128.store (local.get 2)
+          (i8x16.shuffle 4 5 6 7 20 21 22 23 12 13 14 15 28 29 30 31
+            (v128.load (local.get 0)) (v128.load (local.get 1)))))
+
+      ;; UZP1.2D binary: {a[lo64],b[lo64]}
+      (func (export "uzp1_2d") (param i32 i32 i32)
+        (v128.store (local.get 2)
+          (i8x16.shuffle 0 1 2 3 4 5 6 7 16 17 18 19 20 21 22 23
+            (v128.load (local.get 0)) (v128.load (local.get 1)))))
+
+      ;; UZP2.2D binary: {a[hi64],b[hi64]}
+      (func (export "uzp2_2d") (param i32 i32 i32)
+        (v128.store (local.get 2)
+          (i8x16.shuffle 8 9 10 11 12 13 14 15 24 25 26 27 28 29 30 31
+            (v128.load (local.get 0)) (v128.load (local.get 1)))))
+
+      ;; Unary REV64.4S: swap 32-bit pairs within 64-bit lanes
+      (func (export "rev64_4s_unary") (param i32 i32)
+        (v128.store (local.get 1)
+          (i8x16.shuffle 4 5 6 7 0 1 2 3 12 13 14 15 8 9 10 11
+            (v128.load (local.get 0))
+            (v128.load (local.get 0)))))
+
+      ;; Unary REV32.8H: swap 16-bit elements within 32-bit groups
+      (func (export "rev32_8h_unary") (param i32 i32)
+        (v128.store (local.get 1)
+          (i8x16.shuffle 2 3 0 1 6 7 4 5 10 11 8 9 14 15 12 13
+            (v128.load (local.get 0))
+            (v128.load (local.get 0)))))
+
+      ;; Unary REV16.16B: swap bytes within 16-bit groups
+      (func (export "rev16_16b_unary") (param i32 i32)
+        (v128.store (local.get 1)
+          (i8x16.shuffle 1 0 3 2 5 4 7 6 9 8 11 10 13 12 15 14
+            (v128.load (local.get 0))
+            (v128.load (local.get 0)))))
+
+      ;; Unary UZP1.4S(v,v): {v[0],v[2],v[0],v[2]}
+      (func (export "uzp1_4s_unary") (param i32 i32)
+        (v128.store (local.get 1)
+          (i8x16.shuffle 0 1 2 3 8 9 10 11 0 1 2 3 8 9 10 11
+            (v128.load (local.get 0))
+            (v128.load (local.get 0)))))
+
+      ;; Unary TRN1.4S(v,v): {v[0],v[0],v[2],v[2]}
+      (func (export "trn1_4s_unary") (param i32 i32)
+        (v128.store (local.get 1)
+          (i8x16.shuffle 0 1 2 3 0 1 2 3 8 9 10 11 8 9 10 11
+            (v128.load (local.get 0))
+            (v128.load (local.get 0)))))
+    )`
+
+    const instance = await instantiate(wat, {}, { simd: true })
+    const mem = new DataView(instance.exports.mem.buffer)
+
+    function setI32x4(offset, a, b, c, d) {
+        mem.setUint32(offset, a, true)
+        mem.setUint32(offset+4, b, true)
+        mem.setUint32(offset+8, c, true)
+        mem.setUint32(offset+12, d, true)
+    }
+    function getI32x4(offset) {
+        return [mem.getUint32(offset, true), mem.getUint32(offset+4, true),
+                mem.getUint32(offset+8, true), mem.getUint32(offset+12, true)]
+    }
+    function setBytes(offset, arr) {
+        const u8 = new Uint8Array(instance.exports.mem.buffer)
+        for (let i = 0; i < arr.length; i++) u8[offset+i] = arr[i]
+    }
+    function getBytes(offset, len) {
+        const u8 = new Uint8Array(instance.exports.mem.buffer)
+        return Array.from(u8.slice(offset, offset+len))
+    }
+
+    // Setup: a = {0x11, 0x22, 0x33, 0x44}, b = {0x55, 0x66, 0x77, 0x88}
+    setI32x4(0, 0x11, 0x22, 0x33, 0x44)
+    setI32x4(16, 0x55, 0x66, 0x77, 0x88)
+
+    function verify(name, fn, args, expected) {
+        fn(...args)
+        let got = getI32x4(args[args.length-1])
+        assert.eq(got.join(','), expected.join(','), name)
+    }
+
+    // Binary patterns
+    verify("UZP1.4S", instance.exports.uzp1_4s, [0,16,32], [0x11,0x33,0x55,0x77])
+    verify("UZP2.4S", instance.exports.uzp2_4s, [0,16,32], [0x22,0x44,0x66,0x88])
+    verify("ZIP1.4S", instance.exports.zip1_4s, [0,16,32], [0x11,0x55,0x22,0x66])
+    verify("ZIP2.4S", instance.exports.zip2_4s, [0,16,32], [0x33,0x77,0x44,0x88])
+    verify("TRN1.4S", instance.exports.trn1_4s, [0,16,32], [0x11,0x55,0x33,0x77])
+    verify("TRN2.4S", instance.exports.trn2_4s, [0,16,32], [0x22,0x66,0x44,0x88])
+    verify("UZP1.2D", instance.exports.uzp1_2d, [0,16,32], [0x11,0x22,0x55,0x66])
+    verify("UZP2.2D", instance.exports.uzp2_2d, [0,16,32], [0x33,0x44,0x77,0x88])
+
+    // Unary patterns
+    verify("REV64.4S unary", instance.exports.rev64_4s_unary, [0,32], [0x22,0x11,0x44,0x33])
+    verify("UZP1.4S unary", instance.exports.uzp1_4s_unary, [0,32], [0x11,0x33,0x11,0x33])
+    verify("TRN1.4S unary", instance.exports.trn1_4s_unary, [0,32], [0x11,0x11,0x33,0x33])
+
+    // Byte-level tests
+    setBytes(0, [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15])
+    instance.exports.rev32_8h_unary(0, 32)
+    assert.eq(getBytes(32, 16).join(','), '2,3,0,1,6,7,4,5,10,11,8,9,14,15,12,13', 'REV32.8H')
+
+    instance.exports.rev16_16b_unary(0, 32)
+    assert.eq(getBytes(32, 16).join(','), '1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14', 'REV16.16B')
+
+    // Trigger OMG and re-verify
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        instance.exports.uzp1_4s(0, 16, 32)
+        instance.exports.uzp2_4s(0, 16, 32)
+        instance.exports.zip1_4s(0, 16, 32)
+        instance.exports.zip2_4s(0, 16, 32)
+        instance.exports.trn1_4s(0, 16, 32)
+        instance.exports.trn2_4s(0, 16, 32)
+        instance.exports.rev64_4s_unary(0, 32)
+        instance.exports.rev32_8h_unary(0, 32)
+        instance.exports.rev16_16b_unary(0, 32)
+        instance.exports.uzp1_4s_unary(0, 32)
+        instance.exports.trn1_4s_unary(0, 32)
+    }
+
+    // Re-verify after OMG
+    setI32x4(0, 0x11, 0x22, 0x33, 0x44)
+    setI32x4(16, 0x55, 0x66, 0x77, 0x88)
+    verify("UZP1.4S post-OMG", instance.exports.uzp1_4s, [0,16,32], [0x11,0x33,0x55,0x77])
+    verify("ZIP1.4S post-OMG", instance.exports.zip1_4s, [0,16,32], [0x11,0x55,0x22,0x66])
+    verify("TRN1.4S post-OMG", instance.exports.trn1_4s, [0,16,32], [0x11,0x55,0x33,0x77])
+    verify("REV64.4S post-OMG", instance.exports.rev64_4s_unary, [0,32], [0x22,0x11,0x44,0x33])
+
+    setBytes(0, [0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15])
+    instance.exports.rev16_16b_unary(0, 32)
+    assert.eq(getBytes(32, 16).join(','), '1,0,3,2,5,4,7,6,9,8,11,10,13,12,15,14', 'REV16.16B post-OMG')
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-ext-pattern.js
+++ b/JSTests/wasm/stress/simd-ext-pattern.js
@@ -1,0 +1,108 @@
+//@ requireOptions("--useWasmSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test binary shuffle patterns recognized as EXT, UZP, ZIP instructions.
+
+async function test() {
+    let wat = `(module
+      (memory (export "mem") 1)
+
+      ;; EXT #8: bytes {8,...,15, 16,...,23}
+      (func (export "ext8") (param i32 i32)
+        (v128.store (i32.const 32)
+          (i8x16.shuffle 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23
+            (v128.load (local.get 0)) (v128.load (local.get 1)))))
+
+      ;; EXT #4
+      (func (export "ext4") (param i32 i32)
+        (v128.store (i32.const 32)
+          (i8x16.shuffle 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19
+            (v128.load (local.get 0)) (v128.load (local.get 1)))))
+
+      ;; UZP1.2D: {a[0..7], b[0..7]}
+      (func (export "uzp1_64") (param i32 i32)
+        (v128.store (i32.const 32)
+          (i8x16.shuffle 0 1 2 3 4 5 6 7 16 17 18 19 20 21 22 23
+            (v128.load (local.get 0)) (v128.load (local.get 1)))))
+
+      ;; UZP2.2D: {a[8..15], b[8..15]}
+      (func (export "uzp2_64") (param i32 i32)
+        (v128.store (i32.const 32)
+          (i8x16.shuffle 8 9 10 11 12 13 14 15 24 25 26 27 28 29 30 31
+            (v128.load (local.get 0)) (v128.load (local.get 1)))))
+
+      ;; ZIP1.4S: {a[0],b[0],a[1],b[1]}
+      (func (export "zip1_32") (param i32 i32)
+        (v128.store (i32.const 32)
+          (i8x16.shuffle 0 1 2 3 16 17 18 19 4 5 6 7 20 21 22 23
+            (v128.load (local.get 0)) (v128.load (local.get 1)))))
+
+      ;; ZIP2.4S: {a[2],b[2],a[3],b[3]}
+      (func (export "zip2_32") (param i32 i32)
+        (v128.store (i32.const 32)
+          (i8x16.shuffle 8 9 10 11 24 25 26 27 12 13 14 15 28 29 30 31
+            (v128.load (local.get 0)) (v128.load (local.get 1)))))
+
+      ;; UZP1.4S: {a[0],a[2],b[0],b[2]}
+      (func (export "uzp1_32") (param i32 i32)
+        (v128.store (i32.const 32)
+          (i8x16.shuffle 0 1 2 3 8 9 10 11 16 17 18 19 24 25 26 27
+            (v128.load (local.get 0)) (v128.load (local.get 1)))))
+    )`
+
+    const instance = await instantiate(wat, {}, { simd: true })
+    const mem = new Uint8Array(instance.exports.mem.buffer)
+
+    // Set up test vectors: a = [0..15], b = [16..31]
+    for (let i = 0; i < 16; i++) {
+        mem[i] = i
+        mem[16 + i] = 16 + i
+    }
+
+    function getResult() {
+        return Array.from(mem.slice(32, 48)).join(',')
+    }
+
+    // EXT #8
+    instance.exports.ext8(0, 16)
+    assert.eq(getResult(), '8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23')
+
+    // EXT #4
+    instance.exports.ext4(0, 16)
+    assert.eq(getResult(), '4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19')
+
+    // UZP1.2D
+    instance.exports.uzp1_64(0, 16)
+    assert.eq(getResult(), '0,1,2,3,4,5,6,7,16,17,18,19,20,21,22,23')
+
+    // UZP2.2D
+    instance.exports.uzp2_64(0, 16)
+    assert.eq(getResult(), '8,9,10,11,12,13,14,15,24,25,26,27,28,29,30,31')
+
+    // ZIP1.4S
+    instance.exports.zip1_32(0, 16)
+    assert.eq(getResult(), '0,1,2,3,16,17,18,19,4,5,6,7,20,21,22,23')
+
+    // ZIP2.4S
+    instance.exports.zip2_32(0, 16)
+    assert.eq(getResult(), '8,9,10,11,24,25,26,27,12,13,14,15,28,29,30,31')
+
+    // UZP1.4S
+    instance.exports.uzp1_32(0, 16)
+    assert.eq(getResult(), '0,1,2,3,8,9,10,11,16,17,18,19,24,25,26,27')
+
+    // Run many times for OMG
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        instance.exports.ext8(0, 16)
+        instance.exports.uzp1_64(0, 16)
+        instance.exports.zip1_32(0, 16)
+    }
+
+    // Re-verify after optimization
+    instance.exports.ext8(0, 16)
+    assert.eq(getResult(), '8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23')
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-shift-left-one.js
+++ b/JSTests/wasm/stress/simd-shift-left-one.js
@@ -1,0 +1,67 @@
+//@ requireOptions("--useWasmSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test that i64x2.shl by constant 1 is optimized to i64x2.add(x, x).
+// This is a strength reduction: x << 1 == x + x.
+
+async function test() {
+    let wat = `(module
+      (memory (export "mem") 1)
+
+      ;; Simple shift left by 1
+      (func (export "shl1") (param i32 i32)
+        (v128.store (local.get 1)
+          (i64x2.shl (v128.load (local.get 0)) (i32.const 1))))
+
+      ;; Multiply-and-double pattern (common in BLAKE2b):
+      ;; (lo32(a) * lo32(b)) << 1
+      (func (export "mul_double") (param i32 i32 i32)
+        (v128.store (local.get 2)
+          (i64x2.shl
+            (i64x2.mul (v128.load (local.get 0)) (v128.load (local.get 1)))
+            (i32.const 1))))
+    )`
+
+    const instance = await instantiate(wat, {}, { simd: true })
+    const mem = new DataView(instance.exports.mem.buffer)
+
+    // Test shl1: [3, 7] << 1 = [6, 14]
+    mem.setBigUint64(0, 3n, true)
+    mem.setBigUint64(8, 7n, true)
+    instance.exports.shl1(0, 16)
+    assert.eq(mem.getBigUint64(16, true), 6n)
+    assert.eq(mem.getBigUint64(24, true), 14n)
+
+    // Test with large values near overflow
+    mem.setBigUint64(0, 0x8000000000000000n, true)
+    mem.setBigUint64(8, 0xFFFFFFFFFFFFFFFFn, true)
+    instance.exports.shl1(0, 16)
+    assert.eq(mem.getBigUint64(16, true), 0n) // overflow wraps
+    assert.eq(mem.getBigUint64(24, true), 0xFFFFFFFFFFFFFFFEn)
+
+    // Test mul_double: [5, 3] * [4, 6] << 1 = [40, 36]
+    mem.setBigUint64(0, 5n, true)
+    mem.setBigUint64(8, 3n, true)
+    mem.setBigUint64(16, 4n, true)
+    mem.setBigUint64(24, 6n, true)
+    instance.exports.mul_double(0, 16, 32)
+    assert.eq(mem.getBigUint64(32, true), 40n)
+    assert.eq(mem.getBigUint64(40, true), 36n)
+
+    // Run many times to trigger OMG
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        instance.exports.shl1(0, 16)
+        instance.exports.mul_double(0, 16, 32)
+    }
+
+    // Re-verify after OMG
+    mem.setBigUint64(0, 3n, true)
+    mem.setBigUint64(8, 7n, true)
+    instance.exports.shl1(0, 16)
+    assert.eq(mem.getBigUint64(16, true), 6n)
+    assert.eq(mem.getBigUint64(24, true), 14n)
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-shuffle-compose.js
+++ b/JSTests/wasm/stress/simd-shuffle-compose.js
@@ -1,0 +1,77 @@
+//@ requireOptions("--useWasmSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test chained shuffle composition (shuffle-of-shuffle optimization)
+// and same-child binary shuffle normalization.
+
+async function test() {
+    let wat = `(module
+      (memory (export "mem") 1)
+
+      ;; unpackhi(a, unpacklo(b, b)):
+      ;; Inner: shuffle(b, b, {0..7, 16..23}) = dup low qword of b
+      ;; Outer: shuffle(a, inner, {8..15, 24..31}) = {a[8..15], inner[8..15]=[b[0..7]]}
+      ;; Composed result: {a[8..15], b[0..7]}
+      (func (export "unpackhi_unpacklo") (param i32 i32)
+        (v128.store (i32.const 32)
+          (i8x16.shuffle 8 9 10 11 12 13 14 15 24 25 26 27 28 29 30 31
+            (v128.load (local.get 0))
+            (i8x16.shuffle 0 1 2 3 4 5 6 7 16 17 18 19 20 21 22 23
+              (v128.load (local.get 1))
+              (v128.load (local.get 1))))))
+
+      ;; Same child on both sides: shuffle(x, x, {0..7, 16..23}) → dup low qword
+      (func (export "dup_low_qword") (param i32)
+        (v128.store (i32.const 16)
+          (i8x16.shuffle 0 1 2 3 4 5 6 7 16 17 18 19 20 21 22 23
+            (v128.load (local.get 0))
+            (v128.load (local.get 0)))))
+
+      ;; Identity shuffle
+      (func (export "identity") (param i32)
+        (v128.store (i32.const 16)
+          (i8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
+            (v128.load (local.get 0))
+            (v128.load (local.get 0)))))
+    )`
+
+    const instance = await instantiate(wat, {}, { simd: true })
+    const mem = new Uint8Array(instance.exports.mem.buffer)
+
+    // Set up: a = [0..15] at offset 0, b = [16..31] at offset 64
+    for (let i = 0; i < 16; i++) {
+        mem[i] = i
+        mem[64 + i] = 16 + i
+    }
+
+    function getResult(offset, len) {
+        return Array.from(mem.slice(offset, offset + len)).join(',')
+    }
+
+    // unpackhi_unpacklo: {a[8..15], b[0..7]}
+    instance.exports.unpackhi_unpacklo(0, 64)
+    assert.eq(getResult(32, 16), '8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23')
+
+    // dup_low_qword: {a[0..7], a[0..7]}
+    instance.exports.dup_low_qword(0)
+    assert.eq(getResult(16, 16), '0,1,2,3,4,5,6,7,0,1,2,3,4,5,6,7')
+
+    // identity: unchanged
+    instance.exports.identity(0)
+    assert.eq(getResult(16, 16), '0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15')
+
+    // Run many times to trigger OMG
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        instance.exports.unpackhi_unpacklo(0, 64)
+        instance.exports.dup_low_qword(0)
+        instance.exports.identity(0)
+    }
+
+    // Verify correctness after OMG
+    instance.exports.unpackhi_unpacklo(0, 64)
+    assert.eq(getResult(32, 16), '8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23')
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-shuffle-narrowing.js
+++ b/JSTests/wasm/stress/simd-shuffle-narrowing.js
@@ -1,0 +1,87 @@
+//@ requireOptions("--useWasmSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test that shuffle patterns feeding extend_low / extmul_low are correctly compiled
+// (the B3 ReduceSIMDShuffle phase may narrow them to VectorSwizzle8).
+
+async function test() {
+    let wat = `(module
+      (memory (export "mem") 1)
+
+      ;; shuffle(x, x, {0,1,2,3,8,9,10,11,...}) → i64x2.extend_low_i32x4_u
+      ;; Extracts i32 elements [0] and [2], then zero-extends to i64x2.
+      (func (export "shuffle_extend_low") (param i32)
+        (v128.store (i32.const 16)
+          (i64x2.extend_low_i32x4_u
+            (i8x16.shuffle 0 1 2 3 8 9 10 11 0 1 2 3 8 9 10 11
+              (v128.load (local.get 0))
+              (v128.load (local.get 0))))))
+
+      ;; shuffle + i64x2.extmul_low_i32x4_u
+      (func (export "shuffle_extmul_low") (param i32 i32)
+        (v128.store (i32.const 32)
+          (i64x2.extmul_low_i32x4_u
+            (i8x16.shuffle 0 1 2 3 8 9 10 11 0 1 2 3 8 9 10 11
+              (v128.load (local.get 0))
+              (v128.load (local.get 0)))
+            (i8x16.shuffle 0 1 2 3 8 9 10 11 0 1 2 3 8 9 10 11
+              (v128.load (local.get 1))
+              (v128.load (local.get 1))))))
+
+      ;; shuffle → i32x4.extract_lane 0
+      (func (export "shuffle_extract_lane0") (param i32) (result i32)
+        (i32x4.extract_lane 0
+          (i8x16.shuffle 4 5 6 7 0 1 2 3 4 5 6 7 0 1 2 3
+            (v128.load (local.get 0))
+            (v128.load (local.get 0)))))
+    )`
+
+    const instance = await instantiate(wat, {}, { simd: true })
+    const mem = new DataView(instance.exports.mem.buffer)
+
+    // Test shuffle_extend_low: input [1, 2, 3, 4] as i32x4
+    // shuffle picks elements [0]=1 and [2]=3 → extend_low → [1n, 3n]
+    mem.setUint32(0, 1, true)
+    mem.setUint32(4, 2, true)
+    mem.setUint32(8, 3, true)
+    mem.setUint32(12, 4, true)
+    instance.exports.shuffle_extend_low(0)
+    assert.eq(mem.getBigUint64(16, true), 1n)
+    assert.eq(mem.getBigUint64(24, true), 3n)
+
+    // Test shuffle_extmul_low: a=[2,0,3,0], b=[5,0,7,0]
+    // shuffle a→[2,3], shuffle b→[5,7], extmul→[10,21]
+    mem.setUint32(0, 2, true)
+    mem.setUint32(4, 0, true)
+    mem.setUint32(8, 3, true)
+    mem.setUint32(12, 0, true)
+    mem.setUint32(48, 5, true)
+    mem.setUint32(52, 0, true)
+    mem.setUint32(56, 7, true)
+    mem.setUint32(60, 0, true)
+    instance.exports.shuffle_extmul_low(0, 48)
+    assert.eq(mem.getBigUint64(32, true), 10n)
+    assert.eq(mem.getBigUint64(40, true), 21n)
+
+    // Test shuffle_extract_lane0: input [10, 20, 30, 40]
+    // shuffle {4,5,6,7,...} puts element [1]=20 at lane 0 → extract → 20
+    mem.setUint32(0, 10, true)
+    mem.setUint32(4, 20, true)
+    mem.setUint32(8, 30, true)
+    mem.setUint32(12, 40, true)
+    assert.eq(instance.exports.shuffle_extract_lane0(0), 20)
+
+    // Run many iterations for OMG compilation
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        instance.exports.shuffle_extend_low(0)
+        instance.exports.shuffle_extmul_low(0, 48)
+        instance.exports.shuffle_extract_lane0(0)
+    }
+
+    // Verify correctness after optimization
+    assert.eq(instance.exports.shuffle_extract_lane0(0), 20)
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-unary-shuffle-canonical.js
+++ b/JSTests/wasm/stress/simd-unary-shuffle-canonical.js
@@ -1,0 +1,113 @@
+//@ requireOptions("--useWasmSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test unary shuffle patterns that should be matched as UZP1/UZP2/ZIP1/ZIP2
+// with the same register on both inputs (unary-as-binary canonical matching).
+
+async function test() {
+    let wat = `(module
+      (memory (export "mem") 1)
+
+      ;; UZP1.4S(v, v): extract even 32-bit elements {v[0], v[2], v[0], v[2]}
+      ;; Pattern: {0,1,2,3, 8,9,10,11, 0,1,2,3, 8,9,10,11}
+      (func (export "uzp1_4s_unary") (param i32 i32)
+        (v128.store (local.get 1)
+          (i8x16.shuffle 0 1 2 3 8 9 10 11 0 1 2 3 8 9 10 11
+            (v128.load (local.get 0))
+            (v128.load (local.get 0)))))
+
+      ;; UZP2.4S(v, v): extract odd 32-bit elements {v[1], v[3], v[1], v[3]}
+      ;; Pattern: {4,5,6,7, 12,13,14,15, 4,5,6,7, 12,13,14,15}
+      (func (export "uzp2_4s_unary") (param i32 i32)
+        (v128.store (local.get 1)
+          (i8x16.shuffle 4 5 6 7 12 13 14 15 4 5 6 7 12 13 14 15
+            (v128.load (local.get 0))
+            (v128.load (local.get 0)))))
+
+      ;; UZP1.2D(v, v): duplicate low 64-bit element {v[0], v[0]}
+      ;; Pattern: {0,1,2,3,4,5,6,7, 0,1,2,3,4,5,6,7}
+      (func (export "uzp1_2d_unary") (param i32 i32)
+        (v128.store (local.get 1)
+          (i8x16.shuffle 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7
+            (v128.load (local.get 0))
+            (v128.load (local.get 0)))))
+
+      ;; UZP2.2D(v, v): duplicate high 64-bit element {v[1], v[1]}
+      ;; Pattern: {8,9,10,11,12,13,14,15, 8,9,10,11,12,13,14,15}
+      (func (export "uzp2_2d_unary") (param i32 i32)
+        (v128.store (local.get 1)
+          (i8x16.shuffle 8 9 10 11 12 13 14 15 8 9 10 11 12 13 14 15
+            (v128.load (local.get 0))
+            (v128.load (local.get 0)))))
+
+      ;; ZIP1.4S(v, v): interleave low 32-bit halves {v[0], v[0], v[1], v[1]}
+      ;; Pattern: {0,1,2,3, 0,1,2,3, 4,5,6,7, 4,5,6,7}
+      (func (export "zip1_4s_unary") (param i32 i32)
+        (v128.store (local.get 1)
+          (i8x16.shuffle 0 1 2 3 0 1 2 3 4 5 6 7 4 5 6 7
+            (v128.load (local.get 0))
+            (v128.load (local.get 0)))))
+    )`
+
+    const instance = await instantiate(wat, {}, { simd: true })
+    const mem = new Uint8Array(instance.exports.mem.buffer)
+    const memView = new DataView(instance.exports.mem.buffer)
+
+    // Set up: v = [0x11223344, 0x55667788, 0x99AABBCC, 0xDDEEFF00] as i32x4
+    memView.setUint32(0, 0x11223344, true)
+    memView.setUint32(4, 0x55667788, true)
+    memView.setUint32(8, 0x99AABBCC, true)
+    memView.setUint32(12, 0xDDEEFF00, true)
+
+    function getResult32(offset) {
+        return [
+            memView.getUint32(offset, true),
+            memView.getUint32(offset + 4, true),
+            memView.getUint32(offset + 8, true),
+            memView.getUint32(offset + 12, true)
+        ].map(x => '0x' + x.toString(16).padStart(8, '0')).join(',')
+    }
+
+    // UZP1.4S: {v[0], v[2], v[0], v[2]}
+    instance.exports.uzp1_4s_unary(0, 16)
+    assert.eq(getResult32(16), '0x11223344,0x99aabbcc,0x11223344,0x99aabbcc')
+
+    // UZP2.4S: {v[1], v[3], v[1], v[3]}
+    instance.exports.uzp2_4s_unary(0, 16)
+    assert.eq(getResult32(16), '0x55667788,0xddeeff00,0x55667788,0xddeeff00')
+
+    // UZP1.2D: {v[0..1], v[0..1]}
+    instance.exports.uzp1_2d_unary(0, 16)
+    assert.eq(getResult32(16), '0x11223344,0x55667788,0x11223344,0x55667788')
+
+    // UZP2.2D: {v[2..3], v[2..3]}
+    instance.exports.uzp2_2d_unary(0, 16)
+    assert.eq(getResult32(16), '0x99aabbcc,0xddeeff00,0x99aabbcc,0xddeeff00')
+
+    // ZIP1.4S: {v[0], v[0], v[1], v[1]}
+    instance.exports.zip1_4s_unary(0, 16)
+    assert.eq(getResult32(16), '0x11223344,0x11223344,0x55667788,0x55667788')
+
+    // Run many times to trigger OMG
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        instance.exports.uzp1_4s_unary(0, 16)
+        instance.exports.uzp2_4s_unary(0, 16)
+        instance.exports.uzp1_2d_unary(0, 16)
+        instance.exports.uzp2_2d_unary(0, 16)
+        instance.exports.zip1_4s_unary(0, 16)
+    }
+
+    // Re-verify after OMG
+    instance.exports.uzp1_4s_unary(0, 16)
+    assert.eq(getResult32(16), '0x11223344,0x99aabbcc,0x11223344,0x99aabbcc')
+
+    instance.exports.uzp2_4s_unary(0, 16)
+    assert.eq(getResult32(16), '0x55667788,0xddeeff00,0x55667788,0xddeeff00')
+
+    instance.exports.uzp1_2d_unary(0, 16)
+    assert.eq(getResult32(16), '0x11223344,0x55667788,0x11223344,0x55667788')
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-xor-rotate.js
+++ b/JSTests/wasm/stress/simd-xor-rotate.js
@@ -1,0 +1,123 @@
+//@ requireOptions("--useWasmSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test XOR-and-rotate-right patterns for i64x2.
+// On ARM64 with SHA3 support, these should be lowered to XAR instructions.
+// Pattern: (v128.or (i64x2.shl (v128.xor a b) (64-n)) (i64x2.shr_u (v128.xor a b) n))
+
+async function test() {
+    let wat = `(module
+      (memory (export "mem") 1)
+
+      ;; XOR + rotate right by 32 (BLAKE2b rotation)
+      (func (export "xor_rotr32") (param i32 i32 i32)
+        (v128.store (local.get 2)
+          (v128.or
+            (i64x2.shl
+              (v128.xor (v128.load (local.get 0)) (v128.load (local.get 1)))
+              (i32.const 32))
+            (i64x2.shr_u
+              (v128.xor (v128.load (local.get 0)) (v128.load (local.get 1)))
+              (i32.const 32)))))
+
+      ;; XOR + rotate right by 24 (BLAKE2b rotation)
+      (func (export "xor_rotr24") (param i32 i32 i32)
+        (v128.store (local.get 2)
+          (v128.or
+            (i64x2.shl
+              (v128.xor (v128.load (local.get 0)) (v128.load (local.get 1)))
+              (i32.const 40))
+            (i64x2.shr_u
+              (v128.xor (v128.load (local.get 0)) (v128.load (local.get 1)))
+              (i32.const 24)))))
+
+      ;; XOR + rotate right by 16 (BLAKE2b rotation)
+      (func (export "xor_rotr16") (param i32 i32 i32)
+        (v128.store (local.get 2)
+          (v128.or
+            (i64x2.shl
+              (v128.xor (v128.load (local.get 0)) (v128.load (local.get 1)))
+              (i32.const 48))
+            (i64x2.shr_u
+              (v128.xor (v128.load (local.get 0)) (v128.load (local.get 1)))
+              (i32.const 16)))))
+
+      ;; XOR + rotate right by 63 (BLAKE2b rotation)
+      (func (export "xor_rotr63") (param i32 i32 i32)
+        (v128.store (local.get 2)
+          (v128.or
+            (i64x2.shl
+              (v128.xor (v128.load (local.get 0)) (v128.load (local.get 1)))
+              (i32.const 1))
+            (i64x2.shr_u
+              (v128.xor (v128.load (local.get 0)) (v128.load (local.get 1)))
+              (i32.const 63)))))
+    )`
+
+    const instance = await instantiate(wat, {}, { simd: true })
+    const mem = new DataView(instance.exports.mem.buffer)
+    const mem8 = new Uint8Array(instance.exports.mem.buffer)
+
+    // Set up test vectors at offsets 0 and 16.
+    // a = [0x0123456789ABCDEF, 0xFEDCBA9876543210]
+    // b = [0xFF00FF00FF00FF00, 0x00FF00FF00FF00FF]
+    mem.setBigUint64(0, 0x0123456789ABCDEFn, true)
+    mem.setBigUint64(8, 0xFEDCBA9876543210n, true)
+    mem.setBigUint64(16, 0xFF00FF00FF00FF00n, true)
+    mem.setBigUint64(24, 0x00FF00FF00FF00FFn, true)
+
+    function rotr64(val, n) {
+        n = BigInt(n)
+        return ((val >> n) | (val << (64n - n))) & 0xFFFFFFFFFFFFFFFFn
+    }
+
+    let xor0 = 0x0123456789ABCDEFn ^ 0xFF00FF00FF00FF00n
+    let xor1 = 0xFEDCBA9876543210n ^ 0x00FF00FF00FF00FFn
+
+    function verify(funcName, rotateAmount) {
+        let expected0 = rotr64(xor0, rotateAmount)
+        let expected1 = rotr64(xor1, rotateAmount)
+        let got0 = mem.getBigUint64(32, true)
+        let got1 = mem.getBigUint64(40, true)
+        assert.eq(got0, expected0, `${funcName} lane 0`)
+        assert.eq(got1, expected1, `${funcName} lane 1`)
+    }
+
+    // Test each rotation
+    instance.exports.xor_rotr32(0, 16, 32)
+    verify("xor_rotr32", 32)
+
+    instance.exports.xor_rotr24(0, 16, 32)
+    verify("xor_rotr24", 24)
+
+    instance.exports.xor_rotr16(0, 16, 32)
+    verify("xor_rotr16", 16)
+
+    instance.exports.xor_rotr63(0, 16, 32)
+    verify("xor_rotr63", 63)
+
+    // Run many times to trigger OMG
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        instance.exports.xor_rotr32(0, 16, 32)
+        instance.exports.xor_rotr24(0, 16, 32)
+        instance.exports.xor_rotr16(0, 16, 32)
+        instance.exports.xor_rotr63(0, 16, 32)
+    }
+
+    // Re-verify after OMG optimization
+    instance.exports.xor_rotr32(0, 16, 32)
+    verify("xor_rotr32 (post-OMG)", 32)
+
+    instance.exports.xor_rotr24(0, 16, 32)
+    verify("xor_rotr24 (post-OMG)", 24)
+
+    instance.exports.xor_rotr16(0, 16, 32)
+    verify("xor_rotr16 (post-OMG)", 16)
+
+    instance.exports.xor_rotr63(0, 16, 32)
+    verify("xor_rotr63 (post-OMG)", 63)
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -813,7 +813,6 @@
 		23968F0E2F295B1B001AED63 /* WebAssemblySuspending.h in Headers */ = {isa = PBXBuildFile; fileRef = 23968F0C2F295B1B001AED63 /* WebAssemblySuspending.h */; };
 		23968F0F2F295B1B001AED63 /* WebAssemblyPromising.h in Headers */ = {isa = PBXBuildFile; fileRef = 23968F0A2F295B1B001AED63 /* WebAssemblyPromising.h */; };
 		23A356912E9790F40039C82A /* PinballCompletion.h in Headers */ = {isa = PBXBuildFile; fileRef = 23A3568E2E9790F40039C82A /* PinballCompletion.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		F04DFCBEDED74A4E92B8A9DA /* PinballHandlerContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 8791D173F2EE43A7E6469029 /* PinballHandlerContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		23A9696C2E95A903005A36F5 /* EvacuatedStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 23A969692E95A903005A36F5 /* EvacuatedStack.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		23D7A3E22F3D0F4C00A27B88 /* JSPIContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 23D7A3E02F3D0F4C00A27B88 /* JSPIContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		23D7A3E32F3D0F4C00A27B88 /* JSPIContextInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 23D7A3E12F3D0F4C00A27B88 /* JSPIContextInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2162,6 +2161,7 @@
 		E3F23A811ECF13FA00978D99 /* SnippetParams.h in Headers */ = {isa = PBXBuildFile; fileRef = E3F23A7C1ECF13E500978D99 /* SnippetParams.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3F23A821ECF13FE00978D99 /* Snippet.h in Headers */ = {isa = PBXBuildFile; fileRef = E3F23A7B1ECF13E500978D99 /* Snippet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3F429BD2A41742F00C5FEFF /* AirOptimizePairedLoadStore.h in Headers */ = {isa = PBXBuildFile; fileRef = E3F429BB2A41742700C5FEFF /* AirOptimizePairedLoadStore.h */; };
+		E3F5152C2F62AD4300C15A3C /* B3ReduceSIMDShuffle.h in Headers */ = {isa = PBXBuildFile; fileRef = F576E170731B25C8AD83FF16 /* B3ReduceSIMDShuffle.h */; };
 		E3F52B2B2A8D9BB70080E92D /* NativeCallee.h in Headers */ = {isa = PBXBuildFile; fileRef = E3F52B292A8D9BB60080E92D /* NativeCallee.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3FB5BEC2F0886090016B5F5 /* AirDominators.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FB5BEB2F0886090016B5F5 /* AirDominators.h */; };
 		E3FB5BEE2F0886E00016B5F5 /* AirNaturalLoops.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FB5BED2F0886E00016B5F5 /* AirNaturalLoops.h */; };
@@ -2169,6 +2169,7 @@
 		E3FF75331D9CEA1800C7E16D /* DOMJITGetterSetter.h in Headers */ = {isa = PBXBuildFile; fileRef = E3FF752F1D9CEA1200C7E16D /* DOMJITGetterSetter.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E49DC16C12EF294E00184A1F /* SourceProviderCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E49DC15112EF272200184A1F /* SourceProviderCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E49DC16D12EF295300184A1F /* SourceProviderCacheItem.h in Headers */ = {isa = PBXBuildFile; fileRef = E49DC14912EF261A00184A1F /* SourceProviderCacheItem.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		F04DFCBEDED74A4E92B8A9DA /* PinballHandlerContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 8791D173F2EE43A7E6469029 /* PinballHandlerContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F300DBB02E259A8B00430A24 /* MARReportCrashPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = F300DBAE2E259A7900430A24 /* MARReportCrashPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F323932D2A43748000421AD2 /* WasmFunctionIPIntMetadataGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = F323932B2A43748000421AD2 /* WasmFunctionIPIntMetadataGenerator.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F395BE252A43C5920083DE3A /* InPlaceInterpreter.h in Headers */ = {isa = PBXBuildFile; fileRef = F395BE242A43C58B0083DE3A /* InPlaceInterpreter.h */; };
@@ -4007,7 +4008,6 @@
 		23968F0C2F295B1B001AED63 /* WebAssemblySuspending.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = WebAssemblySuspending.h; path = js/WebAssemblySuspending.h; sourceTree = "<group>"; };
 		23968F0D2F295B1B001AED63 /* WebAssemblySuspending.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblySuspending.cpp; path = js/WebAssemblySuspending.cpp; sourceTree = "<group>"; };
 		23A3568E2E9790F40039C82A /* PinballCompletion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PinballCompletion.h; sourceTree = "<group>"; };
-		8791D173F2EE43A7E6469029 /* PinballHandlerContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PinballHandlerContext.h; sourceTree = "<group>"; };
 		23A3568F2E9790F40039C82A /* PinballCompletion.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PinballCompletion.cpp; sourceTree = "<group>"; };
 		23A969692E95A903005A36F5 /* EvacuatedStack.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EvacuatedStack.h; sourceTree = "<group>"; };
 		23A9696A2E95A903005A36F5 /* EvacuatedStack.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = EvacuatedStack.cpp; sourceTree = "<group>"; };
@@ -4777,6 +4777,7 @@
 		73190D962400934900F891C9 /* DeleteByStatus.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DeleteByStatus.cpp; sourceTree = "<group>"; };
 		734B655423F4A33100A069D1 /* DeletePropertySlot.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeletePropertySlot.h; sourceTree = "<group>"; };
 		73AD062823FF662600F53593 /* DeleteByStatus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeleteByStatus.h; sourceTree = "<group>"; };
+		7569FA8AB74C4BA387DB8F97 /* B3ReduceSIMDShuffle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = B3ReduceSIMDShuffle.cpp; path = b3/B3ReduceSIMDShuffle.cpp; sourceTree = "<group>"; };
 		77B25CB2C3094A92A38E1DB3 /* JSModuleLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSModuleLoader.h; sourceTree = "<group>"; };
 		790081361E95A8EC0052D7CD /* WasmModule.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmModule.cpp; sourceTree = "<group>"; };
 		790081371E95A8EC0052D7CD /* WasmModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmModule.h; sourceTree = "<group>"; };
@@ -4980,6 +4981,7 @@
 		86F75EFD151C062F007C9BA3 /* RegExpMatchesArray.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RegExpMatchesArray.cpp; sourceTree = "<group>"; };
 		86FA9E8F142BBB2D001773B7 /* JSBoundFunction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSBoundFunction.cpp; sourceTree = "<group>"; };
 		86FA9E90142BBB2E001773B7 /* JSBoundFunction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSBoundFunction.h; sourceTree = "<group>"; };
+		8791D173F2EE43A7E6469029 /* PinballHandlerContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PinballHandlerContext.h; sourceTree = "<group>"; };
 		8852151A9C3842389B3215B7 /* ScriptFetcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScriptFetcher.h; sourceTree = "<group>"; };
 		8AA92D3D2CACA137002D872B /* JSIteratorHelperPrototype.js */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.javascript; path = JSIteratorHelperPrototype.js; sourceTree = "<group>"; };
 		8AF85BDA2C9CD1E4005E28DA /* JSIteratorHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSIteratorHelper.h; sourceTree = "<group>"; };
@@ -6140,6 +6142,7 @@
 		F3D9C2362A426CB7006EE152 /* WasmIPIntPlan.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmIPIntPlan.cpp; sourceTree = "<group>"; };
 		F3D9C2372A426CB7006EE152 /* WasmIPIntPlan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WasmIPIntPlan.h; sourceTree = "<group>"; };
 		F3D9C2382A426CB7006EE152 /* WasmIPIntGenerator.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WasmIPIntGenerator.cpp; sourceTree = "<group>"; };
+		F576E170731B25C8AD83FF16 /* B3ReduceSIMDShuffle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = B3ReduceSIMDShuffle.h; path = b3/B3ReduceSIMDShuffle.h; sourceTree = "<group>"; };
 		F5BB2BC5030F772101FCFE1D /* Completion.h */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = Completion.h; sourceTree = "<group>"; tabWidth = 8; };
 		F5C290E60284F98E018635CA /* JavaScriptCorePrefix.h */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = JavaScriptCorePrefix.h; sourceTree = "<group>"; tabWidth = 8; };
 		F68EBB8C0255D4C601FF60F7 /* config.h */ = {isa = PBXFileReference; fileEncoding = 30; indentWidth = 4; lastKnownFileType = sourcecode.c.h; path = config.h; sourceTree = "<group>"; tabWidth = 8; };
@@ -6943,6 +6946,8 @@
 				0F725CA61C503DED00AD943A /* B3PureCSE.h */,
 				43422A641C16221E00E2EB98 /* B3ReduceDoubleToFloat.cpp */,
 				43422A651C16221E00E2EB98 /* B3ReduceDoubleToFloat.h */,
+				7569FA8AB74C4BA387DB8F97 /* B3ReduceSIMDShuffle.cpp */,
+				F576E170731B25C8AD83FF16 /* B3ReduceSIMDShuffle.h */,
 				0FEC85B71BE1462F0080FF74 /* B3ReduceStrength.cpp */,
 				0FEC85B81BE1462F0080FF74 /* B3ReduceStrength.h */,
 				4B78E098294427D2003C6682 /* B3SIMDValue.cpp */,
@@ -10984,6 +10989,7 @@
 				0FEC852D1BDACDAC0080FF74 /* B3ProcedureInlines.h in Headers */,
 				0F725CAA1C503DED00AD943A /* B3PureCSE.h in Headers */,
 				43422A671C16267800E2EB98 /* B3ReduceDoubleToFloat.h in Headers */,
+				E3F5152C2F62AD4300C15A3C /* B3ReduceSIMDShuffle.h in Headers */,
 				0FEC85BD1BE1462F0080FF74 /* B3ReduceStrength.h in Headers */,
 				4B78E09F29442801003C6682 /* B3SIMDValue.h in Headers */,
 				0FEC85351BDACDAC0080FF74 /* B3SlotBaseValue.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -170,6 +170,7 @@ b3/B3PhiChildren.cpp
 b3/B3Procedure.cpp
 b3/B3PureCSE.cpp
 b3/B3ReduceDoubleToFloat.cpp
+b3/B3ReduceSIMDShuffle.cpp
 b3/B3ReduceStrength.cpp
 b3/B3SSACalculator.cpp
 b3/B3SIMDValue.cpp

--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -1729,9 +1729,57 @@ public:
         insn(0b01'001110'00'0'00000'001110'00000'00000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
     }
 
+    ALWAYS_INLINE void zip2(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        // ZIP2 is the same encoding as ZIP1 but with op=1 (bit 14).
+        insn(0b01'001110'00'0'00000'011110'00000'00000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
     ALWAYS_INLINE void uzip1(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
     {
         insn(0b01'001110'00'0'00000'0'0'01'10'00000'00000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void uzip2(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        // UZP2 is the same encoding as UZP1 but with op=1 (bit 14).
+        insn(0b01'001110'00'0'00000'0'1'01'10'00000'00000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void trn1(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        insn(0b01'001110'00'0'00000'0'0'10'10'00000'00000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void trn2(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, SIMDLane lane)
+    {
+        // TRN2 is the same encoding as TRN1 but with op=1 (bit 14).
+        insn(0b01'001110'00'0'00000'0'1'10'10'00000'00000 | (sizeForIntegralSIMDOp(lane) << 22) | (vm << 16) | (vn << 5) | vd);
+    }
+
+    // REV16.16B: reverse bytes within 16-bit groups
+    // REV32.T: reverse elements within 32-bit groups (T = 16B or 8H)
+    // REV64.T: reverse elements within 64-bit groups (T = 16B, 8H, or 4S)
+    // The 'size' field in the encoding is the element size being reversed.
+    // 'op' selects the group size: 00=REV64, 01=REV32, 10=REV16.
+    ALWAYS_INLINE void rev64(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        // REV64: 01001110_ss_10000_0000_10_Rn_Rd, op=00
+        insn(0b01'001110'00'10000'00000'10'00000'00000 | (sizeForIntegralSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void rev32(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        // REV32: 01101110_ss_10000_0000_10_Rn_Rd, op=01
+        insn(0b01'101110'00'10000'00000'10'00000'00000 | (sizeForIntegralSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void rev16(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
+    {
+        // REV16: 01001110_ss_10000_0001_10_Rn_Rd, op=10
+        // Only valid with i8x16 element size.
+        ASSERT(lane == SIMDLane::i8x16);
+        insn(0b01'001110'00'10000'00001'10'00000'00000 | (sizeForIntegralSIMDOp(lane) << 22) | (vn << 5) | vd);
     }
 
     ALWAYS_INLINE void ext(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, uint8_t firstLane, SIMDLane lane)
@@ -2143,6 +2191,12 @@ public:
     ALWAYS_INLINE void vectorUaddlp(FPRegisterID vd, FPRegisterID vn, SIMDLane lane)
     {
         insn(0b011'01110'00'10000'00'0'10'10'00000'00000 | (sizeForIntegralSIMDOp(lane) << 22) | (vn << 5) | vd);
+    }
+
+    ALWAYS_INLINE void xar(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, uint8_t imm6)
+    {
+        ASSERT(imm6 < 64);
+        insn(0b11001110100'00000'000000'00000'00000 | (static_cast<uint32_t>(vm) << 16) | (static_cast<uint32_t>(imm6) << 10) | (static_cast<uint32_t>(vn) << 5) | static_cast<uint32_t>(vd));
     }
 
     ALWAYS_INLINE void tbl(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm)

--- a/Source/JavaScriptCore/assembler/CPU.cpp
+++ b/Source/JavaScriptCore/assembler/CPU.cpp
@@ -105,11 +105,22 @@ int32_t hwPhysicalCPUMax()
 
 #endif // #if (CPU(X86) || CPU(X86_64)) && OS(DARWIN)
 
-#if CPU(ARM64) && !(CPU(ARM64E) || OS(MAC_OS_X))
+#if CPU(ARM64) && !(CPU(ARM64E) || OS(MACOS))
 bool isARM64_LSE()
 {
 #if ENABLE(ASSEMBLER)
     return MacroAssembler::supportsLSE();
+#else
+    return false;
+#endif
+}
+#endif
+
+#if CPU(ARM64) && !OS(MACOS)
+bool isARM64_SHA3()
+{
+#if ENABLE(ASSEMBLER)
+    return MacroAssembler::supportsSHA3();
 #else
     return false;
 #endif

--- a/Source/JavaScriptCore/assembler/CPU.h
+++ b/Source/JavaScriptCore/assembler/CPU.h
@@ -81,16 +81,24 @@ JS_EXPORT_PRIVATE bool isARM64E_FPAC();
 constexpr bool isARM64E_FPAC() { return false; }
 #endif
 
-#if CPU(ARM64E) || OS(MAC_OS_X)
+#if CPU(ARM64E) || OS(MACOS)
 // ARM64E or all macOS ARM64 CPUs have LSE.
 constexpr bool isARM64_LSE() { return true; }
 #else
 JS_EXPORT_PRIVATE bool isARM64_LSE();
 #endif
 
+#if OS(MACOS)
+// All macOS ARM64 CPUs have SHA3, but ARM64E does not mean SHA3 feature is enabled since A12 chip does not have that.
+constexpr bool isARM64_SHA3() { return true; }
+#else
+JS_EXPORT_PRIVATE bool isARM64_SHA3();
+#endif
+
 #else // not CPU(ARM64)
 constexpr bool isARM64_LSE() { return false; }
 constexpr bool isARM64E_FPAC() { return false; }
+constexpr bool isARM64_SHA3() { return false; }
 #endif
 
 constexpr bool isX86()

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp
@@ -638,6 +638,10 @@ void MacroAssemblerARM64::collectCPUFeatures()
 #define HWCAP_JSCVT (1 << 13)
 #endif
 
+#if !defined(HWCAP_SHA3)
+#define HWCAP_SHA3 (1 << 17)
+#endif
+
 #if !defined(HWCAP2_FRINT)
 #define HWCAP2_FRINT (1 << 8)
 #endif
@@ -646,6 +650,7 @@ void MacroAssemblerARM64::collectCPUFeatures()
         s_jscvtCheckState = (hwcaps & HWCAP_JSCVT) ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
         s_float16CheckState = ((hwcaps & HWCAP_FPHP) && (hwcaps & HWCAP_ASIMDHP)) ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
         s_frintCheckState = (hwcaps2 & HWCAP2_FRINT) ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
+        s_sha3CheckState = (hwcaps & HWCAP_SHA3) ? CPUIDCheckState::Set : CPUIDCheckState::Clear;
     });
 #endif
 
@@ -663,6 +668,7 @@ void MacroAssemblerARM64::collectCPUFeatures()
         s_jscvtCheckState = checkCPU("hw.optional.arm.FEAT_JSCVT");
         s_float16CheckState = checkCPU("hw.optional.arm.FEAT_FP16");
         s_frintCheckState = checkCPU("hw.optional.arm.FEAT_FRINTTS");
+        s_sha3CheckState = checkCPU("hw.optional.arm.FEAT_SHA3");
     });
 #endif
 
@@ -697,12 +703,21 @@ void MacroAssemblerARM64::collectCPUFeatures()
         s_frintCheckState = CPUIDCheckState::Clear;
 #endif
     }
+
+    if (s_sha3CheckState == CPUIDCheckState::NotChecked) {
+#if HAVE(SHA3_INSTRUCTION)
+        s_sha3CheckState = CPUIDCheckState::Set;
+#else
+        s_sha3CheckState = CPUIDCheckState::Clear;
+#endif
+    }
 }
 
 MacroAssemblerARM64::CPUIDCheckState MacroAssemblerARM64::s_lseCheckState = CPUIDCheckState::NotChecked;
 MacroAssemblerARM64::CPUIDCheckState MacroAssemblerARM64::s_jscvtCheckState = CPUIDCheckState::NotChecked;
 MacroAssemblerARM64::CPUIDCheckState MacroAssemblerARM64::s_float16CheckState = CPUIDCheckState::NotChecked;
 MacroAssemblerARM64::CPUIDCheckState MacroAssemblerARM64::s_frintCheckState = CPUIDCheckState::NotChecked;
+MacroAssemblerARM64::CPUIDCheckState MacroAssemblerARM64::s_sha3CheckState = CPUIDCheckState::NotChecked;
 
 } // namespace JSC
 

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -6334,6 +6334,18 @@ public:
 #endif
     }
 
+    ALWAYS_INLINE static bool supportsSHA3()
+    {
+#if HAVE(SHA3_INSTRUCTION)
+        return true;
+#else
+        if (s_sha3CheckState == CPUIDCheckState::NotChecked)
+            collectCPUFeatures();
+
+        return s_sha3CheckState == CPUIDCheckState::Set;
+#endif
+    }
+
     void convertDoubleToInt32UsingJavaScriptSemantics(FPRegisterID src, RegisterID dest)
     {
         m_assembler.fjcvtzs(dest, src); // This zero extends.
@@ -6701,6 +6713,13 @@ public:
         m_assembler.vectorEor(dest, left, right);
     }
 
+    void vectorXorRotateRight64(FPRegisterID a, FPRegisterID b, TrustedImm32 rotate, FPRegisterID dest)
+    {
+        ASSERT(supportsSHA3());
+        ASSERT(rotate.m_value >= 0 && rotate.m_value < 64);
+        m_assembler.xar(dest, a, b, static_cast<uint8_t>(rotate.m_value));
+    }
+
     void moveZeroToVector(FPRegisterID dest)
     {
         m_assembler.movi<128, 8>(dest, 0);
@@ -6869,16 +6888,58 @@ public:
         m_assembler.addv(dest, input, simdInfo.lane);
     }
 
-    void vectorZipUpper(SIMDInfo simdInfo, FPRegisterID n, FPRegisterID m, FPRegisterID dest)
+    void vectorZipLower(SIMDInfo simdInfo, FPRegisterID n, FPRegisterID m, FPRegisterID dest)
     {
         ASSERT(scalarTypeIsIntegral(simdInfo.lane));
         m_assembler.zip1(dest, n, m, simdInfo.lane);
+    }
+
+    void vectorZipHigher(SIMDInfo simdInfo, FPRegisterID n, FPRegisterID m, FPRegisterID dest)
+    {
+        ASSERT(scalarTypeIsIntegral(simdInfo.lane));
+        m_assembler.zip2(dest, n, m, simdInfo.lane);
     }
 
     void vectorUnzipEven(SIMDInfo simdInfo, FPRegisterID n, FPRegisterID m, FPRegisterID dest)
     {
         ASSERT(scalarTypeIsIntegral(simdInfo.lane));
         m_assembler.uzip1(dest, n, m, simdInfo.lane);
+    }
+
+    void vectorUnzipOdd(SIMDInfo simdInfo, FPRegisterID n, FPRegisterID m, FPRegisterID dest)
+    {
+        ASSERT(scalarTypeIsIntegral(simdInfo.lane));
+        m_assembler.uzip2(dest, n, m, simdInfo.lane);
+    }
+
+    void vectorTransposeEven(SIMDInfo simdInfo, FPRegisterID n, FPRegisterID m, FPRegisterID dest)
+    {
+        ASSERT(scalarTypeIsIntegral(simdInfo.lane));
+        m_assembler.trn1(dest, n, m, simdInfo.lane);
+    }
+
+    void vectorTransposeOdd(SIMDInfo simdInfo, FPRegisterID n, FPRegisterID m, FPRegisterID dest)
+    {
+        ASSERT(scalarTypeIsIntegral(simdInfo.lane));
+        m_assembler.trn2(dest, n, m, simdInfo.lane);
+    }
+
+    void vectorReverse(SIMDInfo simdInfo, TrustedImm32 groupSize, FPRegisterID input, FPRegisterID dest)
+    {
+        ASSERT(scalarTypeIsIntegral(simdInfo.lane));
+        switch (groupSize.m_value) {
+        case 2:
+            m_assembler.rev16(dest, input, simdInfo.lane);
+            break;
+        case 4:
+            m_assembler.rev32(dest, input, simdInfo.lane);
+            break;
+        case 8:
+            m_assembler.rev64(dest, input, simdInfo.lane);
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
     }
 
     void reverseBits64(RegisterID src, RegisterID dest)
@@ -8027,6 +8088,7 @@ protected:
     JS_EXPORT_PRIVATE static CPUIDCheckState s_jscvtCheckState;
     JS_EXPORT_PRIVATE static CPUIDCheckState s_float16CheckState;
     JS_EXPORT_PRIVATE static CPUIDCheckState s_frintCheckState;
+    JS_EXPORT_PRIVATE static CPUIDCheckState s_sha3CheckState;
 
     CachedTempRegister m_dataMemoryTempRegister;
     CachedTempRegister m_cachedMemoryTempRegister;

--- a/Source/JavaScriptCore/b3/B3Generate.cpp
+++ b/Source/JavaScriptCore/b3/B3Generate.cpp
@@ -46,6 +46,7 @@
 #include "B3OptimizeAssociativeExpressionTrees.h"
 #include "B3Procedure.h"
 #include "B3ReduceDoubleToFloat.h"
+#include "B3ReduceSIMDShuffle.h"
 #include "B3ReduceStrength.h"
 #include "B3Validate.h"
 #include "CompilerTimingScope.h"
@@ -84,7 +85,9 @@ void generateToAir(Procedure& procedure)
     
     if (procedure.optLevel() >= 2) {
         reduceDoubleToFloat(procedure);
-        reduceStrength(procedure);
+        reduceStrength(procedure, ReduceStrengthPass::Initial);
+        if (isARM64() && procedure.usesSIMD() && Options::useB3ReduceSIMDShuffle())
+            reduceSIMDShuffle(procedure);
         if (Options::useB3HoistLoopInvariantValues())
             hoistLoopInvariantValues(procedure);
         if (eliminateCommonSubexpressions(procedure))
@@ -99,7 +102,7 @@ void generateToAir(Procedure& procedure)
         // https://bugs.webkit.org/show_bug.cgi?id=150507
     } else if (procedure.optLevel() >= 1) {
         // FIXME: Explore better "quick mode" optimizations.
-        reduceStrength(procedure);
+        reduceStrength(procedure, ReduceStrengthPass::Initial);
     }
 
     // This puts the IR in quirks mode.
@@ -107,7 +110,7 @@ void generateToAir(Procedure& procedure)
 
     if (procedure.optLevel() >= 2) {
         optimizeAssociativeExpressionTrees(procedure);
-        reduceStrength(procedure);
+        reduceStrength(procedure, ReduceStrengthPass::Final);
 
         // FIXME: Add more optimizations here.
         // https://bugs.webkit.org/show_bug.cgi?id=150507

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015-2026 Apple Inc. All rights reserved.
- * Copyright (C) 2014 the V8 project authors. All rights reserved.
+ * Copyright (C) 2014-2026 the V8 project authors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -77,6 +77,7 @@
 #include "B3Variable.h"
 #include "B3VariableValue.h"
 #include "B3WasmAddressValue.h"
+#include "SIMDShuffle.h"
 #include <wtf/IndexMap.h>
 #include <wtf/IndexSet.h>
 #include <wtf/StdLibExtras.h>
@@ -5026,12 +5027,154 @@ private:
         case B3::VectorAndnot:
             emitSIMDBinaryOp(Air::VectorAndnot);
             return;
-        case B3::VectorOr:
+        case B3::VectorOr: {
+#if CPU(ARM64)
+            // Try to match XAR (XOR-and-rotate-right) pattern for i64x2.
+            // Pattern: VectorOr(VectorShiftByVector(x, shiftVecL), VectorShiftByVector(x, shiftVecR))
+            // After optimization, the shift vectors are Const128 (splatted byte values).
+            // One is a positive byte (left shift amount), the other is a negative byte (right shift).
+            // When x = VectorXor(a, b), emit XAR(a, b, rotateRight).
+            if (isARM64_SHA3()) {
+                Value* left = m_value->child(0);
+                Value* right = m_value->child(1);
+
+                // Extract the shift amount from a shift vector (Const128 with splatted bytes
+                // or VectorSplat of a Const32).
+                auto extractShiftAmount = [](Value* shiftVec) -> std::optional<int8_t> {
+                    if (shiftVec->opcode() != Const128)
+                        return std::nullopt;
+
+                    auto result = SIMDShuffle::isI8x16SameElement(shiftVec->as<Const128Value>()->value());
+                    if (!result)
+                        return std::nullopt;
+
+                    return static_cast<int8_t>(result.value());
+                };
+
+                auto tryMatchXAR = [&]() -> bool {
+                    // Each child of VectorOr should be either:
+                    // - VectorShiftByVector:i64x2(x, shiftConst) — a general shift
+                    // - VectorAdd:i64x2(x, x) — equivalent to shl-by-1 (from strength reduction)
+                    // We need one left-shift and one right-shift on the same value x,
+                    // with shift amounts summing to 64.
+
+                    struct ShiftInfo {
+                        Value* shiftedValue { nullptr };
+                        int8_t amount { 0 }; // positive = left shift, negative = right shift
+                    };
+
+                    auto extractShift = [&](Value* v) -> std::optional<ShiftInfo> {
+                        if (v->opcode() == B3::VectorShiftByVector) {
+                            SIMDValue* sv = v->as<SIMDValue>();
+                            if (sv->simdLane() != SIMDLane::i64x2)
+                                return std::nullopt;
+                            auto amt = extractShiftAmount(sv->child(1));
+                            if (!amt)
+                                return std::nullopt;
+                            return ShiftInfo { sv->child(0), *amt };
+                        }
+
+                        // We lowered left-shift by 1 to VectorAdd(x, x)
+                        if (v->opcode() == B3::VectorAdd && v->as<SIMDValue>()->simdLane() == SIMDLane::i64x2
+                            && v->child(0) == v->child(1)) {
+                            return ShiftInfo { v->child(0), 1 };
+                        }
+
+                        return std::nullopt;
+                    };
+
+                    auto leftInfo = extractShift(left);
+                    auto rightInfo = extractShift(right);
+                    if (!leftInfo || !rightInfo)
+                        return false;
+
+                    // Both shifts must operate on the same value.
+                    if (leftInfo->shiftedValue != rightInfo->shiftedValue)
+                        return false;
+                    Value* shiftedValue = leftInfo->shiftedValue;
+
+                    int8_t leftAmount = leftInfo->amount;
+                    int8_t rightAmount = rightInfo->amount;
+
+                    // For a rotate-right by n: one shift is positive (64-n), the other is negative (-n).
+                    // Try both orderings since VectorOr is commutative.
+                    int32_t rotateRight = 0;
+                    if (rightAmount < 0 && leftAmount > 0) {
+                        rotateRight = -rightAmount;
+                        if (rotateRight < 1 || rotateRight > 63 || leftAmount != 64 - rotateRight)
+                            return false;
+                    } else if (leftAmount < 0 && rightAmount > 0) {
+                        rotateRight = -leftAmount;
+                        if (rotateRight < 1 || rotateRight > 63 || rightAmount != 64 - rotateRight)
+                            return false;
+                    } else
+                        return false;
+
+                    // Both ops must be foldable (single-use).
+                    if (!canBeInternal(left) || !canBeInternal(right))
+                        return false;
+
+                    // Check if the shifted value is VectorXor(a, b) that we can fold.
+                    // The XOR's use count depends on how the shifts reference it:
+                    // - VectorShiftByVector(xor, ...) adds 1 use
+                    // - VectorAdd(xor, xor) adds 2 uses (both children reference xor)
+                    unsigned expectedXorUses = 0;
+                    expectedXorUses += (left->opcode() == B3::VectorAdd) ? 2 : 1;
+                    expectedXorUses += (right->opcode() == B3::VectorAdd) ? 2 : 1;
+
+                    if (shiftedValue->opcode() == B3::VectorXor
+                        && m_useCounts.numUses(shiftedValue) == expectedXorUses
+                        && !m_valueToTmp[shiftedValue]) {
+                        commitInternal(left);
+                        commitInternal(right);
+                        commitInternal(shiftedValue);
+                        append(Air::VectorXorRotateRight64, tmp(shiftedValue->child(0)), tmp(shiftedValue->child(1)), Arg::imm(rotateRight), tmp(m_value));
+                        return true;
+                    }
+
+                    return false;
+                };
+
+                if (tryMatchXAR())
+                    return;
+            }
+#endif
             emitSIMDBinaryOp(Air::VectorOr);
             return;
+        }
         case B3::VectorXor:
             emitSIMDBinaryOp(Air::VectorXor);
             return;
+        case B3::VectorUnzipEven:
+            emitSIMDBinaryOp(Air::VectorUnzipEven);
+            return;
+        case B3::VectorUnzipOdd:
+            emitSIMDBinaryOp(Air::VectorUnzipOdd);
+            return;
+        case B3::VectorZipLower:
+            emitSIMDBinaryOp(Air::VectorZipLower);
+            return;
+        case B3::VectorZipHigher:
+            emitSIMDBinaryOp(Air::VectorZipHigher);
+            return;
+        case B3::VectorTransposeEven:
+            emitSIMDBinaryOp(Air::VectorTransposeEven);
+            return;
+        case B3::VectorTransposeOdd:
+            emitSIMDBinaryOp(Air::VectorTransposeOdd);
+            return;
+        case B3::VectorReverse: {
+            SIMDValue* value = m_value->as<SIMDValue>();
+            unsigned groupSize = value->immediate();
+            append(Air::VectorReverse, Arg::simdInfo(value->simdInfo()), Arg::imm(groupSize), tmp(value->child(0)), tmp(value));
+            return;
+        }
+        case B3::VectorExtractPair: {
+            SIMDValue* value = m_value->as<SIMDValue>();
+            SIMDInfo info { SIMDLane::i8x16, SIMDSignMode::None };
+            append(Air::VectorExtractPair, Arg::simdInfo(info), Arg::imm(value->immediate()), tmp(value->child(0)), tmp(value->child(1)), tmp(value));
+            return;
+        }
         case B3::VectorNot:
             emitSIMDUnaryOp(Air::VectorNot);
             return;
@@ -5160,25 +5303,27 @@ private:
             }
             emitSIMDMonomorphicBinaryOp(Air::VectorMulSat);
             return;
-        case B3::VectorSwizzle:
-            if (m_value->numChildren() == 2)
+        case B3::VectorSwizzle: {
+            if (m_value->numChildren() == 2) {
                 emitSIMDMonomorphicBinaryOp(Air::VectorSwizzle);
-            else {
-                ASSERT(isARM64());
-                ASSERT(m_value->numChildren() == 3);
-#if CPU(ARM64)
-                // The tbl instruction requires these values to be adjacent.
-                Tmp a(ARM64Registers::q30);
-                Tmp b(ARM64Registers::q31);
-#else
-                Tmp a;
-                Tmp b;
-#endif
-                append(Air::MoveVector, tmp(m_value->child(0)), a);
-                append(Air::MoveVector, tmp(m_value->child(1)), b);
-                append(Air::VectorSwizzle2, a, b, tmp(m_value->child(2)), tmp(m_value));
+                return;
             }
+
+            ASSERT(isARM64());
+            ASSERT(m_value->numChildren() == 3);
+#if CPU(ARM64)
+            // The tbl instruction requires these values to be adjacent.
+            Tmp a(ARM64Registers::q30);
+            Tmp b(ARM64Registers::q31);
+#else
+            Tmp a;
+            Tmp b;
+#endif
+            append(Air::MoveVector, tmp(m_value->child(0)), a);
+            append(Air::MoveVector, tmp(m_value->child(1)), b);
+            append(Air::VectorSwizzle2, a, b, tmp(m_value->child(2)), tmp(m_value));
             return;
+        }
 
         case B3::VectorRelaxedSwizzle:
             emitSIMDMonomorphicBinaryOp(Air::VectorSwizzle);

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -441,6 +441,16 @@ enum Opcode : uint8_t {
     VectorMulSat,
     VectorSwizzle,
 
+    // Canonical shuffle patterns, lowered from VectorSwizzle in strength reduction.
+    VectorUnzipEven,     // UZP1: extract even-indexed elements from two vectors
+    VectorUnzipOdd,      // UZP2: extract odd-indexed elements from two vectors
+    VectorZipLower,      // ZIP1: interleave low halves of two vectors
+    VectorZipHigher,     // ZIP2: interleave high halves of two vectors
+    VectorTransposeEven, // TRN1: transpose even elements of two vectors
+    VectorTransposeOdd,  // TRN2: transpose odd elements of two vectors
+    VectorReverse,       // REV16/REV32/REV64: reverse elements within groups (unary)
+    VectorExtractPair,   // EXT: extract bytes from concatenation of two vectors (binary + imm)
+
     // Relaxed SIMD
 
     VectorRelaxedSwizzle,

--- a/Source/JavaScriptCore/b3/B3ReduceSIMDShuffle.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceSIMDShuffle.cpp
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ * Copyright (C) 2025-2026 the V8 project authors. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "B3ReduceSIMDShuffle.h"
+
+#if ENABLE(B3_JIT)
+
+#include "B3BasicBlock.h"
+#include "B3Const128Value.h"
+#include "B3InsertionSetInlines.h"
+#include "B3PhaseScope.h"
+#include "B3Procedure.h"
+#include "B3SIMDValue.h"
+#include "B3UseCounts.h"
+#include "B3ValueInlines.h"
+#include "SIMDShuffle.h"
+#include <wtf/HashMap.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace JSC::B3 {
+
+namespace {
+
+namespace B3ReduceSIMDShuffleInternal {
+static constexpr bool verbose = false;
+}
+
+class SIMDShuffleReduction {
+public:
+    SIMDShuffleReduction(Procedure& proc)
+        : m_proc(proc)
+        , m_insertionSet(proc)
+    {
+    }
+
+    void run()
+    {
+        composeShuffles();
+    }
+
+private:
+    // Compose shuffle-of-shuffle patterns into a single shuffle.
+    //
+    // We look for a 3-child (binary) VectorSwizzle whose child(0) or child(1) is a
+    // 2-child (unary) VectorSwizzle with a single use. The outer and inner shuffle
+    // patterns are composed into a single pattern, eliminating one shuffle operation.
+    //
+    // Before:
+    //   inner = VectorSwizzle(innerSrc, innerPattern)          ; unary shuffle
+    //   outer = VectorSwizzle(inner, other, outerPattern)      ; binary shuffle using inner's result
+    //   -- or --
+    //   outer = VectorSwizzle(other, inner, outerPattern)      ; binary shuffle with inner on other side
+    //
+    // After composition:
+    //   composed = VectorSwizzle(innerSrc, other, composedPattern)   ; single binary shuffle
+    //   -- or, if all composed indices come from one side --
+    //   composed = VectorSwizzle(src, composedPattern)               ; single unary shuffle
+    //
+    // The composedPattern is computed by chasing each output byte through the outer pattern,
+    // and if it references the inner's output, further chasing through the inner pattern to
+    // find the original source byte.
+    //
+    // Example (from argon2/BLAKE2b):
+    //   inner = VectorSwizzle(b, dupLowPattern)                ; dup low 64-bit element of b
+    //   outer = VectorSwizzle(a, inner, {8..15, 24..31})       ; UZP2.2D: {a[hi64], inner[hi64]}
+    //   Composed: {a[hi64], b[lo64]} — inner[hi64] = dupLow(b)[hi64] = b[lo64]
+    //   Result: VectorSwizzle(a, b, {8..15, 16..23})           ; EXT #8
+    //
+    // This runs iteratively (up to maxIterations) because composing one level may
+    // expose another composition opportunity.
+    void composeShuffles()
+    {
+        UseCountsWithoutUsingInstructions useCounts(m_proc);
+        bool changed = true;
+        unsigned iterations = 0;
+        constexpr unsigned maxIterations = 4;
+
+        while (changed && iterations < maxIterations) {
+            changed = false;
+            ++iterations;
+
+            for (BasicBlock* block : m_proc) {
+                for (unsigned index = 0; index < block->size(); ++index) {
+                    Value* value = block->at(index);
+                    if (value->opcode() != VectorSwizzle)
+                        continue;
+                    if (value->numChildren() != 3)
+                        continue;
+
+                    Value* patternValue = value->child(2);
+                    if (!patternValue->isConstant())
+                        continue;
+
+                    v128_t outerPattern = patternValue->as<Const128Value>()->value();
+
+                    for (unsigned childIdx = 0; childIdx < 2; ++childIdx) {
+                        Value* inner = value->child(childIdx);
+                        // The inner must be a single-use unary VectorSwizzle with a constant pattern.
+                        if (inner->opcode() != VectorSwizzle)
+                            continue;
+                        if (inner->numChildren() != 2)
+                            continue;
+                        if (useCounts.numUses(inner) != 1)
+                            continue;
+                        if (!inner->child(1)->isConstant())
+                            continue;
+
+                        v128_t innerPattern = inner->child(1)->as<Const128Value>()->value();
+                        // Compose: for each output byte, chase through outer → inner patterns
+                        // to find the original source byte index.
+                        v128_t newPattern = SIMDShuffle::composeShuffle(outerPattern, innerPattern, childIdx == 0);
+
+                        // After composition, the new shuffle reads from innerSrc (the inner's
+                        // original input) and other (the outer's other child).
+                        Value* innerSrc = inner->child(0);
+                        Value* other = value->child(1 - childIdx);
+
+                        // Maintain the convention: child(0) = newChild0, child(1) = newChild1.
+                        // If inner was child(0), innerSrc becomes newChild0 and other stays newChild1.
+                        // If inner was child(1), other stays newChild0 and innerSrc becomes newChild1.
+                        Value* newChild0;
+                        Value* newChild1;
+                        if (childIdx == 0) {
+                            newChild0 = innerSrc;
+                            newChild1 = other;
+                        } else {
+                            newChild0 = other;
+                            newChild1 = innerSrc;
+                        }
+
+                        // If all composed indices reference only one side (0..15 or 16..31),
+                        // emit a 2-child unary shuffle instead of a 3-child binary shuffle.
+                        // This enables further optimizations like DUP detection in ReduceStrength.
+                        if (auto side = SIMDShuffle::isOnlyOneSideMask(newPattern)) {
+                            Value* src;
+                            v128_t unaryPattern = newPattern;
+                            if (*side == 0)
+                                src = newChild0;
+                            else {
+                                src = newChild1;
+                                for (unsigned i = 0; i < 16; ++i)
+                                    unaryPattern.u8x16[i] -= 16;
+                            }
+                            Value* newPat = m_proc.addConstant(value->origin(), B3::V128, unaryPattern);
+                            m_insertionSet.insertValue(index, newPat);
+                            Value* newShuffle = m_insertionSet.insert<SIMDValue>(
+                                index, value->origin(), VectorSwizzle, B3::V128,
+                                SIMDLane::i8x16, SIMDSignMode::None, src, newPat);
+                            value->replaceWithIdentity(newShuffle);
+                        } else {
+                            Value* newPat = m_proc.addConstant(value->origin(), B3::V128, newPattern);
+                            m_insertionSet.insertValue(index, newPat);
+                            Value* newShuffle = m_insertionSet.insert<SIMDValue>(
+                                index, value->origin(), VectorSwizzle, B3::V128,
+                                SIMDLane::i8x16, SIMDSignMode::None, newChild0, newChild1, newPat);
+                            value->replaceWithIdentity(newShuffle);
+                        }
+
+                        changed = true;
+                        dataLogLnIf(B3ReduceSIMDShuffleInternal::verbose, "Composed shuffle: ", *value);
+                        break;
+                    }
+                }
+
+                m_insertionSet.execute(block);
+            }
+
+            if (changed)
+                useCounts = UseCountsWithoutUsingInstructions(m_proc);
+        }
+    }
+
+    Procedure& m_proc;
+    InsertionSet m_insertionSet;
+};
+
+} // anonymous namespace
+
+void reduceSIMDShuffle(Procedure& procedure)
+{
+    PhaseScope phaseScope(procedure, "reduceSIMDShuffle"_s);
+
+    SIMDShuffleReduction reduction(procedure);
+    reduction.run();
+}
+
+} // namespace JSC::B3
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3ReduceSIMDShuffle.h
+++ b/Source/JavaScriptCore/b3/B3ReduceSIMDShuffle.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ * Copyright (C) 2025-2026 the V8 project authors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -20,50 +21,23 @@
  * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
  * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
- * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "B3UseCounts.h"
+#pragma once
 
 #if ENABLE(B3_JIT)
 
-#include "B3Procedure.h"
-#include "B3ValueInlines.h"
+namespace JSC::B3 {
 
-namespace JSC { namespace B3 {
+class Procedure;
 
-UseCounts::UseCounts(Procedure& procedure)
-    : m_counts(procedure.values().size())
-{
-    Vector<Value*, 64> children;
-    for (Value* value : procedure.values()) {
-        children.shrink(0);
-        for (Value* child : value->children()) {
-            m_counts[child].numUses++;
-            children.append(child);
-        }
-        std::ranges::sort(children);
-        Value* last = nullptr;
-        for (Value* child : children) {
-            if (child == last)
-                continue;
+// SIMD shuffle-specific optimizations for ARM64:
+// - Shuffle-of-shuffle composition: merges chained shuffles into a single shuffle,
+//   enabling recognition of patterns like EXT (byte extraction).
 
-            m_counts[child].numUsingInstructions++;
-            last = child;
-        }
-    }
-}
+void reduceSIMDShuffle(Procedure&);
 
-UseCountsWithoutUsingInstructions::UseCountsWithoutUsingInstructions(Procedure& procedure)
-    : m_counts(procedure.values().size())
-{
-    for (Value* value : procedure.values()) {
-        for (Value* child : value->children())
-            m_counts[child]++;
-    }
-}
-
-} } // namespace JSC::B3
+} // namespace JSC::B3
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -95,6 +95,45 @@ namespace B3ReduceStrengthInternal {
 static constexpr bool verbose = false;
 }
 
+struct CanonicalShuffleInfo {
+    B3::Opcode opcode;
+    SIMDLane lane;
+    uint8_t groupSize; // For VectorReverse: 2, 4, or 8. 0 otherwise.
+};
+
+static inline std::optional<CanonicalShuffleInfo> canonicalShuffleInfo(CanonicalShuffle canonical)
+{
+    switch (canonical) {
+    case CanonicalShuffle::S64x2UnzipEven: return CanonicalShuffleInfo { VectorUnzipEven, SIMDLane::i64x2, 0 };
+    case CanonicalShuffle::S64x2UnzipOdd: return CanonicalShuffleInfo { VectorUnzipOdd, SIMDLane::i64x2, 0 };
+    case CanonicalShuffle::S32x4UnzipEven: return CanonicalShuffleInfo { VectorUnzipEven, SIMDLane::i32x4, 0 };
+    case CanonicalShuffle::S32x4UnzipOdd: return CanonicalShuffleInfo { VectorUnzipOdd, SIMDLane::i32x4, 0 };
+    case CanonicalShuffle::S32x4ZipLower: return CanonicalShuffleInfo { VectorZipLower, SIMDLane::i32x4, 0 };
+    case CanonicalShuffle::S32x4ZipHigher: return CanonicalShuffleInfo { VectorZipHigher, SIMDLane::i32x4, 0 };
+    case CanonicalShuffle::S32x4TransposeEven: return CanonicalShuffleInfo { VectorTransposeEven, SIMDLane::i32x4, 0 };
+    case CanonicalShuffle::S32x4TransposeOdd: return CanonicalShuffleInfo { VectorTransposeOdd, SIMDLane::i32x4, 0 };
+    case CanonicalShuffle::S32x2Reverse: return CanonicalShuffleInfo { VectorReverse, SIMDLane::i32x4, 8 };
+    case CanonicalShuffle::S16x8UnzipEven: return CanonicalShuffleInfo { VectorUnzipEven, SIMDLane::i16x8, 0 };
+    case CanonicalShuffle::S16x8UnzipOdd: return CanonicalShuffleInfo { VectorUnzipOdd, SIMDLane::i16x8, 0 };
+    case CanonicalShuffle::S16x8ZipLower: return CanonicalShuffleInfo { VectorZipLower, SIMDLane::i16x8, 0 };
+    case CanonicalShuffle::S16x8ZipHigher: return CanonicalShuffleInfo { VectorZipHigher, SIMDLane::i16x8, 0 };
+    case CanonicalShuffle::S16x8TransposeEven: return CanonicalShuffleInfo { VectorTransposeEven, SIMDLane::i16x8, 0 };
+    case CanonicalShuffle::S16x8TransposeOdd: return CanonicalShuffleInfo { VectorTransposeOdd, SIMDLane::i16x8, 0 };
+    case CanonicalShuffle::S16x2Reverse: return CanonicalShuffleInfo { VectorReverse, SIMDLane::i16x8, 4 };
+    case CanonicalShuffle::S16x4Reverse: return CanonicalShuffleInfo { VectorReverse, SIMDLane::i16x8, 8 };
+    case CanonicalShuffle::S8x16UnzipEven: return CanonicalShuffleInfo { VectorUnzipEven, SIMDLane::i8x16, 0 };
+    case CanonicalShuffle::S8x16UnzipOdd: return CanonicalShuffleInfo { VectorUnzipOdd, SIMDLane::i8x16, 0 };
+    case CanonicalShuffle::S8x16ZipLower: return CanonicalShuffleInfo { VectorZipLower, SIMDLane::i8x16, 0 };
+    case CanonicalShuffle::S8x16ZipHigher: return CanonicalShuffleInfo { VectorZipHigher, SIMDLane::i8x16, 0 };
+    case CanonicalShuffle::S8x16TransposeEven: return CanonicalShuffleInfo { VectorTransposeEven, SIMDLane::i8x16, 0 };
+    case CanonicalShuffle::S8x16TransposeOdd: return CanonicalShuffleInfo { VectorTransposeOdd, SIMDLane::i8x16, 0 };
+    case CanonicalShuffle::S8x2Reverse: return CanonicalShuffleInfo { VectorReverse, SIMDLane::i8x16, 2 };
+    case CanonicalShuffle::S8x4Reverse: return CanonicalShuffleInfo { VectorReverse, SIMDLane::i8x16, 4 };
+    case CanonicalShuffle::S8x8Reverse: return CanonicalShuffleInfo { VectorReverse, SIMDLane::i8x16, 8 };
+    default: return std::nullopt;
+    }
+}
+
 // FIXME: This IntRange stuff should be refactored into a general constant propagator. It's weird
 // that it's just sitting here in this file.
 class IntRange {
@@ -484,8 +523,9 @@ private:
 
 class ReduceStrength {
 public:
-    ReduceStrength(Procedure& proc)
+    ReduceStrength(Procedure& proc, ReduceStrengthPass pass)
         : m_proc(proc)
+        , m_pass(pass)
         , m_insertionSet(proc)
         , m_blockInsertionSet(proc)
         , m_root(proc.at(0))
@@ -3382,6 +3422,25 @@ private:
             break;
         }
 
+        case VectorShiftByVector: {
+            // VectorShiftByVector(x, splat(1)) for unsigned left shift → VectorAdd(x, x)
+            // Since x + x = x << 1, this avoids the shift instruction.
+            if constexpr (isARM64()) {
+                SIMDValue* value = m_value->as<SIMDValue>();
+                if (value->signMode() == SIMDSignMode::Unsigned || value->signMode() == SIMDSignMode::None) {
+                    Value* shiftVec = m_value->child(1);
+                    if (shiftVec->opcode() == Const128) {
+                        auto result = SIMDShuffle::isI8x16SameElement(shiftVec->as<Const128Value>()->value());
+                        if (result && result.value() == 1) {
+                            replaceWithNew<SIMDValue>(m_value->origin(), VectorAdd, B3::V128, value->simdLane(), SIMDSignMode::None, m_value->child(0), m_value->child(0));
+                            break;
+                        }
+                    }
+                }
+            }
+            break;
+        }
+
         case VectorSwizzle: {
             if (m_value->numChildren() == 2 && m_value->child(1)->isConstant()) {
                 v128_t pattern = m_value->child(1)->as<Const128Value>()->value();
@@ -3415,6 +3474,36 @@ private:
                         replaceWithNew<SIMDValue>(m_value->origin(), VectorDupElement, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, lane.value(), m_value->child(0));
                         break;
                     }
+
+                    if (m_pass == ReduceStrengthPass::Final) {
+                        // Check if this unary pattern matches a canonical instruction
+                        // (UZP, ZIP, TRN) when treated as both inputs being the same register.
+                        // Reduce to the dedicated B3 opcode.
+                        {
+                            auto canonical = SIMDShuffle::tryMatchUnaryAsBinaryCanonical(pattern);
+                            if (auto info = canonicalShuffleInfo(canonical)) {
+                                auto newOp = info->opcode;
+                                ASSERT(newOp != VectorReverse);
+                                replaceWithNew<SIMDValue>(m_value->origin(), newOp, B3::V128, info->lane, SIMDSignMode::None, m_value->child(0), m_value->child(0));
+                                break;
+                            }
+                        }
+
+                        // Also try unary-specific patterns (REV, EXT).
+                        {
+                            auto canonical = SIMDShuffle::tryMatchCanonicalUnary(pattern);
+                            if (canonical == CanonicalShuffle::S64x2Reverse) {
+                                replaceWithNew<SIMDValue>(m_value->origin(), VectorExtractPair, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, static_cast<uint8_t>(8), m_value->child(0), m_value->child(0));
+                                break;
+                            }
+                            if (auto info = canonicalShuffleInfo(canonical)) {
+                                if (info->opcode == VectorReverse) {
+                                    replaceWithNew<SIMDValue>(m_value->origin(), info->opcode, B3::V128, info->lane, SIMDSignMode::None, info->groupSize, m_value->child(0));
+                                    break;
+                                }
+                            }
+                        }
+                    }
                     break;
                 }
             }
@@ -3422,6 +3511,44 @@ private:
             if constexpr (isARM64()) {
                 if (m_value->numChildren() == 3 && m_value->child(2)->isConstant()) {
                     v128_t pattern = m_value->child(2)->as<Const128Value>()->value();
+                    if (m_pass == ReduceStrengthPass::Final) {
+                        // Try to match binary canonical patterns (UZP, ZIP, TRN).
+                        {
+                            auto canonical = SIMDShuffle::tryMatchCanonicalBinary(pattern);
+                            if (auto info = canonicalShuffleInfo(canonical)) {
+                                auto newOp = info->opcode;
+                                ASSERT(newOp != VectorReverse);
+                                replaceWithNew<SIMDValue>(m_value->origin(), newOp, B3::V128, info->lane, SIMDSignMode::None, m_value->child(0), m_value->child(1));
+                                break;
+                            }
+                        }
+
+                        // Try EXT pattern: contiguous byte extraction from concatenation.
+                        if (auto extInfo = SIMDShuffle::isEXTWithSwap(pattern)) {
+                            if (extInfo->needsSwap)
+                                replaceWithNew<SIMDValue>(m_value->origin(), VectorExtractPair, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, static_cast<uint8_t>(extInfo->offset), m_value->child(1), m_value->child(0));
+                            else
+                                replaceWithNew<SIMDValue>(m_value->origin(), VectorExtractPair, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, static_cast<uint8_t>(extInfo->offset), m_value->child(0), m_value->child(1));
+                            break;
+                        }
+                    }
+
+                    // If both inputs are the same value, normalize all indices to 0-15 range
+                    // and convert to a 2-child (unary) VectorSwizzle.
+                    // e.g. {0,1,2,3,4,5,6,7, 16,17,18,19,20,21,22,23} with child(0)==child(1)
+                    // becomes {0,1,2,3,4,5,6,7, 0,1,2,3,4,5,6,7} which can then be detected as DUP.
+                    if (m_value->child(0) == m_value->child(1)) {
+                        v128_t newPattern = pattern;
+                        for (unsigned i = 0; i < 16; ++i) {
+                            if (newPattern.u8x16[i] >= 16 && newPattern.u8x16[i] < 32)
+                                newPattern.u8x16[i] -= 16;
+                        }
+                        Value* newPatternValue = m_proc.addConstant(m_value->origin(), B3::V128, newPattern);
+                        m_insertionSet.insertValue(m_index, newPatternValue);
+                        replaceWithNew<SIMDValue>(m_value->origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, m_value->child(0), newPatternValue);
+                        break;
+                    }
+
                     if (auto child = SIMDShuffle::isOnlyOneSideMask(pattern)) {
                         switch (child.value()) {
                         case 0: {
@@ -3442,6 +3569,60 @@ private:
                     }
                 }
             }
+            break;
+        }
+
+        case VectorUnzipEven: {
+            ASSERT(isARM64());
+            // Turn this: VectorUnzipEven(i64x2, i64x2)
+            // Into this: VectorDupElement(i64x2, 0)
+            if (tryReduceSameInputShuffleToDup(0))
+                break;
+            break;
+        }
+
+        case VectorUnzipOdd: {
+            ASSERT(isARM64());
+            // Turn this: VectorUnzipOdd(i64x2, i64x2)
+            // Into this: VectorDupElement(i64x2, 1)
+            if (tryReduceSameInputShuffleToDup(1))
+                break;
+            break;
+        }
+
+        case VectorZipLower: {
+            ASSERT(isARM64());
+            // Turn this: VectorZipLower(i64x2, i64x2)
+            // Into this: VectorDupElement(i64x2, 0)
+            if (tryReduceSameInputShuffleToDup(0))
+                break;
+            break;
+        }
+
+        case VectorZipHigher: {
+            ASSERT(isARM64());
+            // Turn this: VectorZipHigher(i64x2, i64x2)
+            // Into this: VectorDupElement(i64x2, 1)
+            if (tryReduceSameInputShuffleToDup(1))
+                break;
+            break;
+        }
+
+        case VectorTransposeEven: {
+            ASSERT(isARM64());
+            // Turn this: VectorTransposeEven(i64x2, i64x2)
+            // Into this: VectorDupElement(i64x2, 0)
+            if (tryReduceSameInputShuffleToDup(0))
+                break;
+            break;
+        }
+
+        case VectorTransposeOdd: {
+            ASSERT(isARM64());
+            // Turn this: VectorTransposeOdd(i64x2, i64x2)
+            // Into this: VectorDupElement(i64x2, 1)
+            if (tryReduceSameInputShuffleToDup(1))
+                break;
             break;
         }
 
@@ -4081,6 +4262,21 @@ private:
         DUMP_INT_RANGE_AND_RETURN(IntRange::top(value->type()));
     }
 
+    bool tryReduceSameInputShuffleToDup(uint8_t dupLane)
+    {
+        ASSERT(isARM64());
+        SIMDValue* value = m_value->as<SIMDValue>();
+
+        if (value->simdInfo().lane != SIMDLane::i64x2)
+            return false;
+
+        if (value->child(0) != value->child(1))
+            return false;
+
+        replaceWithNew<SIMDValue>(m_value->origin(), VectorDupElement, B3::V128, SIMDLane::i64x2, SIMDSignMode::None, dupLane, m_value->child(0));
+        return true;
+    }
+
     template<typename ValueType, typename... Arguments>
     void replaceWithNew(Arguments... arguments)
     {
@@ -4341,6 +4537,7 @@ private:
     }
 
     Procedure& m_proc;
+    ReduceStrengthPass m_pass;
     InsertionSet m_insertionSet;
     BlockInsertionSet m_blockInsertionSet;
     UncheckedKeyHashMap<ValueKey, Value*> m_valueForConstant;
@@ -4356,10 +4553,10 @@ private:
 
 } // anonymous namespace
 
-bool reduceStrength(Procedure& proc)
+bool reduceStrength(Procedure& proc, ReduceStrengthPass pass)
 {
     PhaseScope phaseScope(proc, "reduceStrength"_s);
-    ReduceStrength reduceStrength(proc);
+    ReduceStrength reduceStrength(proc, pass);
     return reduceStrength.run();
 }
 

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.h
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.h
@@ -39,7 +39,12 @@ class Procedure;
 // add sophisticated optimizations to it. For that reason we have full CSE in a different phase, for
 // example.
 
-JS_EXPORT_PRIVATE bool reduceStrength(Procedure&);
+enum class ReduceStrengthPass : uint8_t {
+    Initial,
+    Final,
+};
+
+JS_EXPORT_PRIVATE bool reduceStrength(Procedure&, ReduceStrengthPass = ReduceStrengthPass::Final);
 
 } } // namespace JSC::B3
 

--- a/Source/JavaScriptCore/b3/B3SIMDValue.h
+++ b/Source/JavaScriptCore/b3/B3SIMDValue.h
@@ -97,6 +97,14 @@ public:
         case VectorExtaddPairwise:
         case VectorMulSat:
         case VectorSwizzle:
+        case VectorUnzipEven:
+        case VectorUnzipOdd:
+        case VectorZipLower:
+        case VectorZipHigher:
+        case VectorTransposeEven:
+        case VectorTransposeOdd:
+        case VectorReverse:
+        case VectorExtractPair:
         case VectorMulByElement:
         case VectorShiftByVector:
         case VectorDotProduct:

--- a/Source/JavaScriptCore/b3/B3UseCounts.h
+++ b/Source/JavaScriptCore/b3/B3UseCounts.h
@@ -37,18 +37,28 @@ class Procedure;
 class UseCounts {
 public:
     JS_EXPORT_PRIVATE UseCounts(Procedure&);
-    JS_EXPORT_PRIVATE ~UseCounts();
+    ~UseCounts() = default;
 
     unsigned numUses(Value* value) const { return m_counts[value].numUses; }
     unsigned numUsingInstructions(Value* value) const { return m_counts[value].numUsingInstructions; }
-    
+
 private:
     struct Counts {
         unsigned numUses { 0 };
         unsigned numUsingInstructions { 0 };
     };
-    
+
     IndexMap<Value*, Counts> m_counts;
+};
+
+class UseCountsWithoutUsingInstructions {
+public:
+    UseCountsWithoutUsingInstructions(Procedure&);
+    ~UseCountsWithoutUsingInstructions() = default;
+
+    unsigned numUses(Value* value) const { return m_counts[value]; }
+private:
+    IndexMap<Value*, unsigned> m_counts;
 };
 
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -553,6 +553,37 @@ public:
                 VALIDATE(value->asSIMDValue()->simdLane() == SIMDLane::i8x16, ("At ", *value));
                 break;
 
+            case VectorUnzipEven:
+            case VectorUnzipOdd:
+            case VectorZipLower:
+            case VectorZipHigher:
+            case VectorTransposeEven:
+            case VectorTransposeOdd:
+                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                VALIDATE(value->numChildren() == 2, ("At ", *value));
+                VALIDATE(value->type() == V128, ("At ", *value));
+                VALIDATE(value->child(0)->type() == V128, ("At ", *value));
+                VALIDATE(value->child(1)->type() == V128, ("At ", *value));
+                break;
+
+            case VectorReverse: {
+                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                VALIDATE(value->numChildren() == 1, ("At ", *value));
+                VALIDATE(value->type() == V128, ("At ", *value));
+                VALIDATE(value->child(0)->type() == V128, ("At ", *value));
+                unsigned groupSize = value->as<SIMDValue>()->immediate();
+                VALIDATE(groupSize == 2 || groupSize == 4 || groupSize == 8, ("At ", *value));
+                break;
+            }
+
+            case VectorExtractPair:
+                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
+                VALIDATE(value->numChildren() == 2, ("At ", *value));
+                VALIDATE(value->type() == V128, ("At ", *value));
+                VALIDATE(value->child(0)->type() == V128, ("At ", *value));
+                VALIDATE(value->child(1)->type() == V128, ("At ", *value));
+                break;
+
             case VectorMulByElement:
                 VALIDATE(isARM64(), ("At ", *value));
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -778,6 +778,14 @@ Effects Value::effects() const
     case VectorExtaddPairwise:
     case VectorMulSat:
     case VectorSwizzle:
+    case VectorUnzipEven:
+    case VectorUnzipOdd:
+    case VectorZipLower:
+    case VectorZipHigher:
+    case VectorTransposeEven:
+    case VectorTransposeOdd:
+    case VectorReverse:
+    case VectorExtractPair:
     case VectorMulByElement:
     case VectorShiftByVector:
     case VectorRelaxedSwizzle:
@@ -1051,6 +1059,7 @@ ValueKey Value::key() const
         return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0));
     case VectorExtractLane:
     case VectorDupElement:
+    case VectorReverse:
         numChildrenForKind(kind(), 1);
         return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), as<SIMDValue>()->immediate());
     case VectorEqual:
@@ -1087,10 +1096,17 @@ ValueKey Value::key() const
     case VectorAvgRound:
     case VectorShiftByVector:
     case VectorRelaxedSwizzle:
+    case VectorUnzipEven:
+    case VectorUnzipOdd:
+    case VectorZipLower:
+    case VectorZipHigher:
+    case VectorTransposeEven:
+    case VectorTransposeOdd:
         numChildrenForKind(kind(), 2);
         return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), child(1));
     case VectorReplaceLane:
     case VectorMulByElement:
+    case VectorExtractPair:
         numChildrenForKind(kind(), 2);
         return ValueKey(kind(), type(), as<SIMDValue>()->simdInfo(), child(0), child(1), as<SIMDValue>()->immediate());
     case VectorRelaxedMAdd:

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -480,6 +480,7 @@ protected:
         case VectorAllTrue:
         case VectorExtaddPairwise:
         case VectorDupElement:
+        case VectorReverse:
             return sizeof(Value*);
         case Add:
         case Sub:
@@ -558,6 +559,13 @@ protected:
         case VectorMulByElement:
         case VectorShiftByVector:
         case VectorRelaxedSwizzle:
+        case VectorUnzipEven:
+        case VectorUnzipOdd:
+        case VectorZipLower:
+        case VectorZipHigher:
+        case VectorTransposeEven:
+        case VectorTransposeOdd:
+        case VectorExtractPair:
         case Stitch:
             return 2 * sizeof(Value*);
         case Select:
@@ -728,6 +736,7 @@ private:
         case VectorAllTrue:
         case VectorExtaddPairwise:
         case VectorDupElement:
+        case VectorReverse:
         case VectorRelaxedTruncSat:
             if (numArgs != 1) [[unlikely]]
                 badKind(kind, numArgs);
@@ -798,6 +807,13 @@ private:
         case VectorMulByElement:
         case VectorShiftByVector:
         case VectorRelaxedSwizzle:
+        case VectorUnzipEven:
+        case VectorUnzipOdd:
+        case VectorZipLower:
+        case VectorZipHigher:
+        case VectorTransposeEven:
+        case VectorTransposeOdd:
+        case VectorExtractPair:
         case Stitch:
             if (numArgs != 2) [[unlikely]]
                 badKind(kind, numArgs);

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -256,6 +256,14 @@ namespace JSC { namespace B3 {
     case VectorExtaddPairwise: \
     case VectorMulSat: \
     case VectorSwizzle: \
+    case VectorUnzipEven: \
+    case VectorUnzipOdd: \
+    case VectorZipLower: \
+    case VectorZipHigher: \
+    case VectorTransposeEven: \
+    case VectorTransposeOdd: \
+    case VectorReverse: \
+    case VectorExtractPair: \
     case VectorRelaxedSwizzle: \
     case VectorMulByElement: \
     case VectorShiftByVector: \

--- a/Source/JavaScriptCore/b3/B3ValueKey.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueKey.cpp
@@ -164,6 +164,7 @@ Value* ValueKey::materialize(Procedure& proc, Origin origin) const
         return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), child(proc, 0));
     case VectorExtractLane:
     case VectorDupElement:
+    case VectorReverse:
         return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), static_cast<uint8_t>(u.indices[1]), child(proc, 0));
     case VectorEqual:
     case VectorNotEqual:
@@ -198,10 +199,17 @@ Value* ValueKey::materialize(Procedure& proc, Origin origin) const
     case VectorMulSat:
     case VectorAvgRound:
     case VectorShiftByVector:
+    case VectorUnzipEven:
+    case VectorUnzipOdd:
+    case VectorZipLower:
+    case VectorZipHigher:
+    case VectorTransposeEven:
+    case VectorTransposeOdd:
     case VectorRelaxedSwizzle:
         return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), child(proc, 0), child(proc, 1));
     case VectorReplaceLane:
     case VectorMulByElement:
+    case VectorExtractPair:
         return proc.add<SIMDValue>(origin, kind(), type(), simdInfo(), static_cast<uint8_t>(u.indices[2]), child(proc, 0), child(proc, 1));
     case VectorRelaxedMAdd:
     case VectorRelaxedNMAdd:

--- a/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/air/AirLowerMacros.cpp
@@ -415,7 +415,7 @@ void lowerMacros(Code& code)
                 if (simdInfo.lane == SIMDLane::i8x16) {
                     Tmp maskedHi = code.newTmp(FP);
                     insertionSet.insert(instIndex, VectorExtractPair, origin, Arg::simdInfo({ SIMDLane::i8x16, SIMDSignMode::None }), Arg::imm(8), vectorTmp, vectorTmp, maskedHi);
-                    insertionSet.insert(instIndex, VectorZipUpper, origin, Arg::simdInfo({ SIMDLane::i8x16, SIMDSignMode::None }), vectorTmp, maskedHi, vectorTmp);
+                    insertionSet.insert(instIndex, VectorZipLower, origin, Arg::simdInfo({ SIMDLane::i8x16, SIMDSignMode::None }), vectorTmp, maskedHi, vectorTmp);
                     simdInfo.lane = SIMDLane::i16x8;
                 }
                 insertionSet.insert(instIndex, VectorHorizontalAdd, origin, Arg::simdInfo(simdInfo), vectorTmp, vectorTmp);

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -2007,14 +2007,32 @@ x86_64: VectorUshr8 U:G:Ptr, U:F:128, U:G:8, D:F:128
 arm64: VectorHorizontalAdd U:G:Ptr, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp
 
-arm64: VectorZipUpper U:G:Ptr, U:F:128, U:F:128, D:F:128
+arm64: VectorZipLower U:G:Ptr, U:F:128, U:F:128, D:F:128
+    SIMDInfo, Tmp, Tmp, Tmp
+
+arm64: VectorZipHigher U:G:Ptr, U:F:128, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp, Tmp
 
 arm64: VectorUnzipEven U:G:Ptr, U:F:128, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp, Tmp
 
+arm64: VectorUnzipOdd U:G:Ptr, U:F:128, U:F:128, D:F:128
+    SIMDInfo, Tmp, Tmp, Tmp
+
+arm64: VectorTransposeEven U:G:Ptr, U:F:128, U:F:128, D:F:128
+    SIMDInfo, Tmp, Tmp, Tmp
+
+arm64: VectorTransposeOdd U:G:Ptr, U:F:128, U:F:128, D:F:128
+    SIMDInfo, Tmp, Tmp, Tmp
+
+arm64: VectorReverse U:G:Ptr, U:G:8, U:F:128, D:F:128
+    SIMDInfo, Imm, Tmp, Tmp
+
 arm64: VectorExtractPair U:G:Ptr, U:G:8, U:F:128, U:F:128, D:F:128
     SIMDInfo, Imm, Tmp, Tmp, Tmp
+
+arm64_sha3: VectorXorRotateRight64 U:F:128, U:F:128, U:G:8, D:F:128
+    Tmp, Tmp, Imm, Tmp
 
 64: VectorAbs U:G:Ptr, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp

--- a/Source/JavaScriptCore/b3/air/opcode_generator.rb
+++ b/Source/JavaScriptCore/b3/air/opcode_generator.rb
@@ -233,7 +233,7 @@ def isKind(token)
 end
 
 def isArch(token)
-    token =~ /\A((x86)|(x86_32)|(x86_64_avx)|(x86_64)|(arm)|(armv7)|(arm64e)|(arm64_lse)|(arm64)|(32)|(64))\Z/
+    token =~ /\A((x86)|(x86_32)|(x86_64_avx)|(x86_64)|(arm)|(armv7)|(arm64e)|(arm64_lse)|(arm64_sha3)|(arm64)|(32)|(64))\Z/
 end
 
 def isWidth(token)
@@ -341,6 +341,8 @@ class Parser
                 result << "ARM64E"
             when "arm64_lse"
                 result << "ARM64_LSE"
+            when "arm64_sha3"
+                result << "ARM64_SHA3"
             when "32"
                 result << "X86"
                 result << "ARM_THUMB2"
@@ -689,6 +691,7 @@ end
 
 $runTimeArchs = {
     "ARM64_LSE" => "ARM64",
+    "ARM64_SHA3" => "ARM64",
     "X86_64_AVX" => "X86_64"
 }
 def beginArchs(outp, archs)

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1501,4 +1501,31 @@ void testFCCmpGreaterEqualOrDouble(double, double, double, double);
 void testFCCmpNaN(double, double, double, double);
 void testFCCmpNegatedAndDouble(double, double, double, double);
 
+// SIMD XOR+rotate pattern matching
+void testVectorXorRotateRight64();
+
+// SIMD VectorUnzip/Zip/Transpose/Reverse B3 opcodes
+void testVectorUnzipEven();
+void testVectorUnzipOdd();
+void testVectorZipLower();
+void testVectorZipHigher();
+void testVectorTransposeEven();
+void testVectorTransposeOdd();
+void testVectorReverse();
+
+// SIMD strength reduction: shift-by-1 → add
+void testVectorShiftByVectorShlByOne();
+
+// SIMD shuffle → canonical instruction strength reduction
+void testVectorSwizzleToUnzipEven();
+void testVectorSwizzleBinaryToUnzipOdd();
+void testVectorSwizzleBinaryCanonical();
+void testVectorSwizzleUnaryCanonical();
+void testVectorExtractPair();
+void testVectorSwizzleBinaryToEXT();
+void testVectorSwizzleUnaryToEXT();
+void testVectorCanonicalSameInputFolding();
+void testVectorSwizzleToDupElement();
+void testVectorSwizzleComposition();
+
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1142,6 +1142,25 @@ void run(const TestConfig* config)
         if (isARM64()) {
             RUN(testVectorFmulByElementFloat());
             RUN(testVectorFmulByElementDouble());
+            RUN(testVectorXorRotateRight64());
+            RUN(testVectorUnzipEven());
+            RUN(testVectorUnzipOdd());
+            RUN(testVectorZipLower());
+            RUN(testVectorZipHigher());
+            RUN(testVectorTransposeEven());
+            RUN(testVectorTransposeOdd());
+            RUN(testVectorReverse());
+            RUN(testVectorShiftByVectorShlByOne());
+            RUN(testVectorSwizzleToUnzipEven());
+            RUN(testVectorSwizzleBinaryToUnzipOdd());
+            RUN(testVectorSwizzleBinaryCanonical());
+            RUN(testVectorSwizzleUnaryCanonical());
+            RUN(testVectorExtractPair());
+            RUN(testVectorSwizzleBinaryToEXT());
+            RUN(testVectorSwizzleUnaryToEXT());
+            RUN(testVectorCanonicalSameInputFolding());
+            RUN(testVectorSwizzleToDupElement());
+            RUN(testVectorSwizzleComposition());
         }
         RUN(testMulHigh32());
         RUN(testMulHigh64());

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -3161,6 +3161,1055 @@ void testTruncSShrAddUnalignedConstant()
     CHECK_EQ(invoke<int32_t>(*code, static_cast<int64_t>(-2048)), static_cast<int32_t>((-2048LL + constant) >> 12));
 }
 
+// Test XOR-and-rotate-right pattern matching for XAR instruction (SHA3).
+// Pattern: VectorOr(VectorShiftByVector(VectorXor(a, b), shlAmount), VectorShiftByVector(VectorXor(a, b), shrAmount))
+// Should be folded into a single XAR instruction on ARM64 with SHA3 support.
+void testVectorXorRotateRight64()
+{
+    if constexpr (!isARM64())
+        return;
+    if (!isARM64_SHA3())
+        return;
+
+    // Test various rotation amounts used in BLAKE2b: 32, 24, 16, 63
+    for (int32_t rotateRight : { 1, 16, 24, 32, 63 }) {
+        int32_t shiftLeft = 64 - rotateRight;
+
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+        auto arguments = cCallArgumentValues<void*>(proc, root);
+
+        Value* address = arguments[0];
+
+        // Load two vectors
+        Value* a = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+        Value* b = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
+
+        // XOR
+        Value* xorResult = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, a, b);
+
+        // Shift left
+        Value* shlAmount = root->appendNew<Const32Value>(proc, Origin(), shiftLeft);
+        Value* shlResult = root->appendNew<SIMDValue>(proc, Origin(), VectorShl, B3::V128, SIMDLane::i64x2, SIMDSignMode::Unsigned, xorResult, shlAmount);
+
+        // Shift right
+        Value* shrAmount = root->appendNew<Const32Value>(proc, Origin(), rotateRight);
+        Value* shrResult = root->appendNew<SIMDValue>(proc, Origin(), VectorShr, B3::V128, SIMDLane::i64x2, SIMDSignMode::Unsigned, xorResult, shrAmount);
+
+        // OR = rotate
+        Value* orResult = root->appendNew<SIMDValue>(proc, Origin(), VectorOr, B3::V128, SIMDLane::v128, SIMDSignMode::None, shlResult, shrResult);
+
+        root->appendNew<MemoryValue>(proc, Store, Origin(), orResult, address, static_cast<int32_t>(2 * sizeof(v128_t)));
+        root->appendNewControlValue(proc, Return, Origin());
+
+        auto code = compileProc(proc);
+
+        // Test with known values
+        alignas(16) v128_t vectors[3];
+        vectors[0].u64x2[0] = 0x0123456789ABCDEFULL;
+        vectors[0].u64x2[1] = 0xFEDCBA9876543210ULL;
+        vectors[1].u64x2[0] = 0xFF00FF00FF00FF00ULL;
+        vectors[1].u64x2[1] = 0x00FF00FF00FF00FFULL;
+
+        invoke<void>(*code, vectors);
+
+        // Compute expected: (a XOR b) >>> rotateRight
+        uint64_t xor0 = vectors[0].u64x2[0] ^ vectors[1].u64x2[0];
+        uint64_t xor1 = vectors[0].u64x2[1] ^ vectors[1].u64x2[1];
+        uint64_t expected0 = (xor0 >> rotateRight) | (xor0 << (64 - rotateRight));
+        uint64_t expected1 = (xor1 >> rotateRight) | (xor1 << (64 - rotateRight));
+
+        CHECK(vectors[2].u64x2[0] == expected0);
+        CHECK(vectors[2].u64x2[1] == expected1);
+    }
+}
+
+// Test VectorUnzipEven/Odd B3 opcodes (reduced from VectorSwizzle in ReduceStrength).
+void testVectorUnzipEven()
+{
+    // UZP1.4S(a, b): extract even 32-bit elements = {a[0], a[2], b[0], b[2]}
+    alignas(16) v128_t vectors[3];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* a = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* b = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorUnzipEven, B3::V128, SIMDLane::i32x4, SIMDSignMode::None, a, b);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(2 * sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+    vectors[0].u32x4[0] = 0x11; vectors[0].u32x4[1] = 0x22; vectors[0].u32x4[2] = 0x33; vectors[0].u32x4[3] = 0x44;
+    vectors[1].u32x4[0] = 0x55; vectors[1].u32x4[1] = 0x66; vectors[1].u32x4[2] = 0x77; vectors[1].u32x4[3] = 0x88;
+    invoke<void>(*code, vectors);
+    // {a[0], a[2], b[0], b[2]}
+    CHECK(vectors[2].u32x4[0] == 0x11);
+    CHECK(vectors[2].u32x4[1] == 0x33);
+    CHECK(vectors[2].u32x4[2] == 0x55);
+    CHECK(vectors[2].u32x4[3] == 0x77);
+}
+
+void testVectorUnzipOdd()
+{
+    // UZP2.4S(a, b): extract odd 32-bit elements = {a[1], a[3], b[1], b[3]}
+    alignas(16) v128_t vectors[3];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* a = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* b = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorUnzipOdd, B3::V128, SIMDLane::i32x4, SIMDSignMode::None, a, b);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(2 * sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+    vectors[0].u32x4[0] = 0x11; vectors[0].u32x4[1] = 0x22; vectors[0].u32x4[2] = 0x33; vectors[0].u32x4[3] = 0x44;
+    vectors[1].u32x4[0] = 0x55; vectors[1].u32x4[1] = 0x66; vectors[1].u32x4[2] = 0x77; vectors[1].u32x4[3] = 0x88;
+    invoke<void>(*code, vectors);
+    // {a[1], a[3], b[1], b[3]}
+    CHECK(vectors[2].u32x4[0] == 0x22);
+    CHECK(vectors[2].u32x4[1] == 0x44);
+    CHECK(vectors[2].u32x4[2] == 0x66);
+    CHECK(vectors[2].u32x4[3] == 0x88);
+}
+
+void testVectorZipLower()
+{
+    // ZIP1.4S(a, b): interleave low halves = {a[0], b[0], a[1], b[1]}
+    alignas(16) v128_t vectors[3];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* a = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* b = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorZipLower, B3::V128, SIMDLane::i32x4, SIMDSignMode::None, a, b);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(2 * sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+    vectors[0].u32x4[0] = 0x11; vectors[0].u32x4[1] = 0x22; vectors[0].u32x4[2] = 0x33; vectors[0].u32x4[3] = 0x44;
+    vectors[1].u32x4[0] = 0x55; vectors[1].u32x4[1] = 0x66; vectors[1].u32x4[2] = 0x77; vectors[1].u32x4[3] = 0x88;
+    invoke<void>(*code, vectors);
+    // {a[0], b[0], a[1], b[1]}
+    CHECK(vectors[2].u32x4[0] == 0x11);
+    CHECK(vectors[2].u32x4[1] == 0x55);
+    CHECK(vectors[2].u32x4[2] == 0x22);
+    CHECK(vectors[2].u32x4[3] == 0x66);
+}
+
+void testVectorZipHigher()
+{
+    // ZIP2.4S(a, b): interleave high halves = {a[2], b[2], a[3], b[3]}
+    alignas(16) v128_t vectors[3];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* a = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* b = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorZipHigher, B3::V128, SIMDLane::i32x4, SIMDSignMode::None, a, b);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(2 * sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+    vectors[0].u32x4[0] = 0x11; vectors[0].u32x4[1] = 0x22; vectors[0].u32x4[2] = 0x33; vectors[0].u32x4[3] = 0x44;
+    vectors[1].u32x4[0] = 0x55; vectors[1].u32x4[1] = 0x66; vectors[1].u32x4[2] = 0x77; vectors[1].u32x4[3] = 0x88;
+    invoke<void>(*code, vectors);
+    // {a[2], b[2], a[3], b[3]}
+    CHECK(vectors[2].u32x4[0] == 0x33);
+    CHECK(vectors[2].u32x4[1] == 0x77);
+    CHECK(vectors[2].u32x4[2] == 0x44);
+    CHECK(vectors[2].u32x4[3] == 0x88);
+}
+
+void testVectorTransposeEven()
+{
+    // TRN1.4S(a, b): {a[0], b[0], a[2], b[2]}
+    alignas(16) v128_t vectors[3];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* a = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* b = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorTransposeEven, B3::V128, SIMDLane::i32x4, SIMDSignMode::None, a, b);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(2 * sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+    vectors[0].u32x4[0] = 0x11; vectors[0].u32x4[1] = 0x22; vectors[0].u32x4[2] = 0x33; vectors[0].u32x4[3] = 0x44;
+    vectors[1].u32x4[0] = 0x55; vectors[1].u32x4[1] = 0x66; vectors[1].u32x4[2] = 0x77; vectors[1].u32x4[3] = 0x88;
+    invoke<void>(*code, vectors);
+    CHECK(vectors[2].u32x4[0] == 0x11);
+    CHECK(vectors[2].u32x4[1] == 0x55);
+    CHECK(vectors[2].u32x4[2] == 0x33);
+    CHECK(vectors[2].u32x4[3] == 0x77);
+}
+
+void testVectorTransposeOdd()
+{
+    // TRN2.4S(a, b): {a[1], b[1], a[3], b[3]}
+    alignas(16) v128_t vectors[3];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* a = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* b = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorTransposeOdd, B3::V128, SIMDLane::i32x4, SIMDSignMode::None, a, b);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(2 * sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+    vectors[0].u32x4[0] = 0x11; vectors[0].u32x4[1] = 0x22; vectors[0].u32x4[2] = 0x33; vectors[0].u32x4[3] = 0x44;
+    vectors[1].u32x4[0] = 0x55; vectors[1].u32x4[1] = 0x66; vectors[1].u32x4[2] = 0x77; vectors[1].u32x4[3] = 0x88;
+    invoke<void>(*code, vectors);
+    CHECK(vectors[2].u32x4[0] == 0x22);
+    CHECK(vectors[2].u32x4[1] == 0x66);
+    CHECK(vectors[2].u32x4[2] == 0x44);
+    CHECK(vectors[2].u32x4[3] == 0x88);
+}
+
+void testVectorReverse()
+{
+    if constexpr (!isARM64())
+        return;
+
+    // REV64.4S: reverse pairs of 32-bit elements within 64-bit lanes
+    // {v[1], v[0], v[3], v[2]}
+    alignas(16) v128_t vectors[2];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorReverse, B3::V128, SIMDLane::i32x4, SIMDSignMode::None, static_cast<uint8_t>(8), input);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+    vectors[0].u32x4[0] = 0xAA; vectors[0].u32x4[1] = 0xBB; vectors[0].u32x4[2] = 0xCC; vectors[0].u32x4[3] = 0xDD;
+    invoke<void>(*code, vectors);
+    CHECK(vectors[1].u32x4[0] == 0xBB);
+    CHECK(vectors[1].u32x4[1] == 0xAA);
+    CHECK(vectors[1].u32x4[2] == 0xDD);
+    CHECK(vectors[1].u32x4[3] == 0xCC);
+}
+
+// Test that VectorShiftByVector(x, splat(1)) is strength-reduced to VectorAdd(x, x).
+void testVectorShiftByVectorShlByOne()
+{
+    alignas(16) v128_t vectors[2];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+
+    // Build VectorShl(input, 1) — will become VectorShiftByVector after LowerMacros,
+    // then VectorAdd(input, input) after ReduceStrength.
+    Value* shiftAmount = root->appendNew<Const32Value>(proc, Origin(), 1);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorShl, B3::V128, SIMDLane::i64x2, SIMDSignMode::Unsigned, input, shiftAmount);
+
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    vectors[0].u64x2[0] = 0x0123456789ABCDEFULL;
+    vectors[0].u64x2[1] = 0x8000000000000001ULL;
+    invoke<void>(*code, vectors);
+    CHECK(vectors[1].u64x2[0] == (0x0123456789ABCDEFULL << 1));
+    CHECK(vectors[1].u64x2[1] == (0x8000000000000001ULL << 1));
+
+    // Test with max value (overflow wraps)
+    vectors[0].u64x2[0] = UINT64_MAX;
+    vectors[0].u64x2[1] = 1;
+    invoke<void>(*code, vectors);
+    CHECK(vectors[1].u64x2[0] == (UINT64_MAX << 1));
+    CHECK(vectors[1].u64x2[1] == 2);
+}
+
+// Helper: build a 3-child (binary) VectorSwizzle with the given byte pattern, verify result.
+static void testBinarySwizzlePattern(const char*, const uint8_t pattern[16], v128_t inputA, v128_t inputB, v128_t expected)
+{
+    if constexpr (!isARM64())
+        return;
+
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* a = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* b = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
+
+    v128_t pat;
+    for (unsigned i = 0; i < 16; ++i)
+        pat.u8x16[i] = pattern[i];
+    Value* patternConst = root->appendNew<Const128Value>(proc, Origin(), pat);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, a, b, patternConst);
+
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(2 * sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    alignas(16) v128_t vectors[3];
+    vectors[0] = inputA;
+    vectors[1] = inputB;
+    invoke<void>(*code, vectors);
+    CHECK(bitEquals(vectors[2], expected));
+}
+
+// Helper: build a 2-child (unary) VectorSwizzle with the given byte pattern, verify result.
+static void testUnarySwizzlePattern(const char*, const uint8_t pattern[16], v128_t input, v128_t expected)
+{
+    if constexpr (!isARM64())
+        return;
+
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* inputVal = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+
+    v128_t pat;
+    for (unsigned i = 0; i < 16; ++i)
+        pat.u8x16[i] = pattern[i];
+    Value* patternConst = root->appendNew<Const128Value>(proc, Origin(), pat);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, inputVal, patternConst);
+
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    alignas(16) v128_t vectors[2];
+    vectors[0] = input;
+    invoke<void>(*code, vectors);
+    CHECK(bitEquals(vectors[1], expected));
+}
+
+// Test strength reduction of unary shuffle → VectorUnzipEven through VectorSwizzle.
+// Pattern: VectorSwizzle(v, {0,1,2,3,8,9,10,11, 0,1,2,3,8,9,10,11}) → VectorUnzipEven(v, v)
+void testVectorSwizzleToUnzipEven()
+{
+    if constexpr (!isARM64())
+        return;
+
+    alignas(16) v128_t vectors[2];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+
+    // UZP1.4S pattern as unary shuffle: extract even 32-bit elements, duplicated
+    v128_t pattern;
+    pattern.u8x16[0] = 0; pattern.u8x16[1] = 1; pattern.u8x16[2] = 2; pattern.u8x16[3] = 3;
+    pattern.u8x16[4] = 8; pattern.u8x16[5] = 9; pattern.u8x16[6] = 10; pattern.u8x16[7] = 11;
+    pattern.u8x16[8] = 0; pattern.u8x16[9] = 1; pattern.u8x16[10] = 2; pattern.u8x16[11] = 3;
+    pattern.u8x16[12] = 8; pattern.u8x16[13] = 9; pattern.u8x16[14] = 10; pattern.u8x16[15] = 11;
+    Value* patternConst = root->appendNew<Const128Value>(proc, Origin(), pattern);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, input, patternConst);
+
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    vectors[0].u32x4[0] = 0xAA; vectors[0].u32x4[1] = 0xBB; vectors[0].u32x4[2] = 0xCC; vectors[0].u32x4[3] = 0xDD;
+    invoke<void>(*code, vectors);
+    // UZP1.4S(v, v) = {v[0], v[2], v[0], v[2]}
+    CHECK(vectors[1].u32x4[0] == 0xAA);
+    CHECK(vectors[1].u32x4[1] == 0xCC);
+    CHECK(vectors[1].u32x4[2] == 0xAA);
+    CHECK(vectors[1].u32x4[3] == 0xCC);
+}
+
+// Test strength reduction of binary shuffle → VectorUnzipOdd through 3-child VectorSwizzle.
+// Pattern: VectorSwizzle(a, b, {8..15, 24..31}) → VectorUnzipOdd.2D (UZP2)
+void testVectorSwizzleBinaryToUnzipOdd()
+{
+    if constexpr (!isARM64())
+        return;
+
+    alignas(16) v128_t vectors[3];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* a = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* b = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
+
+    // UZP2.2D pattern: {a[hi64], b[hi64]}
+    v128_t pattern;
+    for (unsigned i = 0; i < 8; ++i) pattern.u8x16[i] = 8 + i;
+    for (unsigned i = 0; i < 8; ++i) pattern.u8x16[8 + i] = 24 + i;
+    Value* patternConst = root->appendNew<Const128Value>(proc, Origin(), pattern);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, a, b, patternConst);
+
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(2 * sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    vectors[0].u64x2[0] = 0x1111111111111111ULL;
+    vectors[0].u64x2[1] = 0x2222222222222222ULL;
+    vectors[1].u64x2[0] = 0x3333333333333333ULL;
+    vectors[1].u64x2[1] = 0x4444444444444444ULL;
+    invoke<void>(*code, vectors);
+    // {a[hi64], b[hi64]}
+    CHECK(vectors[2].u64x2[0] == 0x2222222222222222ULL);
+    CHECK(vectors[2].u64x2[1] == 0x4444444444444444ULL);
+}
+
+// Test VectorExtractPair B3 opcode directly.
+void testVectorExtractPair()
+{
+    if constexpr (!isARM64())
+        return;
+
+    // EXT #4: extract 4 bytes from concatenation
+    {
+        alignas(16) v128_t vectors[3];
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+        auto arguments = cCallArgumentValues<void*>(proc, root);
+        Value* address = arguments[0];
+        Value* a = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+        Value* b = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
+        Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorExtractPair, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, static_cast<uint8_t>(4), a, b);
+        root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(2 * sizeof(v128_t)));
+        root->appendNewControlValue(proc, Return, Origin());
+
+        auto code = compileProc(proc);
+        for (unsigned i = 0; i < 16; ++i) vectors[0].u8x16[i] = i;
+        for (unsigned i = 0; i < 16; ++i) vectors[1].u8x16[i] = 16 + i;
+        invoke<void>(*code, vectors);
+        // EXT #4: {a[4..15], b[0..3]}
+        for (unsigned i = 0; i < 12; ++i)
+            CHECK(vectors[2].u8x16[i] == 4 + i);
+        for (unsigned i = 0; i < 4; ++i)
+            CHECK(vectors[2].u8x16[12 + i] == 16 + i);
+    }
+
+    // EXT #8: extract 8 bytes (common S64x2 swap-halves pattern)
+    {
+        alignas(16) v128_t vectors[3];
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+        auto arguments = cCallArgumentValues<void*>(proc, root);
+        Value* address = arguments[0];
+        Value* a = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+        Value* b = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
+        Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorExtractPair, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, static_cast<uint8_t>(8), a, b);
+        root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(2 * sizeof(v128_t)));
+        root->appendNewControlValue(proc, Return, Origin());
+
+        auto code = compileProc(proc);
+        for (unsigned i = 0; i < 16; ++i) vectors[0].u8x16[i] = i;
+        for (unsigned i = 0; i < 16; ++i) vectors[1].u8x16[i] = 16 + i;
+        invoke<void>(*code, vectors);
+        // EXT #8: {a[8..15], b[0..7]}
+        for (unsigned i = 0; i < 8; ++i)
+            CHECK(vectors[2].u8x16[i] == 8 + i);
+        for (unsigned i = 0; i < 8; ++i)
+            CHECK(vectors[2].u8x16[8 + i] == 16 + i);
+    }
+}
+
+// Test strength reduction of binary shuffle → VectorExtractPair through VectorSwizzle.
+void testVectorSwizzleBinaryToEXT()
+{
+    if constexpr (!isARM64())
+        return;
+
+    v128_t a, b;
+    for (unsigned i = 0; i < 16; ++i) a.u8x16[i] = i;
+    for (unsigned i = 0; i < 16; ++i) b.u8x16[i] = 16 + i;
+
+    // EXT #4: {a[4..15], b[0..3]} = byte indices {4,5,...,15, 16,17,18,19}
+    {
+        const uint8_t pat[] = { 4,5,6,7, 8,9,10,11, 12,13,14,15, 16,17,18,19 };
+        v128_t exp;
+        for (unsigned i = 0; i < 12; ++i) exp.u8x16[i] = 4 + i;
+        for (unsigned i = 0; i < 4; ++i) exp.u8x16[12 + i] = 16 + i;
+        testBinarySwizzlePattern("EXT #4", pat, a, b, exp);
+    }
+
+    // EXT #8: {a[8..15], b[0..7]}
+    {
+        const uint8_t pat[] = { 8,9,10,11,12,13,14,15, 16,17,18,19,20,21,22,23 };
+        v128_t exp;
+        for (unsigned i = 0; i < 8; ++i) exp.u8x16[i] = 8 + i;
+        for (unsigned i = 0; i < 8; ++i) exp.u8x16[8 + i] = 16 + i;
+        testBinarySwizzlePattern("EXT #8", pat, a, b, exp);
+    }
+
+    // EXT #1: {a[1..15], b[0]}
+    {
+        const uint8_t pat[] = { 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15, 16 };
+        v128_t exp;
+        for (unsigned i = 0; i < 15; ++i) exp.u8x16[i] = 1 + i;
+        exp.u8x16[15] = 16;
+        testBinarySwizzlePattern("EXT #1", pat, a, b, exp);
+    }
+
+    // EXT #15: {a[15], b[0..14]}
+    {
+        const uint8_t pat[] = { 15, 16,17,18,19,20,21,22,23,24,25,26,27,28,29,30 };
+        v128_t exp;
+        exp.u8x16[0] = 15;
+        for (unsigned i = 0; i < 15; ++i) exp.u8x16[1 + i] = 16 + i;
+        testBinarySwizzlePattern("EXT #15", pat, a, b, exp);
+    }
+
+    // Swapped EXT: indices from child1 first, then child0 = EXT with swapped operands
+    // Pattern {16..23, 0..7} = EXT #0 with swapped operands... actually that's
+    // {b[0..7], a[0..7]} which is UZP1.2D(b, a), not EXT.
+    // Let's test {20,21,...,31, 0,1,...,3} = swapped EXT #4
+    {
+        const uint8_t pat[] = { 20,21,22,23,24,25,26,27,28,29,30,31, 0,1,2,3 };
+        v128_t exp;
+        for (unsigned i = 0; i < 12; ++i) exp.u8x16[i] = 20 + i;
+        for (unsigned i = 0; i < 4; ++i) exp.u8x16[12 + i] = i;
+        testBinarySwizzlePattern("Swapped EXT #4", pat, a, b, exp);
+    }
+}
+
+// Test strength reduction of unary shuffle → VectorExtractPair (S64x2 swap halves).
+void testVectorSwizzleUnaryToEXT()
+{
+    if constexpr (!isARM64())
+        return;
+
+    // S64x2 reverse = swap 64-bit halves = EXT #8 with same register
+    // Pattern: {8,9,10,11,12,13,14,15, 0,1,2,3,4,5,6,7}
+    v128_t v;
+    for (unsigned i = 0; i < 16; ++i) v.u8x16[i] = i;
+    {
+        const uint8_t pat[] = { 8,9,10,11,12,13,14,15, 0,1,2,3,4,5,6,7 };
+        v128_t exp;
+        for (unsigned i = 0; i < 8; ++i) exp.u8x16[i] = 8 + i;
+        for (unsigned i = 0; i < 8; ++i) exp.u8x16[8 + i] = i;
+        testUnarySwizzlePattern("S64x2Reverse → EXT #8", pat, v, exp);
+    }
+}
+
+// Test all canonical binary shuffle patterns through VectorSwizzle strength reduction.
+void testVectorSwizzleBinaryCanonical()
+{
+    // Input vectors: a = {0x11, 0x22, 0x33, 0x44} as i32x4, b = {0x55, 0x66, 0x77, 0x88}
+    v128_t a, b;
+    a.u32x4[0] = 0x11; a.u32x4[1] = 0x22; a.u32x4[2] = 0x33; a.u32x4[3] = 0x44;
+    b.u32x4[0] = 0x55; b.u32x4[1] = 0x66; b.u32x4[2] = 0x77; b.u32x4[3] = 0x88;
+
+    // UZP1.4S: {a[0], a[2], b[0], b[2]}
+    {
+        const uint8_t pat[] = { 0,1,2,3, 8,9,10,11, 16,17,18,19, 24,25,26,27 };
+        v128_t exp; exp.u32x4[0] = 0x11; exp.u32x4[1] = 0x33; exp.u32x4[2] = 0x55; exp.u32x4[3] = 0x77;
+        testBinarySwizzlePattern("UZP1.4S", pat, a, b, exp);
+    }
+    // UZP2.4S: {a[1], a[3], b[1], b[3]}
+    {
+        const uint8_t pat[] = { 4,5,6,7, 12,13,14,15, 20,21,22,23, 28,29,30,31 };
+        v128_t exp; exp.u32x4[0] = 0x22; exp.u32x4[1] = 0x44; exp.u32x4[2] = 0x66; exp.u32x4[3] = 0x88;
+        testBinarySwizzlePattern("UZP2.4S", pat, a, b, exp);
+    }
+    // ZIP1.4S: {a[0], b[0], a[1], b[1]}
+    {
+        const uint8_t pat[] = { 0,1,2,3, 16,17,18,19, 4,5,6,7, 20,21,22,23 };
+        v128_t exp; exp.u32x4[0] = 0x11; exp.u32x4[1] = 0x55; exp.u32x4[2] = 0x22; exp.u32x4[3] = 0x66;
+        testBinarySwizzlePattern("ZIP1.4S", pat, a, b, exp);
+    }
+    // ZIP2.4S: {a[2], b[2], a[3], b[3]}
+    {
+        const uint8_t pat[] = { 8,9,10,11, 24,25,26,27, 12,13,14,15, 28,29,30,31 };
+        v128_t exp; exp.u32x4[0] = 0x33; exp.u32x4[1] = 0x77; exp.u32x4[2] = 0x44; exp.u32x4[3] = 0x88;
+        testBinarySwizzlePattern("ZIP2.4S", pat, a, b, exp);
+    }
+    // TRN1.4S: {a[0], b[0], a[2], b[2]}
+    {
+        const uint8_t pat[] = { 0,1,2,3, 16,17,18,19, 8,9,10,11, 24,25,26,27 };
+        v128_t exp; exp.u32x4[0] = 0x11; exp.u32x4[1] = 0x55; exp.u32x4[2] = 0x33; exp.u32x4[3] = 0x77;
+        testBinarySwizzlePattern("TRN1.4S", pat, a, b, exp);
+    }
+    // TRN2.4S: {a[1], b[1], a[3], b[3]}
+    {
+        const uint8_t pat[] = { 4,5,6,7, 20,21,22,23, 12,13,14,15, 28,29,30,31 };
+        v128_t exp; exp.u32x4[0] = 0x22; exp.u32x4[1] = 0x66; exp.u32x4[2] = 0x44; exp.u32x4[3] = 0x88;
+        testBinarySwizzlePattern("TRN2.4S", pat, a, b, exp);
+    }
+    // UZP1.2D: {a[lo64], b[lo64]}
+    {
+        const uint8_t pat[] = { 0,1,2,3,4,5,6,7, 16,17,18,19,20,21,22,23 };
+        v128_t exp; exp.u32x4[0] = 0x11; exp.u32x4[1] = 0x22; exp.u32x4[2] = 0x55; exp.u32x4[3] = 0x66;
+        testBinarySwizzlePattern("UZP1.2D", pat, a, b, exp);
+    }
+    // UZP2.2D: {a[hi64], b[hi64]}
+    {
+        const uint8_t pat[] = { 8,9,10,11,12,13,14,15, 24,25,26,27,28,29,30,31 };
+        v128_t exp; exp.u32x4[0] = 0x33; exp.u32x4[1] = 0x44; exp.u32x4[2] = 0x77; exp.u32x4[3] = 0x88;
+        testBinarySwizzlePattern("UZP2.2D", pat, a, b, exp);
+    }
+
+    // 16-bit (8H) patterns: a16 has 8 distinct u16 values, b16 has 8 more
+    v128_t a16, b16;
+    a16.u16x8[0] = 0x11; a16.u16x8[1] = 0x22; a16.u16x8[2] = 0x33; a16.u16x8[3] = 0x44;
+    a16.u16x8[4] = 0x55; a16.u16x8[5] = 0x66; a16.u16x8[6] = 0x77; a16.u16x8[7] = 0x88;
+    b16.u16x8[0] = 0x99; b16.u16x8[1] = 0xAA; b16.u16x8[2] = 0xBB; b16.u16x8[3] = 0xCC;
+    b16.u16x8[4] = 0xDD; b16.u16x8[5] = 0xEE; b16.u16x8[6] = 0xFF; b16.u16x8[7] = 0x100;
+
+    // UZP1.8H: {a[0],a[2],a[4],a[6], b[0],b[2],b[4],b[6]}
+    {
+        const uint8_t pat[] = { 0,1, 4,5, 8,9, 12,13, 16,17, 20,21, 24,25, 28,29 };
+        v128_t exp;
+        exp.u16x8[0] = 0x11; exp.u16x8[1] = 0x33; exp.u16x8[2] = 0x55; exp.u16x8[3] = 0x77;
+        exp.u16x8[4] = 0x99; exp.u16x8[5] = 0xBB; exp.u16x8[6] = 0xDD; exp.u16x8[7] = 0xFF;
+        testBinarySwizzlePattern("UZP1.8H", pat, a16, b16, exp);
+    }
+    // UZP2.8H: {a[1],a[3],a[5],a[7], b[1],b[3],b[5],b[7]}
+    {
+        const uint8_t pat[] = { 2,3, 6,7, 10,11, 14,15, 18,19, 22,23, 26,27, 30,31 };
+        v128_t exp;
+        exp.u16x8[0] = 0x22; exp.u16x8[1] = 0x44; exp.u16x8[2] = 0x66; exp.u16x8[3] = 0x88;
+        exp.u16x8[4] = 0xAA; exp.u16x8[5] = 0xCC; exp.u16x8[6] = 0xEE; exp.u16x8[7] = 0x100;
+        testBinarySwizzlePattern("UZP2.8H", pat, a16, b16, exp);
+    }
+    // ZIP1.8H: {a[0],b[0],a[1],b[1],a[2],b[2],a[3],b[3]}
+    {
+        const uint8_t pat[] = { 0,1, 16,17, 2,3, 18,19, 4,5, 20,21, 6,7, 22,23 };
+        v128_t exp;
+        exp.u16x8[0] = 0x11; exp.u16x8[1] = 0x99; exp.u16x8[2] = 0x22; exp.u16x8[3] = 0xAA;
+        exp.u16x8[4] = 0x33; exp.u16x8[5] = 0xBB; exp.u16x8[6] = 0x44; exp.u16x8[7] = 0xCC;
+        testBinarySwizzlePattern("ZIP1.8H", pat, a16, b16, exp);
+    }
+    // ZIP2.8H: {a[4],b[4],a[5],b[5],a[6],b[6],a[7],b[7]}
+    {
+        const uint8_t pat[] = { 8,9, 24,25, 10,11, 26,27, 12,13, 28,29, 14,15, 30,31 };
+        v128_t exp;
+        exp.u16x8[0] = 0x55; exp.u16x8[1] = 0xDD; exp.u16x8[2] = 0x66; exp.u16x8[3] = 0xEE;
+        exp.u16x8[4] = 0x77; exp.u16x8[5] = 0xFF; exp.u16x8[6] = 0x88; exp.u16x8[7] = 0x100;
+        testBinarySwizzlePattern("ZIP2.8H", pat, a16, b16, exp);
+    }
+    // TRN1.8H: {a[0],b[0],a[2],b[2],a[4],b[4],a[6],b[6]}
+    {
+        const uint8_t pat[] = { 0,1, 16,17, 4,5, 20,21, 8,9, 24,25, 12,13, 28,29 };
+        v128_t exp;
+        exp.u16x8[0] = 0x11; exp.u16x8[1] = 0x99; exp.u16x8[2] = 0x33; exp.u16x8[3] = 0xBB;
+        exp.u16x8[4] = 0x55; exp.u16x8[5] = 0xDD; exp.u16x8[6] = 0x77; exp.u16x8[7] = 0xFF;
+        testBinarySwizzlePattern("TRN1.8H", pat, a16, b16, exp);
+    }
+    // TRN2.8H: {a[1],b[1],a[3],b[3],a[5],b[5],a[7],b[7]}
+    {
+        const uint8_t pat[] = { 2,3, 18,19, 6,7, 22,23, 10,11, 26,27, 14,15, 30,31 };
+        v128_t exp;
+        exp.u16x8[0] = 0x22; exp.u16x8[1] = 0xAA; exp.u16x8[2] = 0x44; exp.u16x8[3] = 0xCC;
+        exp.u16x8[4] = 0x66; exp.u16x8[5] = 0xEE; exp.u16x8[6] = 0x88; exp.u16x8[7] = 0x100;
+        testBinarySwizzlePattern("TRN2.8H", pat, a16, b16, exp);
+    }
+
+    // 8-bit (16B) patterns: a8 has bytes 0..15, b8 has bytes 16..31
+    v128_t a8, b8;
+    for (unsigned i = 0; i < 16; ++i) a8.u8x16[i] = i;
+    for (unsigned i = 0; i < 16; ++i) b8.u8x16[i] = 16 + i;
+
+    // UZP1.16B: {a[0],a[2],a[4],...,a[14], b[0],b[2],b[4],...,b[14]}
+    {
+        const uint8_t pat[] = { 0,2,4,6,8,10,12,14, 16,18,20,22,24,26,28,30 };
+        v128_t exp;
+        for (unsigned i = 0; i < 8; ++i) exp.u8x16[i] = i * 2;
+        for (unsigned i = 0; i < 8; ++i) exp.u8x16[8 + i] = 16 + i * 2;
+        testBinarySwizzlePattern("UZP1.16B", pat, a8, b8, exp);
+    }
+    // UZP2.16B: {a[1],a[3],a[5],...,a[15], b[1],b[3],b[5],...,b[15]}
+    {
+        const uint8_t pat[] = { 1,3,5,7,9,11,13,15, 17,19,21,23,25,27,29,31 };
+        v128_t exp;
+        for (unsigned i = 0; i < 8; ++i) exp.u8x16[i] = 1 + i * 2;
+        for (unsigned i = 0; i < 8; ++i) exp.u8x16[8 + i] = 17 + i * 2;
+        testBinarySwizzlePattern("UZP2.16B", pat, a8, b8, exp);
+    }
+    // ZIP1.16B: {a[0],b[0],a[1],b[1],a[2],b[2],a[3],b[3],a[4],b[4],a[5],b[5],a[6],b[6],a[7],b[7]}
+    {
+        const uint8_t pat[] = { 0,16, 1,17, 2,18, 3,19, 4,20, 5,21, 6,22, 7,23 };
+        v128_t exp;
+        for (unsigned i = 0; i < 8; ++i) { exp.u8x16[i * 2] = i; exp.u8x16[i * 2 + 1] = 16 + i; }
+        testBinarySwizzlePattern("ZIP1.16B", pat, a8, b8, exp);
+    }
+    // ZIP2.16B: {a[8],b[8],a[9],b[9],...,a[15],b[15]}
+    {
+        const uint8_t pat[] = { 8,24, 9,25, 10,26, 11,27, 12,28, 13,29, 14,30, 15,31 };
+        v128_t exp;
+        for (unsigned i = 0; i < 8; ++i) { exp.u8x16[i * 2] = 8 + i; exp.u8x16[i * 2 + 1] = 24 + i; }
+        testBinarySwizzlePattern("ZIP2.16B", pat, a8, b8, exp);
+    }
+    // TRN1.16B: {a[0],b[0],a[2],b[2],a[4],b[4],...,a[14],b[14]}
+    {
+        const uint8_t pat[] = { 0,16, 2,18, 4,20, 6,22, 8,24, 10,26, 12,28, 14,30 };
+        v128_t exp;
+        for (unsigned i = 0; i < 8; ++i) { exp.u8x16[i * 2] = i * 2; exp.u8x16[i * 2 + 1] = 16 + i * 2; }
+        testBinarySwizzlePattern("TRN1.16B", pat, a8, b8, exp);
+    }
+    // TRN2.16B: {a[1],b[1],a[3],b[3],a[5],b[5],...,a[15],b[15]}
+    {
+        const uint8_t pat[] = { 1,17, 3,19, 5,21, 7,23, 9,25, 11,27, 13,29, 15,31 };
+        v128_t exp;
+        for (unsigned i = 0; i < 8; ++i) { exp.u8x16[i * 2] = 1 + i * 2; exp.u8x16[i * 2 + 1] = 17 + i * 2; }
+        testBinarySwizzlePattern("TRN2.16B", pat, a8, b8, exp);
+    }
+}
+
+// Test all canonical unary shuffle patterns through VectorSwizzle strength reduction.
+void testVectorSwizzleUnaryCanonical()
+{
+    v128_t v;
+    v.u32x4[0] = 0xAA; v.u32x4[1] = 0xBB; v.u32x4[2] = 0xCC; v.u32x4[3] = 0xDD;
+
+    // UZP1.4S(v,v): {v[0], v[2], v[0], v[2]}
+    {
+        const uint8_t pat[] = { 0,1,2,3, 8,9,10,11, 0,1,2,3, 8,9,10,11 };
+        v128_t exp; exp.u32x4[0] = 0xAA; exp.u32x4[1] = 0xCC; exp.u32x4[2] = 0xAA; exp.u32x4[3] = 0xCC;
+        testUnarySwizzlePattern("unary UZP1.4S", pat, v, exp);
+    }
+    // UZP2.4S(v,v): {v[1], v[3], v[1], v[3]}
+    {
+        const uint8_t pat[] = { 4,5,6,7, 12,13,14,15, 4,5,6,7, 12,13,14,15 };
+        v128_t exp; exp.u32x4[0] = 0xBB; exp.u32x4[1] = 0xDD; exp.u32x4[2] = 0xBB; exp.u32x4[3] = 0xDD;
+        testUnarySwizzlePattern("unary UZP2.4S", pat, v, exp);
+    }
+    // ZIP1.4S(v,v): {v[0], v[0], v[1], v[1]}
+    {
+        const uint8_t pat[] = { 0,1,2,3, 0,1,2,3, 4,5,6,7, 4,5,6,7 };
+        v128_t exp; exp.u32x4[0] = 0xAA; exp.u32x4[1] = 0xAA; exp.u32x4[2] = 0xBB; exp.u32x4[3] = 0xBB;
+        testUnarySwizzlePattern("unary ZIP1.4S", pat, v, exp);
+    }
+    // ZIP2.4S(v,v): {v[2], v[2], v[3], v[3]}
+    {
+        const uint8_t pat[] = { 8,9,10,11, 8,9,10,11, 12,13,14,15, 12,13,14,15 };
+        v128_t exp; exp.u32x4[0] = 0xCC; exp.u32x4[1] = 0xCC; exp.u32x4[2] = 0xDD; exp.u32x4[3] = 0xDD;
+        testUnarySwizzlePattern("unary ZIP2.4S", pat, v, exp);
+    }
+    // TRN1.4S(v,v): {v[0], v[0], v[2], v[2]}
+    {
+        const uint8_t pat[] = { 0,1,2,3, 0,1,2,3, 8,9,10,11, 8,9,10,11 };
+        v128_t exp; exp.u32x4[0] = 0xAA; exp.u32x4[1] = 0xAA; exp.u32x4[2] = 0xCC; exp.u32x4[3] = 0xCC;
+        testUnarySwizzlePattern("unary TRN1.4S", pat, v, exp);
+    }
+    // TRN2.4S(v,v): {v[1], v[1], v[3], v[3]}
+    {
+        const uint8_t pat[] = { 4,5,6,7, 4,5,6,7, 12,13,14,15, 12,13,14,15 };
+        v128_t exp; exp.u32x4[0] = 0xBB; exp.u32x4[1] = 0xBB; exp.u32x4[2] = 0xDD; exp.u32x4[3] = 0xDD;
+        testUnarySwizzlePattern("unary TRN2.4S", pat, v, exp);
+    }
+    // REV64.4S: {v[1], v[0], v[3], v[2]}
+    {
+        const uint8_t pat[] = { 4,5,6,7, 0,1,2,3, 12,13,14,15, 8,9,10,11 };
+        v128_t exp; exp.u32x4[0] = 0xBB; exp.u32x4[1] = 0xAA; exp.u32x4[2] = 0xDD; exp.u32x4[3] = 0xCC;
+        testUnarySwizzlePattern("unary REV64.4S", pat, v, exp);
+    }
+
+    // Test 16-bit patterns
+    v128_t v16;
+    v16.u16x8[0] = 0x11; v16.u16x8[1] = 0x22; v16.u16x8[2] = 0x33; v16.u16x8[3] = 0x44;
+    v16.u16x8[4] = 0x55; v16.u16x8[5] = 0x66; v16.u16x8[6] = 0x77; v16.u16x8[7] = 0x88;
+
+    // REV32.8H: swap 16-bit elements within 32-bit groups {v[1],v[0],v[3],v[2],v[5],v[4],v[7],v[6]}
+    {
+        const uint8_t pat[] = { 2,3,0,1, 6,7,4,5, 10,11,8,9, 14,15,12,13 };
+        v128_t exp;
+        exp.u16x8[0] = 0x22; exp.u16x8[1] = 0x11; exp.u16x8[2] = 0x44; exp.u16x8[3] = 0x33;
+        exp.u16x8[4] = 0x66; exp.u16x8[5] = 0x55; exp.u16x8[6] = 0x88; exp.u16x8[7] = 0x77;
+        testUnarySwizzlePattern("unary REV32.8H", pat, v16, exp);
+    }
+
+    // Test 8-bit REV16: swap bytes within 16-bit groups
+    v128_t v8;
+    for (unsigned i = 0; i < 16; ++i)
+        v8.u8x16[i] = i;
+    {
+        const uint8_t pat[] = { 1,0, 3,2, 5,4, 7,6, 9,8, 11,10, 13,12, 15,14 };
+        v128_t exp;
+        for (unsigned i = 0; i < 16; i += 2) { exp.u8x16[i] = i + 1; exp.u8x16[i + 1] = i; }
+        testUnarySwizzlePattern("unary REV16.16B", pat, v8, exp);
+    }
+
+    // UZP1.2D(v,v): {lo64, lo64}
+    {
+        const uint8_t pat[] = { 0,1,2,3,4,5,6,7, 0,1,2,3,4,5,6,7 };
+        v128_t exp;
+        exp.u32x4[0] = 0xAA; exp.u32x4[1] = 0xBB; exp.u32x4[2] = 0xAA; exp.u32x4[3] = 0xBB;
+        testUnarySwizzlePattern("unary UZP1.2D", pat, v, exp);
+    }
+    // UZP2.2D(v,v): {hi64, hi64}
+    {
+        const uint8_t pat[] = { 8,9,10,11,12,13,14,15, 8,9,10,11,12,13,14,15 };
+        v128_t exp;
+        exp.u32x4[0] = 0xCC; exp.u32x4[1] = 0xDD; exp.u32x4[2] = 0xCC; exp.u32x4[3] = 0xDD;
+        testUnarySwizzlePattern("unary UZP2.2D", pat, v, exp);
+    }
+
+    // UZP1.8H(v,v): {v[0],v[2],v[4],v[6], v[0],v[2],v[4],v[6]}
+    {
+        const uint8_t pat[] = { 0,1, 4,5, 8,9, 12,13, 0,1, 4,5, 8,9, 12,13 };
+        v128_t exp;
+        exp.u16x8[0] = 0x11; exp.u16x8[1] = 0x33; exp.u16x8[2] = 0x55; exp.u16x8[3] = 0x77;
+        exp.u16x8[4] = 0x11; exp.u16x8[5] = 0x33; exp.u16x8[6] = 0x55; exp.u16x8[7] = 0x77;
+        testUnarySwizzlePattern("unary UZP1.8H", pat, v16, exp);
+    }
+    // UZP2.8H(v,v): {v[1],v[3],v[5],v[7], v[1],v[3],v[5],v[7]}
+    {
+        const uint8_t pat[] = { 2,3, 6,7, 10,11, 14,15, 2,3, 6,7, 10,11, 14,15 };
+        v128_t exp;
+        exp.u16x8[0] = 0x22; exp.u16x8[1] = 0x44; exp.u16x8[2] = 0x66; exp.u16x8[3] = 0x88;
+        exp.u16x8[4] = 0x22; exp.u16x8[5] = 0x44; exp.u16x8[6] = 0x66; exp.u16x8[7] = 0x88;
+        testUnarySwizzlePattern("unary UZP2.8H", pat, v16, exp);
+    }
+    // ZIP1.8H(v,v): {v[0],v[0],v[1],v[1],v[2],v[2],v[3],v[3]}
+    {
+        const uint8_t pat[] = { 0,1, 0,1, 2,3, 2,3, 4,5, 4,5, 6,7, 6,7 };
+        v128_t exp;
+        exp.u16x8[0] = 0x11; exp.u16x8[1] = 0x11; exp.u16x8[2] = 0x22; exp.u16x8[3] = 0x22;
+        exp.u16x8[4] = 0x33; exp.u16x8[5] = 0x33; exp.u16x8[6] = 0x44; exp.u16x8[7] = 0x44;
+        testUnarySwizzlePattern("unary ZIP1.8H", pat, v16, exp);
+    }
+    // ZIP2.8H(v,v): {v[4],v[4],v[5],v[5],v[6],v[6],v[7],v[7]}
+    {
+        const uint8_t pat[] = { 8,9, 8,9, 10,11, 10,11, 12,13, 12,13, 14,15, 14,15 };
+        v128_t exp;
+        exp.u16x8[0] = 0x55; exp.u16x8[1] = 0x55; exp.u16x8[2] = 0x66; exp.u16x8[3] = 0x66;
+        exp.u16x8[4] = 0x77; exp.u16x8[5] = 0x77; exp.u16x8[6] = 0x88; exp.u16x8[7] = 0x88;
+        testUnarySwizzlePattern("unary ZIP2.8H", pat, v16, exp);
+    }
+    // TRN1.8H(v,v): {v[0],v[0],v[2],v[2],v[4],v[4],v[6],v[6]}
+    {
+        const uint8_t pat[] = { 0,1, 0,1, 4,5, 4,5, 8,9, 8,9, 12,13, 12,13 };
+        v128_t exp;
+        exp.u16x8[0] = 0x11; exp.u16x8[1] = 0x11; exp.u16x8[2] = 0x33; exp.u16x8[3] = 0x33;
+        exp.u16x8[4] = 0x55; exp.u16x8[5] = 0x55; exp.u16x8[6] = 0x77; exp.u16x8[7] = 0x77;
+        testUnarySwizzlePattern("unary TRN1.8H", pat, v16, exp);
+    }
+    // TRN2.8H(v,v): {v[1],v[1],v[3],v[3],v[5],v[5],v[7],v[7]}
+    {
+        const uint8_t pat[] = { 2,3, 2,3, 6,7, 6,7, 10,11, 10,11, 14,15, 14,15 };
+        v128_t exp;
+        exp.u16x8[0] = 0x22; exp.u16x8[1] = 0x22; exp.u16x8[2] = 0x44; exp.u16x8[3] = 0x44;
+        exp.u16x8[4] = 0x66; exp.u16x8[5] = 0x66; exp.u16x8[6] = 0x88; exp.u16x8[7] = 0x88;
+        testUnarySwizzlePattern("unary TRN2.8H", pat, v16, exp);
+    }
+
+    // UZP1.16B(v,v): {v[0],v[2],v[4],...,v[14], v[0],v[2],v[4],...,v[14]}
+    {
+        const uint8_t pat[] = { 0,2,4,6,8,10,12,14, 0,2,4,6,8,10,12,14 };
+        v128_t exp;
+        for (unsigned i = 0; i < 8; ++i) exp.u8x16[i] = i * 2;
+        for (unsigned i = 0; i < 8; ++i) exp.u8x16[8 + i] = i * 2;
+        testUnarySwizzlePattern("unary UZP1.16B", pat, v8, exp);
+    }
+    // UZP2.16B(v,v): {v[1],v[3],v[5],...,v[15], v[1],v[3],v[5],...,v[15]}
+    {
+        const uint8_t pat[] = { 1,3,5,7,9,11,13,15, 1,3,5,7,9,11,13,15 };
+        v128_t exp;
+        for (unsigned i = 0; i < 8; ++i) exp.u8x16[i] = 1 + i * 2;
+        for (unsigned i = 0; i < 8; ++i) exp.u8x16[8 + i] = 1 + i * 2;
+        testUnarySwizzlePattern("unary UZP2.16B", pat, v8, exp);
+    }
+    // ZIP1.16B(v,v): {v[0],v[0],v[1],v[1],...,v[7],v[7]}
+    {
+        const uint8_t pat[] = { 0,0, 1,1, 2,2, 3,3, 4,4, 5,5, 6,6, 7,7 };
+        v128_t exp;
+        for (unsigned i = 0; i < 8; ++i) { exp.u8x16[i * 2] = i; exp.u8x16[i * 2 + 1] = i; }
+        testUnarySwizzlePattern("unary ZIP1.16B", pat, v8, exp);
+    }
+    // ZIP2.16B(v,v): {v[8],v[8],v[9],v[9],...,v[15],v[15]}
+    {
+        const uint8_t pat[] = { 8,8, 9,9, 10,10, 11,11, 12,12, 13,13, 14,14, 15,15 };
+        v128_t exp;
+        for (unsigned i = 0; i < 8; ++i) { exp.u8x16[i * 2] = 8 + i; exp.u8x16[i * 2 + 1] = 8 + i; }
+        testUnarySwizzlePattern("unary ZIP2.16B", pat, v8, exp);
+    }
+    // TRN1.16B(v,v): {v[0],v[0],v[2],v[2],...,v[14],v[14]}
+    {
+        const uint8_t pat[] = { 0,0, 2,2, 4,4, 6,6, 8,8, 10,10, 12,12, 14,14 };
+        v128_t exp;
+        for (unsigned i = 0; i < 8; ++i) { exp.u8x16[i * 2] = i * 2; exp.u8x16[i * 2 + 1] = i * 2; }
+        testUnarySwizzlePattern("unary TRN1.16B", pat, v8, exp);
+    }
+    // TRN2.16B(v,v): {v[1],v[1],v[3],v[3],...,v[15],v[15]}
+    {
+        const uint8_t pat[] = { 1,1, 3,3, 5,5, 7,7, 9,9, 11,11, 13,13, 15,15 };
+        v128_t exp;
+        for (unsigned i = 0; i < 8; ++i) { exp.u8x16[i * 2] = 1 + i * 2; exp.u8x16[i * 2 + 1] = 1 + i * 2; }
+        testUnarySwizzlePattern("unary TRN2.16B", pat, v8, exp);
+    }
+}
+
+// Test VectorDupElement folding: when canonical ops have identical inputs (v, v)
+// and lane is i64x2, they should be folded to VectorDupElement.
+void testVectorCanonicalSameInputFolding()
+{
+    if constexpr (!isARM64())
+        return;
+
+    // Helper: build canonical op with same input, verify result equals DUP behavior.
+    auto testSameInputOp = [](B3::Opcode op, SIMDLane lane, uint64_t lo, uint64_t hi, uint64_t expectedLo, uint64_t expectedHi) {
+        alignas(16) v128_t vectors[2];
+        Procedure proc;
+        BasicBlock* root = proc.addBlock();
+        auto arguments = cCallArgumentValues<void*>(proc, root);
+        Value* address = arguments[0];
+        Value* v = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+        Value* result = root->appendNew<SIMDValue>(proc, Origin(), op, B3::V128, lane, SIMDSignMode::None, v, v);
+        root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(sizeof(v128_t)));
+        root->appendNewControlValue(proc, Return, Origin());
+
+        auto code = compileProc(proc);
+        vectors[0].u64x2[0] = lo;
+        vectors[0].u64x2[1] = hi;
+        invoke<void>(*code, vectors);
+        CHECK(vectors[1].u64x2[0] == expectedLo);
+        CHECK(vectors[1].u64x2[1] == expectedHi);
+    };
+
+    uint64_t lo = 0x1111111111111111ULL;
+    uint64_t hi = 0x2222222222222222ULL;
+
+    // All of these with i64x2 and same input should produce DUP behavior:
+    // UZP1.2D(v,v) = {lo, lo}
+    testSameInputOp(VectorUnzipEven, SIMDLane::i64x2, lo, hi, lo, lo);
+    // UZP2.2D(v,v) = {hi, hi}
+    testSameInputOp(VectorUnzipOdd, SIMDLane::i64x2, lo, hi, hi, hi);
+    // ZIP1.2D(v,v) = {lo, lo}
+    testSameInputOp(VectorZipLower, SIMDLane::i64x2, lo, hi, lo, lo);
+    // ZIP2.2D(v,v) = {hi, hi}
+    testSameInputOp(VectorZipHigher, SIMDLane::i64x2, lo, hi, hi, hi);
+    // TRN1.2D(v,v) = {lo, lo}
+    testSameInputOp(VectorTransposeEven, SIMDLane::i64x2, lo, hi, lo, lo);
+    // TRN2.2D(v,v) = {hi, hi}
+    testSameInputOp(VectorTransposeOdd, SIMDLane::i64x2, lo, hi, hi, hi);
+}
+
+// Test that VectorSwizzle DupElement patterns (unary) are correctly detected.
+// These test the path: VectorSwizzle → (ReduceStrength) → VectorDupElement
+void testVectorSwizzleToDupElement()
+{
+    if constexpr (!isARM64())
+        return;
+
+    v128_t v;
+    v.u32x4[0] = 0xAA; v.u32x4[1] = 0xBB; v.u32x4[2] = 0xCC; v.u32x4[3] = 0xDD;
+
+    // i64x2 DUP element 0: {lo64, lo64}
+    {
+        const uint8_t pat[] = { 0,1,2,3,4,5,6,7, 0,1,2,3,4,5,6,7 };
+        v128_t exp; exp.u32x4[0] = 0xAA; exp.u32x4[1] = 0xBB; exp.u32x4[2] = 0xAA; exp.u32x4[3] = 0xBB;
+        testUnarySwizzlePattern("DUP.2D element 0", pat, v, exp);
+    }
+    // i64x2 DUP element 1: {hi64, hi64}
+    {
+        const uint8_t pat[] = { 8,9,10,11,12,13,14,15, 8,9,10,11,12,13,14,15 };
+        v128_t exp; exp.u32x4[0] = 0xCC; exp.u32x4[1] = 0xDD; exp.u32x4[2] = 0xCC; exp.u32x4[3] = 0xDD;
+        testUnarySwizzlePattern("DUP.2D element 1", pat, v, exp);
+    }
+    // i32x4 DUP element 0: {v[0], v[0], v[0], v[0]}
+    {
+        const uint8_t pat[] = { 0,1,2,3, 0,1,2,3, 0,1,2,3, 0,1,2,3 };
+        v128_t exp; exp.u32x4[0] = 0xAA; exp.u32x4[1] = 0xAA; exp.u32x4[2] = 0xAA; exp.u32x4[3] = 0xAA;
+        testUnarySwizzlePattern("DUP.4S element 0", pat, v, exp);
+    }
+    // i32x4 DUP element 2: {v[2], v[2], v[2], v[2]}
+    {
+        const uint8_t pat[] = { 8,9,10,11, 8,9,10,11, 8,9,10,11, 8,9,10,11 };
+        v128_t exp; exp.u32x4[0] = 0xCC; exp.u32x4[1] = 0xCC; exp.u32x4[2] = 0xCC; exp.u32x4[3] = 0xCC;
+        testUnarySwizzlePattern("DUP.4S element 2", pat, v, exp);
+    }
+    // i16x8 DUP element 3
+    {
+        v128_t v16;
+        for (unsigned i = 0; i < 8; ++i)
+            v16.u16x8[i] = 0x10 * (i + 1);
+        const uint8_t pat[] = { 6,7, 6,7, 6,7, 6,7, 6,7, 6,7, 6,7, 6,7 };
+        v128_t exp;
+        for (unsigned i = 0; i < 8; ++i)
+            exp.u16x8[i] = 0x40;
+        testUnarySwizzlePattern("DUP.8H element 3", pat, v16, exp);
+    }
+    // i8x16 DUP element 5
+    {
+        v128_t v8;
+        for (unsigned i = 0; i < 16; ++i)
+            v8.u8x16[i] = i + 1;
+        const uint8_t pat[] = { 5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5 };
+        v128_t exp;
+        for (unsigned i = 0; i < 16; ++i)
+            exp.u8x16[i] = 6;
+        testUnarySwizzlePattern("DUP.16B element 5", pat, v8, exp);
+    }
+}
+
+// Test shuffle-of-shuffle composition (ReduceSIMDShuffle).
+// An inner unary shuffle fed into an outer binary shuffle should be composed
+// into a single shuffle.
+void testVectorSwizzleComposition()
+{
+    if constexpr (!isARM64())
+        return;
+
+    // Inner: reverse bytes within 32-bit elements (unary pattern)
+    // Outer: take high 64 bits of inner result and low 64 bits of other
+    // Composed: should be a single binary shuffle
+
+    alignas(16) v128_t vectors[3];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* a = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* b = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
+
+    // Inner: swap bytes within 32-bit groups of 'a' → {a[3],a[2],a[1],a[0], a[7],a[6],a[5],a[4], ...}
+    v128_t innerPat;
+    for (unsigned i = 0; i < 16; i += 4) {
+        innerPat.u8x16[i] = i + 3;
+        innerPat.u8x16[i + 1] = i + 2;
+        innerPat.u8x16[i + 2] = i + 1;
+        innerPat.u8x16[i + 3] = i;
+    }
+    Value* innerPatConst = root->appendNew<Const128Value>(proc, Origin(), innerPat);
+    Value* innerResult = root->appendNew<SIMDValue>(proc, Origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, a, innerPatConst);
+
+    // Outer: UZP1.2D(b, inner) = {b[lo64], inner[lo64]}
+    v128_t outerPat;
+    for (unsigned i = 0; i < 8; ++i) outerPat.u8x16[i] = i;
+    for (unsigned i = 0; i < 8; ++i) outerPat.u8x16[8 + i] = 16 + i;
+    Value* outerPatConst = root->appendNew<Const128Value>(proc, Origin(), outerPat);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, b, innerResult, outerPatConst);
+
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(2 * sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+    for (unsigned i = 0; i < 16; ++i) vectors[0].u8x16[i] = i;       // a
+    for (unsigned i = 0; i < 16; ++i) vectors[1].u8x16[i] = 0x80 + i; // b
+    invoke<void>(*code, vectors);
+
+    // Expected: {b[0..7], rev32(a)[0..7]} = {b[0..7], a[3],a[2],a[1],a[0],a[7],a[6],a[5],a[4]}
+    for (unsigned i = 0; i < 8; ++i)
+        CHECK(vectors[2].u8x16[i] == 0x80 + i);
+    CHECK(vectors[2].u8x16[8] == 3);
+    CHECK(vectors[2].u8x16[9] == 2);
+    CHECK(vectors[2].u8x16[10] == 1);
+    CHECK(vectors[2].u8x16[11] == 0);
+    CHECK(vectors[2].u8x16[12] == 7);
+    CHECK(vectors[2].u8x16[13] == 6);
+    CHECK(vectors[2].u8x16[14] == 5);
+    CHECK(vectors[2].u8x16[15] == 4);
+}
+
 #endif // ENABLE(B3_JIT)
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/JavaScriptCore/jit/SIMDInfo.h
+++ b/Source/JavaScriptCore/jit/SIMDInfo.h
@@ -45,6 +45,48 @@ typedef union v128_u {
     constexpr v128_u(uint64_t first, uint64_t second)
         : u64x2 { first, second }
     { }
+
+    static constexpr v128_u fromU8x16(std::integral auto... args)
+    {
+        static_assert(sizeof...(args) == 16, "v128_u requires exactly 16 bytes");
+        const uint8_t d[] = { static_cast<uint8_t>(args)... };
+        uint64_t low = 0;
+        uint64_t high = 0;
+        for (int i = 0; i < 8; ++i) {
+            low  |= (static_cast<uint64_t>(d[i]) << (i * 8));
+            high |= (static_cast<uint64_t>(d[i + 8]) << (i * 8));
+        }
+        return v128_u(low, high);
+    }
+
+    static constexpr v128_u fromU16x8(std::integral auto... args)
+    {
+        static_assert(sizeof...(args) == 8, "v128_u: fromU16x8 requires 8 arguments.");
+        const uint16_t d[] = { static_cast<uint16_t>(args)... };
+        uint64_t low = 0;
+        uint64_t high = 0;
+        for (int i = 0; i < 4; ++i) {
+            low  |= (static_cast<uint64_t>(d[i]) << (i * 16));
+            high |= (static_cast<uint64_t>(d[i + 4]) << (i * 16));
+        }
+        return v128_u(low, high);
+    }
+
+    static constexpr v128_u fromU32x4(std::integral auto... args)
+    {
+        static_assert(sizeof...(args) == 4, "v128_u: fromU32x4 requires 4 arguments.");
+        const uint32_t d[] = { static_cast<uint32_t>(args)... };
+        uint64_t low  = (static_cast<uint64_t>(d[1]) << 32) | d[0];
+        uint64_t high = (static_cast<uint64_t>(d[3]) << 32) | d[2];
+        return v128_u(low, high);
+    }
+
+    static constexpr v128_u fromU64x2(std::integral auto... args)
+    {
+        static_assert(sizeof...(args) == 2, "v128_u: fromU64x2 requires 2 arguments.");
+        const uint64_t d[] = { static_cast<uint64_t>(args)... };
+        return v128_u(d[0], d[1]);
+    }
 } v128_t;
 
 constexpr v128_t vectorAllOnes()

--- a/Source/JavaScriptCore/jit/SIMDShuffle.h
+++ b/Source/JavaScriptCore/jit/SIMDShuffle.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Apple Inc. All rights reserved.
+ * Copyright (C) 2025-2026 the V8 project authors. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +33,43 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
+// Canonical shuffle patterns recognized for ARM64 specialized instruction selection.
+enum class CanonicalShuffle : uint8_t {
+    Unknown,
+    Identity,
+    // 64-bit element patterns
+    S64x2UnzipEven,                // UZP1.2D
+    S64x2UnzipOdd,                 // UZP2.2D
+    S64x2Reverse,                  // EXT #8 (unary): swap two 64-bit halves
+    // 32-bit element patterns
+    S32x4UnzipEven,                // UZP1.4S
+    S32x4UnzipOdd,                 // UZP2.4S
+    S32x4ZipLower,                 // ZIP1.4S
+    S32x4ZipHigher,                // ZIP2.4S
+    S32x4TransposeEven,            // TRN1.4S
+    S32x4TransposeOdd,             // TRN2.4S
+    S32x2Reverse,                  // REV64.4S
+    // 16-bit element patterns
+    S16x8UnzipEven,                // UZP1.8H
+    S16x8UnzipOdd,                 // UZP2.8H
+    S16x8ZipLower,                 // ZIP1.8H
+    S16x8ZipHigher,                // ZIP2.8H
+    S16x8TransposeEven,            // TRN1.8H
+    S16x8TransposeOdd,             // TRN2.8H
+    S16x2Reverse,                  // REV32.8H
+    S16x4Reverse,                  // REV64.8H
+    // 8-bit element patterns
+    S8x16UnzipEven,                // UZP1.16B
+    S8x16UnzipOdd,                 // UZP2.16B
+    S8x16ZipLower,                 // ZIP1.16B
+    S8x16ZipHigher,                // ZIP2.16B
+    S8x16TransposeEven,            // TRN1.16B
+    S8x16TransposeOdd,             // TRN2.16B
+    S8x2Reverse,                   // REV16.16B
+    S8x4Reverse,                   // REV32.16B
+    S8x8Reverse,                   // REV64.16B
+};
+
 class SIMDShuffle {
 public:
     static std::optional<unsigned> isOnlyOneSideMask(v128_t pattern)
@@ -55,6 +93,14 @@ public:
                 return std::nullopt;
         }
         return 1;
+    }
+
+    static std::optional<uint8_t> isI8x16SameElement(v128_t pattern)
+    {
+        constexpr unsigned numberOfElements = 16 / sizeof(uint8_t);
+        if (std::all_of(pattern.u8x16, pattern.u8x16 + numberOfElements, [&](auto value) { return value == pattern.u8x16[0]; }))
+            return pattern.u8x16[0];
+        return std::nullopt;
     }
 
     static std::optional<uint8_t> isI8x16DupElement(v128_t pattern)
@@ -158,7 +204,209 @@ public:
         return true;
     }
 
+    // Detect EXT (byte extraction / concatenation) pattern for binary shuffle.
+    // Returns the byte offset if the pattern is {offset, offset+1, ..., 31, 0, 1, ...}
+    // i.e., pattern[i] == (offset + i) % 32 for some offset in [0, 15].
+    // ARM64 EXT instruction: EXT Vd.16B, Vn.16B, Vm.16B, #imm
+    // extracts bytes from the concatenation of Vn:Vm.
+    // Returns {offset, needsSwap}.
+    struct EXTInfo {
+        uint8_t offset;
+        bool needsSwap;
+    };
+    static std::optional<EXTInfo> isEXTWithSwap(v128_t pattern)
+    {
+        uint8_t first = pattern.u8x16[0];
+        if (first >= 32)
+            return std::nullopt;
+        for (unsigned i = 1; i < 16; ++i) {
+            if (pattern.u8x16[i] != ((first + i) % 32))
+                return std::nullopt;
+        }
+        if (first < 16)
+            return EXTInfo { first, false };
+        return EXTInfo { static_cast<uint8_t>(first - 16), true };
+    }
+
+    // Try to match a canonical binary shuffle pattern for ARM64 specialized instructions.
+    static CanonicalShuffle tryMatchCanonicalBinary(v128_t pattern)
+    {
+        return tryMatchCanonicalBinaryImpl(pattern, [](v128_t v) constexpr { return v; });
+    }
+
+    // Try to match a unary shuffle pattern as a binary canonical shuffle.
+    // Binary canonical pattern gets converted to unary canonical pattern with the invariant that both inputs are the same.
+    // TRN2.16B {1,17, 3,19, 5,21, 7,23, 9,25, 11,27, 13,29, 15,31} gets converted to
+    // {1,1, 3,3, 5,5, 7,7, 9,9, 11,11, 13,13, 15,15}.
+    static CanonicalShuffle tryMatchUnaryAsBinaryCanonical(v128_t pattern)
+    {
+        return tryMatchCanonicalBinaryImpl(pattern,
+            [](v128_t v) constexpr {
+                for (unsigned i = 0; i < 16; ++i) {
+                    if (v.u8x16[i] >= 16)
+                        v.u8x16[i] = v.u8x16[i] - 16;
+                }
+                return v;
+            });
+    }
+
+    // Try to match a canonical unary shuffle pattern.
+    static CanonicalShuffle tryMatchCanonicalUnary(v128_t pattern)
+    {
+        // REV64.4S: reverse 32-bit pairs within 64-bit lanes
+        if (bitEquals(pattern, v128_t::fromU8x16(4,5,6,7, 0,1,2,3, 12,13,14,15, 8,9,10,11)))
+            return CanonicalShuffle::S32x2Reverse;
+        // REV64.8H: reverse 16-bit elements within 64-bit lanes
+        if (bitEquals(pattern, v128_t::fromU8x16(6,7, 4,5, 2,3, 0,1, 14,15, 12,13, 10,11, 8,9)))
+            return CanonicalShuffle::S16x4Reverse;
+        // REV32.8H: reverse 16-bit pairs within 32-bit groups
+        if (bitEquals(pattern, v128_t::fromU8x16(2,3, 0,1, 6,7, 4,5, 10,11, 8,9, 14,15, 12,13)))
+            return CanonicalShuffle::S16x2Reverse;
+        // REV64.16B: reverse bytes within 64-bit lanes
+        if (bitEquals(pattern, v128_t::fromU8x16(7,6,5,4,3,2,1,0, 15,14,13,12,11,10,9,8)))
+            return CanonicalShuffle::S8x8Reverse;
+        // REV32.16B: reverse bytes within 32-bit groups
+        if (bitEquals(pattern, v128_t::fromU8x16(3,2,1,0, 7,6,5,4, 11,10,9,8, 15,14,13,12)))
+            return CanonicalShuffle::S8x4Reverse;
+        // REV16.16B: reverse bytes within 16-bit groups
+        if (bitEquals(pattern, v128_t::fromU8x16(1,0, 3,2, 5,4, 7,6, 9,8, 11,10, 13,12, 15,14)))
+            return CanonicalShuffle::S8x2Reverse;
+        // S64x2 reverse: swap two 64-bit halves = {8..15, 0..7}
+        if (bitEquals(pattern, v128_t::fromU8x16(8,9,10,11,12,13,14,15, 0,1,2,3,4,5,6,7)))
+            return CanonicalShuffle::S64x2Reverse;
+
+        return CanonicalShuffle::Unknown;
+    }
+
+    // Compose an outer shuffle with an inner shuffle.
+    // Given outer = shuffle(inner_result, other, outerPattern) or
+    //       outer = shuffle(other, inner_result, outerPattern)
+    // where inner_result = shuffle(innerSrc, innerPattern) [unary]
+    // Produces a combined pattern that reads from (innerSrc, other) or (other, innerSrc).
+    //
+    // innerIsChild0: whether the inner shuffle's result is child(0) of the outer.
+    // Returns nullopt if composition is not possible (e.g., indices go out of range).
+    static v128_t composeShuffle(v128_t outerPattern, v128_t innerPattern, bool innerIsChild0)
+    {
+        v128_t result;
+        for (unsigned i = 0; i < 16; ++i) {
+            uint8_t outerIdx = outerPattern.u8x16[i];
+            if (outerIdx >= 32) {
+                // Out of bounds in outer — result is 0 on ARM64 TBL.
+                result.u8x16[i] = 0xFF; // OOB
+                continue;
+            }
+
+            if (innerIsChild0) {
+                if (outerIdx < 16) {
+                    // Reads from inner's output. Chase through inner.
+                    uint8_t innerIdx = innerPattern.u8x16[outerIdx];
+                    if (innerIdx >= 16) {
+                        result.u8x16[i] = 0xFF; // OOB in inner → zero
+                        continue;
+                    }
+                    // innerIdx is 0..15, referring to inner's input.
+                    // In the composed shuffle, inner's input is child0, other is child1.
+                    result.u8x16[i] = innerIdx;
+                } else {
+                    // Reads from the other child (child1 of outer).
+                    // In composed result, other is child1, offset 16..31.
+                    result.u8x16[i] = outerIdx; // stays as 16..31
+                }
+            } else {
+                // inner is child1 of outer
+                if (outerIdx >= 16) {
+                    // Reads from inner's output (which is child1 of outer).
+                    uint8_t innerIdx = innerPattern.u8x16[outerIdx - 16];
+                    if (innerIdx >= 16) {
+                        result.u8x16[i] = 0xFF;
+                        continue;
+                    }
+                    // inner's input becomes child1 in composed result.
+                    result.u8x16[i] = innerIdx + 16;
+                } else {
+                    // Reads from the other child (child0 of outer).
+                    result.u8x16[i] = outerIdx; // stays as 0..15
+                }
+            }
+        }
+        return result;
+    }
+
 private:
+    static CanonicalShuffle tryMatchCanonicalBinaryImpl(v128_t pattern, const Invocable<v128_t(v128_t)> auto& canonicalize)
+    {
+        // 64-bit element patterns
+        // UZP1.2D: {a[lo64], b[lo64]}
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(0,1,2,3,4,5,6,7, 16,17,18,19,20,21,22,23))))
+            return CanonicalShuffle::S64x2UnzipEven;
+        // UZP2.2D: {a[hi64], b[hi64]}
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(8,9,10,11,12,13,14,15, 24,25,26,27,28,29,30,31))))
+            return CanonicalShuffle::S64x2UnzipOdd;
+
+        // 32-bit element patterns
+        // UZP1.4S: {a[0], a[2], b[0], b[2]}
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(0,1,2,3, 8,9,10,11, 16,17,18,19, 24,25,26,27))))
+            return CanonicalShuffle::S32x4UnzipEven;
+        // UZP2.4S: {a[1], a[3], b[1], b[3]}
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(4,5,6,7, 12,13,14,15, 20,21,22,23, 28,29,30,31))))
+            return CanonicalShuffle::S32x4UnzipOdd;
+        // ZIP1.4S: {a[0], b[0], a[1], b[1]}
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(0,1,2,3, 16,17,18,19, 4,5,6,7, 20,21,22,23))))
+            return CanonicalShuffle::S32x4ZipLower;
+        // ZIP2.4S: {a[2], b[2], a[3], b[3]}
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(8,9,10,11, 24,25,26,27, 12,13,14,15, 28,29,30,31))))
+            return CanonicalShuffle::S32x4ZipHigher;
+        // TRN1.4S: {a[0], b[0], a[2], b[2]}
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(0,1,2,3, 16,17,18,19, 8,9,10,11, 24,25,26,27))))
+            return CanonicalShuffle::S32x4TransposeEven;
+        // TRN2.4S: {a[1], b[1], a[3], b[3]}
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(4,5,6,7, 20,21,22,23, 12,13,14,15, 28,29,30,31))))
+            return CanonicalShuffle::S32x4TransposeOdd;
+
+        // 16-bit element patterns
+        // UZP1.8H: {a[0],a[2],a[4],a[6], b[0],b[2],b[4],b[6]}
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(0,1, 4,5, 8,9, 12,13, 16,17, 20,21, 24,25, 28,29))))
+            return CanonicalShuffle::S16x8UnzipEven;
+        // UZP2.8H
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(2,3, 6,7, 10,11, 14,15, 18,19, 22,23, 26,27, 30,31))))
+            return CanonicalShuffle::S16x8UnzipOdd;
+        // ZIP1.8H
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(0,1, 16,17, 2,3, 18,19, 4,5, 20,21, 6,7, 22,23))))
+            return CanonicalShuffle::S16x8ZipLower;
+        // ZIP2.8H
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(8,9, 24,25, 10,11, 26,27, 12,13, 28,29, 14,15, 30,31))))
+            return CanonicalShuffle::S16x8ZipHigher;
+        // TRN1.8H
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(0,1, 16,17, 4,5, 20,21, 8,9, 24,25, 12,13, 28,29))))
+            return CanonicalShuffle::S16x8TransposeEven;
+        // TRN2.8H
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(2,3, 18,19, 6,7, 22,23, 10,11, 26,27, 14,15, 30,31))))
+            return CanonicalShuffle::S16x8TransposeOdd;
+
+        // 8-bit element patterns
+        // UZP1.16B
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(0,2,4,6,8,10,12,14, 16,18,20,22,24,26,28,30))))
+            return CanonicalShuffle::S8x16UnzipEven;
+        // UZP2.16B
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(1,3,5,7,9,11,13,15, 17,19,21,23,25,27,29,31))))
+            return CanonicalShuffle::S8x16UnzipOdd;
+        // ZIP1.16B
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(0,16, 1,17, 2,18, 3,19, 4,20, 5,21, 6,22, 7,23))))
+            return CanonicalShuffle::S8x16ZipLower;
+        // ZIP2.16B
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(8,24, 9,25, 10,26, 11,27, 12,28, 13,29, 14,30, 15,31))))
+            return CanonicalShuffle::S8x16ZipHigher;
+        // TRN1.16B
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(0,16, 2,18, 4,20, 6,22, 8,24, 10,26, 12,28, 14,30))))
+            return CanonicalShuffle::S8x16TransposeEven;
+        // TRN2.16B
+        if (bitEquals(pattern, canonicalize(v128_t::fromU8x16(1,17, 3,19, 5,21, 7,23, 9,25, 11,27, 13,29, 15,31))))
+            return CanonicalShuffle::S8x16TransposeOdd;
+
+        return CanonicalShuffle::Unknown;
+    }
+
     static bool isLargerElementShuffle(v128_t pattern, unsigned size)
     {
         unsigned numberOfElements = 16 / size;

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -520,6 +520,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Unsigned, maxB3TailDupBlockSuccessors, 3, Normal, nullptr) \
     v(Bool, useB3HoistLoopInvariantValues, true, Normal, nullptr) \
     v(Bool, useB3CanonicalizePrePostIncrements, false, Normal, nullptr) \
+    v(Bool, useB3ReduceSIMDShuffle, true, Normal, nullptr) \
     v(Bool, useAirOptimizePairedLoadStore, true, Normal, nullptr) \
     \
     v(Bool, useDollarVM, false, Restricted, "installs the $vm debugging tool in global objects"_s) \

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -3942,7 +3942,7 @@ void BBQJIT::materializeVectorConstant(v128_t value, Location result)
 
             if (info.lane == SIMDLane::i8x16) {
                 m_jit.vectorExtractPair(SIMDInfo { SIMDLane::i8x16, SIMDSignMode::None }, TrustedImm32(8), scratches.fpr(0), scratches.fpr(0), wasmScratchFPR);
-                m_jit.vectorZipUpper(SIMDInfo { SIMDLane::i8x16, SIMDSignMode::None }, scratches.fpr(0), wasmScratchFPR, scratches.fpr(0));
+                m_jit.vectorZipLower(SIMDInfo { SIMDLane::i8x16, SIMDSignMode::None }, scratches.fpr(0), wasmScratchFPR, scratches.fpr(0));
                 info.lane = SIMDLane::i16x8;
             }
 

--- a/Source/WTF/wtf/PlatformHave.h
+++ b/Source/WTF/wtf/PlatformHave.h
@@ -285,6 +285,10 @@
 #define HAVE_FRINT_INSTRUCTION 1
 #endif
 
+#if COMPILER(CLANG) && defined(__ARM_FEATURE_SHA3) && __ARM_FEATURE_SHA3
+#define HAVE_SHA3_INSTRUCTION 1
+#endif
+
 #if OS(DARWIN) && CPU(ARM64)
 #define HAVE_FLOAT16 1
 #endif


### PR DESCRIPTION
#### 8eb745ff86d09f8b7853e2a507741fcc6ed332f7
<pre>
[JSC] Implement SIMD Shuffle reduction
<a href="https://bugs.webkit.org/show_bug.cgi?id=309764">https://bugs.webkit.org/show_bug.cgi?id=309764</a>
<a href="https://rdar.apple.com/172351912">rdar://172351912</a>

Reviewed by Keith Miller.

This patch implements recently enabled V8&apos;s SIMD shuffle optimization.

1. Add SIMD reductions

ARM64 has zip1, zip2, uzp1, uzp2, trn1, trn2, ext, rev16, rev32, rev64
instructions. And they are more specific shuffling than using tbl
instruction, and it is cheaper than that. We do strength-reduction for
the input to optimize it. However if we do it too early, it makes
analysis of Shuffle hard.
Thus we introduce two passes to B3ReduceStrength. And we do this Vector
shuffle reduction only in the latter pass.

We also add several simple reductions which can be seen in the
JetStream3/argon2-wasm, Vector left-shift to VectorAdd. Using
VectorDupElement.

2. Add B3SIMDShuffleReduction phase

This phase analyzes VectorSwizzle of VectorSwizzle, and attempt to remove
it by reconstructing the pattern for the final output.

3. ARM64 SHA3 XAR lowering

Particular pattern can be converted into ARM64 SHA3-feature&apos;s XAR
instruction. We add a lowering rule for that when ARM64 SHA3-feature is
available.

Tests: JSTests/wasm/stress/simd-canonical-shuffle.js
       JSTests/wasm/stress/simd-ext-pattern.js
       JSTests/wasm/stress/simd-shift-left-one.js
       JSTests/wasm/stress/simd-shuffle-compose.js
       JSTests/wasm/stress/simd-shuffle-narrowing.js
       JSTests/wasm/stress/simd-unary-shuffle-canonical.js
       JSTests/wasm/stress/simd-xor-rotate.js
       Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_7.cpp

* JSTests/wasm/stress/simd-canonical-shuffle.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test.const.mem.new.DataView.setI32x4):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test.getI32x4):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test.setBytes):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test.getBytes):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test.verify):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test):
* JSTests/wasm/stress/simd-ext-pattern.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test.getResult):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test):
* JSTests/wasm/stress/simd-shift-left-one.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test):
* JSTests/wasm/stress/simd-shuffle-compose.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test.getResult):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test):
* JSTests/wasm/stress/simd-shuffle-narrowing.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test):
* JSTests/wasm/stress/simd-unary-shuffle-canonical.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test.getResult32):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test):
* JSTests/wasm/stress/simd-xor-rotate.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test.rotr64):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test.let.xor0.0x0123456789ABCDEFn.0xFF00FF00FF00FF00n.let.xor1.0xFEDCBA9876543210n.0x00FF00FF00FF00FFn.verify):
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async test):
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/assembler/ARM64Assembler.h:
* Source/JavaScriptCore/assembler/CPU.cpp:
(JSC::isARM64_SHA3):
* Source/JavaScriptCore/assembler/CPU.h:
(JSC::isARM64_SHA3):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.cpp:
(JSC::MacroAssemblerARM64::collectCPUFeatures):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::supportsSHA3):
(JSC::MacroAssemblerARM64::vectorXorRotateRight64):
(JSC::MacroAssemblerARM64::vectorZipLower):
(JSC::MacroAssemblerARM64::vectorZipHigher):
(JSC::MacroAssemblerARM64::vectorUnzipOdd):
(JSC::MacroAssemblerARM64::vectorTransposeEven):
(JSC::MacroAssemblerARM64::vectorTransposeOdd):
(JSC::MacroAssemblerARM64::vectorReverse):
(JSC::MacroAssemblerARM64::vectorZipUpper): Deleted.
* Source/JavaScriptCore/b3/B3Generate.cpp:
(JSC::B3::generateToAir):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3ReduceSIMDShuffle.cpp: Added.
(JSC::B3::reduceSIMDShuffle):
* Source/JavaScriptCore/b3/B3ReduceSIMDShuffle.h: Copied from Source/JavaScriptCore/b3/B3ReduceStrength.h.
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
(JSC::B3::reduceStrength):
* Source/JavaScriptCore/b3/B3ReduceStrength.h:
* Source/JavaScriptCore/b3/B3SIMDValue.h:
* Source/JavaScriptCore/b3/B3UseCounts.cpp:
(JSC::B3::UseCountsWithoutUsingInstructions::UseCountsWithoutUsingInstructions):
* Source/JavaScriptCore/b3/B3UseCounts.h:
(JSC::B3::UseCountsWithoutUsingInstructions::numUses const):
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effects const):
(JSC::B3::Value::key const):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
(JSC::B3::ValueKey::materialize const):
* Source/JavaScriptCore/b3/air/AirLowerMacros.cpp:
(JSC::B3::Air::lowerMacros):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/b3/air/opcode_generator.rb:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testVectorXorRotateRight64):
(testVectorUnzipEven):
(testVectorUnzipOdd):
(testVectorZipLower):
(testVectorZipHigher):
(testVectorTransposeEven):
(testVectorTransposeOdd):
(testVectorReverse):
(testVectorShiftByVectorShlByOne):
(testBinarySwizzlePattern):
(testUnarySwizzlePattern):
(testVectorSwizzleToUnzipEven):
(testVectorSwizzleBinaryToUnzipOdd):
(testVectorExtractPair):
(testVectorSwizzleBinaryToEXT):
(testVectorSwizzleUnaryToEXT):
(testVectorSwizzleBinaryCanonical):
(testVectorSwizzleUnaryCanonical):
(testVectorCanonicalSameInputFolding):
(testVectorSwizzleToDupElement):
(testVectorSwizzleComposition):
* Source/JavaScriptCore/jit/SIMDInfo.h:
* Source/JavaScriptCore/jit/SIMDShuffle.h:
(JSC::SIMDShuffle::isI8x16SameElement):
(JSC::SIMDShuffle::isEXTWithSwap):
(JSC::SIMDShuffle::tryMatchCanonicalBinary):
(JSC::SIMDShuffle::tryMatchUnaryAsBinaryCanonical):
(JSC::SIMDShuffle::tryMatchCanonicalUnary):
(JSC::SIMDShuffle::composeShuffle):
(JSC::SIMDShuffle::tryMatchCanonicalBinaryImpl):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDI_V):
* Source/WTF/wtf/PlatformHave.h:

Canonical link: <a href="https://commits.webkit.org/309250@main">https://commits.webkit.org/309250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b094a5a192dcd8594d934cce54080488e717f6a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150032 "284 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158743 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4437559a-b9ff-4fdf-9474-3e6d5e8c4622) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22883 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115734 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da85b2e5-b3bd-4fc9-af7f-f55f89226ec3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152992 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134607 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96463 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36f16f90-33ae-4368-af67-5b7af3222f5d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6589 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142015 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/12531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161217 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10830 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14083 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123736 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/22559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123938 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/22564 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134326 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23079 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11082 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181463 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22164 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85992 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/21894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/22046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/21952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->