### PR TITLE
REGRESSION(309010@main): Wheel events not dispatched to empty SVG root element

### DIFF
--- a/LayoutTests/fast/events/wheel/wheel-event-on-empty-svg-expected.txt
+++ b/LayoutTests/fast/events/wheel/wheel-event-on-empty-svg-expected.txt
@@ -1,0 +1,10 @@
+Wheel events should be dispatched to an empty SVG root element.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS wheel event was dispatched to empty SVG element.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/wheel/wheel-event-on-empty-svg.html
+++ b/LayoutTests/fast/events/wheel/wheel-event-on-empty-svg.html
@@ -1,0 +1,48 @@
+<html>
+<head>
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+description("Wheel events should be dispatched to an empty SVG root element.");
+
+jsTestIsAsync = true;
+
+async function runTest()
+{
+    if (!window.eventSender) {
+        testFailed("This test requires window.eventSender.");
+        finishJSTest();
+        return;
+    }
+
+    var svg = document.querySelector('svg');
+    svg.addEventListener('wheel', function(e) {
+        testPassed("wheel event was dispatched to empty SVG element.");
+        finishJSTest();
+    });
+
+    await UIHelper.ensurePresentationUpdate();
+    eventSender.mouseMoveTo(350, 350);
+    eventSender.mouseScrollBy(0, 10);
+}
+
+window.addEventListener('load', runTest);
+</script>
+<style>
+body { margin: 0; }
+svg {
+    position: absolute;
+    top: 250px;
+    left: 250px;
+    width: 200px;
+    height: 200px;
+    background-color: brown;
+}
+</style>
+</head>
+<body>
+<svg></svg>
+<div id="console"></div>
+<script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -59,6 +59,8 @@
 #include "RenderVideo.h"
 #include "RenderView.h"
 #include "RenderedDocumentMarker.h"
+#include "SVGResources.h"
+#include "SVGResourcesCache.h"
 #include "Settings.h"
 #include "StyleComputedStyle+InitialInlines.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
@@ -264,7 +266,9 @@ void RenderReplaced::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     LayoutPoint adjustedPaintOffset = paintOffset + location();
 
     if (paintInfo.phase == PaintPhase::EventRegion) {
-        if (isRenderOrLegacyRenderSVGRoot() && !isSkippedContentRoot(*this))
+        auto* resources = SVGResourcesCache::cachedResourcesForRenderer(*this);
+        bool svgRootHasChildrenOrFilters = isRenderOrLegacyRenderSVGRoot() && (firstChild() || (resources && resources->filter()) || svgFilterResourceFromStyle());
+        if (svgRootHasChildrenOrFilters && !isSkippedContentRoot(*this))
             paintReplaced(paintInfo, adjustedPaintOffset);
         else if (visibleToHitTesting()) {
             auto borderRect = LayoutRect(adjustedPaintOffset, size());


### PR DESCRIPTION
#### c6c7a1adfa417b5a065e2891b5c64a6484369b1c
<pre>
REGRESSION(309010@main): Wheel events not dispatched to empty SVG root element
<a href="https://bugs.webkit.org/show_bug.cgi?id=309779">https://bugs.webkit.org/show_bug.cgi?id=309779</a>

Reviewed by Nikolas Zimmermann.

309010@main removed the #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION) guard in RenderReplaced::paint,
applying unconditionally the logic that was previously guarded under that macro. And the issue is that
this logic has an &quot;else if&quot; that makes the two branches mutually exclusive: either call paintReplaced()
to register the SVG children in the event region, or register the own SVG root.

For a non-empty SVG this works correctly because paintReplaced() iterates over children and each child
registers itself. But for an empty SVG without filters, paintReplaced() returns early without
registering anything.

So, the combination of these two means that, for an empty SVG root without filters, nothing ever gets
added to the event region, making the element invisible to the event system, so wheel and scroll events
over it are silently dropped.

Test: fast/events/wheel/wheel-event-on-empty-svg.html

* LayoutTests/fast/events/wheel/wheel-event-on-empty-svg-expected.txt: Added.
* LayoutTests/fast/events/wheel/wheel-event-on-empty-svg.html: Added.
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):

Canonical link: <a href="https://commits.webkit.org/310013@main">https://commits.webkit.org/310013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/253a30c603931a4694de0c52afa6b3135f96b684

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159685 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104393 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152830 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23936 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116534 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82736 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18649 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135443 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97254 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17743 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15696 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7531 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162158 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5283 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14931 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124541 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23521 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19746 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124728 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/34180 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Checked out pull request; Reviewed by Nikolas Zimmermann; Compiled WebKit (cancelled)") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23511 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135157 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79918 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23372 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19790 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11922 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23121 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87311 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22833 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22985 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->