### PR TITLE
Begin tracking scrollbar changes in subtree for intrinsically sized renderers.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  background-color: green;
+  width: max-content;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  background-color: green;
+  width: max-content;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="/299   max-width-container-with-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  background-color: green;
+  width: max-content;
+}
+.parent {
+  height: 79px;
+  overflow: auto;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WTF/wtf/ListHashSet.h
+++ b/Source/WTF/wtf/ListHashSet.h
@@ -165,6 +165,11 @@ public:
     AddResult add(const ValueType&) LIFETIME_BOUND;
     AddResult add(ValueType&&) LIFETIME_BOUND;
 
+    // Attempts to add a list of things to the set. Returns true if any of
+    // them are new to the set. Returns false if the set is unchanged.
+    template<typename ContainerType>
+    bool addAll(ContainerType&&);
+
     // Add the value to the end of the collection. If the value was already in
     // the list, it is moved to the end.
     AddResult appendOrMoveToLast(const ValueType&) LIFETIME_BOUND;
@@ -713,6 +718,16 @@ auto ListHashSet<T, U>::add(ValueType&& value) LIFETIME_BOUND -> AddResult
     if (result.isNewEntry)
         appendNode(result.iterator->get());
     return AddResult(makeIterator(result.iterator->get()), result.isNewEntry);
+}
+
+template<typename T, typename U>
+template<typename ContainerType>
+inline bool ListHashSet<T, U>::addAll(ContainerType&& container)
+{
+    bool changed = false;
+    for (auto&& item : std::forward<ContainerType>(container))
+        changed |= add(std::forward<decltype(item)>(item)).isNewEntry;
+    return changed;
 }
 
 template<typename T, typename U>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3030,6 +3030,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/RenderView.h
     rendering/RenderWidget.h
     rendering/RepaintRectCalculation.h
+    rendering/SubtreeScrollbarChangeState.h
+
     rendering/TextBoxSelectableRange.h
     rendering/TransformOperationData.h
     rendering/VisibleRectContext.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2984,6 +2984,7 @@ rendering/RenderVideo.cpp
 rendering/RenderView.cpp
 rendering/RenderViewTransitionCapture.cpp
 rendering/RenderWidget.cpp
+rendering/SubtreeScrollbarChangeState.cpp
 rendering/StyledMarkedText.cpp
 rendering/TableLayout.cpp
 rendering/TextBoxPainter.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -4283,6 +4283,7 @@
 		A5071E871C56D0E1009951BE /* ResourceUsageThread.h in Headers */ = {isa = PBXBuildFile; fileRef = A5071E841C56D079009951BE /* ResourceUsageThread.h */; };
 		A513B3D7114B1666001C429B /* KeyEventCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = A5C974CF11485FF10066F2AB /* KeyEventCocoa.h */; };
 		A51432582DE0CE6E0059FFA1 /* GridSpan.h in Headers */ = {isa = PBXBuildFile; fileRef = A51432552DE0CE6E0059FFA1 /* GridSpan.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A515729D2F7AD717008975E0 /* SubtreeScrollbarChangeState.h in Headers */ = {isa = PBXBuildFile; fileRef = A515729A2F7AD717008975E0 /* SubtreeScrollbarChangeState.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A52B348F1FA3BDA6008B6246 /* ServiceWorkerDebuggable.h in Headers */ = {isa = PBXBuildFile; fileRef = A52B348C1FA3BD79008B6246 /* ServiceWorkerDebuggable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A52B34961FA3E290008B6246 /* ServiceWorkerInspectorProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = A52B34931FA3E286008B6246 /* ServiceWorkerInspectorProxy.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A52B349E1FA41703008B6246 /* WorkerDebuggerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = A52B349C1FA416F8008B6246 /* WorkerDebuggerProxy.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -17079,6 +17080,8 @@
 		A51324D7290A235900C0DCFA /* GridMasonryLayout.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridMasonryLayout.h; sourceTree = "<group>"; };
 		A51432552DE0CE6E0059FFA1 /* GridSpan.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GridSpan.h; sourceTree = "<group>"; };
 		A51432562DE0CE6E0059FFA1 /* GridSpan.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GridSpan.cpp; sourceTree = "<group>"; };
+		A515729A2F7AD717008975E0 /* SubtreeScrollbarChangeState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SubtreeScrollbarChangeState.h; sourceTree = "<group>"; };
+		A515729B2F7AD717008975E0 /* SubtreeScrollbarChangeState.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SubtreeScrollbarChangeState.cpp; sourceTree = "<group>"; };
 		A52B348C1FA3BD79008B6246 /* ServiceWorkerDebuggable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerDebuggable.h; sourceTree = "<group>"; };
 		A52B348E1FA3BD79008B6246 /* ServiceWorkerDebuggable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ServiceWorkerDebuggable.cpp; sourceTree = "<group>"; };
 		A52B34931FA3E286008B6246 /* ServiceWorkerInspectorProxy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerInspectorProxy.h; sourceTree = "<group>"; };
@@ -41351,6 +41354,8 @@
 				BCAE822B2E7C705800F30967 /* RepaintRectCalculation.h */,
 				E440FD5425A4AFEE00F7C849 /* StyledMarkedText.cpp */,
 				E440FD5125A4AFDF00F7C849 /* StyledMarkedText.h */,
+				A515729B2F7AD717008975E0 /* SubtreeScrollbarChangeState.cpp */,
+				A515729A2F7AD717008975E0 /* SubtreeScrollbarChangeState.h */,
 				E31CD750229F749500FBDA19 /* TableLayout.cpp */,
 				A8CFF04C0A154F09000A4234 /* TableLayout.h */,
 				0F54DCE31881051D003EEDBB /* TextAutoSizing.cpp */,
@@ -48085,6 +48090,7 @@
 				659A7D130B6DB4D9001155B3 /* SubstituteData.h in Headers */,
 				1A8F6B020DB53006001DB794 /* SubstituteResource.h in Headers */,
 				5778BD821DA4806C009E3009 /* SubtleCrypto.h in Headers */,
+				A515729D2F7AD717008975E0 /* SubtreeScrollbarChangeState.h in Headers */,
 				93B2D8160F9920D2006AE6B2 /* SuddenTermination.h in Headers */,
 				97C078501165D5BE003A32EF /* SuffixTree.h in Headers */,
 				97627B9814FB5424002CDCA1 /* Supplementable.h in Headers */,

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -760,6 +760,7 @@ bool LocalFrameViewLayoutContext::pushLayoutState(RenderBox& renderer, const Lay
 {
     // We push LayoutState even if layoutState is disabled because it stores layoutDelta too.
     auto* layoutState = this->layoutState();
+    CheckedPtr subtreeRootForDescendantScrollbarChanges = (layoutState && layoutState->isTrackingRendererForDescendantScrollbarChanges()) ? layoutState->subtreeScrollbarChangesState()->subtreeRoot.ptr() : nullptr;
     if (!layoutState || !needsFullRepaint() || layoutState->isPaginated() || renderer.enclosingFragmentedFlow()
         || layoutState->lineGrid() || (!renderer.style().lineGrid().isNone() && renderer.isRenderBlockFlow())) {
         m_layoutStateStack.append(makeUnique<RenderLayoutState>(m_layoutStateStack
@@ -768,7 +769,8 @@ bool LocalFrameViewLayoutContext::pushLayoutState(RenderBox& renderer, const Lay
             , pageHeight
             , pageHeightChanged
             , layoutState ? layoutState->lineClamp() : std::nullopt
-            , layoutState ? layoutState->legacyLineClamp() : std::nullopt));
+            , layoutState ? layoutState->legacyLineClamp() : std::nullopt
+            , subtreeRootForDescendantScrollbarChanges));
         return true;
     }
     return false;
@@ -781,14 +783,30 @@ void LocalFrameViewLayoutContext::popLayoutState()
 
     auto currentLineClamp = layoutState()->legacyLineClamp();
 
+    auto poppedSubtreeScrollbarChangesState = layoutState()->subtreeScrollbarChangesState();
+
     m_layoutStateStack.removeLast();
+
+    auto* layoutState = this->layoutState();
+    if (!layoutState)
+        return;
+
+    // It should be considered an error if a client explicitly created some state to track
+    // scrollbar changes for a subtree but did not handle the content that changed.
+    ASSERT_IMPLIES(!layoutState->subtreeScrollbarChangesState() && poppedSubtreeScrollbarChangesState, poppedSubtreeScrollbarChangesState->renderersWithScrollbarChange.isEmpty());
 
     if (currentLineClamp) {
         // Propagates the current line clamp state to the parent.
-        if (auto* layoutState = this->layoutState(); layoutState && layoutState->legacyLineClamp()) {
+        if (layoutState->legacyLineClamp()) {
             ASSERT(layoutState->legacyLineClamp()->maximumLineCount == currentLineClamp->maximumLineCount);
             layoutState->setLegacyLineClamp(currentLineClamp);
         }
+    }
+
+    if (layoutState->subtreeScrollbarChangesState() && !poppedSubtreeScrollbarChangesState->renderersWithScrollbarChange.isEmpty()) {
+        // Make sure we did not start tracking two different roots in the same subtree before we combine the descendants with changes.
+        ASSERT(layoutState->subtreeScrollbarChangesState()->subtreeRoot.ptr() == poppedSubtreeScrollbarChangesState->subtreeRoot.ptr());
+        layoutState->subtreeScrollbarChangesState()->renderersWithScrollbarChange.addAll(poppedSubtreeScrollbarChangesState->renderersWithScrollbarChange);
     }
 }
 

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -506,16 +506,42 @@ void RenderBlock::updateScrollInfoAfterLayout()
         layer()->updateScrollInfoAfterLayout();
 }
 
+static bool needsToTrackDescendantScrollbarChanges(const RenderBlock& renderBlock, const RenderLayoutState& layoutState)
+{
+    auto computedLogicalWidth = renderBlock.style().logicalWidth();
+    return computedLogicalWidth.isIntrinsic() && !layoutState.subtreeScrollbarChangesState();
+}
+
+static bool canContainDescendantScrollbarChanges(const RenderBlock& renderBlock, const RenderLayoutState& layoutState)
+{
+    return layoutState.isTrackingRendererForDescendantScrollbarChanges() && renderBlock.style().logicalWidth().isFixed();
+}
+
 void RenderBlock::layout()
 {
     StackStats::LayoutCheckPoint layoutCheckPoint;
 
+    auto* layoutState = layoutContext().layoutState();
+    bool isTrackingDescendantScrollbarChanges = false;
+    if (layoutState && needsToTrackDescendantScrollbarChanges(*this, *layoutState)) {
+        layoutState->setSubtreeScrollbarChangeState(SubtreeScrollbarChangesState { *this, { } });
+        isTrackingDescendantScrollbarChanges = true;
+    }
+
     // Table cells call layoutBlock directly, so don't add any logic here. Put code into layoutBlock().
     {
+        bool willHandleDescendantScrollbarChanges = isTrackingDescendantScrollbarChanges || (layoutState && canContainDescendantScrollbarChanges(*this, *layoutState));
         auto scope = LayoutScope { *this };
-        layoutBlock(RelayoutChildren::No);
+        if (willHandleDescendantScrollbarChanges) {
+            SubtreeScrollbarChangesHandler descendantScrollbarChangesHandler(*this);
+            layoutBlock(RelayoutChildren::No);
+        } else
+            layoutBlock(RelayoutChildren::No);
     }
-    
+
+    if (isTrackingDescendantScrollbarChanges)
+        layoutState->setSubtreeScrollbarChangeState({ });
+
     // It's safe to check for control clip here, since controls can never be table cells.
     // If we have a lightweight clip, there can never be any overflow from children.
     if (hasControlClip() && m_overflow && !isDelayingUpdateScrollInfoAfterLayout(*this))

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1307,6 +1307,29 @@ void RenderLayerScrollableArea::updateScrollbarsAfterLayout()
     bool autoHorizontalScrollBarChanged = box->hasAutoScrollbar(ScrollbarOrientation::Horizontal) && (hadHorizontalScrollbar != hasHorizontalScrollbar());
     bool autoVerticalScrollBarChanged = box->hasAutoScrollbar(ScrollbarOrientation::Vertical) && (hadVerticalScrollbar != hasVerticalScrollbar());
 
+    auto handleOverflowRelayoutForRenderer = [&](RenderLayerModelObject& renderer)  {
+        if (m_inOverflowRelayout)
+            return;
+
+        SetForScope inOverflowRelayoutScope(m_inOverflowRelayout, true);
+        renderer.setNeedsLayout(MarkOnlyThis);
+
+        if (!renderer.isRenderBlock()) {
+            renderer.layout();
+            return;
+        }
+
+        CheckedRef renderBlock = downcast<RenderBlock>(renderer);
+        renderBlock->scrollbarsChanged(autoHorizontalScrollBarChanged, autoVerticalScrollBarChanged);
+        if (auto* layoutState = renderer.layoutContext().layoutState(); layoutState && layoutState->isTrackingRendererForDescendantScrollbarChanges()) {
+            layoutState->addDescendantForScrollbarChange(renderBlock);
+            return;
+        }
+        // FIXME: Calling layoutBlock here is a bit of a layering violation.
+        auto scope = LayoutScope { renderBlock };
+        renderBlock->layoutBlock(RelayoutChildren::Yes);
+    };
+
     if (autoHorizontalScrollBarChanged || autoVerticalScrollBarChanged) {
         if (autoVerticalScrollBarChanged && shouldPlaceVerticalScrollbarOnLeft())
             computeScrollOrigin();
@@ -1316,19 +1339,8 @@ void RenderLayerScrollableArea::updateScrollbarsAfterLayout()
         auto& renderer = m_layer.renderer();
         renderer.repaint();
 
-        if (renderer.style().overflowX() == Overflow::Auto || renderer.style().overflowY() == Overflow::Auto) {
-            if (!m_inOverflowRelayout) {
-                SetForScope inOverflowRelayoutScope(m_inOverflowRelayout, true);
-                renderer.setNeedsLayout(MarkOnlyThis);
-                if (CheckedPtr block = dynamicDowncast<RenderBlock>(renderer)) {
-                    // FIXME: Calling layoutBlock here is a bit of a layering violation.
-                    auto scope = LayoutScope { *block };
-                    block->scrollbarsChanged(autoHorizontalScrollBarChanged, autoVerticalScrollBarChanged);
-                    block->layoutBlock(RelayoutChildren::Yes);
-                } else
-                    renderer.layout();
-            }
-        }
+        if (renderer.style().overflowX() == Overflow::Auto || renderer.style().overflowY() == Overflow::Auto)
+            handleOverflowRelayoutForRenderer(renderer);
 
         // FIXME: This does not belong here.
         auto* parent = renderer.parent();

--- a/Source/WebCore/rendering/RenderLayoutState.cpp
+++ b/Source/WebCore/rendering/RenderLayoutState.cpp
@@ -69,7 +69,8 @@ RenderLayoutState::RenderLayoutState(RenderElement& renderer)
     }
 }
 
-RenderLayoutState::RenderLayoutState(const LocalFrameViewLayoutContext::LayoutStateStack& layoutStateStack, RenderBox& renderer, const LayoutSize& offset, LayoutUnit pageLogicalHeight, bool pageLogicalHeightChanged, std::optional<LineClamp> lineClamp, std::optional<LegacyLineClamp> legacyLineClamp)
+RenderLayoutState::RenderLayoutState(const LocalFrameViewLayoutContext::LayoutStateStack& layoutStateStack, RenderBox& renderer, const LayoutSize& offset, LayoutUnit pageLogicalHeight,
+    bool pageLogicalHeightChanged, std::optional<LineClamp> lineClamp, std::optional<LegacyLineClamp> legacyLineClamp, RenderBlock* rendererTrackedForDescendantScrollbarChanges)
     : m_clipped(false)
     , m_isPaginated(false)
     , m_pageLogicalHeightChanged(false)
@@ -80,6 +81,7 @@ RenderLayoutState::RenderLayoutState(const LocalFrameViewLayoutContext::LayoutSt
     , m_marginTrimBlockStart(false)
     , m_lineClamp(lineClamp)
     , m_legacyLineClamp(legacyLineClamp)
+    , m_subtreeScrollbarChangesState(rendererTrackedForDescendantScrollbarChanges ? std::make_optional<SubtreeScrollbarChangesState>({ *rendererTrackedForDescendantScrollbarChanges, { } }) : std::nullopt)
 #if ASSERT_ENABLED
     , m_renderer(&renderer)
 #endif
@@ -367,6 +369,12 @@ ContentVisibilityOverrideScope::~ContentVisibilityOverrideScope()
     m_layoutContext->setIsVisiblityHiddenIgnored(false);
     m_layoutContext->setIsVisiblityAutoIgnored(false);
     m_layoutContext->setIsRevealedWhenFoundIgnored(false);
+}
+
+void RenderLayoutState::addDescendantForScrollbarChange(RenderBlock& descendant)
+{
+    ASSERT(descendant.isDescendantOf(m_subtreeScrollbarChangesState->subtreeRoot.ptr()));
+    m_subtreeScrollbarChangesState->renderersWithScrollbarChange.add(descendant);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayoutState.h
+++ b/Source/WebCore/rendering/RenderLayoutState.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/LayoutRect.h>
 #include <WebCore/LocalFrameViewLayoutContext.h>
+#include <WebCore/SubtreeScrollbarChangeState.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -68,7 +69,8 @@ public:
         , m_marginTrimBlockStart(false)
     {
     }
-    RenderLayoutState(const LocalFrameViewLayoutContext::LayoutStateStack&, RenderBox&, const LayoutSize& offset, LayoutUnit pageHeight, bool pageHeightChanged, std::optional<LineClamp>, std::optional<LegacyLineClamp>);
+    RenderLayoutState(const LocalFrameViewLayoutContext::LayoutStateStack&, RenderBox&, const LayoutSize& offset, LayoutUnit pageHeight, bool pageHeightChanged, std::optional<LineClamp>, std::optional<LegacyLineClamp>,
+        RenderBlock* subtreeRootForDescendantScrollbarChanges);
     explicit RenderLayoutState(RenderElement&);
 
     bool isPaginated() const { return m_isPaginated; }
@@ -90,6 +92,12 @@ public:
     LayoutSize pageOffset() const { return m_pageOffset; }
 
     bool needsBlockDirectionLocationSetBeforeLayout() const { return m_lineGrid || (m_isPaginated && m_pageLogicalHeight); }
+
+    bool isTrackingRendererForDescendantScrollbarChanges() const { return m_subtreeScrollbarChangesState.has_value(); }
+    void addDescendantForScrollbarChange(RenderBlock&);
+    void setSubtreeScrollbarChangeState(std::optional<SubtreeScrollbarChangesState> subtreeScrollbarChangeState) { m_subtreeScrollbarChangesState = subtreeScrollbarChangeState; }
+    std::optional<SubtreeScrollbarChangesState>& subtreeScrollbarChangesState() { return m_subtreeScrollbarChangesState; }
+    const std::optional<SubtreeScrollbarChangesState>& subtreeScrollbarChangesState() const { return m_subtreeScrollbarChangesState; }
 
 #if ASSERT_ENABLED
     RenderElement* renderer() const { return m_renderer; }
@@ -156,6 +164,8 @@ private:
     LayoutSize m_lineGridPaginationOrigin;
     std::optional<LineClamp> m_lineClamp;
     std::optional<LegacyLineClamp> m_legacyLineClamp;
+    std::optional<SubtreeScrollbarChangesState> m_subtreeScrollbarChangesState;
+
 #if ASSERT_ENABLED
     RenderElement* m_renderer { nullptr };
 #endif

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -674,6 +674,16 @@ void RenderObject::setNeedsPreferredWidthsUpdate(MarkingBehavior markParents)
         ensureRareData().preferredLogicalWidthsNeedUpdateIsMarkOnlyThis = false;
 }
 
+void RenderObject::setNeedsPreferredWidthsUpdateUpTo(const RenderObject& ancestor)
+{
+    ASSERT(isDescendantOf(&ancestor));
+    for (auto& renderer : lineageOfType<RenderElement>(*this)) {
+        if (&renderer == &ancestor)
+            return;
+        renderer.setNeedsPreferredWidthsUpdate(MarkOnlyThis);
+    }
+}
+
 void RenderObject::invalidateContainerPreferredLogicalWidths()
 {
     // In order to avoid pathological behavior when inlines are deeply nested, we do include them

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -759,6 +759,7 @@ public:
     enum class HadSkippedLayout { No, Yes };
     void clearNeedsLayout(HadSkippedLayout = HadSkippedLayout::No);
     void setNeedsPreferredWidthsUpdate(MarkingBehavior = MarkContainingBlockChain);
+    void setNeedsPreferredWidthsUpdateUpTo(const RenderObject& ancestor);
     void clearNeedsPreferredWidthsUpdate() { m_stateBitfields.setFlag(StateFlag::PreferredLogicalWidthsNeedUpdate, { }); }
     
     inline void setNeedsLayoutAndPreferredWidthsUpdate();

--- a/Source/WebCore/rendering/SubtreeScrollbarChangeState.cpp
+++ b/Source/WebCore/rendering/SubtreeScrollbarChangeState.cpp
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SubtreeScrollbarChangeState.h"
+
+#include "LayoutScope.h"
+#include "LocalFrameViewLayoutContext.h"
+#include "RenderBlock.h"
+#include "RenderLayoutState.h"
+
+#include <wtf/Scope.h>
+
+namespace WebCore {
+
+SubtreeScrollbarChangesHandler::SubtreeScrollbarChangesHandler(RenderBlock& rendererHandlingScrollbarChanges)
+    : m_rendererHandlingScrollbarChanges(rendererHandlingScrollbarChanges)
+{
+    auto* layoutState = rendererHandlingScrollbarChanges.layoutContext().layoutState();
+    ASSERT(layoutState);
+    if (!layoutState)
+        return;
+
+    auto& subtreeScrollbarChangeState = layoutState->subtreeScrollbarChangesState();
+    ASSERT(subtreeScrollbarChangeState);
+    if (!subtreeScrollbarChangeState)
+        return;
+
+    bool isSubtreeRootHandlingScrollbarChanges = subtreeScrollbarChangeState->subtreeRoot.ptr() == &rendererHandlingScrollbarChanges;
+    if (!isSubtreeRootHandlingScrollbarChanges) {
+        m_renderersWithScrollbarChangesHandledByAncestor = WTF::move(subtreeScrollbarChangeState->renderersWithScrollbarChange);
+        layoutState->setSubtreeScrollbarChangeState(SubtreeScrollbarChangesState { subtreeScrollbarChangeState->subtreeRoot, { } });
+    }
+}
+
+SubtreeScrollbarChangesHandler::~SubtreeScrollbarChangesHandler()
+{
+    auto* layoutState = m_rendererHandlingScrollbarChanges->layoutContext().layoutState();
+    ASSERT(layoutState);
+    if (!layoutState)
+        return;
+
+    auto& subtreeScrollbarChangesState = layoutState->subtreeScrollbarChangesState();
+    bool isSubtreeRootHandlingScrollbarChanges = subtreeScrollbarChangesState->subtreeRoot.ptr() == m_rendererHandlingScrollbarChanges.ptr();
+
+    auto descendantsWithScrollbarChange = WTF::move(subtreeScrollbarChangesState->renderersWithScrollbarChange);
+    auto restoreRenderersWithScrollbarChanges = makeScopeExit([&]() {
+        subtreeScrollbarChangesState->renderersWithScrollbarChange = WTF::move(m_renderersWithScrollbarChangesHandledByAncestor);
+        ASSERT(descendantsWithScrollbarChange.isEmpty());
+    });
+
+    if (descendantsWithScrollbarChange.isEmpty())
+        return;
+
+    if (!isSubtreeRootHandlingScrollbarChanges) {
+        while (!descendantsWithScrollbarChange.isEmpty()) {
+            CheckedPtr rendererWithScrollbarChange = descendantsWithScrollbarChange.takeFirst();
+            auto scope = LayoutScope { *rendererWithScrollbarChange };
+            rendererWithScrollbarChange->setNeedsLayout(MarkingBehavior::MarkOnlyThis);
+            rendererWithScrollbarChange->layoutBlock(RelayoutChildren::Yes);
+        }
+        return;
+    }
+
+    auto& subtreeRoot = subtreeScrollbarChangesState->subtreeRoot;
+    while (!descendantsWithScrollbarChange.isEmpty()) {
+        CheckedPtr rendererWithScrollbarChange = descendantsWithScrollbarChange.takeFirst();
+        rendererWithScrollbarChange->setNeedsPreferredWidthsUpdateUpTo(subtreeRoot);
+    }
+
+    auto scope = LayoutScope { subtreeRoot };
+    subtreeRoot->setNeedsLayout(MarkingBehavior::MarkOnlyThis);
+    subtreeRoot->layoutBlock(RelayoutChildren::Yes);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/SubtreeScrollbarChangeState.h
+++ b/Source/WebCore/rendering/SubtreeScrollbarChangeState.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/CheckedRef.h>
+#include <wtf/ListHashSet.h>
+
+namespace WebCore {
+
+class RenderBlock;
+class RenderLayoutState;
+
+struct SubtreeScrollbarChangesState {
+    CheckedRef<RenderBlock> subtreeRoot;
+    ListHashSet<CheckedRef<RenderBlock>> renderersWithScrollbarChange;
+};
+
+class SubtreeScrollbarChangesHandler {
+public:
+    SubtreeScrollbarChangesHandler(RenderBlock&);
+    ~SubtreeScrollbarChangesHandler();
+private:
+    const CheckedRef<RenderBlock> m_rendererHandlingScrollbarChanges;
+    ListHashSet<CheckedRef<RenderBlock>> m_renderersWithScrollbarChangesHandledByAncestor;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.cpp
@@ -35,6 +35,7 @@
 #include "MathMLElement.h"
 #include "MathMLNames.h"
 #include "MathMLPresentationElement.h"
+#include "OpenTypeMathData.h"
 #include "RenderChildIterator.h"
 #include "RenderBoxInlines.h"
 #include "RenderElementStyleInlines.h"

--- a/Source/WebCore/rendering/updating/RenderTreePosition.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreePosition.cpp
@@ -29,6 +29,7 @@
 #include "ComposedTreeIterator.h"
 #include "ContainerNodeInlines.h"
 #include "PseudoElement.h"
+#include "RenderBlockFlow.h"
 #include "RenderElementInlines.h"
 #include "RenderInline.h"
 #include "RenderObject.h"

--- a/Source/WebCore/svg/SVGMarkerTypes.h
+++ b/Source/WebCore/svg/SVGMarkerTypes.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "CommonAtomStrings.h"
+#include "ExceptionOr.h"
 #include "SVGAngleValue.h"
 #include "SVGPropertyTraits.h"
 


### PR DESCRIPTION
#### 8945152d3bcc22def5faf1d7e2f9f57ca0e60828
<pre>
Begin tracking scrollbar changes in subtree for intrinsically sized renderers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=310940">https://bugs.webkit.org/show_bug.cgi?id=310940</a>
<a href="https://rdar.apple.com/166836126">rdar://166836126</a>

Reviewed by NOBODY (OOPS!).

According to css-overflow, when a box has some type of scrollbar change,
it is supposed to impact its intrinsic size.

&quot;When reserving space for a scrollbar placed at the edge of an element’s box,
the reserved space is inserted between the inner border edge and the
outer padding edge... When the box is intrinsically sized, this reserved space
is added to the size of its contents.&quot;
<a href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing</a>

In some cases, this type of change to a box&apos;s intrinsic size may be just
limited to it and its descendants. However, there are cases in which
these changes may end up impacting an ancestor and the final layout of
its subtree. For example, consider the following type of content:

.container {
  background-color: green;
  width: max-content;
}
.parent {
  height: 79px;
  overflow: auto;
}

.content {
  width: 10px;
  height: 80px;
}
&lt;div class=container&gt;
  &lt;div class=parent&gt;
    &lt;div class=content&gt;&lt;/div&gt;
  &lt;/div&gt;
&lt;/div&gt;

When parent ends up getting a scrollbar, this is supposed to affect the
max-content width of container, but we end up failing to take that into
account.

This patch serves as a first step towards fixing this class of bugs by
adding some infrastructure that keeps track of scrollbar changes for a
subtree where the root is intrinsically sized from its style. The basic
idea is that if a renderer has an intrinsic computed logical width, then
we will start to keep track of any of its descendants that have a
scrollbar update. Then, when we get to the end of that renderer&apos;s layout,
we will see if we have any such renderers, invalidate them, and rerun
layout so that it can recompute its logical width with these changes.

* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant.html: Added.
* Source/WTF/wtf/ListHashSet.h:
(WTF::U&gt;::addAll):
Convenience method added onto ListHashSet to combine two of the data
structures just like the implementation in HashSet.

* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::pushLayoutState):
When we add a new RenderLayoutState onto the stack, we will check to see
if we are already tracking a subtree. If that is the case, then we should
pass in the current root to the new RenderLayoutState. We only care
about the root and do not want to add in the existing list of renderers
that have scrollbar changes since this portion of the subtree may be
able to handle its own scrollbar changes.

(WebCore::LocalFrameViewLayoutContext::popLayoutState):
When coming back up the tree, we want to make sure we coalesce the list
of descendants. The order in which these renderers are added should
match the depth-first order we do layout in. This is so that if we find
an ancestor that can handle the scrollbar changes, for example by having
a fixed width, then we call layoutBlock on those renderers in
RenderBlock::tryHandlingDescendantScrollbarChanges in the same order
they would have been called in RenderLayerScrollableArea::updateScrollbarsAfterLayout.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::tryHandlingDescendantScrollbarChanges):
When we reach the end of layout for a RenderBlock, we will try to see if
we can handle any scrollbar changes that have been accumulated. When
|this| renderer is the one being tracked, we *must* handle it here. This
is done by updating the preferred logical widths for the descendants so
that we can recompute the logical width properly and then performing
layout again on the subtree root.

In some cases |this| renderer may be a descendant of the subtree root
but still may be able to handle the changes. For example, if it has a
fixed width, then the scrollbars in that subtree should have no impact on
the ancestors. In that case, we just call layoutBlock on them like we
would have done in RenderLayerScrollableArea::updateScrollbarsAfterLayout.

(WebCore::RenderBlock::layout):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::updateScrollbarsAfterLayout):
There are two main things that changed here:
1.) A small little cleanup where we move the logic to handle relayout
for renderers with scrollbar changes into its own lambda. This is just
to improve readability by reducing the nesting with some early returns.

2.) If we are currently tracking a subtree for scrollbar changes then we
will add them into the list to be propagated back up. In that case we
also do not want to call layoutBlock here since it should be handled by
an ancestor.

* Source/WebCore/rendering/RenderLayoutState.cpp:
(WebCore::RenderLayoutState::RenderLayoutState):
(WebCore::RenderLayoutState::startTrackingRendererForDescendantScrollbarChanges):
(WebCore::RenderLayoutState::stopTrackingRendererForDescendantScrollbarChanges):
(WebCore::RenderLayoutState::addDescendantForScrollbarChange):
New API added onto RenderLayoutState to interact with the SubtreeScrollbarChangeState
class that was added. Clients will pass in the subtree root when they
want to start tracking scrollbar changes for its subtree. They will then
clear out the state, which stops tracking that renderer, when they have
handled all of the damage. We enforce this invariant by adding a debug
assert in LocalFrameViewLayoutContext::popLayoutState to make sure the
caller cleared the state, which indicates they handled the damage.

(WebCore::SubtreeScrollbarChangesState::descendantsWithScrollbarChange):
* Source/WebCore/rendering/RenderLayoutState.h:
(WebCore::SubtreeScrollbarChangesState::SubtreeScrollbarChangesState):
This new helper class is what will be used alongside RenderLayoutState
to keep track of descendants that have scrollbar changes for a
particular subtree. In order to begin tracking a subtree, clients will
need to pass in the renderer that will be the root of that subtree.

(WebCore::SubtreeScrollbarChangesState::trackedRendererForDescendantScrollbarChanges const):
(WebCore::RenderLayoutState::isTrackingRendererForDescendantScrollbarChanges const):
(WebCore::RenderLayoutState::subtreeScrollbarChangesState):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::setNeedsPreferredWidthsUpdateUpTo):
Helper method added to invalidate the preferred widths of the subtree
once we get back up to the root. This just simply iterates over the
ancestors of the renderer and invalidates the preferred widths.
* Source/WebCore/rendering/RenderObject.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8945152d3bcc22def5faf1d7e2f9f57ca0e60828

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27982 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163483 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108192 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6afbdf87-9b65-4bc5-ac70-7771bc312a70) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28119 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119688 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84636 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21976 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138958 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100382 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/763c5809-47a7-43ae-9c4b-8dfabcd3c01e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21062 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19080 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11309 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146773 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130724 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165957 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15554 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/9213 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18411 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127790 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127929 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138595 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84156 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22825 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15389 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186457 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27143 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91245 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47790 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26721 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26952 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26794 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->