### PR TITLE
[visionOS] Enable 3D depth-patching for Spatial Scenes

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Rendering.swift
+++ b/Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Rendering.swift
@@ -149,6 +149,9 @@ extension WKSeparatedImageView {
 
         let portalEntity = ModelEntity()
         var ipc = ImagePresentationComponent(spatial3DImage: spatial3DImage)
+        #if canImport(RealityKit, _version: 420)
+        ipc.enableSpatial3DDepthPatching = true
+        #endif
         ipc.desiredViewingMode = desiredViewingModeSpatial ? .spatial3D : .mono
         #if USE_APPLE_INTERNAL_SDK
         ipc.cornerRadiusInPoints = Float(layer.cornerRadius)


### PR DESCRIPTION
#### 2ce75b21d702ad4231142b217acff2544f2fb759
<pre>
[visionOS] Enable 3D depth-patching for Spatial Scenes
<a href="https://bugs.webkit.org/show_bug.cgi?id=309827">https://bugs.webkit.org/show_bug.cgi?id=309827</a>
<a href="https://rdar.apple.com/163648153">rdar://163648153</a>

Reviewed by Etienne Segonzac.

Enable 3D depth patching for Spatial Scenes. This should reduce some
potential visual artifacts.

* Source/WebKit/UIProcess/Cocoa/Separated/WKSeparatedImageView+Rendering.swift:
(WKSeparatedImageView.preparePortalEntity):

Canonical link: <a href="https://commits.webkit.org/309229@main">https://commits.webkit.org/309229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e2b0a95e1cac37534166efbb1741d21b2f93070

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149753 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22472 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158458 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103185 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22559 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115518 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82113 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17644 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96259 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16740 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14660 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6304 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126348 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160935 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13849 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123541 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22274 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123747 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33650 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22281 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134100 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78506 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18913 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10851 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21882 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85702 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21612 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21764 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21669 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->