### PR TITLE
[DRAFT] [Events] Clicking on overflow element scrollbar should not change focus

### DIFF
--- a/LayoutTests/fast/overflow/scrollbar-click-does-not-blur-focused-input-expected.txt
+++ b/LayoutTests/fast/overflow/scrollbar-click-does-not-blur-focused-input-expected.txt
@@ -1,0 +1,18 @@
+Clicking on an overflow scrollbar should not blur the focused input, even when there is a mouse-focusable ancestor.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Overflow scrollbar click should not blur input when no focusable ancestor exists
+PASS document.activeElement.tagName is "INPUT"
+PASS blurCount is 0
+
+Overflow scrollbar click should not blur input when a focusable ancestor exists
+PASS document.activeElement.tagName is "INPUT"
+PASS blurCount is 0
+
+Overflow scrollbar click should not blur textarea
+PASS document.activeElement.tagName is "TEXTAREA"
+PASS blurCount is 0
+PASS successfullyParsed is true
+

--- a/LayoutTests/fast/overflow/scrollbar-click-does-not-blur-focused-input.html
+++ b/LayoutTests/fast/overflow/scrollbar-click-does-not-blur-focused-input.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test-pre.js"></script>
+<style>
+.scroll-container {
+    width: 200px;
+    height: 100px;
+    overflow: auto;
+    border: 1px solid black;
+    float: left;
+    margin: 10px;
+}
+.tall-content {
+    height: 500px;
+    background: linear-gradient(to bottom, lightblue, blue);
+}
+input, textarea {
+    float: left;
+    margin: 10px;
+}
+</style>
+</head>
+<body>
+<!-- Test 1: Overflow scrollbar with no focusable ancestor (baseline) -->
+<input id="input1" type="text" value="Test 1">
+<div id="scroller1" class="scroll-container">
+    <div class="tall-content"></div>
+</div>
+
+<br style="clear: both;">
+
+<!-- Test 2: Overflow scrollbar with a focusable ancestor (the bug case) -->
+<input id="input2" type="text" value="Test 2">
+<div tabindex="0" id="focusable-ancestor" style="float: left; padding: 5px; border: 2px solid red;">
+    <div id="scroller2" class="scroll-container">
+        <div class="tall-content"></div>
+    </div>
+</div>
+
+<br style="clear: both;">
+
+<!-- Test 3: Same with textarea as the focused element -->
+<textarea id="textarea1" rows="2">Focused textarea</textarea>
+<div tabindex="0" style="float: left; padding: 5px; border: 2px solid green;">
+    <div id="scroller3" class="scroll-container">
+        <div class="tall-content"></div>
+    </div>
+</div>
+
+<br style="clear: both;">
+
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+var blurCount;
+
+function click(x, y)
+{
+    if (window.eventSender) {
+        eventSender.mouseMoveTo(x, y);
+        eventSender.mouseDown();
+        eventSender.mouseUp();
+    }
+}
+
+function clickVerticalScrollbar(elementId)
+{
+    var element = document.getElementById(elementId);
+    // Click near the right edge (on the scrollbar track) and vertically centered.
+    click(element.offsetLeft + element.offsetWidth - 5, element.offsetTop + element.offsetHeight / 2);
+}
+
+function resetBlurCount(elementId)
+{
+    blurCount = 0;
+    document.getElementById(elementId).addEventListener("blur", function() { blurCount++; });
+}
+
+description("Clicking on an overflow scrollbar should not blur the focused input, even when there is a mouse-focusable ancestor.");
+
+debug("<br>Overflow scrollbar click should not blur input when no focusable ancestor exists");
+resetBlurCount("input1");
+document.getElementById("input1").focus();
+clickVerticalScrollbar("scroller1");
+shouldBeEqualToString("document.activeElement.tagName", "INPUT");
+shouldBe("blurCount", "0");
+
+debug("<br>Overflow scrollbar click should not blur input when a focusable ancestor exists");
+resetBlurCount("input2");
+document.getElementById("input2").focus();
+clickVerticalScrollbar("scroller2");
+shouldBeEqualToString("document.activeElement.tagName", "INPUT");
+shouldBe("blurCount", "0");
+

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3310,9 +3310,12 @@ bool EventHandler::dispatchMouseEvent(const AtomString& eventType, Node* targetN
 
     m_mouseDownDelegatedFocus = false;
 
-    // If clicking on a frame scrollbar, do not make any change to which element is focused.
+    // If clicking on a scrollbar, do not make any change to which element is focused.
+    // This covers both frame-level scrollbars and overflow element scrollbars.
     RefPtr view = frame->view();
     if (view && view->scrollbarAtPoint(flooredIntPoint(platformMouseEvent.position())))
+        return true;
+    if (isInsideScrollbar(flooredIntPoint(platformMouseEvent.position())))
         return true;
 
     // The layout needs to be up to date to determine if an element is focusable.


### PR DESCRIPTION
#### 6937e927031aa2e7bcd5f75932d4b5ef3889bfc3
<pre>
Clicking an overflow element&apos;s scrollbar should not blur the focused element
<a href="https://bugs.webkit.org/show_bug.cgi?id=239524">https://bugs.webkit.org/show_bug.cgi?id=239524</a>
<a href="https://rdar.apple.com/92367314">rdar://92367314</a>

Reviewed by NOBODY (OOPS!).

When an input was focused and the user clicked the scrollbar of an unrelated
overflow element (e.g. a typeahead suggestions list on linkedin.com), WebKit
cleared focus to the body. Chrome and Firefox preserve focus.

EventHandler::dispatchMouseEvent already had the right check from bug 96335,
but its isInsideScrollbar() hit test did not flag overflow scrollbars in this
code path. The original hit test in handleMousePressEvent already identifies
the clicked scrollbar (frame or overflow) via scrollbarForMouseEvent, so plumb
it through and check it directly. isInsideScrollbar() is removed.

Cases with a mouse-focusable click ancestor (tabindex / contenteditable /
textarea / select) still move focus, preserving the existing
scrollbar-click-retains-focus.html test.

Test: fast/overflow/scrollbar-click-does-not-blur-focused-input.html

* LayoutTests/fast/overflow/scrollbar-click-does-not-blur-focused-input.html: Added.
* LayoutTests/fast/overflow/scrollbar-click-does-not-blur-focused-input-expected.txt: Added.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMousePressEvent): Pass the identified scrollbar to dispatchMouseEvent.
(WebCore::EventHandler::dispatchMouseEvent): Use the passed-in scrollbar instead of isInsideScrollbar().
(WebCore::EventHandler::isInsideScrollbar const): Deleted.
* Source/WebCore/page/EventHandler.h:
</pre>