### PR TITLE
WPT webrtc/simulcast/screenshare.https.html calls getDisplayMedia without a user gesture

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/simulcast/screenshare.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/simulcast/screenshare.https-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Basic simulcast setup with two spatial layers promise_test: Unhandled rejection with value: object "InvalidStateError: getDisplayMedia must be called from a user gesture handler."
+PASS Basic simulcast setup with two spatial layers
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/simulcast/screenshare.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/simulcast/screenshare.https.html
@@ -1,4 +1,6 @@
 <!doctype html>
+<html>
+<head>
 <meta charset=utf-8>
 <title>RTCPeerConnection Screen-sharing Simulcast Tests</title>
 <meta name="timeout" content="long">
@@ -9,11 +11,25 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
+</head>
+<body>
 <script>
+async function getDisplayMedia(options) {
+  const button = document.createElement("button");
+  button.innerHTML = "getDisplayMedia button";
+  document.body.prepend(button);
+  const p = new Promise((resolve, reject) => button.onclick = () => {
+    navigator.mediaDevices.getDisplayMedia(options).then(resolve, reject);
+    button.remove();
+  });
+  await test_driver.click(button);
+  return p;
+}
+
 promise_test(async t => {
   // Test getDisplayMedia with simulcast
   await test_driver.bless('getDisplayMedia');
-  const stream = await navigator.mediaDevices.getDisplayMedia({
+  const stream = await getDisplayMedia({
     video: {width: 640, height: 480}
   });
   t.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
@@ -26,3 +42,5 @@ promise_test(async t => {
   return negotiateSimulcastAndWaitForVideo(t, stream, rids, pc1, pc2);
 }, 'Basic simulcast setup with two spatial layers');
 </script>
+</body>
+</html>


### PR DESCRIPTION
#### b53de98cc3cf687ccc318644684be4a1946737d1
<pre>
WPT webrtc/simulcast/screenshare.https.html calls getDisplayMedia without a user gesture
<a href="https://rdar.apple.com/172361766">rdar://172361766</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309774">https://bugs.webkit.org/show_bug.cgi?id=309774</a>

Reviewed by Eric Carlson.

Instead of relying on chrome specific test driver, we reuse web driver click existing support to call getDisplayMedia with a user gesture.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/simulcast/screenshare.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/simulcast/screenshare.https.html:

Canonical link: <a href="https://commits.webkit.org/309192@main">https://commits.webkit.org/309192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87013ffb7d37a59342a48490b0b5d8d27b856cad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158285 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103014 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3784ee8b-13c0-42b8-8945-badfd4e6e7ca) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115387 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82037 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19ec5872-97c3-4511-9629-8e575498beef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134235 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96128 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/005ef95f-d0d1-4e1a-9c7b-828cf516c7c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16618 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14524 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6129 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126226 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160761 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13708 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123422 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123627 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33622 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22110 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133959 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78324 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18809 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10710 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21710 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21441 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21593 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21498 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->