### PR TITLE
IDB: ASSERT(spaceCheckResult == SpaceCheckResult::Pass) failed in WebCore::IDBServer::UniqueIDBDatabase::abortTransaction()

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp
@@ -207,6 +207,7 @@ IDBStorageManager::IDBStorageManager(const String& path, IDBStorageRegistry& reg
 
 IDBStorageManager::~IDBStorageManager()
 {
+    m_isClosing = true;
     for (auto& database : m_databases.values())
         database->immediateClose();
 }
@@ -352,6 +353,8 @@ std::unique_ptr<WebCore::IDBServer::IDBBackingStore> IDBStorageManager::createBa
 
 void IDBStorageManager::requestSpace(const WebCore::ClientOrigin&, uint64_t size, CompletionHandler<void(bool)>&& completionHandler)
 {
+    if (m_isClosing)
+        return completionHandler(size ? false : true);
     m_quotaCheckFunction(size, WTF::move(completionHandler));
 }
 

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageManager.h
@@ -86,6 +86,7 @@ private:
     QuotaCheckFunction m_quotaCheckFunction;
     HashMap<WebCore::IDBDatabaseIdentifier, std::unique_ptr<WebCore::IDBServer::UniqueIDBDatabase>> m_databases;
     bool m_useSQLiteMemoryBackingStore { false };
+    bool m_isClosing { false };
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 5861503be1bb95bdda74e97ccca87420ab652cfb
<pre>
IDB: ASSERT(spaceCheckResult == SpaceCheckResult::Pass) failed in WebCore::IDBServer::UniqueIDBDatabase::abortTransaction()
<a href="https://bugs.webkit.org/show_bug.cgi?id=309780">https://bugs.webkit.org/show_bug.cgi?id=309780</a>

Reviewed by Sihui Liu.

During destruction of the IDBStorageManager, transactions are aborted.
Because UniqueIDBDatabase::abortTransaction() is called without a
SpaceCheckResult, one is requested via a call to
UniqueIDBDatabaseManager::requestSpace(). But this is happening
while the OriginStorageManager that installs a lambda to perform
the space check is already being destructed, so the lambda
will default to call the completion handler with false.

This will cause the innermost call to UniqueIDBDatabase::abortTransaction()
to happen with SpaceCheckResult::Fail, hitting the assertion mentioned.
For details, refer to the stacktrace in the bug report.

We can track the IDBStorageManager closure so that when
requestSpace() is called, we can directly grant or deny the
request depending on the size requested.

* Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp:
(WebKit::IDBStorageManager::~IDBStorageManager):
(WebKit::IDBStorageManager::requestSpace):
* Source/WebKit/NetworkProcess/storage/IDBStorageManager.h:

Canonical link: <a href="https://commits.webkit.org/309248@main">https://commits.webkit.org/309248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/864b5d520eb2e0e5d2d0bfc3de6b5ca834fbf751

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22675 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158663 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103390 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23126 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22783 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115672 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82189 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96409 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16902 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14831 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6509 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126517 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161140 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14023 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123682 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123885 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33659 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22488 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134273 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78732 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19048 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11026 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22085 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85905 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21815 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21970 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21872 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->