### PR TITLE
ANGLE: ContextMtl::setupDraw mode is unused and error-prone

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.h
@@ -417,7 +417,6 @@ class ContextMtl : public ContextImpl, public mtl::Context
     void endBlitAndComputeEncoding();
     angle::Result resyncDrawFramebufferIfNeeded(const gl::Context *context);
     angle::Result setupDraw(const gl::Context *context,
-                            gl::PrimitiveMode mode,
                             GLint firstVertex,
                             GLsizei vertexOrIndexCount,
                             GLsizei instanceCount,
@@ -427,7 +426,6 @@ class ContextMtl : public ContextImpl, public mtl::Context
                             bool *isNoOp);
 
     angle::Result setupDrawImpl(const gl::Context *context,
-                                gl::PrimitiveMode mode,
                                 GLint firstVertex,
                                 GLsizei vertexOrIndexCount,
                                 GLsizei instanceCount,
@@ -531,7 +529,6 @@ class ContextMtl : public ContextImpl, public mtl::Context
     angle::Result handleDirtyDepthBias(const gl::Context *context);
     angle::Result handleDirtyRenderPass(const gl::Context *context);
     angle::Result checkIfPipelineChanged(const gl::Context *context,
-                                         gl::PrimitiveMode primitiveMode,
                                          bool xfbPass,
                                          bool *pipelineDescChanged);
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm
@@ -324,7 +324,7 @@ angle::Result ContextMtl::drawTriFanArraysWithBaseVertex(const gl::Context *cont
 
     ASSERT(!getState().isTransformFeedbackActiveUnpaused());
     bool isNoOp = false;
-    ANGLE_TRY(setupDraw(context, gl::PrimitiveMode::TriangleFan, first, count, instances,
+    ANGLE_TRY(setupDraw(context, first, count, instances,
                         gl::DrawElementsType::InvalidEnum, reinterpret_cast<const void *>(0), false,
                         &isNoOp));
     if (!isNoOp)
@@ -357,7 +357,7 @@ angle::Result ContextMtl::drawTriFanArraysLegacy(const gl::Context *context,
 
     ASSERT(!getState().isTransformFeedbackActiveUnpaused());
     bool isNoOp = false;
-    ANGLE_TRY(setupDraw(context, gl::PrimitiveMode::TriangleFan, first, count, instances,
+    ANGLE_TRY(setupDraw(context, first, count, instances,
                         gl::DrawElementsType::InvalidEnum, reinterpret_cast<const void *>(0), false,
                         &isNoOp));
     if (!isNoOp)
@@ -424,7 +424,7 @@ angle::Result ContextMtl::drawLineLoopArrays(const gl::Context *context,
 
     ASSERT(!getState().isTransformFeedbackActiveUnpaused());
     bool isNoOp = false;
-    ANGLE_TRY(setupDraw(context, gl::PrimitiveMode::LineLoop, first, count, instances,
+    ANGLE_TRY(setupDraw(context, first, count, instances,
                         gl::DrawElementsType::InvalidEnum, nullptr, false, &isNoOp));
     if (!isNoOp)
     {
@@ -477,7 +477,7 @@ angle::Result ContextMtl::drawArraysImpl(const gl::Context *context,
 #define DRAW_GENERIC_ARRAY(xfbPass)                                                                \
     {                                                                                              \
         bool isNoOp = false;                                                                       \
-        ANGLE_TRY(setupDraw(context, mode, first, count, instances,                                \
+        ANGLE_TRY(setupDraw(context, first, count, instances,                                      \
                             gl::DrawElementsType::InvalidEnum, nullptr, xfbPass, &isNoOp));        \
         if (!isNoOp)                                                                               \
         {                                                                                          \
@@ -566,7 +566,7 @@ angle::Result ContextMtl::drawTriFanElements(const gl::Context *context,
 
         ANGLE_TRY(mTriFanIndexBuffer.commit(this));
         bool isNoOp = false;
-        ANGLE_TRY(setupDraw(context, gl::PrimitiveMode::TriangleFan, 0, count, instances, type,
+        ANGLE_TRY(setupDraw(context, 0, count, instances, type,
                             indices, false, &isNoOp));
         if (!isNoOp && genIndicesCount > 0)
         {
@@ -636,7 +636,7 @@ angle::Result ContextMtl::drawLineLoopElements(const gl::Context *context,
 
         ANGLE_TRY(mLineLoopIndexBuffer.commit(this));
         bool isNoOp = false;
-        ANGLE_TRY(setupDraw(context, gl::PrimitiveMode::LineLoop, 0, count, instances, type,
+        ANGLE_TRY(setupDraw(context, 0, count, instances, type,
                             indices, false, &isNoOp));
         if (!isNoOp && genIndicesCount > 0)
         {
@@ -688,7 +688,7 @@ angle::Result ContextMtl::drawArraysProvokingVertexImpl(const gl::Context *conte
     if (xfbPass)                                                                                   \
     {                                                                                              \
         bool isNoOp = false;                                                                       \
-        ANGLE_TRY(setupDraw(context, mode, first, count, instances,                                \
+        ANGLE_TRY(setupDraw(context, first, count, instances,                                      \
                             gl::DrawElementsType::InvalidEnum, nullptr, xfbPass, &isNoOp));        \
         if (!isNoOp)                                                                               \
         {                                                                                          \
@@ -715,7 +715,7 @@ angle::Result ContextMtl::drawArraysProvokingVertexImpl(const gl::Context *conte
     else                                                                                           \
     {                                                                                              \
         bool isNoOp = false;                                                                       \
-        ANGLE_TRY(setupDraw(context, mode, first, count, instances,                                \
+        ANGLE_TRY(setupDraw(context, first, count, instances,                                      \
                             gl::DrawElementsType::InvalidEnum, nullptr, xfbPass, &isNoOp));        \
                                                                                                    \
         if (!isNoOp)                                                                               \
@@ -816,7 +816,7 @@ angle::Result ContextMtl::drawElementsImpl(const gl::Context *context,
     const std::vector<DrawCommandRange> drawCommands = mVertexArray->getDrawIndices(
         context, type, convertedType, mode, idxBuffer, convertedCounti32, convertedOffset);
     bool isNoOp = false;
-    ANGLE_TRY(setupDraw(context, mode, 0, count, instances, type, indices, false, &isNoOp));
+    ANGLE_TRY(setupDraw(context, 0, count, instances, type, indices, false, &isNoOp));
     if (!isNoOp)
     {
         MTLPrimitiveType mtlType = mtl::GetPrimitiveType(mode);
@@ -2505,7 +2505,6 @@ static bool isDrawNoOp(const mtl::RenderPipelineDesc &descriptor,
 }
 
 angle::Result ContextMtl::setupDraw(const gl::Context *context,
-                                    gl::PrimitiveMode mode,
                                     GLint firstVertex,
                                     GLsizei vertexOrIndexCount,
                                     GLsizei instances,
@@ -2514,7 +2513,7 @@ angle::Result ContextMtl::setupDraw(const gl::Context *context,
                                     bool xfbPass,
                                     bool *isNoOp)
 {
-    ANGLE_TRY(setupDrawImpl(context, mode, firstVertex, vertexOrIndexCount, instances,
+    ANGLE_TRY(setupDrawImpl(context, firstVertex, vertexOrIndexCount, instances,
                             indexTypeOrNone, indices, xfbPass, isNoOp));
     if (*isNoOp)
     {
@@ -2526,7 +2525,7 @@ angle::Result ContextMtl::setupDraw(const gl::Context *context,
         // pass state. This would happen for example when there is no more space in the uniform
         // buffers in the uniform buffer pool. The rendering would be flushed to free the uniform
         // buffer memory for new usage. In this case, re-run the setup.
-        ANGLE_TRY(setupDrawImpl(context, mode, firstVertex, vertexOrIndexCount, instances,
+        ANGLE_TRY(setupDrawImpl(context, firstVertex, vertexOrIndexCount, instances,
                                 indexTypeOrNone, indices, xfbPass, isNoOp));
 
         if (*isNoOp)
@@ -2555,7 +2554,6 @@ angle::Result ContextMtl::setupDraw(const gl::Context *context,
 }
 
 angle::Result ContextMtl::setupDrawImpl(const gl::Context *context,
-                                        gl::PrimitiveMode mode,
                                         GLint firstVertex,
                                         GLsizei vertexOrIndexCount,
                                         GLsizei instances,
@@ -2616,7 +2614,7 @@ angle::Result ContextMtl::setupDrawImpl(const gl::Context *context,
     }
 
     bool isPipelineDescChanged;
-    ANGLE_TRY(checkIfPipelineChanged(context, mode, xfbPass, &isPipelineDescChanged));
+    ANGLE_TRY(checkIfPipelineChanged(context, xfbPass, &isPipelineDescChanged));
 
     bool uniformBuffersDirty = false;
 
@@ -2970,15 +2968,12 @@ angle::Result ContextMtl::handleDirtyDepthBias(const gl::Context *context)
 }
 
 angle::Result ContextMtl::checkIfPipelineChanged(const gl::Context *context,
-                                                 gl::PrimitiveMode primitiveMode,
                                                  bool xfbPass,
                                                  bool *isPipelineDescChanged)
 {
     ASSERT(mRenderEncoder.valid());
-    MTLPrimitiveTopologyClass topologyClass = mtl::GetPrimitiveTopologyClass(primitiveMode);
-
     bool rppChange = mDirtyBits.test(DIRTY_BIT_RENDER_PIPELINE) ||
-                     topologyClass != mRenderPipelineDesc.inputPrimitiveTopology;
+                     MTLPrimitiveTopologyClassUnspecified != mRenderPipelineDesc.inputPrimitiveTopology;
 
     // Obtain RenderPipelineDesc's vertex array descriptor.
     ANGLE_TRY(mVertexArray->setupDraw(context, &mRenderEncoder, &rppChange,
@@ -3008,7 +3003,7 @@ angle::Result ContextMtl::checkIfPipelineChanged(const gl::Context *context,
         {
             mRenderPipelineDesc.rasterizationType = mtl::RenderPipelineRasterization::Enabled;
         }
-        mRenderPipelineDesc.inputPrimitiveTopology = topologyClass;
+        mRenderPipelineDesc.inputPrimitiveTopology = MTLPrimitiveTopologyClassUnspecified;
         mRenderPipelineDesc.alphaToCoverageEnabled =
             mState.isSampleAlphaToCoverageEnabled() &&
             mRenderPipelineDesc.outputDescriptor.rasterSampleCount > 1 &&

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.h
@@ -154,7 +154,6 @@ MTLStencilOperation GetStencilOp(GLenum op);
 
 MTLWinding GetFrontfaceWinding(GLenum frontFaceMode, bool invert);
 
-MTLPrimitiveTopologyClass GetPrimitiveTopologyClass(gl::PrimitiveMode mode);
 MTLPrimitiveType GetPrimitiveType(gl::PrimitiveMode mode);
 MTLIndexType GetIndexType(gl::DrawElementsType type);
 

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm
@@ -1191,13 +1191,6 @@ MTLWinding GetFrontfaceWinding(GLenum frontFaceMode, bool invert)
     }
 }
 
-MTLPrimitiveTopologyClass GetPrimitiveTopologyClass(gl::PrimitiveMode mode)
-{
-    // NOTE(hqle): Support layered renderring in future.
-    // In non-layered rendering mode, unspecified is enough.
-    return MTLPrimitiveTopologyClassUnspecified;
-}
-
 MTLPrimitiveType GetPrimitiveType(gl::PrimitiveMode mode)
 {
     switch (mode)


### PR DESCRIPTION
#### 1eb6e2b7f97b5f857a2fac37811f96f9a9a0bdda
<pre>
ANGLE: ContextMtl::setupDraw mode is unused and error-prone
<a href="https://bugs.webkit.org/show_bug.cgi?id=309785">https://bugs.webkit.org/show_bug.cgi?id=309785</a>
<a href="https://rdar.apple.com/172373825">rdar://172373825</a>

Reviewed by Dan Glastonbury.

In ContextMtl::setupDraw(..., gl::PrimitiveMode mode, ...), the `mode`
would not be used for anything. However, it is confusing. The original
count, instances, type, indices parameters would be as what GL client
passed, but mode would be modified to the possible rewritten primitive
mode.

If the primitive class is needed in the future, the setup should
accept the Metal enums, in Metal section of the parameter list, to
indicate the Metal implementation details. So either MTLPrimitiveType
or MTLPrimitiveTopologyClass.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm:
(rx::ContextMtl::drawTriFanArraysWithBaseVertex):
(rx::ContextMtl::drawTriFanArraysLegacy):
(rx::ContextMtl::drawLineLoopArrays):
(rx::ContextMtl::drawArraysImpl):
(rx::ContextMtl::drawTriFanElements):
(rx::ContextMtl::drawLineLoopElements):
(rx::ContextMtl::drawArraysProvokingVertexImpl):
(rx::ContextMtl::drawElementsImpl):
(rx::ContextMtl::setupDraw):
(rx::ContextMtl::setupDrawImpl):
(rx::ContextMtl::checkIfPipelineChanged):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_utils.mm:
(rx::mtl::GetPrimitiveTopologyClass): Deleted.

Canonical link: <a href="https://commits.webkit.org/309189@main">https://commits.webkit.org/309189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51bbb158f6f0a6eebf4aaf1c99fd892a970b5115

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158579 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22695 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/115610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dfb3d937-90df-4230-a116-e51ab7c20d6d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17732 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/134489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96349 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/587cdcd4-c6ec-48a7-82d6-ed5398c18856) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6426 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12420 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161055 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13962 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/123626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22394 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/18799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123830 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33619 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22401 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134213 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18989 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/10965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22002 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21732 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21884 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21789 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->