### PR TITLE
[DRAFT] Fix canvas drawImage(video) flickering during camera resolution changes when filters are applied

### DIFF
--- a/LayoutTests/fast/canvas/canvas-drawImage-video-with-filter-expected.txt
+++ b/LayoutTests/fast/canvas/canvas-drawImage-video-with-filter-expected.txt
@@ -1,0 +1,10 @@
+Ensure drawImage(video) with canvas filter produces correct output and does not flicker. Bug: rdar://169617372
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+Baseline center pixel (no filter): [PIXEL VALUES]
+PASS isNonBlack(pixelAt(160, 120)) is true
+Filtered center pixel (blur 1px): [PIXEL VALUES]
+PASS isNonBlack(pixelAt(160, 120)) is true
+Partial src filtered pixel: [PIXEL VALUES]
+PASS isNonBlack(pixelAt(160, 120)) is true

--- a/LayoutTests/fast/canvas/canvas-drawImage-video-with-filter.html
+++ b/LayoutTests/fast/canvas/canvas-drawImage-video-with-filter.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<meta name="fuzzy" content="maxDifference=0-5; totalPixels=0-40000" />
+<script src="../../resources/js-test-pre.js"></script>
+<script src="../../media/utilities.js"></script>
+<script>
+    description("Ensure drawImage(video) with canvas filter produces correct output and does not flicker. Bug: rdar://169617372");
+    jsTestIsAsync = true;
+
+    let video = document.createElement("video");
+    video.muted = true;
+    video.playsInline = true;
+
+    let canvas = document.createElement("canvas");
+    canvas.width = 320;
+    canvas.height = 240;
+    document.body.appendChild(canvas);
+
+    let ctx = canvas.getContext("2d");
+
+    function pixelAt(x, y) {
+        return ctx.getImageData(x, y, 1, 1).data;
+    }
+
+    function isNonBlack(pixel) {
+        return pixel[0] > 10 || pixel[1] > 10 || pixel[2] > 10;
+    }
+
+    waitForVideoFrame(video, async function() {
+        // Draw without filter first to establish baseline
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+        let baselinePixel = pixelAt(160, 120);
+        debug("Baseline center pixel (no filter): [" + baselinePixel[0] + ", " + baselinePixel[1] + ", " + baselinePixel[2] + ", " + baselinePixel[3] + "]");
+        shouldBeTrue("isNonBlack(pixelAt(160, 120))");
+
+        // Draw with blur filter applied — exercises the CG native image path with filter
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.filter = "blur(1px)";
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+        ctx.filter = "none";
+
+        let filteredPixel = pixelAt(160, 120);
+        debug("Filtered center pixel (blur 1px): [" + filteredPixel[0] + ", " + filteredPixel[1] + ", " + filteredPixel[2] + ", " + filteredPixel[3] + "]");
+        shouldBeTrue("isNonBlack(pixelAt(160, 120))");
+
+        // Draw with partial source rect — exercises the normalizedSrcRect remapping code
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.filter = "blur(1px)";
+        ctx.drawImage(video, 0, 0, video.videoWidth / 2, video.videoHeight / 2, 0, 0, canvas.width, canvas.height);
+        ctx.filter = "none";
+
+        let partialPixel = pixelAt(160, 120);
+        debug("Partial src filtered pixel: [" + partialPixel[0] + ", " + partialPixel[1] + ", " + partialPixel[2] + ", " + partialPixel[3] + "]");
+        shouldBeTrue("isNonBlack(pixelAt(160, 120))");
+
+        finishJSTest();
+    });
+
+    video.src = findMediaFile("video", "../../media/content/test");
+</script>
+<script src="../../resources/js-test-post.js"></script>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1901,8 +1901,21 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(HTMLVideoElement& vide
 #if USE(CG)
     if (c->hasPlatformContext() && video.shouldGetNativeImageForCanvasDrawing()) {
         if (auto image = video.nativeImageForCurrentTime()) {
-            c->drawNativeImage(*image, normalizedDstRect, normalizedSrcRect);
-
+            // During a camera resolution change, naturalSize() and the native image can be
+            // temporarily out of sync: naturalSize() reflects the new resolution while the
+            // native image is still from the previous resolution (or vice versa). Remap
+            // normalizedSrcRect from naturalSize coordinate space to the actual native image
+            // coordinate space to prevent rendering artifacts and flickering.
+            auto imageSize = FloatSize(image->size());
+            auto videoSize = size(video);
+            FloatRect effectiveSrcRect = normalizedSrcRect;
+            if (!imageSize.isEmpty() && !videoSize.isEmpty() && imageSize != videoSize) {
+                float scaleX = imageSize.width() / videoSize.width();
+                float scaleY = imageSize.height() / videoSize.height();
+                effectiveSrcRect = { normalizedSrcRect.x() * scaleX, normalizedSrcRect.y() * scaleY,
+                    normalizedSrcRect.width() * scaleX, normalizedSrcRect.height() * scaleY };
+            }
+            c->drawNativeImage(*image, normalizedDstRect, effectiveSrcRect);
             didDraw(repaintEntireCanvas, targetSwitcher ? targetSwitcher->expandedBounds() : normalizedDstRect, defaultDidDrawOptionsWithoutPostProcessing());
             return { };
         }


### PR DESCRIPTION
#### 234d4217df20e7fbd7ae7bd657ca42bedbe0592e
<pre>
Fix canvas drawImage(video) flickering during camera resolution changes when filters are applied
<a href="https://bugs.webkit.org/show_bug.cgi?id=309813">https://bugs.webkit.org/show_bug.cgi?id=309813</a>
<a href="https://rdar.apple.com/169617372">rdar://169617372</a>

Reviewed by NOBODY (OOPS!).

During a camera resolution change, naturalSize() and nativeImageForCurrentTime() can
temporarily be out of sync: the cached natural size reflects the new resolution while the
native image is still from the previous resolution (or vice versa). When drawImage() uses
the CG native image path, normalizedSrcRect is computed from naturalSize() coordinates but
applied to a native image with different dimensions, producing incorrect source-to-destination
mapping and visible flickering -- especially noticeable when a canvas filter is active.

Fix by detecting the size mismatch at the point of drawing and proportionally remapping
normalizedSrcRect into the actual native image&apos;s coordinate space before calling
drawNativeImage. This matches the pattern already used by paintWithVideoOutput in
MediaPlayerPrivateAVFoundationObjC, which uses lastImage-&gt;size() for its source rect.

The non-CG fallback path (paintCurrentFrameInContext) is not affected because it obtains
the video size synchronously within the same call, so no mismatch can occur.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawImage): Remap normalizedSrcRect to native
image coordinate space when naturalSize() and native image dimensions are out of sync
during resolution transitions.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/234d4217df20e7fbd7ae7bd657ca42bedbe0592e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158394 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103123 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61ed4c5c-0194-4d8d-8dc1-b4242a584747) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22860 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22432 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115467 "Found 1 new test failure: fast/canvas/canvas-drawImage-video-with-filter.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82084 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23f25af1-e06b-4962-8ab5-82a73a0607c8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152651 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17627 "Found 1 new test failure: fast/canvas/canvas-drawImage-video-with-filter.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134324 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96209 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de4721e0-d569-435b-805c-c4811fd40654) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16723 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14609 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6239 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126331 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160873 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3970 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13797 "Found 1 new test failure: fast/canvas/canvas-drawImage-video-with-filter.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123500 "Found 1 new test failure: fast/canvas/canvas-drawImage-video-with-filter.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22212 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18650 "Found 1 new test failure: fast/canvas/canvas-drawImage-video-with-filter.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123706 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22219 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134048 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78444 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18879 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10799 "Found 1 new test failure: fast/canvas/canvas-drawImage-video-with-filter.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85640 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21550 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21702 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21607 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->