### PR TITLE
[DRAFT] Do not report minimized windows as visible when backgroundTextExtractionEnabled is set

### DIFF
--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -220,6 +220,9 @@ bool PageClientImpl::isViewVisible(NSView *view, NSWindow *viewWindow)
 
         if (windowIsOccluded())
             return false;
+    } else if (viewWindow.miniaturized) {
+        RELEASE_LOG(ActivityState, "PageClientImpl %p isViewVisible(): returning false because window %p is miniaturized (backgroundTextExtractionEnabled bypass does not apply to miniaturized windows)", this, viewWindow);
+        return false;
     }
 
     return true;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/VisibilityState.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/VisibilityState.mm
@@ -31,6 +31,7 @@
 #import "WKWebViewConfigurationExtras.h"
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebViewConfiguration.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
 
 #if !PLATFORM(IOS_SIMULATOR)
 #import "DeprecatedGlobalValues.h"
@@ -65,6 +66,69 @@ TEST(VisibilityState, InitialVisibleState)
     }];
     TestWebKitAPI::Util::run(&done);
 }
+
+#if PLATFORM(MAC)
+
+TEST(VisibilityState, MiniaturizedWindowIsHiddenWithBackgroundTextExtraction)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration _setBackgroundTextExtractionEnabled:YES];
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get() addToWindow:YES]);
+
+    [webView synchronouslyLoadHTMLString:@"<html><body>test</body></html>"];
+
+    // Verify the window is visible and document.visibilityState is "visible".
+    __block bool done = false;
+    [webView evaluateJavaScript:@"document.visibilityState" completionHandler:^(NSString *visibilityState, NSError *error) {
+        EXPECT_WK_STREQ("visible", visibilityState);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    // Miniaturize the window. Even with backgroundTextExtractionEnabled,
+    // the page should report as hidden.
+    [webView.get().window miniaturize:nil];
+    [webView waitUntilActivityStateUpdateDone];
+
+    done = false;
+    [webView evaluateJavaScript:@"document.visibilityState" completionHandler:^(NSString *visibilityState, NSError *error) {
+        EXPECT_WK_STREQ("hidden", visibilityState);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    // Deminiaturize the window. The page should report as visible again.
+    [webView.get().window deminiaturize:nil];
+    [webView waitUntilActivityStateUpdateDone];
+
+    done = false;
+    [webView evaluateJavaScript:@"document.visibilityState" completionHandler:^(NSString *visibilityState, NSError *error) {
+        EXPECT_WK_STREQ("visible", visibilityState);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
+TEST(VisibilityState, OccludedWindowIsVisibleWithBackgroundTextExtraction)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration _setBackgroundTextExtractionEnabled:YES];
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get() addToWindow:YES]);
+
+    [webView synchronouslyLoadHTMLString:@"<html><body>test</body></html>"];
+
+    // Verify the window is visible and document.visibilityState is "visible".
+    // This test ensures that backgroundTextExtractionEnabled still works for
+    // occluded (not miniaturized) windows -- the bypass should still apply.
+    __block bool done = false;
+    [webView evaluateJavaScript:@"document.visibilityState" completionHandler:^(NSString *visibilityState, NSError *error) {
+        EXPECT_WK_STREQ("visible", visibilityState);
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+}
+
+#endif // PLATFORM(MAC)
 
 #if !PLATFORM(IOS_SIMULATOR)
 


### PR DESCRIPTION
#### da08cabc1d99e70097ef016130e0a1b1d5f0951f
<pre>
Do not report minimized windows as visible when backgroundTextExtractionEnabled is set
<a href="https://bugs.webkit.org/show_bug.cgi?id=309808">https://bugs.webkit.org/show_bug.cgi?id=309808</a>
<a href="https://rdar.apple.com/169468617">rdar://169468617</a>

Reviewed by NOBODY (OOPS!).

When backgroundTextExtractionEnabled is true, PageClientImpl::isViewVisible() bypasses
both the NSWindow.isVisible and window occlusion state checks. This is intended to allow
text extraction from windows that are behind other windows. However, it also incorrectly
reports miniaturized (minimized to Dock) windows as visible, which causes media elements
to autoplay in minimized windows.

Fix this by adding a miniaturized check in the backgroundTextExtractionEnabled branch.
Miniaturization is a deliberate user action to dismiss a window, so text extraction
bypass should not apply. This prevents ActivityState::IsVisible from being set for
miniaturized windows, which in turn prevents autoplay.

* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::isViewVisible): Return false for miniaturized windows even
when backgroundTextExtractionEnabled is set.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da08cabc1d99e70097ef016130e0a1b1d5f0951f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15977 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158381 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103110 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115456 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82077 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17593 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134322 "Found 1 new API test failure: TestWebKitAPI.VisibilityState.MiniaturizedWindowIsHiddenWithBackgroundTextExtraction (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96199 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16690 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14604 "2 api tests failed or timed out") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6226 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126298 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12253 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160860 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3858 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13795 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123491 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123698 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22206 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134046 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78431 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18870 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10797 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21807 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85627 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21537 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21689 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21594 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->