### PR TITLE
[DRAFT] [WebCore] Guard setCategory() in updateSessionState() against redundant mode changes

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h
@@ -148,6 +148,7 @@ private:
 
     RunLoop::Timer m_delayCategoryChangeTimer;
     AudioSession::CategoryType m_previousCategory { AudioSession::CategoryType::None };
+    AudioSession::Mode m_previousAudioMode { AudioSession::Mode::Default };
     bool m_previousHadAudibleAudioOrVideoMediaType { false };
 };
 

--- a/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
+++ b/Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm
@@ -207,10 +207,21 @@ void MediaSessionManagerCocoa::updateSessionState()
 
     RouteSharingPolicy policy = (category == AudioSession::CategoryType::MediaPlayback) ? RouteSharingPolicy::LongFormAudio : RouteSharingPolicy::Default;
 
-    ALWAYS_LOG(LOGIDENTIFIER, "setting category = ", category, ", mode = ", mode, ", policy = ", policy, ", previous category = ", m_previousCategory);
+    bool categoryOrModeChanged = category != m_previousCategory || mode != m_previousAudioMode;
+
+    ALWAYS_LOG(LOGIDENTIFIER, "setting category = ", category, ", mode = ", mode, ", policy = ", policy, ", previous category = ", m_previousCategory, ", categoryOrModeChanged = ", categoryOrModeChanged);
 
     m_previousCategory = category;
-    sharedSession->setCategory(category, mode, policy);
+    m_previousAudioMode = mode;
+
+    // Only call setCategory() when the category or mode has actually changed.
+    // On visionOS, Travel Mode transitions may trigger updateSessionState() via
+    // an audio session interruption, but the desired category/mode remain the same.
+    // AudioSessionIOS::setCategory() has its own guard against redundant AVAudioSession
+    // calls, but during an interruption the transient AVAudioSession state may differ
+    // from the logical WebKit state, causing an unnecessary session reconfiguration.
+    if (categoryOrModeChanged)
+        sharedSession->setCategory(category, mode, policy);
 
     forEachSession([&] (auto& session) {
         session.audioSessionCategoryChanged(category, mode, policy);
@@ -221,6 +232,7 @@ void MediaSessionManagerCocoa::possiblyChangeAudioCategory()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     m_previousCategory = AudioSession::CategoryType::None;
+    m_previousAudioMode = AudioSession::Mode::Default;
     updateSessionState();
 }
 
@@ -229,6 +241,7 @@ void MediaSessionManagerCocoa::resetSessionState()
     ALWAYS_LOG(LOGIDENTIFIER);
     m_delayCategoryChangeTimer.stop();
     m_previousCategory = AudioSession::CategoryType::None;
+    m_previousAudioMode = AudioSession::Mode::Default;
     m_previousHadAudibleAudioOrVideoMediaType = false;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/MediaSessionManagerCocoaTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/MediaSessionManagerCocoaTest.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Test concept for rdar://171834999
+// Verifies that MediaSessionManagerCocoa::updateSessionState() does not issue
+// redundant setCategory() calls when category and mode have not changed.
+//
+// This test requires MockAudioSession support. The test outline below describes
+// the expected behavior; actual integration depends on the test harness available
+// in the WebKit tree.
+
+// TEST(MediaSessionManagerCocoa, UpdateSessionStateSkipsRedundantSetCategory)
+//
+// Setup:
+//   1. Create a MediaSessionManagerCocoa instance.
+//   2. Add a PlatformMediaSession with MediaType::VideoAudio that is audible
+//      and playing (to trigger MediaPlayback category with MoviePlayback mode
+//      on visionOS).
+//   3. Install a mock or counting wrapper around AudioSession::setCategory()
+//      to track call count.
+//
+// Test steps:
+//   1. Call updateSessionState() -- expect setCategory() called once.
+//      Verify category = MediaPlayback, mode = MoviePlayback (on VISION).
+//   2. Call updateSessionState() again with same session state --
+//      expect setCategory() NOT called (count remains 1).
+//   3. Verify forEachSession audioSessionCategoryChanged WAS called on both
+//      invocations (downstream state always notified).
+//
+// TEST(MediaSessionManagerCocoa, PossiblyChangeAudioCategoryResetsTrackedMode)
+//
+// Setup:
+//   Same as above.
+//
+// Test steps:
+//   1. Call updateSessionState() -- setCategory() called once.
+//   2. Call updateSessionState() -- setCategory() NOT called (dedup).
+//   3. Call possiblyChangeAudioCategory() -- this resets m_previousCategory
+//      and m_previousAudioMode, then calls updateSessionState().
+//      Expect setCategory() called again (count = 2).
+//
+// TEST(MediaSessionManagerCocoa, ResetSessionStateClearsTrackedMode)
+//
+// Setup:
+//   Same as above.
+//


### PR DESCRIPTION
#### 61a9f0c17b58be7df95f9ba7de67dbebb6da9144
<pre>
[WebCore] Guard setCategory() in updateSessionState() against redundant mode changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=309812">https://bugs.webkit.org/show_bug.cgi?id=309812</a>
<a href="https://rdar.apple.com/171834999">rdar://171834999</a>

On visionOS, toggling Travel Mode while Safari is playing audio causes a
brief ~39ms stutter. Travel Mode transitions trigger audio session
interruptions which cause updateSessionState() to be called. When the
interruption transiently changes AVAudioSession&apos;s internal state,
AudioSessionIOS::setCategory() may see a difference and issue a redundant
[AVAudioSession setCategory:mode:routeSharingPolicy:options:error:] call,
forcing an unnecessary session reconfiguration during the interruption
window and exacerbating the stutter.

Add m_previousAudioMode tracking alongside the existing m_previousCategory
to skip the setCategory() call when neither category nor mode has changed
from WebKit&apos;s perspective. Continue calling forEachSession
audioSessionCategoryChanged unconditionally so downstream state (e.g.,
VideoPresentationInterfaceIOS route sharing policy) remains consistent.

* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.h:
  Add m_previousAudioMode member (AudioSession::Mode) to track last-set mode.
* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
  (MediaSessionManagerCocoa::updateSessionState): Guard setCategory() call
  behind a category-or-mode-changed check. Always call
  audioSessionCategoryChanged on sessions so downstream consumers remain
  in sync.
  (MediaSessionManagerCocoa::possiblyChangeAudioCategory): Reset
  m_previousAudioMode to Default alongside m_previousCategory reset.
  (MediaSessionManagerCocoa::resetSessionState): Reset m_previousAudioMode
  to Default alongside m_previousCategory reset.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61a9f0c17b58be7df95f9ba7de67dbebb6da9144

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158392 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103121 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83b123ba-3367-4885-bd19-1f66927c1c35) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22858 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115469 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82083 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ef4039d-b8b9-4890-ad9f-0ca0ba3fae33) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152649 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17599 "Found 5 new test failures: media/audio-session-category-play-unmute-pause.html media/audio-session-category-unmute-mute.html media/audio-session-category.html media/audioSession/audioSessionType.html media/video-audio-session-mode.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96208 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/395429ce-66f8-48f1-85c9-baf3a8c79dbc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16696 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14613 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6237 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126304 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160871 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3968 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13796 "Found 2 new test failures: media/audio-session-category-unmute-mute.html media/audioSession/audioSessionType.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123498 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22210 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18654 "Found 3 new test failures: media/audio-session-category-unmute-mute.html media/audio-session-category.html media/audioSession/audioSessionType.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123704 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22217 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134047 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78442 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18878 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10798 "Found 2 new test failures: media/audio-session-category-unmute-mute.html media/audioSession/audioSessionType.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21818 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85638 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 16.4; Checked out pull request; Found 41209 issues") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21548 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21700 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21605 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->