### PR TITLE
[DRAFT] PaintRenderingContext2D should reset unrealized save count before restore loop

### DIFF
--- a/LayoutTests/fast/css-custom-paint/unrealized-saves-no-crash-expected.txt
+++ b/LayoutTests/fast/css-custom-paint/unrealized-saves-no-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS: No crash with unrealized saves in paint worklet.

--- a/LayoutTests/fast/css-custom-paint/unrealized-saves-no-crash.html
+++ b/LayoutTests/fast/css-custom-paint/unrealized-saves-no-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html><!-- webkit-test-runner [ CSSPaintingAPIEnabled=true ] -->
+<meta name="assert" content="PaintRenderingContext2D should not crash when destroyed with unrealized saves">
+<link rel="help" content="https://drafts.css-houdini.org/css-paint-api-1/">
+
+<script id="code" type="text/worklet">
+  class UnrealizedSavePaint {
+    paint(ctx, geom) {
+      // Create some unrealized saves.
+      ctx.save();
+      ctx.save();
+
+      // Perform a draw to realize the pending saves.
+      ctx.fillStyle = "green";
+      ctx.fillRect(0, 0, geom.width, geom.height);
+
+      // Create more unrealized saves (these will not be realized
+      // because no further draws occur). When the PaintRenderingContext2D
+      // is destroyed, the destructor must properly account for these
+      // unrealized saves when unwinding the RecorderImpl state stack.
+      ctx.save();
+      ctx.save();
+      // Intentionally no matching restore() calls.
+    }
+  }
+  registerPaint('unrealized-save-paint', UnrealizedSavePaint);
+</script>
+
+<div id="target" style="width: 100px; height: 100px; background-image: paint(unrealized-save-paint);"></div>
+<pre id="result"></pre>
+
+<script>
+  importWorklet(CSS.paintWorklet, document.getElementById('code').textContent);
+  // If we reach here without crashing, the test passes.
+  // Allow a rAF for the paint to execute.
+  requestAnimationFrame(() => {
+    document.getElementById('result').textContent = "PASS: No crash with unrealized saves in paint worklet.";
+    if (window.testRunner)
+      testRunner.notifyDone();
+  });
+  if (window.testRunner)
+    testRunner.waitUntilDone();
+</script>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -403,6 +403,7 @@ protected:
     RefPtr<ImageBuffer> makeRenderingResultsAvailable(ShouldApplyPostProcessingToDirtyRect = ShouldApplyPostProcessingToDirtyRect::Yes);
     RefPtr<ImageBuffer> createImageForNoiseInjection() const;
     void didUpdateCanvasSizeProperties(bool) override;
+    void resetUnrealizedSaveCount() { m_unrealizedSaveCount = 0; }
 
 private:
     struct CachedContentsTransparent {

--- a/Source/WebCore/html/canvas/PaintRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/PaintRenderingContext2D.cpp
@@ -58,6 +58,7 @@ PaintRenderingContext2D::~PaintRenderingContext2D()
     // Call the user-induced restore()s. Restore through the restore() method
     // to let the CanvasRenderingContext2DBase::~CanvasRenderingContext2DBase()
     // code make sense.
+    resetUnrealizedSaveCount();
     size_t restoreCount = stateStack().size() - 1;
     for (size_t i = 0; i < restoreCount; ++i)
         restore();
@@ -94,6 +95,7 @@ void PaintRenderingContext2D::replayDisplayList(GraphicsContext& target) const
 
 void PaintRenderingContext2D::didUpdateCanvasSizeProperties(bool sizeChanged)
 {
+    resetUnrealizedSaveCount();
     size_t restoreCount = stateStack().size() - 1;
     for (size_t i = 0; i < restoreCount; ++i)
         restore();


### PR DESCRIPTION
#### 508abce6e9dcc7757dca641fca78669c0384152d
<pre>
PaintRenderingContext2D should reset unrealized save count before restore loop
<a href="https://bugs.webkit.org/show_bug.cgi?id=309811">https://bugs.webkit.org/show_bug.cgi?id=309811</a>
<a href="https://rdar.apple.com/171486515">rdar://171486515</a>

Reviewed by NOBODY (OOPS!).

PaintRenderingContext2D::didUpdateCanvasSizeProperties() and its destructor
call restore() in a loop to unwind the canvas state stack. However, if there
are pending unrealized saves (saves that incremented m_unrealizedSaveCount
but had not yet triggered a context-&gt;save() on the underlying RecorderImpl),
the first N restore() calls merely decrement the unrealized counter without
calling through to the RecorderImpl. This leaves the RecorderImpl&apos;s state
stack with more entries than expected, causing ASSERT(stateStack().size() == 1)
to fire in RecorderImpl::~RecorderImpl().

This is the same bug pattern that was fixed in CanvasRenderingContext2DBase::
didUpdateCanvasSizeProperties() by bug 308741 (commit b5da4b256925), but the
override in PaintRenderingContext2D was not updated with the same fix.

Since m_unrealizedSaveCount is private to CanvasRenderingContext2DBase, add a
protected resetUnrealizedSaveCount() helper, and call it in both
PaintRenderingContext2D::didUpdateCanvasSizeProperties() and its destructor
before the restore loop.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
(WebCore::CanvasRenderingContext2DBase::resetUnrealizedSaveCount):
* Source/WebCore/html/canvas/PaintRenderingContext2D.cpp:
(WebCore::PaintRenderingContext2D::~PaintRenderingContext2D):
(WebCore::PaintRenderingContext2D::didUpdateCanvasSizeProperties):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/508abce6e9dcc7757dca641fca78669c0384152d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158388 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103117 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01b731ad-7766-42c4-8797-8f71c7fc87ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22419 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115465 "Found 1 new test failure: fast/css-custom-paint/unrealized-saves-no-crash.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82080 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c6f7ffb-7d7e-43e0-a231-a9bad87ed0cc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152645 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17598 "Found 1 new test failure: fast/css-custom-paint/unrealized-saves-no-crash.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96207 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/356f16f3-7f0e-4a6f-b614-30574f7f27d0) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16695 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14606 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6233 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126303 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160867 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3966 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13804 "Found 1 new test failure: fast/css-custom-paint/unrealized-saves-no-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123496 "Found 1 new test failure: fast/css-custom-paint/unrealized-saves-no-crash.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22206 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18647 "Found 1 new test failure: fast/css-custom-paint/unrealized-saves-no-crash.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123702 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22213 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134055 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78438 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18876 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10806 "Found 1 new test failure: fast/css-custom-paint/unrealized-saves-no-crash.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21814 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85634 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21544 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21696 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21601 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->