### PR TITLE
[Github.com] Skip full style resolution for non-var() descendants during custom property changes

### DIFF
--- a/LayoutTests/fast/css/variables/custom-property-fastpath-preserves-custom-properties-expected.txt
+++ b/LayoutTests/fast/css/variables/custom-property-fastpath-preserves-custom-properties-expected.txt
@@ -1,0 +1,37 @@
+Custom property fast path must not drop or stale an element's own/inherited custom properties when an ancestor's custom property changes.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getComputedStyle(mid).getPropertyValue('--mine').trim() is "99px"
+PASS getComputedStyle(leaf).width is "99px"
+PASS getComputedStyle(mid).getPropertyValue('--mine').trim() is "99px"
+PASS getComputedStyle(leaf).width is "99px"
+PASS getComputedStyle(d5).getPropertyValue('--p1').trim() is "1px"
+PASS getComputedStyle(d5).getPropertyValue('--p2').trim() is "2px"
+PASS getComputedStyle(d5).getPropertyValue('--p3').trim() is "3px"
+PASS getComputedStyle(d5).getPropertyValue('--p4').trim() is "4px"
+PASS getComputedStyle(d5).getPropertyValue('--own').trim() is "50px"
+PASS getComputedStyle(d5).width is "50px"
+PASS getComputedStyle(d5).getPropertyValue('--p1').trim() is "1px"
+PASS getComputedStyle(d5).getPropertyValue('--p2').trim() is "222px"
+PASS getComputedStyle(d5).getPropertyValue('--p3').trim() is "3px"
+PASS getComputedStyle(d5).getPropertyValue('--p4').trim() is "4px"
+PASS getComputedStyle(d5).getPropertyValue('--own').trim() is "50px"
+PASS getComputedStyle(d5).width is "50px"
+PASS getComputedStyle(refDirect).width is "5px"
+PASS getComputedStyle(refFallback).width is "5px"
+PASS getComputedStyle(refChained).width is "5px"
+PASS getComputedStyle(refShorthand).marginTop is "5px"
+PASS getComputedStyle(refDirect).width is "77px"
+PASS getComputedStyle(refFallback).width is "77px"
+PASS getComputedStyle(refChained).width is "77px"
+PASS getComputedStyle(refShorthand).marginTop is "77px"
+PASS genBefore.offsetHeight is 30
+PASS genAfter.offsetHeight is 40
+PASS genBefore.offsetHeight is 30
+PASS genAfter.offsetHeight is 40
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/variables/custom-property-fastpath-preserves-custom-properties.html
+++ b/LayoutTests/fast/css/variables/custom-property-fastpath-preserves-custom-properties.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test-pre.js"></script>
+<style>
+#genBefore::before { content: "x"; display: block; height: 30px; }
+#genAfter::after { content: "x"; display: block; height: 40px; }
+</style>
+</head>
+<body>
+<div id="ancestor" style="--changed: 1px;">
+  <div id="mid" style="--mine: 99px;">
+    <div id="leaf" style="width: var(--mine); height: 10px;"></div>
+  </div>
+</div>
+
+<div id="d1" style="--p1: 1px;">
+  <div id="d2" style="--p2: 2px;">
+    <div id="d3" style="--p3: 3px;">
+      <div id="d4" style="--p4: 4px;">
+        <div id="d5" style="--own: 50px; width: var(--own); height: 5px;"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="r" style="--ref: 5px;">
+  <div>
+    <div>
+      <div id="refDirect" style="width: var(--ref); height: 1px;"></div>
+      <div id="refFallback" style="width: var(--missing, var(--ref)); height: 1px;"></div>
+      <div id="refChained" style="--local: var(--ref); width: var(--local); height: 1px;"></div>
+      <div id="refShorthand" style="margin: var(--ref);"></div>
+    </div>
+  </div>
+</div>
+
+<div id="genAncestor" style="--unrelated: 1px;">
+  <div id="genBefore"></div>
+  <div id="genAfter"></div>
+</div>
+<script>
+description("Custom property fast path must not drop or stale an element's own/inherited custom properties when an ancestor's custom property changes.");
+
+document.body.offsetHeight;
+
+shouldBeEqualToString("getComputedStyle(mid).getPropertyValue('--mine').trim()", "99px");
+shouldBeEqualToString("getComputedStyle(leaf).width", "99px");
+
+ancestor.style.setProperty('--changed', '2px');
+document.body.offsetHeight;
+
+shouldBeEqualToString("getComputedStyle(mid).getPropertyValue('--mine').trim()", "99px");
+shouldBeEqualToString("getComputedStyle(leaf).width", "99px");
+
+// Deep chain where every level declares its own inherited custom
+// property. Internally these get flattened into descendants' data, so this
+// guards against a fix that reinstates a stale value when an *intermediate*
+// ancestor's property changes.
+shouldBeEqualToString("getComputedStyle(d5).getPropertyValue('--p1').trim()", "1px");
+shouldBeEqualToString("getComputedStyle(d5).getPropertyValue('--p2').trim()", "2px");
+shouldBeEqualToString("getComputedStyle(d5).getPropertyValue('--p3').trim()", "3px");
+shouldBeEqualToString("getComputedStyle(d5).getPropertyValue('--p4').trim()", "4px");
+shouldBeEqualToString("getComputedStyle(d5).getPropertyValue('--own').trim()", "50px");
+shouldBeEqualToString("getComputedStyle(d5).width", "50px");
+
+d2.style.setProperty('--p2', '222px');
+document.body.offsetHeight;
+
+shouldBeEqualToString("getComputedStyle(d5).getPropertyValue('--p1').trim()", "1px");
+shouldBeEqualToString("getComputedStyle(d5).getPropertyValue('--p2').trim()", "222px");
+shouldBeEqualToString("getComputedStyle(d5).getPropertyValue('--p3').trim()", "3px");
+shouldBeEqualToString("getComputedStyle(d5).getPropertyValue('--p4').trim()", "4px");
+shouldBeEqualToString("getComputedStyle(d5).getPropertyValue('--own').trim()", "50px");
+shouldBeEqualToString("getComputedStyle(d5).width", "50px");
+
+shouldBeEqualToString("getComputedStyle(refDirect).width", "5px");
+shouldBeEqualToString("getComputedStyle(refFallback).width", "5px");
+shouldBeEqualToString("getComputedStyle(refChained).width", "5px");
+shouldBeEqualToString("getComputedStyle(refShorthand).marginTop", "5px");
+
+r.style.setProperty('--ref', '77px');
+document.body.offsetHeight;
+
+shouldBeEqualToString("getComputedStyle(refDirect).width", "77px");
+shouldBeEqualToString("getComputedStyle(refFallback).width", "77px");
+shouldBeEqualToString("getComputedStyle(refChained).width", "77px");
+shouldBeEqualToString("getComputedStyle(refShorthand).marginTop", "77px");
+
+shouldBe("genBefore.offsetHeight", "30");
+shouldBe("genAfter.offsetHeight", "40");
+
+genAncestor.style.setProperty('--unrelated', '2px');
+document.body.offsetHeight;
+
+shouldBe("genBefore.offsetHeight", "30");
+shouldBe("genAfter.offsetHeight", "40");
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/PerformanceTests/CSS/CustomPropertySubtreeInvalidation.html
+++ b/PerformanceTests/CSS/CustomPropertySubtreeInvalidation.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/runner.js"></script>
+<style id="bulkStyles"></style>
+<style>
+    #root {
+        --sidebar-width: 200px;
+    }
+    .container {
+        position: relative;
+        width: 100%;
+        overflow: hidden;
+    }
+    .item {
+        display: flex;
+        align-items: center;
+        padding: 4px 8px;
+        white-space: nowrap;
+    }
+    .item .label {
+        overflow: hidden;
+    }
+</style>
+<script>
+    window.addEventListener('load', event => {
+        const numberOfIterations = 5;
+        const numberOfChildren = 100;
+        const resizeSteps = 10;
+        const numberOfCSSRules = 10000;
+
+        let css = '';
+        for (let i = 0; i < numberOfCSSRules; ++i) {
+            css += `.container > .item:nth-child(${i + 1}n) { opacity: 1; }\n`;
+            css += `.container .item.type-${i % 10} .label { color: #${String(i % 256).padStart(2, '0')}0000; }\n`;
+        }
+        document.getElementById('bulkStyles').textContent = css;
+
+        PerfTestRunner.prepareToMeasureValuesAsync({
+            customIterationCount: numberOfIterations,
+            unit: 'ms',
+            done: function () {
+                PerfTestRunner.gc();
+            }
+        });
+
+        const root = document.createElement('div');
+        root.id = 'root';
+        const container = document.createElement('div');
+        container.className = 'container';
+        root.appendChild(container);
+        for (let i = 0; i < numberOfChildren; ++i) {
+            const item = document.createElement('div');
+            item.className = `item type-${i % 10}`;
+            const label = document.createElement('span');
+            label.className = 'label';
+            item.appendChild(label);
+            container.appendChild(item);
+        }
+        document.body.appendChild(root);
+
+        root.offsetHeight;
+
+        function startIteration() {
+            testGenerator = runIteration();
+            testGenerator.next();
+        }
+
+        function *runIteration() {
+            const startTime = PerfTestRunner.now();
+
+            // Simulate a drag/resize: change --sidebar-width on the ancestor each frame. The
+            // rows inherit it (as grandchildren), so the subtree is invalidated.
+            for (let step = 0; step < resizeSteps; ++step) {
+                const width = 200 + step * 5;
+                root.style.setProperty('--sidebar-width', `${width}px`);
+                getComputedStyle(root).color;
+            }
+
+            if (!PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime)) {
+                return;
+            }
+
+            PerfTestRunner.gc();
+            setTimeout(startIteration, 0);
+        }
+
+        startIteration();
+    });
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -119,6 +119,20 @@ void Builder::applyAllProperties()
     adjustAfterApplying();
 }
 
+void Builder::addCustomPropertyFilterBit(const AtomString& name)
+{
+    m_customPropertyFilter |= ComputedStyleBase::maskForCustomPropertyName(name);
+}
+
+void Builder::commitCustomPropertyState()
+{
+    auto& style = m_state->style();
+    if (m_customPropertyFilter)
+        style.setCustomPropertyFilter(m_customPropertyFilter);
+    if (m_declaresInheritedCustomProperty)
+        style.setDeclaresInheritedCustomProperty();
+}
+
 // Top priority properties affect resolution of high priority properties.
 void Builder::applyTopPriorityProperties()
 {
@@ -441,10 +455,14 @@ void Builder::applyCustomProperty(const AtomString& name, Variant<Ref<const Styl
 {
     auto& style = m_state->style();
 
+    addCustomPropertyFilterBit(name);
+
     auto registeredCustomProperty = m_state->registeredProperty(name);
 
     auto applyValue = [&](Ref<const CustomProperty>&& valueToApply) {
         bool isInherited = !registeredCustomProperty || registeredCustomProperty->inherits;
+        if (isInherited)
+            m_declaresInheritedCustomProperty = true;
         state().style().setCustomPropertyValue(WTF::move(valueToApply), isInherited);
     };
 

--- a/Source/WebCore/style/StyleBuilder.h
+++ b/Source/WebCore/style/StyleBuilder.h
@@ -60,6 +60,11 @@ public:
     BuilderState& state() { return m_state; }
     const MatchResult& matchResult() const { return m_cascade.matchResult(); }
 
+    void addCustomPropertyFilterBit(const AtomString& name);
+    uint32_t customPropertyFilter() const { return m_customPropertyFilter; }
+    bool declaresInheritedCustomProperty() const { return m_declaresInheritedCustomProperty; }
+    void commitCustomPropertyState();
+
     ValueOrReference<HashSet<AnimatableCSSProperty>> overriddenAnimatedProperties() const { return m_cascade.overriddenAnimatedProperties(); }
 
 private:
@@ -96,6 +101,8 @@ private:
     HashMap<RollbackCascadeKey, std::unique_ptr<const PropertyCascade>> m_rollbackCascades;
 
     const UniqueRef<BuilderState> m_state;
+    uint32_t m_customPropertyFilter { 0 };
+    bool m_declaresInheritedCustomProperty { false };
 };
 
 }

--- a/Source/WebCore/style/StyleChange.cpp
+++ b/Source/WebCore/style/StyleChange.cpp
@@ -39,8 +39,10 @@ OptionSet<Change> determineChanges(const Style::ComputedStyle& s1, const Style::
 
     if (!s1.nonInheritedEqual(s2))
         result.add(Change::NonInherited);
-    if (!s1.nonFastPathInheritedEqual(s2))
+    if (!s1.nonFastPathInheritedEqualIgnoringCustomProperties(s2))
         result.add(Change::Inherited);
+    if (!s1.inheritedCustomPropertiesEqual(s2))
+        result.add(Change::InheritedCustomProperty);
     if (!s1.fastPathInheritedEqual(s2))
         result.add(Change::FastPathInherited);
 
@@ -95,6 +97,7 @@ TextStream& operator<<(TextStream& ts, Change change)
     case Change::Inherited: ts << "Inherited"_s; break;
     case Change::Container: ts << "Container"_s; break;
     case Change::Renderer: ts << "Renderer"_s; break;
+    case Change::InheritedCustomProperty: ts << "InheritedCustomProperty"_s; break;
     }
     return ts;
 }

--- a/Source/WebCore/style/StyleChange.h
+++ b/Source/WebCore/style/StyleChange.h
@@ -41,7 +41,8 @@ enum class Change : uint8_t {
     Inherited = 1 << 1,
     FastPathInherited = 1 << 2,
     Container = 1 << 3,
-    Renderer = 1 << 4
+    Renderer = 1 << 4,
+    InheritedCustomProperty = 1 << 5,
 };
 
 constexpr OptionSet<Change> inheritedChanges() { return { Change::Inherited, Change::FastPathInherited }; }

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -419,6 +419,7 @@ std::unique_ptr<Style::ComputedStyle> Resolver::styleForKeyframe(Element& elemen
     Builder builder(*state.style(), builderContext(state), collector.matchResult());
     builder.state().setIsBuildingKeyframeStyle();
     builder.applyAllProperties();
+    builder.commitCustomPropertyState();
 
     if (state.style()->usesViewportUnits())
         element.document().setHasStyleWithViewportUnits();
@@ -616,6 +617,7 @@ std::unique_ptr<Style::ComputedStyle> Resolver::styleForPage(int pageIndex)
 
     Builder builder(*state.style(), builderContext(state), result);
     builder.applyAllProperties();
+    builder.commitCustomPropertyState();
 
     // Now return the style.
     return state.takeStyle();
@@ -745,6 +747,8 @@ void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResu
 
     builder.applyNonHighPriorityProperties();
     builder.adjustAfterApplying();
+
+    builder.commitCustomPropertyState();
 
     setGlobalStateAfterApplyingProperties(builder.state());
 

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -142,6 +142,8 @@ bool SubstitutionResolver::substituteVariableFunction(CSSParserTokenRange range,
         return false;
     auto variableName = range.consumeIncludingWhitespace().value().toAtomString();
 
+    m_styleBuilder.addCustomPropertyFilterBit(variableName);
+
     // Fallback has to be resolved even when not used to detect cycles and invalid syntax.
     auto [fallbackResult, fallbackTokens] = substituteVariableFallback(variableName, range, functionId, context);
     if (fallbackResult == FallbackResult::Invalid)
@@ -715,6 +717,9 @@ RefPtr<CSSVariableData> SubstitutionResolver::trySimpleSubstitution(const CSSSub
         return value.m_cache.isBaseAppearance == isBaseAppearance() ? value.m_cache.dependencyData : nullptr;
 
     // Shortcut for the simple common case of property:var(--foo)
+
+    m_styleBuilder.addCustomPropertyFilterBit(value.m_simpleReference->name);
+
     RefPtr property = propertyValueForVariableName(value.m_simpleReference->name, value.m_simpleReference->functionId);
     if (!property || !std::holds_alternative<Ref<CSSVariableData>>(property->value()))
         return nullptr;

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -65,6 +65,7 @@
 #include "StyleAdjuster.h"
 #include "StyleBuilder.h"
 #include "StyleComputedStyle+SettersInlines.h"
+#include "StyleCustomPropertyData.h"
 #include "StyleFontSizeFunctions.h"
 #include "StyleOriginatedTimelinesController.h"
 #include "StylePositionTryFallbackTactic.h"
@@ -279,7 +280,7 @@ static bool affectsRenderedSubtree(Element& element, const Style::ComputedStyle&
     return false;
 }
 
-auto TreeResolver::computeDescendantsToResolve(const ElementUpdate& update, const Style::ComputedStyle* existingStyle, Validity validity) const -> DescendantsToResolve
+auto TreeResolver::computeDescendantsToResolve(ElementUpdate& update, const Style::ComputedStyle* existingStyle, Validity validity) const -> DescendantsToResolve
 {
     if (parent().descendantsToResolve == DescendantsToResolve::All)
         return DescendantsToResolve::All;
@@ -296,8 +297,10 @@ auto TreeResolver::computeDescendantsToResolve(const ElementUpdate& update, cons
             }
             return false;
         }();
-        if (customPropertyInStyleContainerQueryChanged)
+        if (customPropertyInStyleContainerQueryChanged) {
+            update.changes.add(Change::Container);
             return DescendantsToResolve::All;
+        }
     }
 
     if (update.changes.containsAny({ Change::Container, Change::Renderer }))
@@ -305,6 +308,11 @@ auto TreeResolver::computeDescendantsToResolve(const ElementUpdate& update, cons
 
     if (update.changes.containsAny(inheritedChanges()))
         return DescendantsToResolve::Children;
+
+    if (update.changes.contains(Change::InheritedCustomProperty)) {
+        ASSERT(!update.changes.containsAny(inheritedChanges()));
+        return DescendantsToResolve::Children;
+    }
 
     if (update.changes.contains(Change::NonInherited))
         return DescendantsToResolve::ChildrenWithExplicitInherit;
@@ -1053,6 +1061,7 @@ std::unique_ptr<Style::ComputedStyle> TreeResolver::resolveAgainInDifferentConte
     };
 
     styleBuilder.applyAllProperties();
+    styleBuilder.commitCustomPropertyState();
 
     if (newStyle->display() == DisplayType::None)
         return nullptr;
@@ -1091,6 +1100,7 @@ HashSet<AnimatableCSSProperty> TreeResolver::applyCascadeAfterAnimation(Style::C
     };
 
     styleBuilder.applyAllProperties();
+    styleBuilder.commitCustomPropertyState();
 
     return styleBuilder.overriddenAnimatedProperties();
 }
@@ -1330,13 +1340,36 @@ void TreeResolver::resolveComposedTree()
 
         auto changes = OptionSet<Change> { };
         auto descendantsToResolve = DescendantsToResolve::None;
+        uint32_t changedCustomPropertyFilter = 0;
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
         bool didAXUpdateFontSubtree = parent.didAXUpdateFontSubtree;
         bool didAXUpdateTextColorSubtree = parent.didAXUpdateTextColorSubtree;
 #endif
         auto resolutionType = determineResolutionType(element.get(), style, parent.descendantsToResolve, parent.changes);
-        if (resolutionType) {
+        auto canTakeCustomPropertyFastPath = [&] {
+            return parent.changedCustomPropertyFilter
+                && parent.changes.containsOnly(Change::InheritedCustomProperty)
+                && parent.descendantsToResolve == DescendantsToResolve::Children
+                && style
+                && !style->hasPseudoElementStyles()
+                && !element->needsStyleRecalc()
+                && !element->hasKeyframeEffects({ })
+                && !(style->customPropertyFilter() & parent.changedCustomPropertyFilter)
+                && !style->declaresInheritedCustomProperty();
+        };
+
+        if (canTakeCustomPropertyFastPath()) {
+            auto clonedStyle = Style::ComputedStyle::clonePtr(*style);
+            clonedStyle->setInheritedCustomPropertiesFrom(parent.style);
+            ElementUpdate elementUpdate { WTF::move(clonedStyle), Change::InheritedCustomProperty };
+            changes = Change::InheritedCustomProperty;
+            descendantsToResolve = DescendantsToResolve::Children;
+            changedCustomPropertyFilter = parent.changedCustomPropertyFilter;
+            style = elementUpdate.style.get();
+            m_update->addElement(element.get(), parent.element, WTF::move(elementUpdate));
+            clearNeedsStyleResolution(element.get());
+        } else if (resolutionType) {
             element->resetComputedStyle();
 
             if (*resolutionType == ResolutionType::Full)
@@ -1358,6 +1391,11 @@ void TreeResolver::resolveComposedTree()
                     didAXUpdateTextColorSubtree = cache->onTextColorChange(element.get(), style, elementUpdate.style.get());
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
             }
+
+            if (parent.changedCustomPropertyFilter)
+                changedCustomPropertyFilter = parent.changedCustomPropertyFilter;
+            else if (elementUpdate.changes.contains(Change::InheritedCustomProperty) && style && elementUpdate.style)
+                changedCustomPropertyFilter = elementUpdate.style->inheritedCustomProperties().changedCustomPropertiesFilter(style->inheritedCustomProperties());
 
             style = elementUpdate.style.get();
             changes = elementUpdate.changes;
@@ -1414,6 +1452,8 @@ void TreeResolver::resolveComposedTree()
 #else
         pushParent(element.get(), *style, changes, descendantsToResolve, isInDisplayNoneTree ? IsInDisplayNoneTree::Yes : IsInDisplayNoneTree::No);
 #endif
+        if (changedCustomPropertyFilter)
+            m_parentStack.last().changedCustomPropertyFilter = changedCustomPropertyFilter;
         it.traverseNext();
     }
 

--- a/Source/WebCore/style/StyleTreeResolver.h
+++ b/Source/WebCore/style/StyleTreeResolver.h
@@ -38,6 +38,7 @@
 #include "Styleable.h"
 #include "TreeResolutionState.h"
 #include <wtf/Function.h>
+#include <wtf/HashSet.h>
 #include <wtf/Ref.h>
 
 namespace WebCore {
@@ -127,6 +128,7 @@ private:
         const Style::ComputedStyle& style;
         OptionSet<Change> changes;
         DescendantsToResolve descendantsToResolve { DescendantsToResolve::None };
+        uint32_t changedCustomPropertyFilter { 0 };
         bool didPushScope { false };
         bool resolvedFirstLineAndLetterChild { false };
         bool needsUpdateQueryContainerDependentStyle { false };
@@ -160,7 +162,7 @@ private:
     void popParent();
     void popParentsToDepth(unsigned depth);
 
-    DescendantsToResolve computeDescendantsToResolve(const ElementUpdate&, const Style::ComputedStyle* existingStyle, Validity) const;
+    DescendantsToResolve computeDescendantsToResolve(ElementUpdate&, const Style::ComputedStyle* existingStyle, Validity) const;
     static std::optional<ResolutionType> determineResolutionType(const Element&, const Style::ComputedStyle*, DescendantsToResolve, OptionSet<Change> parentChange);
     void resetDescendantStyleRelations(Element&, DescendantsToResolve);
 

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -33,6 +33,7 @@
 #include "RenderBlock.h"
 #include "RenderTheme.h"
 #include "StyleComputedStyleBase+ConstructionInlines.h"
+#include "StyleCustomPropertyData.h"
 #include "StyleCustomPropertyRegistry.h"
 #include "StyleLineHeight.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
@@ -210,6 +211,13 @@ void ComputedStyle::inheritIgnoringCustomPropertiesFrom(const ComputedStyle& inh
         m_inheritedRareData.access().customProperties = oldCustomProperties;
 }
 
+void ComputedStyle::setInheritedCustomPropertiesFrom(const ComputedStyle& other)
+{
+    ASSERT(!declaresInheritedCustomProperty());
+    if (m_inheritedRareData->customProperties != other.m_inheritedRareData->customProperties)
+        m_inheritedRareData.access().customProperties = other.m_inheritedRareData->customProperties;
+}
+
 void ComputedStyle::inheritUnicodeBidiFrom(const ComputedStyle& inheritParent)
 {
     m_nonInheritedFlags.unicodeBidi = inheritParent.m_nonInheritedFlags.unicodeBidi;
@@ -294,6 +302,12 @@ bool ComputedStyle::fastPathInheritedEqual(const ComputedStyle& other) const
 
 bool ComputedStyle::nonFastPathInheritedEqual(const ComputedStyle& other) const
 {
+    return nonFastPathInheritedEqualIgnoringCustomProperties(other)
+        && inheritedCustomPropertiesEqual(other);
+}
+
+bool ComputedStyle::nonFastPathInheritedEqualIgnoringCustomProperties(const ComputedStyle& other) const
+{
     auto withoutFastPathFlags = [](auto flags) {
         flags.visibility = { };
         flags.hasExplicitlySetColor = { };
@@ -303,11 +317,17 @@ bool ComputedStyle::nonFastPathInheritedEqual(const ComputedStyle& other) const
         return false;
     if (m_inheritedData.ptr() != other.m_inheritedData.ptr() && !m_inheritedData->nonFastPathInheritedEqual(*other.m_inheritedData))
         return false;
-    if (m_inheritedRareData != other.m_inheritedRareData)
+    if (m_inheritedRareData.ptr() != other.m_inheritedRareData.ptr() && !m_inheritedRareData->equalIgnoringCustomProperties(other.m_inheritedRareData.get()))
         return false;
     if (m_svgData.ptr() != other.m_svgData.ptr() && !m_svgData->inheritedEqual(other.m_svgData))
         return false;
     return true;
+}
+
+bool ComputedStyle::inheritedCustomPropertiesEqual(const ComputedStyle& other) const
+{
+    return m_inheritedRareData.ptr() == other.m_inheritedRareData.ptr()
+        || m_inheritedRareData->customProperties == other.m_inheritedRareData->customProperties;
 }
 
 bool ComputedStyle::descendantAffectingNonInheritedPropertiesEqual(const ComputedStyle& other) const

--- a/Source/WebCore/style/computed/StyleComputedStyle.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <WebCore/StyleComputedStyleProperties.h>
+#include <wtf/HashSet.h>
 
 namespace WebCore {
 namespace Style {
@@ -58,6 +59,7 @@ public:
 
     void inheritFrom(const ComputedStyle&);
     void inheritIgnoringCustomPropertiesFrom(const ComputedStyle&);
+    void setInheritedCustomPropertiesFrom(const ComputedStyle&);
     void NODELETE inheritUnicodeBidiFrom(const ComputedStyle&);
     inline void inheritColumnPropertiesFrom(const ComputedStyle&);
     void fastPathInheritFrom(const ComputedStyle&);
@@ -79,6 +81,8 @@ public:
     bool nonInheritedEqual(const ComputedStyle&) const;
     bool NODELETE fastPathInheritedEqual(const ComputedStyle&) const;
     bool nonFastPathInheritedEqual(const ComputedStyle&) const;
+    bool nonFastPathInheritedEqualIgnoringCustomProperties(const ComputedStyle&) const;
+    bool inheritedCustomPropertiesEqual(const ComputedStyle&) const;
     bool NODELETE descendantAffectingNonInheritedPropertiesEqual(const ComputedStyle&) const;
     bool borderAndBackgroundEqual(const ComputedStyle&) const;
     inline bool containerTypeAndNamesEqual(const ComputedStyle&) const;

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -179,6 +179,30 @@ void ComputedStyleBase::addCustomPaintWatchProperty(const AtomString& name)
     data->customPaintWatchedProperties.add(name);
 }
 
+// MARK: - Variable reference tracking
+
+uint32_t ComputedStyleBase::customPropertyFilter() const
+{
+    return m_nonInheritedData->customPropertyFilter;
+}
+
+void ComputedStyleBase::setCustomPropertyFilter(uint32_t customPropertyFilter)
+{
+    m_nonInheritedData.access().customPropertyFilter = customPropertyFilter;
+}
+
+bool ComputedStyleBase::declaresInheritedCustomProperty() const
+{
+    return m_nonInheritedData->declaresInheritedCustomProperty;
+}
+
+void ComputedStyleBase::setDeclaresInheritedCustomProperty()
+{
+    if (m_nonInheritedData->declaresInheritedCustomProperty)
+        return;
+    m_nonInheritedData.access().declaresInheritedCustomProperty = true;
+}
+
 // MARK: - FontCascade support.
 
 FontCascade& ComputedStyleBase::mutableFontCascadeWithoutUpdate()

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -484,6 +484,13 @@ public:
     inline bool hasExplicitlyInheritedProperties() const;
     inline void setHasExplicitlyInheritedProperties();
 
+    uint32_t customPropertyFilter() const;
+    void setCustomPropertyFilter(uint32_t);
+    static uint32_t maskForCustomPropertyName(const AtomString& name) { return 1U << (name.existingHash() % 31); }
+
+    bool declaresInheritedCustomProperty() const;
+    void setDeclaresInheritedCustomProperty();
+
     inline bool disallowsFastPathInheritance() const;
     inline void setDisallowsFastPathInheritance();
 

--- a/Source/WebCore/style/computed/data/StyleCustomPropertyData.cpp
+++ b/Source/WebCore/style/computed/data/StyleCustomPropertyData.cpp
@@ -27,6 +27,8 @@
 #include "config.h"
 #include "StyleCustomPropertyData.h"
 
+#include "StyleComputedStyleBase.h"
+
 namespace WebCore {
 namespace Style {
 
@@ -125,6 +127,23 @@ bool CustomPropertyData::operator==(const CustomPropertyData& other) const
     });
 
     return isEqual;
+}
+
+uint32_t CustomPropertyData::changedCustomPropertiesFilter(const CustomPropertyData& other) const
+{
+    uint32_t filter = 0;
+    forEachInternal([&](auto& entry) {
+        auto* otherValue = other.get(entry.key);
+        if (!otherValue || entry.value.get() != *otherValue)
+            filter |= ComputedStyleBase::maskForCustomPropertyName(entry.key);
+        return IterationStatus::Continue;
+    });
+    other.forEachInternal([&](auto& entry) {
+        if (!get(entry.key))
+            filter |= ComputedStyleBase::maskForCustomPropertyName(entry.key);
+        return IterationStatus::Continue;
+    });
+    return filter;
 }
 
 template<typename Callback>

--- a/Source/WebCore/style/computed/data/StyleCustomPropertyData.h
+++ b/Source/WebCore/style/computed/data/StyleCustomPropertyData.h
@@ -44,6 +44,7 @@ public:
     Ref<CustomPropertyData> copy() const { return adoptRef(*new CustomPropertyData(*this)); }
 
     bool operator==(const CustomPropertyData&) const;
+    uint32_t changedCustomPropertiesFilter(const CustomPropertyData&) const;
 
 #if !LOG_DISABLED
     void dumpDifferences(TextStream&, const CustomPropertyData&) const;

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.cpp
@@ -254,6 +254,12 @@ InheritedRareData::~InheritedRareData() = default;
 
 bool InheritedRareData::operator==(const InheritedRareData& o) const
 {
+    return equalIgnoringCustomProperties(o)
+        && customProperties == o.customProperties;
+}
+
+bool InheritedRareData::equalIgnoringCustomProperties(const InheritedRareData& o) const
+{
     return usedZoom == o.usedZoom
         && deviceScaleFactor == o.deviceScaleFactor
         && textStrokeWidth == o.textStrokeWidth
@@ -349,7 +355,6 @@ bool InheritedRareData::operator==(const InheritedRareData& o) const
         && strokeWidth == o.strokeWidth
         && strokeColor == o.strokeColor
         && visitedLinkStrokeColor == o.visitedLinkStrokeColor
-        && customProperties == o.customProperties
         && listStyleImage == o.listStyleImage
         && listStyleType == o.listStyleType
         && blockEllipsis == o.blockEllipsis

--- a/Source/WebCore/style/computed/data/StyleInheritedRareData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedRareData.h
@@ -99,6 +99,7 @@ public:
     ~InheritedRareData();
 
     bool operator==(const InheritedRareData&) const;
+    bool equalIgnoringCustomProperties(const InheritedRareData&) const;
 
 #if !LOG_DISABLED
     void dumpDifferences(TextStream&, const InheritedRareData&) const;

--- a/Source/WebCore/style/computed/data/StyleNonInheritedData.cpp
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedData.cpp
@@ -49,6 +49,8 @@ NonInheritedData::NonInheritedData()
 
 NonInheritedData::NonInheritedData(const NonInheritedData& other)
     : RefCounted<NonInheritedData>()
+    , customPropertyFilter(other.customPropertyFilter)
+    , declaresInheritedCustomProperty(other.declaresInheritedCustomProperty)
     , boxData(other.boxData)
     , backgroundData(other.backgroundData)
     , surroundData(other.surroundData)

--- a/Source/WebCore/style/computed/data/StyleNonInheritedData.h
+++ b/Source/WebCore/style/computed/data/StyleNonInheritedData.h
@@ -53,6 +53,9 @@ public:
     void dumpDifferences(TextStream&, const NonInheritedData&) const;
 #endif
 
+    unsigned customPropertyFilter : 31 { 0 };
+    unsigned declaresInheritedCustomProperty : 1 { 0 };
+
     DataRef<BoxData> boxData;
     DataRef<BackgroundData> backgroundData;
     DataRef<SurroundData> surroundData;


### PR DESCRIPTION
#### f3c4bda80ceabecfa33c6df0bfe067b311e6dcba
<pre>
[Github.com] Skip full style resolution for non-var() descendants during custom property changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=309838">https://bugs.webkit.org/show_bug.cgi?id=309838</a>
<a href="https://rdar.apple.com/167267369">rdar://167267369</a>

Reviewed by NOBODY (OOPS!).

Resizing the sidebar on GitHub changes a CSS custom property on a parent with ~15,000
descendants. Previously all descendants got full selector matching and cascade even though the
vast majority do not reference the changed property via var().

This patch adds a fast path. When a descendant does not reference the changed property, its
existing style is cloned, the parent&apos;s inherited custom properties are copied onto the clone,
and the result is handed to Style::Update. This skips selector matching, property application,
and the MatchedDeclarationsCache. Elements that reference the changed property still get full
resolution.

Split inherited property comparison in determineChanges so custom property changes produce a
separate Change::CustomProperty flag instead of being folded into Change::Inherited.
The fast path activates when the parent&apos;s only change is to custom properties.

Track which custom property names each element references via var() or declares using a 31-bit
bloom filter stored on NonInheritedData. Each name is hashed into a single bit of the filter
via maskForCustomPropertyName.
Also use 1 bit to track if the element declares its own inherited custom properties.
Filter bits are accumulated on the Builder during property
application and written to NonInheritedData once after all properties are applied, avoiding
copy-on-write on the shared style data.

When a parent element&apos;s inherited custom properties change, compute a bloom filter of the changed names and
propagate it to descendants via the TreeResolver. Each descendant ANDs its own filter with the changed filter. A
zero result means the element does not reference any changed property and can take the fast path.
A nonzero result means the element may reference a changed property and needs full resolution.

The optimization is conservative. Bloom filter false positives cause unnecessary full
resolution but never skip elements that need it. If a parent has any non-custom-property
inherited change alongside the custom property change, the optimization falls back to full
resolution for all children. We also do not take the optimization if the element itself
declares its own inherited custom properties.

A microbenchmark was added to test this optimization. The median time on a Macbook Pro at desk
decreased from 556 ms per iteration to 5 ms per iteration.

* LayoutTests/fast/css/variables/custom-property-fastpath-preserves-custom-properties-expected.txt: Added.
* LayoutTests/fast/css/variables/custom-property-fastpath-preserves-custom-properties.html: Added.
* PerformanceTests/CSS/CustomPropertySubtreeInvalidation.html: Added.
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::addCustomPropertyFilterBit):
(WebCore::Style::Builder::commitCustomPropertyState):
(WebCore::Style::Builder::applyCustomProperty):
* Source/WebCore/style/StyleBuilder.h:
(WebCore::Style::Builder::customPropertyFilter const):
(WebCore::Style::Builder::declaresInheritedCustomProperty const):
* Source/WebCore/style/StyleChange.cpp:
(WebCore::Style::determineChanges):
(WebCore::Style::operator&lt;&lt;):
* Source/WebCore/style/StyleChange.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::styleForKeyframe const):
(WebCore::Style::Resolver::styleForPage):
(WebCore::Style::Resolver::applyMatchedProperties):
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteVariableFunction):
(WebCore::Style::SubstitutionResolver::trySimpleSubstitution):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::computeDescendantsToResolve const):
(WebCore::Style::TreeResolver::resolveAgainInDifferentContext):
(WebCore::Style::TreeResolver::applyCascadeAfterAnimation):
(WebCore::Style::TreeResolver::resolveComposedTree):
* Source/WebCore/style/StyleTreeResolver.h:
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
(WebCore::Style::ComputedStyle::setInheritedCustomPropertiesFrom):
(WebCore::Style::ComputedStyle::nonFastPathInheritedEqual const):
(WebCore::Style::ComputedStyle::nonFastPathInheritedEqualIgnoringCustomProperties const):
(WebCore::Style::ComputedStyle::inheritedCustomPropertiesEqual const):
* Source/WebCore/style/computed/StyleComputedStyle.h:
* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
(WebCore::Style::ComputedStyleBase::customPropertyFilter const):
(WebCore::Style::ComputedStyleBase::setCustomPropertyFilter):
(WebCore::Style::ComputedStyleBase::declaresInheritedCustomProperty const):
(WebCore::Style::ComputedStyleBase::setDeclaresInheritedCustomProperty):
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
(WebCore::Style::ComputedStyleBase::maskForCustomPropertyName):
* Source/WebCore/style/computed/data/StyleCustomPropertyData.cpp:
(WebCore::Style::CustomPropertyData::changedCustomPropertiesFilter const):
* Source/WebCore/style/computed/data/StyleCustomPropertyData.h:
* Source/WebCore/style/computed/data/StyleInheritedRareData.cpp:
(WebCore::Style::InheritedRareData::operator== const):
(WebCore::Style::InheritedRareData::equalIgnoringCustomProperties const):
* Source/WebCore/style/computed/data/StyleInheritedRareData.h:
* Source/WebCore/style/computed/data/StyleNonInheritedData.cpp:
(WebCore::Style::NonInheritedData::NonInheritedData):
* Source/WebCore/style/computed/data/StyleNonInheritedData.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3c4bda80ceabecfa33c6df0bfe067b311e6dcba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40255 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175813 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124023 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac5a8fda-2325-4b39-96d8-cf9b11c66c36) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168631 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40688 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40263 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129670 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91328 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc6f6e02-3640-437a-baa0-8cf681b2b3e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149841 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110195 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4998190-55aa-464d-befb-12452e59ae94) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31045 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29745 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24549 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178353 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31247 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29245 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138040 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33893 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137953 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149336 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103810 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33233 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26201 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39524 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112598 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38920 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4292 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39165 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39063 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->