### PR TITLE
[JSC] Update ICStats to record handler counts

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -89,7 +89,7 @@ jit/BaselineJITPlan.cpp
 jit/ExecutableAllocator.cpp
 jit/GCAwareJITStubRoutine.cpp
 jit/ICStats.cpp
-jit/ICStats.h
+[ iOS ] jit/ICStats.h
 jit/JIT.cpp
 jit/JITSafepoint.cpp
 jit/JITWorklist.cpp

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -41,6 +41,7 @@
 #include "GetterSetter.h"
 #include "GetterSetterAccessCase.h"
 #include "Heap.h"
+#include "ICStats.h"
 #include "InstanceOfAccessCase.h"
 #include "IntrinsicGetterAccessCase.h"
 #include "JIT.h"
@@ -78,17 +79,25 @@ namespace JSC {
 namespace InlineCacheCompilerInternal {
 static constexpr bool verbose = false;
 static constexpr bool traceHandlerExecution = false;
+static constexpr bool traceHandlerStats = false;
 }
 
 template<typename... Args>
-static void traceHandler(CCallHelpers& jit, Args&&... args)
+static void traceHandler(CCallHelpers& jit, ICEvent::Kind kind, Args&&... args)
 {
     if constexpr (InlineCacheCompilerInternal::traceHandlerExecution) {
 #if CPU(ARM64)
-        jit.println("IC: ", std::forward<Args>(args)..., " ", Printer::PCRegister(), " ", CCallHelpers::linkRegister);
+        jit.println("IC: ", kind, std::forward<Args>(args)..., " ", Printer::PCRegister(), " ", CCallHelpers::linkRegister);
 #else
-        jit.println("IC: ", std::forward<Args>(args)..., " ", Printer::PCRegister());
+        jit.println("IC: ", kind, std::forward<Args>(args)..., " ", Printer::PCRegister());
 #endif
+    }
+    if constexpr (InlineCacheCompilerInternal::traceHandlerStats) {
+        if (Options::useICStats()) {
+            jit.probeDebug([=] (Probe::Context&) {
+                ICStats::singleton().add(ICEvent(kind));
+            });
+        }
     }
 }
 
@@ -1328,7 +1337,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByIdSlowPathCodeGenerator(VM& vm
     using BaselineJITRegisters::GetById::propertyCacheGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "GetById slow path");
+    traceHandler(jit, ICEvent::GetByIdSlowPath);
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1357,7 +1366,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByIdWithThisSlowPathCodeGenerato
     using BaselineJITRegisters::GetByIdWithThis::propertyCacheGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "GetByIdWithThis slow path");
+    traceHandler(jit, ICEvent::GetByIdWithThisSlowPath);
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1387,7 +1396,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValSlowPathCodeGenerator(VM& v
     using BaselineJITRegisters::GetByVal::profileGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "GetByVal slow path");
+    traceHandler(jit, ICEvent::GetByValSlowPath);
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1416,7 +1425,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getPrivateNameSlowPathCodeGenerator
     using BaselineJITRegisters::PrivateBrand::propertyCacheGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "GetPrivateName slow path");
+    traceHandler(jit, ICEvent::GetPrivateNameSlowPath);
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1448,7 +1457,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValWithThisSlowPathCodeGenerat
     using BaselineJITRegisters::GetByValWithThis::profileGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "GetByValWithThis slow path");
+    traceHandler(jit, ICEvent::GetByValWithThisSlowPath);
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1478,7 +1487,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByIdSlowPathCodeGenerator(VM& vm
     using BaselineJITRegisters::PutById::propertyCacheGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "PutById slow path");
+    traceHandler(jit, ICEvent::PutByIdSlowPath);
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1509,7 +1518,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValSlowPathCodeGenerator(VM& v
     using BaselineJITRegisters::PutByVal::propertyCacheGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "PutByVal slow path");
+    traceHandler(jit, ICEvent::PutByValSlowPath);
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1541,7 +1550,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> instanceOfSlowPathCodeGenerator(VM&
     using BaselineJITRegisters::Instanceof::propertyCacheGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "InstanceOf slow path");
+    traceHandler(jit, ICEvent::InstanceOfSlowPath);
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1569,7 +1578,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> delByIdSlowPathCodeGenerator(VM& vm
     using BaselineJITRegisters::DelById::propertyCacheGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "DeleteById slow path");
+    traceHandler(jit, ICEvent::DeleteByIdSlowPath);
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -1598,7 +1607,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> delByValSlowPathCodeGenerator(VM& v
     using BaselineJITRegisters::DelByVal::propertyCacheGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "DeleteByVal slow path");
+    traceHandler(jit, ICEvent::DeleteByValSlowPath);
 
     // Call slow operation
     jit.prepareCallOperation(vm);
@@ -5292,7 +5301,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByIdLoadHandlerImpl(VM& vm)
     using BaselineJITRegisters::GetById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "GetById Load ", ownProperty ? "OwnProperty" : "PrototypeProperty", " handler");
+    traceHandler(jit, ownProperty ? ICEvent::GetByIdLoadOwnPropertyHandler : ICEvent::GetByIdLoadPrototypePropertyHandler);
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5332,7 +5341,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdMissHandler(VM&)
     using BaselineJITRegisters::GetById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "GetById Miss handler");
+    traceHandler(jit, ICEvent::GetByIdMissHandler);
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5396,7 +5405,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByIdCustomHandlerImpl(VM& vm)
     using BaselineJITRegisters::GetById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "GetById Custom ", isAccessor ? "Accessor" : "Value", " handler");
+    traceHandler(jit, isAccessor ? ICEvent::GetByIdCustomAccessorHandler : ICEvent::GetByIdCustomValueHandler);
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5493,7 +5502,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdGetterHandler(VM& vm)
     using BaselineJITRegisters::GetById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "GetById Getter handler");
+    traceHandler(jit, ICEvent::GetByIdGetterHandler);
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5520,7 +5529,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdProxyObjectLoadHandler(VM&)
     using BaselineJITRegisters::GetById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "GetById ProxyObjectLoad handler");
+    traceHandler(jit, ICEvent::GetByIdProxyObjectLoadHandler);
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5596,7 +5605,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> getByIdModuleNamespaceLoadHandler(VM&)
     using BaselineJITRegisters::GetById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "GetById ModuleNamespaceLoad handler");
+    traceHandler(jit, ICEvent::GetByIdModuleNamespaceLoadHandler);
 
     CCallHelpers::JumpList fallThrough;
     CCallHelpers::JumpList failAndIgnore;
@@ -5633,7 +5642,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> putByIdReplaceHandler(VM&)
     using BaselineJITRegisters::PutById::scratch2GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "PutById Replace handler");
+    traceHandler(jit, ICEvent::PutByIdReplaceHandler);
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5732,7 +5741,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByIdTransitionHandlerImpl(VM& vm
     using BaselineJITRegisters::PutById::scratch4GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "PutById Transition handler");
+    traceHandler(jit, ICEvent::PutByIdTransitionHandler);
 
     CCallHelpers::JumpList fallThrough;
     CCallHelpers::JumpList allocationFailure;
@@ -5794,7 +5803,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> putByIdTransitionReallocatingOutOfLineHand
     using BaselineJITRegisters::PutById::scratch1GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "PutById TransitionReallocatingOutOfLine handler");
+    traceHandler(jit, ICEvent::PutByIdTransitionReallocatingOutOfLineHandler);
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5862,7 +5871,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByIdCustomHandlerImpl(VM& vm)
     using BaselineJITRegisters::PutById::scratch3GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "PutById Custom ", isAccessor ? "Accessor" : "Value", " handler");
+    traceHandler(jit, isAccessor ? ICEvent::PutByIdCustomAccessorHandler : ICEvent::PutByIdCustomValueHandler);
 
     CCallHelpers::JumpList fallThrough;
 
@@ -5967,7 +5976,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByIdSetterHandlerImpl(VM& vm)
     using BaselineJITRegisters::PutById::scratch2GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "PutById ", isStrict ? "Strict" : "Sloppy", " Setter handler");
+    traceHandler(jit, isStrict ? ICEvent::PutByIdStrictSetterHandler : ICEvent::PutByIdSloppySetterHandler);
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6007,7 +6016,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> inByIdInHandlerImpl(VM&)
     using BaselineJITRegisters::InById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "InById ", hit ? "Hit" : "Miss", " handler");
+    traceHandler(jit, hit ? ICEvent::InByIdHitHandler : ICEvent::InByIdMissHandler);
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6047,7 +6056,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> deleteByIdDeleteHandler(VM&)
     using BaselineJITRegisters::DelById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "DeleteById Delete handler");
+    traceHandler(jit, ICEvent::DeleteByIdDeleteHandler);
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6079,7 +6088,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> deleteByIdIgnoreHandlerImpl(VM&)
     using BaselineJITRegisters::DelById::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "DeleteById ", returnValue ? "Miss" : "NonConfigurable", " handler");
+    traceHandler(jit, returnValue ? ICEvent::DeleteByIdMissHandler : ICEvent::DeleteByIdNonConfigurableHandler);
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6120,7 +6129,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> instanceOfHandlerImpl(VM&)
     using BaselineJITRegisters::Instanceof::scratch1GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "InstanceOf ", hit ? "Hit" : "Miss", " handler");
+    traceHandler(jit, hit ? ICEvent::InstanceOfHitHandler : ICEvent::InstanceOfMissHandler);
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6163,7 +6172,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValLoadHandlerImpl(VM& vm)
     using BaselineJITRegisters::GetByVal::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "GetByVal Load ", ownProperty ? "OwnProperty" : "PrototypeProperty", isSymbol ? " Symbol" : " String", " handler");
+    traceHandler(jit, ownProperty ? ICEvent::GetByValLoadOwnPropertyHandler : ICEvent::GetByValLoadPrototypePropertyHandler, isSymbol ? " Symbol" : " String");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6221,7 +6230,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValMissHandlerImpl(VM&)
     using BaselineJITRegisters::GetByVal::profileGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "GetByVal Miss ", isSymbol ? "Symbol" : "String", " handler");
+    traceHandler(jit, ICEvent::GetByValMissHandler, isSymbol ? " Symbol" : " String");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6265,7 +6274,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValCustomHandlerImpl(VM& vm)
     using BaselineJITRegisters::GetByVal::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "GetByVal Custom ", isAccessor ? "Accessor" : "Value", isSymbol ? " Symbol" : " String", " handler");
+    traceHandler(jit, isAccessor ? ICEvent::GetByValCustomAccessorHandler : ICEvent::GetByValCustomValueHandler, isSymbol ? " Symbol" : " String");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6324,7 +6333,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> getByValGetterHandlerImpl(VM& vm)
     using BaselineJITRegisters::GetByVal::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "GetByVal Getter ", isSymbol ? "Symbol" : "String", " handler");
+    traceHandler(jit, ICEvent::GetByValGetterHandler, isSymbol ? " Symbol" : " String");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6367,7 +6376,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValReplaceHandlerImpl(VM&)
     using BaselineJITRegisters::PutByVal::scratch2GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "PutByVal Replace ", isSymbol ? "Symbol" : "String", " handler");
+    traceHandler(jit, ICEvent::PutByValReplaceHandler, isSymbol ? " Symbol" : " String");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6412,7 +6421,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValTransitionHandlerImpl(VM& v
     using BaselineJITRegisters::PutByVal::profileGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "PutByVal Transition ", isSymbol ? "Symbol" : "String", " handler");
+    traceHandler(jit, ICEvent::PutByValTransitionHandler, isSymbol ? " Symbol" : " String");
 
     CCallHelpers::JumpList fallThrough;
     CCallHelpers::JumpList allocationFailure;
@@ -6506,7 +6515,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValTransitionOutOfLineHandlerI
     using BaselineJITRegisters::PutByVal::scratch1GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "PutByVal TransitionOutOfLine ", isSymbol ? "Symbol" : "String", " handler");
+    traceHandler(jit, ICEvent::PutByValTransitionOutOfLineHandler, isSymbol ? " Symbol" : " String");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6555,7 +6564,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValCustomHandlerImpl(VM& vm)
     using BaselineJITRegisters::PutByVal::profileGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "PutByVal Custom ", isAccessor ? "Accessor" : "Value", isSymbol ? " Symbol" : " String", " handler");
+    traceHandler(jit, isAccessor ? ICEvent::PutByValCustomAccessorHandler : ICEvent::PutByValCustomValueHandler, isSymbol ? " Symbol" : " String");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6617,7 +6626,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> putByValSetterHandlerImpl(VM& vm)
     using BaselineJITRegisters::PutByVal::profileGPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "PutByVal ", isStrict ? "Strict" : "Sloppy", " Setter ", isSymbol ? "Symbol" : "String", " handler");
+    traceHandler(jit, isStrict ? ICEvent::PutByValStrictSetterHandler : ICEvent::PutByValSloppySetterHandler, isSymbol ? " Symbol" : " String");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6674,7 +6683,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> inByValInHandlerImpl(VM&)
     using BaselineJITRegisters::InByVal::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "InByVal ", hit ? "Hit" : "Miss", isSymbol ? " Symbol" : " String", " handler");
+    traceHandler(jit, hit ? ICEvent::InByValHitHandler : ICEvent::InByValMissHandler, isSymbol ? " Symbol" : " String");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6733,7 +6742,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> deleteByValDeleteHandlerImpl(VM&)
     using BaselineJITRegisters::DelByVal::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "DeleteByVal Delete ", isSymbol ? "Symbol" : "String", " handler");
+    traceHandler(jit, ICEvent::DeleteByValDeleteHandler, isSymbol ? " Symbol" : " String");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6767,7 +6776,7 @@ static MacroAssemblerCodeRef<JITThunkPtrTag> deleteByValIgnoreHandlerImpl(VM&)
     using BaselineJITRegisters::DelByVal::resultJSR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "DeleteByVal ", returnValue ? "Miss" : "NonConfigurable", isSymbol ? " Symbol" : " String", " handler");
+    traceHandler(jit, returnValue ? ICEvent::DeleteByValMissHandler : ICEvent::DeleteByValNonConfigurableHandler, isSymbol ? " Symbol" : " String");
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6834,7 +6843,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> checkPrivateBrandHandler(VM&)
     using BaselineJITRegisters::PrivateBrand::scratch1GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "CheckPrivateBrand handler");
+    traceHandler(jit, ICEvent::CheckPrivateBrandHandler);
 
     CCallHelpers::JumpList fallThrough;
 
@@ -6861,7 +6870,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> setPrivateBrandHandler(VM&)
     using BaselineJITRegisters::PrivateBrand::scratch1GPR;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "SetPrivateBrand handler");
+    traceHandler(jit, ICEvent::SetPrivateBrandHandler);
 
     CCallHelpers::JumpList fallThrough;
 
@@ -7650,7 +7659,7 @@ AccessGenerationResult InlineCacheCompiler::compileOneAccessCaseHandler(const Ve
     m_jit = &jit;
 
     emitDataICPrologue(*m_jit);
-    traceHandler(jit, "Compiled handler");
+    traceHandler(jit, ICEvent::CompiledHandler);
 
     m_preservedReusedRegisterState = allocator.preserveReusedRegistersByPushing(jit, ScratchRegisterAllocator::ExtraStackSpace::NoExtraSpace);
 
@@ -7773,7 +7782,7 @@ MacroAssemblerCodeRef<JITStubRoutinePtrTag> InlineCacheCompiler::compileGetByDOM
     m_jit = &jit;
 
     InlineCacheCompiler::emitDataICPrologue(jit);
-    traceHandler(jit, "DOMJIT handler");
+    traceHandler(jit, ICEvent::DOMJITHandler);
 
     CCallHelpers::JumpList fallThrough;
 

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -541,7 +541,7 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
                 && !loadTargetFromProxy) {
                 bool generatedCodeInline = InlineAccess::generateSelfPropertyAccess(propertyCache, structure, slot.cachedOffset());
                 if (generatedCodeInline) {
-                    LOG_IC((vm, ICEvent::GetBySelfPatch, structure->classInfoForCells(), Identifier::fromUid(vm, propertyName.uid()), slot.slotBase() == baseValue));
+                    LOG_IC((ICEvent::GetBySelfPatch, structure->classInfoForCells(), slot.slotBase() == baseValue));
                     structure->startWatchingPropertyForReplacements(vm, slot.cachedOffset());
                     repatchSlowPathCall(codeBlock, propertyCache, appropriateGetByOptimizeFunction(kind));
                     propertyCache.initGetByIdSelf(locker, codeBlock, structure, slot.cachedOffset());
@@ -677,12 +677,12 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
             }
         }
 
-        LOG_IC((vm, ICEvent::GetByAddAccessCase, baseValue.classInfoOrNull(), Identifier::fromUid(vm, propertyName.uid()), slot.slotBase() == baseValue));
+        LOG_IC((ICEvent::GetByAddAccessCase, baseValue.classInfoOrNull(), slot.slotBase() == baseValue));
 
         result = propertyCache.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), propertyName, WTF::move(newCase));
 
         if (result.generatedSomeCode())
-            LOG_IC((vm, ICEvent::GetByReplaceWithJump, baseValue.classInfoOrNull(), Identifier::fromUid(vm, propertyName.uid()), slot.slotBase() == baseValue));
+            LOG_IC((ICEvent::GetByReplaceWithJump, baseValue.classInfoOrNull(), slot.slotBase() == baseValue));
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, propertyCache, codeBlock, result);
@@ -856,7 +856,7 @@ static InlineCacheAction tryCacheArrayGetByVal(JSGlobalObject* globalObject, Cod
         result = propertyCache.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), nullptr, newCase.releaseNonNull());
 
         if (result.generatedSomeCode())
-            LOG_IC((vm, ICEvent::GetByReplaceWithJump, baseValue.classInfoOrNull(), Identifier()));
+            LOG_IC((ICEvent::GetByReplaceWithJump, baseValue.classInfoOrNull()));
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, propertyCache, codeBlock, result);
@@ -1062,7 +1062,7 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
                     
                     bool generatedCodeInline = InlineAccess::generateSelfPropertyReplace(propertyCache, oldStructure, slot.cachedOffset());
                     if (generatedCodeInline) {
-                        LOG_IC((vm, ICEvent::PutBySelfPatch, oldStructure->classInfoForCells(), ident, slot.base() == baseValue));
+                        LOG_IC((ICEvent::PutBySelfPatch, oldStructure->classInfoForCells(), slot.base() == baseValue));
                         repatchSlowPathCall(codeBlock, propertyCache, appropriatePutByOptimizeFunction(putByKind));
                         propertyCache.initPutByIdReplace(locker, codeBlock, oldStructure, slot.cachedOffset());
                         return RetryCacheLater;
@@ -1235,12 +1235,12 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
             }
         }
 
-        LOG_IC((vm, ICEvent::PutByAddAccessCase, oldStructure->classInfoForCells(), ident, slot.base() == baseValue));
+        LOG_IC((ICEvent::PutByAddAccessCase, oldStructure->classInfoForCells(), slot.base() == baseValue));
         
         result = propertyCache.addAccessCase(locker, globalObject, codeBlock, slot.isStrictMode() ? ECMAMode::strict() : ECMAMode::sloppy(), propertyName, WTF::move(newCase));
 
         if (result.generatedSomeCode())
-            LOG_IC((vm, ICEvent::PutByReplaceWithJump, oldStructure->classInfoForCells(), ident, slot.base() == baseValue));
+            LOG_IC((ICEvent::PutByReplaceWithJump, oldStructure->classInfoForCells(), slot.base() == baseValue));
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, propertyCache, codeBlock, result);
@@ -1384,7 +1384,7 @@ static InlineCacheAction tryCacheArrayPutByVal(JSGlobalObject* globalObject, Cod
         result = propertyCache.addAccessCase(locker, globalObject, codeBlock, ecmaModeFor(putByKind), nullptr, WTF::move(newCase));
 
         if (result.generatedSomeCode())
-            LOG_IC((vm, ICEvent::PutByReplaceWithJump, baseValue.classInfoOrNull(), Identifier()));
+            LOG_IC((ICEvent::PutByReplaceWithJump, baseValue.classInfoOrNull()));
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, propertyCache, codeBlock, result);
@@ -1485,7 +1485,7 @@ static InlineCacheAction tryCacheDeleteBy(JSGlobalObject* globalObject, CodeBloc
         result = propertyCache.addAccessCase(locker, globalObject, codeBlock, ecmaMode, propertyName, WTF::move(newCase));
 
         if (result.generatedSomeCode())
-            LOG_IC((vm, ICEvent::DelByReplaceWithJump, oldStructure->classInfoForCells(), Identifier::fromUid(vm, propertyName.uid())));
+            LOG_IC((ICEvent::DelByReplaceWithJump, oldStructure->classInfoForCells()));
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, propertyCache, codeBlock, result);
@@ -1497,7 +1497,7 @@ void repatchDeleteBy(JSGlobalObject* globalObject, CodeBlock* codeBlock, DeleteP
     SuperSamplerScope superSamplerScope(false);
 
     if (tryCacheDeleteBy(globalObject, codeBlock, slot, baseValue, oldStructure, propertyName, propertyCache, kind, ecmaMode) == GiveUpOnCache) {
-        LOG_IC((globalObject->vm(), ICEvent::DelByReplaceWithGeneric, baseValue.classInfoOrNull(), Identifier::fromUid(globalObject->vm(), propertyName.uid())));
+        LOG_IC((ICEvent::DelByReplaceWithGeneric, baseValue.classInfoOrNull()));
         switch (kind) {
         case DelByKind::ByIdStrict:
             repatchSlowPathCall(codeBlock, propertyCache, operationDeleteByIdStrictGaveUp);
@@ -1599,7 +1599,7 @@ static InlineCacheAction tryCacheInBy(
                 && !structure->needImpurePropertyWatchpoint()) {
                 bool generatedCodeInline = InlineAccess::generateSelfInAccess(propertyCache, structure);
                 if (generatedCodeInline) {
-                    LOG_IC((vm, ICEvent::InBySelfPatch, structure->classInfoForCells(), ident, slot.slotBase() == base));
+                    LOG_IC((ICEvent::InBySelfPatch, structure->classInfoForCells(), slot.slotBase() == base));
                     structure->startWatchingPropertyForReplacements(vm, slot.cachedOffset());
                     repatchSlowPathCall(codeBlock, propertyCache, operationInByIdOptimize);
                     propertyCache.initInByIdSelf(locker, codeBlock, structure, slot.cachedOffset());
@@ -1649,7 +1649,7 @@ static InlineCacheAction tryCacheInBy(
             }
         }
 
-        LOG_IC((vm, ICEvent::InAddAccessCase, structure->classInfoForCells(), ident, slot.slotBase() == base));
+        LOG_IC((ICEvent::InAddAccessCase, structure->classInfoForCells(), slot.slotBase() == base));
 
         if (!newCase)
             newCase = AccessCase::create(vm, codeBlock, wasFound ? AccessCase::InHit : AccessCase::InMiss, propertyName, wasFound ? slot.cachedOffset() : invalidOffset, structure, conditionSet, WTF::move(prototypeAccessChain));
@@ -1657,7 +1657,7 @@ static InlineCacheAction tryCacheInBy(
         result = propertyCache.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), propertyName, WTF::move(newCase));
 
         if (result.generatedSomeCode())
-            LOG_IC((vm, ICEvent::InReplaceWithJump, structure->classInfoForCells(), ident, slot.slotBase() == base));
+            LOG_IC((ICEvent::InReplaceWithJump, structure->classInfoForCells(), slot.slotBase() == base));
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, propertyCache, codeBlock, result);
@@ -1686,7 +1686,7 @@ void repatchInBy(JSGlobalObject* globalObject, CodeBlock* codeBlock, JSObject* b
         break;
     }
     case GiveUpOnCache:
-        LOG_IC((globalObject->vm(), ICEvent::InReplaceWithGeneric, baseObject->classInfo(), Identifier::fromUid(globalObject->vm(), propertyName.uid())));
+        LOG_IC((ICEvent::InReplaceWithGeneric, baseObject->classInfo()));
         repatchSlowPathCall(codeBlock, propertyCache, appropriateInByGaveUpFunction(kind));
         break;
     case RetryCacheLater:
@@ -1713,14 +1713,14 @@ static InlineCacheAction tryCacheHasPrivateBrand(JSGlobalObject* globalObject, C
             return action;
 
         bool isBaseProperty = true;
-        LOG_IC((vm, ICEvent::InAddAccessCase, structure->classInfoForCells(), ident, isBaseProperty));
+        LOG_IC((ICEvent::InAddAccessCase, structure->classInfoForCells(), isBaseProperty));
 
         Ref<AccessCase> newCase = AccessCase::create(vm, codeBlock, wasFound ? AccessCase::InHit : AccessCase::InMiss, brandID, invalidOffset, structure, { }, { });
 
         result = propertyCache.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), brandID, WTF::move(newCase));
 
         if (result.generatedSomeCode())
-            LOG_IC((vm, ICEvent::InReplaceWithJump, structure->classInfoForCells(), ident, isBaseProperty));
+            LOG_IC((ICEvent::InReplaceWithJump, structure->classInfoForCells(), isBaseProperty));
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, propertyCache, codeBlock, result);
@@ -1755,14 +1755,14 @@ static InlineCacheAction tryCacheCheckPrivateBrand(
             return action;
 
         bool isBaseProperty = true;
-        LOG_IC((vm, ICEvent::CheckPrivateBrandAddAccessCase, structure->classInfoForCells(), ident, isBaseProperty));
+        LOG_IC((ICEvent::CheckPrivateBrandAddAccessCase, structure->classInfoForCells(), isBaseProperty));
 
         Ref<AccessCase> newCase = AccessCase::createCheckPrivateBrand(vm, codeBlock, brandID, structure);
 
         result = propertyCache.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), brandID, WTF::move(newCase));
 
         if (result.generatedSomeCode())
-            LOG_IC((vm, ICEvent::CheckPrivateBrandReplaceWithJump, structure->classInfoForCells(), ident, isBaseProperty));
+            LOG_IC((ICEvent::CheckPrivateBrandReplaceWithJump, structure->classInfoForCells(), isBaseProperty));
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, propertyCache, codeBlock, result);
@@ -1809,14 +1809,14 @@ static InlineCacheAction tryCacheSetPrivateBrand(
         ASSERT(newStructure->isObject());
         
         bool isBaseProperty = true;
-        LOG_IC((vm, ICEvent::SetPrivateBrandAddAccessCase, oldStructure->classInfoForCells(), ident, isBaseProperty));
+        LOG_IC((ICEvent::SetPrivateBrandAddAccessCase, oldStructure->classInfoForCells(), isBaseProperty));
 
         Ref<AccessCase> newCase = AccessCase::createSetPrivateBrand(vm, codeBlock, brandID, oldStructure, newStructure);
 
         result = propertyCache.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), brandID, WTF::move(newCase));
 
         if (result.generatedSomeCode())
-            LOG_IC((vm, ICEvent::SetPrivateBrandReplaceWithJump, oldStructure->classInfoForCells(), ident, isBaseProperty));
+            LOG_IC((ICEvent::SetPrivateBrandReplaceWithJump, oldStructure->classInfoForCells(), isBaseProperty));
     }
 
     fireWatchpointsAndClearStubIfNeeded(vm, propertyCache, codeBlock, result);
@@ -1872,12 +1872,12 @@ static InlineCacheAction tryCacheInstanceOf(JSGlobalObject* globalObject, CodeBl
         if (!newCase)
             newCase = AccessCase::create(vm, codeBlock, AccessCase::InstanceOfMegamorphic, nullptr);
         
-        LOG_IC((vm, ICEvent::InstanceOfAddAccessCase, structure->classInfoForCells(), Identifier()));
+        LOG_IC((ICEvent::InstanceOfAddAccessCase, structure->classInfoForCells()));
         
         result = propertyCache.addAccessCase(locker, globalObject, codeBlock, ECMAMode::strict(), nullptr, WTF::move(newCase));
 
         if (result.generatedSomeCode())
-            LOG_IC((vm, ICEvent::InstanceOfReplaceWithJump, structure->classInfoForCells(), Identifier()));
+            LOG_IC((ICEvent::InstanceOfReplaceWithJump, structure->classInfoForCells()));
     }
     
     fireWatchpointsAndClearStubIfNeeded(vm, propertyCache, codeBlock, result);

--- a/Source/JavaScriptCore/jit/ICStats.cpp
+++ b/Source/JavaScriptCore/jit/ICStats.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "ICStats.h"
 
+#include <cstdlib>
+#include <mutex>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace JSC {
@@ -43,9 +45,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         return strcmp(m_classInfo->className, other.m_classInfo->className) < 0;
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
-    
-    if (m_propertyName != other.m_propertyName)
-        return codePointCompare(m_propertyName.string(), other.m_propertyName.string()) < 0;
 
     if (m_kind != other.m_kind)
         return m_kind < other.m_kind;
@@ -55,7 +54,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 void ICEvent::dump(PrintStream& out) const
 {
-    out.print(m_kind, "(", m_classInfo ? m_classInfo->className : "<null>", ", ", m_propertyName, ")");
+    out.print(m_kind, "(", m_classInfo ? m_classInfo->className : "<null>", ")");
     if (m_propertyLocation != Unknown)
         out.print(m_propertyLocation == BaseObject ? " self" : " proto lookup");
 }
@@ -69,6 +68,17 @@ Atomic<ICStats*> ICStats::s_instance;
 
 ICStats::ICStats()
 {
+    std::atexit([] {
+        ICStats* stats = s_instance.load();
+        if (!stats)
+            return;
+        dataLog("ICStats at exit:\n");
+        Locker spectrumLocker { stats->m_spectrum.getLock() };
+        auto list = stats->m_spectrum.buildList(spectrumLocker);
+        for (unsigned i = list.size(); i--;)
+            dataLog("    ", *list[i].key, ": ", list[i].count, "\n");
+    });
+
     m_thread = Thread::create(
         "JSC ICStats"_s,
         [this] () {
@@ -103,22 +113,17 @@ ICStats::~ICStats()
 
 void ICStats::add(const ICEvent& event)
 {
-    m_spectrum.add(event);
+    if (JSC::activeJSGlobalObjectSignpostIntervalCount.load())
+        m_spectrum.add(event);
 }
 
 ICStats& ICStats::singleton()
 {
-    for (;;) {
-        ICStats* result = s_instance.load();
-        if (result)
-            return *result;
-        
-        ICStats* newStats = new ICStats();
-        if (s_instance.compareExchangeWeak(nullptr, newStats))
-            return *newStats;
-        
-        delete newStats;
-    }
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        s_instance.store(new ICStats());
+    });
+    return *s_instance.load();
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/ICStats.h
+++ b/Source/JavaScriptCore/jit/ICStats.h
@@ -47,20 +47,22 @@ namespace JSC {
     macro(InReplaceWithGeneric) \
     macro(InstanceOfAddAccessCase) \
     macro(InstanceOfReplaceWithJump) \
-    macro(OperationGetById) \
+    macro(OperationGetByIdGaveUp) \
     macro(OperationGetByIdGeneric) \
     macro(OperationGetByIdBuildList) \
     macro(OperationGetByIdOptimize) \
     macro(OperationGetByValOptimize) \
     macro(OperationGetByIdWithThisOptimize) \
+    macro(OperationGetByIdWithThisGaveUp) \
+    macro(OperationGetByIdWithThisGeneric) \
     macro(OperationGetByValWithThisOptimize) \
     macro(OperationGenericIn) \
     macro(OperationInByIdGeneric) \
     macro(OperationInByIdOptimize) \
-    macro(OperationPutByIdStrict) \
-    macro(OperationPutByIdSloppy) \
-    macro(OperationPutByIdDirectStrict) \
-    macro(OperationPutByIdDirectSloppy) \
+    macro(OperationPutByIdStrictGaveUp) \
+    macro(OperationPutByIdSloppyGaveUp) \
+    macro(OperationPutByIdDirectStrictGaveUp) \
+    macro(OperationPutByIdDirectSloppyGaveUp) \
     macro(OperationPutByIdStrictOptimize) \
     macro(OperationPutByIdSloppyOptimize) \
     macro(OperationPutByIdDirectStrictOptimize) \
@@ -83,7 +85,87 @@ namespace JSC {
     macro(SetPrivateBrandAddAccessCase) \
     macro(CheckPrivateBrandReplaceWithJump) \
     macro(SetPrivateBrandReplaceWithJump) \
-    macro(OperationPutByIdSetPrivateFieldStrictOptimize)
+    macro(OperationPutByIdSetPrivateFieldStrictOptimize) \
+    macro(OperationPutByIdDefinePrivateFieldStrictGaveUp) \
+    macro(OperationPutByIdSetPrivateFieldStrictGaveUp) \
+    macro(OperationGetByValGaveUp) \
+    macro(OperationGetByValGeneric) \
+    macro(OperationGetByValWithThisGaveUp) \
+    macro(OperationGetByValWithThisGeneric) \
+    macro(OperationPutByValStrictGaveUp) \
+    macro(OperationPutByValStrictGeneric) \
+    macro(OperationPutByValSloppyGaveUp) \
+    macro(OperationPutByValSloppyGeneric) \
+    macro(OperationPutByValDefinePrivateFieldGaveUp) \
+    macro(OperationPutByValDefinePrivateFieldGeneric) \
+    macro(OperationPutByValSetPrivateFieldGaveUp) \
+    macro(OperationPutByValSetPrivateFieldGeneric) \
+    /* JIT execution tracing events */ \
+    /* Slow path handlers */ \
+    macro(GetByIdSlowPath) \
+    macro(GetByIdWithThisSlowPath) \
+    macro(GetByValSlowPath) \
+    macro(GetPrivateNameSlowPath) \
+    macro(GetByValWithThisSlowPath) \
+    macro(PutByIdSlowPath) \
+    macro(PutByValSlowPath) \
+    macro(InstanceOfSlowPath) \
+    macro(DeleteByIdSlowPath) \
+    macro(DeleteByValSlowPath) \
+    /* GetById handlers */ \
+    macro(GetByIdLoadOwnPropertyHandler) \
+    macro(GetByIdLoadPrototypePropertyHandler) \
+    macro(GetByIdMissHandler) \
+    macro(GetByIdCustomAccessorHandler) \
+    macro(GetByIdCustomValueHandler) \
+    macro(GetByIdGetterHandler) \
+    macro(GetByIdProxyObjectLoadHandler) \
+    macro(GetByIdModuleNamespaceLoadHandler) \
+    /* PutById handlers */ \
+    macro(PutByIdReplaceHandler) \
+    macro(PutByIdTransitionHandler) \
+    macro(PutByIdTransitionReallocatingOutOfLineHandler) \
+    macro(PutByIdCustomAccessorHandler) \
+    macro(PutByIdCustomValueHandler) \
+    macro(PutByIdStrictSetterHandler) \
+    macro(PutByIdSloppySetterHandler) \
+    /* InById handlers */ \
+    macro(InByIdHitHandler) \
+    macro(InByIdMissHandler) \
+    /* DeleteById handlers */ \
+    macro(DeleteByIdDeleteHandler) \
+    macro(DeleteByIdMissHandler) \
+    macro(DeleteByIdNonConfigurableHandler) \
+    /* InstanceOf handlers */ \
+    macro(InstanceOfHitHandler) \
+    macro(InstanceOfMissHandler) \
+    /* GetByVal handlers */ \
+    macro(GetByValLoadOwnPropertyHandler) \
+    macro(GetByValLoadPrototypePropertyHandler) \
+    macro(GetByValMissHandler) \
+    macro(GetByValCustomAccessorHandler) \
+    macro(GetByValCustomValueHandler) \
+    macro(GetByValGetterHandler) \
+    /* PutByVal handlers */ \
+    macro(PutByValReplaceHandler) \
+    macro(PutByValTransitionHandler) \
+    macro(PutByValTransitionOutOfLineHandler) \
+    macro(PutByValCustomAccessorHandler) \
+    macro(PutByValCustomValueHandler) \
+    macro(PutByValStrictSetterHandler) \
+    macro(PutByValSloppySetterHandler) \
+    /* InByVal handlers */ \
+    macro(InByValHitHandler) \
+    macro(InByValMissHandler) \
+    /* DeleteByVal handlers */ \
+    macro(DeleteByValDeleteHandler) \
+    macro(DeleteByValMissHandler) \
+    macro(DeleteByValNonConfigurableHandler) \
+    /* Other handlers */ \
+    macro(CheckPrivateBrandHandler) \
+    macro(SetPrivateBrandHandler) \
+    macro(CompiledHandler) \
+    macro(DOMJITHandler)
 
 class ICEvent {
 public:
@@ -99,28 +181,34 @@ public:
         ProtoLookup
     };
 
-    ICEvent()
-    {
-    }
-    
-    ICEvent(VM& vm, Kind kind, const ClassInfo* classInfo, PropertyName propertyName)
+    ICEvent() = default;
+
+    explicit ICEvent(Kind kind)
         : m_kind(kind)
-        , m_classInfo(classInfo)
-        , m_propertyName(Identifier::fromUid(vm, propertyName.uid()))
         , m_propertyLocation(Unknown)
     {
+        ASSERT(kind != InvalidKind);
     }
 
-    ICEvent(VM& vm, Kind kind, const ClassInfo* classInfo, PropertyName propertyName, bool isBaseProperty)
+    ICEvent(Kind kind, const ClassInfo* classInfo)
         : m_kind(kind)
         , m_classInfo(classInfo)
-        , m_propertyName(Identifier::fromUid(vm, propertyName.uid()))
+        , m_propertyLocation(Unknown)
+    {
+        ASSERT(kind != InvalidKind);
+    }
+
+    ICEvent(Kind kind, const ClassInfo* classInfo, bool isBaseProperty)
+        : m_kind(kind)
+        , m_classInfo(classInfo)
         , m_propertyLocation(isBaseProperty ? BaseObject : ProtoLookup)
     {
+        ASSERT(kind != InvalidKind);
     }
     
     ICEvent(WTF::HashTableDeletedValueType)
-        : m_kind(OperationGetById)
+        : m_kind(InvalidKind)
+        , m_propertyLocation(BaseObject)
     {
     }
     
@@ -128,14 +216,14 @@ public:
     {
         return m_kind == other.m_kind
             && m_classInfo == other.m_classInfo
-            && m_propertyName == other.m_propertyName;
+            && m_propertyLocation == other.m_propertyLocation;
     }
     
     bool operator<(const ICEvent& other) const;
     bool operator>(const ICEvent& other) const { return other < *this; }
     bool operator<=(const ICEvent& other) const { return !(*this > other); }
     bool operator>=(const ICEvent& other) const { return !(*this < other); }
-    
+
     explicit operator bool() const
     {
         return *this != ICEvent();
@@ -143,13 +231,10 @@ public:
     
     Kind kind() const { return m_kind; }
     const ClassInfo* classInfo() const { return m_classInfo; }
-    const Identifier& propertyName() const { return m_propertyName; }
     
     unsigned hash() const
     {
-        if (m_propertyName.isNull())
-            return static_cast<unsigned>(m_kind) + static_cast<unsigned>(m_propertyLocation) + WTF::PtrHash<const ClassInfo*>::hash(m_classInfo);
-        return static_cast<unsigned>(m_kind) + static_cast<unsigned>(m_propertyLocation) + WTF::PtrHash<const ClassInfo*>::hash(m_classInfo) + StringHash::hash(m_propertyName.string());
+        return static_cast<unsigned>(m_kind) + static_cast<unsigned>(m_propertyLocation) + WTF::PtrHash<const ClassInfo*>::hash(m_classInfo);
     }
     
     bool isHashTableDeletedValue() const
@@ -167,8 +252,7 @@ private:
     
     Kind m_kind { InvalidKind };
     const ClassInfo* m_classInfo { nullptr };
-    Identifier m_propertyName;
-    PropertyLocation m_propertyLocation;
+    PropertyLocation m_propertyLocation { Unknown };
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -520,7 +520,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetByIdGaveUp, EncodedJSValue, (EncodedJSValue
     CacheableIdentifier identifier = propertyCache->identifier();
     JSValue result = baseValue.get(globalObject, identifier, slot);
 
-    LOG_IC((vm, ICEvent::OperationGetById, baseValue.classInfoOrNull(), identifier, baseValue == slot.slotBase()));
+    LOG_IC((ICEvent::OperationGetByIdGaveUp, baseValue.classInfoOrNull(), baseValue == slot.slotBase()));
 
     OPERATION_RETURN(scope, JSValue::encode(result));
 }
@@ -539,7 +539,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetByIdGeneric, EncodedJSValue, (JSGlobalObjec
     CacheableIdentifier identifier = CacheableIdentifier::createFromRawBits(rawCacheableIdentifier);
     JSValue result = baseValue.get(globalObject, identifier, slot);
     
-    LOG_IC((vm, ICEvent::OperationGetByIdGeneric, baseValue.classInfoOrNull(), identifier, baseValue == slot.slotBase()));
+    LOG_IC((ICEvent::OperationGetByIdGeneric, baseValue.classInfoOrNull(), baseValue == slot.slotBase()));
     
     OPERATION_RETURN(scope, JSValue::encode(result));
 }
@@ -560,7 +560,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetByIdOptimize, EncodedJSValue, (EncodedJSVal
 
     OPERATION_RETURN(scope, JSValue::encode(baseValue.getPropertySlot(globalObject, identifier, [&] (bool found, PropertySlot& slot) -> JSValue {
         
-        LOG_IC((vm, ICEvent::OperationGetByIdOptimize, baseValue.classInfoOrNull(), identifier, baseValue == slot.slotBase()));
+        LOG_IC((ICEvent::OperationGetByIdOptimize, baseValue.classInfoOrNull(), baseValue == slot.slotBase()));
         
         CodeBlock* codeBlock = callFrame->codeBlock();
         if (propertyCache->considerRepatchingCacheBy(vm, codeBlock, baseValue.structureOrNull(), identifier))
@@ -587,7 +587,11 @@ JSC_DEFINE_JIT_OPERATION(operationGetByIdWithThisGaveUp, EncodedJSValue, (Encode
     JSValue thisValue = JSValue::decode(thisEncoded);
     PropertySlot slot(thisValue, PropertySlot::InternalMethodType::Get);
 
-    OPERATION_RETURN(scope, JSValue::encode(baseValue.get(globalObject, identifier, slot)));
+    JSValue result = baseValue.get(globalObject, identifier, slot);
+
+    LOG_IC((ICEvent::OperationGetByIdWithThisGaveUp, baseValue.classInfoOrNull(), baseValue == slot.slotBase()));
+
+    OPERATION_RETURN(scope, JSValue::encode(result));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationGetByIdWithThisGeneric, EncodedJSValue, (JSGlobalObject* globalObject, EncodedJSValue base, EncodedJSValue thisEncoded, uintptr_t rawCacheableIdentifier))
@@ -605,7 +609,11 @@ JSC_DEFINE_JIT_OPERATION(operationGetByIdWithThisGeneric, EncodedJSValue, (JSGlo
     JSValue thisValue = JSValue::decode(thisEncoded);
     PropertySlot slot(thisValue, PropertySlot::InternalMethodType::Get);
 
-    OPERATION_RETURN(scope, JSValue::encode(baseValue.get(globalObject, identifier, slot)));
+    JSValue result = baseValue.get(globalObject, identifier, slot);
+
+    LOG_IC((ICEvent::OperationGetByIdWithThisGeneric, baseValue.classInfoOrNull(), baseValue == slot.slotBase()));
+
+    OPERATION_RETURN(scope, JSValue::encode(result));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationGetByIdWithThisOptimize, EncodedJSValue, (EncodedJSValue base, EncodedJSValue thisEncoded, PropertyInlineCache* propertyCache))
@@ -625,7 +633,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetByIdWithThisOptimize, EncodedJSValue, (Enco
 
     PropertySlot slot(thisValue, PropertySlot::InternalMethodType::Get);
     OPERATION_RETURN(scope, JSValue::encode(baseValue.getPropertySlot(globalObject, identifier, slot, [&] (bool found, PropertySlot& slot) -> JSValue {
-        LOG_IC((vm, ICEvent::OperationGetByIdWithThisOptimize, baseValue.classInfoOrNull(), identifier, baseValue == slot.slotBase()));
+        LOG_IC((ICEvent::OperationGetByIdWithThisOptimize, baseValue.classInfoOrNull(), baseValue == slot.slotBase()));
         
         CodeBlock* codeBlock = callFrame->codeBlock();
         if (propertyCache->considerRepatchingCacheBy(vm, codeBlock, baseValue.structureOrNull(), identifier))
@@ -680,7 +688,7 @@ JSC_DEFINE_JIT_OPERATION(operationInByIdGaveUp, EncodedJSValue, (EncodedJSValue 
     }
     JSObject* baseObject = asObject(baseValue);
 
-    LOG_IC((vm, ICEvent::OperationInByIdGeneric, baseObject->classInfo(), identifier));
+    LOG_IC((ICEvent::OperationInByIdGeneric, baseObject->classInfo()));
 
     scope.release();
     PropertySlot slot(baseObject, PropertySlot::InternalMethodType::HasProperty);
@@ -706,7 +714,7 @@ JSC_DEFINE_JIT_OPERATION(operationInByIdOptimize, EncodedJSValue, (EncodedJSValu
     }
     JSObject* baseObject = asObject(baseValue);
 
-    LOG_IC((vm, ICEvent::OperationInByIdOptimize, baseObject->classInfo(), identifier));
+    LOG_IC((ICEvent::OperationInByIdOptimize, baseObject->classInfo()));
 
     PropertySlot slot(baseObject, PropertySlot::InternalMethodType::HasProperty);
     bool found = baseObject->getPropertySlot(globalObject, identifier, slot);
@@ -1142,7 +1150,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdStrictGaveUp, void, (EncodedJSValue enc
     PutPropertySlot slot(baseValue, true, callFrame->codeBlock()->putByIdContext());
     baseValue.putInline(globalObject, identifier, JSValue::decode(encodedValue), slot);
     
-    LOG_IC((vm, ICEvent::OperationPutByIdStrict, baseValue.classInfoOrNull(), identifier, slot.base() == baseValue));
+    LOG_IC((ICEvent::OperationPutByIdStrictGaveUp, baseValue.classInfoOrNull(), slot.base() == baseValue));
     OPERATION_RETURN(scope);
 }
 
@@ -1163,7 +1171,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdSloppyGaveUp, void, (EncodedJSValue enc
     PutPropertySlot slot(baseValue, false, callFrame->codeBlock()->putByIdContext());
     baseValue.putInline(globalObject, identifier, JSValue::decode(encodedValue), slot);
 
-    LOG_IC((vm, ICEvent::OperationPutByIdSloppy, baseValue.classInfoOrNull(), identifier, slot.base() == baseValue));
+    LOG_IC((ICEvent::OperationPutByIdSloppyGaveUp, baseValue.classInfoOrNull(), slot.base() == baseValue));
     OPERATION_RETURN(scope);
 }
 
@@ -1360,7 +1368,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdDirectStrictGaveUp, void, (EncodedJSVal
     PutPropertySlot slot(baseValue, true, callFrame->codeBlock()->putByIdContext());
     CommonSlowPaths::putDirectWithReify(vm, globalObject, asObject(baseValue), identifier, JSValue::decode(encodedValue), slot);
 
-    LOG_IC((vm, ICEvent::OperationPutByIdDirectStrict, baseValue.classInfoOrNull(), identifier, slot.base() == baseValue));
+    LOG_IC((ICEvent::OperationPutByIdDirectStrictGaveUp, baseValue.classInfoOrNull(), slot.base() == baseValue));
     OPERATION_RETURN(scope);
 }
 
@@ -1381,7 +1389,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdDirectSloppyGaveUp, void, (EncodedJSVal
     PutPropertySlot slot(baseValue, false, callFrame->codeBlock()->putByIdContext());
     CommonSlowPaths::putDirectWithReify(vm, globalObject, asObject(baseValue), identifier, JSValue::decode(encodedValue), slot);
 
-    LOG_IC((vm, ICEvent::OperationPutByIdDirectSloppy, baseValue.classInfoOrNull(), identifier, slot.base() == baseValue));
+    LOG_IC((ICEvent::OperationPutByIdDirectSloppyGaveUp, baseValue.classInfoOrNull(), slot.base() == baseValue));
     OPERATION_RETURN(scope);
 }
 
@@ -1406,7 +1414,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdStrictOptimize, void, (EncodedJSValue e
     Structure* structure = CommonSlowPaths::originalStructureBeforePut(baseValue);
     baseValue.putInline(globalObject, identifier, value, slot);
 
-    LOG_IC((vm, ICEvent::OperationPutByIdStrictOptimize, baseValue.classInfoOrNull(), identifier, slot.base() == baseValue));
+    LOG_IC((ICEvent::OperationPutByIdStrictOptimize, baseValue.classInfoOrNull(), slot.base() == baseValue));
 
     OPERATION_RETURN_IF_EXCEPTION(scope);
 
@@ -1439,7 +1447,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdSloppyOptimize, void, (EncodedJSValue e
     Structure* structure = CommonSlowPaths::originalStructureBeforePut(baseValue);
     baseValue.putInline(globalObject, identifier, value, slot);
 
-    LOG_IC((vm, ICEvent::OperationPutByIdSloppyOptimize, baseValue.classInfoOrNull(), identifier, slot.base() == baseValue));
+    LOG_IC((ICEvent::OperationPutByIdSloppyOptimize, baseValue.classInfoOrNull(), slot.base() == baseValue));
 
     OPERATION_RETURN_IF_EXCEPTION(scope);
 
@@ -1471,7 +1479,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdDirectStrictOptimize, void, (EncodedJSV
     Structure* structure = nullptr;
     CommonSlowPaths::putDirectWithReify(vm, globalObject, baseObject, identifier, value, slot, &structure);
 
-    LOG_IC((vm, ICEvent::OperationPutByIdDirectStrictOptimize, baseObject->classInfo(), identifier, slot.base() == baseObject));
+    LOG_IC((ICEvent::OperationPutByIdDirectStrictOptimize, baseObject->classInfo(), slot.base() == baseObject));
 
     OPERATION_RETURN_IF_EXCEPTION(scope);
     
@@ -1503,7 +1511,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdDirectSloppyOptimize, void, (EncodedJSV
     Structure* structure = nullptr;
     CommonSlowPaths::putDirectWithReify(vm, globalObject, baseObject, identifier, value, slot, &structure);
 
-    LOG_IC((vm, ICEvent::OperationPutByIdDirectSloppyOptimize, baseObject->classInfo(), identifier, slot.base() == baseObject));
+    LOG_IC((ICEvent::OperationPutByIdDirectSloppyOptimize, baseObject->classInfo(), slot.base() == baseObject));
 
     OPERATION_RETURN_IF_EXCEPTION(scope);
     
@@ -1568,6 +1576,9 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdDefinePrivateFieldStrictGaveUp, void, (
     JSValue baseValue = JSValue::decode(encodedBase);
 
     definePrivateField(vm, globalObject, callFrame, baseValue, identifier, value, [](VM&, CodeBlock*, Structure*, PutPropertySlot&) { });
+
+    LOG_IC((ICEvent::OperationPutByIdDefinePrivateFieldStrictGaveUp, baseValue.classInfoOrNull()));
+
     OPERATION_RETURN(scope);
 }
 
@@ -1587,7 +1598,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdDefinePrivateFieldStrictOptimize, void,
     
     definePrivateField(vm, globalObject, callFrame, baseValue, identifier, value, [&](VM& vm, CodeBlock* codeBlock, Structure* oldStructure, PutPropertySlot& putSlot) {
         JSObject* baseObject = asObject(baseValue);
-        LOG_IC((vm, ICEvent::OperationPutByIdDefinePrivateFieldStrictOptimize, baseObject->classInfo(), identifier, putSlot.base() == baseObject));
+        LOG_IC((ICEvent::OperationPutByIdDefinePrivateFieldStrictOptimize, baseObject->classInfo(), putSlot.base() == baseObject));
 
         ASSERT_UNUSED(accessType, accessType == static_cast<AccessType>(propertyCache->accessType));
 
@@ -1612,6 +1623,9 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdSetPrivateFieldStrictGaveUp, void, (Enc
     JSValue baseValue = JSValue::decode(encodedBase);
 
     setPrivateField(vm, globalObject, callFrame, baseValue, identifier, value, [](VM&, CodeBlock*, Structure*, PutPropertySlot&) { });
+
+    LOG_IC((ICEvent::OperationPutByIdSetPrivateFieldStrictGaveUp, baseValue.classInfoOrNull()));
+
     OPERATION_RETURN(scope);
 }
 
@@ -1631,7 +1645,7 @@ JSC_DEFINE_JIT_OPERATION(operationPutByIdSetPrivateFieldStrictOptimize, void, (E
 
     setPrivateField(vm, globalObject, callFrame, baseValue, identifier, value, [&](VM& vm, CodeBlock* codeBlock, Structure* oldStructure, PutPropertySlot& putSlot) {
         JSObject* baseObject = asObject(baseValue);
-        LOG_IC((vm, ICEvent::OperationPutByIdSetPrivateFieldStrictOptimize, baseObject->classInfo(), identifier, putSlot.base() == baseObject));
+        LOG_IC((ICEvent::OperationPutByIdSetPrivateFieldStrictOptimize, baseObject->classInfo(), putSlot.base() == baseObject));
 
         ASSERT_UNUSED(accessType, accessType == static_cast<AccessType>(propertyCache->accessType));
 
@@ -1901,6 +1915,9 @@ JSC_DEFINE_JIT_OPERATION(operationPutByValStrictGaveUp, void, (EncodedJSValue en
     JSValue value = JSValue::decode(encodedValue);
 
     putByVal(globalObject, baseValue, subscript, value, profile, ECMAMode::strict());
+
+    LOG_IC((ICEvent::OperationPutByValStrictGaveUp, baseValue.classInfoOrNull()));
+
     OPERATION_RETURN(scope);
 }
 
@@ -1916,6 +1933,9 @@ JSC_DEFINE_JIT_OPERATION(operationPutByValStrictGeneric, void, (JSGlobalObject* 
     JSValue value = JSValue::decode(encodedValue);
 
     putByVal(globalObject, baseValue, subscript, value, nullptr, ECMAMode::strict());
+
+    LOG_IC((ICEvent::OperationPutByValStrictGeneric, baseValue.classInfoOrNull()));
+
     OPERATION_RETURN(scope);
 }
 
@@ -1934,6 +1954,9 @@ JSC_DEFINE_JIT_OPERATION(operationPutByValSloppyGaveUp, void, (EncodedJSValue en
     JSValue value = JSValue::decode(encodedValue);
 
     putByVal(globalObject, baseValue, subscript, value, profile, ECMAMode::sloppy());
+
+    LOG_IC((ICEvent::OperationPutByValSloppyGaveUp, baseValue.classInfoOrNull()));
+
     OPERATION_RETURN(scope);
 }
 
@@ -1949,6 +1972,9 @@ JSC_DEFINE_JIT_OPERATION(operationPutByValSloppyGeneric, void, (JSGlobalObject* 
     JSValue value = JSValue::decode(encodedValue);
 
     putByVal(globalObject, baseValue, subscript, value, nullptr, ECMAMode::sloppy());
+
+    LOG_IC((ICEvent::OperationPutByValSloppyGeneric, baseValue.classInfoOrNull()));
+
     OPERATION_RETURN(scope);
 }
 
@@ -2372,6 +2398,9 @@ JSC_DEFINE_JIT_OPERATION(operationPutByValDefinePrivateFieldGaveUp, void, (Encod
     JSValue value = JSValue::decode(encodedValue);
 
     putPrivateName<true>(globalObject, baseValue, subscript, value);
+
+    LOG_IC((ICEvent::OperationPutByValDefinePrivateFieldGaveUp, baseValue.classInfoOrNull()));
+
     OPERATION_RETURN(scope);
 }
 
@@ -2387,6 +2416,9 @@ JSC_DEFINE_JIT_OPERATION(operationPutByValDefinePrivateFieldGeneric, void, (JSGl
     JSValue value = JSValue::decode(encodedValue);
 
     putPrivateName<true>(globalObject, baseValue, subscript, value);
+
+    LOG_IC((ICEvent::OperationPutByValDefinePrivateFieldGeneric, baseValue.classInfoOrNull()));
+
     OPERATION_RETURN(scope);
 }
 
@@ -2405,6 +2437,9 @@ JSC_DEFINE_JIT_OPERATION(operationPutByValSetPrivateFieldGaveUp, void, (EncodedJ
     JSValue value = JSValue::decode(encodedValue);
 
     putPrivateName<false>(globalObject, baseValue, subscript, value);
+
+    LOG_IC((ICEvent::OperationPutByValSetPrivateFieldGaveUp, baseValue.classInfoOrNull()));
+
     OPERATION_RETURN(scope);
 }
 
@@ -2420,6 +2455,9 @@ JSC_DEFINE_JIT_OPERATION(operationPutByValSetPrivateFieldGeneric, void, (JSGloba
     JSValue value = JSValue::decode(encodedValue);
 
     putPrivateName<false>(globalObject, baseValue, subscript, value);
+
+    LOG_IC((ICEvent::OperationPutByValSetPrivateFieldGeneric, baseValue.classInfoOrNull()));
+
     OPERATION_RETURN(scope);
 }
 
@@ -3475,7 +3513,11 @@ JSC_DEFINE_JIT_OPERATION(operationGetByValGaveUp, EncodedJSValue, (EncodedJSValu
     JSValue baseValue = JSValue::decode(encodedBase);
     JSValue subscript = JSValue::decode(encodedSubscript);
 
-    OPERATION_RETURN(scope, JSValue::encode(getByVal(globalObject, callFrame, profile, baseValue, subscript)));
+    JSValue result = getByVal(globalObject, callFrame, profile, baseValue, subscript);
+
+    LOG_IC((ICEvent::OperationGetByValGaveUp, baseValue.classInfoOrNull()));
+
+    OPERATION_RETURN(scope, JSValue::encode(result));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationGetByValOptimize, EncodedJSValue, (EncodedJSValue encodedBase, EncodedJSValue encodedSubscript, PropertyInlineCache* propertyCache, ArrayProfile* profile))
@@ -3506,7 +3548,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetByValOptimize, EncodedJSValue, (EncodedJSVa
             if (subscript.isSymbol() || !parseIndex(*propertyName.data)) {
                 scope.release();
                 OPERATION_RETURN(scope, JSValue::encode(baseValue.getPropertySlot(globalObject, propertyName.data, [&] (bool found, PropertySlot& slot) -> JSValue {
-                    LOG_IC((vm, ICEvent::OperationGetByValOptimize, baseValue.classInfoOrNull(), propertyName.data, baseValue == slot.slotBase()));
+                    LOG_IC((ICEvent::OperationGetByValOptimize, baseValue.classInfoOrNull(), baseValue == slot.slotBase()));
 
                     CacheableIdentifier identifier = CacheableIdentifier::createFromCell(subscript.asCell());
                     if (propertyCache->considerRepatchingCacheBy(vm, codeBlock, baseValue.structureOrNull(), identifier))
@@ -3731,7 +3773,11 @@ JSC_DEFINE_JIT_OPERATION(operationGetByValGeneric, EncodedJSValue, (JSGlobalObje
     JSValue baseValue = JSValue::decode(encodedBase);
     JSValue subscript = JSValue::decode(encodedSubscript);
 
-    OPERATION_RETURN(scope, JSValue::encode(getByVal(globalObject, callFrame, nullptr, baseValue, subscript)));
+    JSValue result = getByVal(globalObject, callFrame, nullptr, baseValue, subscript);
+
+    LOG_IC((ICEvent::OperationGetByValGeneric, baseValue.classInfoOrNull()));
+
+    OPERATION_RETURN(scope, JSValue::encode(result));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationGetByValWithThisGaveUp, EncodedJSValue, (EncodedJSValue encodedBase, EncodedJSValue encodedSubscript, EncodedJSValue encodedThis, PropertyInlineCache* propertyCache, ArrayProfile* profile))
@@ -3748,7 +3794,11 @@ JSC_DEFINE_JIT_OPERATION(operationGetByValWithThisGaveUp, EncodedJSValue, (Encod
     JSValue subscript = JSValue::decode(encodedSubscript);
     JSValue thisValue = JSValue::decode(encodedThis);
 
-    OPERATION_RETURN(scope, JSValue::encode(getByValWithThis(globalObject, callFrame, profile, baseValue, subscript, thisValue)));
+    JSValue result = getByValWithThis(globalObject, callFrame, profile, baseValue, subscript, thisValue);
+
+    LOG_IC((ICEvent::OperationGetByValWithThisGaveUp, baseValue.classInfoOrNull()));
+
+    OPERATION_RETURN(scope, JSValue::encode(result));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationGetByValWithThisOptimize, EncodedJSValue, (EncodedJSValue encodedBase, EncodedJSValue encodedSubscript, EncodedJSValue encodedThis, PropertyInlineCache* propertyCache, ArrayProfile* profile))
@@ -3781,7 +3831,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetByValWithThisOptimize, EncodedJSValue, (Enc
         if (subscript.isSymbol() || !parseIndex(propertyName)) {
             scope.release();
             OPERATION_RETURN(scope, JSValue::encode(baseValue.getPropertySlot(globalObject, propertyName, slot, [&] (bool found, PropertySlot& slot) -> JSValue {
-                LOG_IC((vm, ICEvent::OperationGetByValWithThisOptimize, baseValue.classInfoOrNull(), propertyName, baseValue == slot.slotBase()));
+                LOG_IC((ICEvent::OperationGetByValWithThisOptimize, baseValue.classInfoOrNull(), baseValue == slot.slotBase()));
 
                 CacheableIdentifier identifier = CacheableIdentifier::createFromCell(subscript.asCell());
                 if (propertyCache->considerRepatchingCacheBy(vm, codeBlock, baseValue.structureOrNull(), identifier))
@@ -3829,7 +3879,11 @@ JSC_DEFINE_JIT_OPERATION(operationGetByValWithThisGeneric, EncodedJSValue, (JSGl
     auto propertyName = property.toPropertyKey(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
     PropertySlot slot(thisValue, PropertySlot::PropertySlot::InternalMethodType::Get);
-    OPERATION_RETURN(scope, JSValue::encode(baseValue.get(globalObject, propertyName, slot)));
+    JSValue result = baseValue.get(globalObject, propertyName, slot);
+
+    LOG_IC((ICEvent::OperationGetByValWithThisGeneric, baseValue.classInfoOrNull(), baseValue == slot.slotBase()));
+
+    OPERATION_RETURN(scope, JSValue::encode(result));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationGetByValWithThisMegamorphic, EncodedJSValue, (EncodedJSValue encodedBase, EncodedJSValue encodedSubscript, EncodedJSValue encodedThis, PropertyInlineCache* propertyCache, ArrayProfile* profile))
@@ -3916,7 +3970,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetPrivateNameOptimize, EncodedJSValue, (Encod
         base->getPrivateField(globalObject, fieldName, slot);
         OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
-        LOG_IC((vm, ICEvent::OperationGetPrivateNameOptimize, baseValue.classInfoOrNull(), fieldName, true));
+        LOG_IC((ICEvent::OperationGetPrivateNameOptimize, baseValue.classInfoOrNull(), true));
 
         CacheableIdentifier identifier = CacheableIdentifier::createFromCell(fieldNameValue.asCell());
         if (propertyCache->considerRepatchingCacheBy(vm, codeBlock, baseValue.structureOrNull(), identifier))
@@ -3973,7 +4027,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetPrivateNameByIdGaveUp, EncodedJSValue, (Enc
 
     JSValue result = getPrivateName(globalObject, callFrame, baseValue, identifier);
 
-    LOG_IC((vm, ICEvent::OperationGetPrivateNameById, baseValue.classInfoOrNull(), identifier, true));
+    LOG_IC((ICEvent::OperationGetPrivateNameById, baseValue.classInfoOrNull(), true));
 
     OPERATION_RETURN(scope, JSValue::encode(result));
 }
@@ -3998,7 +4052,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetPrivateNameByIdOptimize, EncodedJSValue, (E
         base->getPrivateField(globalObject, identifier, slot);
         OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
 
-        LOG_IC((vm, ICEvent::OperationGetPrivateNameByIdOptimize, baseValue.classInfoOrNull(), identifier, true));
+        LOG_IC((ICEvent::OperationGetPrivateNameByIdOptimize, baseValue.classInfoOrNull(), true));
 
         CodeBlock* codeBlock = callFrame->codeBlock();
         if (propertyCache->considerRepatchingCacheBy(vm, codeBlock, baseValue.structureOrNull(), identifier))
@@ -4023,7 +4077,7 @@ JSC_DEFINE_JIT_OPERATION(operationGetPrivateNameByIdGeneric, EncodedJSValue, (JS
 
     JSValue result = getPrivateName(globalObject, callFrame, baseValue, identifier);
 
-    LOG_IC((vm, ICEvent::OperationGetPrivateNameByIdGeneric, baseValue.classInfoOrNull(), identifier, true));
+    LOG_IC((ICEvent::OperationGetPrivateNameByIdGeneric, baseValue.classInfoOrNull(), true));
 
     OPERATION_RETURN(scope, JSValue::encode(result));
 }


### PR DESCRIPTION
#### c8a159ededf132ebe0b86b6ad6bffdb79efef396
<pre>
[JSC] Update ICStats to record handler counts
<a href="https://bugs.webkit.org/show_bug.cgi?id=309820">https://bugs.webkit.org/show_bug.cgi?id=309820</a>
<a href="https://rdar.apple.com/172399794">rdar://172399794</a>

Reviewed by Marcus Plutowski.

This adds stats for how often a particular handler is run in ICStats. I
also updated a number of the GiveUp cases to make them more obvious.

A couple of bug fixes:

The m_propertyLocation was not included in equality, which randomly
broke the HashMap.

Stop recording the indenifier because it is printed from a background
thread, which crashed when run under ASSERTs.

Canonical link: <a href="https://commits.webkit.org/309213@main">https://commits.webkit.org/309213@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a9b6c42c4c63e3e0517874ab32692028d75ab36

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149941 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22660 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/16244 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/158648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/23111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22768 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/158648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152901 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/23111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/134538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/158648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/23111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/6494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141918 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/23111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/12469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/161125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10735 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/14012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/161125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/22462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/18856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/161125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/22469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/134262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23060 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/11015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/181371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/22070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85890 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/181371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/21800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/21952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/21857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->