### PR TITLE
[Site Isolation] Skip API tests timing out due to backforward cache dependency

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache.cpp
@@ -78,8 +78,9 @@ TEST(WebKit, DidRemoveFrameFromHiearchyInBackForwardCache)
 
     PlatformWebView webView(context.get());
 
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     if (!isUsingBackForwardCache(static_cast<WKWebView*>(webView.platformView()))) {
-        WTFLogAlways("WebKit.DidRemoveFrameFromHiearchyInBackForwardCache: Test is skipped as backfoward cache is disabled");
+        WTFLogAlways("WebKit.DidRemoveFrameFromHiearchyInBackForwardCache: Test is skipped as back-forward cache is disabled");
         return;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm
@@ -971,6 +971,7 @@ static void runGoBackAfterNavigatingSameSiteIframe(ShouldEnablePageCache shouldE
     RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     const bool backForwardCacheEnabled = isUsingBackForwardCache(webView.get());
     webView.get().navigationDelegate = navigationDelegate.get();
     static bool didCommitLoadForAllFrames = false;
@@ -1060,6 +1061,7 @@ static void runGoBackAfterNavigatingSameSiteIframe2(ShouldEnablePageCache should
     RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
     [navigationDelegate allowAnyTLSCertificate];
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     const bool backForwardCacheEnabled = isUsingBackForwardCache(webView.get());
     webView.get().navigationDelegate = navigationDelegate.get();
     static bool didCommitLoadForAllFrames = false;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBInPageCache.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBInPageCache.mm
@@ -81,6 +81,8 @@ TEST(IndexedDB, IndexedDBInPageCache)
     receivedScriptMessage = false;
     TestWebKitAPI::Util::run(&receivedScriptMessage);
     RetainPtr<NSString> string3 = (NSString *)[lastScriptMessage body];
+
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     if (isUsingBackForwardCache(webView.get()))
         EXPECT_WK_STREQ(@"First Database Connection Closed, Second Database Connection Not Failed, Third Database Connection Opened", string3.get());
     else {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm
@@ -849,6 +849,7 @@ static bool navigationComplete;
     EXPECT_STREQ(item.URL.absoluteString.UTF8String, expectedURL);
     EXPECT_TRUE(item.title == nil);
     EXPECT_STREQ(item.initialURL.absoluteString.UTF8String, expectedURL);
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     EXPECT_EQ(inPageCache, isUsingBackForwardCache(webView));
     isDone = true;
 }
@@ -888,7 +889,7 @@ static bool didRejectNavigation = false;
 {
     EXPECT_EQ(item, _targetItem);
     EXPECT_TRUE(item.title == nil);
-
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     EXPECT_EQ(willUseInstantBack, isUsingBackForwardCache(webView));
 
     completionHandler(_allowNavigation);
@@ -922,6 +923,7 @@ static bool didRejectNavigation = false;
 {
     EXPECT_EQ(item, _targetItem);
     EXPECT_TRUE(item.title == nil);
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     EXPECT_EQ(inPageCache, isUsingBackForwardCache(webView));
 
     completionHandler(_allowNavigation);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -993,6 +993,8 @@ TEST(ProcessSwap, Back)
     EXPECT_WK_STREQ(@"PageShow called. Persisted: false, and window.history.state is: null", receivedMessages.get()[0]);
     EXPECT_WK_STREQ(@"PageShow called. Persisted: false, and window.history.state is: null", receivedMessages.get()[1]);
     EXPECT_WK_STREQ(@"PageShow called. Persisted: false, and window.history.state is: null", receivedMessages.get()[2]);
+
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     if (isUsingBackForwardCache(webView.get()))
         EXPECT_WK_STREQ(@"PageShow called. Persisted: true, and window.history.state is: onloadCalled", receivedMessages.get()[3]);
     else
@@ -1000,6 +1002,7 @@ TEST(ProcessSwap, Back)
 
     // The number of suspended pages we keep around is determined at runtime.
     if ([processPool _maximumSuspendedPageCount] > 1) {
+        // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
         if (isUsingBackForwardCache(webView.get()))
             EXPECT_WK_STREQ(@"PageShow called. Persisted: true, and window.history.state is: onloadCalled", receivedMessages.get()[4]);
         else
@@ -1140,8 +1143,10 @@ TEST(ProcessSwap, SuspendedPagesInActivityMonitor)
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     if (!isUsingBackForwardCache(webView.get())) {
-        NSLog(@"ProcessSwap.SuspendedPagesInActivityMonitor: Test is skipped as backfoward cache is disabled");
+        NSLog(@"ProcessSwap.SuspendedPagesInActivityMonitor: Test is skipped as back-forward cache is disabled");
         return;
     }
     auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
@@ -2416,6 +2421,12 @@ static void runNavigationWithLockedHistoryTest(ShouldEnablePSON shouldEnablePSON
     auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
     [webView setNavigationDelegate:delegate.get()];
 
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
+    if (!isUsingBackForwardCache(webView.get())) {
+        NSLog(@"ProcessSwap.NavigationWithLockedHistoryWith/WithoutPSON: Test is skipped as back-forward cache is disabled");
+        return;
+    }
+
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:@"pson://www.webkit.org/main.html"]];
     [webView loadRequest:request];
 
@@ -2470,6 +2481,11 @@ static void runNavigationWithLockedHistoryTest(ShouldEnablePSON shouldEnablePSON
 TEST(ProcessSwap, NavigationWithLockedHistoryWithPSON)
 {
     runNavigationWithLockedHistoryTest(ShouldEnablePSON::Yes);
+}
+
+TEST(ProcessSwap, NavigationWithLockedHistoryWithoutPSON)
+{
+    runNavigationWithLockedHistoryTest(ShouldEnablePSON::No);
 }
 
 static void runQuickBackForwardNavigationTest(ShouldEnablePSON shouldEnablePSON)
@@ -2548,11 +2564,6 @@ TEST(ProcessSwap, QuickBackForwardNavigationWithoutPSON)
 TEST(ProcessSwap, QuickBackForwardNavigationWithPSON)
 {
     runQuickBackForwardNavigationTest(ShouldEnablePSON::Yes);
-}
-
-TEST(ProcessSwap, NavigationWithLockedHistoryWithoutPSON)
-{
-    runNavigationWithLockedHistoryTest(ShouldEnablePSON::No);
 }
 
 static constexpr auto sessionStorageTestBytes = R"PSONRESOURCE(
@@ -2671,6 +2682,7 @@ TEST(ProcessSwap, ReuseSuspendedProcess)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     const bool backForwardCacheEnabled = isUsingBackForwardCache(webView.get());
     if (backForwardCacheEnabled) {
         // We should have gone back to the webkit.org process for this load since we reuse SuspendedPages' process when possible.
@@ -3468,6 +3480,7 @@ TEST(ProcessSwap, SuspendedPageLimit)
     EXPECT_EQ(5u, seenPIDs.size());
 
     auto expectedProcessCount = 1u;
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     if (isUsingBackForwardCache(webView.get())) {
         // But not all of those processes should still be alive (1 visible, maximumSuspendedPageCount suspended).
         expectedProcessCount += maximumSuspendedPageCount;
@@ -3497,8 +3510,10 @@ TEST(ProcessSwap, PageCache1)
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     if (!isUsingBackForwardCache(webView.get())) {
-        NSLog(@"ProcessSwap.PageCache1: Test is skipped as backfoward cache is disabled");
+        NSLog(@"ProcessSwap.PageCache1: Test is skipped as back-forward cache is disabled");
         return;
     }
 
@@ -3731,8 +3746,10 @@ TEST(ProcessSwap, PageCacheAfterProcessSwapByClient)
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     if (!isUsingBackForwardCache(webView.get())) {
-        NSLog(@"ProcessSwap.PageCacheAfterProcessSwapByClient: Test is skipped as backfoward cache is disabled");
+        NSLog(@"ProcessSwap.PageCacheAfterProcessSwapByClient: Test is skipped as back-forward cache is disabled");
         return;
     }
     auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
@@ -3811,8 +3828,10 @@ TEST(ProcessSwap, PageCacheWhenNavigatingFromJS)
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     if (!isUsingBackForwardCache(webView.get())) {
-        NSLog(@"ProcessSwap.PageCacheWhenNavigatingFromJS: Test is skipped as backfoward cache is disabled");
+        NSLog(@"ProcessSwap.PageCacheWhenNavigatingFromJS: Test is skipped as back-forward cache is disabled");
         return;
     }
 
@@ -4135,6 +4154,7 @@ TEST(ProcessSwap, NumberOfPrewarmedProcesses)
     EXPECT_EQ(2u + [processPool _prewarmedProcessCountLimit], [processPool _webProcessCount]);
 
     // If page cache is enabled, process for webkit.org will stay active.
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     unsigned expectedActiveProcessCount = isUsingBackForwardCache(webView.get()) ? 2u : 1u;
     EXPECT_EQ(expectedActiveProcessCount, [processPool _webProcessCountIgnoringPrewarmedAndCached]);
     EXPECT_TRUE([processPool _hasPrewarmedWebProcess]);
@@ -5125,6 +5145,7 @@ static void runAPIControlledProcessSwappingThenBackTest(WithDelay withDelay)
     TestWebKitAPI::Util::run(&done);
     done = false;
 
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     if (isUsingBackForwardCache(webView.get()))
         EXPECT_EQ(pid1, [webView _webProcessIdentifier]);
     else
@@ -6819,8 +6840,10 @@ TEST(ProcessSwap, GoBackToSuspendedPageWithMainFrameIDThatIsNotOne)
     [[webViewConfiguration userContentController] addScriptMessageHandler:messageHandler.get() name:@"pson"];
 
     auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
+
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
     if (!isUsingBackForwardCache(webView1.get())) {
-        NSLog(@"ProcessSwap.GoBackToSuspendedPageWithMainFrameIDThatIsNotOne: Test is skipped as backfoward cache is disabled");
+        NSLog(@"ProcessSwap.GoBackToSuspendedPageWithMainFrameIDThatIsNotOne: Test is skipped as back-forward cache is disabled");
         return;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm
@@ -29,6 +29,7 @@
 
 #import "HTTPServer.h"
 #import "PlatformUtilities.h"
+#import "SiteIsolationUtilities.h"
 #import "Test.h"
 #import "TestNavigationDelegate.h"
 #import "TestUIDelegate.h"
@@ -928,6 +929,12 @@ TEST(WebTransport, BackForwardCache)
     auto delegate = adoptNS([TestNavigationDelegate new]);
     [delegate allowAnyTLSCertificate];
     [webView setNavigationDelegate:delegate.get()];
+
+    // FIXME: Remove once the back-forward cache is enabled for site isolation: rdar://161762363.
+    if (!isUsingBackForwardCache(webView.get())) {
+        NSLog(@"WebTransport.BackForwardCache: Test is skipped as back-forward cache is disabled");
+        return;
+    }
 
     [webView loadRequest:loadingServer.request()];
     EXPECT_WK_STREQ([webView _test_waitForAlert], "successfully read abc");


### PR DESCRIPTION
#### 582d48525cbb3319800ee42739ae09a23100f231
<pre>
[Site Isolation] Skip API tests timing out due to backforward cache dependency
<a href="https://bugs.webkit.org/show_bug.cgi?id=309815">https://bugs.webkit.org/show_bug.cgi?id=309815</a>
<a href="https://rdar.apple.com/172397684">rdar://172397684</a>

Reviewed by Sihui Liu.

These three API tests are timing out with site isolation enabled. If the bf
cache is disabled, they time out even with site isolation off. Skipping them
for now since they require the bf cache.

TEST(ProcessSwap, NavigationWithLockedHistoryWithPSON)
TEST(ProcessSwap, NavigationWithLockedHistoryWithoutPSON)
TEST(WebTransport, BackForwardCache)

* Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache.cpp:
(TestWebKitAPI::TEST(WebKit, DidRemoveFrameFromHiearchyInBackForwardCache)):
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(runGoBackAfterNavigatingSameSiteIframe):
(runGoBackAfterNavigatingSameSiteIframe2):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBInPageCache.mm:
(TEST(IndexedDB, IndexedDBInPageCache)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Navigation.mm:
(-[BackForwardDelegate _webView:willGoToBackForwardListItem:inPageCache:]):
(-[BackForwardDelegateWithShouldGo webView:shouldGoToBackForwardListItem:willUseInstantBack:completionHandler:]):
(-[BackForwardDelegateWithShouldGoSPI _webView:shouldGoToBackForwardListItem:inPageCache:completionHandler:]):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
((ProcessSwap, Back)):
((ProcessSwap, SuspendedPagesInActivityMonitor)):
((ProcessSwap, NavigationWithLockedHistoryWithoutPSON)):
((ProcessSwap, ReuseSuspendedProcess)):
((ProcessSwap, SuspendedPageLimit)):
((ProcessSwap, PageCache1)):
((ProcessSwap, PageCacheAfterProcessSwapByClient)):
((ProcessSwap, PageCacheWhenNavigatingFromJS)):
((ProcessSwap, NumberOfPrewarmedProcesses)):
((ProcessSwap, GoBackToSuspendedPageWithMainFrameIDThatIsNotOne)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::BackForwardCache)):

Canonical link: <a href="https://commits.webkit.org/309214@main">https://commits.webkit.org/309214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6f012d654d03f4c629c8adf3e6c61e0624e2b08

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149877 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158583 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6090240-0f58-4e04-af18-22de5dfa9b8b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151750 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22699 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115613 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d71452d-bc48-4122-8573-a5af24c5b38b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134493 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96352 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c3bee86-b5f3-4351-a5c3-7c59d8e9f4fb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16833 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14759 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6430 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161059 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123629 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22398 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123833 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22405 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134217 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78630 "Built successfully") | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/23062 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18993 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10969 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22006 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21736 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21888 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21793 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->