### PR TITLE
[Site Isolation] Fix the inspector/console/x-frame-options-message.html test

### DIFF
--- a/LayoutTests/inspector/console/x-frame-options-message-expected.txt
+++ b/LayoutTests/inspector/console/x-frame-options-message-expected.txt
@@ -3,7 +3,7 @@ CONSOLE MESSAGE: The X-Frame-Option 'deny' supplied in a <meta> element was igno
 
 == Running test suite: Console.XFrameOptionsMessages
 -- Running test case: XFrameOptionsDeny
-Evaluating expression: triggerXFrameOptionDeny();
-PASS: ConsoleMessage type should be 'security'.
-PASS: ConsoleMessage level should be 'error'.
+PASS: The message should be due to a security violation.
+PASS: The message should be an error.
+PASS: The message should come from the main target.
 

--- a/LayoutTests/inspector/console/x-frame-options-message.html
+++ b/LayoutTests/inspector/console/x-frame-options-message.html
@@ -1,33 +1,31 @@
 <!doctype html>
 <html>
 <head>
-<script src="../../http/tests/inspector/resources/protocol-test.js"></script>
-<script src="../../http/tests/inspector/resources/console-test.js"></script>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
 <script>
 function test()
 {
-    let suite = ProtocolTest.createAsyncSuite("Console.XFrameOptionsMessages");
+    let suite = InspectorTest.createAsyncSuite("Console.XFrameOptionsMessages");
 
-    ProtocolTest.Console.addTestCase(suite, {
+    suite.addTestCase({
         name: "XFrameOptionsDeny",
         description: "Ensure that a console message is logged when enforcing an X-Frame-Options policy. In this case, setting X-Frame-Options: 'deny' means the iframe does not want to be embedded in the test page.",
-        expression: "triggerXFrameOptionDeny();",
-        expected: {source: 'security', level: 'error'}
+        test(resolve) {
+            WI.consoleManager.singleFireEventListener(WI.ConsoleManager.Event.MessageAdded, function (event) {
+                let { source, level, target } = event.data.message;
+                InspectorTest.expectEqual(source, "security", "The message should be due to a security violation.");
+                InspectorTest.expectEqual(level, "error", "The message should be an error.");
+
+                let mainTargetType = WI.isSiteIsolationEnabled() ? WI.TargetType.Frame : WI.TargetType.Page;
+                InspectorTest.expectEqual(target.type, mainTargetType, "The message should come from the main target.");
+
+                resolve();
+            });
+            InspectorTest.evaluateInPage(`triggerXFrameOptionDeny();`);
+        }
     });
 
-    InspectorProtocol.awaitCommand({
-        method: "Console.enable",
-        params: {}
-    })
-    .then(function() {
-        suite.runTestCasesAndFinish();
-    })
-    .catch(fatalError);
-
-    function fatalError(e) {
-        ProtocolTest.log("Test failed with fatal error: " + JSON.stringify(e));
-        ProtocolTest.completeTest();
-    }
+    suite.runTestCasesAndFinish();
 }
 </script>
 </head>

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -383,7 +383,6 @@ imported/w3c/web-platform-tests/websockets/back-forward-cache-with-closed-websoc
 imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-and-close-it-in-pagehide.window.html [ Failure ]
 imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-ccns.tentative.window.html [ Failure ]
 imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection.window.html [ Failure ]
-inspector/console/x-frame-options-message.html [ Failure ]
 inspector/dom/inspect-template-node.html [ Failure ]
 inspector/dom/inspect.html [ Failure ]
 inspector/dom/willDestroyDOMNode.html [ Failure ]


### PR DESCRIPTION
#### 59204ab5a1d737b78dbfbd9a743db4c9d56cb16c
<pre>
[Site Isolation] Fix the inspector/console/x-frame-options-message.html test
<a href="https://rdar.apple.com/172421450">rdar://172421450</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309842">https://bugs.webkit.org/show_bug.cgi?id=309842</a>

Reviewed by BJ Burg.

Progress the test by converting it into an inspector-test which can
work with multiple inspector targets, given the test involves an iframe.

See 302178@main for more details around protocol tests and site
isolation.

* LayoutTests/inspector/console/x-frame-options-message-expected.txt:
* LayoutTests/inspector/console/x-frame-options-message.html:
* LayoutTests/platform/mac-site-isolation/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/309339@main">https://commits.webkit.org/309339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ed11321a09d049aa2b4fa9d60acb37b71c2bb70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/150379 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/23137 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/16698 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/159101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/23568 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/23272 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/159101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/153339 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/23568 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/16698 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/159101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/23568 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/16698 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/6949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/23568 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/16698 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/161575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/16698 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/161575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/22939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/23272 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/161575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/22926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/16698 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23111 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/16698 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/22540 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/22253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/22405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/22307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->