### PR TITLE
Update defaultTestingiPadViewSize to the current iPad simulator size

### DIFF
--- a/LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint-expected.txt
+++ b/LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint-expected.txt
@@ -1,10 +1,10 @@
-This test verifies that the shrink-to-fit-content heuristic doesn't induce more horizontal scrolling than we would otherwise have. To run the test manually, load the page and check that the bar almost entirely fits within the viewport, with no more than 480px of horizontal scrolling (on a 320px-wide device) and 20px of scrolling (on a 768px-wide device).
+This test verifies that the shrink-to-fit-content heuristic doesn't induce more horizontal scrolling than we would otherwise have. To run the test manually, load the page and check that the bar almost entirely fits within the viewport, with no more than 480px of horizontal scrolling (on a 320px-wide device) and 20px of scrolling (on a 810px-wide device).
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
 PASS minScale is 1
-PASS 800 is >= document.scrollingElement.scrollWidth
+PASS 840 is >= document.scrollingElement.scrollWidth
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint.html
+++ b/LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint.html
@@ -9,14 +9,14 @@ body, html {
     height: 100%;
 }
 
-@media screen and (min-width: 780px) {
+@media screen and (min-width: 820px) {
     #bar {
         min-width: 10000px;
     }
 }
 
 .bar {
-    width: 800px;
+    width: 840px;
     height: 100px;
     background: linear-gradient(to right, red 0%, green 50%, blue 100%);
 }
@@ -31,7 +31,7 @@ body, html {
 <script>
 jsTestIsAsync = true;
 
-description("This test verifies that the shrink-to-fit-content heuristic doesn't induce more horizontal scrolling than we would otherwise have. To run the test manually, load the page and check that the bar almost entirely fits within the viewport, with no more than 480px of horizontal scrolling (on a 320px-wide device) and 20px of scrolling (on a 768px-wide device).");
+description("This test verifies that the shrink-to-fit-content heuristic doesn't induce more horizontal scrolling than we would otherwise have. To run the test manually, load the page and check that the bar almost entirely fits within the viewport, with no more than 480px of horizontal scrolling (on a 320px-wide device) and 20px of scrolling (on a 810px-wide device).");
 
 addEventListener("load", async () => {
     if (!window.testRunner)
@@ -40,7 +40,7 @@ addEventListener("load", async () => {
     await UIHelper.ensurePresentationUpdate();
     minScale = await UIHelper.minimumZoomScale();
     shouldBe("minScale", "1");
-    shouldBeGreaterThanOrEqual("800", "document.scrollingElement.scrollWidth");
+    shouldBeGreaterThanOrEqual("840", "document.scrollingElement.scrollWidth");
     finishJSTest();
 });
 </script>

--- a/LayoutTests/interaction-region/clip-path-expected.txt
+++ b/LayoutTests/interaction-region/clip-path-expected.txt
@@ -1,14 +1,14 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 1600.00 2092.00)
+  (bounds 1600.00 2094.00)
   (children 1
     (GraphicsLayer
-      (bounds 1600.00 2092.00)
+      (bounds 1600.00 2094.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=1600 height=2092)
+        (rect (0,0) width=1600 height=2094)
 
       (interaction regions [
         (interaction (0,12.50) width=253.50 height=253.50)

--- a/LayoutTests/interaction-region/clip-path-with-label-expected.txt
+++ b/LayoutTests/interaction-region/clip-path-with-label-expected.txt
@@ -1,14 +1,14 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 1600.00 2092.00)
+  (bounds 1600.00 2094.00)
   (children 1
     (GraphicsLayer
-      (bounds 1600.00 2092.00)
+      (bounds 1600.00 2094.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=1600 height=2092)
+        (rect (0,0) width=1600 height=2094)
 
       (interaction regions [
         (interaction (4,3) width=116.84 height=44)

--- a/LayoutTests/interaction-region/content-hint-expected.txt
+++ b/LayoutTests/interaction-region/content-hint-expected.txt
@@ -1,14 +1,14 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 1600.00 2092.00)
+  (bounds 1600.00 2094.00)
   (children 1
     (GraphicsLayer
-      (bounds 1600.00 2092.00)
+      (bounds 1600.00 2094.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=1600 height=2092)
+        (rect (0,0) width=1600 height=2094)
 
       (interaction regions [
         (guard (0,41) width=522.50 height=318),

--- a/LayoutTests/interaction-region/form-control-refresh/button-native-interaction-region-expected.txt
+++ b/LayoutTests/interaction-region/form-control-refresh/button-native-interaction-region-expected.txt
@@ -1,14 +1,14 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 1600.00 2092.00)
+  (bounds 1600.00 2094.00)
   (children 1
     (GraphicsLayer
-      (bounds 1600.00 2092.00)
+      (bounds 1600.00 2094.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=1600 height=2092)
+        (rect (0,0) width=1600 height=2094)
 
       (interaction regions [
         (interaction (0,0) width=59 height=20)

--- a/LayoutTests/interaction-region/form-control-refresh/checkbox-native-interaction-region-expected.txt
+++ b/LayoutTests/interaction-region/form-control-refresh/checkbox-native-interaction-region-expected.txt
@@ -1,14 +1,14 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 1600.00 2092.00)
+  (bounds 1600.00 2094.00)
   (children 1
     (GraphicsLayer
-      (bounds 1600.00 2092.00)
+      (bounds 1600.00 2094.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=1600 height=2092)
+        (rect (0,0) width=1600 height=2094)
 
       (interaction regions [
         (interaction (2,3) width=16 height=16)

--- a/LayoutTests/interaction-region/form-control-refresh/radio-native-interaction-region-expected.txt
+++ b/LayoutTests/interaction-region/form-control-refresh/radio-native-interaction-region-expected.txt
@@ -1,14 +1,14 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 1600.00 2092.00)
+  (bounds 1600.00 2094.00)
   (children 1
     (GraphicsLayer
-      (bounds 1600.00 2092.00)
+      (bounds 1600.00 2094.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=1600 height=2092)
+        (rect (0,0) width=1600 height=2094)
 
       (interaction regions [
         (interaction (2,3) width=16 height=16)

--- a/LayoutTests/interaction-region/form-control-refresh/search-native-interaction-region-expected.txt
+++ b/LayoutTests/interaction-region/form-control-refresh/search-native-interaction-region-expected.txt
@@ -1,14 +1,14 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 1600.00 2092.00)
+  (bounds 1600.00 2094.00)
   (children 1
     (GraphicsLayer
-      (bounds 1600.00 2092.00)
+      (bounds 1600.00 2094.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=1600 height=2092)
+        (rect (0,0) width=1600 height=2094)
 
       (interaction regions [
         (interaction (0,0) width=154 height=20)

--- a/LayoutTests/interaction-region/form-control-refresh/select-native-interaction-region-expected.txt
+++ b/LayoutTests/interaction-region/form-control-refresh/select-native-interaction-region-expected.txt
@@ -1,14 +1,14 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 1600.00 2092.00)
+  (bounds 1600.00 2094.00)
   (children 1
     (GraphicsLayer
-      (bounds 1600.00 2092.00)
+      (bounds 1600.00 2094.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=1600 height=2092)
+        (rect (0,0) width=1600 height=2094)
 
       (interaction regions [
         (interaction (0,0) width=60 height=20)

--- a/LayoutTests/interaction-region/form-control-refresh/slider-thumb-native-interaction-region-expected.txt
+++ b/LayoutTests/interaction-region/form-control-refresh/slider-thumb-native-interaction-region-expected.txt
@@ -1,14 +1,14 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 1600.00 2092.00)
+  (bounds 1600.00 2094.00)
   (children 1
     (GraphicsLayer
-      (bounds 1600.00 2092.00)
+      (bounds 1600.00 2094.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=1600 height=2092)
+        (rect (0,0) width=1600 height=2094)
 
       (interaction regions [
         (interaction (54.50,2) width=24 height=16)

--- a/LayoutTests/interaction-region/form-control-refresh/switch-native-interaction-region-expected.txt
+++ b/LayoutTests/interaction-region/form-control-refresh/switch-native-interaction-region-expected.txt
@@ -1,14 +1,14 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 1600.00 2092.00)
+  (bounds 1600.00 2094.00)
   (children 1
     (GraphicsLayer
-      (bounds 1600.00 2092.00)
+      (bounds 1600.00 2094.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=1600 height=2092)
+        (rect (0,0) width=1600 height=2094)
 
       (interaction regions [
         (interaction (0,0) width=51 height=31)

--- a/LayoutTests/interaction-region/form-control-refresh/textfield-native-interaction-region-expected.txt
+++ b/LayoutTests/interaction-region/form-control-refresh/textfield-native-interaction-region-expected.txt
@@ -1,14 +1,14 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 1600.00 2092.00)
+  (bounds 1600.00 2094.00)
   (children 1
     (GraphicsLayer
-      (bounds 1600.00 2092.00)
+      (bounds 1600.00 2094.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=1600 height=2092)
+        (rect (0,0) width=1600 height=2094)
 
       (interaction regions [
         (interaction (0,0) width=154 height=20)

--- a/LayoutTests/interaction-region/full-page-overlay-expected.txt
+++ b/LayoutTests/interaction-region/full-page-overlay-expected.txt
@@ -1,17 +1,17 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 1536.00 5013.00)
+  (bounds 1620.00 5013.00)
   (children 1
     (GraphicsLayer
-      (bounds 1536.00 5013.00)
+      (bounds 1620.00 5013.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=1536 height=5013)
+        (rect (0,0) width=1620 height=5013)
 
       (interaction regions [
-        (occlusion (0,0) width=1536 height=5000)])
+        (occlusion (0,0) width=1620 height=5000)])
       )
     )
   )

--- a/LayoutTests/interaction-region/full-page-overlay-page-zoom-expected.txt
+++ b/LayoutTests/interaction-region/full-page-overlay-page-zoom-expected.txt
@@ -1,17 +1,17 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 1536.00 2008.00)
+  (bounds 1620.00 2120.00)
   (children 1
     (GraphicsLayer
-      (bounds 1536.00 2008.00)
+      (bounds 1620.00 2120.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=1536 height=2008)
+        (rect (0,0) width=1620 height=2120)
 
       (interaction regions [
-        (occlusion (0,0) width=1536 height=2008)])
+        (occlusion (0,0) width=1620 height=2120)])
       )
     )
   )

--- a/LayoutTests/interaction-region/icon-masking-expected.txt
+++ b/LayoutTests/interaction-region/icon-masking-expected.txt
@@ -1,14 +1,14 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 1600.00 2092.00)
+  (bounds 1600.00 2094.00)
   (children 1
     (GraphicsLayer
-      (bounds 1600.00 2092.00)
+      (bounds 1600.00 2094.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=1600 height=2092)
+        (rect (0,0) width=1600 height=2094)
 
       (interaction regions [
         (guard (0,0) width=108.50 height=108.50),

--- a/LayoutTests/interaction-region/text-input-focused-edited-empty-expected.txt
+++ b/LayoutTests/interaction-region/text-input-focused-edited-empty-expected.txt
@@ -1,15 +1,15 @@
 
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 768.00 1004.00)
+  (bounds 810.00 1060.00)
   (children 1
     (GraphicsLayer
-      (bounds 768.00 1004.00)
+      (bounds 810.00 1060.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=768 height=1004)
+        (rect (0,0) width=810 height=1060)
 
       (interaction regions [
         (interaction (8,8) width=332 height=57)])

--- a/LayoutTests/interaction-region/text-input-focused-edited-expected.txt
+++ b/LayoutTests/interaction-region/text-input-focused-edited-expected.txt
@@ -1,15 +1,15 @@
 
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 768.00 1004.00)
+  (bounds 810.00 1060.00)
   (children 1
     (GraphicsLayer
-      (bounds 768.00 1004.00)
+      (bounds 810.00 1060.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=768 height=1004)
+        (rect (0,0) width=810 height=1060)
       )
     )
   )

--- a/LayoutTests/interaction-region/textarea-focused-edited-empty-expected.txt
+++ b/LayoutTests/interaction-region/textarea-focused-edited-empty-expected.txt
@@ -1,15 +1,15 @@
 
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 768.00 1004.00)
+  (bounds 810.00 1060.00)
   (children 1
     (GraphicsLayer
-      (bounds 768.00 1004.00)
+      (bounds 810.00 1060.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=768 height=1004)
+        (rect (0,0) width=810 height=1060)
 
       (interaction regions [
         (interaction (9,9) width=211 height=204)])

--- a/LayoutTests/interaction-region/textarea-focused-edited-expected.txt
+++ b/LayoutTests/interaction-region/textarea-focused-edited-expected.txt
@@ -1,15 +1,15 @@
 
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 768.00 1004.00)
+  (bounds 810.00 1060.00)
   (children 1
     (GraphicsLayer
-      (bounds 768.00 1004.00)
+      (bounds 810.00 1060.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=768 height=1004)
+        (rect (0,0) width=810 height=1060)
       )
     )
   )

--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -167,10 +167,6 @@ webkit.org/b/307451 imported/w3c/web-platform-tests/html/semantics/forms/the-sel
 
 # webkit.org/b/307469 4x fast/viewport/iOS tests are constant text failures on iPad
 fast/viewport/ios/viewport-fit-auto-safe-area-inset-change.html [ Failure ]
-fast/viewport/ios/shrink-to-fit-content-responsive-viewport-with-horizontal-overflow.html [ Failure ]
 fast/viewport/ios/shrink-to-fit-content-large-constant-width.html [ Failure ]
-fast/viewport/ios/shrink-to-fit-content-constant-width.html [ Failure ]
-
-webkit.org/b/307477 editing/selection/ios/scrolling-to-focused-element-inside-iframe.html [ Failure ]
 
 webkit.org/b/307488 media/volume-activate-audio-session.html [ Failure ]

--- a/LayoutTests/platform/ipad/fast/viewport/empty-meta-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/empty-meta-expected.txt
@@ -1,6 +1,6 @@
 Viewport:
 
-scale	0.78376
+scale	0.82683
 maxScale	5.00000
-minScale	0.78376
-visibleRect	{"left":"0.00000","top":"0.00000","width":"979.88843","height":"1281.00000"}
+minScale	0.82683
+visibleRect	{"left":"0.00000","top":"0.00000","width":"979.64148","height":"1282.00000"}

--- a/LayoutTests/platform/ipad/fast/viewport/ios/responsive-viewport-with-minimum-width-after-changing-view-scale-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/responsive-viewport-with-minimum-width-after-changing-view-scale-expected.txt
@@ -1,17 +1,17 @@
 setViewScale(1.00)
-window size: [768, 1004]
+window size: [810, 1060]
 zoom scale: 1.00
 
 setViewScale(2.00)
-window size: [384, 502]
+window size: [405, 530]
 zoom scale: 2.00
 
 setViewScale(2.50)
-window size: [307, 401]
+window size: [324, 424]
 zoom scale: 2.50
 
 setViewScale(1.00)
-window size: [768, 1004]
+window size: [810, 1060]
 zoom scale: 1.00
 
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint-expected.txt
@@ -1,10 +1,10 @@
-This test verifies that the shrink-to-fit-content heuristic doesn't induce more horizontal scrolling than we would otherwise have. To run the test manually, load the page and check that the bar almost entirely fits within the viewport, with no more than 480px of horizontal scrolling (on a 320px-wide device) and 20px of scrolling (on a 768px-wide device).
+This test verifies that the shrink-to-fit-content heuristic doesn't induce more horizontal scrolling than we would otherwise have. To run the test manually, load the page and check that the bar almost entirely fits within the viewport, with no more than 480px of horizontal scrolling (on a 320px-wide device) and 20px of scrolling (on a 810px-wide device).
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
 PASS minScale is 1
-PASS 800 is >= document.scrollingElement.scrollWidth
+PASS 840 is >= document.scrollingElement.scrollWidth
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-for-page-without-viewport-meta-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-for-page-without-viewport-meta-expected.txt
@@ -1,4 +1,4 @@
-window size: [1131, 1479]
-zoom scale: 0.68
+window size: [1208, 1581]
+zoom scale: 0.67
 
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-auto-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-auto-expected.txt
@@ -1,8 +1,8 @@
 Viewport: initial-scale=1, viewport-fit=auto
 
-Window Size: 708 x 994
+Window Size: 750 x 1050
 
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"-40.00000","top":"-10.00000","width":"768.00000","height":"1004.00000"}
+visibleRect	{"left":"-40.00000","top":"-10.00000","width":"810.00000","height":"1060.00000"}

--- a/LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-contain-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-contain-expected.txt
@@ -1,8 +1,8 @@
 Viewport: initial-scale=1, viewport-fit=contain
 
-Window Size: 708 x 994
+Window Size: 750 x 1050
 
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"-40.00000","top":"-10.00000","width":"768.00000","height":"1004.00000"}
+visibleRect	{"left":"-40.00000","top":"-10.00000","width":"810.00000","height":"1060.00000"}

--- a/LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-cover-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-cover-expected.txt
@@ -1,8 +1,8 @@
 Viewport: initial-scale=1, viewport-fit=cover
 
-Window Size: 768 x 1004
+Window Size: 810 x 1060
 
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"810.00000","height":"1060.00000"}

--- a/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-expected.txt
@@ -3,4 +3,4 @@ Viewport: width=device-width
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"810.00000","height":"1060.00000"}

--- a/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-expected.txt
@@ -3,5 +3,5 @@ Viewport: width=device-width, shrink-to-fit=no
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"810.00000","height":"1060.00000"}
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-tall-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-tall-expected.txt
@@ -1,7 +1,7 @@
 Viewport: width=device-width
 
 scale	0.81349
-maxScale	3.80952
+maxScale	4.01786
 minScale	0.81349
-visibleRect	{"left":"0.00000","top":"0.00000","width":"944.07806","height":"1234.18542"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"995.70734","height":"1303.02441"}
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-expected.txt
@@ -3,5 +3,5 @@ Viewport: width=device-width, shrink-to-fit=no
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"810.00000","height":"1060.00000"}
 

--- a/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-no-shrink-to-fit-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-no-shrink-to-fit-expected.txt
@@ -3,5 +3,5 @@ Viewport: width=device-width, shrink-to-fit=no
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"810.00000","height":"1060.00000"}
 

--- a/LayoutTests/platform/ipad/fast/viewport/meta-viewport-ignored-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/meta-viewport-ignored-expected.txt
@@ -3,4 +3,4 @@ Viewport:
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"810.00000","height":"1060.00000"}

--- a/LayoutTests/platform/ipad/fast/viewport/width-is-device-width-expected.txt
+++ b/LayoutTests/platform/ipad/fast/viewport/width-is-device-width-expected.txt
@@ -3,4 +3,4 @@ Viewport: width=device-width
 scale	1.00000
 maxScale	5.00000
 minScale	1.00000
-visibleRect	{"left":"0.00000","top":"0.00000","width":"768.00000","height":"1004.00000"}
+visibleRect	{"left":"0.00000","top":"0.00000","width":"810.00000","height":"1060.00000"}

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -490,10 +490,10 @@ void TestController::platformConfigureViewForTest(const TestInvocation& test)
     UIWindowScene *scene = webView.window.windowScene;
     CGRect sceneBounds = [UIScreen mainScreen].bounds;
     if (scene.sizeRestrictions) {
-        // For platforms that support resizeable scenes, resize to match iPad 5th Generation,
+        // For platforms that support resizeable scenes, resize to match iPad 9th Generation,
         // the default iPad device used for layout testing.
         // We add the status bar in here because it is subtracted back out in viewRectForWindowRect.
-        static constexpr CGSize defaultTestingiPadViewSize = { 768, 1004 };
+        static constexpr CGSize defaultTestingiPadViewSize = { 810, 1060 };
         sceneBounds = CGRectMake(0, 0, defaultTestingiPadViewSize.width, defaultTestingiPadViewSize.height + CGRectGetHeight(UIApplication.sharedApplication.statusBarFrame));
         scene.sizeRestrictions.minimumSize = sceneBounds.size;
         scene.sizeRestrictions.maximumSize = sceneBounds.size;


### PR DESCRIPTION
#### 07df996359cd89510b8b74cb19f42d3660221794
<pre>
Update defaultTestingiPadViewSize to the current iPad simulator size
<a href="https://bugs.webkit.org/show_bug.cgi?id=309756">https://bugs.webkit.org/show_bug.cgi?id=309756</a>
<a href="https://rdar.apple.com/172344253">rdar://172344253</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Since updating iPad simulators to use the iPad 9th gen instead of the
iPad 5th gen, defaultTestingiPadViewSize also needs to be change
to reflect the iPad size.

Given this change, update test expectations and results for the current
iPad simulator.

Also, change shrink-to-fit-content-large-width-breakpoint to test with an
810pt width screen size.

* LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint-expected.txt:
* LayoutTests/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint.html:
* LayoutTests/interaction-region/clip-path-expected.txt:
* LayoutTests/interaction-region/clip-path-with-label-expected.txt:
* LayoutTests/interaction-region/content-hint-expected.txt:
* LayoutTests/interaction-region/form-control-refresh/button-native-interaction-region-expected.txt:
* LayoutTests/interaction-region/form-control-refresh/checkbox-native-interaction-region-expected.txt:
* LayoutTests/interaction-region/form-control-refresh/radio-native-interaction-region-expected.txt:
* LayoutTests/interaction-region/form-control-refresh/search-native-interaction-region-expected.txt:
* LayoutTests/interaction-region/form-control-refresh/select-native-interaction-region-expected.txt:
* LayoutTests/interaction-region/form-control-refresh/slider-thumb-native-interaction-region-expected.txt:
* LayoutTests/interaction-region/form-control-refresh/switch-native-interaction-region-expected.txt:
* LayoutTests/interaction-region/form-control-refresh/textfield-native-interaction-region-expected.txt:
* LayoutTests/interaction-region/full-page-overlay-expected.txt:
* LayoutTests/interaction-region/full-page-overlay-page-zoom-expected.txt:
* LayoutTests/interaction-region/icon-masking-expected.txt:
* LayoutTests/interaction-region/text-input-focused-edited-empty-expected.txt:
* LayoutTests/interaction-region/text-input-focused-edited-expected.txt:
* LayoutTests/interaction-region/textarea-focused-edited-empty-expected.txt:
* LayoutTests/interaction-region/textarea-focused-edited-expected.txt:
* LayoutTests/platform/ipad/TestExpectations:
* LayoutTests/platform/ipad/fast/viewport/empty-meta-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/responsive-viewport-with-minimum-width-after-changing-view-scale-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-content-large-width-breakpoint-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/shrink-to-fit-for-page-without-viewport-meta-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-auto-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-contain-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/viewport-fit-cover-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-body-overflow-hidden-tall-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/ios/width-is-device-width-overflowing-no-shrink-to-fit-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/meta-viewport-ignored-expected.txt:
* LayoutTests/platform/ipad/fast/viewport/width-is-device-width-expected.txt:
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::TestController::platformConfigureViewForTest):

Canonical link: <a href="https://commits.webkit.org/309348@main">https://commits.webkit.org/309348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/107494552fd72da77ef4ca3102622bbfb2b52016

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23124 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159088 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103800 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152239 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23555 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116023 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82446 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a8f2dd2-ab5e-41e5-82dc-b41c5482416f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134885 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96751 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17230 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15171 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6936 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161562 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14362 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124022 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124220 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33729 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22913 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134604 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79293 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19342 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11361 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22527 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22240 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22392 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22294 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->