### PR TITLE
[JSC] Array.prototype.copyWithin should return ToObject(this) when finalIndex < from

### DIFF
--- a/JSTests/stress/array-prototype-copyWithin-primitive-this-toobject.js
+++ b/JSTests/stress/array-prototype-copyWithin-primitive-this-toobject.js
@@ -1,0 +1,48 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual}, expected: ${expected}`);
+}
+
+// Array.prototype.copyWithin step 1: Let O be ? ToObject(this value).
+// The spec always returns O, so when |this| is a primitive, the return
+// value must be the wrapper object, not the original primitive.
+
+// finalIndex < from path (early return)
+{
+    let result = Array.prototype.copyWithin.call("hello", 0, 3, 1);
+    shouldBe(typeof result, "object");
+    shouldBe(result instanceof String, true);
+    shouldBe(result.valueOf(), "hello");
+}
+
+// count == 0 path
+{
+    let result = Array.prototype.copyWithin.call("hello", 0, 0, 0);
+    shouldBe(typeof result, "object");
+    shouldBe(result instanceof String, true);
+    shouldBe(result.valueOf(), "hello");
+}
+
+// Number primitive, finalIndex < from
+{
+    let result = Array.prototype.copyWithin.call(42, 0, 3, 1);
+    shouldBe(typeof result, "object");
+    shouldBe(result instanceof Number, true);
+    shouldBe(result.valueOf(), 42);
+}
+
+// Boolean primitive, finalIndex < from
+{
+    let result = Array.prototype.copyWithin.call(true, 0, 3, 1);
+    shouldBe(typeof result, "object");
+    shouldBe(result instanceof Boolean, true);
+    shouldBe(result.valueOf(), true);
+}
+
+// Symbol primitive, finalIndex < from
+{
+    let sym = Symbol("s");
+    let result = Array.prototype.copyWithin.call(sym, 0, 3, 1);
+    shouldBe(typeof result, "object");
+    shouldBe(result.valueOf(), sym);
+}

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1993,7 +1993,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncCopyWithin, (JSGlobalObject* globalObject
     RETURN_IF_EXCEPTION(scope, { });
 
     if (finalIndex < from)
-        return JSValue::encode(thisValue);
+        return JSValue::encode(thisObject);
 
     ASSERT(to <= length);
     ASSERT(from <= length);


### PR DESCRIPTION
#### 685247318fa25a58949852eac7ef2cae70be0d18
<pre>
[JSC] Array.prototype.copyWithin should return ToObject(this) when finalIndex &lt; from
<a href="https://bugs.webkit.org/show_bug.cgi?id=309769">https://bugs.webkit.org/show_bug.cgi?id=309769</a>

Reviewed by Yusuke Suzuki.

Per spec[1], Array.prototype.copyWithin always returns the result of
ToObject(this value). When |this| is a primitive and the early return
path (finalIndex &lt; from) is taken, we were returning the original
primitive value instead of the wrapper object.

[1]: <a href="https://tc39.es/ecma262/#sec-array.prototype.copywithin">https://tc39.es/ecma262/#sec-array.prototype.copywithin</a>

Test: JSTests/stress/array-prototype-copyWithin-primitive-this-toobject.js

* JSTests/stress/array-prototype-copyWithin-primitive-this-toobject.js: Added.
(shouldBe):
(throw.new.Error):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/309182@main">https://commits.webkit.org/309182@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/287e71776e8c0e5c25e1a10cc84f6f8182c003e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149571 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158274 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103003 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22211 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115376 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82029 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152531 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17512 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96117 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16609 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14512 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6118 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141546 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126217 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160750 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10365 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3747 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123407 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18553 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123616 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33615 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133947 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78313 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18796 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10698 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181000 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21699 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85520 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46369 "Found 1 new JSC stress test failure: Too many failures: 5741 jsc tests failed (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21430 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21582 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->