### PR TITLE
Reduce duplicated comparisons in RenderLayer::rebuildZOrderLists

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2013-2014 Google Inc. All rights reserved.
  * Copyright (C) 2019 Adobe. All rights reserved.
  * Copyright (c) 2020, 2021, 2022 Igalia S.L.
@@ -839,18 +839,26 @@ void RenderLayer::rebuildZOrderLists(std::unique_ptr<Vector<RenderLayer*>>& posZ
             child->collectLayers(posZOrderList, negZOrderList, accumulatedDirtyFlags);
     }
 
-    auto compareZIndex = [] (const RenderLayer* first, const RenderLayer* second) -> bool {
-        return first->zIndex() < second->zIndex();
+    // Precompute z-indices to avoid recomputing them on every sort comparison.
+    struct LayerWithZIndex {
+        RenderLayer* layer;
+        int zIndex;
+    };
+    auto sortByZIndex = [](Vector<RenderLayer*>& list) {
+        auto pairs = list.map([](auto* layer) -> LayerWithZIndex {
+            return { layer, layer->zIndex() };
+        });
+        std::ranges::stable_sort(pairs, { }, &LayerWithZIndex::zIndex);
+        std::ranges::transform(pairs, list.begin(), &LayerWithZIndex::layer);
     };
 
-    // Sort the two lists.
     if (posZOrderList) {
-        std::stable_sort(posZOrderList->begin(), posZOrderList->end(), compareZIndex);
+        sortByZIndex(*posZOrderList);
         posZOrderList->shrinkToFit();
     }
 
     if (negZOrderList) {
-        std::stable_sort(negZOrderList->begin(), negZOrderList->end(), compareZIndex);
+        sortByZIndex(*negZOrderList);
         negZOrderList->shrinkToFit();
     }
 


### PR DESCRIPTION
#### 2342d8ad81df16d2889ddf976bbd8d00a38c792d
<pre>
Reduce duplicated comparisons in RenderLayer::rebuildZOrderLists
<a href="https://bugs.webkit.org/show_bug.cgi?id=309823">https://bugs.webkit.org/show_bug.cgi?id=309823</a>
<a href="https://rdar.apple.com/172404561">rdar://172404561</a>

Reviewed by NOBODY (OOPS!).

The current implementation computes ZIndex multiple times during the sort operation. We
can reduce redundant calculations be caching the indices before sorting.

No new tests: No change in behavior.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::rebuildZOrderLists):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2342d8ad81df16d2889ddf976bbd8d00a38c792d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158430 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103158 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115497 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82099 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134354 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96238 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22bf7968-7969-441b-b6e9-95c82ea38c6a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16717 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14637 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6276 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160908 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13827 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123523 "Found 1 new test failure: media/media-sources-selection.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18678 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123729 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22254 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134078 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78479 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18897 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10829 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21855 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85675 "Found 2 new failures in rendering/RenderLayer.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21585 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21737 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21642 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->