### PR TITLE
[test-webkitpy] Capture excess logging in tests

### DIFF
--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkout_unittest.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkout_unittest.py
@@ -36,7 +36,7 @@ class CheckoutUnittest(testing.PathTestCase):
         os.mkdir(os.path.join(self.path, '.git'))
 
     def test_json(self):
-        with mocks.local.Git(self.path) as repo, OutputCapture():
+        with OutputCapture(), mocks.local.Git(self.path) as repo:
             checkout = Checkout(
                 path=self.path,
                 url=repo.remote,
@@ -72,13 +72,13 @@ class CheckoutUnittest(testing.PathTestCase):
 
 
     def test_constructor_sentinal(self):
-        with mocks.local.Git(self.path) as repo, OutputCapture():
+        with OutputCapture(), mocks.local.Git(self.path) as repo:
             with open(os.path.join(os.path.dirname(self.path), 'cloned'), 'w') as sentinal:
                 sentinal.write('yes\n')
             Checkout(path=self.path, url=repo.remote, sentinal=True)
 
     def test_constructor_no_sentinal(self):
-        with mocks.local.Git(self.path) as repo, OutputCapture():
+        with OutputCapture(), mocks.local.Git(self.path) as repo:
             Checkout(path=self.path, url=repo.remote, sentinal=False)
 
             with self.assertRaises(Checkout.Exception):

--- a/Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkoutroute_unittest.py
+++ b/Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkoutroute_unittest.py
@@ -137,7 +137,7 @@ class CheckoutRouteUnittest(testing.PathTestCase):
 
     @mock_app
     def test_landing(self, app=None, client=None):
-        with mocks.local.Git(self.path) as repo, OutputCapture():
+        with OutputCapture(), mocks.local.Git(self.path) as repo:
             app.register_blueprint(CheckoutRoute(
                 Checkout(path=self.path, url=repo.remote, sentinal=False),
                 redirectors=[Redirector('https://trac.webkit.org')],
@@ -148,7 +148,7 @@ class CheckoutRouteUnittest(testing.PathTestCase):
 
     @mock_app
     def test_json_details_origin(self, app=None, client=None):
-        with mocks.local.Git(self.path) as repo:
+        with OutputCapture(), mocks.local.Git(self.path) as repo:
             app.register_blueprint(CheckoutRoute(
                 Checkout(path=self.path, url=repo.remote, sentinal=False),
                 redirectors=[Redirector('https://trac.webkit.org')],
@@ -162,7 +162,7 @@ class CheckoutRouteUnittest(testing.PathTestCase):
 
     @mock_app
     def test_json_strip_details_non_origin_commits(self, app=None, client=None):
-        with mocks.local.Git(self.path) as repo:
+        with OutputCapture(), mocks.local.Git(self.path) as repo:
             repo.remotes['fork/main'] = repo.remotes.pop('origin/main')
             app.register_blueprint(CheckoutRoute(
                 Checkout(path=self.path, url=repo.remote, sentinal=False),
@@ -179,7 +179,7 @@ class CheckoutRouteUnittest(testing.PathTestCase):
 
     @mock_app
     def test_json_invalid(self, app=None, client=None):
-        with mocks.local.Git(self.path) as repo:
+        with OutputCapture(), mocks.local.Git(self.path) as repo:
             app.register_blueprint(CheckoutRoute(
                 Checkout(path=self.path, url=repo.remote, sentinal=False),
                 redirectors=[Redirector('https://trac.webkit.org')],
@@ -195,7 +195,7 @@ class CheckoutRouteUnittest(testing.PathTestCase):
 
     @mock_app
     def test_redirect(self, app=None, client=None):
-        with mocks.local.Git(self.path) as repo:
+        with OutputCapture(), mocks.local.Git(self.path) as repo:
             app.register_blueprint(CheckoutRoute(
                 Checkout(path=self.path, url=repo.remote, sentinal=False),
                 redirectors=[Redirector('https://github.com/WebKit/WebKit')],
@@ -210,7 +210,7 @@ class CheckoutRouteUnittest(testing.PathTestCase):
 
     @mock_app
     def test_invoked_redirect(self, app=None, client=None):
-        with mocks.local.Git(self.path, git_svn=True) as repo, OutputCapture():
+        with OutputCapture(), mocks.local.Git(self.path, git_svn=True) as repo:
             app.register_blueprint(CheckoutRoute(
                 Checkout(path=self.path, url=repo.remote, sentinal=False),
                 redirectors=[Redirector('https://github.com/WebKit/WebKit'), Redirector('https://trac.webkit.org')],
@@ -225,7 +225,7 @@ class CheckoutRouteUnittest(testing.PathTestCase):
 
     @mock_app
     def test_trac(self, app=None, client=None):
-        with mocks.local.Git(self.path, git_svn=True) as repo, OutputCapture():
+        with OutputCapture(), mocks.local.Git(self.path, git_svn=True) as repo:
             app.register_blueprint(CheckoutRoute(
                 Checkout(path=self.path, url=repo.remote, sentinal=False),
                 redirectors=[Redirector('https://github.com/WebKit/WebKit')],
@@ -240,7 +240,7 @@ class CheckoutRouteUnittest(testing.PathTestCase):
 
     @mock_app
     def test_compare(self, app=None, client=None):
-        with mocks.local.Git(self.path) as repo:
+        with OutputCapture(), mocks.local.Git(self.path) as repo:
             app.register_blueprint(CheckoutRoute(
                 Checkout(path=self.path, url=repo.remote, sentinal=False),
                 redirectors=[Redirector('https://github.com/WebKit/WebKit')],
@@ -255,7 +255,7 @@ class CheckoutRouteUnittest(testing.PathTestCase):
 
     @mock_app
     def test_compare_trac(self, app=None, client=None):
-        with mocks.local.Git(self.path) as repo:
+        with OutputCapture(), mocks.local.Git(self.path) as repo:
             app.register_blueprint(CheckoutRoute(
                 Checkout(path=self.path, url=repo.remote, sentinal=False),
                 redirectors=[Redirector('https://github.com/WebKit/WebKit'), Redirector('https://trac.webkit.org')],

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -798,7 +798,7 @@ CommitDate: {time_c}
             self.assertEqual(mock_git.remotes[remote_ref][-1].hash, fetched_commit.hash)
 
     def test_branches_for(self):
-        with mocks.local.Git(
+        with OutputCapture(), mocks.local.Git(
             self.path,
             remotes={
                 'security': 'git@github.example.com:WebKit/WebKit-security.git',

--- a/Tools/Scripts/webkitpy/common/net/bugzilla/bugzilla_unittest.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/bugzilla_unittest.py
@@ -30,6 +30,7 @@
 import datetime
 import logging
 import unittest
+import warnings
 
 from webkitcorepy import StringIO, OutputCapture
 
@@ -203,8 +204,10 @@ Ignore this bug.  Just for testing failure modes of webkit-patch and the commit-
             self.assertEqual(actual[key], expected_value, ("Failure for key: %s: Actual='%s' Expected='%s'" % (key, actual[key], expected_value)))
 
     def test_parse_bug_dictionary_from_xml(self):
-        bug = Bugzilla()._parse_bug_dictionary_from_xml(self._single_bug_xml)
-        self._assert_dictionaries_equal(bug, self._expected_example_bug_parsing)
+        with OutputCapture(), warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            bug = Bugzilla()._parse_bug_dictionary_from_xml(self._single_bug_xml)
+            self._assert_dictionaries_equal(bug, self._expected_example_bug_parsing)
 
     _sample_multi_bug_xml = """
 <bugzilla version="3.2.3" urlbase="https://bugs.webkit.org/" maintainer="admin@webkit.org" exporter="eric@webkit.org">
@@ -215,12 +218,13 @@ Ignore this bug.  Just for testing failure modes of webkit-patch and the commit-
 
     # This could be combined into test_bug_parsing later if desired.
     def test_attachment_parsing(self):
-        bugzilla = Bugzilla()
-        soup = BeautifulSoup(self._example_attachment)
-        attachment_element = soup.find("attachment")
-        attachment = bugzilla._parse_attachment_element(attachment_element, self._expected_example_attachment_parsing['bug_id'])
-        self.assertTrue(attachment)
-        self._assert_dictionaries_equal(attachment, self._expected_example_attachment_parsing)
+        with OutputCapture():
+            bugzilla = Bugzilla()
+            soup = BeautifulSoup(self._example_attachment)
+            attachment_element = soup.find("attachment")
+            attachment = bugzilla._parse_attachment_element(attachment_element, self._expected_example_attachment_parsing['bug_id'])
+            self.assertTrue(attachment)
+            self._assert_dictionaries_equal(attachment, self._expected_example_attachment_parsing)
 
     _sample_attachment_detail_page = """
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py
@@ -81,8 +81,9 @@ def passing_run(extra_args=None, port_obj=None, tests_included=False, host=None,
     if shared_port:
         port_obj.host.port_factory.get = lambda *args, **kwargs: port_obj
 
-    logging_stream = StringIO()
-    run_details = run_webkit_tests.run(port_obj, options, parsed_args, logging_stream=logging_stream)
+    with OutputCapture():
+        logging_stream = StringIO()
+        run_details = run_webkit_tests.run(port_obj, options, parsed_args, logging_stream=logging_stream)
     return run_details.exit_code == 0
 
 
@@ -1141,11 +1142,20 @@ class RunTest(unittest.TestCase, StreamTestingMixin):
         if not self.should_test_processes:
             return
 
+        import logging
         options, parsed_args = parse_args(['--verbose', '--fully-parallel', '--child-processes', '2', 'passes/text.html', 'passes/image.html'], tests_included=True, print_nothing=False)
         host = MockHost()
         port_obj = host.port_factory.get(port_name=options.platform, options=options)
         logging_stream = StringIO()
-        run_webkit_tests.run(port_obj, options, parsed_args, logging_stream=logging_stream)
+        # Suppress 'worker/N starting/stopping' messages from webkitcorepy.task_pool
+        # that would leak through message_pool's log forwarding to the parent process.
+        wkc_logger = logging.getLogger('webkitcorepy')
+        saved_level = wkc_logger.level
+        wkc_logger.setLevel(logging.WARNING)
+        try:
+            run_webkit_tests.run(port_obj, options, parsed_args, logging_stream=logging_stream)
+        finally:
+            wkc_logger.setLevel(saved_level)
         self.assertTrue('text.html passed' in logging_stream.getvalue())
         self.assertTrue('image.html passed' in logging_stream.getvalue())
 

--- a/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server_unittest.py
+++ b/Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server_unittest.py
@@ -26,6 +26,8 @@ import sys
 import time
 import unittest
 
+from webkitcorepy import OutputCapture
+
 from webkitpy.common.host_mock import MockHost
 from webkitpy.common.system.filesystem import FileSystem
 from webkitpy.port import Port
@@ -37,78 +39,82 @@ from webkitpy.layout_tests.servers.web_platform_test_server import WebPlatformTe
 
 class TestWebPlatformTestServer(unittest.TestCase):
     def test_previously_spawned_instance(self):
-        host = MockHost()
-        options = optparse.Values()
-        options.ensure_value("results_directory", "/mock/output_dir")
-        port = Port(host, "test", options)
-        server = WebPlatformTestServer(port, "wpttest", "/mock/output_dir/pid.txt")
-        server._check_that_all_ports_are_available = lambda: True
-        server._is_server_running_on_all_ports = lambda: True
-        host.filesystem.write_text_file("/mock-checkout/LayoutTests/resources/testharness.js", "0")
-        host.filesystem.write_text_file("/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js", "0")
+        with OutputCapture():
+            host = MockHost()
+            options = optparse.Values()
+            options.ensure_value("results_directory", "/mock/output_dir")
+            port = Port(host, "test", options)
+            server = WebPlatformTestServer(port, "wpttest", "/mock/output_dir/pid.txt")
+            server._check_that_all_ports_are_available = lambda: True
+            server._is_server_running_on_all_ports = lambda: True
+            host.filesystem.write_text_file("/mock-checkout/LayoutTests/resources/testharness.js", "0")
+            host.filesystem.write_text_file("/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js", "0")
 
-        host.filesystem.write_text_file("/mock_output_dir/pid.txt", "0")
-        server.start()
-        server.stop()
+            host.filesystem.write_text_file("/mock_output_dir/pid.txt", "0")
+            server.start()
+            server.stop()
 
     def test_custom_layout_tests_directory(self):
-        host = MockHost()
-        options = optparse.Values()
-        options.ensure_value("layout_tests_dir", "/mock-layout-tests-directory/LayoutTests")
-        options.ensure_value("results_directory", "/mock/output_dir")
-        port = Port(host, "test", options)
-        server = WebPlatformTestServer(port, "wpttest", "/mock/output_dir/pid.txt")
-        server._check_that_all_ports_are_available = lambda: True
-        server._is_server_running_on_all_ports = lambda: True
-        host.filesystem.write_text_file("/mock-layout-tests-directory/LayoutTests/resources/testharness.js", "0")
-        host.filesystem.write_text_file("/mock-layout-tests-directory/LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js", "0")
+        with OutputCapture():
+            host = MockHost()
+            options = optparse.Values()
+            options.ensure_value("layout_tests_dir", "/mock-layout-tests-directory/LayoutTests")
+            options.ensure_value("results_directory", "/mock/output_dir")
+            port = Port(host, "test", options)
+            server = WebPlatformTestServer(port, "wpttest", "/mock/output_dir/pid.txt")
+            server._check_that_all_ports_are_available = lambda: True
+            server._is_server_running_on_all_ports = lambda: True
+            host.filesystem.write_text_file("/mock-layout-tests-directory/LayoutTests/resources/testharness.js", "0")
+            host.filesystem.write_text_file("/mock-layout-tests-directory/LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js", "0")
 
-        host.filesystem.write_text_file("/mock_output_dir/pid.txt", "0")
-        server.start()
-        server.stop()
+            host.filesystem.write_text_file("/mock_output_dir/pid.txt", "0")
+            server.start()
+            server.stop()
 
     def test_corrupted_subserver_files(self):
-        host = MockHost()
-        options = optparse.Values()
-        options.ensure_value("results_directory", "/mock/output_dir")
-        port = Port(host, "test", options)
-        server = WebPlatformTestServer(port, "wpttest", "/mock/output_dir/pid.txt")
-        server._check_that_all_ports_are_available = lambda: True
-        server._is_server_running_on_all_ports = lambda: True
-        host.filesystem.write_text_file("/mock-checkout/LayoutTests/resources/testharness.js", "0")
-        host.filesystem.write_text_file("/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js", "0")
+        with OutputCapture():
+            host = MockHost()
+            options = optparse.Values()
+            options.ensure_value("results_directory", "/mock/output_dir")
+            port = Port(host, "test", options)
+            server = WebPlatformTestServer(port, "wpttest", "/mock/output_dir/pid.txt")
+            server._check_that_all_ports_are_available = lambda: True
+            server._is_server_running_on_all_ports = lambda: True
+            host.filesystem.write_text_file("/mock-checkout/LayoutTests/resources/testharness.js", "0")
+            host.filesystem.write_text_file("/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js", "0")
 
-        host.filesystem.write_text_file("/mock_output_dir/wpttest_servers.json", "0")
-        server.stop()
-        self.assertFalse(host.filesystem.exists("/mock/output_dir/wpttest_servers.json"))
+            host.filesystem.write_text_file("/mock_output_dir/wpttest_servers.json", "0")
+            server.stop()
+            self.assertFalse(host.filesystem.exists("/mock/output_dir/wpttest_servers.json"))
 
-        host.filesystem.write_text_file("/mock_output_dir/wpttest_servers.json", "[0,")
-        server.start()
-        self.assertFalse(host.filesystem.exists("/mock/output_dir/wpttest_servers.json"))
-        server.stop()
+            host.filesystem.write_text_file("/mock_output_dir/wpttest_servers.json", "[0,")
+            server.start()
+            self.assertFalse(host.filesystem.exists("/mock/output_dir/wpttest_servers.json"))
+            server.stop()
 
-        host.filesystem.write_text_file("/mock_output_dir/wpttest_servers.json", "[{'protocol': 'http', 'port': 80 }]")
-        server.start()
-        self.assertFalse(host.filesystem.exists("/mock/output_dir/wpttest_servers.json"))
-        server.stop()
+            host.filesystem.write_text_file("/mock_output_dir/wpttest_servers.json", "[{'protocol': 'http', 'port': 80 }]")
+            server.start()
+            self.assertFalse(host.filesystem.exists("/mock/output_dir/wpttest_servers.json"))
+            server.stop()
 
-        host.filesystem.write_text_file("/mock_output_dir/wpttest_servers.json", "[{'protocol': 'http', 'port': 80, 'pid': {} }]")
-        server.start()
-        self.assertFalse(host.filesystem.exists("/mock/output_dir/wpttest_servers.json"))
-        server.stop()
+            host.filesystem.write_text_file("/mock_output_dir/wpttest_servers.json", "[{'protocol': 'http', 'port': 80, 'pid': {} }]")
+            server.start()
+            self.assertFalse(host.filesystem.exists("/mock/output_dir/wpttest_servers.json"))
+            server.stop()
 
     def test_server_fails_to_start_throws_exception(self):
-        host = MockHost()
-        options = optparse.Values()
-        options.ensure_value("results_directory", "/mock/output_dir")
-        port = Port(host, "test", options)
-        server = WebPlatformTestServer(port, "wpttest", "/mock/output_dir/pid.txt")
-        server._check_that_all_ports_are_available = lambda: True
-        server._is_server_running_on_all_ports = lambda: True
-        host.filesystem.write_text_file("/mock-checkout/LayoutTests/resources/testharness.js", "0")
-        host.filesystem.write_text_file("/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js", "0")
+        with OutputCapture():
+            host = MockHost()
+            options = optparse.Values()
+            options.ensure_value("results_directory", "/mock/output_dir")
+            port = Port(host, "test", options)
+            server = WebPlatformTestServer(port, "wpttest", "/mock/output_dir/pid.txt")
+            server._check_that_all_ports_are_available = lambda: True
+            server._is_server_running_on_all_ports = lambda: True
+            host.filesystem.write_text_file("/mock-checkout/LayoutTests/resources/testharness.js", "0")
+            host.filesystem.write_text_file("/mock-checkout/LayoutTests/imported/w3c/web-platform-tests/resources/testharness.js", "0")
 
-        server.start()
-        server.stop()
-        server._process.poll = lambda: 1
-        self.assertRaises(ServerError, server.start)
+            server.start()
+            server.stop()
+            server._process.poll = lambda: 1
+            self.assertRaises(ServerError, server.start)


### PR DESCRIPTION
#### 7e0dbd20d0ae80dd6619aed2401ce8c217d1f06b
<pre>
[test-webkitpy] Capture excess logging in tests
<a href="https://rdar.apple.com/172338868">rdar://172338868</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309750">https://bugs.webkit.org/show_bug.cgi?id=309750</a>

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkout_unittest.py:
(CheckoutUnittest.test_json): Capture logging before instantiation the mock git repository.
(CheckoutUnittest.test_constructor_sentinal): Ditto.
(CheckoutUnittest.test_constructor_no_sentinal): Ditto.
* Tools/Scripts/libraries/reporelaypy/reporelaypy/tests/checkoutroute_unittest.py:
(CheckoutRouteUnittest.test_landing): Capture logging before instantiation the mock git repository.
(CheckoutRouteUnittest.test_json_details_origin): Ditto.
(CheckoutRouteUnittest.test_json_strip_details_non_origin_commits): Ditto.
(CheckoutRouteUnittest.test_json_invalid): Ditto.
(CheckoutRouteUnittest.test_redirect): Ditto.
(CheckoutRouteUnittest.test_invoked_redirect): Ditto.
(CheckoutRouteUnittest.test_trac): Ditto.
(CheckoutRouteUnittest.test_compare): Ditto.
(CheckoutRouteUnittest.test_compare_trac): Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:
(test_branches_for): Capture logging before instantiation the mock git repository.
* Tools/Scripts/webkitpy/common/net/bugzilla/bugzilla_unittest.py:
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests_integrationtest.py:
(passing_run): Capture logging with running tests.
(RunTest.test_verbose_in_child_processes): Ditto.
* Tools/Scripts/webkitpy/layout_tests/servers/web_platform_test_server_unittest.py:
(TestWebPlatformTestServer.test_previously_spawned_instance): Capture logs during test.
(TestWebPlatformTestServer.test_custom_layout_tests_directory): Ditto.
(TestWebPlatformTestServer.test_corrupted_subserver_files): Ditto.
(TestWebPlatformTestServer.test_server_fails_to_start_throws_exception): Ditto.

Canonical link: <a href="https://commits.webkit.org/309243@main">https://commits.webkit.org/309243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dfb90bd38e7e0cebb9e8763398054e8ae816891

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15939 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158344 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103073 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/495b5fdc-cf08-4e88-acd5-91e0fa8f6bf4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22810 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115432 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82057 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/718a7066-2355-4306-a0ba-e216eda08646) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17569 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134286 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96174 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/393e94ed-8936-4424-81ef-aae6bbda95c6) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/148962 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16666 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14572 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6189 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12217 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160821 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123463 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/149041 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123670 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22169 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134009 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78394 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23075 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18850 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10761 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21770 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21500 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21652 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21557 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->