### PR TITLE
[DRAFT] Guard pseudo-element animation cancellation to avoid MotionMark regression

### DIFF
--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -199,7 +199,9 @@ void RenderTreeUpdater::GeneratedContent::updateBeforeOrAfterPseudoElement(Eleme
     // cancel any animations that were on it so we do not end up thinking we need to keep
     // the renderer around. We cannot completely rely on needsPseudoElement because
     // we may need to animate a box with display: none.
-    if (!updateStyle)
+    // Only cancel if we actually have animations on this pseudo-element to avoid
+    // performance overhead on pages with frequent style updates.
+    if (!updateStyle && keyframeEffectStackForPseudoElement(current, pseudoElementType))
         Styleable { current, Style::PseudoElementIdentifier { pseudoElementType } }.cancelStyleOriginatedAnimations();
 
     ASSERT(!is<PseudoElement>(current));


### PR DESCRIPTION
#### 540e91a2bd36af7be9a891fef424a6dc60b4b8b8
<pre>
Guard pseudo-element animation cancellation to avoid MotionMark regression
<a href="https://bugs.webkit.org/show_bug.cgi?id=309796">https://bugs.webkit.org/show_bug.cgi?id=309796</a>
<a href="https://rdar.apple.com/171888738">rdar://171888738</a>

Reviewed by NOBODY (OOPS!).

Commit 36150a6e1139 introduced unconditional `cancelStyleOriginatedAnimations()`
calls when pseudo-element styles are removed.  This caused a 0.36% overall
MotionMark regression because the cancellation runs even when no animations exist
on the pseudo-element.

Add a guard using `keyframeEffectStackForPseudoElement()`, which performs an O(1)
bitflag check via `mayHaveKeyframeEffects()`, skipping the cancellation overhead
in the common case while preserving correctness when animations are actually present.

No new tests since this is a performance fix with no change in behavior when
animations are present.

* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(RenderTreeUpdater::GeneratedContent::updateBeforeOrAfterPseudoElement): Guard `cancelStyleOriginatedAnimations()` behind `keyframeEffectStackForPseudoElement()`.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/540e91a2bd36af7be9a891fef424a6dc60b4b8b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149666 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15964 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158369 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103098 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b7d853e-5346-4fc5-a2f5-7dbb09f20505) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115447 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82066 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3053b7c-c027-41fb-b88c-f072a70aa262) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134304 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96189 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c11d224a-6e80-4db8-bf74-b278f06422f4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16676 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14588 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6214 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126284 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160847 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3846 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13776 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123481 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123687 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22194 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134027 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78419 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18868 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10779 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21795 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85615 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21525 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21677 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21582 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->