### PR TITLE
SVGLength.value for percentage types should resolve against up-to-date layout dimensions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-px-with-context-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-px-with-context-expected.txt
@@ -1,7 +1,7 @@
 
 PASS SVGLength, converting from 'px' to other units (attached), unitless
 PASS SVGLength, converting from 'px' to other units (attached), percentage
-FAIL SVGLength, converting from 'px' to other units (attached), changing percentage basis assert_equals: expected 150 but got 75
+PASS SVGLength, converting from 'px' to other units (attached), changing percentage basis
 PASS SVGLength, converting from 'px' to other units (attached), ems
 PASS SVGLength, converting from 'px' to other units (attached) , exs
 PASS SVGLength, converting from 'px' to other units (attached), exs (check style flush)

--- a/LayoutTests/svg/custom/svg-length-value-handled-expected.txt
+++ b/LayoutTests/svg/custom/svg-length-value-handled-expected.txt
@@ -1,1 +1,1 @@
-PASS: root svg element size handled (0x0)
+PASS: root svg element size handled (800x600)

--- a/Source/WebCore/svg/SVGLength.cpp
+++ b/Source/WebCore/svg/SVGLength.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "SVGLength.h"
 
+#include "Document.h"
 #include "SVGElement.h"
 
 namespace WebCore {
@@ -33,26 +34,32 @@ namespace WebCore {
 ExceptionOr<float> SVGLength::valueForBindings()
 {
     RefPtr element = contextElement();
-    // Ensure style is up-to-date for font-relative units (e.g., ch).
-    // https://www.w3.org/TR/css-values-3/#absolute-lengths
-    auto requiresStyleUpdate = [](SVGLengthType type) {
-        switch (type) {
-        case SVGLengthType::Number:
-        case SVGLengthType::Pixels:
-        case SVGLengthType::Centimeters:
-        case SVGLengthType::Millimeters:
-        case SVGLengthType::Inches:
-        case SVGLengthType::Points:
-        case SVGLengthType::Picas:
-            return false; // Absolute units don't need style update.
-        default:
-            return true; // Font-relative units need style update.
-        }
-    };
+    if (element) {
+        if (m_value.lengthType() == SVGLengthType::Percentage) {
+            // Percentage values depend on the viewport size from the renderer,
+            // so layout must be up-to-date to reflect any recent attribute changes.
+            protect(element->document())->updateLayoutIgnorePendingStylesheets();
+        } else {
+            // Ensure style is up-to-date for font-relative units (e.g., ch).
+            // https://www.w3.org/TR/css-values-3/#absolute-lengths
+            auto requiresStyleUpdate = [](SVGLengthType type) {
+                switch (type) {
+                case SVGLengthType::Number:
+                case SVGLengthType::Pixels:
+                case SVGLengthType::Centimeters:
+                case SVGLengthType::Millimeters:
+                case SVGLengthType::Inches:
+                case SVGLengthType::Points:
+                case SVGLengthType::Picas:
+                    return false; // Absolute units don't need style update.
+                default:
+                    return true; // Font-relative units need style update.
+                }
+            };
 
-    if (requiresStyleUpdate(m_value.lengthType())) {
-        if (element)
-            protect(element->document())->updateStyleIfNeeded();
+            if (requiresStyleUpdate(m_value.lengthType()))
+                protect(element->document())->updateStyleIfNeeded();
+        }
     }
 
     return m_value.valueForBindings(SVGLengthContext { element.get() });


### PR DESCRIPTION
#### d657fa9e5ed9a45d6428a2d9d3bd7211e6475fad
<pre>
SVGLength.value for percentage types should resolve against up-to-date layout dimensions
<a href="https://bugs.webkit.org/show_bug.cgi?id=309839">https://bugs.webkit.org/show_bug.cgi?id=309839</a>
<a href="https://rdar.apple.com/172419355">rdar://172419355</a>

Reviewed by NOBODY (OOPS!).

SVGLength.value for percentage types queries the renderer&apos;s viewport
dimensions, which may be stale if attributes were changed without
triggering layout. Force layout via updateLayoutIgnorePendingStylesheets()
for percentage types, matching how other layout-dependent DOM APIs
(e.g., offsetWidth) behave.

This also fixes the outermost &lt;svg&gt; with defaulted 100% width/height
correctly resolving to viewport dimensions instead of returning 0.

* Source/WebCore/svg/SVGLength.cpp:
(WebCore::SVGLength::valueForBindings):
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGLength-px-with-context-expected.txt: Progression
* LayoutTests/svg/custom/svg-length-value-handled-expected.txt: Ditto
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d657fa9e5ed9a45d6428a2d9d3bd7211e6475fad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158481 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103207 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ede16c15-4aaf-407d-9927-2774bd8af68d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22594 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115535 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82121 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1c416e7-a342-4f02-9c03-1bf4c90e0916) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152735 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134403 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96275 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66933446-50c8-4e3e-bca3-395af462a4f1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16758 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14675 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6326 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126365 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160957 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4041 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123556 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123761 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134127 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78528 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18923 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10878 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21904 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85724 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21634 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21786 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21691 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->