### PR TITLE
Switch UIHelper's activeAt() to use eventSender.asyncMouse*()

### DIFF
--- a/LayoutTests/editing/selection/click-selection-with-selectstart-node-removal.html
+++ b/LayoutTests/editing/selection/click-selection-with-selectstart-node-removal.html
@@ -26,7 +26,7 @@ editor.addEventListener('mousedown', () => {
 });
 
 if (window.testRunner)
-    UIHelper.activateElement(editor);
+    (async () => { await UIHelper.activateElement(editor); })();
 
 successfullyParsed = true;
 

--- a/LayoutTests/fast/dom/FileList-iterator-using-open-panel.html
+++ b/LayoutTests/fast/dom/FileList-iterator-using-open-panel.html
@@ -12,12 +12,12 @@
 description("Tests that FileList objects have an iterator.");
 jsTestIsAsync = true;
 
-function runTest()
+async function runTest()
 {
     testRunner.setOpenPanelFiles(['test.txt']);
 
     var inputElement = document.getElementsByTagName('input')[0];
-    UIHelper.activateAt(inputElement.offsetLeft + inputElement.offsetWidth / 2,
+    await UIHelper.activateAt(inputElement.offsetLeft + inputElement.offsetWidth / 2,
         inputElement.offsetTop + inputElement.offsetHeight / 2);
 }
 

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-unset.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-unset.html
@@ -13,23 +13,23 @@ if (window.testRunner) {
 <body>
 <a id="blob-url" download>Blob URL</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
     var string = "<!doctype html><html><head><title>Title</title><script>if (window.testRunner) testRunner.dumpAsText(); </" + "script></head><body>PASS</body><script>if (window.testRunner) testRunner.notifyDone();</scr" + "ipt></html>";
     var blob = new Blob([string], {type: "text/html"});
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(blob);
     link.removeAttribute('download');
-    click(link);
+    await click(link);
 }
 runTest();
 </script>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-user-triggered-synthetic-click.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-download-user-triggered-synthetic-click.html
@@ -17,16 +17,16 @@ if (window.testRunner) {
 <a style="display:none" id="blob-url" download>Blob URL</a>
 <input type="button" id="testButton" value="Download">
 <script>
-function userClick(element)
+async function userClick(element)
 {
     if (!window.eventSender) {
         alert('Click the button to run the test.');
         return;
     }
-    UIHelper.activateAt(element.offsetLeft + 5, element.offsetTop + 5);
+    await UIHelper.activateAt(element.offsetLeft + 5, element.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
     var string = "test";
     var blob = new Blob([string], {type: "text/html"});
@@ -36,7 +36,7 @@ function runTest()
     button.onclick = function() {
         link.click();
     }
-    userClick(button);
+    await userClick(button);
 }
 runTest();
 </script>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download-async-delegate.html
@@ -21,13 +21,13 @@ onload = async () => {
 <p>The download should succeed.</p>
 <a id="blob-url">File backed blob URL</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
 async function runTest()
@@ -35,7 +35,7 @@ async function runTest()
     file = await internals.asyncCreateFile("../../../resources/Ahem.otf");
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(file);
-    click(link);
+    await click(link);
 }
 </script>
 </body>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-convert-to-download.html
@@ -19,13 +19,13 @@ onload = async () => {
 <p>The download should succeed.</p>
 <a id="blob-url">File backed blob URL</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
 async function runTest()
@@ -33,7 +33,7 @@ async function runTest()
     file = await internals.asyncCreateFile("../../../resources/Ahem.otf");
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(file);
-    click(link);
+    await click(link);
 }
 </script>
 </body>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-base-target-popup-not-allowed.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-base-target-popup-not-allowed.html
@@ -19,13 +19,13 @@ onload = async () => {
 <p>The suggested filename above should be "abe.png" and the download should succeed.</p>
 <a id="blob-url" download="abe.png" target="_blank">File backed blob URL</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
 async function runTest()
@@ -33,7 +33,7 @@ async function runTest()
     file = await internals.asyncCreateFile("../resources/abe.png");
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(file);
-    click(link);
+    await click(link);
 }
 </script>
 </body>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target-popup-not-allowed.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target-popup-not-allowed.html
@@ -15,21 +15,21 @@ if (window.testRunner) {
 <p>The suggested filename above should be "abe.png" and the download should succeed.</p>
 <a id="blob-url" download="abe.png" target="_blank">File backed blob URL</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
     file = internals.createFile("../resources/abe.png");
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(file);
-    click(link);
+    await click(link);
 }
 runTest();
 </script>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-blank-target.html
@@ -15,21 +15,21 @@ if (window.testRunner) {
 <p>The suggested filename above should be "abe.png" and the download should succeed.</p>
 <a id="blob-url" download="abe.png" target="_blank">File backed blob URL</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
     file = internals.createFile("../resources/abe.png");
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(file);
-    click(link);
+    await click(link);
 }
 runTest();
 </script>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-backslash.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-backslash.html
@@ -18,13 +18,13 @@ onload = async () => {
 <p>The suggested filename above should be "*.png" and the download should succeed.</p>
 <a id="blob-url" download="*\">File backed blob URL</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
 async function runTest()
@@ -32,7 +32,7 @@ async function runTest()
     file = await internals.asyncCreateFile("../resources/abe.png");
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(file);
-    click(link);
+    await click(link);
 }
 </script>
 </body>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-doublequote.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-doublequote.html
@@ -15,21 +15,21 @@ if (window.testRunner) {
 <p>The suggested filename above should be 'test"abe.png' and the download should succeed.</p>
 <a id="blob-url" download='test"abe.png'>File backed blob URL</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
     file = internals.createFile("../resources/abe.png");
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(file);
-    click(link);
+    await click(link);
 }
 runTest();
 </script>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-slashes.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-slashes.html
@@ -15,21 +15,21 @@ if (window.testRunner) {
 <p>The suggested filename above should NOT include slashes or backslashes and the download should succeed.</p>
 <a id="blob-url" download="test1/test2\\abe.png">File backed blob URL</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
     file = internals.createFile("../resources/abe.png");
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(file);
-    click(link);
+    await click(link);
 }
 runTest();
 </script>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-unicode.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-includes-unicode.html
@@ -16,21 +16,21 @@ if (window.testRunner) {
 <p>The suggested filename above should be "你好.png" and the download should succeed.</p>
 <a id="blob-url" download='你好.png'>File backed blob URL</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
     file = internals.createFile("../resources/abe.png");
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(file);
-    click(link);
+    await click(link);
 }
 runTest();
 </script>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-no-extension.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download-no-extension.html
@@ -15,21 +15,21 @@ if (window.testRunner) {
 <p>The suggested filename above should be "abe.png" and the download should succeed.</p>
 <a id="blob-url" download="abe">File backed blob URL</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
     file = internals.createFile("../resources/abe.png");
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(file);
-    click(link);
+    await click(link);
 }
 runTest();
 </script>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-file-blob-download.html
@@ -15,21 +15,21 @@ if (window.testRunner) {
 <p>The suggested filename above should be "abe.png" and the download should succeed.</p>
 <a id="blob-url" download="abe.png">File backed blob URL</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
     file = internals.createFile("../resources/abe.png");
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(file);
-    click(link);
+    await click(link);
 }
 runTest();
 </script>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-nodownload-set.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-nodownload-set.html
@@ -14,23 +14,23 @@ if (window.testRunner) {
 <body>
 <a id="blob-url">Blob URL</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
     var string = "<!doctype html><html><head><title>Title</title><script>if (window.testRunner) testRunner.dumpAsText(); </" + "script></head><body>FAIL</body><script>if (window.testRunner) testRunner.notifyDone();</scr" + "ipt></html>";
     var blob = new Blob([string], {type: "text/html"});
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(blob);
     link.setAttribute('download', '');
-    click(link);
+    await click(link);
 }
 runTest();
 </script>

--- a/LayoutTests/fast/dom/HTMLAnchorElement/anchor-nodownload.html
+++ b/LayoutTests/fast/dom/HTMLAnchorElement/anchor-nodownload.html
@@ -13,22 +13,22 @@ if (window.testRunner) {
 <body>
 <a id="blob-url">Blob URL</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
     var string = "<!doctype html><html><head><title>Title</title><script>if (window.testRunner) testRunner.dumpAsText(); </" + "script></head><body>PASS</body><script>if (window.testRunner) testRunner.notifyDone();</scr" + "ipt></html>";
     var blob = new Blob([string], {type: "text/html"});
     var link = document.getElementById("blob-url");
     link.href = window.URL.createObjectURL(blob);
-    click(link);
+    await click(link);
 }
 runTest();
 </script>

--- a/LayoutTests/fast/events/can-click-element-on-page-with-active-pseudo-class-and-search-field.html
+++ b/LayoutTests/fast/events/can-click-element-on-page-with-active-pseudo-class-and-search-field.html
@@ -21,7 +21,7 @@ function notifyPass()
     finishJSTest();
 }
 
-function runTest()
+async function runTest()
 {
     if (!window.testRunner)
         return;
@@ -29,7 +29,7 @@ function runTest()
     var square = iframe.contentDocument.getElementById("square");
     var x = iframe.offsetLeft + square.offsetLeft + Math.floor(square.offsetWidth / 2);
     var y = iframe.offsetTop + square.offsetTop + Math.floor(square.offsetHeight / 2);
-    UIHelper.activateAt(x, y);
+    await UIHelper.activateAt(x, y);
 }
 </script>
 </head>

--- a/LayoutTests/fast/events/ios/fire-input-and-keypress-on-return-key.html
+++ b/LayoutTests/fast/events/ios/fire-input-and-keypress-on-return-key.html
@@ -28,7 +28,7 @@ function checkKeypressAndDone()
     shouldBeEqualToString("event.key", "Enter");
 }
 
-function runTest()
+async function runTest()
 {
     function handleFocus(event) {
         event.target.addEventListener("input", checkInputEvent, { once: true });
@@ -39,7 +39,7 @@ function runTest()
     let test = document.getElementById("test");
     test.addEventListener("focus", handleFocus, { once: true });
     if (window.testRunner)
-        UIHelper.activateElement(test);
+        await UIHelper.activateElement(test);
 }
 
 description("Tests that pressing the Return key in a content editable elemnent dispatches a DOM input event and DOM keypress event (in that order). To run this test by hand, focus the content editable element below and press the <key>Return<key> key.");

--- a/LayoutTests/fast/events/ios/key-command-italic-dispatches-keydown.html
+++ b/LayoutTests/fast/events/ios/key-command-italic-dispatches-keydown.html
@@ -55,7 +55,7 @@ function handleKeyDownEvent(event)
     finishJSTest();
 }
 
-function runTest()
+async function runTest()
 {
     if (!window.testRunner)
         return;
@@ -64,7 +64,7 @@ function runTest()
         UIHelper.keyDown("i", ["metaKey"]);
     }
     testElement.addEventListener("focus", handleFocus, { once: true });
-    UIHelper.activateElement(testElement);
+    await UIHelper.activateElement(testElement);
 }
 
 description("Tests that pressing Command + I in a rich editing field dispatches a key down event. To run this test by hand, select all the text below and press Command + I.");

--- a/LayoutTests/fast/events/ios/key-command-italic.html
+++ b/LayoutTests/fast/events/ios/key-command-italic.html
@@ -31,7 +31,7 @@ function handleChildListModified()
     Markup.notifyDone();
 }
 
-function runTest()
+async function runTest()
 {
     if (!window.testRunner) {
         document.getElementById("manual-instructions").classList.remove("hidden");
@@ -48,7 +48,7 @@ function runTest()
         UIHelper.keyDown("i", ["metaKey"]);
     }
     testElement.addEventListener("focus", handleFocus, { once: true });
-    UIHelper.activateElement(testElement);
+    await UIHelper.activateElement(testElement);
 }
 
 Markup.waitUntilDone();

--- a/LayoutTests/fast/events/ios/key-command-transpose.html
+++ b/LayoutTests/fast/events/ios/key-command-transpose.html
@@ -35,7 +35,7 @@ function handleMutation()
     finishJSTest();
 }
 
-function runTest()
+async function runTest()
 {
     if (!window.testRunner)
         document.getElementById("manual-instructions").classList.remove("hidden");
@@ -50,7 +50,7 @@ function runTest()
     }
     testElement.addEventListener("focus", handleFocus, { once: true });
     if (window.testRunner)
-        UIHelper.activateElement(testElement);
+        await UIHelper.activateElement(testElement);
 }
 
 description("Tests that pressing Control + t in a content-editable field performs a tranpose.");

--- a/LayoutTests/fast/events/ios/submit-form-target-blank-using-return-key.html
+++ b/LayoutTests/fast/events/ios/submit-form-target-blank-using-return-key.html
@@ -30,7 +30,7 @@ function checkKeypressAndDone()
     shouldBeEqualToString("event.key", "Enter");
 }
 
-function runTest()
+async function runTest()
 {
     function handleFocus(event) {
         event.target.addEventListener("input", checkInputEvent, { once: true });
@@ -41,7 +41,7 @@ function runTest()
     let test = document.getElementById("test");
     test.addEventListener("focus", handleFocus, { once: true });
     if (window.testRunner)
-        UIHelper.activateElement(test);
+        await UIHelper.activateElement(test);
 }
 
 description("Tests that pressing the Return key in a text field with an associated form implicitly submits the form. To run this test by hand, focus the text field below and press the <key>Return<key> key.");

--- a/LayoutTests/fast/files/apply-blob-url-to-img-using-open-panel.html
+++ b/LayoutTests/fast/files/apply-blob-url-to-img-using-open-panel.html
@@ -30,14 +30,14 @@ function onImgLoad()
         testRunner.notifyDone();
 }
 
-function runTests()
+async function runTests()
 {
     testRunner.setOpenPanelFiles(['resources/abe.png']);
 
     var element = document.getElementById('file');
     var x = element.offsetLeft + element.offsetWidth / 2;
     var y = element.offsetTop + element.offsetHeight / 2;
-    UIHelper.activateAt(x, y);
+    await UIHelper.activateAt(x, y);
 }
 
 if (window.eventSender) {

--- a/LayoutTests/fast/files/apply-blob-url-to-xhr-using-open-panel.html
+++ b/LayoutTests/fast/files/apply-blob-url-to-xhr-using-open-panel.html
@@ -44,14 +44,14 @@ function onInputFileChange()
         testRunner.notifyDone();
 }
 
-function runTests()
+async function runTests()
 {
     testRunner.setOpenPanelFiles(['resources/UTF8.txt']);
 
     var inputElement = document.getElementById("file");
     var centerX = inputElement.offsetLeft + inputElement.offsetWidth / 2;
     var centerY = inputElement.offsetTop + inputElement.offsetHeight / 2;
-    UIHelper.activateAt(centerX, centerY);
+    await UIHelper.activateAt(centerX, centerY);
 }
 
 if (window.eventSender) {

--- a/LayoutTests/fast/files/file-list-test-using-open-panel.html
+++ b/LayoutTests/fast/files/file-list-test-using-open-panel.html
@@ -40,7 +40,11 @@ testRunner.setOpenPanelFiles(["resources/UTF8.txt", "resources/UTF8-2.txt"]);
 var inputElement = document.getElementById("file");
 var centerX = inputElement.offsetLeft + inputElement.offsetWidth / 2;
 var centerY = inputElement.offsetTop + inputElement.offsetHeight / 2;
-UIHelper.activateAt(centerX, centerY);
+
+async function runTest() {
+    await UIHelper.activateAt(centerX, centerY);
+}
+runTest();
 
 </script>
 </body>

--- a/LayoutTests/fast/files/file-reader-abort-using-open-panel.html
+++ b/LayoutTests/fast/files/file-reader-abort-using-open-panel.html
@@ -39,14 +39,14 @@ function onInputFileChange()
     };
 }
 
-function runTests()
+async function runTests()
 {
     testRunner.setOpenPanelFiles(['resources/UTF8.txt']);
 
     var inputElement = document.getElementById("file");
     var centerX = inputElement.offsetLeft + inputElement.offsetWidth / 2;
     var centerY = inputElement.offsetTop + inputElement.offsetHeight / 2;
-    UIHelper.activateAt(centerX, centerY);
+    await UIHelper.activateAt(centerX, centerY);
 }
 
 if (window.eventSender) {

--- a/LayoutTests/fast/files/file-reader-directory-crash-using-open-panel.html
+++ b/LayoutTests/fast/files/file-reader-directory-crash-using-open-panel.html
@@ -27,7 +27,11 @@ if (window.testRunner) {
 }
 
 testRunner.setOpenPanelFiles(['resources']);
-UIHelper.activateAt(input.offsetLeft + 1, input.offsetTop + 1);
+
+async function runTest() {
+    await UIHelper.activateAt(input.offsetLeft + 1, input.offsetTop + 1);
+}
+runTest();
 
 </script>
 </body>

--- a/LayoutTests/fast/files/filereader-zip-bundle-using-open-panel.html
+++ b/LayoutTests/fast/files/filereader-zip-bundle-using-open-panel.html
@@ -16,7 +16,7 @@ if (window.testRunner)
 description("Test that bundles are automatically zipped when accessed via FileReader. To test manually, please select a bundle in the \"Choose File\" input below.");
 jsTestIsAsync = true;
 
-window.onload = function()
+window.onload = async function()
 {
     var fileTarget = document.getElementById("fileTarget");
 
@@ -27,9 +27,9 @@ window.onload = function()
 
     var x = fileTarget.offsetLeft + fileTarget.offsetWidth / 2;
     var y = fileTarget.offsetTop + fileTarget.offsetHeight / 2
-    
+
     testRunner.setOpenPanelFiles(["resources/document.rtfd"]);
-    UIHelper.activateAt(x, y);
+    await UIHelper.activateAt(x, y);
 }
 
 function onchange(event)

--- a/LayoutTests/fast/forms/auto-fill-button/caps-lock-indicator-should-be-visible-after-hiding-auto-fill-strong-password-button.html
+++ b/LayoutTests/fast/forms/auto-fill-button/caps-lock-indicator-should-be-visible-after-hiding-auto-fill-strong-password-button.html
@@ -46,7 +46,7 @@ async function runTest()
         UIHelper.toggleCapsLock();
     }
     input.addEventListener("focus", handleFocus, { once: true });
-    UIHelper.activateElement(input);
+    await UIHelper.activateElement(input);
 }
 
 runTest();

--- a/LayoutTests/fast/forms/auto-fill-button/caps-lock-indicator-should-not-be-visible-when-auto-fill-strong-password-button-is-visible.html
+++ b/LayoutTests/fast/forms/auto-fill-button/caps-lock-indicator-should-not-be-visible-when-auto-fill-strong-password-button-is-visible.html
@@ -39,7 +39,7 @@ async function runTest()
         UIHelper.toggleCapsLock();
     }
     input.addEventListener("focus", handleFocus, { once: true });
-    UIHelper.activateElement(input);
+    await UIHelper.activateElement(input);
 }
 
 runTest();

--- a/LayoutTests/fast/forms/datalist/datalist-textinput-keydown.html
+++ b/LayoutTests/fast/forms/datalist/datalist-textinput-keydown.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/js-test.js"></script>
 <script src="../../../resources/ui-helper.js"></script>
 </head>
 <body>
@@ -19,21 +19,25 @@ description('Test for keyboard operations for &lt;input type=text&gt; with list 
 
 var input = document.getElementById("fruit");
 
-UIHelper.activateElement(input);
+jsTestIsAsync = true;
+
+(async () => {
+
+await UIHelper.activateElement(input);
 eventSender.keyDown("downArrow");
 eventSender.keyDown("\r");
 shouldBe('input.value', '"Apple"');
 
 input.value = "";
 
-UIHelper.activateElement(input);
+await UIHelper.activateElement(input);
 eventSender.keyDown("upArrow");
 eventSender.keyDown("\r");
 shouldBe('input.value', '"Pear"');
 
 input.value = "Appl";
 
-UIHelper.activateElement(input);
+await UIHelper.activateElement(input);
 eventSender.keyDown("\r");
 shouldBe('input.value', '"Appl"');
 
@@ -41,7 +45,7 @@ const arrowKeysCycleThroughOptions = !(UIHelper.isIOSFamily() || UIHelper.isMac(
 
 input.value = "";
 
-UIHelper.activateElement(input);
+await UIHelper.activateElement(input);
 eventSender.keyDown("downArrow");
 eventSender.keyDown("upArrow");
 eventSender.keyDown("\r");
@@ -49,14 +53,16 @@ shouldBe('input.value', arrowKeysCycleThroughOptions ? '"Pear"' : '"Apple"');
 
 input.value = "";
 
-UIHelper.activateElement(input);
+await UIHelper.activateElement(input);
 eventSender.keyDown("upArrow");
 eventSender.keyDown("downArrow");
 eventSender.keyDown("\r");
 shouldBe('input.value', arrowKeysCycleThroughOptions ? '"Apple"' : '"Pear"');
 
+finishJSTest();
+})();
+
 </script>
 
-<script src="../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-focus-and-blur-events.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-focus-and-blur-events.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="../../../../resources/ui-helper.js"></script>
 <style>
 input {
@@ -53,6 +53,10 @@ input.addEventListener("focus", onFocusEvent);
 
 const center = input.offsetHeight / 2;
 
+jsTestIsAsync = true;
+
+(async () => {
+
 debug("Focus/blur using mouse\n");
 
 // Click on month field.
@@ -74,7 +78,7 @@ resetFocusAndBlurCount();
 
 debug("\nFocus/blur using keyboard\n");
 
-UIHelper.activateElement(before);
+await UIHelper.activateElement(before);
 // Focus on month field.
 UIHelper.keyDown("\t");
 assertFocusAndBlurCount(1, 0);
@@ -105,7 +109,7 @@ debug("\nFocus/blur on disabled input\n")
 
 input.disabled = true;
 
-UIHelper.activateElement(before);
+await UIHelper.activateElement(before);
 // Tab to focus should skip disabled input.
 UIHelper.keyDown("\t");
 assertFocusAndBlurCount(0, 0);
@@ -128,7 +132,7 @@ debug("\nFocus/blur on readonly input\n")
 input.disabled = false;
 input.readOnly = true;
 
-UIHelper.activateElement(before);
+await UIHelper.activateElement(before);
 // Tab to focus should not skip readonly input.
 UIHelper.keyDown("\t");
 assertFocusAndBlurCount(1, 0);
@@ -146,8 +150,9 @@ mouseClickOn(input.offsetWidth + 5, input.offsetHeight + 5);
 assertFocusAndBlurCount(1, 1);
 resetFocusAndBlurCount();
 
-</script>
+finishJSTest();
+})();
 
-<script src="../../../../resources/js-test-post.js"></script>
+</script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-mouse-events.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-mouse-events.html
@@ -40,18 +40,22 @@ const monthField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-month
 const dayField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-day-field");
 const yearField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-year-field");
 
+jsTestIsAsync = true;
+
+(async () => {
+
 debug("Enabled Input\n");
 
-UIHelper.activateElement(monthField);
+await UIHelper.activateElement(monthField);
 UIHelper.keyDown("9");
 shouldBeEqualToString("input.value", "2020-09-26");
 
-UIHelper.activateElement(dayField);
+await UIHelper.activateElement(dayField);
 UIHelper.keyDown("1");
 UIHelper.keyDown("2");
 shouldBeEqualToString("input.value", "2020-09-12");
 
-UIHelper.activateElement(yearField);
+await UIHelper.activateElement(yearField);
 UIHelper.keyDown("3");
 UIHelper.keyDown("0");
 UIHelper.keyDown("3");
@@ -75,9 +79,9 @@ clickEventsFired = 0;
 input.disabled = true;
 input.readOnly = false;
 
-UIHelper.activateElement(monthField);
-UIHelper.activateElement(dayField);
-UIHelper.activateElement(yearField);
+await UIHelper.activateElement(monthField);
+await UIHelper.activateElement(dayField);
+await UIHelper.activateElement(yearField);
 // Click on control, but not a specific field, defaults to first field.
 mouseClickOn(250, center);
 // Click outside control.
@@ -90,15 +94,18 @@ clickEventsFired = 0;
 input.disabled = false;
 input.readOnly = true;
 
-UIHelper.activateElement(monthField);
-UIHelper.activateElement(dayField);
-UIHelper.activateElement(yearField);
+await UIHelper.activateElement(monthField);
+await UIHelper.activateElement(dayField);
+await UIHelper.activateElement(yearField);
 // Click on control, but not a specific field, defaults to first field.
 mouseClickOn(250, center);
 // Click outside control.
 mouseClickOn(input.offsetWidth + 5, input.offsetHeight + 5);
 
 shouldBe("clickEventsFired", "4");
+
+finishJSTest();
+})();
 
 </script>
 </body>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-focus-and-blur-events.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-focus-and-blur-events.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="../../../../resources/ui-helper.js"></script>
 <style>
 input {
@@ -53,6 +53,10 @@ input.addEventListener("focus", onFocusEvent);
 
 const center = input.offsetHeight / 2;
 
+jsTestIsAsync = true;
+
+(async () => {
+
 debug("Focus/blur using mouse\n");
 
 // Click on month field.
@@ -83,7 +87,7 @@ resetFocusAndBlurCount();
 
 debug("\nFocus/blur using keyboard\n");
 
-UIHelper.activateElement(before);
+await UIHelper.activateElement(before);
 // Focus on month field.
 UIHelper.keyDown("\t");
 assertFocusAndBlurCount(1, 0);
@@ -132,7 +136,7 @@ debug("\nFocus/blur on disabled input\n")
 
 input.disabled = true;
 
-UIHelper.activateElement(before);
+await UIHelper.activateElement(before);
 // Tab to focus should skip disabled input.
 UIHelper.keyDown("\t");
 assertFocusAndBlurCount(0, 0);
@@ -158,7 +162,7 @@ debug("\nFocus/blur on readonly input\n")
 input.disabled = false;
 input.readOnly = true;
 
-UIHelper.activateElement(before);
+await UIHelper.activateElement(before);
 // Tab to focus should not skip readonly input.
 UIHelper.keyDown("\t");
 assertFocusAndBlurCount(1, 0);
@@ -182,8 +186,9 @@ mouseClickOn(input.offsetWidth + 5, input.offsetHeight + 5);
 assertFocusAndBlurCount(1, 1);
 resetFocusAndBlurCount();
 
-</script>
+finishJSTest();
+})();
 
-<script src="../../../../resources/js-test-post.js"></script>
+</script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-mouse-events.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-editable-components-mouse-events.html
@@ -43,34 +43,38 @@ const hourField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-hour-f
 const minuteField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-minute-field");
 const meridiemField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-meridiem-field");
 
+jsTestIsAsync = true;
+
+(async () => {
+
 debug("Enabled Input\n");
 
-UIHelper.activateElement(monthField);
+await UIHelper.activateElement(monthField);
 UIHelper.keyDown("9");
 shouldBeEqualToString("input.value", "2020-09-20T05:30");
 
-UIHelper.activateElement(dayField);
+await UIHelper.activateElement(dayField);
 UIHelper.keyDown("1");
 UIHelper.keyDown("2");
 shouldBeEqualToString("input.value", "2020-09-12T05:30");
 
-UIHelper.activateElement(yearField);
+await UIHelper.activateElement(yearField);
 UIHelper.keyDown("3");
 UIHelper.keyDown("0");
 UIHelper.keyDown("3");
 UIHelper.keyDown("0");
 shouldBeEqualToString("input.value", "3030-09-12T05:30");
 
-UIHelper.activateElement(hourField);
+await UIHelper.activateElement(hourField);
 UIHelper.keyDown("8");
 shouldBeEqualToString("input.value", "3030-09-12T08:30");
 
-UIHelper.activateElement(minuteField);
+await UIHelper.activateElement(minuteField);
 UIHelper.keyDown("4");
 UIHelper.keyDown("5");
 shouldBeEqualToString("input.value", "3030-09-12T08:45");
 
-UIHelper.activateElement(meridiemField);
+await UIHelper.activateElement(meridiemField);
 UIHelper.keyDown("P");
 shouldBeEqualToString("input.value", "3030-09-12T20:45");
 
@@ -91,12 +95,12 @@ clickEventsFired = 0;
 input.disabled = true;
 input.readOnly = false;
 
-UIHelper.activateElement(monthField);
-UIHelper.activateElement(dayField);
-UIHelper.activateElement(yearField);
-UIHelper.activateElement(hourField);
-UIHelper.activateElement(minuteField);
-UIHelper.activateElement(meridiemField);
+await UIHelper.activateElement(monthField);
+await UIHelper.activateElement(dayField);
+await UIHelper.activateElement(yearField);
+await UIHelper.activateElement(hourField);
+await UIHelper.activateElement(minuteField);
+await UIHelper.activateElement(meridiemField);
 // Click on control, but not a specific field, defaults to first field.
 mouseClickOn(550, center);
 // Click outside control.
@@ -109,18 +113,21 @@ clickEventsFired = 0;
 input.disabled = false;
 input.readOnly = true;
 
-UIHelper.activateElement(monthField);
-UIHelper.activateElement(dayField);
-UIHelper.activateElement(yearField);
-UIHelper.activateElement(hourField);
-UIHelper.activateElement(minuteField);
-UIHelper.activateElement(meridiemField);
+await UIHelper.activateElement(monthField);
+await UIHelper.activateElement(dayField);
+await UIHelper.activateElement(yearField);
+await UIHelper.activateElement(hourField);
+await UIHelper.activateElement(minuteField);
+await UIHelper.activateElement(meridiemField);
 // Click on control, but not a specific field, defaults to first field.
 mouseClickOn(550, center);
 // Click outside control.
 mouseClickOn(input.offsetWidth + 5, input.offsetHeight + 5);
 
 shouldBe("clickEventsFired", "7");
+
+finishJSTest();
+})();
 
 </script>
 </body>

--- a/LayoutTests/fast/forms/file/entries-api/image-no-transcode-open-panel.html
+++ b/LayoutTests/fast/forms/file/entries-api/image-no-transcode-open-panel.html
@@ -10,12 +10,12 @@
         description("Tests a HEIC image, chosen via the file picker which accepts HEIC, will not be converted to any supported MIME type.");
         jsTestIsAsync = true;
 
-        function runTest()
+        async function runTest()
         {
             testRunner.setOpenPanelFiles(['resources/images/green-400x400.heic']);
 
             inputElement = document.getElementsByTagName('input')[0];
-            UIHelper.activateAt(inputElement.offsetLeft + inputElement.offsetWidth / 2,
+            await UIHelper.activateAt(inputElement.offsetLeft + inputElement.offsetWidth / 2,
                 inputElement.offsetTop + inputElement.offsetHeight / 2);
         }
 

--- a/LayoutTests/fast/forms/file/entries-api/image-transcode-open-panel.html
+++ b/LayoutTests/fast/forms/file/entries-api/image-transcode-open-panel.html
@@ -10,12 +10,12 @@
         description("Tests a HEIC image, chosen via the file picker which accepts PNG, will be converted to a PNG image.");
         jsTestIsAsync = true;
 
-        function runTest()
+        async function runTest()
         {
             testRunner.setOpenPanelFiles(['resources/images/green-400x400.heic']);
 
             inputElement = document.getElementsByTagName('input')[0];
-            UIHelper.activateAt(inputElement.offsetLeft + inputElement.offsetWidth / 2,
+            await UIHelper.activateAt(inputElement.offsetLeft + inputElement.offsetWidth / 2,
                 inputElement.offsetTop + inputElement.offsetHeight / 2);
         }
 

--- a/LayoutTests/fast/forms/file/entries-api/pages-jpeg-open-panel.html
+++ b/LayoutTests/fast/forms/file/entries-api/pages-jpeg-open-panel.html
@@ -27,7 +27,7 @@ addEventListener("load", async () => {
         finishJSTest();
     });
 
-    UIHelper.activateElement(input);
+    await UIHelper.activateElement(input);
 });
 
 </script>

--- a/LayoutTests/fast/forms/file/entries-api/pdf-jpeg-open-panel.html
+++ b/LayoutTests/fast/forms/file/entries-api/pdf-jpeg-open-panel.html
@@ -27,7 +27,7 @@ addEventListener("load", async () => {
         finishJSTest();
     });
 
-    UIHelper.activateElement(input);
+    await UIHelper.activateElement(input);
 });
 
 </script>

--- a/LayoutTests/fast/forms/file/entries-api/png-raw-open-panel.html
+++ b/LayoutTests/fast/forms/file/entries-api/png-raw-open-panel.html
@@ -29,7 +29,7 @@ addEventListener("load", async () => {
         finishJSTest();
     });
 
-    UIHelper.activateElement(input);
+    await UIHelper.activateElement(input);
 });
 
 </script>

--- a/LayoutTests/fast/forms/file/entries-api/webkitdirectory-open-panel.html
+++ b/LayoutTests/fast/forms/file/entries-api/webkitdirectory-open-panel.html
@@ -10,13 +10,13 @@
 description("Tests choosing a folder via the file picker when using webkitdirectory.");
 jsTestIsAsync = true;
 
-function runTest()
+async function runTest()
 {
     testRunner.setOpenPanelFiles(['resources/testFiles']);
 
     inputElement = document.getElementsByTagName('input')[0];
     shouldBeTrue("inputElement.webkitdirectory");
-    UIHelper.activateAt(inputElement.offsetLeft + inputElement.offsetWidth / 2,
+    await UIHelper.activateAt(inputElement.offsetLeft + inputElement.offsetWidth / 2,
         inputElement.offsetTop + inputElement.offsetHeight / 2);
 }
 

--- a/LayoutTests/fast/forms/file/file-input-reset-using-open-panel.html
+++ b/LayoutTests/fast/forms/file/file-input-reset-using-open-panel.html
@@ -37,11 +37,11 @@ if (testRunner && eventSender) {
     openFilesInElement(file, ["foo.txt"]);
 }
 
-function openFilesInElement(element, files) {
+async function openFilesInElement(element, files) {
     testRunner.setOpenPanelFiles(files);
     var centerX = element.offsetLeft + element.offsetWidth / 2;
     var centerY = element.offsetTop + element.offsetHeight / 2;
-    UIHelper.activateAt(centerX, centerY);
+    await UIHelper.activateAt(centerX, centerY);
 }
 </script>
 </body>

--- a/LayoutTests/fast/forms/file/file-input-type-detached-on-change.html
+++ b/LayoutTests/fast/forms/file/file-input-type-detached-on-change.html
@@ -23,7 +23,9 @@
         if (window.testRunner) {
             testRunner.setOpenPanelFiles(['foo.txt']);
             testRunner.setOpenPanelFilesMediaIcon(testIconBytes);
-            UIHelper.activateElement(fileInput);
+            (async () => {
+                await UIHelper.activateElement(fileInput);
+            })();
         }
     </script>
     <script src=../../../resources/js-test-post.js></script>

--- a/LayoutTests/fast/forms/file/file-input-user-selection-events.html
+++ b/LayoutTests/fast/forms/file/file-input-user-selection-events.html
@@ -33,11 +33,11 @@ if (window.testRunner) {
     openFilesInElement(file, ["foo.txt"]);
 }
 
-function openFilesInElement(input, files) {
+async function openFilesInElement(input, files) {
     testRunner.setOpenPanelFiles(files);
     var centerX = input.offsetLeft + input.offsetWidth / 2;
     var centerY = input.offsetTop + input.offsetHeight / 2;
-    UIHelper.activateAt(centerX, centerY);
+    await UIHelper.activateAt(centerX, centerY);
 }
 </script>
 <script src="../../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/forms/file/file-reset-in-change-using-open-panel-with-icon.html
+++ b/LayoutTests/fast/forms/file/file-reset-in-change-using-open-panel-with-icon.html
@@ -7,12 +7,12 @@
 <input id=file1 type=file multiple=multiple>
 </form>
 <script>
-function openFilesInElement(element, files, icon) {
+async function openFilesInElement(element, files, icon) {
     testRunner.setOpenPanelFiles(files);
     testRunner.setOpenPanelFilesMediaIcon(icon);
     var centerX = element.offsetLeft + element.offsetWidth / 2;
     var centerY = element.offsetTop + element.offsetHeight / 2;
-    UIHelper.activateAt(centerX, centerY);
+    await UIHelper.activateAt(centerX, centerY);
 }
 
 function handleChange() {

--- a/LayoutTests/fast/forms/file/file-reset-in-change-using-open-panel.html
+++ b/LayoutTests/fast/forms/file/file-reset-in-change-using-open-panel.html
@@ -6,11 +6,11 @@
 <input id=file1 type=file>
 </form>
 <script>
-function openFilesInElement(element, files) {
+async function openFilesInElement(element, files) {
     testRunner.setOpenPanelFiles(files);
     var centerX = element.offsetLeft + element.offsetWidth / 2;
     var centerY = element.offsetTop + element.offsetHeight / 2;
-    UIHelper.activateAt(centerX, centerY);
+    await UIHelper.activateAt(centerX, centerY);
 }
 
 function handleChange() {

--- a/LayoutTests/fast/forms/file/get-file-upload-using-open-panel.html
+++ b/LayoutTests/fast/forms/file/get-file-upload-using-open-panel.html
@@ -14,7 +14,7 @@ function log(message)
     document.getElementById('console').appendChild(document.createTextNode(message + "\n"));
 }
 
-function startOrVerify()
+async function startOrVerify()
 {
     var query = window.location.search;
     if (query.indexOf('submitted=true') != -1) {
@@ -34,7 +34,7 @@ function startOrVerify()
         var inputElement = document.getElementById("file");
         var centerX = inputElement.offsetLeft + inputElement.offsetWidth / 2;
         var centerY = inputElement.offsetTop + inputElement.offsetHeight / 2;
-        UIHelper.activateAt(centerX, centerY);
+        await UIHelper.activateAt(centerX, centerY);
     }
 }
 

--- a/LayoutTests/fast/forms/file/input-file-value-using-open-panel.html
+++ b/LayoutTests/fast/forms/file/input-file-value-using-open-panel.html
@@ -31,11 +31,11 @@ if (window.testRunner) {
     openFilesInElement(file, ["foo.txt"]);
 }
 
-function openFilesInElement(input, files) {
+async function openFilesInElement(input, files) {
     testRunner.setOpenPanelFiles(files);
     var centerX = input.offsetLeft + input.offsetWidth / 2;
     var centerY = input.offsetTop + input.offsetHeight / 2;
-    UIHelper.activateAt(centerX, centerY);
+    await UIHelper.activateAt(centerX, centerY);
 }
 </script>
 <script src="../../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/forms/file/input-file-write-files-using-open-panel.html
+++ b/LayoutTests/fast/forms/file/input-file-write-files-using-open-panel.html
@@ -45,11 +45,11 @@ function runTest(file1, file2) {
     shouldBeEqualToString("file1.files.item(0).name", "bar.txt");
 }
 
-function dragFilesOntoInput(input, files) {
+async function dragFilesOntoInput(input, files) {
     testRunner.setOpenPanelFiles(files);
     var centerX = input.offsetLeft + input.offsetWidth / 2;
     var centerY = input.offsetTop + input.offsetHeight / 2;
-    UIHelper.activateAt(centerX, centerY);
+    await UIHelper.activateAt(centerX, centerY);
 }
 </script>
 <script src="../../../resources/js-test-post.js"></script>

--- a/LayoutTests/fast/forms/file/open-file-panel-crash.html
+++ b/LayoutTests/fast/forms/file/open-file-panel-crash.html
@@ -6,12 +6,12 @@
 <input id=file1 type=file multiple=multiple>
 </form>
 <script>
-function openFilesInElement(element, files, icon) {
+async function openFilesInElement(element, files, icon) {
     testRunner.setOpenPanelFiles(files);
     testRunner.setOpenPanelFilesMediaIcon(icon);
     var centerX = element.offsetLeft + element.offsetWidth / 2;
     var centerY = element.offsetTop + element.offsetHeight / 2;
-    UIHelper.activateAt(centerX, centerY);
+    await UIHelper.activateAt(centerX, centerY);
 }
 
 function handleChange() {

--- a/LayoutTests/fast/forms/focus-change-after-layout-update-during-focus-crash.html
+++ b/LayoutTests/fast/forms/focus-change-after-layout-update-during-focus-crash.html
@@ -24,7 +24,7 @@ addEventListener("load", async function() {
         finishJSTest();
     });
 
-    UIHelper.activateElement(input);
+    await UIHelper.activateElement(input);
 });
 
 </script>

--- a/LayoutTests/fast/forms/ios/refocus-select-after-size-change.html
+++ b/LayoutTests/fast/forms/ios/refocus-select-after-size-change.html
@@ -47,7 +47,7 @@ addEventListener("load", async () => {
         await UIHelper.activateElement(finishTestButton);
     });
 
-    UIHelper.activateElement(showSelectButton);
+    await UIHelper.activateElement(showSelectButton);
 });
 </script>
 </html>

--- a/LayoutTests/fast/forms/ios/show-select-menu-in-unparented-view-crash.html
+++ b/LayoutTests/fast/forms/ios/show-select-menu-in-unparented-view-crash.html
@@ -36,7 +36,7 @@ addEventListener("load", async () => {
         finishJSTest();
     });
 
-    UIHelper.activateElement(select);
+    await UIHelper.activateElement(select);
 });
 </script>
 </html>

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-focus-and-blur-events.html
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-focus-and-blur-events.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="../../../../resources/ui-helper.js"></script>
 <style>
 input {
@@ -53,6 +53,10 @@ input.addEventListener("focus", onFocusEvent);
 
 const center = input.offsetHeight / 2;
 
+jsTestIsAsync = true;
+
+(async () => {
+
 debug("Focus/blur using mouse\n");
 
 // Click on month field.
@@ -71,7 +75,7 @@ resetFocusAndBlurCount();
 
 debug("\nFocus/blur using keyboard\n");
 
-UIHelper.activateElement(before);
+await UIHelper.activateElement(before);
 // Focus on month field.
 UIHelper.keyDown("\t");
 assertFocusAndBlurCount(1, 0);
@@ -96,7 +100,7 @@ debug("\nFocus/blur on disabled input\n")
 
 input.disabled = true;
 
-UIHelper.activateElement(before);
+await UIHelper.activateElement(before);
 // Tab to focus should skip disabled input.
 UIHelper.keyDown("\t");
 assertFocusAndBlurCount(0, 0);
@@ -118,7 +122,7 @@ debug("\nFocus/blur on readonly input\n")
 input.disabled = false;
 input.readOnly = true;
 
-UIHelper.activateElement(before);
+await UIHelper.activateElement(before);
 // Tab to focus should not skip readonly input.
 UIHelper.keyDown("\t");
 assertFocusAndBlurCount(1, 0);
@@ -134,8 +138,9 @@ mouseClickOn(input.offsetWidth + 5, input.offsetHeight + 5);
 assertFocusAndBlurCount(1, 1);
 resetFocusAndBlurCount();
 
-</script>
+finishJSTest();
+})();
 
-<script src="../../../../resources/js-test-post.js"></script>
+</script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-mouse-events.html
+++ b/LayoutTests/fast/forms/month/month-editable-components/month-editable-components-mouse-events.html
@@ -39,13 +39,17 @@ const shadowRoot = internals.shadowRoot(input);
 const monthField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-month-field");
 const yearField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-year-field");
 
+jsTestIsAsync = true;
+
+(async () => {
+
 debug("Enabled Input\n");
 
-UIHelper.activateElement(monthField);
+await UIHelper.activateElement(monthField);
 UIHelper.keyDown("9");
 shouldBeEqualToString("input.value", "2020-09");
 
-UIHelper.activateElement(yearField);
+await UIHelper.activateElement(yearField);
 UIHelper.keyDown("1");
 UIHelper.keyDown("2");
 shouldBeEqualToString("input.value", "0012-09");
@@ -67,8 +71,8 @@ clickEventsFired = 0;
 input.disabled = true;
 input.readOnly = false;
 
-UIHelper.activateElement(monthField);
-UIHelper.activateElement(yearField);
+await UIHelper.activateElement(monthField);
+await UIHelper.activateElement(yearField);
 // Click on control, but not a specific field, defaults to first field.
 mouseClickOn(250, center);
 // Click outside control.
@@ -81,14 +85,17 @@ clickEventsFired = 0;
 input.disabled = false;
 input.readOnly = true;
 
-UIHelper.activateElement(monthField);
-UIHelper.activateElement(yearField);
+await UIHelper.activateElement(monthField);
+await UIHelper.activateElement(yearField);
 // Click on control, but not a specific field, defaults to first field.
 mouseClickOn(250, center);
 // Click outside control.
 mouseClickOn(input.offsetWidth + 5, input.offsetHeight + 5);
 
 shouldBe("clickEventsFired", "3");
+
+finishJSTest();
+})();
 
 </script>
 </body>

--- a/LayoutTests/fast/forms/password-scrolled-after-caps-lock-toggled.html
+++ b/LayoutTests/fast/forms/password-scrolled-after-caps-lock-toggled.html
@@ -49,7 +49,7 @@ function runTest()
     runNextTest();
 }
 
-function testFocusedEmptyFieldIsNotScrolled()
+async function testFocusedEmptyFieldIsNotScrolled()
 {
     debug("Case 1: Empty field:");
     function handleFocus() {
@@ -58,7 +58,7 @@ function testFocusedEmptyFieldIsNotScrolled()
     }
     input.addEventListener("focus", handleFocus, { once: true });
     if (window.testRunner)
-        UIHelper.activateElement(input);
+        await UIHelper.activateElement(input);
     else
         input.focus();
 }

--- a/LayoutTests/fast/forms/switch/click-animation-disabled.html
+++ b/LayoutTests/fast/forms/switch/click-animation-disabled.html
@@ -3,8 +3,8 @@
 <script src="../../../resources/ui-helper.js"></script>
 <input type=checkbox switch onclick=end()>
 <script>
-window.onload = () => {
-    UIHelper.activateAt(10, 10);
+window.onload = async () => {
+    await UIHelper.activateAt(10, 10);
 }
 function end() {
     setTimeout(() => {

--- a/LayoutTests/fast/forms/switch/click-animation-interrupted-document-removed.html
+++ b/LayoutTests/fast/forms/switch/click-animation-interrupted-document-removed.html
@@ -3,8 +3,8 @@
 <script src="../../../resources/ui-helper.js"></script>
 <iframe srcdoc="<input type=checkbox switch onclick=parent.end()>"></iframe>
 <script>
-window.onload = () => {
-    UIHelper.activateAt(20, 20);
+window.onload = async () => {
+    await UIHelper.activateAt(20, 20);
 }
 function end() {
     setTimeout(() => {

--- a/LayoutTests/fast/forms/switch/click-animation-interrupted-type-change.html
+++ b/LayoutTests/fast/forms/switch/click-animation-interrupted-type-change.html
@@ -3,8 +3,8 @@
 <script src="../../../resources/ui-helper.js"></script>
 <input type=checkbox switch onclick=end()>
 <script>
-window.onload = () => {
-    UIHelper.activateAt(10, 10);
+window.onload = async () => {
+    await UIHelper.activateAt(10, 10);
 }
 function end() {
     setTimeout(() => {

--- a/LayoutTests/fast/forms/switch/click-animation-interrupted.html
+++ b/LayoutTests/fast/forms/switch/click-animation-interrupted.html
@@ -3,8 +3,8 @@
 <script src="../../../resources/ui-helper.js"></script>
 <input type=checkbox switch onclick=end()>
 <script>
-window.onload = () => {
-    UIHelper.activateAt(10, 10);
+window.onload = async () => {
+    await UIHelper.activateAt(10, 10);
 }
 function end() {
     setTimeout(() => {

--- a/LayoutTests/fast/forms/switch/click-animation-preventdefault.html
+++ b/LayoutTests/fast/forms/switch/click-animation-preventdefault.html
@@ -3,8 +3,8 @@
 <script src="../../../resources/ui-helper.js"></script>
 <input type=checkbox switch onclick=end()>
 <script>
-window.onload = () => {
-    UIHelper.activateAt(10, 10);
+window.onload = async () => {
+    await UIHelper.activateAt(10, 10);
 }
 function end() {
     event.preventDefault();

--- a/LayoutTests/fast/forms/switch/click-animation-redundant-checked.html
+++ b/LayoutTests/fast/forms/switch/click-animation-redundant-checked.html
@@ -3,8 +3,8 @@
 <script src="../../../resources/ui-helper.js"></script>
 <input type=checkbox switch onclick=end()>
 <script>
-window.onload = () => {
-    UIHelper.activateAt(10, 10);
+window.onload = async () => {
+    await UIHelper.activateAt(10, 10);
 }
 function end() {
     setTimeout(() => {

--- a/LayoutTests/fast/forms/switch/click-animation-redundant-disabled.html
+++ b/LayoutTests/fast/forms/switch/click-animation-redundant-disabled.html
@@ -3,8 +3,8 @@
 <script src="../../../resources/ui-helper.js"></script>
 <input type=checkbox switch onclick=end()>
 <script>
-window.onload = () => {
-    UIHelper.activateAt(10, 10);
+window.onload = async () => {
+    await UIHelper.activateAt(10, 10);
 }
 function end() {
     setTimeout(() => {

--- a/LayoutTests/fast/forms/switch/click-animation-twice.html
+++ b/LayoutTests/fast/forms/switch/click-animation-twice.html
@@ -3,13 +3,13 @@
 <script src="../../../resources/ui-helper.js"></script>
 <input type=checkbox switch onclick=each()>
 <script>
-window.onload = () => {
-    UIHelper.activateAt(10, 10);
+window.onload = async () => {
+    await UIHelper.activateAt(10, 10);
 }
 let count = 0;
 function each() {
     if (count === 0) {
-        setTimeout(() => UIHelper.activateAt(10, 10), 25);
+        setTimeout(async () => await UIHelper.activateAt(10, 10), 25);
         count += 1;
     } else if (count === 1)
         setTimeout(() => document.documentElement.removeAttribute("class"), 75);

--- a/LayoutTests/fast/forms/switch/click-animation.html
+++ b/LayoutTests/fast/forms/switch/click-animation.html
@@ -3,8 +3,8 @@
 <script src="../../../resources/ui-helper.js"></script>
 <input type=checkbox switch onclick=end()>
 <script>
-window.onload = () => {
-    UIHelper.activateAt(10, 10);
+window.onload = async () => {
+    await UIHelper.activateAt(10, 10);
 }
 function end() {
     setTimeout(() => document.documentElement.removeAttribute("class"), 50);

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-focus-and-blur-events.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-focus-and-blur-events.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="../../../../resources/ui-helper.js"></script>
 <style>
 input {
@@ -53,6 +53,10 @@ input.addEventListener("focus", onFocusEvent);
 
 const center = input.offsetHeight / 2;
 
+jsTestIsAsync = true;
+
+(async () => {
+
 debug("Focus/blur using mouse\n");
 
 // Click on hour field.
@@ -74,7 +78,7 @@ resetFocusAndBlurCount();
 
 debug("\nFocus/blur using keyboard\n");
 
-UIHelper.activateElement(before);
+await UIHelper.activateElement(before);
 // Focus on hour field.
 UIHelper.keyDown("\t");
 assertFocusAndBlurCount(1, 0);
@@ -105,7 +109,7 @@ debug("\nFocus/blur on disabled input\n")
 
 input.disabled = true;
 
-UIHelper.activateElement(before);
+await UIHelper.activateElement(before);
 // Tab to focus should skip disabled input.
 UIHelper.keyDown("\t");
 assertFocusAndBlurCount(0, 0);
@@ -128,7 +132,7 @@ debug("\nFocus/blur on readonly input\n")
 input.disabled = false;
 input.readOnly = true;
 
-UIHelper.activateElement(before);
+await UIHelper.activateElement(before);
 // Tab to focus should not skip readonly input.
 UIHelper.keyDown("\t");
 assertFocusAndBlurCount(1, 0);
@@ -146,8 +150,9 @@ mouseClickOn(input.offsetWidth + 5, input.offsetHeight + 5);
 assertFocusAndBlurCount(1, 1);
 resetFocusAndBlurCount();
 
-</script>
+finishJSTest();
+})();
 
-<script src="../../../../resources/js-test-post.js"></script>
+</script>
 </body>
 </html>

--- a/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-mouse-events.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-editable-components-mouse-events.html
@@ -40,18 +40,22 @@ const hourField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-hour-f
 const minuteField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-minute-field");
 const meridiemField = getElementByPseudoId(shadowRoot, "-webkit-datetime-edit-meridiem-field");
 
+jsTestIsAsync = true;
+
+(async () => {
+
 debug("Enabled Input\n");
 
-UIHelper.activateElement(hourField);
+await UIHelper.activateElement(hourField);
 UIHelper.keyDown("9");
 shouldBeEqualToString("input.value", "09:30");
 
-UIHelper.activateElement(minuteField);
+await UIHelper.activateElement(minuteField);
 UIHelper.keyDown("1");
 UIHelper.keyDown("2");
 shouldBeEqualToString("input.value", "09:12");
 
-UIHelper.activateElement(meridiemField);
+await UIHelper.activateElement(meridiemField);
 UIHelper.keyDown("upArrow");
 shouldBeEqualToString("input.value", "21:12");
 
@@ -72,9 +76,9 @@ clickEventsFired = 0;
 input.disabled = true;
 input.readOnly = false;
 
-UIHelper.activateElement(hourField);
-UIHelper.activateElement(minuteField);
-UIHelper.activateElement(meridiemField);
+await UIHelper.activateElement(hourField);
+await UIHelper.activateElement(minuteField);
+await UIHelper.activateElement(meridiemField);
 // Click on control, but not a specific field, defaults to first field.
 mouseClickOn(250, center);
 // Click outside control.
@@ -87,15 +91,18 @@ clickEventsFired = 0;
 input.disabled = false;
 input.readOnly = true;
 
-UIHelper.activateElement(hourField);
-UIHelper.activateElement(minuteField);
-UIHelper.activateElement(meridiemField);
+await UIHelper.activateElement(hourField);
+await UIHelper.activateElement(minuteField);
+await UIHelper.activateElement(meridiemField);
 // Click on control, but not a specific field, defaults to first field.
 mouseClickOn(250, center);
 // Click outside control.
 mouseClickOn(input.offsetWidth + 5, input.offsetHeight + 5);
 
 shouldBe("clickEventsFired", "4");
+
+finishJSTest();
+})();
 
 </script>
 </body>

--- a/LayoutTests/fast/frames/consume_transient_activation.html
+++ b/LayoutTests/fast/frames/consume_transient_activation.html
@@ -16,10 +16,10 @@
             const target = document.getElementById("target");
             const x = target.offsetLeft + target.offsetWidth / 2;
             const y = target.offsetTop + target.offsetHeight / 2;
-            return new Promise((r) => {
+            const clickPromise = new Promise((r) => {
                 target.addEventListener("click", r, { once: true });
-                UIHelper.activateAt(x, y);
             });
+            return UIHelper.activateAt(x, y).then(() => clickPromise);
         }
 
         async function doTest() {

--- a/LayoutTests/fast/history/page-cache-createObjectURL-using-open-panel.html
+++ b/LayoutTests/fast/history/page-cache-createObjectURL-using-open-panel.html
@@ -64,12 +64,12 @@ window.addEventListener("pagehide", function(event) {
     }
 }, false);
 
-window.addEventListener('load', function() {
+window.addEventListener('load', async function() {
     testRunner.setOpenPanelFiles(['../files/resources/abe.png']);
     var element = document.getElementById('file');
     var centerX = element.offsetLeft + element.offsetWidth / 2;
     var centerY = element.offsetTop + element.offsetHeight / 2;
-    UIHelper.activateAt(centerX, centerY);
+    await UIHelper.activateAt(centerX, centerY);
 }, false);
 
 </script>

--- a/LayoutTests/fast/inline-block/hittest-fails-on-inline-block-with-visibility-change.html
+++ b/LayoutTests/fast/inline-block/hittest-fails-on-inline-block-with-visibility-change.html
@@ -28,6 +28,6 @@ document.body.offsetHeight;
 if (window.testRunner) {
   testRunner.dumpAsText();
   testRunner.waitUntilDone();
-  UIHelper.activateElement(click_me);
+  (async () => { await UIHelper.activateElement(click_me); })();
 }
 </script>

--- a/LayoutTests/fast/loader/form-submission-after-beforeunload-cancel.html
+++ b/LayoutTests/fast/loader/form-submission-after-beforeunload-cancel.html
@@ -45,7 +45,9 @@ onbeforeunload = function() {
 </form>
 
 <script>
+(async () => {
 // Simulate a user interaction with the page so that the beforeunload alert shows.
 const testButton = document.getElementById("testButton");
-UIHelper.activateAt(testButton.offsetLeft + 5, testButton.offsetTop + 5);
+await UIHelper.activateAt(testButton.offsetLeft + 5, testButton.offsetTop + 5);
+})();
 </script>

--- a/LayoutTests/fast/loader/show-only-one-beforeunload-dialog.html
+++ b/LayoutTests/fast/loader/show-only-one-beforeunload-dialog.html
@@ -11,11 +11,11 @@ function navigateFrame()
 	window.location.href = 'resources/notify-done.html';
 }
 
-window.onload = function()
+window.onload = async function()
 {
 	// Simulate a user interaction with the page so that the beforeunload alert shows.
 	const testButton = document.getElementById("testButton");
-	UIHelper.activateAt(testButton.offsetLeft + 5, testButton.offsetTop + 5);
+	await UIHelper.activateAt(testButton.offsetLeft + 5, testButton.offsetTop + 5);
 }
 
 window.onbeforeunload = function()

--- a/LayoutTests/fast/selectors/focus-visible-setSelectionRange.html
+++ b/LayoutTests/fast/selectors/focus-visible-setSelectionRange.html
@@ -33,7 +33,7 @@
         }, 'Script focus after setSelectionRange after mouse focus does not match :focus-visible');
 
         if (window.testRunner)
-            UIHelper.activateElement(initial);
+            (async () => { await UIHelper.activateElement(initial); })();
 
         </script>
     </body>

--- a/LayoutTests/fast/svg/foreign-object-offset-position.html
+++ b/LayoutTests/fast/svg/foreign-object-offset-position.html
@@ -7,8 +7,8 @@
     function runTest() {
       window.jsTestIsAsync = true;
 
-      setTimeout(() => {
-        UIHelper.activateAt(110, 110);
+      setTimeout(async () => {
+        await UIHelper.activateAt(110, 110);
       }, 0);
     }
 

--- a/LayoutTests/fast/web-share/share-transient-activation-expired.html
+++ b/LayoutTests/fast/web-share/share-transient-activation-expired.html
@@ -17,7 +17,7 @@
     
         let write = (message) => output.innerHTML += (message + "<br>");
 
-        function runTest()
+        async function runTest()
         {
             document.getElementById("target").addEventListener("click", () => {
                 fetch("../files/resources/abe.png").then(() => {
@@ -36,8 +36,8 @@
                     testRunner.notifyDone();
                 });
             });
-            
-            UIHelper.activateAt(50, 50);
+
+            await UIHelper.activateAt(50, 50);
         }
 
     </script>

--- a/LayoutTests/fast/web-share/share-transient-activation.html
+++ b/LayoutTests/fast/web-share/share-transient-activation.html
@@ -14,7 +14,7 @@
     
         let write = (message) => output.innerHTML += (message + "<br>");
 
-        function runTest()
+        async function runTest()
         {
             document.getElementById("target").addEventListener("click", () => {
                 fetch("../files/resources/abe.png").then(() => {
@@ -30,8 +30,8 @@
                     testRunner.notifyDone();
                 });
             });
-            
-            UIHelper.activateAt(50, 50);
+
+            await UIHelper.activateAt(50, 50);
         }
 
     </script>

--- a/LayoutTests/fast/web-share/share-with-files-feature-disabled.html
+++ b/LayoutTests/fast/web-share/share-with-files-feature-disabled.html
@@ -9,7 +9,7 @@
         testRunner.waitUntilDone();
     }
 
-    function runTest()
+    async function runTest()
     {
         document.getElementById("target").addEventListener("click", () => {
             const textFile = new File(['This is a text file'], 'TextFile.txt', { type: 'text/plain' });
@@ -24,7 +24,7 @@
             });
         });
 
-        UIHelper.activateAt(50, 50);
+        await UIHelper.activateAt(50, 50);
     }
 </script>
 <style>

--- a/LayoutTests/fast/web-share/share-with-files.html
+++ b/LayoutTests/fast/web-share/share-with-files.html
@@ -15,7 +15,7 @@
     
         let write = (message) => output.innerHTML += (message + "<br>");
 
-        function runTest()
+        async function runTest()
         {
 
             var blob = this.response;
@@ -24,10 +24,10 @@
             navigator.share({text: "This is a text file", files: [textFile]}).then((result) => {
                 write("PASS: Share sheet invoked.");
                     testRunner.notifyDone();
-                });    
+                });
             });
-            
-            UIHelper.activateAt(50, 50);
+
+            await UIHelper.activateAt(50, 50);
         }
 
     </script>

--- a/LayoutTests/fast/web-share/share-with-no-url.html
+++ b/LayoutTests/fast/web-share/share-with-no-url.html
@@ -14,16 +14,16 @@
     
         let write = (message) => output.innerHTML += (message + "<br>");
 
-        function runTest()
+        async function runTest()
         {
             document.getElementById("target").addEventListener("click", () => {
                 navigator.share({ text: "text" }).then((result) => {
                     write("PASS: Share sheet invoked.");
                     testRunner.notifyDone();
-                });    
+                });
             });
-            
-            UIHelper.activateAt(50, 50);
+
+            await UIHelper.activateAt(50, 50);
         }
 
     </script>

--- a/LayoutTests/fast/web-share/share.html
+++ b/LayoutTests/fast/web-share/share.html
@@ -14,16 +14,16 @@
     
         let write = (message) => output.innerHTML += (message + "<br>");
 
-        function runTest()
+        async function runTest()
         {
             document.getElementById("target").addEventListener("click", () => {
                 navigator.share({ title: "Example Page", url: "http://webkit.org", text: "text" }).then((result) => {
                     write("PASS: Share sheet invoked.");
                     testRunner.notifyDone();
-                });    
+                });
             });
-            
-            UIHelper.activateAt(50, 50);
+
+            await UIHelper.activateAt(50, 50);
         }
 
     </script>

--- a/LayoutTests/http/tests/download/anchor-download-attribute-content-disposition-no-extension-octet-stream.html
+++ b/LayoutTests/http/tests/download/anchor-download-attribute-content-disposition-no-extension-octet-stream.html
@@ -16,19 +16,19 @@ if (window.testRunner) {
 <p>The suggested filename above should be "PASS" (without extension) and the download should succeed.</p>
 <a id="download-url" href="resources/content-disposition-pass-no-extension-octet-stream.py" download="FAIL.txt">Link with download attribute.</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
     var link = document.getElementById("download-url");
-    click(link);
+    await click(link);
 }
 runTest();
 </script>

--- a/LayoutTests/http/tests/download/anchor-download-attribute-content-disposition-no-extension-text-plain.html
+++ b/LayoutTests/http/tests/download/anchor-download-attribute-content-disposition-no-extension-text-plain.html
@@ -16,19 +16,19 @@ if (window.testRunner) {
 <p>The suggested filename above should be "PASS.txt" (with extension) and the download should succeed.</p>
 <a id="download-url" href="resources/content-disposition-pass-no-extension-text-plain.py" download="FAIL.txt">Link with download attribute.</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
     var link = document.getElementById("download-url");
-    click(link);
+    await click(link);
 }
 runTest();
 </script>

--- a/LayoutTests/http/tests/download/anchor-download-attribute-content-disposition.html
+++ b/LayoutTests/http/tests/download/anchor-download-attribute-content-disposition.html
@@ -16,19 +16,19 @@ if (window.testRunner) {
 <p>The suggested filename above should be "PASS.txt" and the download should succeed.</p>
 <a id="download-url" href="resources/content-disposition-pass.py" download="FAIL.txt">Link with download attribute.</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
     var link = document.getElementById("download-url");
-    click(link);
+    await click(link);
 }
 runTest();
 </script>

--- a/LayoutTests/http/tests/download/anchor-download-no-extension.html
+++ b/LayoutTests/http/tests/download/anchor-download-no-extension.html
@@ -15,19 +15,19 @@ if (window.testRunner) {
 <p>The suggested filename above should be "image.png" and the download should succeed.</p>
 <a id="download-url" href="/css/resources/abe.png" download="image">Link with download attribute.</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
     var link = document.getElementById("download-url");
-    click(link);
+    await click(link);
 }
 runTest();
 </script>

--- a/LayoutTests/http/tests/download/anchor-download-no-value.html
+++ b/LayoutTests/http/tests/download/anchor-download-no-value.html
@@ -15,19 +15,19 @@ if (window.testRunner) {
 <p>The suggested filename above should be "abe.png" and the download should succeed.</p>
 <a id="download-url" href="/css/resources/abe.png" download>Link with download attribute.</a>
 <script>
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
-function runTest()
+async function runTest()
 {
     var link = document.getElementById("download-url");
-    click(link);
+    await click(link);
 }
 runTest();
 </script>

--- a/LayoutTests/http/tests/download/anchor-download-redirect.html
+++ b/LayoutTests/http/tests/download/anchor-download-redirect.html
@@ -18,18 +18,18 @@ Tests that download redirects are reported to the client.
 <p>
 The suggested filename at the top should be foo.pdf and you should see a redirect to /media/resources/test.pdf.
 <script>
-    function click(elmt)
+    async function click(elmt)
     {
         if (!window.eventSender)
             return;
 
-        UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+        await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
     }
 
-    function runTest()
+    async function runTest()
     {
         var link = document.getElementById("dl");
-        click(link);
+        await click(link);
     }
     runTest();
 </script>

--- a/LayoutTests/http/tests/download/area-download.html
+++ b/LayoutTests/http/tests/download/area-download.html
@@ -19,20 +19,20 @@
 <p>Tests that the download attribute on area elements is working.</p>
 <p>The suggested filename at the top should be foo.pdf.</p>
 <script>
-    function click(elmt)
+    async function click(elmt)
     {
         if (!window.eventSender)
             return;
 
-        UIHelper.activateAt(elmt.offsetLeft + 10, elmt.offsetTop + 10);
+        await UIHelper.activateAt(elmt.offsetLeft + 10, elmt.offsetTop + 10);
     }
 
-    function runTest()
+    async function runTest()
     {
         var img = document.getElementById("testImage");
-        click(img);
+        await click(img);
     }
-    onload = function() {
+    onload = async function() {
         runTest();
     }
 </script>

--- a/LayoutTests/http/tests/download/convert-cached-load-to-download.html
+++ b/LayoutTests/http/tests/download/convert-cached-load-to-download.html
@@ -18,13 +18,13 @@ if (window.testRunner) {
 <script>
 const testURL = "/resources/mock-plugin-cacheable.pl";
 
-function click(elmt)
+async function click(elmt)
 {
     if (!window.eventSender) {
         alert('Click the link to run the test.');
         return;
     }
-    UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+    await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
 }
 
 function cacheTestResource(then)
@@ -37,13 +37,13 @@ function cacheTestResource(then)
 
 function runTest()
 {
-    cacheTestResource(function() {
+    cacheTestResource(async function() {
         if (window.internals)
             internals.clearMemoryCache();
 
         let link = document.getElementById("testLink");
         testLink.href = testURL;
-        click(link);
+        await click(link);
     });
 }
 runTest();

--- a/LayoutTests/http/tests/events/touch/ios/cross-frame-single-tap-same-origin.https.html
+++ b/LayoutTests/http/tests/events/touch/ios/cross-frame-single-tap-same-origin.https.html
@@ -73,11 +73,12 @@
 
             await UIHelper.activateElement(touchTarget);
 
-            await new Promise((resolve) => {
+            const clickPromise = new Promise((resolve) => {
                 const finishTarget = document.querySelector("#finish-target");
                 finishTarget.onclick = () => resolve();
-                UIHelper.activateElement(finishTarget);
             });
+            await UIHelper.activateElement(document.querySelector("#finish-target"));
+            await clickPromise;
 
             shouldBe(() => frameWasClicked, () => frameWasClickedExpected);
             shouldBe(() => alternateWasClicked, () => alternateWasClickedExpected);

--- a/LayoutTests/http/tests/local/blob/resources/hybrid-blob-util.js
+++ b/LayoutTests/http/tests/local/blob/resources/hybrid-blob-util.js
@@ -80,12 +80,12 @@ var HybridBlobTestUtil = function(testFunc, opt_filePaths, opt_useOpenPanel) {
         await eventSender.asyncMouseUp();
     };
 
-    this.runTestsWithOpenPanel = function()
+    this.runTestsWithOpenPanel = async function()
     {
         this.setupForTests();
 
         testRunner.setOpenPanelFiles(this.testFilePaths);
-        UIHelper.activateAt(10, 10);
+        await UIHelper.activateAt(10, 10);
     };
 
     this.runTests = function() {

--- a/LayoutTests/http/tests/local/fileapi/file-last-modified-after-delete-using-open-panel.html
+++ b/LayoutTests/http/tests/local/fileapi/file-last-modified-after-delete-using-open-panel.html
@@ -38,7 +38,7 @@ function onFileChange(file)
     finishJSTest();
 }
 
-function runTest()
+async function runTest()
 {
     var tempFilePath = createTempFile(tempFileName, tempFileContent);
     if (tempFilePath.length == 0)
@@ -49,7 +49,7 @@ function runTest()
 
     var centerX = fileInput.offsetLeft + fileInput.offsetWidth / 2;
     var centerY = fileInput.offsetTop + fileInput.offsetHeight / 2;
-    UIHelper.activateAt(centerX, centerY);
+    await UIHelper.activateAt(centerX, centerY);
 }
 
 if (window.testRunner)

--- a/LayoutTests/http/tests/local/fileapi/file-last-modified-using-open-panel.html
+++ b/LayoutTests/http/tests/local/fileapi/file-last-modified-using-open-panel.html
@@ -31,7 +31,7 @@ function onFileChange(file, filePath)
     finishJSTest();
 }
 
-function runTest()
+async function runTest()
 {
     var testFilePath = "../resources/file-for-drag-to-send.txt";
     setFileInputChangeCallback(function(file) { onFileChange(file, testFilePath); });
@@ -39,7 +39,7 @@ function runTest()
 
     var centerX = fileInput.offsetLeft + fileInput.offsetWidth / 2;
     var centerY = fileInput.offsetTop + fileInput.offsetHeight / 2;
-    UIHelper.activateAt(centerX, centerY);
+    await UIHelper.activateAt(centerX, centerY);
 }
 
 if (window.testRunner)

--- a/LayoutTests/http/tests/local/fileapi/upload-zip-bundle-as-blob-using-open-panel.html
+++ b/LayoutTests/http/tests/local/fileapi/upload-zip-bundle-as-blob-using-open-panel.html
@@ -16,7 +16,7 @@ if (window.testRunner)
 description("Test that bundles are automatically zipped when uploaded with XMLHttpRequest. To test manually, please select a file bundle in the \"Choose File\" input below.");
 jsTestIsAsync = true;
 
-window.onload = function()
+window.onload = async function()
 {
     var fileInput = document.getElementById("fileInput");
 
@@ -28,7 +28,7 @@ window.onload = function()
     var centerX = fileInput.offsetLeft + fileInput.offsetWidth / 2;
     var centerY = fileInput.offsetTop + fileInput.offsetHeight / 2;
     testRunner.setOpenPanelFiles(["resources/document.rtfd"]);
-    UIHelper.activateAt(centerX, centerY);
+    await UIHelper.activateAt(centerX, centerY);
 }
 
 function onchange(event)

--- a/LayoutTests/http/tests/local/formdata/send-form-data-constructed-from-form-using-open-panel.html
+++ b/LayoutTests/http/tests/local/formdata/send-form-data-constructed-from-form-using-open-panel.html
@@ -34,14 +34,14 @@ function onInputFileChange()
         testRunner.notifyDone();
 }
 
-function runTests()
+async function runTests()
 {
     testRunner.setOpenPanelFiles(['resources/test.txt']);
 
     var element = document.getElementById("file")
     var centerX = element.offsetLeft + element.offsetWidth / 2;
     var centerY = element.offsetTop + element.offsetHeight / 2;
-    UIHelper.activateAt(centerX, centerY);
+    await UIHelper.activateAt(centerX, centerY);
 }
 
 if (window.testRunner) {

--- a/LayoutTests/http/tests/local/formdata/send-form-data-with-empty-file-filename-using-open-panel.html
+++ b/LayoutTests/http/tests/local/formdata/send-form-data-with-empty-file-filename-using-open-panel.html
@@ -29,7 +29,7 @@ function onChange(event)
     xhr.send(formData);
 }
 
-function runTest()
+async function runTest()
 {
     debug("Sending FormData containing one file with custom empty filename:");
 
@@ -40,7 +40,7 @@ function runTest()
 
         var centerX = input.offsetLeft + input.offsetWidth / 2;
         var centerY = input.offsetTop + input.offsetHeight / 2;
-        UIHelper.activateAt(centerX, centerY);
+        await UIHelper.activateAt(centerX, centerY);
     }
 }
 

--- a/LayoutTests/http/tests/misc/form-submit-file-cross-site-redirect.html
+++ b/LayoutTests/http/tests/misc/form-submit-file-cross-site-redirect.html
@@ -12,7 +12,7 @@ function onChange()
     document.forms[0].submit();
 }
 
-function test()
+async function test()
 {
     let tempFilePath = createTempFile(tempFileName, tempFileContent);
 
@@ -26,7 +26,7 @@ function test()
 
         var centerX = input.offsetLeft + input.offsetWidth / 2;
         var centerY = input.offsetTop + input.offsetHeight / 2;
-        UIHelper.activateAt(centerX, centerY);
+        await UIHelper.activateAt(centerX, centerY);
     }
 }
 

--- a/LayoutTests/http/tests/misc/form-submit-file-cross-site.html
+++ b/LayoutTests/http/tests/misc/form-submit-file-cross-site.html
@@ -12,7 +12,7 @@ function onChange()
     document.forms[0].submit();
 }
 
-function test()
+async function test()
 {
     let tempFilePath = createTempFile(tempFileName, tempFileContent);
 
@@ -26,7 +26,7 @@ function test()
 
         var centerX = input.offsetLeft + input.offsetWidth / 2;
         var centerY = input.offsetTop + input.offsetHeight / 2;
-        UIHelper.activateAt(centerX, centerY);
+        await UIHelper.activateAt(centerX, centerY);
     }
 }
 

--- a/LayoutTests/http/tests/misc/iframe-beforeunload-dialog-allow-modals.html
+++ b/LayoutTests/http/tests/misc/iframe-beforeunload-dialog-allow-modals.html
@@ -11,11 +11,11 @@ function navigateFrame()
 	window.location.href = 'resources/notify-done.html';
 }
 
-window.onload = function()
+window.onload = async function()
 {
 	// Simulate a user interaction with the page so that the beforeunload alert shows.
 	const testButton = document.getElementById("testButton");
-	UIHelper.activateAt(testButton.offsetLeft + 5, testButton.offsetTop + 5);
+	await UIHelper.activateAt(testButton.offsetLeft + 5, testButton.offsetTop + 5);
 }
 
 </script>

--- a/LayoutTests/http/tests/misc/iframe-beforeunload-dialog-block-modals.html
+++ b/LayoutTests/http/tests/misc/iframe-beforeunload-dialog-block-modals.html
@@ -11,11 +11,11 @@ function navigateFrame()
 	window.location.href = 'resources/notify-done.html';
 }
 
-window.onload = function()
+window.onload = async function()
 {
 	// Simulate a user interaction with the page so that the beforeunload alert shows.
 	const testButton = document.getElementById("testButton");
-	UIHelper.activateAt(testButton.offsetLeft + 5, testButton.offsetTop + 5);
+	await UIHelper.activateAt(testButton.offsetLeft + 5, testButton.offsetTop + 5);
 }
 
 </script>

--- a/LayoutTests/http/tests/misc/iframe-beforeunload-dialog-matching-ancestor-securityorigin.html
+++ b/LayoutTests/http/tests/misc/iframe-beforeunload-dialog-matching-ancestor-securityorigin.html
@@ -11,11 +11,11 @@ function navigateFrame()
 	window.location.href = 'resources/notify-done.html';
 }
 
-window.onload = function()
+window.onload = async function()
 {
 	// Simulate a user interaction with the page so that the beforeunload alert shows.
 	const testButton = document.getElementById("testButton");
-	UIHelper.activateAt(testButton.offsetLeft + 5, testButton.offsetTop + 5);
+	await UIHelper.activateAt(testButton.offsetLeft + 5, testButton.offsetTop + 5);
 }
 
 </script>

--- a/LayoutTests/http/tests/misc/iframe-beforeunload-dialog-not-matching-ancestor-securityorigin.html
+++ b/LayoutTests/http/tests/misc/iframe-beforeunload-dialog-not-matching-ancestor-securityorigin.html
@@ -11,11 +11,11 @@ function navigateFrame()
 	window.location.href = 'resources/notify-done.html';
 }
 
-window.onload = function()
+window.onload = async function()
 {
 	// Simulate a user interaction with the page so that the beforeunload alert shows.
 	const testButton = document.getElementById("testButton");
-	UIHelper.activateAt(testButton.offsetLeft + 5, testButton.offsetTop + 5);
+	await UIHelper.activateAt(testButton.offsetLeft + 5, testButton.offsetTop + 5);
 }
 
 </script>

--- a/LayoutTests/http/tests/paymentrequest/paymentrequest-features.https.html
+++ b/LayoutTests/http/tests/paymentrequest/paymentrequest-features.https.html
@@ -55,8 +55,8 @@ async function go() {
     finishJSTest();
 }
 
-window.onload = function() {
-    UIHelper.activateElement(document.querySelector("button"));
+window.onload = async function() {
+    await UIHelper.activateElement(document.querySelector("button"));
 }
 
 </script>

--- a/LayoutTests/http/tests/resourceLoadStatistics/user-interaction-in-cross-origin-sub-frame.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/user-interaction-in-cross-origin-sub-frame.html
@@ -11,11 +11,11 @@ jsTestIsAsync = true;
 const topFrameOrigin = "http://127.0.0.1:8000";
 const subFrameOrigin = "http://localhost:8000";
 
-function activateElement(elementId) {
+async function activateElement(elementId) {
     var element = document.getElementById(elementId);
     var centerX = element.offsetLeft + element.offsetWidth / 2;
     var centerY = element.offsetTop + element.offsetHeight / 2;
-    UIHelper.activateAt(centerX, centerY);
+    await UIHelper.activateAt(centerX, centerY);
 }
 
 function finishTest() {
@@ -33,7 +33,7 @@ onload = async function() {
             shouldBeFalse("testRunner.isStatisticsHasHadUserInteraction(topFrameOrigin)");
             shouldBeFalse("testRunner.isStatisticsHasHadUserInteraction(subFrameOrigin)");
 
-            activateElement("testFrame");
+            await activateElement("testFrame");
         }
         await testRunner.statisticsProcessStatisticsAndDataRecords();
         finishTest();

--- a/LayoutTests/http/tests/security/anchor-download-allow-blob.html
+++ b/LayoutTests/http/tests/security/anchor-download-allow-blob.html
@@ -17,20 +17,20 @@ Tests that a suggested filename on a download attribute is allowed if
 <a id="dl" download="foo.pdf">the link</a> is a blob URL.
 <p>The suggested filename at the top should be foo.pdf.</p>
 <script>
-    function click(elmt)
+    async function click(elmt)
     {
         if (!window.eventSender)
             return;
 
-        UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+        await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
     }
 
-    function runTest()
+    async function runTest()
     {
         var blob = new Blob(["Hello world!"], {type: "application/octet-stream"});
         var link = document.getElementById("dl");
         link.href = window.URL.createObjectURL(blob);
-        click(link);
+        await click(link);
     }
     runTest();
 </script>

--- a/LayoutTests/http/tests/security/anchor-download-allow-data.html
+++ b/LayoutTests/http/tests/security/anchor-download-allow-data.html
@@ -17,18 +17,18 @@ Tests that a suggested filename on a download attribute is allowed if
 <a id="dl" href="data:application/octet-stream,Hello" download="foo.pdf">the link</a> is a data URL.
 <p>The suggested filename at the top should be foo.pdf.</p>
 <script>
-    function click(elmt)
+    async function click(elmt)
     {
         if (!window.eventSender)
             return;
 
-        UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+        await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
     }
 
-    function runTest()
+    async function runTest()
     {
         var link = document.getElementById("dl");
-        click(link);
+        await click(link);
     }
     runTest();
 </script>

--- a/LayoutTests/http/tests/security/anchor-download-allow-sameorigin.html
+++ b/LayoutTests/http/tests/security/anchor-download-allow-sameorigin.html
@@ -18,18 +18,18 @@ Tests that a suggested filename on a download attribute is allowed if
 <p>
 The suggested filename at the top should be foo.pdf.
 <script>
-    function click(elmt)
+    async function click(elmt)
     {
         if (!window.eventSender)
             return;
 
-        UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+        await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
     }
 
-    function runTest()
+    async function runTest()
     {
         var link = document.getElementById("dl");
-        click(link);
+        await click(link);
     }
     runTest();
 </script>

--- a/LayoutTests/http/tests/security/anchor-download-block-crossorigin.html
+++ b/LayoutTests/http/tests/security/anchor-download-block-crossorigin.html
@@ -17,18 +17,18 @@ Tests that the download attribute is ignored if
 <p>It should navigate the subframe instead of downloading the file.</p>
 <iframe name="targetFrame"></iframe>
 <script>
-    function click(elmt)
+    async function click(elmt)
     {
         if (!window.eventSender)
             return;
 
-        UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+        await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
     }
 
-    function runTest()
+    async function runTest()
     {
         var link = document.getElementById("dl");
-        click(link);
+        await click(link);
     }
     onload = runTest;
 </script>

--- a/LayoutTests/http/tests/security/anchor-download-octet-stream-no-extension.html
+++ b/LayoutTests/http/tests/security/anchor-download-octet-stream-no-extension.html
@@ -17,20 +17,20 @@ Tests that a suggested filename on a download attribute is allowed if
 <a id="dl" download="foo">the link</a> is a blob URL.
 <p>The suggested filename at the top should be "foo" (without extension).</p>
 <script>
-    function click(elmt)
+    async function click(elmt)
     {
         if (!window.eventSender)
             return;
 
-        UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
+        await UIHelper.activateAt(elmt.offsetLeft + 5, elmt.offsetTop + 5);
     }
 
-    function runTest()
+    async function runTest()
     {
         var blob = new Blob(["Hello world!"], {type: "application/octet-stream"});
         var link = document.getElementById("dl");
         link.href = window.URL.createObjectURL(blob);
-        click(link);
+        await click(link);
     }
     runTest();
 </script>

--- a/LayoutTests/http/tests/security/frameNavigation/resources/iframe-that-performs-parent-navigation-with-user-activation.html
+++ b/LayoutTests/http/tests/security/frameNavigation/resources/iframe-that-performs-parent-navigation-with-user-activation.html
@@ -7,10 +7,10 @@
             document.getElementsByTagName('h4')[0].innerHTML = document.domain;
         }
 
-        function startTest(event)
+        async function startTest(event)
         {
             var button = document.getElementById("button");
-            UIHelper.activateAt(event.data.x + button.offsetLeft + 2, event.data.y + button.offsetTop + 2).catch(function(reason) {
+            await UIHelper.activateAt(event.data.x + button.offsetLeft + 2, event.data.y + button.offsetTop + 2).catch(function(reason) {
                 parent.postMessage("Failed to emulate user interaction: " + reason, "*");
             });
         }

--- a/LayoutTests/http/tests/site-isolation/resources/pointer-lock.html
+++ b/LayoutTests/http/tests/site-isolation/resources/pointer-lock.html
@@ -19,7 +19,7 @@
         console.log("Pointer lock failed");
     });
 
-    window.onload = (event) => {
+    window.onload = async (event) => {
         const element = document.getElementById('pointer-lock-element');
         if (element) {
             element.addEventListener('click', () => {
@@ -31,7 +31,7 @@
         }
 
         if (window.eventSender) {
-            UIHelper.activateElement(element);
+            await UIHelper.activateElement(element);
         }
     };
 </script>

--- a/LayoutTests/http/tests/ssl/applepay/ApplePayError.html
+++ b/LayoutTests/http/tests/ssl/applepay/ApplePayError.html
@@ -57,8 +57,8 @@
         finishJSTest();
     }
 
-    window.onload = function() {
-        UIHelper.activateElement(document.querySelector("button"));
+    window.onload = async function() {
+        await UIHelper.activateElement(document.querySelector("button"));
     }
 
 </script>

--- a/LayoutTests/http/tests/ssl/applepay/ApplePaySession.html
+++ b/LayoutTests/http/tests/ssl/applepay/ApplePaySession.html
@@ -230,8 +230,8 @@ function go() {
     finishJSTest();
 }
 
-window.onload = function() {
-    UIHelper.activateElement(document.querySelector("button"));
+window.onload = async function() {
+    await UIHelper.activateElement(document.querySelector("button"));
 }
 
 </script>

--- a/LayoutTests/http/tests/ssl/applepay/ApplePaySessionV3.html
+++ b/LayoutTests/http/tests/ssl/applepay/ApplePaySessionV3.html
@@ -74,8 +74,8 @@ function go() {
     finishJSTest();
 }
 
-window.onload = function() {
-    UIHelper.activateElement(document.querySelector("button"));
+window.onload = async function() {
+    await UIHelper.activateElement(document.querySelector("button"));
 }
 
 </script>

--- a/LayoutTests/http/tests/ssl/applepay/ApplePaySessionV4.html
+++ b/LayoutTests/http/tests/ssl/applepay/ApplePaySessionV4.html
@@ -62,8 +62,8 @@ function go() {
     finishJSTest();
 }
 
-window.onload = function() {
-    UIHelper.activateElement(document.querySelector("button"));
+window.onload = async function() {
+    await UIHelper.activateElement(document.querySelector("button"));
 }
 
 </script>

--- a/LayoutTests/http/tests/ssl/applepay/ApplePaySessionV5.html
+++ b/LayoutTests/http/tests/ssl/applepay/ApplePaySessionV5.html
@@ -58,8 +58,8 @@ function go() {
     finishJSTest();
 }
 
-window.onload = function() {
-    UIHelper.activateElement(document.querySelector("button"));
+window.onload = async function() {
+    await UIHelper.activateElement(document.querySelector("button"));
 }
 
 </script>

--- a/LayoutTests/http/wpt/service-workers/file-upload.html
+++ b/LayoutTests/http/wpt/service-workers/file-upload.html
@@ -32,7 +32,7 @@ function with_iframe(url) {
     });
 }
 
-function prepareUpload()
+async function prepareUpload()
 {
     let resolve, reject;
     const promise = new Promise((resolve_, reject_) => {
@@ -54,7 +54,7 @@ function prepareUpload()
 
         var centerX = input.offsetLeft + input.offsetWidth / 2;
         var centerY = input.offsetTop + input.offsetHeight / 2;
-        UIHelper.activateAt(centerX, centerY);
+        await UIHelper.activateAt(centerX, centerY);
     }
     return promise;
 }

--- a/LayoutTests/http/wpt/service-workers/form-data-upload.html
+++ b/LayoutTests/http/wpt/service-workers/form-data-upload.html
@@ -32,7 +32,7 @@ function with_iframe(url) {
     });
 }
 
-function prepareUpload()
+async function prepareUpload()
 {
     let resolve, reject;
     const promise = new Promise((resolve_, reject_) => {
@@ -54,7 +54,7 @@ function prepareUpload()
 
         var centerX = input.offsetLeft + input.offsetWidth / 2;
         var centerY = input.offsetTop + input.offsetHeight / 2;
-        UIHelper.activateAt(centerX, centerY);
+        await UIHelper.activateAt(centerX, centerY);
     }
     return promise;
 }

--- a/LayoutTests/media/video-src-blob-replay.html
+++ b/LayoutTests/media/video-src-blob-replay.html
@@ -37,7 +37,7 @@
              video.play();
          }
 
-         function runTest() {
+         async function runTest() {
              var inputFile = document.getElementById('file');
              var centerX = inputFile.offsetLeft + inputFile.offsetWidth / 2;
              var centerY = inputFile.offsetTop + inputFile.offsetHeight / 2;
@@ -45,7 +45,7 @@
 
              if (window.testRunner) {
                  testRunner.setOpenPanelFiles([findMediaFile("video", "content/test")]);
-                 UIHelper.activateAt(centerX, centerY);
+                 await UIHelper.activateAt(centerX, centerY);
              }
          }
         </script>

--- a/LayoutTests/media/video-src-blob-using-open-panel.html
+++ b/LayoutTests/media/video-src-blob-using-open-panel.html
@@ -13,7 +13,7 @@
                 video.src = window.URL.createObjectURL(file);
             }
 
-            function runTest() {
+            async function runTest() {
                 var inputFile = document.getElementById('file');
                 var centerX = inputFile.offsetLeft + inputFile.offsetWidth / 2;
                 var centerY = inputFile.offsetTop + inputFile.offsetHeight / 2;
@@ -21,7 +21,7 @@
 
                 if (window.testRunner) {
                     testRunner.setOpenPanelFiles([findMediaFile("video", "content/test")]);
-                    UIHelper.activateAt(centerX, centerY);
+                    await UIHelper.activateAt(centerX, centerY);
                 }
             }
         </script>

--- a/LayoutTests/pdf/annotations/checkbox-set-active.html
+++ b/LayoutTests/pdf/annotations/checkbox-set-active.html
@@ -13,7 +13,7 @@
             let centerX = annotationBounds["x"] + annotationBounds["width"] / 2;
             let centerY = annotationBounds["y"] + annotationBounds["height"] / 2;
 
-            UIHelper.activateAt(centerX, centerY);
+            await UIHelper.activateAt(centerX, centerY);
             await UIHelper.renderingUpdate();
 
             testRunner.notifyDone();

--- a/LayoutTests/pdf/annotations/dropdown-select-second-option.html
+++ b/LayoutTests/pdf/annotations/dropdown-select-second-option.html
@@ -15,12 +15,12 @@ function runTest() {
             let annotationBounds = window.internals.pdfAnnotationRectsForTesting(pluginElement)[0];
             let centerX = annotationBounds["x"] + annotationBounds["width"] / 2;
             let centerY = annotationBounds["y"] + annotationBounds["height"] / 2;
-            UIHelper.activateAt(centerX, centerY);
+            await UIHelper.activateAt(centerX, centerY);
 
             let annotationSelectElement = innerDocument.querySelector("#annotationContainer > select");
             annotationSelectElement.selectedIndex = 1;
-            
-            UIHelper.activateAt(0, 0);
+
+            await UIHelper.activateAt(0, 0);
             await UIHelper.renderingUpdate();
             testRunner.notifyDone();
         }, pluginElement);

--- a/LayoutTests/pdf/annotations/radio-buttons-select-second.html
+++ b/LayoutTests/pdf/annotations/radio-buttons-select-second.html
@@ -13,7 +13,7 @@
             let centerX = annotationBounds["x"] + annotationBounds["width"] / 2;
             let centerY = annotationBounds["y"] + annotationBounds["height"] / 2;
 
-            UIHelper.activateAt(centerX, centerY);
+            await UIHelper.activateAt(centerX, centerY);
             await UIHelper.renderingUpdate();
 
             testRunner.notifyDone();

--- a/LayoutTests/pointerevents/pointer-event-twist-on-tap-or-click.html
+++ b/LayoutTests/pointerevents/pointer-event-twist-on-tap-or-click.html
@@ -17,7 +17,9 @@
             finishJSTest();
         });
 
-        UIHelper.activateAt(10, 10);
+        (async () => {
+            await UIHelper.activateAt(10, 10);
+        })();
     }
 </script>
 </html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -369,13 +369,13 @@ window.UIHelper = class UIHelper {
         });
     }
 
-    static activateAt(x, y, modifiers=[])
+    static async activateAt(x, y, modifiers=[])
     {
         if (!this.isWebKit2() || !this.isIOSFamily()) {
-            eventSender.mouseMoveTo(x, y);
-            eventSender.mouseDown(0, modifiers);
-            eventSender.mouseUp(0, modifiers);
-            return Promise.resolve();
+            await eventSender.asyncMouseMoveTo(x, y);
+            await eventSender.asyncMouseDown(0, modifiers);
+            await eventSender.asyncMouseUp(0, modifiers);
+            return;
         }
 
         return new Promise((resolve) => {


### PR DESCRIPTION
#### daac2a1c6dd35d787e10e1c0fff5a9a60a7c23cb
<pre>
Switch UIHelper&apos;s activeAt() to use eventSender.asyncMouse*()
<a href="https://bugs.webkit.org/show_bug.cgi?id=309768">https://bugs.webkit.org/show_bug.cgi?id=309768</a>

Reviewed by NOBODY (OOPS!).

activeAt() is already asynchronous, but only on iOS would you be truly
required to await its promise. This change make it asynchronous on all
platforms, which is a pre-requisite if you want to use it to open
&lt;select&gt; elements on macOS for instance (and I do, see bug 308457).

124 tests that were not awaiting its promise are changed to await it.
Some of these could probably do without awaiting, but it was easier to
change all of them and it makes copypasta easier going forward.

9 tests were not even asynchronous (despite this being required for
iOS). This is also addressed and some tests were migrated from
js-test-[pre|post] to js-test.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/daac2a1c6dd35d787e10e1c0fff5a9a60a7c23cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149581 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158284 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115384 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3ea72ba-598d-4398-a769-e374078d8dd7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96125 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/acb66868-4bbe-498e-a410-ce94d885be1a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6128 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12171 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160760 "Built successfully") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13712 "Found 2 new test failures: fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html http/tests/webshare/webshare-allow-attribute-share.https.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123416 "Found 1 new test failure: fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22102 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18562 "Found 2 new test failures: fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html http/tests/webshare/webshare-allow-attribute-share.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123625 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22109 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133963 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78323 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18808 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10714 "Found 2 new test failures: fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html http/tests/webshare/webshare-allow-attribute-share.https.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21709 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21440 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21592 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21497 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->