### PR TITLE
[macOS] Allow attributedSubstringForCharacterRangeAsync for non-editable selections

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -353,7 +353,7 @@ void WebPage::attributedSubstringForCharacterRangeAsync(const EditingRange& edit
         return completionHandler({ }, { });
 
     const VisibleSelection& selection = frame->selection().selection();
-    if (selection.isNone() || !selection.isContentEditable() || selection.isInPasswordField()) {
+    if (selection.isNone() || selection.isInPasswordField()) {
         completionHandler({ }, { });
         return;
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm
@@ -40,6 +40,10 @@
 #import "UIKitSPIForTesting.h"
 #endif
 
+#if PLATFORM(MAC)
+#import "AppKitSPI.h"
+#endif
+
 static void* const SelectionAttributesObservationContext = (void*)&SelectionAttributesObservationContext;
 
 @interface SelectionChangeObserver : NSObject
@@ -746,6 +750,15 @@ TEST(EditorStateTests, UnionRectInVisibleSelectedRangeForNonEditableRangeSelecti
     EXPECT_FALSE(NSIsEmptyRect(selectionRect));
     EXPECT_TRUE(NSContainsRect([webView documentVisibleRect], selectionRect));
     EXPECT_GT(didUpdateSelectionCount, 0u);
+
+    __block RetainPtr<NSAttributedString> attributedSubstring;
+    __block bool gotAttributedSubstring = false;
+    [(id<NSTextInputClient_Async>)webView.get() attributedSubstringForProposedRange:NSMakeRange(0, NSUIntegerMax) completionHandler:^(NSAttributedString *string, NSRange actualRange) {
+        attributedSubstring = string;
+        gotAttributedSubstring = true;
+    }];
+    TestWebKitAPI::Util::run(&gotAttributedSubstring);
+    EXPECT_TRUE([[attributedSubstring string] containsString:@"Hello world"]);
 
     auto countBeforeClearingSelection = didUpdateSelectionCount;
     [webView stringByEvaluatingJavaScript:@"getSelection().removeAllRanges()"];


### PR DESCRIPTION
#### 447be98d29228a55b1faa0aa3822e06026e8d14e
<pre>
[macOS] Allow attributedSubstringForCharacterRangeAsync for non-editable selections
<a href="https://bugs.webkit.org/show_bug.cgi?id=309847">https://bugs.webkit.org/show_bug.cgi?id=309847</a>
<a href="https://rdar.apple.com/172295236">rdar://172295236</a>

Reviewed by Abrar Rahman Protyasha.

Remove the `isContentEditable()` early return, so that `attributedSubstringForProposedRange` works
on non-editable content.

Note that from code inspection, this codepath is only currently called by AppKit when the user is
already editing (IME, inspector bar), so opening it up to non-editable selections should not break
existing clients.

* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::attributedSubstringForCharacterRangeAsync):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm:
(TestWebKitAPI::TEST(EditorStateTests, UnionRectInVisibleSelectedRangeForNonEditableRangeSelection)):

Canonical link: <a href="https://commits.webkit.org/309186@main">https://commits.webkit.org/309186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3432391099b23a2d3f3361d0adc4463077981cd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22587 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/16171 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158574 "Failed to checkout and rebase branch from PR 60518") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151741 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23037 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22690 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/158574 "Failed to checkout and rebase branch from PR 60518") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152828 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/17726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/134480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/158574 "Failed to checkout and rebase branch from PR 60518") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6421 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/12411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/161050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/13953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/161050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22389 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/18792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/161050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/22396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/134204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23050 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/10956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/21997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/85817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/21727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/21879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/21784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->