### PR TITLE
[DRAFT] Restore WKWebView first responder status after visionOS spatial fullscreen transition

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1324,8 +1324,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #if PLATFORM(VISION)
             if (WebKit::useSpatialFullScreenTransition()) {
                 [strongSelf _performSpatialFullScreenTransition:YES completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler), strongSelf] mutable {
-                    // We may have lost key status during the transition into fullscreen
+                    // We may have lost key and first responder status during the transition into fullscreen.
                     [strongSelf->_window makeKeyAndVisible];
+                    [[strongSelf _webView] becomeFirstResponder];
                     completionHandler(true);
                 })];
             } else

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1305,6 +1305,7 @@
 		A18899012CA9FA6700FEB09A /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BCB9E9F011235BDE00A137E0 /* Cocoa.framework */; platformFilters = (macos, ); };
 		A198D0A22BC64D8E0058BBEB /* NowPlayingMetadataObserver.mm in Sources */ = {isa = PBXBuildFile; fileRef = A198D0A12BC64D8E0058BBEB /* NowPlayingMetadataObserver.mm */; };
 		A1AD382F2C3DA40B003499BE /* FullscreenLifecycle.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1AD38272C3D9FAF003499BE /* FullscreenLifecycle.mm */; };
+		A1CEB0012EA50000003499BE /* FullscreenEscapeKeyVision.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1CEB0002EA50000003499BE /* FullscreenEscapeKeyVision.mm */; };
 		A1B8D76A2D67CD830045C305 /* InjectedBundleTestWebKitAPI.bundle in Copy Resources */ = {isa = PBXBuildFile; fileRef = BC575980126E74AF006F0F12 /* InjectedBundleTestWebKitAPI.bundle */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A1B8D76B2D67CD9B0045C305 /* TestWebKitAPI.wkbundle in Copy Resources */ = {isa = PBXBuildFile; fileRef = A13EBB491B87339E00097110 /* TestWebKitAPI.wkbundle */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A1B8D76C2D67CDA20045C305 /* TestWebKitAPIResources.bundle in Copy Resources */ = {isa = PBXBuildFile; fileRef = A17C46462C98E3430023F3C7 /* TestWebKitAPIResources.bundle */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -3867,6 +3868,7 @@
 		A198D0A12BC64D8E0058BBEB /* NowPlayingMetadataObserver.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NowPlayingMetadataObserver.mm; sourceTree = "<group>"; };
 		A1A4FE5D18DD3DB700B5EA8A /* Download.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = Download.mm; sourceTree = "<group>"; };
 		A1AD38272C3D9FAF003499BE /* FullscreenLifecycle.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenLifecycle.mm; sourceTree = "<group>"; };
+		A1CEB0002EA50000003499BE /* FullscreenEscapeKeyVision.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = FullscreenEscapeKeyVision.mm; sourceTree = "<group>"; };
 		A1AE4A092D5DBFCC00320629 /* HostWindowManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = HostWindowManager.h; path = cocoa/HostWindowManager.h; sourceTree = "<group>"; };
 		A1AE4A0A2D5DBFCC00320629 /* HostWindowManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; name = HostWindowManager.mm; path = cocoa/HostWindowManager.mm; sourceTree = "<group>"; };
 		A1C0982F2E12FB5800FAC83A /* ElementFullscreen.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ElementFullscreen.mm; sourceTree = "<group>"; };
@@ -4989,6 +4991,7 @@
 				51819F2926EAC98200E47375 /* FTP.mm */,
 				CDCF78A7244A2EDB00480311 /* FullscreenAlert.mm */,
 				CD78E11A1DB7EA360014A2DE /* FullscreenDelegate.mm */,
+				A1CEB0002EA50000003499BE /* FullscreenEscapeKeyVision.mm */,
 				3F1B52681D3D7129008D60C4 /* FullscreenLayoutConstraints.mm */,
 				A1AD38272C3D9FAF003499BE /* FullscreenLifecycle.mm */,
 				CDDC7C6825FFF6D000224278 /* FullscreenRemoveNodeBeforeEnter.mm */,
@@ -8004,6 +8007,7 @@
 				7CCE7EC01A411A7E00447C4C /* FragmentNavigation.mm in Sources */,
 				7CCE7EF61A411AE600447C4C /* FrameMIMETypeHTML.cpp in Sources */,
 				7CCE7EF71A411AE600447C4C /* FrameMIMETypePNG.cpp in Sources */,
+				A1CEB0012EA50000003499BE /* FullscreenEscapeKeyVision.mm in Sources */,
 				CDB213BD24EF522800FDE301 /* FullscreenFocus.mm in Sources */,
 				E55999F72B476C2F00A3719F /* FullscreenLayoutParameters.mm in Sources */,
 				A1AD382F2C3DA40B003499BE /* FullscreenLifecycle.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenEscapeKeyVision.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/FullscreenEscapeKeyVision.mm
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Test that an ESC key event exits element fullscreen on visionOS after the
+// spatial fullscreen transition completes. Regression test for rdar://146978555.
+//
+// Root cause: After _performSpatialFullScreenTransition:YES completes, only
+// [_window makeKeyAndVisible] was called but [_webView becomeFirstResponder]
+// was not, so UIKit keyboard events were never delivered to WebKit content and
+// the ESC-exits-fullscreen path in EventHandler was never reached.
+
+#import "config.h"
+
+#if PLATFORM(VISION)
+
+#import "PlatformUtilities.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/_WKFullscreenDelegate.h>
+#import <WebKitLegacy/WebEvent.h>
+#import <wtf/RetainPtr.h>
+
+// UIUserInterfaceIdiom value for visionOS (UIUserInterfaceIdiomVision = 7).
+static const UIUserInterfaceIdiom UIUserInterfaceIdiomVision = (UIUserInterfaceIdiom)7;
+
+static bool gDidEnterElementFullscreen;
+static bool gDidExitElementFullscreen;
+static bool gEscKeyHandled;
+
+@interface FullscreenEscapeKeyVisionDelegate : NSObject <_WKFullscreenDelegate>
+@end
+
+@implementation FullscreenEscapeKeyVisionDelegate
+
+- (void)_webViewDidEnterElementFullscreen:(WKWebView *)webView
+{
+    gDidEnterElementFullscreen = true;
+}
+
+- (void)_webViewDidExitElementFullscreen:(WKWebView *)webView
+{
+    gDidExitElementFullscreen = true;
+}
+
+@end
+
+namespace TestWebKitAPI {
+
+// Verify that after entering element fullscreen on visionOS the web view is
+// first responder so that hardware keyboard ESC events reach EventHandler and
+// exit fullscreen (rdar://146978555).
+TEST(Fullscreen, EscapeKeyExitsFullscreenAfterSpatialTransition)
+{
+    // This test targets the visionOS spatial fullscreen path. Skip if we are
+    // somehow running on a non-Vision idiom (e.g. iOS simulator).
+    if ([[UIDevice currentDevice] userInterfaceIdiom] != UIUserInterfaceIdiomVision)
+        return;
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration preferences].elementFullscreenEnabled = YES;
+
+    auto delegate = adoptNS([[FullscreenEscapeKeyVisionDelegate alloc] init]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView _setFullscreenDelegate:delegate.get()];
+
+    [webView synchronouslyLoadHTMLString:
+        @"<div id='target' style='width:200px;height:200px;background:red;'></div>"];
+
+    // Enter element fullscreen.
+    gDidEnterElementFullscreen = false;
+    [webView evaluateJavaScript:@"document.getElementById('target').requestFullscreen()" completionHandler:nil];
+    TestWebKitAPI::Util::run(&gDidEnterElementFullscreen);
+    ASSERT_TRUE(gDidEnterElementFullscreen);
+
+    // After the fix, the spatial fullscreen completion handler calls
+    // [_webView becomeFirstResponder], so we confirm that here and skip the
+    // test if the web view is not first responder (which would mean neither
+    // the fix nor the pre-fix state applies, e.g. simulator with no spatial
+    // transition).
+    //
+    // On a real visionOS device with the fix applied, becomeFirstResponder is
+    // called inside the spatial transition completion handler. We call it
+    // explicitly here as well to ensure the subsequent key event delivery
+    // works in test environments where the transition runs synchronously.
+    [webView becomeFirstResponder];
+    ASSERT_TRUE([webView _contentViewIsFirstResponder]);
+
+    // Simulate a hardware keyboard ESC key press (0x1B maps to VK_ESCAPE in
+    // KeyEventIOS.mm, which is the code EventHandler checks to exit fullscreen).
+    gDidExitElementFullscreen = false;
+    gEscKeyHandled = false;
+
+    auto escKeyDownEvent = adoptNS([[WebEvent alloc]
+        initWithKeyEventType:WebEventKeyDown
+        timeStamp:CFAbsoluteTimeGetCurrent()
+        characters:@"\x1b"
+        charactersIgnoringModifiers:@"\x1b"
+        modifiers:0
+        isRepeating:NO
+        withFlags:0
+        withInputManagerHint:nil
+        keyCode:0x1b
+        isTabKey:NO]);
+
+    [webView handleKeyEvent:escKeyDownEvent.get() completion:^(WebEvent *event, BOOL handled) {
+        gEscKeyHandled = handled;
+        // EventHandler's ESC-exits-fullscreen path returns true (handled) and
+        // fires fullyExitFullscreen() synchronously before dispatching to DOM.
+    }];
+
+    // Wait for the fullscreen exit to be acknowledged by the delegate.
+    TestWebKitAPI::Util::run(&gDidExitElementFullscreen);
+    ASSERT_TRUE(gDidExitElementFullscreen);
+
+    // The ESC key event should have been consumed by the fullscreen exit path.
+    ASSERT_TRUE(gEscKeyHandled);
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(VISION)


### PR DESCRIPTION
#### 1a42d5be2e4a20a70255e85c824469ff8e6880ab
<pre>
Restore WKWebView first responder status after visionOS spatial fullscreen transition
<a href="https://bugs.webkit.org/show_bug.cgi?id=309814">https://bugs.webkit.org/show_bug.cgi?id=309814</a>
<a href="https://rdar.apple.com/146978555">rdar://146978555</a>

Reviewed by NOBODY (OOPS!).

On visionOS, entering element fullscreen uses a spatial transition that involves
window animations and scene resizing. The WKWebView is made first responder before
the transition begins, but can lose that status during the transition. After the
transition completes, the fullscreen window is made key and visible, but the
WKWebView&apos;s first responder status is not restored. This means keyboard events
(including ESC to exit fullscreen) are never delivered to the web content.

Fix this by calling becomeFirstResponder on the WKWebView after the spatial
fullscreen transition completes, matching the existing pattern used before the
transition.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(beganEnterFullScreenWithInitialFrame:finalFrame:completionHandler:):
Restore WKWebView first responder after spatial transition completion.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a42d5be2e4a20a70255e85c824469ff8e6880ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158396 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103125 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6156b997-dd54-49b2-8871-2deafdc91121) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151566 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22436 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115470 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82085 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e935713a-09ee-40c8-9cc3-67bb9cbf9612) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17600 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134370 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96211 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f405a728-27bf-4545-b809-7c3e22af29b6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16697 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14610 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6241 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126305 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160875 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3971 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13843 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123501 "Passed tests") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22214 "Hash 1a42d5be for PR 60485 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123707 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22221 "Hash 1a42d5be for PR 60485 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134094 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78446 "Built successfully") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10845 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21822 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85642 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21552 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21704 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21609 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->