### PR TITLE
Test for StabilityTracer: com.apple.WebKit.WebContent at com.apple.WebCore:  WebCore::WorkerOrWorkletGlobalScope::vm

### DIFF
--- a/Tools/TestWebKitAPI/Scripts/generate-unified-sources.sh
+++ b/Tools/TestWebKitAPI/Scripts/generate-unified-sources.sh
@@ -17,7 +17,7 @@ fi
 UnifiedSourceCppFileCount=5
 UnifiedSourceCFileCount=0
 UnifiedSourceMmFileCount=0
-UnifiedSourceNonARCMmFileCount=50
+UnifiedSourceNonARCMmFileCount=51
 
 if [ $# -eq 0 ]; then
     echo "Using unified source list files: Sources.txt, SourcesCocoa.txt"

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -268,6 +268,7 @@ Tests/WebKitCocoa/ScreenWakeLock.mm @nonARC
 Tests/WebKitCocoa/SerializedNode.mm @nonARC
 Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm @nonARC
 Tests/WebKitCocoa/ServiceWorkerBasic.mm @nonARC
+Tests/WebKitCocoa/ServiceWorkerModuleUnregisterDuringLoad.mm @nonARC
 Tests/WebKitCocoa/SessionStorage.mm @nonARC
 Tests/WebKitCocoa/ShouldGoToBackForwardListItem.mm @nonARC
 Tests/WebKitCocoa/ShouldOpenExternalURLsInNewWindowActions.mm @nonARC

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		5CA1DEC81F71F70100E71BD3 /* HTTPHeaderField.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5CA1DEC71F71F40700E71BD3 /* HTTPHeaderField.cpp */; };
 		5CABDBBF2735C9BD00B88BCB /* UnifiedSource16-nonARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CABDB922735C9BA00B88BCB /* UnifiedSource16-nonARC.mm */; };
 		5CABDBC02735C9BD00B88BCB /* UnifiedSource50-nonARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CABDB932735C9BA00B88BCB /* UnifiedSource50-nonARC.mm */; };
+		5CABDBC22735C9BE00B88BC0 /* UnifiedSource51-nonARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CABDB952735C9BB00B88BC0 /* UnifiedSource51-nonARC.mm */; };
 		5CABDBC12735C9BD00B88BCB /* UnifiedSource49-nonARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CABDB942735C9BA00B88BCB /* UnifiedSource49-nonARC.mm */; };
 		5CABDBC22735C9BD00B88BCB /* UnifiedSource40-nonARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CABDB952735C9BA00B88BCB /* UnifiedSource40-nonARC.mm */; };
 		5CABDBC32735C9BD00B88BCB /* UnifiedSource7-nonARC.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5CABDB962735C9BA00B88BCB /* UnifiedSource7-nonARC.mm */; };
@@ -3137,6 +3138,7 @@
 		51EB126124CA6B5F000CB030 /* SteelSeriesNimbus.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SteelSeriesNimbus.mm; sourceTree = "<group>"; };
 		51EB126624CB8493000CB030 /* SunLightApplicationGenericNES.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SunLightApplicationGenericNES.mm; sourceTree = "<group>"; };
 		51EB12931FDF050500A5A1BD /* ServiceWorkerBasic.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ServiceWorkerBasic.mm; sourceTree = "<group>"; };
+		51EB12942FDA134640814000 /* ServiceWorkerModuleUnregisterDuringLoad.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ServiceWorkerModuleUnregisterDuringLoad.mm; sourceTree = "<group>"; };
 		51FA14302AF5BAE00003ACD1 /* IPCSerialization.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = IPCSerialization.mm; sourceTree = "<group>"; };
 		51FBBB4C1513D4E900822738 /* WebViewCanPasteURL.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebViewCanPasteURL.mm; sourceTree = "<group>"; };
 		520BCF4A141EB09E00937EA8 /* WebArchive_Bundle.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebArchive_Bundle.cpp; sourceTree = "<group>"; };
@@ -3304,6 +3306,7 @@
 		5CA985512113CB8C0057EB6B /* SafeBrowsing.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = SafeBrowsing.mm; sourceTree = "<group>"; };
 		5CABDB922735C9BA00B88BCB /* UnifiedSource16-nonARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UnifiedSource16-nonARC.mm"; sourceTree = "<group>"; };
 		5CABDB932735C9BA00B88BCB /* UnifiedSource50-nonARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UnifiedSource50-nonARC.mm"; sourceTree = "<group>"; };
+		5CABDB952735C9BB00B88BC0 /* UnifiedSource51-nonARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UnifiedSource51-nonARC.mm"; sourceTree = "<group>"; };
 		5CABDB942735C9BA00B88BCB /* UnifiedSource49-nonARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UnifiedSource49-nonARC.mm"; sourceTree = "<group>"; };
 		5CABDB952735C9BA00B88BCB /* UnifiedSource40-nonARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UnifiedSource40-nonARC.mm"; sourceTree = "<group>"; };
 		5CABDB962735C9BA00B88BCB /* UnifiedSource7-nonARC.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = "UnifiedSource7-nonARC.mm"; sourceTree = "<group>"; };
@@ -5158,6 +5161,7 @@
 				F4AF63B32C990A47001D782B /* ScriptTrackingPrivacyTests.mm */,
 				FAD420BF2E4AB7AA00069B2E /* SerializedNode.mm */,
 				51EB12931FDF050500A5A1BD /* ServiceWorkerBasic.mm */,
+				51EB12942FDA134640814000 /* ServiceWorkerModuleUnregisterDuringLoad.mm */,
 				466AF38826FE393200CE2EB8 /* ServiceWorkerPagePlugIn.mm */,
 				460C2FC827039D7D0047EF11 /* ServiceWorkerPageProtocol.h */,
 				46A46A192575645600A1B118 /* SessionStorage.mm */,
@@ -5561,6 +5565,7 @@
 				5CABDBA52735C9BB00B88BCB /* UnifiedSource48-nonARC.mm */,
 				5CABDB942735C9BA00B88BCB /* UnifiedSource49-nonARC.mm */,
 				5CABDB932735C9BA00B88BCB /* UnifiedSource50-nonARC.mm */,
+				5CABDB952735C9BB00B88BC0 /* UnifiedSource51-nonARC.mm */,
 			);
 			path = "unified-sources";
 			sourceTree = "<group>";
@@ -8322,6 +8327,7 @@
 				5CABDBD22735C9BD00B88BCB /* UnifiedSource48-nonARC.mm in Sources */,
 				5CABDBC12735C9BD00B88BCB /* UnifiedSource49-nonARC.mm in Sources */,
 				5CABDBC02735C9BD00B88BCB /* UnifiedSource50-nonARC.mm in Sources */,
+				5CABDBC22735C9BE00B88BC0 /* UnifiedSource51-nonARC.mm in Sources */,
 				5C6E27A7224EEBEA00128736 /* URLExtras.mm in Sources */,
 				E3A1E77F21B25B39008C6007 /* URLParserTextEncoding.cpp in Sources */,
 				7CCE7F2D1A411B1000447C4C /* UserContentTest.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerModuleUnregisterDuringLoad.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerModuleUnregisterDuringLoad.mm
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Test for rdar://134640814 / https://bugs.webkit.org/show_bug.cgi?id=309182
+// Verifies that stopping a module service worker while it is still loading
+// does not crash the WebContent process. The bug was that WorkerMainRunLoop::runInMode()
+// unconditionally returned true, so loadModuleSynchronously() continued to call
+// performMicrotaskCheckpoint() after the worker's m_script had been cleared.
+
+#import "config.h"
+
+#import "HTTPServer.h"
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/WKWebsiteDataStorePrivate.h>
+#import <WebKit/_WKWebsiteDataStoreConfiguration.h>
+#import <wtf/RetainPtr.h>
+
+// The module service worker script imports a dependency that will never finish loading.
+static constexpr auto swModuleScript = R"SWRESOURCE(
+import './slow-dep.mjs';
+)SWRESOURCE"_s;
+
+TEST(ServiceWorkers, ModuleUnregisterDuringLoadNoMainThreadCrash)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/sw-module.mjs"_s, { { { "Content-Type"_s, "application/javascript"_s } }, swModuleScript } },
+        // The dependency never responds, keeping the module load pending.
+        { "/slow-dep.mjs"_s, { TestWebKitAPI::HTTPResponse::Behavior::NeverSendResponse } },
+    });
+
+    [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
+
+    auto storeConfiguration = adoptNS([_WKWebsiteDataStoreConfiguration new]);
+    auto dataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:storeConfiguration.get()]);
+
+    // Start with a clean slate data store.
+    __block bool cleanDone = false;
+    [dataStore removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^{
+        cleanDone = true;
+    }];
+    TestWebKitAPI::Util::run(&cleanDone);
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setWebsiteDataStore:dataStore.get()];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    // Use _loadServiceWorker:usingModules: to exercise the production code path
+    // (used by Web Extensions / Safari) where the service worker runs on the main
+    // thread via WorkerMainRunLoop, triggered by serviceWorkerPageIdentifier.
+    //
+    // We cannot wait for the completion handler because for main-thread module workers,
+    // evaluateScriptIfNecessary() calls loadModuleSynchronously() synchronously, which
+    // blocks until the module graph is loaded. Since slow-dep.mjs never responds,
+    // the evaluate callback never fires and the registration never completes.
+    [webView _loadServiceWorker:server.request("/sw-module.mjs"_s).URL usingModules:YES completionHandler:^(BOOL) { }];
+
+    // Wait until the server receives the request for /slow-dep.mjs. At this point the
+    // worker is confirmed to be inside loadModuleSynchronously(), spinning
+    // RunLoop::main().cycle() waiting for the module dependency to load.
+    // Request 1 = /sw-module.mjs, request 2 = /slow-dep.mjs.
+    EXPECT_TRUE(TestWebKitAPI::Util::waitFor([&] {
+        return server.totalRequests() >= 2;
+    }));
+
+    // Closing the view removes the service worker page client, which triggers
+    // the registration to be cleared and the worker to be stopped while the
+    // module is still loading. The stop task is dispatched to the main run loop
+    // and picked up by loadModuleSynchronously()'s RunLoop::main().cycle() call.
+    //
+    // If the bug were present (WorkerMainRunLoop::runInMode() unconditionally
+    // returning true), the WebContent process would crash with SIGSEGV at
+    // address 0x8 when performMicrotaskCheckpoint() called vm() on a null m_script.
+    [webView _close];
+    webView = nil;
+
+    // Spin the run loop to allow the close to propagate through IPC and any
+    // crash to manifest.
+    TestWebKitAPI::Util::spinRunLoop(100);
+}

--- a/Tools/TestWebKitAPI/UnifiedSources-output.xcfilelist
+++ b/Tools/TestWebKitAPI/UnifiedSources-output.xcfilelist
@@ -50,6 +50,7 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource5-nonARC.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource5.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource50-nonARC.mm
+$(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource51-nonARC.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource6-nonARC.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource7-nonARC.mm
 $(BUILT_PRODUCTS_DIR)/DerivedSources/TestWebKitAPI/unified-sources/UnifiedSource8-nonARC.mm


### PR DESCRIPTION
#### f5fbe84ff5650f4512bfef039cbabbe3a350789c
<pre>
Test for StabilityTracer: com.apple.WebKit.WebContent at com.apple.WebCore:  WebCore::WorkerOrWorkletGlobalScope::vm
<a href="https://rdar.apple.com/134640814">rdar://134640814</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309789">https://bugs.webkit.org/show_bug.cgi?id=309789</a>

Reviewed by David Kilzer and Chris Dumez.

Add a test that exercises the production code path where a module service
worker runs on the main thread via WorkerMainRunLoop (triggered by
serviceWorkerPageIdentifier, as used by Web Extensions / Safari). The test
registers a module service worker whose dependency never finishes loading,
then closes the web view to stop the worker while loadModuleSynchronously()
is still spinning RunLoop::main().cycle(). Without the fix in
WorkerMainRunLoop::runInMode() (returning !terminated() instead of true),
this causes a null dereference crash when performMicrotaskCheckpoint() calls
vm() on a cleared m_script.

Test case and analysis assisted by AI.

* Tools/TestWebKitAPI/Scripts/generate-unified-sources.sh:
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerModuleUnregisterDuringLoad.mm: Added.
(ModuleUnregisterDuringLoadNoMainThreadCrash)):
* Tools/TestWebKitAPI/UnifiedSources-output.xcfilelist:

Canonical link: <a href="https://commits.webkit.org/309193@main">https://commits.webkit.org/309193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7768f9f0d37308a788caa092a007ea053e62bf21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149730 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16029 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158434 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103162 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/18be0140-926c-4882-b8b8-1f7bba38a83a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151603 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22899 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115500 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82102 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/381ee424-8e09-43ef-bbb8-e74a973d3f50) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152690 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17626 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134361 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96241 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5abe3fc6-421a-4a2f-9c27-aa2490e44c06) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16722 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14641 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6281 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126330 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160912 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13834 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123527 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18682 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123733 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33624 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134085 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78483 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18898 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10836 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21859 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21589 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21741 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21646 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->