### PR TITLE
[WebXR] Add support for maxRenderLayers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrWebGLBinding_maxLayers.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrWebGLBinding_maxLayers.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Ensure XRSession throws appropriate errors when updating render state with more layers than maxRenderLayers without layers feature enabled - webgl
+PASS Ensure XRSession throws appropriate errors when updating render state with more layers than maxRenderLayers without layers feature enabled - webgl2
+PASS Ensure XRSession throws appropriate errors when updating render state with more layers than maxRenderLayers with layers feature enabled - webgl
+PASS Ensure XRSession throws appropriate errors when updating render state with more layers than maxRenderLayers with layers feature enabled - webgl2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrWebGLBinding_maxLayers.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrWebGLBinding_maxLayers.https.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/webxr_util.js"></script>
+<script src="../resources/webxr_test_constants.js"></script>
+
+<script>
+
+  function testMaxRenderLayers(xrSession, deviceController, t, { gl, glLayer }) {
+    return new Promise((resolve, reject) => {
+      const layersFeatureEnabled = xrSession.enabledFeatures.includes('layers');
+
+      t.step(() => {
+        if (layersFeatureEnabled) {
+          // Create an array of layers with 1 layer more than xrSession.maxRenderLayers
+          let excessLayers = [];
+          for (let i = 0; i < xrSession.maxRenderLayers + 1; i++) {
+            excessLayers.push(new XRWebGLLayer(xrSession, gl));
+	  }
+          const updateRenderStateMultilayer = () => xrSession.updateRenderState({ layers: excessLayers });
+          try {
+            updateRenderStateMultilayer();
+            assert_unreached("updateRenderState should fail when created with more layers than maxRenderLayers.")
+          } catch (err) {
+	    assert_equals(err.name, "NotSupportedError", "Should get InvalidStateError when updating render state with more layers than maxRenderLayers.");
+          }
+        } else {
+          assert_throws_dom('NotSupportedError', updateRenderStateMultilayer, "XRSession should be able to updateRenderState with multiple layers only if the layers feature is enabled.");
+        }
+      resolve();
+      });
+    });
+  }
+
+  xr_session_promise_test("Ensure XRSession throws appropriate errors when updating render state with more layers than maxRenderLayers without layers feature enabled",
+    testMaxRenderLayers, TRACKED_IMMERSIVE_DEVICE, 'immersive-vr', { requiredFeatures: ['layers'] });
+
+  xr_session_promise_test("Ensure XRSession throws appropriate errors when updating render state with more layers than maxRenderLayers with layers feature enabled",
+    testMaxRenderLayers, TRACKED_IMMERSIVE_DEVICE, 'immersive-vr', { requiredFeatures: ['layers'] });
+
+</script>

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1877,6 +1877,7 @@ list(APPEND WebCore_NON_SVG_IDL_FILES
     Modules/webxr/WebXRRenderState.idl
     Modules/webxr/WebXRRigidTransform.idl
     Modules/webxr/WebXRSession+AR.idl
+    Modules/webxr/WebXRSession+Layers.idl
     Modules/webxr/WebXRSession+HitTest.idl
     Modules/webxr/WebXRSession.idl
     Modules/webxr/WebXRSpace.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1140,6 +1140,7 @@ $(PROJECT_DIR)/Modules/webxr/WebXRRenderState+Layers.idl
 $(PROJECT_DIR)/Modules/webxr/WebXRRenderState.idl
 $(PROJECT_DIR)/Modules/webxr/WebXRRigidTransform.idl
 $(PROJECT_DIR)/Modules/webxr/WebXRSession+AR.idl
+$(PROJECT_DIR)/Modules/webxr/WebXRSession+Layers.idl
 $(PROJECT_DIR)/Modules/webxr/WebXRSession+HitTest.idl
 $(PROJECT_DIR)/Modules/webxr/WebXRSession.idl
 $(PROJECT_DIR)/Modules/webxr/WebXRSpace.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -3529,6 +3529,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebXRRigidTransform.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebXRRigidTransform.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebXRSession+AR.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebXRSession+AR.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebXRSession+Layers.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebXRSession+Layers.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebXRSession+HitTest.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebXRSession+HitTest.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSWebXRSession.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -875,6 +875,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/webxr/WebXRRenderState+Layers.idl \
     $(WebCore)/Modules/webxr/WebXRRigidTransform.idl \
     $(WebCore)/Modules/webxr/WebXRSession+AR.idl \
+    $(WebCore)/Modules/webxr/WebXRSession+Layers.idl \
     $(WebCore)/Modules/webxr/WebXRSession+HitTest.idl \
     $(WebCore)/Modules/webxr/WebXRSession.idl \
     $(WebCore)/Modules/webxr/WebXRSpace.idl \

--- a/Source/WebCore/Modules/webxr/WebXRSession+Layers.idl
+++ b/Source/WebCore/Modules/webxr/WebXRSession+Layers.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,28 +23,10 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
-#if ENABLE(WEBXR)
-
-#include "XRDeviceIdentifier.h"
-#include <WebCore/PlatformXR.h>
-
-namespace WebKit {
-
-struct XRDeviceInfo {
-    XRDeviceIdentifier identifier;
-    bool supportsOrientationTracking { false };
-    bool supportsStereoRendering { false };
-    PlatformXR::Device::FeatureList vrFeatures;
-    PlatformXR::Device::FeatureList arFeatures;
-    WebCore::IntSize recommendedResolution { 0, 0 };
-    double minimumNearClipPlane { 0.1 };
-#if ENABLE(WEBXR_LAYERS)
-    unsigned maxRenderLayers { 1 };
-#endif
+[
+    Conditional=WEBXR_LAYERS,
+    EnabledBySetting=WebXREnabled&WebXRLayersAPIEnabled
+] partial interface WebXRSession {
+  // https://immersive-web.github.io/layers/#xrsessionchanges
+  readonly attribute unsigned long maxRenderLayers;
 };
-
-} // namespace WebKit
-
-#endif // ENABLE(WEBXR)

--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -193,6 +193,10 @@ ExceptionOr<void> WebXRSession::updateRenderState(const XRRenderStateInit& newSt
         if (!m_requestedFeatures.contains(PlatformXR::SessionFeature::Layers) && newState.layers->size() > 1)
             return Exception { ExceptionCode::NotSupportedError, "Cannot set layers when the Layers feature is not enabled for this session."_s };
 
+        auto maxLayers = maxRenderLayers();
+        if (newState.layers->size() > maxLayers)
+            return Exception { ExceptionCode::NotSupportedError, makeString("Cannot set more layers than the session's maxRenderLayers limit of "_s, maxLayers) };
+
         if (!m_pendingRenderState)
             m_pendingRenderState = m_activeRenderState->clone();
 
@@ -935,6 +939,14 @@ void WebXRSession::addSessionListener(const WebXRSessionListener& listener)
 {
     m_sessionListeners.append(&listener);
 }
+
+#if ENABLE(WEBXR_LAYERS)
+unsigned WebXRSession::maxRenderLayers() const
+{
+    RefPtr device = m_device.get();
+    return device ? device->maxRenderLayers() : 0;
+}
+#endif
 
 WebCoreOpaqueRoot root(WebXRSession* session)
 {

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Igalia S.L. All rights reserved.
+ * Copyright (C) 2020-2026 Igalia S.L. All rights reserved.
  * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -132,6 +132,10 @@ public:
     void requestHitTestSourceForTransientInput(const XRTransientInputHitTestOptionsInit&, RequestHitTestSourceForTransientInputPromise&&);
     ExceptionOr<void> cancelHitTestSource(PlatformXR::HitTestSource);
     ExceptionOr<void> cancelTransientInputHitTestSource(PlatformXR::TransientInputHitTestSource);
+#endif
+
+#if ENABLE(WEBXR_LAYERS)
+    unsigned maxRenderLayers() const;
 #endif
 
     void initializeTrackingAndRendering(std::optional<XRCanvasConfiguration>&&);

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -545,6 +545,11 @@ public:
     using RequestFrameCallback = Function<void(FrameData&&)>;
     virtual void requestFrame(std::optional<RequestData>&&, RequestFrameCallback&&) = 0;
     virtual void submitFrame(Vector<DeviceLayer>&&) { };
+
+#if ENABLE(WEBXR_LAYERS)
+    unsigned maxRenderLayers() const { return m_maxRenderLayers; }
+#endif
+
 protected:
     Device() = default;
 
@@ -558,6 +563,10 @@ protected:
     bool m_supportsOrientationTracking { false };
     bool m_supportsViewportScaling { false };
     WeakPtr<TrackingAndRenderingClient> m_trackingAndRenderingClient;
+
+#if ENABLE(WEBXR_LAYERS)
+    unsigned m_maxRenderLayers { 1 };
+#endif
 };
 
 using DeviceList = Vector<Ref<Device>>;

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -62,6 +62,11 @@ SimulatedXRDevice::SimulatedXRDevice()
     : m_frameTimer(*this, &SimulatedXRDevice::frameTimerFired)
 {
     m_supportsOrientationTracking = true;
+#if ENABLE(WEBXR_LAYERS)
+    // Same approach as Chromium. From a typical 16 max layer limit we remove the projection layer which is always there
+    // and then we divide by 2 to account for the fact that each layer can be stereo (two views).
+    m_maxRenderLayers = (16 - 1) / 2;
+#endif
 }
 
 SimulatedXRDevice::~SimulatedXRDevice()

--- a/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
+++ b/Source/WebKit/Shared/XR/XRDeviceProxy.cpp
@@ -50,7 +50,9 @@ XRDeviceProxy::XRDeviceProxy(XRDeviceInfo&& deviceInfo, PlatformXRSystemProxy& x
     m_supportsOrientationTracking = deviceInfo.supportsOrientationTracking;
     m_recommendedResolution = deviceInfo.recommendedResolution;
     m_minimumNearClipPlane = deviceInfo.minimumNearClipPlane;
-
+#if ENABLE(WEBXR_LAYERS)
+    m_maxRenderLayers = deviceInfo.maxRenderLayers;
+#endif
     if (!deviceInfo.vrFeatures.contains(SessionFeature::WebGPU))
         deviceInfo.vrFeatures.append(SessionFeature::WebGPU);
 #if ENABLE(WEBXR_LAYERS)

--- a/Source/WebKit/Shared/XR/XRSystem.serialization.in
+++ b/Source/WebKit/Shared/XR/XRSystem.serialization.in
@@ -1,4 +1,5 @@
 # Copyright (C) 2022 Apple Inc. All rights reserved.
+# Copyright (C) 2026 Igalia S.L. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,6 +31,9 @@ struct WebKit::XRDeviceInfo {
     PlatformXR::Device::FeatureList arFeatures;
     WebCore::IntSize recommendedResolution;
     double minimumNearClipPlane;
+#if ENABLE(WEBXR_LAYERS)
+    unsigned maxRenderLayers;
+#endif
 };
 
 #endif

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRUtils.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRUtils.h
@@ -111,6 +111,9 @@ inline ASCIILiteral handednessToString(PlatformXR::XRHandedness handedness)
 struct OpenXRSystemProperties {
     bool supportsOrientationTracking { false };
     bool supportsHandTracking { false };
+#if ENABLE(WEBXR_LAYERS)
+    unsigned maxLayerCount { 1 };
+#endif
 };
 
 inline OpenXRSystemProperties systemProperties(XrInstance instance, XrSystemId systemId)
@@ -129,9 +132,12 @@ inline OpenXRSystemProperties systemProperties(XrInstance instance, XrSystemId s
     return {
         .supportsOrientationTracking = xrSystemProperties.trackingProperties.orientationTracking == XR_TRUE,
 #if defined(XR_EXT_hand_tracking)
-        .supportsHandTracking = handTrackingProperties.supportsHandTracking == XR_TRUE
+        .supportsHandTracking = handTrackingProperties.supportsHandTracking == XR_TRUE,
 #else
-        .supportsHandTracking = false
+        .supportsHandTracking = false,
+#endif
+#if ENABLE(WEBXR_LAYERS)
+        .maxLayerCount = xrSystemProperties.graphicsProperties.maxLayerCount,
 #endif
     };
 }

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -142,6 +142,10 @@ void OpenXRCoordinator::getPrimaryDeviceInfo(WebPageProxy& page, DeviceInfoCallb
     deviceInfo.vrFeatures.append(PlatformXR::SessionFeature::ReferenceSpaceTypeLocalFloor);
     deviceInfo.arFeatures.append(PlatformXR::SessionFeature::ReferenceSpaceTypeLocalFloor);
 
+#if ENABLE(WEBXR_LAYERS)
+    deviceInfo.maxRenderLayers = runtimeProperties.maxLayerCount;
+#endif
+
     callback(WTF::move(deviceInfo));
 }
 


### PR DESCRIPTION
#### 6e6cbb292dbb34fa73305b0192ca06bf7e532d5f
<pre>
[WebXR] Add support for maxRenderLayers
<a href="https://bugs.webkit.org/show_bug.cgi?id=309770">https://bugs.webkit.org/show_bug.cgi?id=309770</a>

Reviewed by Dan Glastonbury.

XR compositors can handle a limitted amount of compositor layers,
usually 16. However there is no limit to the amount of layers
that a WebXR author can create and pass to updateRenderState via the
layers field. That&apos;s why the WebXR Layers spec defines a new attribute
for the XRSession called maxRenderLayers that authors can check to avoid
passing more layers than the number specified by that attribute.

Note that layer creation should not be limitted, what is limitted is the
number of active layers, i.e., the ones set in updateRenderLayers which
are the ones finally passed down to the XR compositor.

Test: imported/w3c/web-platform-tests/webxr/layers/xrWebGLBinding_maxLayers.https.html

* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrWebGLBinding_maxLayers.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrWebGLBinding_maxLayers.https.html: Added.
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/webxr/WebXRSession+Layers.idl: Copied from Source/WebKit/Shared/XR/XRDeviceInfo.h.
* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::updateRenderState):
(WebCore::WebXRSession::maxRenderLayers const):
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/platform/xr/PlatformXR.h:
(PlatformXR::Device::maxRenderLayers const):
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::SimulatedXRDevice):
* Source/WebKit/Shared/XR/XRDeviceInfo.h:
* Source/WebKit/Shared/XR/XRDeviceProxy.cpp:
(WebKit::XRDeviceProxy::XRDeviceProxy):
* Source/WebKit/Shared/XR/XRSystem.serialization.in:
* Source/WebKit/UIProcess/XR/openxr/OpenXRUtils.h:
(WebKit::systemProperties):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::getPrimaryDeviceInfo):

Canonical link: <a href="https://commits.webkit.org/310429@main">https://commits.webkit.org/310429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dae05ffaaeacee69fa9a6cb8a38f57e6e56fa861

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153844 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26628 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/20245 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/162595 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/107305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26950 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/118949 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/107305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21213 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/138146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99659 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/20293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/18254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/10427 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/129941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/16005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165067 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/8199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/17599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/127037 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/26425 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22283 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127204 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34497 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/26427 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/137800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22098 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/14584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26044 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/90332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25735 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/25895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/25795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->