### PR TITLE
[Safer-CPP] Updated expectations in the commit are not reflected in results after a second run

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -7960,7 +7960,7 @@ class ParseStaticAnalyzerResultsWithoutChange(ParseStaticAnalyzerResults):
 
 class FindModifiedSaferCPPExpectations(shell.ShellCommand, AddToLogMixin):
     name = 'find-modified-safer-cpp-expectations'
-    RE_FILE = r'^(\+|-)(?P<file>[^/+/-].+(?:\.cpp|\.mm|\.h|\.m|\.c))$'
+    RE_FILE = r'^(\+|-)(?:\[\s*(?P<platform>[^\]]+?)\s*\]\s+)?(?P<file>[^/+/-].+(?:\.cpp|\.mm|\.h|\.m|\.c))$'
     RE_EXPECTATIONS = r'^(\+\+\+).+(Source/(?P<project>.+)/SaferCPPExpectations/(?P<checker>.+)Expectations)$'
     command = ['git', 'diff', 'HEAD~1', '--', '*Expectations']
 
@@ -7983,8 +7983,8 @@ class FindModifiedSaferCPPExpectations(shell.ShellCommand, AddToLogMixin):
             return defer.returnValue(rc)
 
         yield self._addToLog('stdio', '\nLooking for changes to Safer CPP expectations...\n')
-        removed_tests = []
-        added_tests = []
+        removed_tests = {}
+        added_tests = {}
         for line in logText.splitlines():
             expectation_match = re.search(self.RE_EXPECTATIONS, line, re.IGNORECASE)
             if expectation_match:
@@ -7993,13 +7993,16 @@ class FindModifiedSaferCPPExpectations(shell.ShellCommand, AddToLogMixin):
                 yield self._addToLog('stdio', f'Changes for {project}/{checker}...\n')
             file_match = re.search(self.RE_FILE, line, re.IGNORECASE)
             if file_match:
+                raw_platform = (file_match.group('platform') or '').strip()
+                platform = raw_platform.lower() if raw_platform else 'all'
                 test_name = f"{project}/{file_match.group('file')}/{checker}"
+                platform_str = f'[{raw_platform}] ' if raw_platform else ''
                 if file_match.group(1) == '+':
-                    added_tests.append(test_name)
-                    yield self._addToLog('stdio', f'    {test_name} was added to {checker} expectations.\n')
+                    added_tests.setdefault(platform, []).append(test_name)
+                    yield self._addToLog('stdio', f'    {platform_str}{test_name} was added to {checker} expectations.\n')
                 elif file_match.group(1) == '-':
-                    removed_tests.append(test_name)
-                    yield self._addToLog('stdio', f'    {test_name} was removed from {checker} expectations.\n')
+                    removed_tests.setdefault(platform, []).append(test_name)
+                    yield self._addToLog('stdio', f'    {platform_str}{test_name} was removed from {checker} expectations.\n')
 
         self.setProperty('user_removed_tests', removed_tests)
         self.setProperty('user_added_tests', added_tests)
@@ -8007,7 +8010,7 @@ class FindModifiedSaferCPPExpectations(shell.ShellCommand, AddToLogMixin):
 
     def getResultSummary(self):
         if self.results == SUCCESS:
-            if self.getProperty('user_removed_tests', []) or self.getProperty('user_added_tests', []):
+            if self.getProperty('user_removed_tests', {}) or self.getProperty('user_added_tests', {}):
                 return {'step': 'Found modified expectations'}
             return {'step': 'No modified expectations'}
         else:
@@ -8054,8 +8057,11 @@ class FindUnexpectedStaticAnalyzerResults(shell.ShellCommand, AnalyzeChange, Add
         num_unexpected_results = self.getProperty('num_failing_files', 0) or self.getProperty('num_unexpected_issues', 0) or self.getProperty('num_passing_files', 0)
         unexpected_results_after_filter = None
         if num_unexpected_results:
-            user_removed_tests = self.getProperty('user_removed_tests', [])
-            user_added_tests = self.getProperty('user_added_tests', [])
+            user_removed_tests = self.getProperty('user_removed_tests', {})
+            user_added_tests = self.getProperty('user_added_tests', {})
+            current_platform = self.getProperty('platform', '')
+            user_removed_tests_for_platform = self.get_tests_for_platform(user_removed_tests, current_platform)
+            user_added_tests_for_platform = self.get_tests_for_platform(user_added_tests, current_platform)
 
             results_json = yield self.decode_results_data()
             if not results_json:
@@ -8066,11 +8072,11 @@ class FindUnexpectedStaticAnalyzerResults(shell.ShellCommand, AnalyzeChange, Add
 
             needs_filter = False
             for test in unexpected_passes:
-                if test not in user_added_tests:
+                if test not in user_added_tests_for_platform:
                     needs_filter = True
                     break
             for test in unexpected_failures:
-                if test not in user_removed_tests or needs_filter:
+                if test not in user_removed_tests_for_platform or needs_filter:
                     needs_filter = True
                     break
 
@@ -8188,8 +8194,11 @@ class FindUnexpectedStaticAnalyzerResults(shell.ShellCommand, AnalyzeChange, Add
     def check_results_db(self, results_json, result_type, configuration, identifier):
         yield self._addToLog(self.results_db_log_name, f'\nChecking for unexpected {result_type}...\n')
         filtered_results = set()
-        user_removed_tests = self.getProperty('user_removed_tests', [])
-        user_added_tests = self.getProperty('user_added_tests', [])
+        user_removed_tests = self.getProperty('user_removed_tests', {})
+        user_added_tests = self.getProperty('user_added_tests', {})
+        current_platform = configuration.get('platform', '')
+        user_removed_tests_for_platform = self.get_tests_for_platform(user_removed_tests, current_platform)
+        user_added_tests_for_platform = self.get_tests_for_platform(user_added_tests, current_platform)
 
         for project, checkers in results_json.items():
             for checker, files in checkers.items():
@@ -8209,7 +8218,7 @@ class FindUnexpectedStaticAnalyzerResults(shell.ShellCommand, AnalyzeChange, Add
                     yield self._addToLog(self.results_db_log_name, f"\n{test_name}: pre-existing={data['does_result_match']}\nResponse from results-db: {data}\n{data['logs']}")
 
                     skip_filter = False
-                    if (test_name in user_removed_tests and result_type == 'failures') or (test_name in user_added_tests and result_type == 'passes'):
+                    if (test_name in user_removed_tests_for_platform and result_type == 'failures') or (test_name in user_added_tests_for_platform and result_type == 'passes'):
                         skip_filter = True
 
                     if data['does_result_match'] and skip_filter:
@@ -8223,6 +8232,13 @@ class FindUnexpectedStaticAnalyzerResults(shell.ShellCommand, AnalyzeChange, Add
                         yield self._addToLog('stdio', f'Adding {file} to unexpected {result_type}.\n')
                         filtered_results.add(file)
         return defer.returnValue(filtered_results)
+
+    @staticmethod
+    def get_tests_for_platform(tests_dict, current_platform):
+        result = set(tests_dict.get('all', []))
+        if current_platform:
+            result.update(tests_dict.get(current_platform.lower(), []))
+        return result
 
     def find_unexpected_results(self):
         log_text = self.log_observer.getStdout()
@@ -8308,12 +8324,15 @@ class FindUnexpectedStaticAnalyzerResultsWithoutChange(FindUnexpectedStaticAnaly
 
         self.find_unexpected_results()
 
-        user_removed_tests = self.getProperty('user_removed_tests', [])
-        user_added_tests = self.getProperty('user_added_tests', [])
+        user_removed_tests = self.getProperty('user_removed_tests', {})
+        user_added_tests = self.getProperty('user_added_tests', {})
+        current_platform = self.getProperty('platform', '')
+        user_removed_tests_for_platform = self.get_tests_for_platform(user_removed_tests, current_platform)
+        user_added_tests_for_platform = self.get_tests_for_platform(user_added_tests, current_platform)
 
-        if user_removed_tests or user_added_tests:
+        if user_removed_tests_for_platform or user_added_tests_for_platform:
             self.unexpected_results_filtered = yield self.decode_results_data()
-            yield self.filter_results_by_user_modification(user_added_tests, user_removed_tests)
+            yield self.filter_results_by_user_modification(user_added_tests_for_platform, user_removed_tests_for_platform)
 
         has_unexpected_results = self.getProperty('num_failing_files', 0) or self.getProperty('num_unexpected_issues', 0) or self.getProperty('num_passing_files', 0)
         if has_unexpected_results and self.was_filtered:

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -10104,8 +10104,8 @@ diff --git a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpecta
         )
         self.expect_outcome(result=SUCCESS, state_string='Found modified expectations')
         rc = self.run_step()
-        self.expect_property('user_added_tests', ['WebCore/inspector/agents/worker/WorkerWorkerAgent.h/NoUncountedMemberChecker'])
-        self.expect_property('user_removed_tests', ['WebCore/css/ShorthandSerializer.cpp/NoUncountedMemberChecker', 'WebCore/Modules/WebGPU/GPUQueue.cpp/UncountedCallArgsChecker'])
+        self.expect_property('user_added_tests', {'all': ['WebCore/inspector/agents/worker/WorkerWorkerAgent.h/NoUncountedMemberChecker']})
+        self.expect_property('user_removed_tests', {'all': ['WebCore/css/ShorthandSerializer.cpp/NoUncountedMemberChecker', 'WebCore/Modules/WebGPU/GPUQueue.cpp/UncountedCallArgsChecker']})
         return rc
 
     def test_replace(self):
@@ -10137,8 +10137,41 @@ index 8a2d2375b8d2..f7ebc3b11b94 100644
         )
         self.expect_outcome(result=SUCCESS, state_string='Found modified expectations')
         rc = self.run_step()
-        self.expect_property('user_added_tests', ['WebCore/inspector/agents/worker/WorkerWorkerAgent.h/NoUncountedMemberChecker'])
-        self.expect_property('user_removed_tests', ['WebCore/inspector/agents/worker/WorkerAuditAgent.h/NoUncountedMemberChecker'])
+        self.expect_property('user_added_tests', {'all': ['WebCore/inspector/agents/worker/WorkerWorkerAgent.h/NoUncountedMemberChecker']})
+        self.expect_property('user_removed_tests', {'all': ['WebCore/inspector/agents/worker/WorkerAuditAgent.h/NoUncountedMemberChecker']})
+        return rc
+
+    def test_with_platform_tags(self):
+        self.configureStep()
+        self.setProperty('builddir', 'wkdir')
+        self.setProperty('buildnumber', 1234)
+
+        commit_diff = '''
+diff --git a/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations b/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+--- a/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
++++ b/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+-[ iOS ] dom/NodeInlines.h
++[ iOS ] dom/NodeNewFile.h
+-[ Mac ] page/mac/PageMac.mm
++generic/file.cpp
+'''
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        log_environ=False,
+                        command=['git', 'diff', 'HEAD~1', '--', '*Expectations'])
+            .log('stdio', stdout=commit_diff)
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Found modified expectations')
+        rc = self.run_step()
+        self.expect_property('user_added_tests', {
+            'ios': ['WebCore/dom/NodeNewFile.h/NoDeleteChecker'],
+            'all': ['WebCore/generic/file.cpp/NoDeleteChecker'],
+        })
+        self.expect_property('user_removed_tests', {
+            'ios': ['WebCore/dom/NodeInlines.h/NoDeleteChecker'],
+            'mac': ['WebCore/page/mac/PageMac.mm/NoDeleteChecker'],
+        })
         return rc
 
     @expectedFailure
@@ -10320,8 +10353,8 @@ class TestFindUnexpectedStaticAnalyzerResults(BuildStepMixinAdditions, unittest.
     def test_changed_expectations_match(self):
         self.configureStep(True)
         FindUnexpectedStaticAnalyzerResults.decode_results_data = lambda self: {'passes': {'WebCore': {'NoUncountedMemberChecker': ['css/ShorthandSerializer.cpp']}}, 'failures': {'WebCore': {'NoUncountedMemberChecker': ['inspector/agents/worker/WorkerWorkerAgent.h']}}}
-        self.setProperty('user_removed_tests', ['WebCore/inspector/agents/worker/WorkerWorkerAgent.h/NoUncountedMemberChecker'])
-        self.setProperty('user_added_tests', ['WebCore/css/ShorthandSerializer.cpp/NoUncountedMemberChecker'])
+        self.setProperty('user_removed_tests', {'all': ['WebCore/inspector/agents/worker/WorkerWorkerAgent.h/NoUncountedMemberChecker']})
+        self.setProperty('user_added_tests', {'all': ['WebCore/css/ShorthandSerializer.cpp/NoUncountedMemberChecker']})
         next_steps = []
         self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
         self.expectRemoteCommands(
@@ -10343,8 +10376,8 @@ class TestFindUnexpectedStaticAnalyzerResults(BuildStepMixinAdditions, unittest.
         self.configureStep(True)
         FindUnexpectedStaticAnalyzerResults.decode_results_data = lambda self: {'passes': {'WebCore': {'NoUncountedMemberChecker': ['css/ShorthandSerializer.cpp']}}, 'failures': {'WebCore': {'NoUncountedMemberChecker': ['inspector/agents/worker/WorkerWorkerAgent.h']}}}
         FindUnexpectedStaticAnalyzerResults.filter_results_using_results_db = lambda self, logText: False
-        self.setProperty('user_removed_tests', [])
-        self.setProperty('user_added_tests', ['WebCore/css/ShorthandSerializer.cpp/NoUncountedMemberChecker'])
+        self.setProperty('user_removed_tests', {})
+        self.setProperty('user_added_tests', {'all': ['WebCore/css/ShorthandSerializer.cpp/NoUncountedMemberChecker']})
         next_steps = []
         self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
         self.expectRemoteCommands(
@@ -10368,8 +10401,8 @@ class TestFindUnexpectedStaticAnalyzerResults(BuildStepMixinAdditions, unittest.
         FindUnexpectedStaticAnalyzerResults.decode_results_data = lambda self: {'passes': {'WebCore': {'NoUncountedMemberChecker': []}}, 'failures': {'WebCore': {'NoUncountedMemberChecker': []}}}
         self.setProperty('test_failures', ['WebCore/inspector/agents/worker/WorkerWorkerAgent.h/NoUncountedMemberChecker'])
         self.setProperty('test_passes', [])
-        self.setProperty('user_removed_tests', ['WebCore/inspector/agents/worker/WorkerWorkerAgent.h/NoUncountedMemberChecker'])
-        self.setProperty('user_added_tests', [])
+        self.setProperty('user_removed_tests', {'all': ['WebCore/inspector/agents/worker/WorkerWorkerAgent.h/NoUncountedMemberChecker']})
+        self.setProperty('user_added_tests', {})
         self._expected_uploaded_files = ['public_html/results/Safer-CPP-Checks/1234-1234/unexpected_results.json']
         next_steps = []
         self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
@@ -10391,7 +10424,7 @@ class TestFindUnexpectedStaticAnalyzerResults(BuildStepMixinAdditions, unittest.
     def test_second_pass_no_results(self):
         self.configureStep(False)
         FindUnexpectedStaticAnalyzerResults.decode_results_data = lambda self: {'passes': {'WebCore': {'NoUncountedMemberChecker': []}}, 'failures': {'WebCore': {'NoUncountedMemberChecker': ['css/ShorthandSerializer.cpp']}}}
-        self.setProperty('user_added_tests', ['WebCore/css/ShorthandSerializer.cpp/NoUncountedMemberChecker'])
+        self.setProperty('user_added_tests', {'all': ['WebCore/css/ShorthandSerializer.cpp/NoUncountedMemberChecker']})
         next_steps = []
         self._expected_uploaded_files = ['public_html/results/Safer-CPP-Checks/1234-1234/unexpected_results.json']
         self.patch(self.build, 'addStepsAfterCurrentStep', lambda s: next_steps.extend(s))
@@ -10409,6 +10442,48 @@ class TestFindUnexpectedStaticAnalyzerResults(BuildStepMixinAdditions, unittest.
             rc = self.run_step()
         self.assertEqual([], next_steps)
         return rc
+
+    def test_second_pass_ios_platform_mismatch(self):
+        # iOS-specific added expectation should NOT be filtered on a macOS builder
+        self.configureStep(False)
+        FindUnexpectedStaticAnalyzerResults.decode_results_data = lambda self: {'passes': {'WebCore': {'NoDeleteChecker': []}}, 'failures': {'WebCore': {'NoDeleteChecker': ['dom/NodeInlines.h']}}}
+        self.setProperty('platform', 'mac')
+        self.setProperty('user_added_tests', {'ios': ['WebCore/dom/NodeInlines.h/NoDeleteChecker']})
+        self.setProperty('user_removed_tests', {})
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        log_environ=False,
+                        logfiles={'json': self.jsonFileName},
+                        command=self.command + self.upload_options + self.configuration,
+                        env={'RESULTS_SERVER_API_KEY': 'test-api-key'})
+            .log('stdio', stdout='Total unexpected failing files: 1\n')
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='1 failing file ')
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
+            return self.run_step()
+
+    def test_second_pass_ios_platform_match(self):
+        # iOS-specific added expectation SHOULD be filtered on an iOS builder
+        self.configureStep(False)
+        FindUnexpectedStaticAnalyzerResults.decode_results_data = lambda self: {'passes': {'WebCore': {'NoDeleteChecker': []}}, 'failures': {'WebCore': {'NoDeleteChecker': ['dom/NodeInlines.h']}}}
+        self.setProperty('platform', 'ios')
+        self.setProperty('user_added_tests', {'ios': ['WebCore/dom/NodeInlines.h/NoDeleteChecker']})
+        self.setProperty('user_removed_tests', {})
+        self._expected_uploaded_files = ['public_html/results/Safer-CPP-Checks/1234-1234/unexpected_results.json']
+        ios_configuration = ['--architecture', 'arm64', '--platform', 'ios', '--version', '14.6.1', '--version-name', 'Sonoma', '--style', 'release', '--sdk', '23G93']
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        log_environ=False,
+                        logfiles={'json': self.jsonFileName},
+                        command=self.command + self.upload_options + ios_configuration,
+                        env={'RESULTS_SERVER_API_KEY': 'test-api-key'})
+            .log('stdio', stdout='Total unexpected failing files: 1\n')
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Found no unexpected results')
+        with current_hostname(EWS_BUILD_HOSTNAMES[0]):
+            return self.run_step()
 
 
 class TestDownloadUnexpectedResultsfromMaster(BuildStepMixinAdditions, unittest.TestCase):


### PR DESCRIPTION
#### 8d08842dec9413938324e5647282685d94be37f4
<pre>
[Safer-CPP] Updated expectations in the commit are not reflected in results after a second run
<a href="https://bugs.webkit.org/show_bug.cgi?id=309807">https://bugs.webkit.org/show_bug.cgi?id=309807</a>
<a href="https://rdar.apple.com/168238275">rdar://168238275</a>

Reviewed by NOBODY (OOPS!).

In FindModifiedSaferCPPExpectations:
    - When finding modified expectations, use updated regex to find a platform if it exists.
    - Then, save the modified tests as a mapping of platform -&gt; test name.

The mapping of removed and added tests are later used in FindUnexpectedStaticAnalyzerResults to
filter out the modified test expectations per platform.

This solves the issue where tests with a specified platform were being read as &apos;project/[platform] testname&apos;
and thus not being filtered out from the unexpected results.

* Tools/CISupport/ews-build/steps.py:
(FindModifiedSaferCPPExpectations):
(FindModifiedSaferCPPExpectations.run):
(FindModifiedSaferCPPExpectations.getResultSummary):
(FindUnexpectedStaticAnalyzerResults.run):
(FindUnexpectedStaticAnalyzerResults.check_results_db):
(FindUnexpectedStaticAnalyzerResults):
(FindUnexpectedStaticAnalyzerResults.get_tests_for_platform):
(FindUnexpectedStaticAnalyzerResultsWithoutChange.run):
* Tools/CISupport/ews-build/steps_unittest.py:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d08842dec9413938324e5647282685d94be37f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149677 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/22396 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/15976 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/158380 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103109 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151550 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/22846 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22396 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/158380 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103109 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152637 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/22846 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/134320 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/158380 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/22846 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14599 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/6225 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/22846 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/12251 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/160859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/13793 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/160859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/149077 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/22198 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/18640 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/160859 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/22205 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/134044 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78430 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/10795 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/21806 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/21536 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/21688 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/21593 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->