### PR TITLE
The height of table cells with a cell next to them has rowspan are not computed as expected

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rowspan-height-distribution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rowspan-height-distribution-expected.txt
@@ -1,0 +1,11 @@
+ 	 
+ 	 
+ 	 
+ 
+ 	 
+
+PASS Single row with height attribute and rowspan=5: cells have equal height
+PASS Single row with CSS height and rowspan=5: cells have equal height
+PASS Two rows with rowspan=10: real rows share full table height
+PASS Single row with height attribute and rowspan=3: cells have equal height
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rowspan-height-distribution.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rowspan-height-distribution.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Table cell height with rowspan exceeding actual row count</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#tables-2">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=21397">
+<link rel="author" title="Karl Dubost" href="https://otsukare.info/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+    table { border-collapse: collapse; }
+    td { padding: 0; }
+</style>
+
+<!-- Test 1: Single row, table height attribute, rowspan=5 -->
+<table id="t1" height="100" border="1">
+  <tr>
+    <td id="t1-a">&nbsp;</td>
+    <td id="t1-b" rowspan="5">&nbsp;</td>
+  </tr>
+</table>
+
+<!-- Test 2: Single row, CSS height, rowspan=5 -->
+<table id="t2" style="height: 100px" border="1">
+  <tr>
+    <td id="t2-a">&nbsp;</td>
+    <td id="t2-b" rowspan="5">&nbsp;</td>
+  </tr>
+</table>
+
+<!-- Test 3: Two rows, rowspan=10 on first row -->
+<table id="t3" height="200" border="1">
+  <tr>
+    <td id="t3-a">&nbsp;</td>
+    <td id="t3-b" rowspan="10">&nbsp;</td>
+  </tr>
+  <tr>
+    <td id="t3-c">&nbsp;</td>
+  </tr>
+</table>
+
+<!-- Test 4: Single row, rowspan=3, larger table height -->
+<table id="t4" height="300" border="1">
+  <tr>
+    <td id="t4-a">&nbsp;</td>
+    <td id="t4-b" rowspan="3">&nbsp;</td>
+  </tr>
+</table>
+
+<script>
+test(function() {
+    const cellA = document.getElementById("t1-a");
+    const cellB = document.getElementById("t1-b");
+    assert_equals(cellA.offsetHeight, cellB.offsetHeight,
+        "Both cells should have the same height");
+}, "Single row with height attribute and rowspan=5: cells have equal height");
+
+test(function() {
+    const cellA = document.getElementById("t2-a");
+    const cellB = document.getElementById("t2-b");
+    assert_equals(cellA.offsetHeight, cellB.offsetHeight,
+        "Both cells should have the same height");
+}, "Single row with CSS height and rowspan=5: cells have equal height");
+
+test(function() {
+    const cellA = document.getElementById("t3-a");
+    const cellB = document.getElementById("t3-b");
+    const cellC = document.getElementById("t3-c");
+    assert_approx_equals(cellA.offsetHeight + cellC.offsetHeight, cellB.offsetHeight, 1,
+        "Real rows together should approximately equal the rowspan cell height");
+}, "Two rows with rowspan=10: real rows share full table height");
+
+test(function() {
+    const cellA = document.getElementById("t4-a");
+    const cellB = document.getElementById("t4-b");
+    assert_equals(cellA.offsetHeight, cellB.offsetHeight,
+        "Both cells should have the same height");
+}, "Single row with height attribute and rowspan=3: cells have equal height");
+</script>

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -442,7 +442,7 @@ void RenderTableSection::distributeExtraLogicalHeightToAutoRows(LayoutUnit& extr
 
     LayoutUnit totalLogicalHeightAdded;
     for (unsigned r = 0; r < m_grid.size(); ++r) {
-        if (autoRowsCount > 0 && m_grid[r].logicalHeight.isAuto()) {
+        if (autoRowsCount > 0 && m_grid[r].logicalHeight.isAuto() && m_grid[r].rowRenderer) {
             // Recomputing |extraLogicalHeightForRow| guarantees that we properly ditribute round |extraLogicalHeight|.
             LayoutUnit extraLogicalHeightForRow = extraLogicalHeight / autoRowsCount;
             totalLogicalHeightAdded += extraLogicalHeightForRow;
@@ -486,7 +486,7 @@ LayoutUnit RenderTableSection::distributeExtraLogicalHeightToRows(LayoutUnit ext
     unsigned autoRowsCount = 0;
     int totalPercent = 0;
     for (unsigned r = 0; r < totalRows; r++) {
-        if (m_grid[r].logicalHeight.isAuto())
+        if (m_grid[r].logicalHeight.isAuto() && m_grid[r].rowRenderer)
             ++autoRowsCount;
         else if (auto percentageLogicalHeight = m_grid[r].logicalHeight.tryPercentage())
             totalPercent += percentageLogicalHeight->value;


### PR DESCRIPTION
#### cc3ce1dc902096ff1c91b533d976c792d5db67fb
<pre>
The height of table cells with a cell next to them has rowspan are not computed as expected
<a href="https://bugs.webkit.org/show_bug.cgi?id=21397">https://bugs.webkit.org/show_bug.cgi?id=21397</a>
<a href="https://rdar.apple.com/3209126">rdar://3209126</a>

Reviewed by Darin Adler.

When a table cell has a rowspan exceeding the actual number of &lt;tr&gt; rows,
RenderTableSection::addCell() creates phantom grid rows (no rowRenderer).
These phantom rows were incorrectly counted as auto rows in
distributeExtraLogicalHeightToRows() and received a share of extra table
height in distributeExtraLogicalHeightToAutoRows(), causing non-rowspan
cells to render shorter than the rowspan cell. Firefox and Chrome already
handle this correctly.

The fix adds a rowRenderer check when counting and distributing extra
height to auto rows, so phantom rows are skipped entirely.

Test: imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rowspan-height-distribution.html

* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rowspan-height-distribution-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/tables/table-rowspan-height-distribution.html: Added.
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::RenderTableSection::distributeExtraLogicalHeightToAutoRows):
(WebCore::RenderTableSection::distributeExtraLogicalHeightToRows):

Canonical link: <a href="https://commits.webkit.org/309153@main">https://commits.webkit.org/309153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8b83d5909ceb1576961f196c0b8320a02f3c32b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158268 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102997 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b39b8d47-1c18-4a8c-b74c-95fbda70aa4d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115370 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82034 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a73fef9-475d-4c1d-9132-e650f58f8173) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17503 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96111 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ce3ecb1-9a39-4ea2-a5e8-344568ea2629) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16600 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14505 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6112 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160744 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3741 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13695 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123402 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22086 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18546 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123612 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33592 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133946 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78307 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18802 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10697 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21693 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85514 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21424 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21576 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21481 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->