### PR TITLE
Begin tracking scrollbar changes in subtree for intrinsically sized renderers.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  background-color: green;
+  width: max-content;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  background-color: green;
+  width: max-content;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="/299   max-width-container-with-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  background-color: green;
+  width: max-content;
+}
+.parent {
+  height: 79px;
+  overflow: auto;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3036,6 +3036,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/RenderView.h
     rendering/RenderWidget.h
     rendering/RepaintRectCalculation.h
+    rendering/SubtreeScrollbarChangesState.h
+
     rendering/TextBoxSelectableRange.h
     rendering/TransformOperationData.h
     rendering/VisibleRectContext.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3008,6 +3008,7 @@ rendering/RenderVideo.cpp
 rendering/RenderView.cpp
 rendering/RenderViewTransitionCapture.cpp
 rendering/RenderWidget.cpp
+rendering/SubtreeScrollbarChangesState.cpp
 rendering/StyledMarkedText.cpp
 rendering/TableLayout.cpp
 rendering/TextBoxPainter.cpp

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -158,6 +158,11 @@ LocalFrameViewLayoutContext::LocalFrameViewLayoutContext(LocalFrameView& frameVi
 
 LocalFrameViewLayoutContext::~LocalFrameViewLayoutContext() = default;
 
+void LocalFrameViewLayoutContext::setSubtreeScrollbarChangesState(std::optional<SubtreeScrollbarChangesState> state)
+{
+    m_subtreeScrollbarChangesState = state;
+}
+
 UpdateScrollInfoAfterLayoutTransaction& LocalFrameViewLayoutContext::updateScrollInfoAfterLayoutTransaction()
 {
     if (!m_updateScrollInfoAfterLayoutTransaction)

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -28,6 +28,7 @@
 #include <WebCore/AnchorPositionEvaluator.h>
 #include <WebCore/LayoutUnit.h>
 #include <WebCore/RenderLayerModelObject.h>
+#include <WebCore/SubtreeScrollbarChangesState.h>
 #include <WebCore/Timer.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/SegmentedVector.h>
@@ -157,6 +158,10 @@ public:
 #endif
     using LayoutStateStack = Vector<std::unique_ptr<RenderLayoutState>>;
 
+    std::optional<SubtreeScrollbarChangesState>& subtreeScrollbarChangesState() { return m_subtreeScrollbarChangesState; }
+    const std::optional<SubtreeScrollbarChangesState>& subtreeScrollbarChangesState() const { return m_subtreeScrollbarChangesState; }
+    void setSubtreeScrollbarChangesState(std::optional<SubtreeScrollbarChangesState>);
+
     UpdateScrollInfoAfterLayoutTransaction& updateScrollInfoAfterLayoutTransaction() LIFETIME_BOUND;
     UpdateScrollInfoAfterLayoutTransaction* NODELETE updateScrollInfoAfterLayoutTransactionIfExists() LIFETIME_BOUND { return m_updateScrollInfoAfterLayoutTransaction.get(); }
     void setBoxNeedsTransformUpdateAfterContainerLayout(RenderBox&, RenderBlock& container);
@@ -274,6 +279,7 @@ private:
     SingleThreadWeakHashSet<RenderBox> m_percentHeightIgnoreList;
     Vector<AnchorScrollAdjuster> m_anchorScrollAdjusters;
     std::optional<TextBoxTrim> m_textBoxTrim;
+    std::optional<SubtreeScrollbarChangesState> m_subtreeScrollbarChangesState;
 
     struct UpdateLayerPositions {
         void merge(const UpdateLayerPositions& other)

--- a/Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp
+++ b/Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp
@@ -55,6 +55,10 @@ RelayoutScopeForScrollbarChange::~RelayoutScopeForScrollbarChange()
 
     if (m_renderBlock->style().overflowX() == Overflow::Auto || m_renderBlock->style().overflowY() == Overflow::Auto) {
         if (m_inOverflowRelayout == InOverflowRelayout::No) {
+            if (auto& subtreeScrollbarChangesState = m_renderBlock->layoutContext().subtreeScrollbarChangesState()) {
+                subtreeScrollbarChangesState->renderersWithScrollbarChange.add(m_renderBlock);
+                return;
+            }
             m_renderBlock->setNeedsLayout(MarkingBehavior::MarkOnlyThis);
             auto scope = LayoutScope { m_renderBlock.get(), InOverflowRelayout::Yes };
             m_renderBlock->scrollbarsChanged(scrollbarChanges.contains(ScrollbarChange::AutoHorizontalScrollbarChanged), scrollbarChanges.contains(ScrollbarChange::AutoVerticalScrollBarChanged));

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -511,16 +511,38 @@ std::optional<ScrollbarUpdateScope> RenderBlock::updateScrollInfoAfterLayout()
     return { };
 }
 
+static bool needsToTrackDescendantScrollbarChanges(const RenderBlock& renderBlock, const LocalFrameViewLayoutContext& layoutContext)
+{
+    auto computedLogicalWidth = renderBlock.style().logicalWidth();
+    return computedLogicalWidth.isIntrinsic() && !layoutContext.subtreeScrollbarChangesState();
+}
+
+static bool canContainDescendantScrollbarChanges(const RenderBlock& renderBlock, const LocalFrameViewLayoutContext& layoutContext)
+{
+    return layoutContext.subtreeScrollbarChangesState().has_value() && renderBlock.style().logicalWidth().isFixed();
+}
+
 void RenderBlock::layout()
 {
     StackStats::LayoutCheckPoint layoutCheckPoint;
 
+    auto& layoutContext = this->layoutContext();
+
     // Table cells call layoutBlock directly, so don't add any logic here. Put code into layoutBlock().
     {
+        std::optional<SubtreeScrollbarChangesStateScope> subtreeScrollbarChangesStateScope;
+        if (needsToTrackDescendantScrollbarChanges(*this, layoutContext))
+            subtreeScrollbarChangesStateScope.emplace(layoutContext, *this);
+
+        bool willHandleDescendantScrollbarChanges = subtreeScrollbarChangesStateScope.has_value() || canContainDescendantScrollbarChanges(*this, layoutContext);
         auto scope = LayoutScope { *this };
-        layoutBlock(RelayoutChildren::No);
+        if (willHandleDescendantScrollbarChanges) {
+            SubtreeScrollbarChangesHandler descendantScrollbarChangesHandler(*this);
+            layoutBlock(RelayoutChildren::No);
+        } else
+            layoutBlock(RelayoutChildren::No);
     }
-    
+
     // It's safe to check for control clip here, since controls can never be table cells.
     // If we have a lightweight clip, there can never be any overflow from children.
     if (hasControlClip() && m_overflow && !isDelayingUpdateScrollInfoAfterLayout(*this))

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -653,8 +653,10 @@ RenderElement* RenderObject::markContainingBlocksForLayout(RenderElement* layout
     return { };
 }
 
-void RenderObject::setNeedsPreferredWidthsUpdate(MarkingBehavior markParents)
+void RenderObject::setNeedsPreferredWidthsUpdate(MarkingBehavior markParents, const RenderBlock* ancestorUpdateBoundary)
 {
+    ASSERT_IMPLIES(ancestorUpdateBoundary, markParents == MarkingBehavior::MarkContainingBlockChain);
+
     if (needsPreferredLogicalWidthsUpdate() && (!hasRareData() || !rareData().preferredLogicalWidthsNeedUpdateIsMarkOnlyThis)) {
         // Both this and our ancestor chain are already marked dirty.
         return;
@@ -671,17 +673,19 @@ void RenderObject::setNeedsPreferredWidthsUpdate(MarkingBehavior markParents)
         return;
     }
 
-    invalidateContainerPreferredLogicalWidths();
+    invalidateContainerPreferredLogicalWidths(ancestorUpdateBoundary);
     if (hasRareData())
         ensureRareData().preferredLogicalWidthsNeedUpdateIsMarkOnlyThis = false;
 }
 
-void RenderObject::invalidateContainerPreferredLogicalWidths()
+void RenderObject::invalidateContainerPreferredLogicalWidths(const RenderBlock* ancestorUpdateBoundary)
 {
     // In order to avoid pathological behavior when inlines are deeply nested, we do include them
     // in the chain that we mark dirty (even though they're kind of irrelevant).
     CheckedPtr ancestor = isRenderTableCell() ? containingBlock() : container();
     while (ancestor) {
+        if (ancestor.get() == ancestorUpdateBoundary)
+            break;
         if (ancestor->needsPreferredLogicalWidthsUpdate() && (!ancestor->hasRareData() || !ancestor->rareData().preferredLogicalWidthsNeedUpdateIsMarkOnlyThis))
             break;
         // Don't invalidate the outermost object of an unrooted subtree. That object will be

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -758,7 +758,7 @@ public:
     inline void setNeedsLayout(MarkingBehavior = MarkingBehavior::MarkContainingBlockChain);
     enum class HadSkippedLayout { No, Yes };
     void clearNeedsLayout(HadSkippedLayout = HadSkippedLayout::No);
-    void setNeedsPreferredWidthsUpdate(MarkingBehavior = MarkingBehavior::MarkContainingBlockChain);
+    void setNeedsPreferredWidthsUpdate(MarkingBehavior = MarkingBehavior::MarkContainingBlockChain, const RenderBlock* ancestorUpdateBoundary = nullptr);
     void clearNeedsPreferredWidthsUpdate() { m_stateBitfields.setFlag(StateFlag::PreferredLogicalWidthsNeedUpdate, { }); }
     
     inline void setNeedsLayoutAndPreferredWidthsUpdate();
@@ -1163,7 +1163,7 @@ private:
     void NODELETE setLayerNeedsFullRepaint();
     void NODELETE setLayerNeedsFullRepaintForOutOfFlowMovementLayout();
 
-    void invalidateContainerPreferredLogicalWidths();
+    void invalidateContainerPreferredLogicalWidths(const RenderBlock* ancestorUpdateBoundary = nullptr);
 
     struct SelectionGeometriesInternal {
         Vector<SelectionGeometry> geometries;

--- a/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
+++ b/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SubtreeScrollbarChangesState.h"
+
+#include "LayoutScope.h"
+#include "LocalFrameViewLayoutContext.h"
+#include "RenderBlock.h"
+
+#include <wtf/Scope.h>
+
+namespace WebCore {
+
+SubtreeScrollbarChangesStateScope::SubtreeScrollbarChangesStateScope(LocalFrameViewLayoutContext& layoutContext, RenderBlock& subtreeRoot)
+    : m_layoutContext(layoutContext)
+{
+    layoutContext.setSubtreeScrollbarChangesState(SubtreeScrollbarChangesState { subtreeRoot, { } });
+}
+
+SubtreeScrollbarChangesStateScope::~SubtreeScrollbarChangesStateScope()
+{
+    m_layoutContext->setSubtreeScrollbarChangesState({ });
+}
+
+SubtreeScrollbarChangesHandler::SubtreeScrollbarChangesHandler(RenderBlock& rendererHandlingScrollbarChanges)
+    : m_rendererHandlingScrollbarChanges(rendererHandlingScrollbarChanges)
+{
+    CheckedRef layoutContext = rendererHandlingScrollbarChanges.layoutContext();
+
+    auto& subtreeScrollbarChangesState = layoutContext->subtreeScrollbarChangesState();
+    ASSERT(subtreeScrollbarChangesState);
+    if (!subtreeScrollbarChangesState)
+        return;
+
+    bool isSubtreeRootHandlingScrollbarChanges = subtreeScrollbarChangesState->subtreeRoot.ptr() == &rendererHandlingScrollbarChanges;
+    if (!isSubtreeRootHandlingScrollbarChanges) {
+        m_renderersWithScrollbarChangesHandledByAncestor = WTF::move(subtreeScrollbarChangesState->renderersWithScrollbarChange);
+        layoutContext->setSubtreeScrollbarChangesState(SubtreeScrollbarChangesState { subtreeScrollbarChangesState->subtreeRoot, { } });
+    }
+}
+
+SubtreeScrollbarChangesHandler::~SubtreeScrollbarChangesHandler()
+{
+    CheckedRef layoutContext = m_rendererHandlingScrollbarChanges->layoutContext();
+
+    auto& subtreeScrollbarChangesState = layoutContext->subtreeScrollbarChangesState();
+    bool isSubtreeRootHandlingScrollbarChanges = subtreeScrollbarChangesState->subtreeRoot.ptr() == m_rendererHandlingScrollbarChanges.ptr();
+
+    auto descendantsWithScrollbarChange = WTF::move(subtreeScrollbarChangesState->renderersWithScrollbarChange);
+    auto restoreRenderersWithScrollbarChanges = makeScopeExit([&]() {
+        subtreeScrollbarChangesState->renderersWithScrollbarChange = WTF::move(m_renderersWithScrollbarChangesHandledByAncestor);
+        ASSERT(descendantsWithScrollbarChange.isEmpty());
+    });
+
+    if (descendantsWithScrollbarChange.isEmpty())
+        return;
+
+    if (!isSubtreeRootHandlingScrollbarChanges) {
+        while (!descendantsWithScrollbarChange.isEmpty()) {
+            CheckedPtr rendererWithScrollbarChange = descendantsWithScrollbarChange.takeFirst();
+            auto scope = LayoutScope { *rendererWithScrollbarChange };
+            rendererWithScrollbarChange->setNeedsLayout(MarkingBehavior::MarkOnlyThis);
+            rendererWithScrollbarChange->layoutBlock(RelayoutChildren::Yes);
+        }
+        return;
+    }
+
+    auto& subtreeRoot = subtreeScrollbarChangesState->subtreeRoot;
+    while (!descendantsWithScrollbarChange.isEmpty()) {
+        CheckedPtr rendererWithScrollbarChange = descendantsWithScrollbarChange.takeFirst();
+        rendererWithScrollbarChange->setNeedsPreferredWidthsUpdate(MarkingBehavior::MarkContainingBlockChain, subtreeRoot.ptr());
+    }
+
+    auto scope = LayoutScope { subtreeRoot };
+    subtreeRoot->setNeedsLayout(MarkingBehavior::MarkOnlyThis);
+    subtreeRoot->layoutBlock(RelayoutChildren::Yes);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/SubtreeScrollbarChangesState.h
+++ b/Source/WebCore/rendering/SubtreeScrollbarChangesState.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/CheckedRef.h>
+#include <wtf/ListHashSet.h>
+
+namespace WebCore {
+
+class RenderBlock;
+
+struct SubtreeScrollbarChangesState {
+    CheckedRef<RenderBlock> subtreeRoot;
+    ListHashSet<CheckedRef<RenderBlock>> renderersWithScrollbarChange;
+};
+
+class LocalFrameViewLayoutContext;
+
+class SubtreeScrollbarChangesStateScope {
+    WTF_MAKE_NONCOPYABLE(SubtreeScrollbarChangesStateScope);
+public:
+    SubtreeScrollbarChangesStateScope(LocalFrameViewLayoutContext&, RenderBlock& subtreeRoot);
+    ~SubtreeScrollbarChangesStateScope();
+private:
+    const CheckedRef<LocalFrameViewLayoutContext> m_layoutContext;
+};
+
+class SubtreeScrollbarChangesHandler {
+public:
+    SubtreeScrollbarChangesHandler(RenderBlock&);
+    ~SubtreeScrollbarChangesHandler();
+private:
+    const CheckedRef<RenderBlock> m_rendererHandlingScrollbarChanges;
+    ListHashSet<CheckedRef<RenderBlock>> m_renderersWithScrollbarChangesHandledByAncestor;
+};
+
+} // namespace WebCore


### PR DESCRIPTION
#### 9cc37e9a285bf627be80c888364fbd3e2683c16b
<pre>
Begin tracking scrollbar changes in subtree for intrinsically sized renderers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=310940">https://bugs.webkit.org/show_bug.cgi?id=310940</a>
<a href="https://rdar.apple.com/166836126">rdar://166836126</a>

Reviewed by Alan Baradlay.

According to css-overflow, when a box has some type of scrollbar change,
it is supposed to impact its intrinsic size.

&quot;When reserving space for a scrollbar placed at the edge of an element’s box,
the reserved space is inserted between the inner border edge and the
outer padding edge... When the box is intrinsically sized, this reserved space
is added to the size of its contents.&quot;
<a href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing</a>

For example, consider the following testcase:
&lt;div style=&quot;width: max-content; background-color: green;&quot;&gt;
  &lt;div style=&quot;height: 79px; overflow: auto;&quot;&gt;
    &lt;div style=&quot;width: 10px; height: 80px;&quot;&gt;&lt;/div&gt;
  &lt;/div&gt;
&lt;/div&gt;

When the child of the max-content div ends up getting a scrollbar due to
its overflowing content, the logical width of the max-content div should
be updated to reflact that. However, we currently fail to detect this
change and the size of the width: max-content div ends up remaining the
same.

This patch serves as a first step towards fixing this class of bugs by
adding some infrastructure that keeps track of scrollbar changes for a
subtree where the root is intrinsically sized according to its computed
logical width.

The basic idea is that when we run into such a renderer we want to start
keeping track of any descendants that gain or lose a scrollbar. If that
happens we will want to recompute our logical width in response.

Tests: imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-ref.html
       imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant.html

* Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp: Added.
SubtreeScrollbarChangesState is a new bit of state that indicates a renderer is
interested in knowing about any time a descendant has a scrollbar
change. This state is created with the renderer that wants to know about
these changes and is passed down the subtree during layout. By the time
we are back at the subtree root we should have a list of any descendants
that gained or lost a scrollbar.

SubtreeScrollbarChangesHandler is a new stack-based helper class that
can be used to indicate that the passed-in renderer will be able to
handle and contain any changes that come from a descendant
gaining/losing a scrollbar. The renderer that is the subtree root is
certainly a renderer that will need to handle the changes, but it is
possible for a descendant of that root to be able to contain the
changes. For example, if the descendant has a fixed width, then the
scrollbar changes below it will not have an impact above.

(WebCore::SubtreeScrollbarChangesHandler::SubtreeScrollbarChangesHandler):
If the handler is not the subtree root and is some other descendant that
can contain the scrollbar changes, then we need to make sure to properly
save the list of renderers that is already in the SubtreeScrollbarChangesState
and make sure the list in LocalFrameViewLayoutContext is empty. This is because
we want to only handle the descendants of the handler and not, for
example, those of the siblings of the handler.

(WebCore::SubtreeScrollbarChangesHandler::~SubtreeScrollbarChangesHandler):
1.) Make sure that we restore the list of descendants that were saved in
the constructor by adding a ScopeExit that does so. It will also debug assert
that the list of descendants which was populated for the handler is
empty.

2.) Make sure that the list of descendants is handled properly.

If we are the subtree root, then we need to invalidate the preferred widths of
descendants and the containing block chain up to the subtree root so
that when we perform layout again on the subtree root we can properly
update the logical width.

If we are not the subtree root then we will need to just call
layoutBlock on the renderers which is what would have happened in
the RelayoutScopeForScrollbarChange destructor. A ListHashSet is
used here to make sure that we call layoutBlock in the same order we
would have traversed the tree.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::layout):
We need to initialize the state and handle it some time before and after
we perform layout. Doing it here will allow us to do so before the various
renderers perform layout via layoutBlock. We will need to create the
SubtreeScrollbarChangesHandler if either this renderer is the one that
has the intrinsic logical width or the renderer is some descendant that can
properly contain the changes as we are walking back up the tree.

* Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp:
(WebCore::RelayoutScopeForScrollbarChange::~RelayoutScopeForScrollbarChange):
If we are currently tracking a subtree for scrollbar changes then we
will add them into the list to be propagated back up. In that case we
also do not want to call layoutBlock here since it should be handled by
an ancestor.

Canonical link: <a href="https://commits.webkit.org/311766@main">https://commits.webkit.org/311766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82b2c32f6b7279b010b1759f74362f5a52de1eac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166687 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111941 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122241 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85830 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102907 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23587 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21876 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14460 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133268 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169177 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13971 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130413 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130526 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35369 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30880 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141364 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/88730 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25269 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18170 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30432 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/95306 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29953 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30183 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30080 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->