### PR TITLE
[ MacOS IOS ] http/tests/download/sandboxed-iframe-download-not-allowed.html is a flaky text failure

### DIFF
--- a/LayoutTests/http/tests/download/sandboxed-iframe-download-not-allowed-expected.txt
+++ b/LayoutTests/http/tests/download/sandboxed-iframe-download-not-allowed-expected.txt
@@ -1,7 +1,3 @@
-CONSOLE MESSAGE: Not allowed to download due to sandboxing
-CONSOLE MESSAGE: Not allowed to download due to sandboxing
-CONSOLE MESSAGE: Not allowed to download due to sandboxing
-CONSOLE MESSAGE: Not allowed to download due to sandboxing
 This test passes if no download is started.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/http/tests/download/sandboxed-iframe-download-not-allowed.html
+++ b/LayoutTests/http/tests/download/sandboxed-iframe-download-not-allowed.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE HTML><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <head>
 <script src="/js-test-resources/js-test.js"></script>
@@ -10,6 +10,7 @@ jsTestIsAsync = true;
 if (window.testRunner)
     testRunner.setShouldLogDownloadCallbacks(true);
 
+let handledIframes = new WeakSet();
 let frameCount = 0;
 
 ['', 'target="_blank" ', 'target="_blank" rel="noopener" ', 'download'].forEach(attributes => {
@@ -17,13 +18,18 @@ let frameCount = 0;
     iframe.srcdoc = `<a ${attributes}>Download</a>`;
     iframe.sandbox = "allow-same-origin allow-popups";
     iframe.onload = () => {
+        if (handledIframes.has(iframe))
+            return;
+        let anchor = iframe.contentDocument.getElementsByTagName('a')[0];
+        if (!anchor)
+            return;
+        handledIframes.add(iframe);
         iframe.contentWindow.addEventListener("unload", () => {
            testFailed("Unexpected frame navigation");
         });
-        let anchor = iframe.contentDocument.getElementsByTagName('a')[0];
         anchor.href = 'resources/content-disposition-pass.py';
         anchor.click();
-        if (++frameCount == 4)
+        if (++frameCount === 4)
             setTimeout(finishJSTest, 1000);
     };
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1927,7 +1927,6 @@ webkit.org/b/123431 http/tests/local/link-stylesheet-load-order.html [ Failure ]
 webkit.org/b/296171 fast/files/filereader-zip-bundle-using-open-panel.html [ Skip ]
 webkit.org/b/296171 http/tests/local/fileapi/upload-zip-bundle-as-blob-using-open-panel.html [ Skip ]
 
-webkit.org/b/306360 http/tests/download/sandboxed-iframe-download-not-allowed.html [ Pass Failure ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of HTTP-related bugs

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8447,7 +8447,6 @@ webkit.org/b/305605 media/volume-sleep-disable.html [ Failure ]
 imported/w3c/web-platform-tests/uievents/mouse/layer-coords-transform.html [ Skip ]
 imported/w3c/web-platform-tests/uievents/mouse/mouse_boundary_events_on_image_map.html [ Skip ]
 
-webkit.org/b/306360 http/tests/download/sandboxed-iframe-download-not-allowed.html [ Pass Failure ]
 
 webkit.org/b/306570 http/tests/webcodecs/video-decoder-callbacks-do-not-leak.html [ Pass Failure ]
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2420,7 +2420,6 @@ webkit.org/b/306278 [ arm64 ] media/media-source/media-managedmse-resume-after-r
 
 webkit.org/b/306294 http/wpt/offscreen-canvas/transferToImageBitmap-webgl.html [ ImageOnlyFailure Pass ]
 
-webkit.org/b/306360 http/tests/download/sandboxed-iframe-download-not-allowed.html [ Pass Failure ]
 
 webkit.org/b/306570 [ Tahoe arm64 ] http/tests/webcodecs/video-decoder-callbacks-do-not-leak.html [ Pass Failure ]
 


### PR DESCRIPTION
#### 94eca8c034a989a4446b9bc1d3cd9e081627dcb0
<pre>
[ MacOS IOS ] http/tests/download/sandboxed-iframe-download-not-allowed.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=306360">https://bugs.webkit.org/show_bug.cgi?id=306360</a>
<a href="https://rdar.apple.com/169028449">rdar://169028449</a>

Reviewed by Per Arne Vollan.

Silence console messages to address flakiness. The test relies on a setTimeout
to finish because we don&apos;t have a reliable way to wait to see if downloads
were blocked. Therefore, we wait for a while and make sure there were no
downloads. The console messages do not matter much in this case.

* LayoutTests/http/tests/download/sandboxed-iframe-download-not-allowed-expected.txt:
* LayoutTests/http/tests/download/sandboxed-iframe-download-not-allowed.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/309167@main">https://commits.webkit.org/309167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/774bfd0f12a9769f3b122ac92f9bcdf904e27af3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149564 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22282 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158267 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102996 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5829b465-17b1-4806-b708-b4e7675d8432) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22202 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115371 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82028 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6050b369-dcb6-4516-bdf3-7f65c25baac0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134218 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96112 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16603 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14503 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6111 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126211 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160743 "Built successfully") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13691 "Found 1 new test failure: fast/attachment/mac/wide-attachment-image-controls-basic.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123401 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18544 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123611 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33601 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22092 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133942 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78306 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18797 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10693 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21692 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21423 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21575 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21480 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->