### PR TITLE
[iOS] Editing text in the comment editor of Hacker News sometimes causes a debug assertion crash

### DIFF
--- a/Source/WebKit/UIProcess/ios/TextCheckerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/TextCheckerIOS.mm
@@ -397,16 +397,21 @@ static Vector<TextCheckingResult> convertExtendedCheckingResults(NSArray<NSTextC
 void TextChecker::requestExtendedCheckingOfString(Ref<TextCheckerCompletion>&& textCheckerCompletion, int32_t)
 {
     auto textChecker = textCheckerFor(1);
-    if (![textChecker _doneLoading])
+    if (![textChecker _doneLoading]) {
+        textCheckerCompletion->didFinishCheckingText({ });
         return;
-    if (![textChecker respondsToSelector:@selector(requestProofreadingReviewOfString:range:language:options:completionHandler:)])
+    }
+
+    if (![textChecker respondsToSelector:@selector(requestProofreadingReviewOfString:range:language:options:completionHandler:)]) {
+        textCheckerCompletion->didFinishCheckingText({ });
         return;
+    }
 
     RetainPtr textString = textCheckerCompletion->textCheckingRequestData().text().createNSString();
     NSRange range = NSMakeRange(0, textCheckerCompletion->textCheckingRequestData().text().length());
-    [textChecker requestProofreadingReviewOfString:textString.get() range:range language:nil options:@{ } completionHandler:makeBlockPtr([textCompletion = WTF::move(textCheckerCompletion)](NSArray<NSTextCheckingResult *> *incomingResults) {
+    [textChecker requestProofreadingReviewOfString:textString.get() range:range language:nil options:@{ } completionHandler:makeBlockPtr([textCompletion = WTF::move(textCheckerCompletion)](NSArray<NSTextCheckingResult *> *incomingResults) mutable {
         auto results = convertExtendedCheckingResults(incomingResults);
-        callOnMainRunLoop([textCompletion, results] {
+        callOnMainRunLoop([textCompletion = WTF::move(textCompletion), results = crossThreadCopy(WTF::move(results))] {
             textCompletion->didFinishCheckingText(results);
         });
     }).get()];


### PR DESCRIPTION
#### d9ee7445bbc65d45b0398b1a2b0b18c3626074d3
<pre>
[iOS] Editing text in the comment editor of Hacker News sometimes causes a debug assertion crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=309832">https://bugs.webkit.org/show_bug.cgi?id=309832</a>
<a href="https://rdar.apple.com/172204420">rdar://172204420</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

Speculative fix based on the fact that the completion handler wasn&apos;t
handled in every case, and we weren&apos;t correctly moving objects or
dealing with cross-thread moves correctly.

* Source/WebKit/UIProcess/ios/TextCheckerIOS.mm:
(WebKit::TextChecker::requestExtendedCheckingOfString):

Canonical link: <a href="https://commits.webkit.org/309217@main">https://commits.webkit.org/309217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9be0a6f7a59fb484bdccdbaa758bb69e548b2f45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158453 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103180 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22917 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115513 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82108 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95b9a13e-3e71-462e-81be-d4ba522572c4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152708 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134373 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96254 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac99e462-edc4-4773-bccf-c82f2e373b62) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16736 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14656 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6299 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126344 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160930 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13846 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123538 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123744 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33636 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134097 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78501 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18911 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10848 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21877 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85697 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21607 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21759 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21664 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->