### PR TITLE
[DRAFT] REGRESSION(294225@main): Material UI modal appears grayed out when modal content box lacks position/transform

### DIFF
--- a/LayoutTests/compositing/repaint/opacity-zero-composited-repaint-container-expected.txt
+++ b/LayoutTests/compositing/repaint/opacity-zero-composited-repaint-container-expected.txt
@@ -1,0 +1,4 @@
+This content should be visible and correctly painted after backdrop opacity transition.
+(repaint rects
+  (rect 0 0 800 600)
+)

--- a/LayoutTests/compositing/repaint/opacity-zero-composited-repaint-container.html
+++ b/LayoutTests/compositing/repaint/opacity-zero-composited-repaint-container.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html>
+<head>
+<style>
+    /* Simulate MUI modal structure */
+    .modal-root {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        z-index: 1300;
+    }
+    .backdrop {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.5);
+        opacity: 0;
+        /* Force compositing */
+        will-change: opacity;
+    }
+    .modal-content {
+        /* Intentionally no position or transform — triggers the bug */
+        width: 200px;
+        height: 200px;
+        background: green;
+        margin: 50px;
+    }
+</style>
+</head>
+<body>
+<div class="modal-root">
+    <div id="backdrop" class="backdrop"></div>
+    <div class="modal-content">This content should be visible and correctly painted after backdrop opacity transition.</div>
+</div>
+<pre id="result"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function timerAfterRAF(callback) {
+    return requestAnimationFrame(() => setTimeout(callback, 0));
+}
+
+function runTest() {
+    if (window.internals)
+        internals.startTrackingRepaints();
+
+    document.getElementById("backdrop").style.opacity = 0.5;
+
+    timerAfterRAF(() => {
+        if (window.internals) {
+            result.innerText = internals.repaintRectsAsText();
+            internals.stopTrackingRepaints();
+        }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1292,7 +1292,7 @@ void RenderLayer::recursiveUpdateLayerPositions(OptionSet<UpdateLayerPositionsFl
         if (mode == Verify) {
             WeakPtr repaintContainer = renderer().containerForRepaint().renderer.get();
             LAYER_POSITIONS_ASSERT(repaintRects() || (isSubtreeVisibilityHiddenOrOpacityZero() || !isSelfPaintingLayer()));
-            if (isSubtreeVisibilityHiddenOrOpacityZero())
+            if (!hasVisibleContent() && !hasVisibleDescendant())
                 LAYER_POSITIONS_ASSERT(!m_repaintContainer);
             else
                 LAYER_POSITIONS_ASSERT(m_repaintContainer == repaintContainer);
@@ -1489,7 +1489,12 @@ void RenderLayer::computeRepaintRects(const RenderLayerModelObject* repaintConta
     else
         setRepaintRects(renderer().rectsForRepaintingAfterLayout(repaintContainer, RepaintOutlineBounds::Yes));
 
-    if (isSubtreeVisibilityHiddenOrOpacityZero())
+    // Only null the repaint container when the entire subtree is truly invisible
+    // (no visible content and no visible descendants). A composited layer with
+    // opacity:0 still needs a valid repaint container so that compositing change
+    // notifications reach the correct composited layer backing rather than
+    // falling back to the root view.
+    if (!hasVisibleContent() && !hasVisibleDescendant())
         m_repaintContainer = nullptr;
     else
         m_repaintContainer = repaintContainer;


### PR DESCRIPTION
#### 5d81f7830a58f15865fc5ec59f71f0268028f2d0
<pre>
REGRESSION(<a href="https://commits.webkit.org/294225@main">294225@main</a>): Material UI modal appears grayed out when modal content box lacks position/transform
<a href="https://bugs.webkit.org/show_bug.cgi?id=304133">https://bugs.webkit.org/show_bug.cgi?id=304133</a>
<a href="https://rdar.apple.com/166585575">rdar://166585575</a>

Reviewed by NOBODY (OOPS!).

The change in <a href="https://commits.webkit.org/294225@main">294225@main</a> modified computeRepaintRects() to set
m_repaintContainer to nullptr for layers where
isSubtreeVisibilityHiddenOrOpacityZero() returns true. The partial fix in
<a href="https://commits.webkit.org/302255@main">302255@main</a> narrowed this with a subtree-aware check, but left the opacity:0
case unaddressed: composited layers with opacity:0 (e.g. a position:fixed
backdrop during a CSS opacity transition) still had m_repaintContainer set to
nullptr.

When a compositing update occurs while the MUI backdrop has opacity:0,
repaintOnCompositingChange() receives a null repaint container from
layer.repaintContainer(). repaintUsingContainer(null, ...) falls back to
&amp;view(), so the backdrop&apos;s own composited layer backing is never invalidated.
When the backdrop later transitions to opacity:0.5, its composited layer
renders stale content, causing the modal to appear grayed out. Resizing the
window fixes it by forcing a full compositing update.

Fix by narrowing the condition for nulling m_repaintContainer to only truly
invisible subtrees (!hasVisibleContent() &amp;&amp; !hasVisibleDescendant()),
excluding the opacity:0 case. A composited layer with opacity:0 retains its
valid repaint container so that compositing change notifications reach the
correct composited layer.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::recursiveUpdateLayerPositions): Update assertion to
match the narrowed condition for when m_repaintContainer should be null.
(WebCore::RenderLayer::computeRepaintRects): Only null m_repaintContainer
when the entire subtree has no visible content or descendants, not when
merely opacity is zero.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d81f7830a58f15865fc5ec59f71f0268028f2d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149808 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16109 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158514 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103240 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cac389a2-ddf0-4772-9ec7-82c2ae0f8fa1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151681 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22627 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115556 "Found 1 new test failure: compositing/repaint/opacity-zero-composited-repaint-container.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82132 "3 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d87bf8e-ee50-419c-ba89-14bf59f37921) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152768 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17673 "Found 1 new test failure: compositing/repaint/opacity-zero-composited-repaint-container.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96296 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a74fbb43-8095-4d03-aecd-e0da849572cd) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16770 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14697 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6359 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126377 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160990 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4074 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13895 "Found 1 new test failure: compositing/repaint/opacity-zero-composited-repaint-container.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123572 "Found 1 new test failure: compositing/repaint/opacity-zero-composited-repaint-container.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22329 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18739 "Found 4 new test failures: accessibility/list/list-active-element-selected-children.html accessibility/mac/text-operation/text-operation-capitalize.html accessibility/text-marker/character-offset-visible-position-conversion-hang.html compositing/repaint/opacity-zero-composited-repaint-container.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123777 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22336 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134146 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78561 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18935 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10897 "Found 1 new test failure: compositing/repaint/opacity-zero-composited-repaint-container.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21937 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85757 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21667 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21819 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21724 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->