### PR TITLE
[DRAFT] Allow user-installed fonts in iOS Mail compose

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4938,6 +4938,14 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
 
     updateSettingsGenerated(store, settings);
 
+#if PLATFORM(IOS_FAMILY)
+    // rdar://169732367: iOS Mail compose sets _shouldAllowUserInstalledFonts = NO
+    // for general sandboxing, but must allow user-installed fonts for the custom
+    // font picker. This mirrors the macOS exemption for Apple Mail above.
+    if (!settings.shouldAllowUserInstalledFonts() && (WTF::IOSApplication::isMailCompositionService() || WTF::IOSApplication::isMobileMail()))
+        settings.setShouldAllowUserInstalledFonts(true);
+#endif
+
 #if !PLATFORM(GTK) && !PLATFORM(WIN) && !PLATFORM(PLAYSTATION) && !PLATFORM(WPE)
     if (!settings.acceleratedCompositingEnabled()) {
         WEBPAGE_RELEASE_LOG(Layers, "updatePreferences: acceleratedCompositingEnabled setting was false. WebKit cannot function in this mode; changing setting to true");

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UserInstalledFontsMailOverride.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UserInstalledFontsMailOverride.mm
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "PlatformUtilities.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+
+// This test verifies that when _shouldAllowUserInstalledFonts is set to NO,
+// user-installed fonts are still accessible in the iOS Mail compose context.
+// rdar://169732367
+//
+// NOTE: This test can only fully validate the fix when run inside the
+// com.apple.MailCompositionService or com.apple.mobilemail process.
+// When run under the test harness (com.apple.WebKit.TestWebKitAPI),
+// IOSApplication::isMailCompositionService() returns false, so the
+// override does not activate. This test documents the expected behavior
+// and serves as a regression test framework for when bundle ID simulation
+// becomes available in the test infrastructure.
+
+TEST(WebKit, UserInstalledFontsBlockedByDefault)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration preferences]._shouldAllowUserInstalledFonts = NO;
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568) configuration:configuration.get()]);
+
+    // Load a page that tries to use a font-family and checks computed style.
+    // Under the test harness (not Mail), user-installed fonts should be blocked.
+    [webView synchronouslyLoadHTMLString:@"<html><body><p id='target' style='font-family: \"SomeUserFont\", sans-serif;'>Test</p>"
+        "<script>"
+        "var el = document.getElementById('target');"
+        "var computed = window.getComputedStyle(el).fontFamily;"
+        // The computed font-family should not resolve to the user font
+        // when _shouldAllowUserInstalledFonts = NO (outside of Mail context).
+        "document.title = computed;"
+        "</script></body></html>"];
+


### PR DESCRIPTION
#### 275e2a3f2b666c8d3e0ac3040c7895d0a309b1fb
<pre>
Allow user-installed fonts in iOS Mail compose
<a href="https://bugs.webkit.org/show_bug.cgi?id=309810">https://bugs.webkit.org/show_bug.cgi?id=309810</a>
<a href="https://rdar.apple.com/169732367">rdar://169732367</a>

Reviewed by NOBODY (OOPS!).

iOS Mail compose (com.apple.MailCompositionService) sets
_shouldAllowUserInstalledFonts = NO on its WKWebView for sandboxing purposes.
This causes CoreText to exclude all user-installed custom fonts from matching
via kCTFontUserInstalledAttribute = kCFBooleanFalse, preventing users from
applying custom fonts they have installed on the device.

Override shouldAllowUserInstalledFonts back to true when running in the iOS
Mail compose service or mobile Mail app, mirroring the existing macOS exemption
that skips BlockUserInstalledFonts for Apple Mail.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::updatePreferences):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/275e2a3f2b666c8d3e0ac3040c7895d0a309b1fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149681 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15980 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158384 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103113 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff39dd72-6f09-4d84-a3b7-7331569a0a2a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151554 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115461 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82079 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2003609f-6a4c-43c7-bc0a-5a7b35c8e99e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17595 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96204 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4abe0aa0-0dc6-4ccd-be96-5934145c2b57) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16692 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14601 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6229 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160863 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3862 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13800 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123495 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22202 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18642 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123701 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22209 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134051 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78434 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18872 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10802 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21810 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85630 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21540 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21692 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21597 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->