### PR TITLE
stack-use-after-return in WTR::runPendingEventsCallback(void*)

### DIFF
--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -5703,4 +5703,36 @@ WKRetainPtr<WKTypeRef> TestController::handleAXSearchPredicate(WKDictionaryRef m
 
 #endif // PLATFORM(MAC)
 
+#if !PLATFORM(COCOA)
+void TestController::doAfterProcessingAllPendingMouseEvents(CompletionHandler<void()>&& handler)
+{
+    m_pendingMouseEventsCompletionHanders.append(WTF::move(handler));
+    WKPageDoAfterProcessingAllPendingMouseEvents(mainWebView()->page(), this, [](void* userData) {
+        static_cast<TestController*>(userData)->flushPendingMouseEventsCompletionHanders();
+    });
+}
+
+void TestController::flushPendingMouseEventsCompletionHanders()
+{
+    auto handlers = std::exchange(m_pendingMouseEventsCompletionHanders, { });
+    for (auto& handler : handlers)
+        handler();
+}
+
+void TestController::doAfterProcessingAllPendingKeyEvents(CompletionHandler<void()>&& handler)
+{
+    m_pendingKeyEventsCompletionHanders.append(WTF::move(handler));
+    WKPageDoAfterProcessingAllPendingKeyEvents(mainWebView()->page(), this, [](void* userData) {
+        static_cast<TestController*>(userData)->flushPendingKeyEventsCompletionHanders();
+    });
+}
+
+void TestController::flushPendingKeyEventsCompletionHanders()
+{
+    auto handlers = std::exchange(m_pendingKeyEventsCompletionHanders, { });
+    for (auto& handler : handlers)
+        handler();
+}
+#endif
+
 } // namespace WTR

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -483,6 +483,13 @@ public:
     void initializeWebProcessAccessibility();
 #endif
 
+#if !PLATFORM(COCOA)
+    void doAfterProcessingAllPendingMouseEvents(CompletionHandler<void()>&&);
+    void flushPendingMouseEventsCompletionHanders();
+    void doAfterProcessingAllPendingKeyEvents(CompletionHandler<void()>&&);
+    void flushPendingKeyEventsCompletionHanders();
+#endif
+
 private:
     WKRetainPtr<WKPageConfigurationRef> generatePageConfiguration(const TestOptions&);
     WKRetainPtr<WKContextConfigurationRef> generateContextConfiguration(const TestOptions&) const;
@@ -889,6 +896,11 @@ private:
 
 #if ENABLE(WPE_PLATFORM)
     bool m_useWPELegacyAPI { false };
+#endif
+
+#if !PLATFORM(COCOA)
+    Vector<CompletionHandler<void()>> m_pendingMouseEventsCompletionHanders;
+    Vector<CompletionHandler<void()>> m_pendingKeyEventsCompletionHanders;
 #endif
 };
 

--- a/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
+++ b/Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp
@@ -50,25 +50,6 @@
 
 namespace WTR {
 
-static void runPendingEventsCallback(void* userData)
-{
-    *static_cast<bool*>(userData) = true;
-}
-
-static void waitForPendingKeyEvents(TestController* testController)
-{
-    bool done = false;
-    WKPageDoAfterProcessingAllPendingKeyEvents(testController->mainWebView()->page(), &done, runPendingEventsCallback);
-    testController->runUntil(done, 100_ms);
-}
-
-static void waitForPendingMouseEvents(TestController* testController)
-{
-    bool done = false;
-    WKPageDoAfterProcessingAllPendingMouseEvents(testController->mainWebView()->page(), &done, runPendingEventsCallback);
-    testController->runUntil(done, 100_ms);
-}
-
 // WebCore and layout tests assume this value
 static const float pixelsPerScrollTick = 40;
 
@@ -272,10 +253,8 @@ static inline void processKeyEvent(WebKitWebViewBase* webViewBase, WKStringRef k
 void EventSenderProxy::keyDown(WKStringRef keyRef, WKEventModifiers wkModifiers, unsigned location, CompletionHandler<void()>&& completionHandler)
 {
     processKeyEvent(toWebKitGLibAPI(m_testController->mainWebView()->platformView()), keyRef, wkModifiers, location, KeyEventType::Insert);
-    if (completionHandler) {
-        waitForPendingKeyEvents(m_testController);
-        completionHandler();
-    }
+    if (completionHandler)
+        m_testController->doAfterProcessingAllPendingKeyEvents(WTF::move(completionHandler));
 }
 
 void EventSenderProxy::rawKeyDown(WKStringRef key, WKEventModifiers wkModifiers, unsigned keyLocation)
@@ -315,10 +294,8 @@ void EventSenderProxy::mouseDown(unsigned button, WKEventModifiers wkModifiers, 
 
     webkitWebViewBaseSynthesizeMouseEvent(toWebKitGLibAPI(m_testController->mainWebView()->platformView()),
         MouseEventType::Press, gdkButton, m_mouseButtonsCurrentlyDown, m_position.x, m_position.y, webkitModifiersToGDKModifiers(wkModifiers), m_clickCount, toWTFString(pointerType));
-    if (completionHandler) {
-        waitForPendingMouseEvents(m_testController);
-        completionHandler();
-    }
+    if (completionHandler)
+        m_testController->doAfterProcessingAllPendingMouseEvents(WTF::move(completionHandler));
 }
 
 void EventSenderProxy::mouseUp(unsigned button, WKEventModifiers wkModifiers, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
@@ -331,10 +308,8 @@ void EventSenderProxy::mouseUp(unsigned button, WKEventModifiers wkModifiers, WK
 
     m_clickPosition = m_position;
     m_clickTime = m_time;
-    if (completionHandler) {
-        waitForPendingMouseEvents(m_testController);
-        completionHandler();
-    }
+    if (completionHandler)
+        m_testController->doAfterProcessingAllPendingMouseEvents(WTF::move(completionHandler));
 }
 
 void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
@@ -344,10 +319,8 @@ void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType, 
 
     webkitWebViewBaseSynthesizeMouseEvent(toWebKitGLibAPI(m_testController->mainWebView()->platformView()),
         MouseEventType::Motion, 0, m_mouseButtonsCurrentlyDown, m_position.x, m_position.y, 0, 0, toWTFString(pointerType));
-    if (completionHandler) {
-        waitForPendingMouseEvents(m_testController);
-        completionHandler();
-    }
+    if (completionHandler)
+        m_testController->doAfterProcessingAllPendingMouseEvents(WTF::move(completionHandler));
 }
 
 void EventSenderProxy::mouseScrollBy(int horizontal, int vertical)

--- a/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
+++ b/Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp
@@ -44,25 +44,6 @@
 
 namespace WTR {
 
-static void runPendingEventsCallback(void* userData)
-{
-    *static_cast<bool*>(userData) = true;
-}
-
-static void waitForPendingKeyEvents(TestController* testController)
-{
-    bool done = false;
-    WKPageDoAfterProcessingAllPendingKeyEvents(testController->mainWebView()->page(), &done, runPendingEventsCallback);
-    testController->runUntil(done, 100_ms);
-}
-
-static void waitForPendingMouseEvents(TestController* testController)
-{
-    bool done = false;
-    WKPageDoAfterProcessingAllPendingMouseEvents(testController->mainWebView()->page(), &done, runPendingEventsCallback);
-    testController->runUntil(done, 100_ms);
-}
-
 EventSenderProxy::EventSenderProxy(TestController* testController)
     : m_testController(testController)
     // WPE event timestamps are just MonotonicTime, not actual WallTime, so we can
@@ -104,10 +85,8 @@ void EventSenderProxy::mouseDown(unsigned button, WKEventModifiers wkModifiers, 
 {
     updateClickCountForButton(button);
     m_client->mouseDown(button, m_time, wkModifiers, m_position.x, m_position.y, m_clickCount, m_mouseButtonsCurrentlyDown);
-    if (completionHandler) {
-        waitForPendingMouseEvents(m_testController);
-        completionHandler();
-    }
+    if (completionHandler)
+        m_testController->doAfterProcessingAllPendingMouseEvents(WTF::move(completionHandler));
 }
 
 void EventSenderProxy::mouseUp(unsigned button, WKEventModifiers wkModifiers, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
@@ -115,10 +94,8 @@ void EventSenderProxy::mouseUp(unsigned button, WKEventModifiers wkModifiers, WK
     m_client->mouseUp(button, m_time, wkModifiers, m_position.x, m_position.y, m_mouseButtonsCurrentlyDown);
     m_clickPosition = m_position;
     m_clickTime = m_time;
-    if (completionHandler) {
-        waitForPendingMouseEvents(m_testController);
-        completionHandler();
-    }
+    if (completionHandler)
+        m_testController->doAfterProcessingAllPendingMouseEvents(WTF::move(completionHandler));
 }
 
 void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
@@ -126,10 +103,8 @@ void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType, 
     m_position.x = x;
     m_position.y = y;
     m_client->mouseMoveTo(x, y, m_time, m_clickButton, m_mouseButtonsCurrentlyDown);
-    if (completionHandler) {
-        waitForPendingMouseEvents(m_testController);
-        completionHandler();
-    }
+    if (completionHandler)
+        m_testController->doAfterProcessingAllPendingMouseEvents(WTF::move(completionHandler));
 }
 
 void EventSenderProxy::mouseScrollBy(int horizontal, int vertical)
@@ -158,10 +133,8 @@ void EventSenderProxy::leapForward(int milliseconds)
 void EventSenderProxy::keyDown(WKStringRef keyRef, WKEventModifiers wkModifiers, unsigned location, CompletionHandler<void()>&& completionHandler)
 {
     m_client->keyDown(keyRef, m_time, wkModifiers, location);
-    if (completionHandler) {
-        waitForPendingKeyEvents(m_testController);
-        completionHandler();
-    }
+    if (completionHandler)
+        m_testController->doAfterProcessingAllPendingKeyEvents(WTF::move(completionHandler));
 }
 
 void EventSenderProxy::rawKeyDown(WKStringRef keyRef, WKEventModifiers wkModifiers, unsigned location)

--- a/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
+++ b/Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp
@@ -36,25 +36,6 @@
 
 namespace WTR {
 
-static void runPendingEventsCallback(void* userData)
-{
-    *static_cast<bool*>(userData) = true;
-}
-
-static void waitForPendingKeyEvents(TestController* testController)
-{
-    bool done = false;
-    WKPageDoAfterProcessingAllPendingKeyEvents(testController->mainWebView()->page(), &done, runPendingEventsCallback);
-    testController->runUntil(done, 100_ms);
-}
-
-static void waitForPendingMouseEvents(TestController* testController)
-{
-    bool done = false;
-    WKPageDoAfterProcessingAllPendingMouseEvents(testController->mainWebView()->page(), &done, runPendingEventsCallback);
-    testController->runUntil(done, 100_ms);
-}
-
 LRESULT EventSenderProxy::dispatchMessage(UINT message, WPARAM wParam, LPARAM lParam)
 {
     MSG msg { };
@@ -104,10 +85,8 @@ void EventSenderProxy::mouseDown(unsigned button, WKEventModifiers wkModifiers, 
     }
     WPARAM wparam = 0;
     dispatchMessage(messageType, wparam, MAKELPARAM(positionInPoint().x, positionInPoint().y));
-    if (completionHandler) {
-        waitForPendingMouseEvents(m_testController);
-        completionHandler();
-    }
+    if (completionHandler)
+        m_testController->doAfterProcessingAllPendingMouseEvents(WTF::move(completionHandler));
 }
 
 void EventSenderProxy::mouseUp(unsigned button, WKEventModifiers wkModifiers, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
@@ -134,10 +113,8 @@ void EventSenderProxy::mouseUp(unsigned button, WKEventModifiers wkModifiers, WK
     }
     WPARAM wparam = 0;
     dispatchMessage(messageType, wparam, MAKELPARAM(positionInPoint().x, positionInPoint().y));
-    if (completionHandler) {
-        waitForPendingMouseEvents(m_testController);
-        completionHandler();
-    }
+    if (completionHandler)
+        m_testController->doAfterProcessingAllPendingMouseEvents(WTF::move(completionHandler));
 }
 
 void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType, CompletionHandler<void()>&& completionHandler)
@@ -146,10 +123,8 @@ void EventSenderProxy::mouseMoveTo(double x, double y, WKStringRef pointerType, 
     m_position.y = y;
     WPARAM wParam = m_leftMouseButtonDown ? MK_LBUTTON : 0;
     dispatchMessage(WM_MOUSEMOVE, wParam, MAKELPARAM(positionInPoint().x, positionInPoint().y));
-    if (completionHandler) {
-        waitForPendingMouseEvents(m_testController);
-        completionHandler();
-    }
+    if (completionHandler)
+        m_testController->doAfterProcessingAllPendingMouseEvents(WTF::move(completionHandler));
 }
 
 void EventSenderProxy::mouseScrollBy(int x, int y)
@@ -345,10 +320,8 @@ void EventSenderProxy::keyDown(WKStringRef keyRef, WKEventModifiers wkModifiers,
 
     if (wkModifiers || needsShiftKeyModifier)
         SetKeyboardState(keyState);
-    if (completionHandler) {
-        waitForPendingKeyEvents(m_testController);
-        completionHandler();
-    }
+    if (completionHandler)
+        m_testController->doAfterProcessingAllPendingKeyEvents(WTF::move(completionHandler));
 }
 
 void EventSenderProxy::rawKeyDown(WKStringRef key, WKEventModifiers modifiers, unsigned keyLocation)


### PR DESCRIPTION
#### 1e08ec6a9a5b074387e9ce3898d0f139e42cd336
<pre>
stack-use-after-return in WTR::runPendingEventsCallback(void*)
<a href="https://bugs.webkit.org/show_bug.cgi?id=309648">https://bugs.webkit.org/show_bug.cgi?id=309648</a>

Reviewed by Anne van Kesteren.

ASan detected stack-use-after-return in WTR::runPendingEventsCallback(). If
runUntil() timed out, the local variable `done` is written after the function
returned.

EventSenderProxy class event dispatching methods mouseDown() and keyDown(), etc
shouldn&apos;t block until the event was processed. Mac port uses
_doAfterProcessingAllPendingMouseEvents and
_doAfterProcessingAllPendingKeyEvents.

Added 2 new methods doAfterProcessingAllPendingMouseEvents() and
doAfterProcessingAllPendingKeyEvents() to TestController class.

* Tools/WebKitTestRunner/TestController.cpp:
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/gtk/EventSenderProxyGtk.cpp:
(WTR::EventSenderProxy::keyDown):
(WTR::EventSenderProxy::mouseDown):
(WTR::EventSenderProxy::mouseUp):
(WTR::EventSenderProxy::mouseMoveTo):
(WTR::runPendingEventsCallback): Deleted.
(WTR::waitForPendingKeyEvents):
(WTR::waitForPendingMouseEvents):
* Tools/WebKitTestRunner/libwpe/EventSenderProxyLibWPE.cpp:
(WTR::EventSenderProxy::mouseDown):
(WTR::EventSenderProxy::mouseUp):
(WTR::EventSenderProxy::mouseMoveTo):
(WTR::EventSenderProxy::keyDown):
(WTR::runPendingEventsCallback): Deleted.
(WTR::waitForPendingKeyEvents):
(WTR::waitForPendingMouseEvents):
* Tools/WebKitTestRunner/win/EventSenderProxyWin.cpp:
(WTR::EventSenderProxy::mouseDown):
(WTR::EventSenderProxy::mouseUp):
(WTR::EventSenderProxy::mouseMoveTo):
(WTR::EventSenderProxy::keyDown):
(WTR::runPendingEventsCallback): Deleted.
(WTR::waitForPendingKeyEvents):
(WTR::waitForPendingMouseEvents):

Canonical link: <a href="https://commits.webkit.org/309204@main">https://commits.webkit.org/309204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d42f684cf36e5107c73a4bc2d15e81d5807a48a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22617 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158605 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151771 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115624 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134507 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96363 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6451 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161080 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123640 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18823 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123844 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134231 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78651 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23057 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19010 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10983 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22027 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21757 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21909 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21814 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->