### PR TITLE
[DRAFT] IOSurface VM_ALLOCATE regression: flush pending GPU work before buffer swap

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -127,6 +127,16 @@ void RemoteImageBufferSet::endPrepareForDisplay(RenderingUpdateID renderingUpdat
 void RemoteImageBufferSet::ensureBufferForDisplay(ImageBufferSetPrepareBufferForDisplayInputData& inputData, SwapBuffersDisplayRequirement& displayRequirement, bool isSync)
 {
     assertIsCurrent(workQueue());
+
+    // When AllowMultipleLayerTreeCommitPending is enabled, this message can arrive before
+    // EndPrepareForDisplay for the previous frame has been processed. If the previous frame
+    // used CGIOSurfaceContextFlushQueue (via submitDrawingCommands), the front buffer's
+    // IOSurface may still be marked "in use" by the GPU. Flush any pending GPU work now so
+    // that swapBuffersForDisplay can reuse back buffers instead of falling through to a new
+    // IOSurfaceCreate / VM_ALLOCATE allocation. This is a no-op if there is nothing pending.
+    if (RefPtr frontBuffer = m_frontBuffer)
+        frontBuffer->flushDrawingContext();
+
     LOG_WITH_STREAM(RemoteLayerBuffers, stream << "GPU Process: ::ensureFrontBufferForDisplay " << " - front "
         << m_frontBuffer << " (in-use " << (m_frontBuffer && protect(m_frontBuffer)->isInUse()) << ") "
         << m_backBuffer << " (in-use " << (m_backBuffer && protect(m_backBuffer)->isInUse()) << ") "


### PR DESCRIPTION
#### 52ab8156a7647117ffa785c350ca7dd17b11a307
<pre>
IOSurface VM_ALLOCATE regression: flush pending GPU work before buffer swap
<a href="https://bugs.webkit.org/show_bug.cgi?id=309816">https://bugs.webkit.org/show_bug.cgi?id=309816</a>
<a href="https://rdar.apple.com/171394040">rdar://171394040</a>

Reviewed by NOBODY (OOPS!).

When AllowMultipleLayerTreeCommitPending is enabled, the web
process can pipeline layer tree commits. Combined with the async
CGIOSurfaceContextFlushQueue tile-drawing path, this means
PrepareImageBufferSetsForDisplay for frame N+1 can arrive at the GPU process
before EndPrepareForDisplay for frame N. Since EndPrepareForDisplay is what
calls flushDrawingContext() (CGContextFlush, synchronous GPU drain), the
back buffers for a given RemoteImageBufferSet can still have
IOSurfaceIsInUse()==true when swapBuffersForDisplay() is called for the next
frame. This causes the swap to discard the back buffer and fall through to
allocateImageBuffer(), triggering a new IOSurfaceCreate / VM_ALLOCATE call
instead of reusing a pooled surface.

The fix flushes any pending GPU work on the current front buffer at the
start of ensureBufferForDisplay, before swapBuffersForDisplay checks
isInUse(). This is a no-op when there is nothing pending (e.g., when
EndPrepareForDisplay was already processed, or on builds without
CGIOSurfaceContextFlushQueue). When there IS pending async GPU work, the
flush synchronously drains it, ensuring buffers can be reused.

* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::ensureBufferForDisplay): Flush the front
buffer&apos;s drawing context before swapBuffersForDisplay to drain any pending
CGIOSurfaceContextFlushQueue GPU work from the prior frame.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52ab8156a7647117ffa785c350ca7dd17b11a307

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149700 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15999 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158403 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103132 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115474 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82088 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152660 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17604 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134330 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96215 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e19465c9-b9f0-4aba-aaa6-863d00cf7ca4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16700 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14614 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6248 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126308 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160882 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3972 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13803 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123504 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123710 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22228 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134054 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78453 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18882 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10805 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21829 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85649 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21559 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21711 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21616 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->