### PR TITLE
[DRAFT] [Scrolling] Suppress scroll anchor selection after programmatic scrolls

### DIFF
--- a/LayoutTests/fast/scrolling/scroll-anchoring-not-applied-after-programmatic-scroll-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-anchoring-not-applied-after-programmatic-scroll-expected.txt
@@ -1,0 +1,7 @@
+PASS scroller.scrollTop is 100
+PASS observerFired is true
+PASS scroller.scrollTop is 250
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/scroll-anchoring-not-applied-after-programmatic-scroll.html
+++ b/LayoutTests/fast/scrolling/scroll-anchoring-not-applied-after-programmatic-scroll.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            margin: 0;
+        }
+        .scroller {
+            width: 300px;
+            height: 400px;
+            overflow-y: scroll;
+            border: 1px solid black;
+        }
+        .changing {
+            height: 200px;
+            background-color: orange;
+        }
+        .anchor {
+            height: 200px;
+            background-color: limegreen;
+        }
+        .spacer {
+            height: 1000px;
+            background-color: lightblue;
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script src="../../resources/js-test.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        // This test simulates the facebook.com pattern where:
+        // 1. Page is scrolled so scroll anchoring is active.
+        // 2. A ResizeObserver fires when an element changes size.
+        // 3. The ResizeObserver callback calls scrollTo() to a specific position.
+        // 4. A subsequent layout should NOT undo the programmatic scroll position.
+
+        const targetScrollTop = 250;
+        let observerFired = false;
+
+        window.addEventListener('load', async () => {
+            const scroller = document.querySelector('.scroller');
+            const changing = document.querySelector('.changing');
+
+            // Step 1: Scroll so that anchoring can become active.
+            scroller.scrollTop = 100;
+            await UIHelper.renderingUpdate();
+
+            shouldBe('scroller.scrollTop', '100');
+
+            // Step 2: Set up a ResizeObserver that calls scrollTo() when the
+            // .changing element resizes (simulating the facebook pattern).
+            const observer = new ResizeObserver(() => {
+                if (!observerFired) {
+                    observerFired = true;
+                    // This programmatic scrollTo should NOT be undone by scroll anchoring.
+                    scroller.scrollTo(0, targetScrollTop);
+                }
+            });
+            observer.observe(changing);
+
+            // Step 3: Change the size of the element above the anchor.
+            // This triggers the ResizeObserver and also triggers scroll anchoring
+            // (since the element above the anchor grew, anchoring would normally
+            // push the scroll position to compensate).
+            changing.style.height = '400px';
+
+            await UIHelper.renderingUpdate();
+
+            // Step 4: The ResizeObserver callback called scrollTo(0, 250).
+            // Scroll anchoring should NOT have overridden this to a different value.
+            // Without the fix, scrollTop would be != 250 because anchoring would
+            // compensate for the 200px growth of .changing.
+            shouldBeTrue('observerFired');
+            shouldBe('scroller.scrollTop', String(targetScrollTop));
+
+            observer.disconnect();
+            finishJSTest();
+        });
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="changing"></div>
+        <div class="anchor"></div>

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -118,8 +118,16 @@ void ScrollAnchoringController::scrollPositionDidChange()
     if (m_isUpdatingScrollPositionForAnchoring)
         return;
 
-    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::scrollPositionChanged() to " << m_owningScrollableArea->scrollPosition() << " - clearing scroll anchor");
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::scrollPositionChanged() to "
+        << m_owningScrollableArea->scrollPosition() << " - clearing scroll anchor"
+        << " (programmatic: " << (m_owningScrollableArea->currentScrollType() == ScrollType::Programmatic) << ")");
     clearAnchor();
+
+    // When a programmatic scroll (e.g. scrollTo() from JS) sets a new position, suppress
+    // anchor selection for the next layout pass so scroll anchoring does not undo it.
+    if (m_owningScrollableArea->currentScrollType() == ScrollType::Programmatic)
+        m_suppressAnchorSelectionAfterProgrammaticScroll = true;
+
     updateScrollableAreaRegistration();
 }
 
@@ -582,6 +590,13 @@ void ScrollAnchoringController::updateBeforeLayout()
     }
 
     if (!m_anchorObject) {
+        if (m_suppressAnchorSelectionAfterProgrammaticScroll) {
+            m_suppressAnchorSelectionAfterProgrammaticScroll = false;
+            LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this
+                << " updateBeforeLayout() - suppressed anchor selection after programmatic scroll");
+            return;
+        }
+
         RefPtr document = frameView().frame().document();
         if (!document)
             return;

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -118,6 +118,7 @@ private:
     bool m_isUpdatingScrollPositionForAnchoring { false };
     bool m_isQueuedForScrollPositionUpdate { false };
     bool m_anchoringSuppressedByStyleChange { false };
+    bool m_suppressAnchorSelectionAfterProgrammaticScroll { false };
     unsigned m_inScrollEventCount { 0 };
     unsigned m_suppressionCount { 0 };
 };


### PR DESCRIPTION
#### 0456034e8960ab40880ad5314cacf791da77bfb3
<pre>
[Scrolling] Suppress scroll anchor selection after programmatic scrolls
<a href="https://bugs.webkit.org/show_bug.cgi?id=309803">https://bugs.webkit.org/show_bug.cgi?id=309803</a>
<a href="https://rdar.apple.com/171414590">rdar://171414590</a>

Reviewed by NOBODY (OOPS!).

Facebook&apos;s page JavaScript calls window.scrollTo() from a ResizeObserver callback to
maintain a specific scroll position after content changes. This programmatic scroll was
being undone by scroll anchoring: after the scrollTo() set a new position, the next
layout pass would pick a fresh anchor element at that position, then any additional
content change would cause an anchoring adjustment that moved the scroll away from
where the page intended it to be.

The fix: when scrollPositionDidChange() fires during a programmatic scroll (detected
via currentScrollType() == ScrollType::Programmatic, which is valid because the
ScrollTypeScope is still on the stack at the call site in ScrollableArea::
scrollPositionChanged()), set a one-shot flag that suppresses anchor selection in
the immediately following updateBeforeLayout() call. This allows the programmatic
scroll position to persist through the next layout without scroll anchoring
compensation undoing it. The suppression flag is self-clearing and only active for
a single layout cycle, so normal scroll anchoring behavior resumes immediately
afterward.

* Source/WebCore/page/scrolling/ScrollAnchoringController.h:
  Add m_suppressAnchorSelectionAfterProgrammaticScroll bool member.

* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
  (ScrollAnchoringController::scrollPositionDidChange): Set
  m_suppressAnchorSelectionAfterProgrammaticScroll when current scroll type
  is programmatic.
  (ScrollAnchoringController::updateBeforeLayout): Skip anchor selection
  and clear the suppression flag when
  m_suppressAnchorSelectionAfterProgrammaticScroll is set.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0456034e8960ab40880ad5314cacf791da77bfb3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158375 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103104 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151545 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22389 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115453 "Found 43 new test failures: fast/scrolling/scroll-anchoring-constraints.html fast/scrolling/scroll-anchoring-in-overflow-scroll.html fast/scrolling/scroll-anchoring-in-overflow-with-page-scale.html fast/scrolling/scroll-anchoring-not-applied-after-programmatic-scroll.html fast/scrolling/scroll-anchoring-with-page-scale.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-containing-block-outside-scroller.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-contributes-to-static-parent-bounds.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/adjustments-in-scroll-event-handler.tentative.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-001.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/ancestor-change-heuristic.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82072 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eb25b7c0-a9cd-4f29-9401-831cdecc507a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152632 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17590 "Found 4 new test failures: fast/scrolling/scroll-anchoring-constraints.html fast/scrolling/scroll-anchoring-in-overflow-scroll.html fast/scrolling/scroll-anchoring-in-overflow-with-page-scale.html fast/scrolling/scroll-anchoring-not-applied-after-programmatic-scroll.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134312 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96196 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dab2c7f5-509f-453d-a2d4-f484c2541662) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16687 "Found 33 new test failures: imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-contributes-to-static-parent-bounds.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-001.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/ancestor-change-heuristic.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-updates-after-explicit-scroll.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-used-height-change-does-not-suppress.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchoring-with-bounds-clamping.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/anonymous-block-box.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/basic.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/clipped-scrollers-skipped.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/contain-paint-offscreen-container.html ... (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14594 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6220 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126295 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160854 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3852 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13785 "Found 43 new test failures: fast/scrolling/scroll-anchoring-constraints.html fast/scrolling/scroll-anchoring-in-overflow-scroll.html fast/scrolling/scroll-anchoring-in-overflow-with-page-scale.html fast/scrolling/scroll-anchoring-not-applied-after-programmatic-scroll.html fast/scrolling/scroll-anchoring-with-page-scale.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-containing-block-outside-scroller.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-contributes-to-static-parent-bounds.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/adjustments-in-scroll-event-handler.tentative.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-001.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/ancestor-change-heuristic.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123486 "Found 44 new test failures: fast/scrolling/scroll-anchoring-constraints.html fast/scrolling/scroll-anchoring-in-overflow-scroll.html fast/scrolling/scroll-anchoring-in-overflow-with-page-scale.html fast/scrolling/scroll-anchoring-not-applied-after-programmatic-scroll.html fast/scrolling/scroll-anchoring-with-page-scale.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-containing-block-outside-scroller.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-contributes-to-static-parent-bounds.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/adjustments-in-scroll-event-handler.tentative.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-001.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/ancestor-change-heuristic.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22193 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18635 "Found 43 new test failures: fast/scrolling/scroll-anchoring-constraints.html fast/scrolling/scroll-anchoring-in-overflow-scroll.html fast/scrolling/scroll-anchoring-in-overflow-with-page-scale.html fast/scrolling/scroll-anchoring-not-applied-after-programmatic-scroll.html fast/scrolling/scroll-anchoring-with-page-scale.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-containing-block-outside-scroller.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-contributes-to-static-parent-bounds.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/adjustments-in-scroll-event-handler.tentative.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-001.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/ancestor-change-heuristic.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123693 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22200 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134035 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78425 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18865 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10787 "Found 43 new test failures: fast/scrolling/scroll-anchoring-constraints.html fast/scrolling/scroll-anchoring-in-overflow-scroll.html fast/scrolling/scroll-anchoring-in-overflow-with-page-scale.html fast/scrolling/scroll-anchoring-not-applied-after-programmatic-scroll.html fast/scrolling/scroll-anchoring-with-page-scale.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-containing-block-outside-scroller.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/abspos-contributes-to-static-parent-bounds.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/adjustments-in-scroll-event-handler.tentative.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-001.html imported/w3c/web-platform-tests/css/css-scroll-anchoring/ancestor-change-heuristic.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21801 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85621 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21531 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21683 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21588 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->