### PR TITLE
AX: Fix content-inset-scrollview-frame.html with ACCESSIBILITY_LOCAL_FRAME enabled

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -799,11 +799,10 @@ webkit.org/b/167607 [ Debug ] http/tests/inspector/worker/blob-script-with-cross
 webkit.org/b/160042 accessibility/mac/value-change/value-change-user-info-contenteditable.html [ Pass Failure ]
 
 # Skipped because ACCESSIBILITY_LOCAL_FRAME is not compatable with relative frames.
-accessibility/mac/iframe-relative-frame.html [ Failure ]
+accessibility/mac/iframe-relative-frame.html [ Skip ]
 
 # Regression from ENABLE(ACCESSIBILITY_LOCAL_FRAME).
 accessibility/mac/visible-content-search-in-scrolled-iframe.html [ Failure ]
-platform/mac-wk2/accessibility/content-inset-scrollview-frame.html [ Failure ]
 
 # Regression from disabling ACCESSIBILITY_LOCAL_FRAME.
 http/tests/site-isolation/accessibility/remote-element-returned.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/accessibility/content-inset-scrollview-frame.html
+++ b/LayoutTests/platform/mac-wk2/accessibility/content-inset-scrollview-frame.html
@@ -9,26 +9,29 @@
 <script>
 var output = "This tests that a page with a content inset will not affect the bounds of the main frame scroll view. It will appear as the same as the web area's bounds.\n\n";
 
+var webX, webY, scrollViewX, scrollViewY, scrollViewHeight, newScrollViewHeight, newScrollViewY;
 if (window.accessibilityController) {
     window.jsTestIsAsync = true;
 
     var webArea = accessibilityController.rootElement.childAtIndex(0);
-    var webX = webArea.x;
-    var webY = webArea.y - webArea.height;
-
     var scrollView = webArea.parentElement();
-    var scrollViewX = scrollView.x;
-    // to get what the y that we're expecting, we need to subtract the height, because Cocoa requires the bottom point to be consider the y origin.
-    var scrollViewY = scrollView.y - scrollView.height;
-    var scrollViewHeight = scrollView.height;
 
-    output += "The position of the web area and the scroll view should be the same when there's no content inset.\n";
-    output += expect("webX == scrollViewX && webY == scrollViewY", "true")
-
-    output += "\nSetting the main-frame top content inset to 100px.\n";
-
-    var newScrollViewHeight, newScrollViewY;
     setTimeout(async function() {
+        await waitFor(() => scrollView.y > 0);
+
+        webX = webArea.x;
+        webY = webArea.y - webArea.height;
+
+        scrollViewX = scrollView.x;
+        // to get what the y that we're expecting, we need to subtract the height, because Cocoa requires the bottom point to be consider the y origin.
+        scrollViewY = scrollView.y - scrollView.height;
+        scrollViewHeight = scrollView.height;
+
+        output += "The position of the web area and the scroll view should be the same when there's no content inset.\n";
+        output += expect("webX == scrollViewX && webY == scrollViewY", "true")
+
+        output += "\nSetting the main-frame top content inset to 100px.\n";
+
         if (window.testRunner)
             await testRunner.setObscuredContentInsets(100, 0, 0, 0);
         await waitFor(() => {

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -468,10 +468,13 @@ LayoutRect AccessibilityScrollView::elementRect() const
     auto rect = scrollView->frameRectShrunkByInset();
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    // For the root scroll view of a subframe (local or remote), the frameRect includes
-    // the iframe's position in the parent page. We want to zero it out.
-    if (isRoot() && !rect.location().isZero())
-        rect.setLocation(IntPoint());
+    // The scrollView's frameRect may include the iframe's position in the parent
+    // page (non-zero for subframes, zero for main frames). Remove that offset
+    // but preserve any inset offset applied by frameRectShrunkByInset().
+    if (isRoot()) {
+        auto frameOrigin = scrollView->frameRect().location();
+        rect.move(-frameOrigin.x(), -frameOrigin.y());
+    }
 #else
     auto offset = remoteFrameOffset();
     if (isRoot() && !offset.isZero())


### PR DESCRIPTION
#### 4e251ad1b7a363550887ef7eaa04ca890dee0807
<pre>
AX: Fix content-inset-scrollview-frame.html with ACCESSIBILITY_LOCAL_FRAME enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=309799">https://bugs.webkit.org/show_bug.cgi?id=309799</a>
<a href="https://rdar.apple.com/172392672">rdar://172392672</a>

Reviewed by Tyler Wilcock.

This PR fixes content inset handling with ACCESSIBILITY_LOCAL_FRAME enabled. The root
scroll view&apos;s elementRect() was zeroing the entire  rect location, ignoring the content
inset offset applied by frameRectShrunkByInset. Now, we subtract only the scroll view&apos;s
location (the iframe position, when relevant), preserving the inset offset.

The content-inset-scrollview-frame.html test was also updated to wait for asynchronous
frame geometry to be populated.

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/platform/mac-wk2/accessibility/content-inset-scrollview-frame.html:
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::elementRect const):

Canonical link: <a href="https://commits.webkit.org/309171@main">https://commits.webkit.org/309171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5074534d4e0c341280ca53e3cc86fcd4e9ed8902

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149668 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158371 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103100 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115449 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82068 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/010d8382-d4fc-4948-960e-ec3c3a758cdb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152628 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96191 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ebfa733-9016-4584-986d-6dff0db33dd7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16680 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14590 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6216 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126288 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12239 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160849 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3848 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13780 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123483 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22189 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123690 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33608 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22196 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134031 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78421 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18861 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10783 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21797 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85617 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21527 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21679 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21584 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->