### PR TITLE
MediaStreamTrack/MediaStreamTrackHandle need to be in postMessage transfer list

### DIFF
--- a/LayoutTests/http/wpt/mediastream/crash-mediastreamtrackprocessor-source.html
+++ b/LayoutTests/http/wpt/mediastream/crash-mediastreamtrackprocessor-source.html
@@ -39,7 +39,7 @@ promise_test(async () => {
 
     const worker = new Worker(WORKER_URL);
 
-    worker.postMessage(track);
+    worker.postMessage(track, [track]);
 
     await new Promise(resolve => worker.onmessage = resolve);
 

--- a/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker.html
+++ b/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrack-to-worker.html
@@ -35,6 +35,9 @@ promise_test(async test => {
     `);
     test.add_cleanup(() => worker.terminate());
     const track = stream.getVideoTracks()[0];
+
+    assert_throws_dom('DataCloneError', () => worker.postMessage({ track }));
+
     worker.postMessage({ track }, [track]);
 
     const result = await new Promise(resolve => worker.onmessage = e => resolve(e.data));

--- a/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrackhandle.html
+++ b/LayoutTests/http/wpt/mediastream/transfer-mediastreamtrackhandle.html
@@ -35,6 +35,8 @@ promise_test(async test => {
     const handle1 = new MediaStreamTrackHandle(stream.getVideoTracks()[0]);
     assert_true(handle1 instanceof MediaStreamTrackHandle);
 
+    assert_throws_dom('DataCloneError', () => worker.postMessage(handle1));
+
     worker.postMessage(handle1, [handle1]);
     const handle2 = await new Promise(resolve => worker.onmessage = e => resolve(e.data));
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-transfer-video.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-transfer-video.https.html
@@ -17,7 +17,7 @@ promise_test(async () => {
     };
   });
   iframe.addEventListener("load", () => {
-    iframe.contentWindow.postMessage(track);
+    iframe.contentWindow.postMessage(track, "*", [track]);
   });
   iframe.src = "support/iframe-MediaStreamTrack-transfer-video.html";
   document.body.appendChild(iframe);

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1115,8 +1115,8 @@ public:
         Vector<RefPtr<RTCEncodedVideoFrame>> dummyRTCEncodedVideoFrames;
 #endif
 #if ENABLE(MEDIA_STREAM)
-        Vector<RefPtr<MediaStreamTrack>> dummyMediaStreamTracks;
-        Vector<RefPtr<MediaStreamTrackHandle>> dummyMediaStreamTrackHandles;
+        Vector<Ref<MediaStreamTrack>> dummyMediaStreamTracks;
+        Vector<Ref<MediaStreamTrackHandle>> dummyMediaStreamTrackHandles;
 #endif
 #if ENABLE(WEBASSEMBLY)
         WasmModuleArray dummyModules;
@@ -1185,8 +1185,8 @@ public:
             Vector<RefPtr<WebCodecsAudioData>>& serializedAudioData,
 #endif
 #if ENABLE(MEDIA_STREAM)
-            Vector<RefPtr<MediaStreamTrack>>& serializedMediaStreamTracks,
-            Vector<RefPtr<MediaStreamTrackHandle>>& serializedMediaStreamTrackHandles,
+            const Vector<Ref<MediaStreamTrack>>& detachedMediaStreamTracks,
+            const Vector<Ref<MediaStreamTrackHandle>>& detachedMediaStreamTrackHandles,
 #endif
 #if ENABLE(WEBASSEMBLY)
             WasmModuleArray& wasmModules,
@@ -1224,8 +1224,8 @@ public:
             serializedAudioData,
 #endif
 #if ENABLE(MEDIA_STREAM)
-            serializedMediaStreamTracks,
-            serializedMediaStreamTrackHandles,
+            detachedMediaStreamTracks,
+            detachedMediaStreamTrackHandles,
 #endif
 #if ENABLE(WEBASSEMBLY)
             wasmModules,
@@ -1290,8 +1290,8 @@ private:
             Vector<RefPtr<WebCodecsAudioData>>& serializedAudioData,
 #endif
 #if ENABLE(MEDIA_STREAM)
-            Vector<RefPtr<MediaStreamTrack>>& serializedMediaStreamTracks,
-            Vector<RefPtr<MediaStreamTrackHandle>>& serializedMediaStreamTrackHandles,
+            const Vector<Ref<MediaStreamTrack>>& mediaStreamTracks,
+            const Vector<Ref<MediaStreamTrackHandle>>& mediaStreamTrackHandles,
 #endif
 #if ENABLE(WEBASSEMBLY)
             WasmModuleArray& wasmModules,
@@ -1321,10 +1321,6 @@ private:
         , m_serializedAudioChunks(serializedAudioChunks)
         , m_serializedAudioData(serializedAudioData)
 #endif
-#if ENABLE(MEDIA_STREAM)
-        , m_serializedMediaStreamTracks(serializedMediaStreamTracks)
-        , m_serializedMediaStreamTrackHandles(serializedMediaStreamTrackHandles)
-#endif
         , m_forStorage(forStorage)
     {
         write(currentVersion());
@@ -1342,6 +1338,10 @@ private:
         fillTransferMap(transformStreams, m_transferredTransformStreams);
 #if ENABLE(MEDIA_SOURCE_IN_WORKERS)
         fillTransferMap(mediaSourceHandles, m_transferredMediaSourceHandles);
+#endif
+#if ENABLE(MEDIA_STREAM)
+        fillTransferMap(mediaStreamTracks, m_transferredMediaStreamTracks);
+        fillTransferMap(mediaStreamTrackHandles, m_transferredMediaStreamTrackHandles);
 #endif
     }
 
@@ -1956,31 +1956,27 @@ private:
     }
 #endif
 #if ENABLE(MEDIA_STREAM)
-    void dumpMediaStreamTrack(JSObject* obj)
+    void dumpMediaStreamTrack(JSObject* obj, SerializationReturnCode& code)
     {
-        Ref track = jsCast<JSMediaStreamTrack*>(obj)->wrapped();
-
-        auto index = m_serializedMediaStreamTracks.find(track.ptr());
-        if (index == notFound) {
-            index = m_serializedMediaStreamTracks.size();
-            m_serializedMediaStreamTracks.append(WTF::move(track));
+        auto index = m_transferredMediaStreamTracks.find(obj);
+        if (index != m_transferredMediaStreamTracks.end()) {
+            write(MediaStreamTrackTag);
+            write(index->value);
+            return;
         }
 
-        write(MediaStreamTrackTag);
-        write(static_cast<uint32_t>(index));
+        code = SerializationReturnCode::DataCloneError;
     }
-    void dumpMediaStreamTrackHandle(JSObject* obj)
+    void dumpMediaStreamTrackHandle(JSObject* obj, SerializationReturnCode& code)
     {
-        Ref handle = jsCast<JSMediaStreamTrackHandle*>(obj)->wrapped();
-
-        auto index = m_serializedMediaStreamTrackHandles.find(handle.ptr());
-        if (index == notFound) {
-            index = m_serializedMediaStreamTrackHandles.size();
-            m_serializedMediaStreamTrackHandles.append(WTF::move(handle));
+        auto index = m_transferredMediaStreamTrackHandles.find(obj);
+        if (index != m_transferredMediaStreamTrackHandles.end()) {
+            write(MediaStreamTrackHandleTag);
+            write(index->value);
+            return;
         }
 
-        write(MediaStreamTrackHandleTag);
-        write(static_cast<uint32_t>(index));
+        code = SerializationReturnCode::DataCloneError;
     }
 #endif
 #if ENABLE(MEDIA_SOURCE_IN_WORKERS)
@@ -2351,13 +2347,13 @@ private:
             if (obj->inherits<JSMediaStreamTrack>()) {
                 if (m_forStorage == SerializationForStorage::Yes)
                     return false;
-                dumpMediaStreamTrack(obj);
+                dumpMediaStreamTrack(obj, code);
                 return true;
             }
             if (obj->inherits<JSMediaStreamTrackHandle>()) {
                 if (m_forStorage == SerializationForStorage::Yes)
                     return false;
-                dumpMediaStreamTrackHandle(obj);
+                dumpMediaStreamTrackHandle(obj, code);
                 return true;
             }
 #endif
@@ -2904,8 +2900,8 @@ private:
     Vector<RefPtr<WebCodecsAudioData>>& m_serializedAudioData;
 #endif
 #if ENABLE(MEDIA_STREAM)
-    Vector<RefPtr<MediaStreamTrack>>& m_serializedMediaStreamTracks;
-    Vector<RefPtr<MediaStreamTrackHandle>>& m_serializedMediaStreamTrackHandles;
+    ObjectPoolMap m_transferredMediaStreamTracks;
+    ObjectPoolMap m_transferredMediaStreamTrackHandles;
 #endif
     SerializationForStorage m_forStorage;
 
@@ -3228,8 +3224,8 @@ public:
         , Vector<WebCodecsAudioInternalData>&& serializedAudioData
 #endif
 #if ENABLE(MEDIA_STREAM)
-        , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& serializedMediaStreamTracks
-        , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& serializedMediaStreamTrackHandles
+        , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& detachedMediaStreamTracks
+        , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& detachedMediaStreamTrackHandles
 #endif
         , uint64_t exposedMessagePortCount
         )
@@ -3261,8 +3257,8 @@ public:
             , WTF::move(serializedAudioData)
 #endif
 #if ENABLE(MEDIA_STREAM)
-            , WTF::move(serializedMediaStreamTracks)
-            , WTF::move(serializedMediaStreamTrackHandles)
+            , WTF::move(detachedMediaStreamTracks)
+            , WTF::move(detachedMediaStreamTrackHandles)
 #endif
             );
         if (!deserializer.isValid())
@@ -3296,8 +3292,8 @@ public:
             , deserializer.takeSerializedAudioData()
 #endif
 #if ENABLE(MEDIA_STREAM)
-            , deserializer.takeSerializedMediaStreamTracks()
-            , deserializer.takeSerializedMediaStreamTrackHandles()
+            , deserializer.takeDetachedMediaStreamTracks()
+            , deserializer.takeDetachedMediaStreamTrackHandles()
 #endif
             );
             newDeserializer.upgradeVersion();
@@ -3375,8 +3371,8 @@ private:
         , Vector<WebCodecsAudioInternalData>&& serializedAudioData = { }
 #endif
 #if ENABLE(MEDIA_STREAM)
-        , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& serializedMediaStreamTracks = { }
-        , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& serializedMediaStreamTrackHandles = { }
+        , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& detachedMediaStreamTracks = { }
+        , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& detachedMediaStreamTrackHandles = { }
 #endif
         )
         : CloneBase(lexicalGlobalObject)
@@ -3424,10 +3420,10 @@ private:
         , m_audioData(m_serializedAudioData.size())
 #endif
 #if ENABLE(MEDIA_STREAM)
-        , m_serializedMediaStreamTracks(WTF::move(serializedMediaStreamTracks))
-        , m_mediaStreamTracks(m_serializedMediaStreamTracks.size())
-        , m_serializedMediaStreamTrackHandles(WTF::move(serializedMediaStreamTrackHandles))
-        , m_mediaStreamTrackHandles(m_serializedMediaStreamTrackHandles.size())
+        , m_detachedMediaStreamTracks(WTF::move(detachedMediaStreamTracks))
+        , m_mediaStreamTracks(m_detachedMediaStreamTracks.size())
+        , m_detachedMediaStreamTrackHandles(WTF::move(detachedMediaStreamTrackHandles))
+        , m_mediaStreamTrackHandles(m_detachedMediaStreamTrackHandles.size())
 #endif
     {
         unsigned version;
@@ -3462,8 +3458,8 @@ private:
         , Vector<WebCodecsAudioInternalData>&& serializedAudioData = { }
 #endif
 #if ENABLE(MEDIA_STREAM)
-        , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& serializedMediaStreamTracks = { }
-        , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& serializedMediaStreamTrackHandles = { }
+        , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& detachedMediaStreamTracks = { }
+        , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& detachedMediaStreamTrackHandles = { }
 #endif
         )
         : CloneBase(lexicalGlobalObject)
@@ -3514,10 +3510,10 @@ private:
         , m_audioData(m_serializedAudioData.size())
 #endif
 #if ENABLE(MEDIA_STREAM)
-        , m_serializedMediaStreamTracks(WTF::move(serializedMediaStreamTracks))
-        , m_mediaStreamTracks(m_serializedMediaStreamTracks.size())
-        , m_serializedMediaStreamTrackHandles(WTF::move(serializedMediaStreamTrackHandles))
-        , m_mediaStreamTrackHandles(m_serializedMediaStreamTrackHandles.size())
+        , m_detachedMediaStreamTracks(WTF::move(detachedMediaStreamTracks))
+        , m_mediaStreamTracks(m_detachedMediaStreamTracks.size())
+        , m_detachedMediaStreamTrackHandles(WTF::move(detachedMediaStreamTrackHandles))
+        , m_mediaStreamTrackHandles(m_detachedMediaStreamTrackHandles.size())
 #endif
     {
         unsigned version;
@@ -3596,8 +3592,8 @@ private:
     Vector<WebCodecsAudioInternalData> takeSerializedAudioData() { return std::exchange(m_serializedAudioData, { }); }
 #endif
 #if ENABLE(MEDIA_STREAM)
-    Vector<std::unique_ptr<MediaStreamTrackDataHolder>> takeSerializedMediaStreamTracks() { return std::exchange(m_serializedMediaStreamTracks, { }); }
-    Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>> takeSerializedMediaStreamTrackHandles() { return std::exchange(m_serializedMediaStreamTrackHandles, { }); }
+    Vector<std::unique_ptr<MediaStreamTrackDataHolder>> takeDetachedMediaStreamTracks() { return std::exchange(m_detachedMediaStreamTracks, { }); }
+    Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>> takeDetachedMediaStreamTrackHandles() { return std::exchange(m_detachedMediaStreamTrackHandles, { }); }
 #endif
 #if ENABLE(MEDIA_SOURCE_IN_WORKERS)
     Vector<RefPtr<DetachedMediaSourceHandle>> takeDetachedMediaSourceHandles() { return std::exchange(m_detachedMediaSourceHandles, { }); }
@@ -5019,26 +5015,26 @@ private:
     {
         uint32_t index;
         bool indexSuccessfullyRead = read(index);
-        if (!indexSuccessfullyRead || index >= m_serializedMediaStreamTracks.size()) {
+        if (!indexSuccessfullyRead || index >= m_detachedMediaStreamTracks.size()) {
             fail();
             return JSValue();
         }
 
         if (!m_mediaStreamTracks[index])
-            m_mediaStreamTracks[index] = MediaStreamTrack::create(*protect(executionContext(m_lexicalGlobalObject)), makeUniqueRefFromNonNullUniquePtr(std::exchange(m_serializedMediaStreamTracks.at(index), { })));
+            m_mediaStreamTracks[index] = MediaStreamTrack::create(*protect(executionContext(m_lexicalGlobalObject)), makeUniqueRefFromNonNullUniquePtr(std::exchange(m_detachedMediaStreamTracks.at(index), { })));
         return getJSValue(*m_mediaStreamTracks[index]);
     }
     JSValue readMediaStreamTrackHandle()
     {
         uint32_t index;
         bool indexSuccessfullyRead = read(index);
-        if (!indexSuccessfullyRead || index >= m_serializedMediaStreamTrackHandles.size()) {
+        if (!indexSuccessfullyRead || index >= m_detachedMediaStreamTrackHandles.size()) {
             fail();
             return JSValue();
         }
 
         if (!m_mediaStreamTrackHandles[index])
-            m_mediaStreamTrackHandles[index] = MediaStreamTrackHandle::create(WTF::move(*std::exchange(m_serializedMediaStreamTrackHandles.at(index), { })));
+            m_mediaStreamTrackHandles[index] = MediaStreamTrackHandle::create(WTF::move(*std::exchange(m_detachedMediaStreamTrackHandles.at(index), { })));
 
         return getJSValue(*m_mediaStreamTrackHandles[index]);
     }
@@ -5777,9 +5773,9 @@ private:
     Vector<RefPtr<WebCodecsAudioData>> m_audioData;
 #endif
 #if ENABLE(MEDIA_STREAM)
-    Vector<std::unique_ptr<MediaStreamTrackDataHolder>> m_serializedMediaStreamTracks;
+    Vector<std::unique_ptr<MediaStreamTrackDataHolder>> m_detachedMediaStreamTracks;
     Vector<RefPtr<MediaStreamTrack>> m_mediaStreamTracks;
-    Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>> m_serializedMediaStreamTrackHandles;
+    Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>> m_detachedMediaStreamTrackHandles;
     Vector<RefPtr<MediaStreamTrackHandle>> m_mediaStreamTrackHandles;
 #endif
 
@@ -6213,8 +6209,8 @@ SerializedScriptValue::SerializedScriptValue(Vector<uint8_t>&& buffer
     , Vector<WebCodecsAudioInternalData>&& serializedAudioData
 #endif
 #if ENABLE(MEDIA_STREAM)
-    , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& serializedMediaStreamTracks
-    , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& serializedMediaStreamTrackHandles
+    , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& detachedMediaStreamTracks
+    , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& detachedMediaStreamTrackHandles
 #endif
     , uint64_t exposedMessagePortCount
         )
@@ -6241,8 +6237,8 @@ SerializedScriptValue::SerializedScriptValue(Vector<uint8_t>&& buffer
         , .detachedMediaSourceHandles = WTF::move(detachedMediaSourceHandles)
 #endif
 #if ENABLE(MEDIA_STREAM)
-        , .serializedMediaStreamTracks = WTF::move(serializedMediaStreamTracks)
-        , .serializedMediaStreamTrackHandles = WTF::move(serializedMediaStreamTrackHandles)
+        , .detachedMediaStreamTracks = WTF::move(detachedMediaStreamTracks)
+        , .detachedMediaStreamTrackHandles = WTF::move(detachedMediaStreamTrackHandles)
 #endif
     }
 {
@@ -6278,8 +6274,8 @@ SerializedScriptValue::SerializedScriptValue(Vector<uint8_t>&& buffer
         , Vector<WebCodecsAudioInternalData>&& serializedAudioData
 #endif
 #if ENABLE(MEDIA_STREAM)
-        , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& serializedMediaStreamTracks
-        , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& serializedMediaStreamTrackHandles
+        , Vector<std::unique_ptr<MediaStreamTrackDataHolder>>&& detachedMediaStreamTracks
+        , Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>>&& detachedMediaStreamTrackHandles
 #endif
         , uint64_t exposedMessagePortCount
         )
@@ -6306,8 +6302,8 @@ SerializedScriptValue::SerializedScriptValue(Vector<uint8_t>&& buffer
         , .detachedMediaSourceHandles = WTF::move(detachedMediaSourceHandles)
 #endif
 #if ENABLE(MEDIA_STREAM)
-        , .serializedMediaStreamTracks = WTF::move(serializedMediaStreamTracks)
-        , .serializedMediaStreamTrackHandles = WTF::move(serializedMediaStreamTrackHandles)
+        , .detachedMediaStreamTracks = WTF::move(detachedMediaStreamTracks)
+        , .detachedMediaStreamTrackHandles = WTF::move(detachedMediaStreamTrackHandles)
 #endif
         , .sharedBufferContentsArray = WTF::move(sharedBufferContentsArray)
         , .detachedImageBitmaps = WTF::move(detachedImageBitmaps)
@@ -6744,10 +6740,6 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     Vector<Ref<WebCodecsEncodedAudioChunkStorage>> serializedAudioChunks;
     Vector<RefPtr<WebCodecsAudioData>> serializedAudioData;
 #endif
-#if ENABLE(MEDIA_STREAM)
-    Vector<RefPtr<MediaStreamTrack>> serializedMediaStreamTracks;
-    Vector<RefPtr<MediaStreamTrackHandle>> serializedMediaStreamTrackHandles;
-#endif
 
     auto exposedMessagePortsCount = messagePorts.size();
     auto code = CloneSerializer::serialize(&lexicalGlobalObject, value, messagePorts, arrayBuffers, imageBitmaps,
@@ -6774,8 +6766,8 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
         serializedAudioData,
 #endif
 #if ENABLE(MEDIA_STREAM)
-        serializedMediaStreamTracks,
-        serializedMediaStreamTrackHandles,
+        transferredMediaStreamTracks,
+        transferredMediaStreamTrackHandles,
 #endif
 #if ENABLE(WEBASSEMBLY)
         wasmModules,
@@ -6856,12 +6848,12 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
         audioData->close();
 #endif
 #if ENABLE(MEDIA_STREAM)
-    auto serializedMediaStreamTrackStorages = map(serializedMediaStreamTracks, [](auto& track) -> std::unique_ptr<MediaStreamTrackDataHolder> {
+    auto detachedMediaStreamTrackStorages = map(transferredMediaStreamTracks, [](auto& track) -> std::unique_ptr<MediaStreamTrackDataHolder> {
         return track->detach().moveToUniquePtr();
     });
     for (auto& track : transferredMediaStreamTracks)
         track->stopTrack();
-    auto serializedMediaStreamTrackHandleStorages = map(serializedMediaStreamTrackHandles, [](auto& handle) -> std::unique_ptr<MediaStreamTrackHandle::DataHolder> {
+    auto detachedMediaStreamTrackHandleStorages = map(transferredMediaStreamTrackHandles, [](auto& handle) -> std::unique_ptr<MediaStreamTrackHandle::DataHolder> {
         return handle->detach().moveToUniquePtr();
     });
 #endif
@@ -6891,8 +6883,8 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
                 , WTF::move(serializedAudioInternalData)
 #endif
 #if ENABLE(MEDIA_STREAM)
-                , WTF::move(serializedMediaStreamTrackStorages)
-                , WTF::move(serializedMediaStreamTrackHandleStorages)
+                , WTF::move(detachedMediaStreamTrackStorages)
+                , WTF::move(detachedMediaStreamTrackHandleStorages)
 #endif
                 , exposedMessagePortsCount
                 ));
@@ -6979,8 +6971,8 @@ JSValue SerializedScriptValue::deserialize(JSGlobalObject& lexicalGlobalObject, 
         , WTF::move(m_internals.serializedAudioData)
 #endif
 #if ENABLE(MEDIA_STREAM)
-        , WTF::move(m_internals.serializedMediaStreamTracks)
-        , WTF::move(m_internals.serializedMediaStreamTrackHandles)
+        , WTF::move(m_internals.detachedMediaStreamTracks)
+        , WTF::move(m_internals.detachedMediaStreamTrackHandles)
 #endif
         , m_internals.exposedMessagePortCount
         );

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -234,8 +234,8 @@ private:
         Vector<RefPtr<DetachedMediaSourceHandle>> detachedMediaSourceHandles { };
 #endif
 #if ENABLE(MEDIA_STREAM)
-        Vector<std::unique_ptr<MediaStreamTrackDataHolder>> serializedMediaStreamTracks { };
-        Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>> serializedMediaStreamTrackHandles { };
+        Vector<std::unique_ptr<MediaStreamTrackDataHolder>> detachedMediaStreamTracks { };
+        Vector<std::unique_ptr<MediaStreamTrackHandle::DataHolder>> detachedMediaStreamTrackHandles { };
 #endif
         std::unique_ptr<ArrayBufferContentsArray> sharedBufferContentsArray { };
         Vector<std::optional<DetachedImageBitmap>> detachedImageBitmaps { };

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -8174,8 +8174,8 @@ headers: <JavaScriptCore/WasmModule.h> <WebCore/ImageBitmap.h> <WebCore/MessageP
     [NotSerialized] Vector<RefPtr<WebCore::DetachedMediaSourceHandle>> detachedMediaSourceHandles;
 #endif
 #if ENABLE(MEDIA_STREAM)
-    [NotSerialized] Vector<std::unique_ptr<WebCore::MediaStreamTrackDataHolder>> serializedMediaStreamTracks;
-    [NotSerialized] Vector<std::unique_ptr<WebCore::MediaStreamTrackHandle::DataHolder>> serializedMediaStreamTrackHandles;
+    [NotSerialized] Vector<std::unique_ptr<WebCore::MediaStreamTrackDataHolder>> detachedMediaStreamTracks;
+    [NotSerialized] Vector<std::unique_ptr<WebCore::MediaStreamTrackHandle::DataHolder>> detachedMediaStreamTrackHandles;
 #endif
     [NotSerialized] std::unique_ptr<Vector<JSC::ArrayBufferContents>> sharedBufferContentsArray;
     [NotSerialized] Vector<std::optional<WebCore::DetachedImageBitmap>> detachedImageBitmaps;

--- a/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/GetUserMedia.mm
@@ -551,7 +551,7 @@ function captureAndTransferAudioTrack()
 {
     navigator.mediaDevices.getUserMedia({audio:true}).then(stream => {
         const track = stream.getAudioTracks()[0];
-        self.opener.postMessage({ state : "PASS", track }, [track]);
+        self.opener.postMessage({ state : "PASS", track }, "*", [track]);
     });
 }
 
@@ -559,7 +559,7 @@ function captureAndTransferVideoTrack()
 {
     navigator.mediaDevices.getUserMedia({video:true}).then(stream => {
         const track = stream.getVideoTracks()[0];
-        self.opener.postMessage({ state : "PASS", track }, [track]);
+        self.opener.postMessage({ state : "PASS", track }, "*", [track]);
     });
 }
 


### PR DESCRIPTION
#### 592c97b1a8600ac3544fa6374d5a37b011d5d5cf
<pre>
MediaStreamTrack/MediaStreamTrackHandle need to be in postMessage transfer list
<a href="https://rdar.apple.com/172363324">rdar://172363324</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309778">https://bugs.webkit.org/show_bug.cgi?id=309778</a>

Reviewed by Eric Carlson.

We were doing as if MediaStreamTrack and MediaStreamTrackHandle were serializable while they are only tranferable.
We update dumpMediaStreamTrack and dumpMediaStreamTrackHandle to return a data clone error if a track/track handle object does not have its counterpart in the transferable list.
We update serializedMediaStreamTracks/serializedMediaStreamTrackHandles to detachedMediaStreamTracks/detachedMediaStreamTrackHandles to clarify the code.

Covered by updated tests.

Canonical link: <a href="https://commits.webkit.org/309191@main">https://commits.webkit.org/309191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/270dbaa79c0d891d0cd1aec05441cc3994322c9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149721 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158425 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103153 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5cf3ba05-84c0-4b7a-80bf-4099d79e1a47) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22890 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22487 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115493 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82096 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/47d81159-d37f-47dc-afc5-9371c2bb14fc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134356 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96234 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/247ede0d-a739-4604-a0e6-91b44f47e517) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16725 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14632 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6271 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126333 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160903 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13829 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123519 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123725 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33623 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22249 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134080 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78474 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18902 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10831 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21850 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85670 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21580 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21732 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21637 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->