### PR TITLE
Refactor WebBackForwardListItem::mainFrameState() to clarify copy vs. read-only access.

### DIFF
--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -95,10 +95,7 @@ bool WebBackForwardListItem::itemIsInSameDocument(const WebBackForwardListItem& 
         return false;
 
     // The following logic must be kept in sync with WebCore::HistoryItem::shouldDoSameDocumentNavigationTo().
-    Ref mainFrameState = this->mainFrameState();
-    Ref otherMainFrameState = other.mainFrameState();
-
-    return mainFrameState->documentSequenceNumber == otherMainFrameState->documentSequenceNumber;
+    return mainFrameState().documentSequenceNumber == other.mainFrameState().documentSequenceNumber;
 }
 
 static bool NODELETE hasSameFrames(const FrameState& a, const FrameState& b)
@@ -124,8 +121,8 @@ bool WebBackForwardListItem::itemIsClone(const WebBackForwardListItem& other)
     if (this == &other)
         return false;
 
-    Ref mainFrameState = this->mainFrameState();
-    Ref otherMainFrameState = other.mainFrameState();
+    Ref mainFrameState = copyMainFrameStateWithChildren();
+    Ref otherMainFrameState = other.copyMainFrameStateWithChildren();
 
     if (mainFrameState->itemSequenceNumber != otherMainFrameState->itemSequenceNumber)
         return false;
@@ -162,7 +159,12 @@ Ref<FrameState> WebBackForwardListItem::navigatedFrameState() const
     return protect(navigatedFrameItem())->copyFrameStateWithChildren();
 }
 
-Ref<FrameState> WebBackForwardListItem::mainFrameState() const
+const FrameState& WebBackForwardListItem::mainFrameState() const
+{
+    return m_mainFrameItem->frameState();
+}
+
+Ref<FrameState> WebBackForwardListItem::copyMainFrameStateWithChildren() const
 {
     return m_mainFrameItem->copyFrameStateWithChildren();
 }

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -62,7 +62,8 @@ public:
     BrowsingContextGroup* browsingContextGroup() const { return m_browsingContextGroup.get(); }
 
     Ref<FrameState> navigatedFrameState() const;
-    Ref<FrameState> mainFrameState() const;
+    const FrameState& mainFrameState() const;
+    Ref<FrameState> copyMainFrameStateWithChildren() const;
 
     const String& NODELETE originalURL() const LIFETIME_BOUND;
     const String& NODELETE url() const LIFETIME_BOUND;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
@@ -81,8 +81,8 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (CGPoint)_scrollPosition
 {
-    Ref item = *_item;
-    return CGPointMake(item->mainFrameState()->scrollPosition.x(), item->mainFrameState()->scrollPosition.y());
+    Ref frameState = protect(*_item)->mainFrameState();
+    return CGPointMake(frameState->scrollPosition.x(), frameState->scrollPosition.y());
 }
 
 - (BOOL)_wasCreatedByJSWithoutUserInteraction

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -363,7 +363,7 @@ void ProvisionalPageProxy::goToBackForwardItem(API::Navigation& navigation, WebB
 
     SandboxExtension::Handle sandboxExtensionHandle;
     URL itemURL { item.url() };
-    Ref frameState = navigation.targetFrameItem() ? navigation.targetFrameItem()->copyFrameStateWithChildren() : item.mainFrameState();
+    Ref frameState = navigation.targetFrameItem() ? navigation.targetFrameItem()->copyFrameStateWithChildren() : item.copyMainFrameStateWithChildren();
     page->maybeInitializeSandboxExtensionHandle(process, itemURL, item.resourceDirectoryURL(), true, [
         weakThis = WeakPtr { *this },
         itemURL,

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -439,7 +439,7 @@ BackForwardListState WebBackForwardList::backForwardListState(WTF::Function<bool
             continue;
         }
 
-        backForwardListState.items.append({ entry->mainFrameState(), entry->navigatedFrameID() });
+        backForwardListState.items.append({ entry->copyMainFrameStateWithChildren(), entry->navigatedFrameID() });
     }
 
     if (backForwardListState.items.isEmpty())
@@ -591,7 +591,7 @@ Ref<FrameState> WebBackForwardList::completeFrameStateForNavigation(Ref<FrameSta
     if (!mainFrameItem->childItemForFrameID(*navigatedFrameID))
         return navigatedFrameState;
 
-    Ref frameState = currentItem->mainFrameState();
+    Ref frameState = currentItem->copyMainFrameStateWithChildren();
     setBackForwardItemIdentifier(frameState, *navigatedFrameState->itemID);
     frameState->replaceChildFrameState(WTF::move(navigatedFrameState));
     return frameState;
@@ -747,7 +747,7 @@ void WebBackForwardList::backForwardItemAtIndex(int32_t index, FrameIdentifier f
     if (RefPtr item = itemAtIndex(index)) {
         if (RefPtr frameItem = item->mainFrameItem().childItemForFrameID(frameID))
             return completionHandler(frameItem->copyFrameStateWithChildren());
-        completionHandler(item->mainFrameState());
+        completionHandler(item->copyMainFrameStateWithChildren());
     } else
         completionHandler(nullptr);
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1743,7 +1743,7 @@ RefPtr<API::Navigation> WebPageProxy::launchProcessForReload()
     auto publicSuffix = WebCore::PublicSuffixStore::singleton().publicSuffix(URL(currentItem->url()));
 
     // We allow stale content when reloading a WebProcess that's been killed or crashed.
-    send(Messages::WebPage::GoToBackForwardItem({ navigation->navigationID(), currentItem->mainFrameState(), FrameLoadType::IndexedBackForward, ShouldTreatAsContinuingLoad::No, std::nullopt, m_lastNavigationWasAppInitiated, std::nullopt, publicSuffix, { }, WebCore::ProcessSwapDisposition::None }));
+    send(Messages::WebPage::GoToBackForwardItem({ navigation->navigationID(), currentItem->copyMainFrameStateWithChildren(), FrameLoadType::IndexedBackForward, ShouldTreatAsContinuingLoad::No, std::nullopt, m_lastNavigationWasAppInitiated, std::nullopt, publicSuffix, { }, WebCore::ProcessSwapDisposition::None }));
 
     Ref legacyMainFrameProcess = m_legacyMainFrameProcess;
     legacyMainFrameProcess->startResponsivenessTimer();
@@ -2724,7 +2724,7 @@ RefPtr<API::Navigation> WebPageProxy::goToBackForwardItem(WebBackForwardListFram
 
     process->markProcessAsRecentlyUsed();
 
-    Ref frameState = item->mainFrameState();
+    Ref frameState = item->copyMainFrameStateWithChildren();
     if (protect(preferences())->siteIsolationEnabled()) {
         if (RefPtr frame = WebFrameProxy::webFrame(frameItem.frameID()); frame && frame->page() == this) {
             process = frame->process();
@@ -5754,7 +5754,7 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
         if (currentItem && (navigation->lockBackForwardList() == LockBackForwardList::Yes || navigation->lockHistory() == LockHistory::Yes)) {
             // If WebCore is supposed to lock the history for this load, then the new process needs to know about the current history item so it can update
             // it instead of creating a new one.
-            provisionalPage->send(Messages::WebPage::SetCurrentHistoryItemForReattach(currentItem->mainFrameState()));
+            provisionalPage->send(Messages::WebPage::SetCurrentHistoryItemForReattach(currentItem->copyMainFrameStateWithChildren()));
         }
 
         // FIXME: Work out timing of responding with the last policy delegate, etc

--- a/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm
@@ -249,7 +249,7 @@ void ViewGestureController::beginSwipeGesture(_UINavigationInteractiveTransition
         WebCore::FloatSize swipeLayerSizeInDeviceCoordinates(liveSwipeViewFrame.size);
         swipeLayerSizeInDeviceCoordinates.scale(deviceScaleFactor);
         
-        BOOL shouldRestoreScrollPosition = targetItem->mainFrameState()->shouldRestoreScrollPosition;
+        BOOL shouldRestoreScrollPosition = targetItem->mainFrameState().shouldRestoreScrollPosition;
         WebCore::IntPoint currentScrollPosition = WebCore::roundedIntPoint(page->viewScrollPosition());
 
         bool canUseSnapshot = [&] {


### PR DESCRIPTION
#### 3a3c7f32ff84b6e691f279a53f046ea79369e4aa
<pre>
Refactor WebBackForwardListItem::mainFrameState() to clarify copy vs. read-only access.
<a href="https://bugs.webkit.org/show_bug.cgi?id=309802">https://bugs.webkit.org/show_bug.cgi?id=309802</a>

Reviewed by Sihui Liu and Per Arne Vollan.

The original `mainFrameState()` always returned `Ref&lt;FrameState&gt;` via `copyFrameStateWithChildren()`,
even for callers that only needed to read a property without modifying or owning the state.

This patch splits it into two methods:
- `mainFrameState()` — returns `const FrameState&amp;` for lightweight, read-only access (used in
  `itemIsInSameDocument`, `WKBackForwardListItem._scrollPosition`, `ViewGestureControllerIOS`)
- `copyMainFrameStateWithChildren()` — returns `Ref&lt;FrameState&gt;` for callers that need an owned
  deep copy (back/forward navigation, serialization, frame state replacement)

This avoids unnecessary ref-counted copies in hot paths like same-document navigation checks and
scroll position queries, and makes the intent of each call site clearer.

No new tests because there&apos;s no behavior change.

* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::itemIsInSameDocument const):
(WebKit::WebBackForwardListItem::itemIsClone):
(WebKit::WebBackForwardListItem::mainFrameState const):
(WebKit::WebBackForwardListItem::copyMainFrameStateWithChildren const):
* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm:
(-[WKBackForwardListItem _scrollPosition]):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::goToBackForwardItem):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::backForwardListState const):
(WebKit::WebBackForwardList::completeFrameStateForNavigation):
(WebKit::WebBackForwardList::backForwardItemAtIndex):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::launchProcessForReload):
(WebKit::WebPageProxy::goToBackForwardItem):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
* Source/WebKit/UIProcess/ios/ViewGestureControllerIOS.mm:
(WebKit::ViewGestureController::beginSwipeGesture):

Canonical link: <a href="https://commits.webkit.org/309175@main">https://commits.webkit.org/309175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94b28001ceca662d8e7819d93f1715ddb36cc570

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158412 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103141 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83e8f351-802f-48d7-8e94-f1a30d48b388) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115481 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2b1fc85-9f9b-4d0c-9d9f-c9cff1c2bac7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17611 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134338 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96222 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11bf1e93-5d07-4861-8481-bb7e23e20cff) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16707 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14622 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6260 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126315 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160891 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123511 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123717 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33610 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22237 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134062 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78462 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18888 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10813 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21838 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85658 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21568 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21720 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21625 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->