### PR TITLE
REGRESSION(307450@main): WebGL: Crash resizing canvas after losing WebGL context due to many contexts

### DIFF
--- a/LayoutTests/webgl/lose-context-after-context-lost-expected.txt
+++ b/LayoutTests/webgl/lose-context-after-context-lost-expected.txt
@@ -2,44 +2,266 @@ Test that WEBGL_lose_context functions do not crash after context has been lost.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
-TEST COMPLETE: 31 PASS, 0 FAIL
+TEST COMPLETE: 217 PASS, 0 FAIL
 
-Running test: loseMethod: loseContext, testedMethod: loseContext
+Running test: canvasType: OffscreenCanvas, contextType: webgl, loseMethod: loseContext, testedMethod: loseContext
 PASS Got webglcontextlost.
 PASS gl.isContextLost() is true
 PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
 PASS gl.getError() is gl.NO_ERROR
 PASS Did not crash on tested method loseContext.
-Running test: loseMethod: loseContext, testedMethod: restoreContext
+Running test: canvasType: OffscreenCanvas, contextType: webgl, loseMethod: loseContext, testedMethod: restoreContext
 PASS Got webglcontextlost.
 PASS gl.isContextLost() is true
 PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
 PASS gl.getError() is gl.NO_ERROR
 PASS Did not crash on tested method restoreContext.
-Running test: loseMethod: manyContexts, testedMethod: loseContext
+Running test: canvasType: OffscreenCanvas, contextType: webgl, loseMethod: loseContext, testedMethod: resize
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method resize.
+Running test: canvasType: OffscreenCanvas, contextType: webgl, loseMethod: loseContext, testedMethod: transferToImageBitmap
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS canvas.transferToImageBitmap() threw exception UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)..
+PASS Did not crash on tested method transferToImageBitmap.
+Running test: canvasType: OffscreenCanvas, contextType: webgl, loseMethod: manyContexts, testedMethod: loseContext
 PASS Got webglcontextlost.
 PASS gl.isContextLost() is true
 PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
 PASS gl.getError() is gl.NO_ERROR
 PASS Did not crash on tested method loseContext.
-Running test: loseMethod: manyContexts, testedMethod: restoreContext
+Running test: canvasType: OffscreenCanvas, contextType: webgl, loseMethod: manyContexts, testedMethod: restoreContext
 PASS Got webglcontextlost.
 PASS gl.isContextLost() is true
 PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
 PASS gl.getError() is gl.NO_ERROR
 PASS Did not crash on tested method restoreContext.
-Running test: loseMethod: gpuStatusFailure, testedMethod: loseContext
+Running test: canvasType: OffscreenCanvas, contextType: webgl, loseMethod: manyContexts, testedMethod: resize
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method resize.
+Running test: canvasType: OffscreenCanvas, contextType: webgl, loseMethod: manyContexts, testedMethod: transferToImageBitmap
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS canvas.transferToImageBitmap() threw exception UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)..
+PASS Did not crash on tested method transferToImageBitmap.
+Running test: canvasType: OffscreenCanvas, contextType: webgl, loseMethod: gpuStatusFailure, testedMethod: loseContext
 PASS Got webglcontextlost.
 PASS gl.isContextLost() is true
 PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
 PASS gl.getError() is gl.NO_ERROR
 PASS Did not crash on tested method loseContext.
-Running test: loseMethod: gpuStatusFailure, testedMethod: restoreContext
+Running test: canvasType: OffscreenCanvas, contextType: webgl, loseMethod: gpuStatusFailure, testedMethod: restoreContext
 PASS Got webglcontextlost.
 PASS gl.isContextLost() is true
 PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
 PASS gl.getError() is gl.NO_ERROR
 PASS Did not crash on tested method restoreContext.
+Running test: canvasType: OffscreenCanvas, contextType: webgl, loseMethod: gpuStatusFailure, testedMethod: resize
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method resize.
+Running test: canvasType: OffscreenCanvas, contextType: webgl, loseMethod: gpuStatusFailure, testedMethod: transferToImageBitmap
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS canvas.transferToImageBitmap() threw exception UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)..
+PASS Did not crash on tested method transferToImageBitmap.
+Running test: canvasType: OffscreenCanvas, contextType: webgl2, loseMethod: loseContext, testedMethod: loseContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method loseContext.
+Running test: canvasType: OffscreenCanvas, contextType: webgl2, loseMethod: loseContext, testedMethod: restoreContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method restoreContext.
+Running test: canvasType: OffscreenCanvas, contextType: webgl2, loseMethod: loseContext, testedMethod: resize
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method resize.
+Running test: canvasType: OffscreenCanvas, contextType: webgl2, loseMethod: loseContext, testedMethod: transferToImageBitmap
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS canvas.transferToImageBitmap() threw exception UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)..
+PASS Did not crash on tested method transferToImageBitmap.
+Running test: canvasType: OffscreenCanvas, contextType: webgl2, loseMethod: manyContexts, testedMethod: loseContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method loseContext.
+Running test: canvasType: OffscreenCanvas, contextType: webgl2, loseMethod: manyContexts, testedMethod: restoreContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method restoreContext.
+Running test: canvasType: OffscreenCanvas, contextType: webgl2, loseMethod: manyContexts, testedMethod: resize
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method resize.
+Running test: canvasType: OffscreenCanvas, contextType: webgl2, loseMethod: manyContexts, testedMethod: transferToImageBitmap
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS canvas.transferToImageBitmap() threw exception UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)..
+PASS Did not crash on tested method transferToImageBitmap.
+Running test: canvasType: OffscreenCanvas, contextType: webgl2, loseMethod: gpuStatusFailure, testedMethod: loseContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method loseContext.
+Running test: canvasType: OffscreenCanvas, contextType: webgl2, loseMethod: gpuStatusFailure, testedMethod: restoreContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method restoreContext.
+Running test: canvasType: OffscreenCanvas, contextType: webgl2, loseMethod: gpuStatusFailure, testedMethod: resize
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method resize.
+Running test: canvasType: OffscreenCanvas, contextType: webgl2, loseMethod: gpuStatusFailure, testedMethod: transferToImageBitmap
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS canvas.transferToImageBitmap() threw exception UnknownError: The operation failed for an unknown transient reason (e.g. out of memory)..
+PASS Did not crash on tested method transferToImageBitmap.
+Running test: canvasType: Canvas, contextType: webgl, loseMethod: loseContext, testedMethod: loseContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method loseContext.
+Running test: canvasType: Canvas, contextType: webgl, loseMethod: loseContext, testedMethod: restoreContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method restoreContext.
+Running test: canvasType: Canvas, contextType: webgl, loseMethod: loseContext, testedMethod: resize
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method resize.
+Running test: canvasType: Canvas, contextType: webgl, loseMethod: manyContexts, testedMethod: loseContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method loseContext.
+Running test: canvasType: Canvas, contextType: webgl, loseMethod: manyContexts, testedMethod: restoreContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method restoreContext.
+Running test: canvasType: Canvas, contextType: webgl, loseMethod: manyContexts, testedMethod: resize
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method resize.
+Running test: canvasType: Canvas, contextType: webgl, loseMethod: gpuStatusFailure, testedMethod: loseContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method loseContext.
+Running test: canvasType: Canvas, contextType: webgl, loseMethod: gpuStatusFailure, testedMethod: restoreContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method restoreContext.
+Running test: canvasType: Canvas, contextType: webgl, loseMethod: gpuStatusFailure, testedMethod: resize
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method resize.
+Running test: canvasType: Canvas, contextType: webgl2, loseMethod: loseContext, testedMethod: loseContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method loseContext.
+Running test: canvasType: Canvas, contextType: webgl2, loseMethod: loseContext, testedMethod: restoreContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method restoreContext.
+Running test: canvasType: Canvas, contextType: webgl2, loseMethod: loseContext, testedMethod: resize
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method resize.
+Running test: canvasType: Canvas, contextType: webgl2, loseMethod: manyContexts, testedMethod: loseContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method loseContext.
+Running test: canvasType: Canvas, contextType: webgl2, loseMethod: manyContexts, testedMethod: restoreContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method restoreContext.
+Running test: canvasType: Canvas, contextType: webgl2, loseMethod: manyContexts, testedMethod: resize
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method resize.
+Running test: canvasType: Canvas, contextType: webgl2, loseMethod: gpuStatusFailure, testedMethod: loseContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method loseContext.
+Running test: canvasType: Canvas, contextType: webgl2, loseMethod: gpuStatusFailure, testedMethod: restoreContext
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method restoreContext.
+Running test: canvasType: Canvas, contextType: webgl2, loseMethod: gpuStatusFailure, testedMethod: resize
+PASS Got webglcontextlost.
+PASS gl.isContextLost() is true
+PASS gl.getError() is gl.CONTEXT_LOST_WEBGL
+PASS gl.getError() is gl.NO_ERROR
+PASS Did not crash on tested method resize.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/webgl/lose-context-after-context-lost.html
+++ b/LayoutTests/webgl/lose-context-after-context-lost.html
@@ -15,6 +15,7 @@ description("Test that WEBGL_lose_context functions do not crash after context h
 
 var wtu = WebGLTestUtils;
 var gl;
+var canvas;
 
 async function waitForWebGLContextLost(canvas)
 {
@@ -28,13 +29,21 @@ function testDescription(subcase) {
     return Object.keys(subcase).map((k) => `${k}: ${typeof subcase[k] === "function" ? subcase[k].name : subcase[k]}`).join(", ");
 }
 
-async function runTest(subcase)
+function createCanvas(subcase)
 {
-    debug(`Running test: ${testDescription(subcase)}`);
+    if (subcase.canvasType == "OffscreenCanvas")
+        return new OffscreenCanvas(1, 1);
     const canvas = document.createElement("canvas");
     canvas.width = 1;
     canvas.height = 1;
-    gl = wtu.create3DContext(canvas);
+    return canvas;
+}
+
+async function runTest(subcase)
+{
+    debug(`Running test: ${testDescription(subcase)}`);
+    canvas = createCanvas(subcase);
+    gl = canvas.getContext(subcase.contextType);
     const WEBGL_lose_context = wtu.getExtensionWithKnownPrefixes(gl, "WEBGL_lose_context");
     if (!WEBGL_lose_context) {
         debug("Could not find WEBGL_lose_context extension");
@@ -53,7 +62,7 @@ async function runTest(subcase)
         // for testing.
         let contexts = [];
         for (let i = 0; i < 50; ++i)
-            contexts.push(document.createElement("canvas").getContext("webgl"));
+            contexts.push(createCanvas(subcase).getContext(subcase.contextType));
     }
 
     try {
@@ -70,18 +79,33 @@ async function runTest(subcase)
         WEBGL_lose_context.loseContext();
     else if (subcase.testedMethod == "restoreContext")
         WEBGL_lose_context.restoreContext();
+    else if (subcase.testedMethod == "resize")
+        canvas.width = canvas.width + 7;
+    else if (subcase.testedMethod == "transferToImageBitmap") {
+        shouldThrow("canvas.transferToImageBitmap()");
+    }
     testPassed(`Did not crash on tested method ${subcase.testedMethod}.`);
 }
 
+const canvasTypes = ["OffscreenCanvas", "Canvas"];
+const contextTypes = ["webgl", "webgl2"];
 const loseMethods = ["loseContext", "manyContexts"];
 if (window.internals)
     loseMethods.push("gpuStatusFailure");
-const testedMethods = ["loseContext", "restoreContext"];
+const testedMethods = ["loseContext", "restoreContext", "resize", "transferToImageBitmap"];
 
 const subcases = [];
-for (const loseMethod of loseMethods)
-    for (const testedMethod of testedMethods)
-        subcases.push({loseMethod, testedMethod});
+for (const canvasType of canvasTypes) {
+    for (const contextType of contextTypes) {
+        for (const loseMethod of loseMethods) {
+            for (const testedMethod of testedMethods) {
+                if (testedMethod == "transferToImageBitmap" && canvasType != "OffscreenCanvas")
+                    continue;
+                subcases.push({canvasType, contextType, loseMethod, testedMethod});
+            }
+        }
+    }
+}
 
 async function test()
 {

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.idl
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.idl
@@ -63,6 +63,7 @@ typedef (ImageBitmap or ImageData or HTMLImageElement or HTMLCanvasElement
     GenerateIsReachable=ImplCanvasBase,
     JSCustomMarkFunction,
     DoNotCheckConstants,
+    ExportMacro=WEBCORE_EXPORT,
     ReportExtraMemoryCost,
     ReportExternalMemoryCost,
     Exposed=(Window,Worker),

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -814,7 +814,7 @@ RefPtr<ByteArrayPixelBuffer> WebGLRenderingContextBase::drawingBufferToPixelBuff
     if (m_attributes.premultipliedAlpha)
         return nullptr;
     clearIfComposited(CallerTypeOther);
-    auto size = m_defaultFramebuffer->size();
+    auto size = clampedCanvasSize();
     if (size.isEmpty())
         return nullptr;
     PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, DestinationColorSpace::SRGB() };
@@ -864,7 +864,7 @@ RefPtr<ImageBuffer> WebGLRenderingContextBase::transferToImageBuffer()
     RefPtr scriptExecutionContext = this->scriptExecutionContext();
     if (!scriptExecutionContext)
         return nullptr;
-    const auto size = m_defaultFramebuffer->size();
+    auto size = clampedCanvasSize();
     if (size.isEmpty())
         return nullptr;
     RefPtr buffer = createImageBufferForWebGLContextReads(size, *scriptExecutionContext);
@@ -884,16 +884,19 @@ RefPtr<ImageBuffer> WebGLRenderingContextBase::transferToImageBuffer()
 
 void WebGLRenderingContextBase::didUpdateCanvasSizeProperties(bool)
 {
+    if (isContextLost()) {
+        m_readDrawingBuffer = nullptr;
+        m_readDisplayBuffer = nullptr;
+        updateMemoryCost();
+        return;
+    }
+
     auto newSize = clampedCanvasSize();
     if (newSize == m_defaultFramebuffer->size())
         return;
 
     m_readDrawingBuffer = nullptr;
     m_readDisplayBuffer = nullptr;
-    if (isContextLost()) {
-        updateMemoryCost();
-        return;
-    }
 
     m_defaultFramebuffer->reshape(newSize);
     updateMemoryCost();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6506,7 +6506,7 @@ void Internals::setAsRunningUserScripts(Document& document)
 }
 
 #if ENABLE(WEBGL)
-void Internals::simulateEventForWebGLContext(SimulatedWebGLContextEvent event, WebGLRenderingContext& context)
+void Internals::simulateEventForWebGLContext(SimulatedWebGLContextEvent event, WebGLRenderingContextBase& context)
 {
     WebGLRenderingContext::SimulatedEventForTesting contextEvent;
     switch (event) {
@@ -6523,7 +6523,7 @@ void Internals::simulateEventForWebGLContext(SimulatedWebGLContextEvent event, W
     context.simulateEventForTesting(contextEvent);
 }
 
-Internals::RequestedGPU Internals::requestedGPU(WebGLRenderingContext& context)
+Internals::RequestedGPU Internals::requestedGPU(WebGLRenderingContextBase& context)
 {
     switch (context.creationAttributes().powerPreference) {
     case WebGLPowerPreference::Default:

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1044,14 +1044,14 @@ public:
         GPUStatusFailure,
         Timeout
     };
-    void simulateEventForWebGLContext(SimulatedWebGLContextEvent, WebGLRenderingContext&);
+    void simulateEventForWebGLContext(SimulatedWebGLContextEvent, WebGLRenderingContextBase&);
 
     enum class RequestedGPU {
         Default,
         LowPower,
         HighPerformance
     };
-    RequestedGPU NODELETE requestedGPU(WebGLRenderingContext&);
+    RequestedGPU NODELETE requestedGPU(WebGLRenderingContextBase&);
 #endif
 
     void setPageVisibility(bool isVisible);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1206,7 +1206,9 @@ enum ContentsFormat {
     undefined setSpeculativeTilingDelayDisabledForTesting(boolean disabled);
 
     [Conditional=WEBGL] undefined simulateEventForWebGLContext(SimulatedWebGLContextEvent event, WebGLRenderingContext context);
+    [Conditional=WEBGL] undefined simulateEventForWebGLContext(SimulatedWebGLContextEvent event, WebGL2RenderingContext context);
     [Conditional=WEBGL] RequestedGPU requestedGPU(WebGLRenderingContext context);
+    [Conditional=WEBGL] RequestedGPU requestedGPU(WebGL2RenderingContext context);
 
     undefined setPageVisibility(boolean isVisible);
     undefined setPageIsFocused(boolean isFocused);


### PR DESCRIPTION
#### bff80081bbf1da132ec13d147020ba45073c1a4f
<pre>
REGRESSION(307450@main): WebGL: Crash resizing canvas after losing WebGL context due to many contexts
<a href="https://bugs.webkit.org/show_bug.cgi?id=309777">https://bugs.webkit.org/show_bug.cgi?id=309777</a>
<a href="https://rdar.apple.com/172265758">rdar://172265758</a>

Reviewed by Dan Glastonbury.

Avoid accessing WebGLDefaultFramebuffer::size() when context is lost,
in didUpdateCanvasSizeProperties(), transferToImageBuffer().

Prior fix (webkit.org/b/309777, 308389@main, 673b8d7495af) applied to
lost contexts that did not destroy the underlying context.

* LayoutTests/webgl/lose-context-after-context-lost-expected.txt:
* LayoutTests/webgl/lose-context-after-context-lost.html:
* Source/WebCore/html/canvas/WebGL2RenderingContext.idl:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::drawingBufferToPixelBuffer):
(WebCore::WebGLRenderingContextBase::transferToImageBuffer):
(WebCore::WebGLRenderingContextBase::didUpdateCanvasSizeProperties):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::simulateEventForWebGLContext):
(WebCore::Internals::requestedGPU):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/309401@main">https://commits.webkit.org/309401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dbe7969f6e280c62af69ebabc32c02145c719b7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150512 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159234 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4713e10-5710-4f4e-84a6-f6851766f446) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23701 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116141 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f0c31ef-9db9-4862-8a35-0ef67f0678c8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18258 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96869 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17357 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15300 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7082 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126971 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161708 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4828 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14496 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124140 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124338 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33764 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23060 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134738 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79439 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19441 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11498 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22674 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86472 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22386 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22538 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22440 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->