### PR TITLE
[DRAFT] [iOS] Retain active focused state during file upload panel presentation

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -437,6 +437,7 @@ struct ImageAnalysisContextMenuActionData {
     RetainPtr<WKFormInputSession> _formInputSession;
     RetainPtr<WKFileUploadPanel> _fileUploadPanel;
     std::optional<WebKit::FrameInfoData> _frameInfoForFileUploadPanel;
+    BlockPtr<void()> _fileUploadActiveFocusedStateRetainBlock;
 #if HAVE(SHARE_SHEET_UI)
     RetainPtr<WKShareSheet> _shareSheet;
 #endif

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -9766,6 +9766,10 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
     if (_fileUploadPanel)
         return;
 
+    // Retain the active focused state so that the focused element (e.g., a contenteditable
+    // email body in Outlook) is not blurred when the file picker takes first responder.
+    _fileUploadActiveFocusedStateRetainBlock = makeBlockPtr(self.webView._retainActiveFocusedState);
+
     _frameInfoForFileUploadPanel = frameInfo;
     _fileUploadPanel = adoptNS([[WKFileUploadPanel alloc] initWithView:self]);
     [_fileUploadPanel setDelegate:self];
@@ -9775,6 +9779,10 @@ static bool canUseQuickboardControllerFor(UITextContentType type)
 - (void)fileUploadPanelDidDismiss:(WKFileUploadPanel *)fileUploadPanel
 {
     ASSERT(_fileUploadPanel.get() == fileUploadPanel);
+
+    // Release the active focused state retain so that normal focus management resumes.
+    if (auto releaseFocusState = WTF::move(_fileUploadActiveFocusedStateRetainBlock))
+        releaseFocusState();
 
     if ([self window] && ![[self window] firstResponder])
         [self becomeFirstResponder];


### PR DESCRIPTION
#### 3ef515a3a8af300a545dc9f157b5489766240fa7
<pre>
[iOS] Retain active focused state during file upload panel presentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=309794">https://bugs.webkit.org/show_bug.cgi?id=309794</a>
<a href="https://rdar.apple.com/166753155">rdar://166753155</a>

Reviewed by: NOBODY (OOPS!).

When a file upload panel is presented on iOS/visionOS, the content view resigns
first responder, which triggers blurFocusedElement() on the web page. This causes
the previously-focused contenteditable element (e.g., Outlook.com email body) to
lose DOM-level focus. After the file picker dismisses, the content view regains
UIKit first responder status, but the DOM focus has already been lost, so keyboard
input no longer routes to the contenteditable element.

The fix uses the existing _retainActiveFocusedState mechanism (already used by
addFocusedFormControlOverlay on visionOS) to prevent the focused element from
being blurred when the file upload panel takes over first responder. The retain
is balanced by a release in fileUploadPanelDidDismiss.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
  - Add _fileUploadActiveFocusedStateRetainBlock ivar to hold the focus state
    retain block for the duration of the file upload panel presentation.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _showRunOpenPanel:frameInfo:resultListener:]):
  - Retain active focused state before presenting file upload panel.
(-[WKContentView fileUploadPanelDidDismiss:]):
  - Release active focused state after file upload panel dismisses.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ef515a3a8af300a545dc9f157b5489766240fa7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15960 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158365 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103094 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115444 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82063 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152622 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17584 "Found 4 new test failures: fast/forms/ios/file-upload-panel-blur-focus-camera-via-menu.html fast/forms/ios/file-upload-panel-blur-focus-document-picker-via-menu.html fast/forms/ios/file-upload-panel-blur-focus-menu.html fast/forms/ios/file-upload-panel-blur-focus-photo-picker-via-menu.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134302 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96186 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ef135561-d2e3-41a1-8b29-4b450defc368) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16681 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14584 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6210 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126289 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160843 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3841 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13774 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123478 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22183 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18625 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123684 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22190 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134025 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78415 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18867 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10777 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21791 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85611 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21521 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21673 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21578 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->