### PR TITLE
[DRAFT] RenderBlock::hasLineIfEmpty() should not trigger style resolution during layout

### DIFF
--- a/LayoutTests/editing/editability/contenteditable-block-in-inline-no-stack-overflow-expected.txt
+++ b/LayoutTests/editing/editability/contenteditable-block-in-inline-no-stack-overflow-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash with a stack overflow when laying out nested editable block-in-inline content.

--- a/LayoutTests/editing/editability/contenteditable-block-in-inline-no-stack-overflow.html
+++ b/LayoutTests/editing/editability/contenteditable-block-in-inline-no-stack-overflow.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<!-- Regression test for rdar://171573375 -->
+<!-- RenderBlock::hasLineIfEmpty() must not trigger resolveComputedStyle() -->
+<!-- during layout, which caused O(N^2) stack growth in nested block-in-inline -->
+<!-- contenteditable layouts, leading to a stack overflow crash. -->
+<body>
+<p>This test passes if WebKit does not crash with a stack overflow when laying out nested editable block-in-inline content.</p>
+<div id="container"></div>
+<script>
+    // Build nested block-in-inline structure inside contenteditable:
+    // <div contenteditable>text <div>text <div>text...</div></div></div>
+    // Each inner <div> is a block element inside inline content, triggering
+    // block-in-inline layout. Each layout level calls hasLineIfEmpty(), which
+    // previously triggered resolveComputedStyle() traversing all ancestors.
+    function buildNestedContent(depth) {
+        if (depth === 0)
+            return document.createTextNode("leaf");
+        var outer = document.createElement("div");
+        outer.appendChild(document.createTextNode("before "));
+        outer.appendChild(buildNestedContent(depth - 1));
+        outer.appendChild(document.createTextNode(" after"));
+        return outer;
+    }
+
+    var container = document.getElementById("container");
+    container.setAttribute("contenteditable", "true");
+
+    // 30 levels of nesting is enough to trigger the stack overflow in the
+    // unfixed code (each level adds O(depth) stack frames).
+    container.appendChild(buildNestedContent(30));
+
+    // Force layout to exercise the crash path.
+    container.getBoundingClientRect();
+
+    // Also test with CSS-based editability (-webkit-user-modify).
+    var cssContainer = document.createElement("div");
+    cssContainer.style.cssText = "-webkit-user-modify: read-write;";
+    cssContainer.appendChild(buildNestedContent(20));
+    document.body.appendChild(cssContainer);
+    cssContainer.getBoundingClientRect();
+
+    if (window.testRunner)
+        testRunner.dumpAsText();
+</script>
+</body>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2455,8 +2455,30 @@ void RenderBlock::computeChildPreferredLogicalWidths(RenderBox& childBox, Layout
 
 bool RenderBlock::hasLineIfEmpty() const
 {
-    RefPtr element = this->element();
-    return element && element->isRootEditableElement();
+    // Avoid calling element()->isRootEditableElement() here because it triggers
+    // computedStyleForEditability() -> resolveComputedStyle(Editability), which
+    // traverses the full ancestor chain adding O(depth) stack frames. In deeply
+    // nested block-in-inline layouts with editable content, each layout level
+    // calls hasLineIfEmpty(), causing O(N^2) stack growth and a stack overflow
+    // crash. rdar://171573375
+    //
+    // Instead, use the renderer's already-computed style. -webkit-user-modify is
+    // an inherited CSS property, so anonymous parent renderers correctly reflect
+    // the DOM element's editability without any style resolution.
+    if (!element())
+        return false;
+
+    auto& doc = document();
+    bool pageIsEditable = doc.page() && doc.page()->isEditable();
+    if (!pageIsEditable && style().usedUserModify() == UserModify::ReadOnly)
+        return false;
+
+    if (isBody())
+        return true;
+    auto* parentRenderer = parent();
+    if (!parentRenderer)
+        return true;
+    return pageIsEditable ? false : parentRenderer->style().usedUserModify() == UserModify::ReadOnly;
 }
 
 std::optional<LayoutUnit> RenderBlock::firstLineBaseline() const


### PR DESCRIPTION
#### 2453aea541293a56abe3ee38695e28cb5500ec1a
<pre>
RenderBlock::hasLineIfEmpty() should not trigger style resolution during layout
<a href="https://bugs.webkit.org/show_bug.cgi?id=309801">https://bugs.webkit.org/show_bug.cgi?id=309801</a>
<a href="https://rdar.apple.com/171573375">rdar://171573375</a>

Reviewed by NOBODY (OOPS!).

hasLineIfEmpty() calls element()-&gt;isRootEditableElement(), which triggers
computedStyleForEditability() -&gt; resolveComputedStyle(Editability). The
resolveComputedStyle function traverses the full ancestor chain, calling
styleForElementIgnoringPendingStylesheets() for each ancestor.

In block-in-inline layouts with nested editable content, each level of
layout calls hasLineIfEmpty(), which adds O(depth) style resolution stack
frames. For N levels of nesting, total stack depth grows as O(N^2), causing
a stack overflow crash.

The crash manifests as:
  ___chkstk_darwin
  Element::resolveComputedStyle(Editability)
  Element::computedStyleForEditability()
  Node::computeEditabilityWithStyle()
  ...
  RenderBlock::hasLineIfEmpty()
  RenderBlockFlow::markInlineContentDirtyForLayout()
  RenderBlockFlow::layoutInlineContent()
  ...
  LayoutIntegration::layoutWithFormattingContextForBlockInInline()
  RenderBlockFlow::layoutBlockChildFromInlineLayout()
  RenderBlock::layout()    &lt;-- repeating frame

Fix: Replace element()-&gt;isRootEditableElement() with equivalent checks
using the renderer&apos;s already-computed style. Since -webkit-user-modify is
an inherited CSS property, anonymous parent renderers correctly reflect the
DOM element&apos;s editability without requiring any style resolution.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::hasLineIfEmpty): Use renderer style instead of
element()-&gt;isRootEditableElement() to avoid triggering resolveComputedStyle()
during layout. Check page editability, renderer&apos;s usedUserModify(), body
element status, and parent renderer&apos;s usedUserModify() directly.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2453aea541293a56abe3ee38695e28cb5500ec1a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22390 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158374 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103103 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151544 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22391 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115452 "Found 1 new test failure: editing/editability/contenteditable-block-in-inline-no-stack-overflow.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82071 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcdbd72c-88f6-48a2-b1bd-3cea7f7491e8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152631 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17589 "Found 1 new test failure: editing/editability/contenteditable-block-in-inline-no-stack-overflow.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96195 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a896594-1ca3-440f-b901-5d52af4163dd) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16686 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14595 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6219 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126294 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160852 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3859 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13781 "Found 1 new test failure: editing/editability/contenteditable-block-in-inline-no-stack-overflow.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123485 "Found 1 new test failure: editing/editability/contenteditable-block-in-inline-no-stack-overflow.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22192 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18636 "Found 1 new test failure: editing/editability/contenteditable-block-in-inline-no-stack-overflow.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123692 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22199 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134032 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78424 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18864 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10784 "Found 1 new test failure: editing/editability/contenteditable-block-in-inline-no-stack-overflow.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21800 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85620 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21530 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21682 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21587 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->