### PR TITLE
[DRAFT] [Media] Fix video not centered in PiP window on re-entry

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -1101,6 +1101,14 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(PlaybackSessionContext
     // The video may not have been rendered yet, which would have triggered a call to createViewWithID/createLayerHostViewWithID making the AVPlayerLayer and AVPlayerLayerView not yet set. Create them as needed.
     if (!interface->videoView())
         createViewWithID(contextId, hostingContext, initialSize, videoDimensions, hostingDeviceScaleFactor);
+    else if (RetainPtr playerLayer = interface->playerLayer()) {
+        // On PiP re-entry, the existing WebAVPlayerLayer retains stale sublayer
+        // geometry from the previous session. Update bounds and force a layout
+        // pass so layoutSublayers recalculates the centered video position.
+        [playerLayer setBounds:CGRectMake(0, 0, initialSize.width(), initialSize.height())];
+        [playerLayer setVideoDimensions:videoDimensions];
+        [playerLayer setNeedsLayout];
+    }
     ASSERT(interface->videoView());
 #endif
 


### PR DESCRIPTION
#### c64fedab14a21d321268f6edb578df998fe4bfe7
<pre>
[Media] Fix video not centered in PiP window on re-entry
<a href="https://bugs.webkit.org/show_bug.cgi?id=309798">https://bugs.webkit.org/show_bug.cgi?id=309798</a>
<a href="https://rdar.apple.com/167427633">rdar://167427633</a>

Reviewed by NOBODY (OOPS!).

When re-entering PiP after exiting, the video was not centered because
setupFullscreenWithID skips createViewWithID when the videoView already
exists. The WebAVPlayerLayer retains stale sublayer geometry from the
prior session, and nothing triggers layoutSublayers to recalculate.

Force a bounds update and layout pass on the existing player layer when
re-entering PiP, so the existing centering logic in layoutSublayers runs
with fresh values.

* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c64fedab14a21d321268f6edb578df998fe4bfe7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22386 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158370 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103099 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd02bfb1-6495-4aff-a267-bf2a7424a6cb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22379 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115448 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82067 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152627 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17581 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134305 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96190 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ada99416-35d3-4832-a344-e720dd7a4735) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16678 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14589 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6215 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126286 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160848 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3847 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13777 "Found 1 new test failure: fast/attachment/mac/wide-attachment-image-controls-basic.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123480 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22188 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123686 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22195 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134028 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78420 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18860 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10780 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21796 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85616 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21526 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21678 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21583 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->