### PR TITLE
[DRAFT] [WebVTT] Use max(5cqmin, 5vh) for caption font size to fix small inline players

### DIFF
--- a/LayoutTests/media/track/track-cue-inline-min-font-size-expected.txt
+++ b/LayoutTests/media/track/track-cue-inline-min-font-size-expected.txt
@@ -1,0 +1,10 @@
+
+
+RUN(internals.setCaptionDisplayMode('AlwaysOn'))
+RUN(video.textTracks[0].mode = "showing")
+EXPECTED (video.textTracks[0].cues.length > '0') OK
+RUN(video.currentTime = 0.5)
+EXPECTED (firstCueElement() != 'null') OK
+EXPECTED (fontSize > '5') OK
+Caption font size: 30px (5cqmin-only would be 5px)
+END OF TEST

--- a/LayoutTests/media/track/track-cue-inline-min-font-size.html
+++ b/LayoutTests/media/track/track-cue-inline-min-font-size.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<!-- Tests that WebVTT captions in a small inline video player use a minimum
+     viewport-relative font size, matching the WebVTT spec's 5vh default.
+     With container-only sizing (5cqmin), a 200x100 video would give 5px font.
+     With max(5cqmin, 5vh), the viewport-relative floor ensures readable text. -->
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <script src=../media-file.js></script>
+    <script src=../video-test.js></script>
+    <style>
+        /* Small video: 5cqmin = 5% * min(200, 100) = 5px */
+        video { width: 200px; height: 100px; }
+    </style>
+    <script>
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+
+    function firstCueElement() {
+        return internals.shadowRoot(video).querySelector('[useragentpart="-internal-cue-background"]');
+    }
+
+    async function runTest() {
+        consoleWrite("");
+        run("internals.setCaptionDisplayMode('AlwaysOn')");
+
+        findMediaElement();
+        video.src = findMediaFile('video', '../content/test');
+        await waitFor(video, 'canplaythrough', true);
+
+        run('video.textTracks[0].mode = "showing"');
+        await testExpectedEventually('video.textTracks[0].cues.length', '0', '>');
+
+        run('video.currentTime = 0.5');
+        await waitFor(video, 'seeked', true);
+
+        await testExpectedEventually('firstCueElement()', null, '!=');
+
+        // With max(5cqmin, 5vh): 5cqmin = 5px (5% of 100px container min dim).
+        // 5vh depends on the test viewport height (typically 600px in DumpRenderTree),
+        // so 5vh = 30px. The max() should pick the vh value.
+        // We just verify font size is strictly greater than 5px (the cqmin-only value).
+        var fontSize = parseFloat(window.getComputedStyle(firstCueElement()).fontSize);
+        testExpected('fontSize', 5, '>');
+        consoleWrite("Caption font size: " + fontSize + "px (5cqmin-only would be 5px)");
+    }
+    </script>
+</head>
+<body>
+    <video>
+        <track src="captions-webvtt/styling.vtt" kind="captions">
+    </video>
+</body>
+</html>

--- a/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
@@ -63,7 +63,7 @@ video[controls]::-webkit-media-text-track-container.visible-controls-bar {
 [useragentpart="cue"] ruby > rt { display: ruby-text; }
 
 ::cue {
-    font: 5cqmin/normal sans-serif;
+    font: max(5cqmin, 5vh)/normal sans-serif;
     color: rgba(255, 255, 255, 1);
     background: rgba(0, 0, 0, 0.8);
     white-space: pre-line;
@@ -88,7 +88,7 @@ video[controls]::-webkit-media-text-track-container.visible-controls-bar {
     writing-mode: horizontal-tb;
     background: rgba(0,0,0,0.8);
     overflow-wrap: break-word;
-    font: 5cqmin sans-serif;
+    font: max(5cqmin, 5vh) sans-serif;
     color: rgba(255,255,255,1);
     overflow: hidden;
     min-height: 0px;

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -262,9 +262,9 @@ void MediaControlTextTrackContainerElement::updateActiveCuesFontSize()
 
     float fontScale = protect(protect(page->group())->ensureCaptionPreferences())->captionFontSizeScaleAndImportance(m_fontSizeIsImportant);
 
-    // Caption fonts are defined as |size vh| units, so there's no need to
-    // scale by display size. Since |vh| is a decimal percentage, multiply
-    // the scale factor by 100 to achive the final font size.
+    // Caption fonts use max(cqmin, vh) to ensure a minimum viewport-relative
+    // size for small inline players. Since these are percentage-based, multiply
+    // the scale factor by 100 to achieve the final font size for stroke width.
     m_fontSize = lroundf(100 * fontScale);
 }
 

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -517,12 +517,12 @@ String CaptionUserPreferencesMediaAF::captionsFontSizeCSS() const
     bool important = false;
     float fontScale = captionFontSizeScaleAndImportance(important);
 
-    // Caption fonts are defined as |size vh| units, so there's no need to
-    // scale by display size. Since |vh| is a decimal percentage, multiply
-    // the scale factor by 100 to achive the final font size.
+    // Caption fonts use max(cqmin, vh) to ensure a minimum viewport-relative
+    // size for small inline players while using container-relative sizing when
+    // the container is large enough. Multiply the scale factor by 100.
     long fontSize = lroundf(100 * fontScale);
 
-    return makeString("font-size: "_s, fontSize, "cqmin"_s, important ? "!important;"_s : ";"_s);
+    return makeString("font-size: max("_s, fontSize, "cqmin,"_s, fontSize, "vh)"_s, important ? "!important;"_s : ";"_s);
 }
 
 float CaptionUserPreferencesMediaAF::captionFontSizeScaleAndImportance(bool& important) const


### PR DESCRIPTION
#### dffdb08de5641534d2235ada3de9cb8d3ffb3271
<pre>
[WebVTT] Use max(5cqmin, 5vh) for caption font size to fix small inline players
<a href="https://bugs.webkit.org/show_bug.cgi?id=309805">https://bugs.webkit.org/show_bug.cgi?id=309805</a>
<a href="https://rdar.apple.com/171023402">rdar://171023402</a>

Reviewed by NOBODY (OOPS!).

The WebVTT spec defaults caption font size to 5vh (viewport-relative). WebKit
changed this to 5cqmin (container-query-relative) to fix captions being absurdly
large in portrait fullscreen (<a href="https://rdar.apple.com/118030141">rdar://118030141</a>). However, 5cqmin is relative to
the video element&apos;s container dimensions, not the viewport. For inline embedded
players significantly smaller than the viewport (such as Spotify&apos;s video player),
this produces captions ~2.5x smaller than Chrome and other browsers that follow
the spec&apos;s viewport-relative default.

Use max(5cqmin, 5vh) to provide a viewport-relative floor while preserving
container-relative sizing when the container is large enough. In most fullscreen
scenarios, 5cqmin &gt;= 5vh so the container-relative value is used. For small inline
players, 5vh provides the spec-aligned minimum.

Also update CaptionUserPreferencesMediaAF::captionsFontSizeCSS() to use the same
max() pattern for consistency when user caption preferences are applied, and fix
stale comments in both MediaControlTextTrackContainerElement.cpp and
CaptionUserPreferencesMediaAF.cpp that still referenced &quot;vh units&quot; from before
the migration to container query units.

Note: The &quot;captions hidden behind UI items&quot; aspect of <a href="https://rdar.apple.com/171023402">rdar://171023402</a> is a
separate CSS stacking context issue where Spotify&apos;s page-level overlay elements
render above the &lt;video&gt; element. This cannot be fixed within the shadow DOM and
may require a site-specific quirk.

* Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css:
(::cue): Use max(5cqmin, 5vh) for font size floor.
(::-webkit-media-text-track-region): Ditto.
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::updateActiveCuesFontSize):
Update stale comment.
* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::CaptionUserPreferencesMediaAF::captionsFontSizeCSS):
Use max(cqmin, vh) for user preference override. Update stale comment.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dffdb08de5641534d2235ada3de9cb8d3ffb3271

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158376 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103105 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3baf9e95-7245-4d70-9868-a2003908bcdd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22842 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22392 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115457 "Found 28 new test failures: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_50.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line.html ... (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82073 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19a723af-96e1-4850-a581-51185b8ee82c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152633 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17603 "Found 1 new test failure: media/track/track-cue-inline-min-font-size.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134314 "Found 1 new API test failure: TestWebKitAPI.CaptionPreferenceTests.FontSize (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96200 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ae613ad3-a32d-4f19-9aa8-b7ae9dc2163d) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16688 "Found 8 new test failures: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_0_is_top.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/line_50_percent.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/size_50.html (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14596 "Found 2 new API test failures: TestWebKitAPI.CaptionPreferenceTests.FontSize, TestWebKitAPI.CaptionPreferenceTests.PreviewStyles (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6221 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126296 "Found 2 new API test failures: TestWebKitAPI.CaptionPreferenceTests.FontSize, TestWebKitAPI.CaptionPreferenceTests.PreviewStyles (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160855 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3853 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13787 "Found 31 new test failures: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_50.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123487 "Found 120 new test failures: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_50.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u002E_LF_u05D0.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u0041_first.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/bidi/u06E9_no_strong_dir.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22194 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18637 "Found 31 new test failures: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_50.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123694 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22201 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134038 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78426 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18866 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10789 "Found 31 new test failures: imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/2_cues_overlapping_completely_move_up.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_center_position_50.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_end.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/align_start.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/basic.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/decode_escaped_entities.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_align_position_line_size_while_paused.html imported/w3c/web-platform-tests/webvtt/rendering/cues-with-video/processing-model/dom_override_cue_line.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21802 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85622 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21532 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21684 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21589 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->