### PR TITLE
RTCDataChannel needs to check for sctp buffered amount synchronously

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-array-buffer.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-array-buffer.window-expected.txt
@@ -1,9 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_unreached: channel1 must not dispatch error events: OperationError. Reached unreachable code
-
-TIMEOUT Datachannel should be able to send and receive all arraybuffer messages on close Test timed out
-
-Harness Error (FAIL), message = Error: assert_unreached: channel1 must not dispatch error events: OperationError. Reached unreachable code
-
-TIMEOUT Datachannel should be able to send and receive all arraybuffer messages on close Test timed out
+PASS Datachannel should be able to send and receive all arraybuffer messages on close
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-blob-negotiated.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-blob-negotiated.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Negotiated datachannel should be able to send and receive all blob messages on close assert_equals: All the pending sent messages are received after calling close() expected 20971520 but got 0
+PASS Negotiated datachannel should be able to send and receive all blob messages on close
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-blob.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-blob.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Datachannel should be able to send and receive all blob messages on close assert_equals: All the pending sent messages are received after calling close() expected 20971520 but got 0
+PASS Datachannel should be able to send and receive all blob messages on close
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-string-negotiated.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-string-negotiated.window-expected.txt
@@ -1,9 +1,3 @@
 
-Harness Error (FAIL), message = Error: assert_unreached: channel1 must not dispatch error events: OperationError. Reached unreachable code
-
-TIMEOUT Negotiated datachannel should be able to send and receive all string messages on close Test timed out
-
-Harness Error (FAIL), message = Error: assert_unreached: channel1 must not dispatch error events: OperationError. Reached unreachable code
-
-TIMEOUT Negotiated datachannel should be able to send and receive all string messages on close Test timed out
+PASS Negotiated datachannel should be able to send and receive all string messages on close
 

--- a/LayoutTests/webrtc/datachannel/bufferedAmount-afterClose.html
+++ b/LayoutTests/webrtc/datachannel/bufferedAmount-afterClose.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
   <head>
     <meta charset="utf-8">

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -72,9 +72,13 @@ Ref<RTCDataChannel> RTCDataChannel::create(ScriptExecutionContext& context, std:
 Ref<NetworkSendQueue> RTCDataChannel::createMessageQueue(ScriptExecutionContext& context, RTCDataChannel& channel)
 {
     return NetworkSendQueue::create(context, [&channel](auto& utf8) {
+        if (!channel.m_handler)
+            return;
         if (!channel.m_handler->sendStringData(utf8))
             protect(channel.scriptExecutionContext())->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "Error sending string through RTCDataChannel."_s);
     }, [&channel](auto span) {
+        if (!channel.m_handler)
+            return;
         if (!channel.m_handler->sendRawData(span))
             protect(channel.scriptExecutionContext())->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "Error sending binary data through RTCDataChannel."_s);
     }, [&channel](ExceptionCode errorCode) {
@@ -113,6 +117,23 @@ void RTCDataChannel::setBinaryType(BinaryType binaryType)
     m_binaryType = binaryType;
 }
 
+static size_t maxSctpSendQueueSize()
+{
+    // This mirrors webrtc::DataChannelInterface::MaxSendQueueSize()
+    return 16 * 1024 * 1024;
+}
+
+static std::optional<size_t> computeNewBufferedAmount(size_t bufferedAmount, size_t dataSize)
+{
+    if (!WTF::safeAdd(bufferedAmount, dataSize, bufferedAmount))
+        return { };
+
+    if (bufferedAmount > maxSctpSendQueueSize())
+        return { };
+
+    return bufferedAmount;
+}
+
 ExceptionOr<void> RTCDataChannel::send(const String& data)
 {
     if (m_readyState != RTCDataChannelState::Open)
@@ -120,7 +141,12 @@ ExceptionOr<void> RTCDataChannel::send(const String& data)
 
     // FIXME: We might want to use strict conversion like WebSocket.
     auto utf8 = data.utf8();
-    m_bufferedAmount += utf8.length();
+
+    auto newBufferedAmount = computeNewBufferedAmount(m_bufferedAmount, utf8.length());
+    if (!newBufferedAmount)
+        return Exception { ExceptionCode::OperationError, "Trying to send too much data"_s };
+
+    m_bufferedAmount = *newBufferedAmount;
     m_messageQueue->enqueue(WTF::move(utf8));
     return { };
 }
@@ -130,7 +156,11 @@ ExceptionOr<void> RTCDataChannel::send(ArrayBuffer& data)
     if (m_readyState != RTCDataChannelState::Open)
         return Exception { ExceptionCode::InvalidStateError };
 
-    m_bufferedAmount += data.byteLength();
+    auto newBufferedAmount = computeNewBufferedAmount(m_bufferedAmount, data.byteLength());
+    if (!newBufferedAmount)
+        return Exception { ExceptionCode::OperationError, "Trying to send too much data"_s };
+
+    m_bufferedAmount = *newBufferedAmount;
     m_messageQueue->enqueue(data, 0, data.byteLength());
     return { };
 }
@@ -140,7 +170,11 @@ ExceptionOr<void> RTCDataChannel::send(ArrayBufferView& data)
     if (m_readyState != RTCDataChannelState::Open)
         return Exception { ExceptionCode::InvalidStateError };
 
-    m_bufferedAmount += data.byteLength();
+    auto newBufferedAmount = computeNewBufferedAmount(m_bufferedAmount, data.byteLength());
+    if (!newBufferedAmount)
+        return Exception { ExceptionCode::OperationError, "Trying to send too much data"_s };
+
+    m_bufferedAmount = *newBufferedAmount;
     m_messageQueue->enqueue(*data.unsharedBuffer(), data.byteOffset(), data.byteLength());
     return { };
 }
@@ -150,7 +184,11 @@ ExceptionOr<void> RTCDataChannel::send(Blob& blob)
     if (m_readyState != RTCDataChannelState::Open)
         return Exception { ExceptionCode::InvalidStateError };
 
-    m_bufferedAmount += blob.size();
+    auto newBufferedAmount = computeNewBufferedAmount(m_bufferedAmount, blob.size());
+    if (!newBufferedAmount)
+        return Exception { ExceptionCode::OperationError, "Trying to send too much data"_s };
+
+    m_bufferedAmount = *newBufferedAmount;
     m_messageQueue->enqueue(blob);
     return { };
 }
@@ -165,10 +203,10 @@ void RTCDataChannel::close()
 
     m_readyState = RTCDataChannelState::Closing;
 
-    m_messageQueue->clear();
-
-    if (m_handler)
-        m_handler->close();
+    m_messageQueue->whenEmpty([protectedThis = Ref { *this }] {
+        if (protectedThis->m_handler)
+            protectedThis->m_handler->close();
+    });
 }
 
 bool RTCDataChannel::virtualHasPendingActivity() const
@@ -246,6 +284,8 @@ void RTCDataChannel::stop()
     removeFromDataChannelLocalMapIfNeeded();
 
     id();
+
+    m_messageQueue->clear();
     close();
     m_stopped = true;
     m_handler = nullptr;

--- a/Source/WebCore/fileapi/NetworkSendQueue.cpp
+++ b/Source/WebCore/fileapi/NetworkSendQueue.cpp
@@ -91,6 +91,16 @@ void NetworkSendQueue::clear()
     m_queue.clear();
 }
 
+void NetworkSendQueue::whenEmpty(Function<void()>&& callback)
+{
+    if (m_queue.isEmpty()) {
+        callback();
+        return;
+    }
+
+    m_emptyCallback = WTF::move(callback);
+}
+
 void NetworkSendQueue::processMessages()
 {
     while (!m_queue.isEmpty()) {
@@ -118,6 +128,8 @@ void NetworkSendQueue::processMessages()
         m_queue.removeFirst();
     }
 
+    if (auto callback = std::exchange(m_emptyCallback, { }))
+        callback();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/fileapi/NetworkSendQueue.h
+++ b/Source/WebCore/fileapi/NetworkSendQueue.h
@@ -64,6 +64,8 @@ public:
 
     void clear();
 
+    void whenEmpty(Function<void()>&&);
+
 private:
     NetworkSendQueue(ScriptExecutionContext&, WriteString&&, WriteRawData&&, ProcessError&&);
 
@@ -75,6 +77,7 @@ private:
     WriteString m_writeString;
     WriteRawData m_writeRawData;
     ProcessError m_processError;
+    Function<void()> m_emptyCallback;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 0ae47105d8750308a75b7a4ca05276cc4dae3e04
<pre>
RTCDataChannel needs to check for sctp buffered amount synchronously
<a href="https://rdar.apple.com/172386678">rdar://172386678</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309792">https://bugs.webkit.org/show_bug.cgi?id=309792</a>

Reviewed by Jean-Yves Avenard.

We align with chromium&apos;s approach and check synchronously the buffered amount, which is also specified in <a href="https://w3c.github.io/webrtc-pc/#datachannel-send">https://w3c.github.io/webrtc-pc/#datachannel-send</a> step 6.
We use libwebrtc max buffer size.
To ensure blobs are sent while buffered, we add a way for NetworkSendQueue to let us know when the queue is empty. We then close the data channel at that time.

We make sure to clear the message queue in stop, since at that time, no datq should be sent.
We add nullptr checks in NetworkSendQueue::create write callbacks for additionaly safety.

Covered by rebased WPT tests.
We update webrtc/datachannel/bufferedAmount-afterClose.html as we no longer clear the queue when closing the data channel to allow blob sending.
In case peer connection gets closed while blob sending is in flux, sending of the blob might fail, which can trigger a console message.
We add dumpJSConsoleLogInStdErr to ensure that this does not disturb the test.

Canonical link: <a href="https://commits.webkit.org/309322@main">https://commits.webkit.org/309322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23a62d2b996304fd06d9d865b1ff71a07308b6bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159018 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103738 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2fcd8508-fd36-437c-b4cb-b4889c99a1b0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115962 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82400 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb9948e5-ace3-473c-be72-8d6ac6241fb1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96694 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4649b3cc-7d09-4726-9f1e-1989568f46c3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17176 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15117 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6863 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161492 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4620 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14310 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123964 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22864 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19164 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124168 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33711 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22851 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134552 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79218 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19292 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11309 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22464 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86264 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22178 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22330 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22232 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->