### PR TITLE
[DRAFT] Anchor Positioning: reject viewport-fixed elements as anchors for abspos elements

### DIFF
--- a/LayoutTests/fast/css/css-anchor-position/abspos-cannot-anchor-to-viewport-fixed-expected.txt
+++ b/LayoutTests/fast/css/css-anchor-position/abspos-cannot-anchor-to-viewport-fixed-expected.txt
@@ -1,0 +1,5 @@
+
+PASS abspos element cannot anchor to a viewport-fixed element
+PASS fixed element can anchor to a viewport-fixed element
+PASS abspos element can anchor to a descendant of a fixed element
+

--- a/LayoutTests/fast/css/css-anchor-position/abspos-cannot-anchor-to-viewport-fixed.html
+++ b/LayoutTests/fast/css/css-anchor-position/abspos-cannot-anchor-to-viewport-fixed.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Test that abspos elements cannot anchor to viewport-fixed elements</title>
+<meta charset="utf-8">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<!--
+  Test: abspos elements should not be able to anchor to viewport-fixed elements.
+
+  Per CSS Anchor Positioning spec, the "initial fixed containing block" is
+  conceptually the parent of the initial containing block in the containing
+  block chain. An absolutely-positioned element can have at most the initial
+  containing block (viewport) as its containing block. A viewport-fixed anchor
+  element uses the initial fixed containing block, which is above the viewport.
+  Therefore, a viewport-fixed anchor is never "strictly laid out before" a
+  non-viewport-fixed anchored element, making it an unacceptable anchor.
+
+  https://drafts.csswg.org/css-anchor-position-1/#acceptable-anchor-element
+  https://drafts.csswg.org/css-position-3/#def-cb
+-->
+
+<style>
+  body { margin: 0; }
+
+  /* Case 1: viewport-fixed anchor, abspos anchored (no positioned ancestor).
+     The abspos should NOT successfully anchor to the fixed element.
+     Since the anchor is unacceptable, left: anchor(...) uses its fallback (0px). */
+  #fixed-anchor {
+    position: fixed;
+    anchor-name: --fixed;
+    left: 100px;
+    top: 0;
+    width: 50px;
+    height: 50px;
+    background: orange;
+  }
+
+  #abspos-target {
+    position: absolute;
+    left: anchor(--fixed right, 0px);
+    top: 0;
+    width: 10px;
+    height: 10px;
+    background: blue;
+  }
+
+  /* Case 2: viewport-fixed anchor, fixed anchored (both viewport-fixed).
+     The fixed anchored element SHOULD successfully anchor to the fixed anchor. */
+  #fixed-anchor-2 {
+    position: fixed;
+    anchor-name: --fixed-2;
+    left: 200px;
+    top: 50px;
+    width: 50px;
+    height: 50px;
+    background: green;
+  }
+
+  #fixed-target {
+    position: fixed;
+    left: anchor(--fixed-2 right);
+    top: 50px;
+    width: 10px;
+    height: 10px;
+    background: purple;
+  }
+
+  /* Case 3: anchor is a descendant of a fixed element but NOT itself fixed.
+     An abspos element SHOULD be able to anchor to it (regression guard).
+     This matches the scenario from WPT anchor-position-002.html case 3. */
+  #transform-container {
+    position: relative;
+    transform: translate(0, 0); /* Creates a containing block */
+  }
+
+  #fixed-parent {
+    position: fixed;
+    left: 300px;
+    top: 100px;
+  }
+
+  #child-anchor {
+    anchor-name: --child;
+    width: 30px;
+    height: 30px;
+    background: red;
+  }
+
+  #abspos-target-2 {
+    position: absolute;
+    left: anchor(--child right);
+    top: 100px;
+    width: 10px;
+    height: 10px;
+    background: cyan;
+  }
+</style>
+
+<!-- Case 1: Fixed anchor + abspos target (should NOT anchor) -->
+<div id="fixed-anchor"></div>
+<div id="abspos-target"></div>
+
+<!-- Case 2: Fixed anchor + fixed target (SHOULD anchor) -->
+<div id="fixed-anchor-2"></div>
+<div id="fixed-target"></div>
+
+<!-- Case 3: Descendant of fixed + abspos target (SHOULD anchor) -->
+<div id="transform-container">
+  <div id="fixed-parent">
+    <div id="child-anchor"></div>
+  </div>
+  <div id="abspos-target-2"></div>
+</div>
+
+<script>
+  test(function() {
+    // Case 1: abspos should NOT anchor to viewport-fixed element.
+    // anchor() should use its fallback value (0px), so left should be 0.
+    const target = document.getElementById('abspos-target');
+    assert_equals(target.offsetLeft, 0,
+      'abspos element should not anchor to a viewport-fixed element; left should be 0 (fallback)');
+  }, 'abspos element cannot anchor to a viewport-fixed element');
+
+  test(function() {
+    // Case 2: fixed element SHOULD anchor to another viewport-fixed element.
+    // left: anchor(--fixed-2 right) = 200px + 50px = 250px
+    const anchor = document.getElementById('fixed-anchor-2');
+    const target = document.getElementById('fixed-target');
+    const anchorRect = anchor.getBoundingClientRect();
+    const targetRect = target.getBoundingClientRect();

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1157,6 +1157,24 @@ static bool isAcceptableAnchorElement(const RenderBoxModelObject& anchorRenderer
         return true;
     case TopLayerStatus::Same: {
         // "- Both elements are in the same top layer..."
+
+        // Per the CSS spec, a viewport-fixed element (position: fixed using the
+        // viewport as its containing block) actually uses the "initial fixed
+        // containing block", which is conceptually the parent of the initial
+        // containing block in the containing block chain.
+        // https://drafts.csswg.org/css-position-3/#def-cb
+        // An absolutely-positioned element's containing block chain can reach at
+        // most the initial containing block (viewport), never the initial fixed
+        // containing block above it. Therefore, a viewport-fixed anchor element
+        // is never "strictly laid out before" a non-viewport-fixed anchored element.
+        // https://drafts.csswg.org/css-anchor-position-1/#acceptable-anchor-element
+        bool anchorIsViewportFixed = anchorRenderer.isFixedPositioned()
+            && anchorRenderer.container() && anchorRenderer.container()->isRenderView();
+        bool anchoredIsViewportFixed = anchorPositionedRenderer->isFixedPositioned()
+            && containingBlock->isRenderView();
+        if (anchorIsViewportFixed && !anchoredIsViewportFixed)
+            return false;
+
         auto* penultimateElement = penultimateContainingBlockChainElement(anchorRenderer, containingBlock.get());
         if (!penultimateElement)
             return false;


### PR DESCRIPTION
#### 447bdf0178932af6c58ad08758248ba8bbac0d54
<pre>
Anchor Positioning: reject viewport-fixed elements as anchors for abspos elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=307171">https://bugs.webkit.org/show_bug.cgi?id=307171</a>
<a href="https://rdar.apple.com/170323196">rdar://170323196</a>

Reviewed by NOBODY (OOPS!).

Per the CSS Positioned Layout spec, a viewport-fixed element (position: fixed
with the viewport as its containing block) uses the &quot;initial fixed containing
block&quot;, which is conceptually the parent of the initial containing block in the
containing block chain. An absolutely-positioned element&apos;s containing block
chain can reach at most the initial containing block (viewport), never the
initial fixed containing block above it.

Therefore, a viewport-fixed anchor element is never &quot;strictly laid out before&quot;
a non-viewport-fixed anchored element in the same top layer, making it an
unacceptable anchor per the CSS Anchor Positioning spec.

The bug manifested because WebKit&apos;s container() method returns the viewport
(RenderView) for both viewport-fixed elements and abspos elements with no
positioned ancestor. Since both resolve to the same RenderElement,
penultimateContainingBlockChainElement() would find the fixed anchor in the
chain and firstChildPrecedesSecondChild() could incorrectly accept it based
on DOM tree order alone.

Fix: Add an early-exit check in isAcceptableAnchorElement() within the
TopLayerStatus::Same case: if the anchor is viewport-fixed but the anchored
element is not, reject the anchor.

* Source/WebCore/style/AnchorPositionEvaluator.cpp:
  (isAcceptableAnchorElement): Reject viewport-fixed anchors when the
  anchored element is not viewport-fixed, modeling the spec&apos;s containing
  block hierarchy where the initial fixed CB is above the initial CB.
* LayoutTests/fast/css/css-anchor-position/abspos-cannot-anchor-to-viewport-fixed.html: Added.
* LayoutTests/fast/css/css-anchor-position/abspos-cannot-anchor-to-viewport-fixed-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/447bdf0178932af6c58ad08758248ba8bbac0d54

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158385 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103114 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08f94894-2960-4cfc-9f4e-b6d0c4d573b9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22423 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115462 "Found 1 new test failure: fast/css/css-anchor-position/abspos-cannot-anchor-to-viewport-fixed.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82078 "9 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6256abb4-e621-4ee1-9fe8-6cd42d0ca4c4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152642 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17597 "Found 1 new test failure: fast/css/css-anchor-position/abspos-cannot-anchor-to-viewport-fixed.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134328 "Found 1 new API test failure: TestWebKitAPI.ContextMenuTests.ContextMenuElementInfoWithQRCodeDetectionCrash (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96205 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d531d41-5aaa-44fb-b8aa-f9bc9f12d8d2) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16694 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14607 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6230 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126302 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12259 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160864 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3965 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13801 "Found 1 new test failure: fast/css/css-anchor-position/abspos-cannot-anchor-to-viewport-fixed.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123493 "Found 1 new test failure: fast/css/css-anchor-position/abspos-cannot-anchor-to-viewport-fixed.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22203 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18648 "Found 1 new test failure: fast/css/css-anchor-position/abspos-cannot-anchor-to-viewport-fixed.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123700 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22210 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134052 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78435 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18874 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10803 "Found 1 new test failure: fast/css/css-anchor-position/abspos-cannot-anchor-to-viewport-fixed.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21811 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85631 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21541 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21693 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21598 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->