### PR TITLE
[WPE][WPEPlatform] Out-of-bounds read in keysymModifiersGetMask when modifier name is not found

### DIFF
--- a/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.cpp
+++ b/Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.cpp
@@ -35,6 +35,7 @@
 #include <wayland-client-protocol.h>
 #include <wtf/glib/GUniquePtr.h>
 #include <wtf/glib/WTFGType.h>
+#include <wtf/text/StringView.h>
 #include <xkbcommon/xkbcommon.h>
 
 typedef struct _TextInputV1Global TextInputV1Global;
@@ -279,14 +280,12 @@ static void textInputV1UpdateState(WPEIMContextWaylandV1* context)
 static xkb_mod_mask_t keysymModifiersGetMask(struct wl_array *map, const char *name)
 {
     xkb_mod_index_t index = 0;
-    const char* p = static_cast<const char *>(map->data);
+    auto entries = StringView(unsafeMakeSpan(static_cast<const char*>(map->data), map->size));
 
-    while (p < static_cast<const char *>(p + map->size)) {
-        if (!strcmp (p, name))
+    for (auto entry : entries.split('\0')) {
+        if (entry == StringView::fromLatin1(name))
             return 1 << index;
-
         index++;
-        p += strlen(p) + 1;
     }
 
     return XKB_MOD_INVALID;


### PR DESCRIPTION
#### abaf97d89d1a1a4bd15fbefdee5351c0c7af852d
<pre>
[WPE][WPEPlatform] Out-of-bounds read in keysymModifiersGetMask when modifier name is not found
<a href="https://bugs.webkit.org/show_bug.cgi?id=309772">https://bugs.webkit.org/show_bug.cgi?id=309772</a>

Reviewed by Adrian Perez de Castro and Claudio Saavedra.

When iterating through the entries in map-&gt;data, the loop termination
condition compares the current pointer p with p + map-&gt;size, which will
always be true. As a consequence, p will eventually go beyond its bounds
when we do `p += strlen(p) + 1;`.

This rewrites keysymModifiersGetMask using StringView::split(&apos;\0&apos;) to
iterate null-sparated modifier names in the wl_array.

* Source/WebKit/WPEPlatform/wpe/wayland/WPEInputMethodContextWaylandV1.cpp:
(keysymModifiersGetMask):

Canonical link: <a href="https://commits.webkit.org/309327@main">https://commits.webkit.org/309327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c7d4cce48fa617e146cd2e9f4b10c84061a0a53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159034 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103754 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23210 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115977 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82414 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134848 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96709 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17190 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15133 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6879 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126805 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161509 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4636 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123979 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22880 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124183 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33713 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134567 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79246 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19308 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11324 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22481 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86280 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22194 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22346 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22248 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->