### PR TITLE
[DRAFT] REGRESSION(307235@main): CPLT regression due to delayed DisplayDidRefresh in refactored canSendDisplayDidRefresh

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -771,8 +771,11 @@ bool ProcessState::canSendDisplayDidRefresh(RemoteLayerTreeDrawingAreaProxy& dra
 {
     if (pendingCommits.size() >= 2)
         return false;
-    if (pendingCommits.size() == 1)
-        return drawingArea.allowMultipleCommitLayerTreePending() && pendingCommits[0].pendingMessage == PendingCommitMessage::CommitLayerTree && delayedCommits >= 4;
+    if (pendingCommits.size() == 1) {
+        // Allow sending DisplayDidRefresh once the outstanding commit has advanced
+        // to CommitLayerTree state, restoring the pre-307235@main behaviour.
+        return pendingCommits[0].pendingMessage == PendingCommitMessage::CommitLayerTree;
+    }
     return true;
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteLayerTreeDisplayRefreshTiming.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RemoteLayerTreeDisplayRefreshTiming.mm
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestNavigationDelegate.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKNavigationDelegatePrivate.h>
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/_WKPageLoadTiming.h>
+#import <wtf/RetainPtr.h>
+
+// Regression test for rdar://172104196
+// Verifies that page load timing is not delayed by canSendDisplayDidRefresh
+// returning false when a single pending commit has reached CommitLayerTree state.
+// The pre-307235@main behavior allowed DisplayDidRefresh to be sent as soon as
+// NotifyFlushingLayerTree was received; the regression deferred it until the
+// full CommitLayerTree IPC arrived, adding per-frame latency.
+
+TEST(RemoteLayerTree, DisplayRefreshNotDelayedDuringPageLoad)
+{
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+
+    auto delegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    // Load a page that triggers multiple layout passes to exercise the
+    // DisplayDidRefresh pipeline during page load.
+    NSString *html = @"<html><body>"
+        "<div style='width:100%;height:200px;background:red'></div>"
+        "<script>"
+        "for (var i = 0; i < 20; i++) {"
+        "  var d = document.createElement('div');"
+        "  d.style.width = '100%';"
+        "  d.style.height = '50px';"
+        "  d.style.background = (i % 2 == 0) ? 'blue' : 'green';"
+        "  document.body.appendChild(d);"
+        "}"
+        "</script>"
+        "</body></html>";
+
+    __block bool firstPaintReceived = false;
+    __block NSTimeInterval navigationToFirstPaint = 0;
+
+    delegate.get().didGeneratePageLoadTiming = ^(_WKPageLoadTiming *timing) {
+        if (timing.firstVisualLayout && timing.navigationStart) {
+            navigationToFirstPaint = [timing.firstVisualLayout timeIntervalSinceDate:timing.navigationStart];
+            firstPaintReceived = true;
+        }
+    };
+
+    [webView loadHTMLString:html baseURL:[NSURL URLWithString:@"about:blank"]];
+    [delegate waitForDidFinishNavigation];
+
+    // Wait for paint timing to be reported.
+    if (!firstPaintReceived)
+        TestWebKitAPI::Util::run(&firstPaintReceived);


### PR DESCRIPTION
#### c85fac9113ef1383ef48089e7b922c6b0eff20cc
<pre>
REGRESSION(<a href="https://commits.webkit.org/307235@main">307235@main</a>): CPLT regression due to delayed DisplayDidRefresh in refactored canSendDisplayDidRefresh
<a href="https://bugs.webkit.org/show_bug.cgi?id=309817">https://bugs.webkit.org/show_bug.cgi?id=309817</a>
<a href="https://rdar.apple.com/172104196">rdar://172104196</a>

Reviewed by NOBODY (OOPS!).

<a href="https://commits.webkit.org/307235@main">307235@main</a> replaced the variant-based ProcessState state machine in
RemoteLayerTreeDrawingAreaProxy with a Vector&lt;PendingCommit&gt; model. In the
new canSendDisplayDidRefresh(), when pendingCommits.size() == 1, the code
gates on allowMultipleCommitLayerTreePending() &amp;&amp; delayedCommits &gt;= 4.

On iOS (where allowMultipleCommitLayerTreePending() is false), this
unconditionally returns false, deferring DisplayDidRefresh until after the
full CommitLayerTree IPC arrives.

On macOS (where allowMultipleCommitLayerTreePending() is true), the
delayedCommits &gt;= 4 threshold -- which has no equivalent in the old code --
throttles the first several frame cycles during page load.

Both paths differ from the pre-307235 behaviour, where canSendDisplayDidRefresh
returned true as soon as the outstanding frame request reached the equivalent
of CommitLayerTree state (i.e., NotifyFlushingLayerTree had been received).

The consequence is that during page load, where multiple layout/paint passes
occur and the web process may take several milliseconds per commit,
DisplayDidRefresh is sent from commitLayerTree (after the full commit
arrives) rather than from notifyFlushingLayerTree (as soon as the web
process acknowledges the pending frame).

Fix: when pendingCommits.size() == 1 and the pending commit has reached
CommitLayerTree state, return true unconditionally. The size &gt;= 2 guard
already prevents over-pipelining, so the delayedCommits &gt;= 4 heuristic
is unnecessary for the single-pending path.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::ProcessState::canSendDisplayDidRefresh):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c85fac9113ef1383ef48089e7b922c6b0eff20cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149707 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158410 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103139 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84389c86-037c-461c-854e-f813d02e8762) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151580 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22460 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115478 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82090 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/43b1b44f-5f9b-4432-9674-9d90fe54976f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134335 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96219 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45860a25-326f-4483-b5ef-ff6d3ec56167) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16705 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14619 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6259 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126313 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160889 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3973 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13808 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123508 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123714 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134059 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78460 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18886 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10810 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21836 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85656 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21566 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21718 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21623 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->