### PR TITLE
Web Speech API: `speechSynthesis.clear()` removes utterances from following `speechSynthesis.speak(...)` as well

### DIFF
--- a/LayoutTests/fast/speechsynthesis/speech-synthesis-cancel-queued-utterances-expected.txt
+++ b/LayoutTests/fast/speechsynthesis/speech-synthesis-cancel-queued-utterances-expected.txt
@@ -1,0 +1,22 @@
+This tests that cancel() does not drop utterances queued after it is called. Regression test for https://bugs.webkit.org/show_bug.cgi?id=191745
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+u1: start
+u1: error (canceled)
+u2: start
+Called cancel and queued u2, u3
+u2: end
+u3: start
+u3: end
+PASS u2Events.length is 2
+PASS u2Events[0] is 'start'
+PASS u2Events[1] is 'end'
+PASS u3Events.length is 2
+PASS u3Events[0] is 'start'
+PASS u3Events[1] is 'end'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/speechsynthesis/speech-synthesis-cancel-queued-utterances.html
+++ b/LayoutTests/fast/speechsynthesis/speech-synthesis-cancel-queued-utterances.html
@@ -1,0 +1,90 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+</head>
+<body id="body">
+
+<div id="console"></div>
+
+<script>
+
+    description("This tests that cancel() does not drop utterances queued after it is called. Regression test for https://bugs.webkit.org/show_bug.cgi?id=191745");
+
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+    if (window.internals)
+        window.internals.enableMockSpeechSynthesizer();
+
+    window.jsTestIsAsync = true;
+
+    var u1 = new SpeechSynthesisUtterance("First utterance");
+    var u2Events = [];
+    var u3Events = [];
+
+    u1.onstart = function(event) {
+       debug("u1: start");
+    }
+
+    u1.onerror = function(event) {
+       debug("u1: error (canceled)");
+    }
+
+    var u2 = new SpeechSynthesisUtterance("Second utterance");
+    u2.onstart = function(event) {
+       u2Events.push("start");
+       debug("u2: start");
+    }
+
+    u2.onend = function(event) {
+       u2Events.push("end");
+       debug("u2: end");
+    }
+
+    u2.onerror = function(event) {
+       u2Events.push("error");
+       debug("u2: error");
+    }
+
+    var u3 = new SpeechSynthesisUtterance("Third utterance");
+    u3.onstart = function(event) {
+       u3Events.push("start");
+       debug("u3: start");
+    }
+
+    u3.onend = function(event) {
+       u3Events.push("end");
+       debug("u3: end");
+       // All done - verify events
+       shouldBe("u2Events.length", "2");
+       shouldBe("u2Events[0]", "'start'");
+       shouldBe("u2Events[1]", "'end'");
+       shouldBe("u3Events.length", "2");
+       shouldBe("u3Events[0]", "'start'");
+       shouldBe("u3Events[1]", "'end'");
+       finishJSTest();
+    }
+
+    u3.onerror = function(event) {
+       u3Events.push("error");
+       debug("u3: error");
+    }
+
+    // Queue the first job which will start speaking immediately.
+    speechSynthesis.speak(u1);
+
+    // Cancel u1 (with async callback in mock)
+    speechSynthesis.cancel();
+
+    // Queue u2 and u3 after cancel - these should NOT be dropped
+    speechSynthesis.speak(u2);
+    speechSynthesis.speak(u3);
+
+    debug("Called cancel and queued u2, u3");
+
+</script>
+
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
+++ b/Source/WebCore/Modules/speech/SpeechSynthesis.cpp
@@ -183,14 +183,16 @@ void SpeechSynthesis::cancel()
     // Clear m_utteranceQueue before calling cancel to avoid picking up new utterances
     // on completion callback
     auto utteranceQueue = WTF::move(m_utteranceQueue);
-    if (RefPtr speechSynthesisClient = m_speechSynthesisClient.get()) {
+    if (RefPtr speechSynthesisClient = m_speechSynthesisClient.get())
         speechSynthesisClient->cancel();
-        // If we wait for cancel to callback speakingErrorOccurred, then m_currentSpeechUtterance will be null
-        // and the event won't be processed. Instead we process the error immediately.
-        speakingErrorOccurred();
-        m_currentSpeechUtterance = nullptr;
-    } else if (RefPtr platformSpeechSynthesizer = m_platformSpeechSynthesizer)
+    else if (RefPtr platformSpeechSynthesizer = m_platformSpeechSynthesizer)
         platformSpeechSynthesizer->cancel();
+
+    // Process the current utterance's error immediately rather than waiting for the
+    // platform's async cancel callback. This ensures the error event fires before
+    // any new utterances are queued via speak().
+    speakingErrorOccurred();
+    m_currentSpeechUtterance = nullptr;
 
     // Trigger canceled events for queued utterances
     while (!utteranceQueue.isEmpty()) {
@@ -225,7 +227,11 @@ void SpeechSynthesis::resumeSynthesis()
 
 void SpeechSynthesis::handleSpeakingCompleted(SpeechSynthesisUtterance& utterance, bool errorOccurred)
 {
-    ASSERT(m_currentSpeechUtterance);
+    // Ignore callbacks for stale utterances. This can happen when cancel() is called
+    // and a new utterance is queued before the platform's async cancel callback fires.
+    if (!m_currentSpeechUtterance || &utterance != currentSpeechUtterance())
+        return;
+
     Ref<SpeechSynthesisUtterance> protect(utterance);
 
     m_currentSpeechUtterance = nullptr;
@@ -234,7 +240,7 @@ void SpeechSynthesis::handleSpeakingCompleted(SpeechSynthesisUtterance& utteranc
         utterance.errorEventOccurred(eventNames().errorEvent, SpeechSynthesisErrorCode::Canceled);
     else
         utterance.eventOccurred(eventNames().endEvent, 0, 0, String());
-    
+
     if (m_utteranceQueue.size()) {
         Ref<SpeechSynthesisUtterance> firstUtterance = m_utteranceQueue.takeFirst();
         ASSERT(&utterance == firstUtterance.ptr());

--- a/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
+++ b/Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp
@@ -25,7 +25,9 @@
 
 #include "config.h"
 #include "PlatformSpeechSynthesizerMock.h"
+
 #include "PlatformSpeechSynthesisUtterance.h"
+#include <wtf/MainThread.h>
 
 #if ENABLE(SPEECH_SYNTHESIS)
 
@@ -82,8 +84,13 @@ void PlatformSpeechSynthesizerMock::cancel()
         return;
 
     m_speakingFinishedTimer.stop();
+
+    // Schedule the error callback asynchronously to simulate platform behavior
+    // This allows new utterances to be queued before the callback fires.
     RefPtr utterance = std::exchange(m_utterance, nullptr);
-    client().speakingErrorOccurred(*utterance);
+    callOnMainThread([protectedThis = Ref { *this }, utterance]() {
+        protectedThis->client().speakingErrorOccurred(*utterance);
+    });
 }
 
 void PlatformSpeechSynthesizerMock::pause()


### PR DESCRIPTION
#### 3dc3ba3a4d52cd8f24e6c7d491b90b2830f5bcd8
<pre>
Web Speech API: `speechSynthesis.clear()` removes utterances from following `speechSynthesis.speak(...)` as well
<a href="https://bugs.webkit.org/show_bug.cgi?id=191745">https://bugs.webkit.org/show_bug.cgi?id=191745</a>
<a href="https://rdar.apple.com/46151521">rdar://46151521</a>

Reviewed by Tyler Wilcock.

Because cancel() callbacks happen asynchronously on the platform synthesizer, they can clear out the wrong utterance.

Test: fast/speechsynthesis/speech-synthesis-cancel-queued-utterances.html

* LayoutTests/fast/speechsynthesis/speech-synthesis-cancel-queued-utterances-expected.txt: Added.
* LayoutTests/fast/speechsynthesis/speech-synthesis-cancel-queued-utterances.html: Added.
* Source/WebCore/Modules/speech/SpeechSynthesis.cpp:
(WebCore::SpeechSynthesis::cancel):
(WebCore::SpeechSynthesis::handleSpeakingCompleted):
* Source/WebCore/platform/mock/PlatformSpeechSynthesizerMock.cpp:
(WebCore::PlatformSpeechSynthesizerMock::cancel):

Canonical link: <a href="https://commits.webkit.org/309349@main">https://commits.webkit.org/309349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/992224831e8f4671f333b165daa7633585034a4f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158553 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103279 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/504aaf96-5f9f-4ee9-94cc-62b29357be2d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151720 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115585 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82183 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0631e27b-398e-4a31-8c99-03ff685db89d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134460 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96324 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/91738f8b-79af-4923-bcbc-f904d21c5a20) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16808 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14731 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6400 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12391 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161029 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13933 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123600 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123805 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33730 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134184 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78600 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18963 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10936 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21976 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85796 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21706 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21858 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21763 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->