### PR TITLE
Suppress keypress events for Meta+key and Ctrl+key shortcuts

### DIFF
--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-control-expected.txt
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-control-expected.txt
@@ -4,287 +4,246 @@ This logs DOM keydown, keyup, keypress events that are dispatched when pressing 
 Test Control + a:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: a, code: KeyA, keyIdentifier: , keyCode: 1, charCode: 1, keyCode: 1, which: 1, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + b:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: b, code: KeyB, keyIdentifier: , keyCode: 2, charCode: 2, keyCode: 2, which: 2, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + c:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: c, code: KeyC, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + d:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: d, code: KeyD, keyIdentifier: , keyCode: 4, charCode: 4, keyCode: 4, which: 4, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + f:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: f, code: KeyF, keyIdentifier: , keyCode: 6, charCode: 6, keyCode: 6, which: 6, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + g:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: g, code: KeyG, keyIdentifier: , keyCode: 7, charCode: 7, keyCode: 7, which: 7, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + h:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: h, code: KeyH, keyIdentifier: , keyCode: 8, charCode: 8, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + j:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: j, code: KeyJ, keyIdentifier: , keyCode: 10, charCode: 10, keyCode: 10, which: 10, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + k:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: k, code: KeyK, keyIdentifier: , keyCode: 11, charCode: 11, keyCode: 11, which: 11, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + l:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: l, code: KeyL, keyIdentifier: , keyCode: 12, charCode: 12, keyCode: 12, which: 12, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + m:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: m, code: KeyM, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + o:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: o, code: KeyO, keyIdentifier: , keyCode: 15, charCode: 15, keyCode: 15, which: 15, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + p:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: p, code: KeyP, keyIdentifier: , keyCode: 16, charCode: 16, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + q:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: q, code: KeyQ, keyIdentifier: , keyCode: 17, charCode: 17, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + r:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: r, code: KeyR, keyIdentifier: , keyCode: 18, charCode: 18, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + s:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: s, code: KeyS, keyIdentifier: , keyCode: 19, charCode: 19, keyCode: 19, which: 19, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + t:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: t, code: KeyT, keyIdentifier: , keyCode: 20, charCode: 20, keyCode: 20, which: 20, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + v:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: v, code: KeyV, keyIdentifier: , keyCode: 22, charCode: 22, keyCode: 22, which: 22, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + w:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: w, code: KeyW, keyIdentifier: , keyCode: 23, charCode: 23, keyCode: 23, which: 23, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + x:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: x, code: KeyX, keyIdentifier: , keyCode: 24, charCode: 24, keyCode: 24, which: 24, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + y:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: y, code: KeyY, keyIdentifier: , keyCode: 25, charCode: 25, keyCode: 25, which: 25, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + z:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: z, code: KeyZ, keyIdentifier: , keyCode: 26, charCode: 26, keyCode: 26, which: 26, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 0:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 0, code: Digit0, keyIdentifier: , keyCode: 48, charCode: 48, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 1:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 1, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 1, code: Digit1, keyIdentifier: , keyCode: 49, charCode: 49, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: 1, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 2:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 2, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 2, code: Digit2, keyIdentifier: , keyCode: 50, charCode: 50, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: 2, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 3:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 3, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 3, code: Digit3, keyIdentifier: , keyCode: 51, charCode: 51, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: 3, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 4:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 4, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 4, code: Digit4, keyIdentifier: , keyCode: 52, charCode: 52, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: 4, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 5:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 5, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 5, code: Digit5, keyIdentifier: , keyCode: 53, charCode: 53, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: 5, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 6:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 6, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 6, code: Digit6, keyIdentifier: , keyCode: 54, charCode: 54, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: 6, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 7:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 7, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 7, code: Digit7, keyIdentifier: , keyCode: 55, charCode: 55, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: 7, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 8:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 8, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 8, code: Digit8, keyIdentifier: , keyCode: 56, charCode: 56, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: 8, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + 9:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 9, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 9, code: Digit9, keyIdentifier: , keyCode: 57, charCode: 57, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: 9, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + -:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: -, code: Minus, keyIdentifier: , keyCode: 31, charCode: 31, keyCode: 31, which: 31, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + =:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: =, code: Equal, keyIdentifier: , keyCode: 61, charCode: 61, keyCode: 61, which: 61, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + [:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: [, code: BracketLeft, keyIdentifier: U+005B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: [, code: BracketLeft, keyIdentifier: , keyCode: 27, charCode: 27, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: [, code: BracketLeft, keyIdentifier: U+005B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + ]:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ], code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ], code: BracketRight, keyIdentifier: , keyCode: 29, charCode: 29, keyCode: 29, which: 29, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: ], code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + ;:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ;, code: Semicolon, keyIdentifier: , keyCode: 59, charCode: 59, keyCode: 59, which: 59, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + ':
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ', code: Quote, keyIdentifier: , keyCode: 39, charCode: 39, keyCode: 39, which: 39, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + ,:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ,, code: Comma, keyIdentifier: , keyCode: 44, charCode: 44, keyCode: 44, which: 44, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + .:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ., code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ., code: Period, keyIdentifier: , keyCode: 46, charCode: 46, keyCode: 46, which: 46, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: ., code: Period, keyIdentifier: U+002E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Control + /:
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: /, code: Slash, keyIdentifier: , keyCode: 47, charCode: 47, keyCode: 47, which: 47, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: true, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-control-expected.txt
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-control-expected.txt
@@ -5,7 +5,6 @@ Test Command + Control + a:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: a, code: KeyA, keyIdentifier: , keyCode: 1, charCode: 1, keyCode: 1, which: 1, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -13,7 +12,6 @@ Test Command + Control + b:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: b, code: KeyB, keyIdentifier: , keyCode: 2, charCode: 2, keyCode: 2, which: 2, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -21,7 +19,6 @@ Test Command + Control + c:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: c, code: KeyC, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -29,7 +26,6 @@ Test Command + Control + d:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: d, code: KeyD, keyIdentifier: , keyCode: 4, charCode: 4, keyCode: 4, which: 4, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -37,7 +33,6 @@ Test Command + Control + f:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: f, code: KeyF, keyIdentifier: , keyCode: 6, charCode: 6, keyCode: 6, which: 6, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -45,7 +40,6 @@ Test Command + Control + g:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: g, code: KeyG, keyIdentifier: , keyCode: 7, charCode: 7, keyCode: 7, which: 7, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -53,7 +47,6 @@ Test Command + Control + h:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 8, charCode: 0, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: h, code: KeyH, keyIdentifier: , keyCode: 8, charCode: 8, keyCode: 8, which: 8, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -61,7 +54,6 @@ Test Command + Control + j:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: j, code: KeyJ, keyIdentifier: , keyCode: 10, charCode: 10, keyCode: 10, which: 10, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -69,7 +61,6 @@ Test Command + Control + k:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: k, code: KeyK, keyIdentifier: , keyCode: 11, charCode: 11, keyCode: 11, which: 11, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -77,7 +68,6 @@ Test Command + Control + l:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: l, code: KeyL, keyIdentifier: , keyCode: 12, charCode: 12, keyCode: 12, which: 12, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -85,7 +75,6 @@ Test Command + Control + m:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 13, charCode: 0, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: m, code: KeyM, keyIdentifier: , keyCode: 13, charCode: 13, keyCode: 13, which: 13, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -93,7 +82,6 @@ Test Command + Control + o:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: o, code: KeyO, keyIdentifier: , keyCode: 15, charCode: 15, keyCode: 15, which: 15, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -101,7 +89,6 @@ Test Command + Control + p:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: p, code: KeyP, keyIdentifier: , keyCode: 16, charCode: 16, keyCode: 16, which: 16, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -109,7 +96,6 @@ Test Command + Control + q:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: q, code: KeyQ, keyIdentifier: , keyCode: 17, charCode: 17, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -117,7 +103,6 @@ Test Command + Control + r:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: r, code: KeyR, keyIdentifier: , keyCode: 18, charCode: 18, keyCode: 18, which: 18, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -125,7 +110,6 @@ Test Command + Control + s:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: s, code: KeyS, keyIdentifier: , keyCode: 19, charCode: 19, keyCode: 19, which: 19, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -133,7 +117,6 @@ Test Command + Control + t:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: t, code: KeyT, keyIdentifier: , keyCode: 20, charCode: 20, keyCode: 20, which: 20, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -141,7 +124,6 @@ Test Command + Control + v:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: v, code: KeyV, keyIdentifier: , keyCode: 22, charCode: 22, keyCode: 22, which: 22, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -149,7 +131,6 @@ Test Command + Control + w:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: w, code: KeyW, keyIdentifier: , keyCode: 23, charCode: 23, keyCode: 23, which: 23, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -157,7 +138,6 @@ Test Command + Control + x:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: x, code: KeyX, keyIdentifier: , keyCode: 24, charCode: 24, keyCode: 24, which: 24, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -165,7 +145,6 @@ Test Command + Control + y:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: y, code: KeyY, keyIdentifier: , keyCode: 25, charCode: 25, keyCode: 25, which: 25, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -173,7 +152,6 @@ Test Command + Control + z:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: z, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: z, code: KeyZ, keyIdentifier: , keyCode: 26, charCode: 26, keyCode: 26, which: 26, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -181,7 +159,6 @@ Test Command + Control + 0:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 0, code: Digit0, keyIdentifier: , keyCode: 48, charCode: 48, keyCode: 48, which: 48, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -189,7 +166,6 @@ Test Command + Control + 1:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 1, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 1, code: Digit1, keyIdentifier: , keyCode: 49, charCode: 49, keyCode: 49, which: 49, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -197,7 +173,6 @@ Test Command + Control + 2:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 2, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 2, code: Digit2, keyIdentifier: , keyCode: 50, charCode: 50, keyCode: 50, which: 50, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -205,7 +180,6 @@ Test Command + Control + 3:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 3, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 3, code: Digit3, keyIdentifier: , keyCode: 51, charCode: 51, keyCode: 51, which: 51, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -213,7 +187,6 @@ Test Command + Control + 4:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 4, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 4, code: Digit4, keyIdentifier: , keyCode: 52, charCode: 52, keyCode: 52, which: 52, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -221,7 +194,6 @@ Test Command + Control + 5:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 5, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 5, code: Digit5, keyIdentifier: , keyCode: 53, charCode: 53, keyCode: 53, which: 53, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -229,7 +201,6 @@ Test Command + Control + 6:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 6, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 6, code: Digit6, keyIdentifier: , keyCode: 54, charCode: 54, keyCode: 54, which: 54, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -237,7 +208,6 @@ Test Command + Control + 7:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 7, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 7, code: Digit7, keyIdentifier: , keyCode: 55, charCode: 55, keyCode: 55, which: 55, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -245,7 +215,6 @@ Test Command + Control + 8:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 8, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 8, code: Digit8, keyIdentifier: , keyCode: 56, charCode: 56, keyCode: 56, which: 56, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -253,7 +222,6 @@ Test Command + Control + 9:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 9, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 9, code: Digit9, keyIdentifier: , keyCode: 57, charCode: 57, keyCode: 57, which: 57, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -261,7 +229,6 @@ Test Command + Control + -:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: -, code: Minus, keyIdentifier: , keyCode: 31, charCode: 31, keyCode: 31, which: 31, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -269,7 +236,6 @@ Test Command + Control + =:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: =, code: Equal, keyIdentifier: , keyCode: 61, charCode: 61, keyCode: 61, which: 61, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -277,7 +243,6 @@ Test Command + Control + [:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: [, code: BracketLeft, keyIdentifier: U+005B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: [, code: BracketLeft, keyIdentifier: , keyCode: 27, charCode: 27, keyCode: 27, which: 27, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -285,7 +250,6 @@ Test Command + Control + ]:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ], code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ], code: BracketRight, keyIdentifier: , keyCode: 29, charCode: 29, keyCode: 29, which: 29, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -293,7 +257,6 @@ Test Command + Control + ;:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ;, code: Semicolon, keyIdentifier: , keyCode: 59, charCode: 59, keyCode: 59, which: 59, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -301,7 +264,6 @@ Test Command + Control + ':
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ', code: Quote, keyIdentifier: , keyCode: 39, charCode: 39, keyCode: 39, which: 39, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -309,7 +271,6 @@ Test Command + Control + ,:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ,, code: Comma, keyIdentifier: , keyCode: 44, charCode: 44, keyCode: 44, which: 44, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -317,7 +278,6 @@ Test Command + Control + .:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: UIKeyInputEscape, code: Period, keyIdentifier: Unidentified, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: UIKeyInputEscape, code: Period, keyIdentifier: , keyCode: 46, charCode: 46, keyCode: 46, which: 46, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -325,7 +285,6 @@ Test Command + Control + /:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: /, code: Slash, keyIdentifier: , keyCode: 47, charCode: 47, keyCode: 47, which: 47, altKey: false, ctrlKey: true, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Control, code: ControlLeft, keyIdentifier: Control, keyCode: 17, charCode: 0, keyCode: 17, which: 17, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-expected.txt
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-expected.txt
@@ -4,97 +4,81 @@ This logs DOM keydown, keyup, keypress events that are dispatched when pressing 
 Test Command + b:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: b, code: KeyB, keyIdentifier: , keyCode: 98, charCode: 98, keyCode: 98, which: 98, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + c:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: c, code: KeyC, keyIdentifier: , keyCode: 99, charCode: 99, keyCode: 99, which: 99, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + d:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: d, code: KeyD, keyIdentifier: , keyCode: 100, charCode: 100, keyCode: 100, which: 100, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + f:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: f, code: KeyF, keyIdentifier: , keyCode: 102, charCode: 102, keyCode: 102, which: 102, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + g:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: g, code: KeyG, keyIdentifier: , keyCode: 103, charCode: 103, keyCode: 103, which: 103, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + h:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: h, code: KeyH, keyIdentifier: , keyCode: 104, charCode: 104, keyCode: 104, which: 104, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + j:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: j, code: KeyJ, keyIdentifier: , keyCode: 106, charCode: 106, keyCode: 106, which: 106, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + k:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: k, code: KeyK, keyIdentifier: , keyCode: 107, charCode: 107, keyCode: 107, which: 107, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + m:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: m, code: KeyM, keyIdentifier: , keyCode: 109, charCode: 109, keyCode: 109, which: 109, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + o:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: o, code: KeyO, keyIdentifier: , keyCode: 111, charCode: 111, keyCode: 111, which: 111, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + p:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: p, code: KeyP, keyIdentifier: , keyCode: 112, charCode: 112, keyCode: 112, which: 112, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + q:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: q, code: KeyQ, keyIdentifier: , keyCode: 113, charCode: 113, keyCode: 113, which: 113, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + s:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: s, code: KeyS, keyIdentifier: , keyCode: 115, charCode: 115, keyCode: 115, which: 115, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + v:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: v, code: KeyV, keyIdentifier: , keyCode: 118, charCode: 118, keyCode: 118, which: 118, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + x:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: x, code: KeyX, keyIdentifier: , keyCode: 120, charCode: 120, keyCode: 120, which: 120, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + y:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: y, code: KeyY, keyIdentifier: , keyCode: 121, charCode: 121, keyCode: 121, which: 121, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + z:
@@ -105,48 +89,40 @@ type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCo
 Test Command + 0:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: 0, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: 0, code: Digit0, keyIdentifier: , keyCode: 48, charCode: 48, keyCode: 48, which: 48, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + -:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: -, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: -, code: Minus, keyIdentifier: , keyCode: 45, charCode: 45, keyCode: 45, which: 45, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + =:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: =, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: =, code: Equal, keyIdentifier: , keyCode: 61, charCode: 61, keyCode: 61, which: 61, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + ;:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ;, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ;, code: Semicolon, keyIdentifier: , keyCode: 59, charCode: 59, keyCode: 59, which: 59, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + ':
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ', code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ', code: Quote, keyIdentifier: , keyCode: 39, charCode: 39, keyCode: 39, which: 39, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + ,:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ,, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ,, code: Comma, keyIdentifier: , keyCode: 44, charCode: 44, keyCode: 44, which: 44, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + .:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Escape, code: Escape, keyIdentifier: U+001B, keyCode: 27, charCode: 0, keyCode: 27, which: 27, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: Escape, code: Escape, keyIdentifier: , keyCode: 27, charCode: 27, keyCode: 27, which: 27, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
 Test Command + /:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: /, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: /, code: Slash, keyIdentifier: , keyCode: 47, charCode: 47, keyCode: 47, which: 47, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-option-expected.txt
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-option-expected.txt
@@ -5,7 +5,6 @@ Test Command + Option + a:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: å, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: å, code: KeyA, keyIdentifier: , keyCode: 229, charCode: 229, keyCode: 229, which: 229, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -13,7 +12,6 @@ Test Command + Option + b:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ∫, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ∫, code: KeyB, keyIdentifier: , keyCode: 8747, charCode: 8747, keyCode: 8747, which: 8747, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -21,7 +19,6 @@ Test Command + Option + c:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ç, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ç, code: KeyC, keyIdentifier: , keyCode: 231, charCode: 231, keyCode: 231, which: 231, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -29,7 +26,6 @@ Test Command + Option + d:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ∂, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ∂, code: KeyD, keyIdentifier: , keyCode: 8706, charCode: 8706, keyCode: 8706, which: 8706, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -37,7 +33,6 @@ Test Command + Option + g:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ©, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ©, code: KeyG, keyIdentifier: , keyCode: 169, charCode: 169, keyCode: 169, which: 169, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -45,7 +40,6 @@ Test Command + Option + h:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ˙, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ˙, code: KeyH, keyIdentifier: , keyCode: 729, charCode: 729, keyCode: 729, which: 729, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -53,7 +47,6 @@ Test Command + Option + j:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ∆, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ∆, code: KeyJ, keyIdentifier: , keyCode: 8710, charCode: 8710, keyCode: 8710, which: 8710, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -61,7 +54,6 @@ Test Command + Option + k:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ˚, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ˚, code: KeyK, keyIdentifier: , keyCode: 730, charCode: 730, keyCode: 730, which: 730, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -69,7 +61,6 @@ Test Command + Option + l:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ¬, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ¬, code: KeyL, keyIdentifier: , keyCode: 172, charCode: 172, keyCode: 172, which: 172, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -77,7 +68,6 @@ Test Command + Option + m:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: µ, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: µ, code: KeyM, keyIdentifier: , keyCode: 181, charCode: 181, keyCode: 181, which: 181, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -85,7 +75,6 @@ Test Command + Option + o:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ø, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ø, code: KeyO, keyIdentifier: , keyCode: 248, charCode: 248, keyCode: 248, which: 248, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -93,7 +82,6 @@ Test Command + Option + p:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: π, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: π, code: KeyP, keyIdentifier: , keyCode: 960, charCode: 960, keyCode: 960, which: 960, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -101,7 +89,6 @@ Test Command + Option + q:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: œ, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: œ, code: KeyQ, keyIdentifier: , keyCode: 339, charCode: 339, keyCode: 339, which: 339, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -109,7 +96,6 @@ Test Command + Option + s:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ß, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ß, code: KeyS, keyIdentifier: , keyCode: 223, charCode: 223, keyCode: 223, which: 223, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -117,7 +103,6 @@ Test Command + Option + t:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: †, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: †, code: KeyT, keyIdentifier: , keyCode: 8224, charCode: 8224, keyCode: 8224, which: 8224, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -125,7 +110,6 @@ Test Command + Option + v:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: √, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: √, code: KeyV, keyIdentifier: , keyCode: 8730, charCode: 8730, keyCode: 8730, which: 8730, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -133,7 +117,6 @@ Test Command + Option + x:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ≈, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ≈, code: KeyX, keyIdentifier: , keyCode: 8776, charCode: 8776, keyCode: 8776, which: 8776, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -141,7 +124,6 @@ Test Command + Option + y:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ¥, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ¥, code: KeyY, keyIdentifier: , keyCode: 165, charCode: 165, keyCode: 165, which: 165, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -149,7 +131,6 @@ Test Command + Option + z:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Ω, code: KeyZ, keyIdentifier: U+005A, keyCode: 90, charCode: 0, keyCode: 90, which: 90, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: Ω, code: KeyZ, keyIdentifier: , keyCode: 937, charCode: 937, keyCode: 937, which: 937, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -157,7 +138,6 @@ Test Command + Option + 0:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: º, code: Digit0, keyIdentifier: U+0030, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: º, code: Digit0, keyIdentifier: , keyCode: 186, charCode: 186, keyCode: 186, which: 186, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -165,7 +145,6 @@ Test Command + Option + 1:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ¡, code: Digit1, keyIdentifier: U+0031, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ¡, code: Digit1, keyIdentifier: , keyCode: 161, charCode: 161, keyCode: 161, which: 161, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -173,7 +152,6 @@ Test Command + Option + 2:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ™, code: Digit2, keyIdentifier: U+0032, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ™, code: Digit2, keyIdentifier: , keyCode: 8482, charCode: 8482, keyCode: 8482, which: 8482, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -181,7 +159,6 @@ Test Command + Option + 3:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: £, code: Digit3, keyIdentifier: U+0033, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: £, code: Digit3, keyIdentifier: , keyCode: 163, charCode: 163, keyCode: 163, which: 163, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -189,7 +166,6 @@ Test Command + Option + 4:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ¢, code: Digit4, keyIdentifier: U+0034, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ¢, code: Digit4, keyIdentifier: , keyCode: 162, charCode: 162, keyCode: 162, which: 162, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -197,7 +173,6 @@ Test Command + Option + 5:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ∞, code: Digit5, keyIdentifier: U+0035, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ∞, code: Digit5, keyIdentifier: , keyCode: 8734, charCode: 8734, keyCode: 8734, which: 8734, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -205,7 +180,6 @@ Test Command + Option + 6:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: §, code: Digit6, keyIdentifier: U+0036, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: §, code: Digit6, keyIdentifier: , keyCode: 167, charCode: 167, keyCode: 167, which: 167, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -213,7 +187,6 @@ Test Command + Option + 7:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ¶, code: Digit7, keyIdentifier: U+0037, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ¶, code: Digit7, keyIdentifier: , keyCode: 182, charCode: 182, keyCode: 182, which: 182, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -221,7 +194,6 @@ Test Command + Option + 8:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: •, code: Digit8, keyIdentifier: U+0038, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: •, code: Digit8, keyIdentifier: , keyCode: 8226, charCode: 8226, keyCode: 8226, which: 8226, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -229,7 +201,6 @@ Test Command + Option + 9:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ª, code: Digit9, keyIdentifier: U+0039, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ª, code: Digit9, keyIdentifier: , keyCode: 170, charCode: 170, keyCode: 170, which: 170, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -237,7 +208,6 @@ Test Command + Option + -:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: –, code: Minus, keyIdentifier: U+002D, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: –, code: Minus, keyIdentifier: , keyCode: 8211, charCode: 8211, keyCode: 8211, which: 8211, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -245,7 +215,6 @@ Test Command + Option + =:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ≠, code: Equal, keyIdentifier: U+003D, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ≠, code: Equal, keyIdentifier: , keyCode: 8800, charCode: 8800, keyCode: 8800, which: 8800, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -253,7 +222,6 @@ Test Command + Option + [:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: “, code: BracketLeft, keyIdentifier: U+005B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: “, code: BracketLeft, keyIdentifier: , keyCode: 8220, charCode: 8220, keyCode: 8220, which: 8220, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -261,7 +229,6 @@ Test Command + Option + ]:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ‘, code: BracketRight, keyIdentifier: U+005D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ‘, code: BracketRight, keyIdentifier: , keyCode: 8216, charCode: 8216, keyCode: 8216, which: 8216, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -269,7 +236,6 @@ Test Command + Option + ;:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: …, code: Semicolon, keyIdentifier: U+003B, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: …, code: Semicolon, keyIdentifier: , keyCode: 8230, charCode: 8230, keyCode: 8230, which: 8230, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -277,7 +243,6 @@ Test Command + Option + ':
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: æ, code: Quote, keyIdentifier: U+0027, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: æ, code: Quote, keyIdentifier: , keyCode: 230, charCode: 230, keyCode: 230, which: 230, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -285,7 +250,6 @@ Test Command + Option + ,:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ≤, code: Comma, keyIdentifier: U+002C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ≤, code: Comma, keyIdentifier: , keyCode: 8804, charCode: 8804, keyCode: 8804, which: 8804, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -293,7 +257,6 @@ Test Command + Option + .:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ≥, code: Period, keyIdentifier: Unidentified, keyCode: 85, charCode: 0, keyCode: 85, which: 85, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ≥, code: Period, keyIdentifier: , keyCode: 8805, charCode: 8805, keyCode: 8805, which: 8805, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -301,7 +264,6 @@ Test Command + Option + /:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: ÷, code: Slash, keyIdentifier: U+002F, keyCode: 191, charCode: 0, keyCode: 191, which: 191, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
-type: keypress, key: ÷, code: Slash, keyIdentifier: , keyCode: 247, charCode: 247, keyCode: 247, which: 247, altKey: true, ctrlKey: false, metaKey: true, shiftKey: false, location: 0, keyLocation: undefined
 type: keyup, key: Alt, code: AltLeft, keyIdentifier: Alt, keyCode: 18, charCode: 0, keyCode: 18, which: 18, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 

--- a/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-shift-expected.txt
+++ b/LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-shift-expected.txt
@@ -5,7 +5,6 @@ Test Command + Shift + a:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: a, code: KeyA, keyIdentifier: U+0041, keyCode: 65, charCode: 0, keyCode: 65, which: 65, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: a, code: KeyA, keyIdentifier: , keyCode: 97, charCode: 97, keyCode: 97, which: 97, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -13,7 +12,6 @@ Test Command + Shift + b:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: b, code: KeyB, keyIdentifier: U+0042, keyCode: 66, charCode: 0, keyCode: 66, which: 66, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: b, code: KeyB, keyIdentifier: , keyCode: 98, charCode: 98, keyCode: 98, which: 98, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -21,7 +19,6 @@ Test Command + Shift + c:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: c, code: KeyC, keyIdentifier: U+0043, keyCode: 67, charCode: 0, keyCode: 67, which: 67, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: c, code: KeyC, keyIdentifier: , keyCode: 99, charCode: 99, keyCode: 99, which: 99, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -29,7 +26,6 @@ Test Command + Shift + d:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: d, code: KeyD, keyIdentifier: U+0044, keyCode: 68, charCode: 0, keyCode: 68, which: 68, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: d, code: KeyD, keyIdentifier: , keyCode: 100, charCode: 100, keyCode: 100, which: 100, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -37,7 +33,6 @@ Test Command + Shift + f:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: f, code: KeyF, keyIdentifier: U+0046, keyCode: 70, charCode: 0, keyCode: 70, which: 70, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: f, code: KeyF, keyIdentifier: , keyCode: 102, charCode: 102, keyCode: 102, which: 102, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -45,7 +40,6 @@ Test Command + Shift + g:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: g, code: KeyG, keyIdentifier: U+0047, keyCode: 71, charCode: 0, keyCode: 71, which: 71, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: g, code: KeyG, keyIdentifier: , keyCode: 103, charCode: 103, keyCode: 103, which: 103, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -53,7 +47,6 @@ Test Command + Shift + h:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: h, code: KeyH, keyIdentifier: U+0048, keyCode: 72, charCode: 0, keyCode: 72, which: 72, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: h, code: KeyH, keyIdentifier: , keyCode: 104, charCode: 104, keyCode: 104, which: 104, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -61,7 +54,6 @@ Test Command + Shift + j:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: j, code: KeyJ, keyIdentifier: U+004A, keyCode: 74, charCode: 0, keyCode: 74, which: 74, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: j, code: KeyJ, keyIdentifier: , keyCode: 106, charCode: 106, keyCode: 106, which: 106, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -69,7 +61,6 @@ Test Command + Shift + k:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: k, code: KeyK, keyIdentifier: U+004B, keyCode: 75, charCode: 0, keyCode: 75, which: 75, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: k, code: KeyK, keyIdentifier: , keyCode: 107, charCode: 107, keyCode: 107, which: 107, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -77,7 +68,6 @@ Test Command + Shift + l:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: l, code: KeyL, keyIdentifier: U+004C, keyCode: 76, charCode: 0, keyCode: 76, which: 76, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: l, code: KeyL, keyIdentifier: , keyCode: 108, charCode: 108, keyCode: 108, which: 108, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -85,7 +75,6 @@ Test Command + Shift + m:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: m, code: KeyM, keyIdentifier: U+004D, keyCode: 77, charCode: 0, keyCode: 77, which: 77, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: m, code: KeyM, keyIdentifier: , keyCode: 109, charCode: 109, keyCode: 109, which: 109, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -93,7 +82,6 @@ Test Command + Shift + o:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: o, code: KeyO, keyIdentifier: U+004F, keyCode: 79, charCode: 0, keyCode: 79, which: 79, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: o, code: KeyO, keyIdentifier: , keyCode: 111, charCode: 111, keyCode: 111, which: 111, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -101,7 +89,6 @@ Test Command + Shift + p:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: p, code: KeyP, keyIdentifier: U+0050, keyCode: 80, charCode: 0, keyCode: 80, which: 80, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: p, code: KeyP, keyIdentifier: , keyCode: 112, charCode: 112, keyCode: 112, which: 112, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -109,7 +96,6 @@ Test Command + Shift + q:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: q, code: KeyQ, keyIdentifier: U+0051, keyCode: 81, charCode: 0, keyCode: 81, which: 81, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: q, code: KeyQ, keyIdentifier: , keyCode: 113, charCode: 113, keyCode: 113, which: 113, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -117,7 +103,6 @@ Test Command + Shift + r:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: r, code: KeyR, keyIdentifier: U+0052, keyCode: 82, charCode: 0, keyCode: 82, which: 82, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: r, code: KeyR, keyIdentifier: , keyCode: 114, charCode: 114, keyCode: 114, which: 114, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -125,7 +110,6 @@ Test Command + Shift + s:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: s, code: KeyS, keyIdentifier: U+0053, keyCode: 83, charCode: 0, keyCode: 83, which: 83, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: s, code: KeyS, keyIdentifier: , keyCode: 115, charCode: 115, keyCode: 115, which: 115, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -133,7 +117,6 @@ Test Command + Shift + t:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: t, code: KeyT, keyIdentifier: U+0054, keyCode: 84, charCode: 0, keyCode: 84, which: 84, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: t, code: KeyT, keyIdentifier: , keyCode: 116, charCode: 116, keyCode: 116, which: 116, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -141,7 +124,6 @@ Test Command + Shift + v:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: v, code: KeyV, keyIdentifier: U+0056, keyCode: 86, charCode: 0, keyCode: 86, which: 86, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: v, code: KeyV, keyIdentifier: , keyCode: 118, charCode: 118, keyCode: 118, which: 118, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -149,7 +131,6 @@ Test Command + Shift + w:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: w, code: KeyW, keyIdentifier: U+0057, keyCode: 87, charCode: 0, keyCode: 87, which: 87, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: w, code: KeyW, keyIdentifier: , keyCode: 119, charCode: 119, keyCode: 119, which: 119, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -157,7 +138,6 @@ Test Command + Shift + x:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: x, code: KeyX, keyIdentifier: U+0058, keyCode: 88, charCode: 0, keyCode: 88, which: 88, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: x, code: KeyX, keyIdentifier: , keyCode: 120, charCode: 120, keyCode: 120, which: 120, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -165,7 +145,6 @@ Test Command + Shift + y:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: y, code: KeyY, keyIdentifier: U+0059, keyCode: 89, charCode: 0, keyCode: 89, which: 89, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: y, code: KeyY, keyIdentifier: , keyCode: 121, charCode: 121, keyCode: 121, which: 121, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -180,7 +159,6 @@ Test Command + Shift + 0:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: 0, code: Digit0, keyIdentifier: U+0029, keyCode: 48, charCode: 0, keyCode: 48, which: 48, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: 0, code: Digit0, keyIdentifier: , keyCode: 48, charCode: 48, keyCode: 48, which: 48, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -188,7 +166,6 @@ Test Command + Shift + 1:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: 1, code: Digit1, keyIdentifier: U+0021, keyCode: 49, charCode: 0, keyCode: 49, which: 49, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: 1, code: Digit1, keyIdentifier: , keyCode: 49, charCode: 49, keyCode: 49, which: 49, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -196,7 +173,6 @@ Test Command + Shift + 2:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: 2, code: Digit2, keyIdentifier: U+0040, keyCode: 50, charCode: 0, keyCode: 50, which: 50, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: 2, code: Digit2, keyIdentifier: , keyCode: 50, charCode: 50, keyCode: 50, which: 50, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -204,7 +180,6 @@ Test Command + Shift + 3:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: 3, code: Digit3, keyIdentifier: U+0023, keyCode: 51, charCode: 0, keyCode: 51, which: 51, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: 3, code: Digit3, keyIdentifier: , keyCode: 51, charCode: 51, keyCode: 51, which: 51, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -212,7 +187,6 @@ Test Command + Shift + 4:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: 4, code: Digit4, keyIdentifier: U+0024, keyCode: 52, charCode: 0, keyCode: 52, which: 52, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: 4, code: Digit4, keyIdentifier: , keyCode: 52, charCode: 52, keyCode: 52, which: 52, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -220,7 +194,6 @@ Test Command + Shift + 5:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: 5, code: Digit5, keyIdentifier: U+0025, keyCode: 53, charCode: 0, keyCode: 53, which: 53, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: 5, code: Digit5, keyIdentifier: , keyCode: 53, charCode: 53, keyCode: 53, which: 53, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -228,7 +201,6 @@ Test Command + Shift + 6:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: 6, code: Digit6, keyIdentifier: U+005E, keyCode: 54, charCode: 0, keyCode: 54, which: 54, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: 6, code: Digit6, keyIdentifier: , keyCode: 54, charCode: 54, keyCode: 54, which: 54, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -236,7 +208,6 @@ Test Command + Shift + 7:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: 7, code: Digit7, keyIdentifier: U+0026, keyCode: 55, charCode: 0, keyCode: 55, which: 55, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: 7, code: Digit7, keyIdentifier: , keyCode: 55, charCode: 55, keyCode: 55, which: 55, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -244,7 +215,6 @@ Test Command + Shift + 8:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: 8, code: Digit8, keyIdentifier: U+002A, keyCode: 56, charCode: 0, keyCode: 56, which: 56, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: 8, code: Digit8, keyIdentifier: , keyCode: 56, charCode: 56, keyCode: 56, which: 56, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -252,7 +222,6 @@ Test Command + Shift + 9:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: 9, code: Digit9, keyIdentifier: U+0028, keyCode: 57, charCode: 0, keyCode: 57, which: 57, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: 9, code: Digit9, keyIdentifier: , keyCode: 57, charCode: 57, keyCode: 57, which: 57, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -260,7 +229,6 @@ Test Command + Shift + -:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: -, code: Minus, keyIdentifier: U+005F, keyCode: 189, charCode: 0, keyCode: 189, which: 189, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: -, code: Minus, keyIdentifier: , keyCode: 45, charCode: 45, keyCode: 45, which: 45, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -268,7 +236,6 @@ Test Command + Shift + =:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: =, code: Equal, keyIdentifier: U+002B, keyCode: 187, charCode: 0, keyCode: 187, which: 187, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: =, code: Equal, keyIdentifier: , keyCode: 61, charCode: 61, keyCode: 61, which: 61, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -276,7 +243,6 @@ Test Command + Shift + [:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: [, code: BracketLeft, keyIdentifier: U+007B, keyCode: 219, charCode: 0, keyCode: 219, which: 219, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: [, code: BracketLeft, keyIdentifier: , keyCode: 91, charCode: 91, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -284,7 +250,6 @@ Test Command + Shift + ]:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: ], code: BracketRight, keyIdentifier: U+007D, keyCode: 221, charCode: 0, keyCode: 221, which: 221, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: ], code: BracketRight, keyIdentifier: , keyCode: 93, charCode: 93, keyCode: 93, which: 93, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -292,7 +257,6 @@ Test Command + Shift + ;:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: ;, code: Semicolon, keyIdentifier: U+003A, keyCode: 186, charCode: 0, keyCode: 186, which: 186, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: ;, code: Semicolon, keyIdentifier: , keyCode: 59, charCode: 59, keyCode: 59, which: 59, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -300,7 +264,6 @@ Test Command + Shift + ':
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: ', code: Quote, keyIdentifier: U+0022, keyCode: 222, charCode: 0, keyCode: 222, which: 222, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: ', code: Quote, keyIdentifier: , keyCode: 39, charCode: 39, keyCode: 39, which: 39, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -308,7 +271,6 @@ Test Command + Shift + ,:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: ,, code: Comma, keyIdentifier: U+003C, keyCode: 188, charCode: 0, keyCode: 188, which: 188, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: ,, code: Comma, keyIdentifier: , keyCode: 44, charCode: 44, keyCode: 44, which: 44, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 
@@ -316,7 +278,6 @@ Test Command + Shift + .:
 type: keydown, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keydown, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 1, keyLocation: undefined
 type: keydown, key: ., code: Period, keyIdentifier: U+003E, keyCode: 190, charCode: 0, keyCode: 190, which: 190, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
-type: keypress, key: ., code: Period, keyIdentifier: , keyCode: 46, charCode: 46, keyCode: 46, which: 46, altKey: false, ctrlKey: false, metaKey: true, shiftKey: true, location: 0, keyLocation: undefined
 type: keyup, key: Shift, code: ShiftLeft, keyIdentifier: Shift, keyCode: 16, charCode: 0, keyCode: 16, which: 16, altKey: false, ctrlKey: false, metaKey: true, shiftKey: false, location: 1, keyLocation: undefined
 type: keyup, key: Meta, code: MetaLeft, keyIdentifier: Meta, keyCode: 91, charCode: 0, keyCode: 91, which: 91, altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, location: 1, keyLocation: undefined
 

--- a/LayoutTests/imported/w3c/web-platform-tests/uievents/keyboard/keypress-not-fired-for-modifier-shortcuts-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/uievents/keyboard/keypress-not-fired-for-modifier-shortcuts-expected.txt
@@ -1,0 +1,6 @@
+Target
+
+PASS keypress must not be dispatched for Control + v
+PASS keypress must not be dispatched for Meta + v
+PASS keypress must be dispatched for a plain key
+

--- a/LayoutTests/imported/w3c/web-platform-tests/uievents/keyboard/keypress-not-fired-for-modifier-shortcuts.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/uievents/keyboard/keypress-not-fired-for-modifier-shortcuts.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>UI Events Test: keypress not fired for modifier shortcuts</title>
+<link rel="author" title="Karl Dubost" href="https://otsukare.info/">
+<link rel="help" href="https://w3c.github.io/uievents/#keypress" />
+<meta name="assert" content="This test checks that keypress events are not fired when Control or Meta modifier keys are active, per the UI Events spec.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<div id="target" tabindex="0">Target</div>
+<script>
+  // WebDriver modifier key codes.
+  const CONTROL = '\uE009';
+  const META = '\uE03D';
+
+  const modifiers = {
+    "Control": CONTROL,
+    "Meta": META,
+  };
+
+  target.focus();
+
+  for (const [modName, modCode] of Object.entries(modifiers)) {
+    promise_test(() => {
+      let keypressFired = false;
+      return new Promise(resolve => {
+        function onKeypress() {
+          keypressFired = true;
+        }
+        function onKeyup(event) {
+          if (event.key !== modName) {
+            target.removeEventListener("keypress", onKeypress);
+            target.removeEventListener("keyup", onKeyup);
+            resolve(keypressFired);
+          }
+        }
+        target.addEventListener("keypress", onKeypress);
+        target.addEventListener("keyup", onKeyup);
+        test_driver.send_keys(target, modCode + 'v');
+      }).then((fired) => {
+        assert_false(fired, "keypress should not fire for " + modName + "+v");
+      });
+    }, `keypress must not be dispatched for ${modName} + v`);
+  }
+
+  promise_test(() => {
+    let keypressFired = false;
+    return new Promise(resolve => {
+      function onKeypress() {
+        keypressFired = true;
+      }
+      function onKeyup(event) {
+        target.removeEventListener("keypress", onKeypress);
+        target.removeEventListener("keyup", onKeyup);
+        resolve(keypressFired);
+      }
+      target.addEventListener("keypress", onKeypress);
+      target.addEventListener("keyup", onKeyup);
+      test_driver.send_keys(target, 'a');
+    }).then((fired) => {
+      assert_true(fired, "keypress should fire for plain 'a'");
+    });
+  }, `keypress must be dispatched for a plain key`);
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8499,3 +8499,4 @@ webkit.org/b/308849 css3/filters/effect-drop-shadow.html [ Skip ]
 
 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-audio-element/audio-with-replaced-after-pseudo-crash.html [ Skip ] #Timeout
 
+imported/w3c/web-platform-tests/uievents/keyboard/keypress-not-fired-for-modifier-shortcuts.html [ Skip ]

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -136,7 +136,7 @@ enum class SDKAlignedBehavior {
     NoFontFaceSetConstructor,
     NoHTMLEnhancedSelectParsingQuirk,
     DataURLForPastedImages,
-
+    SuppressKeypressForModifierShortcuts,
     NumberOfBehaviors
 };
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -182,6 +182,10 @@
 #include "PointerLockController.h"
 #endif
 
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(EventHandler);
@@ -4334,7 +4338,20 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
     // webkit.org/b/305666: Emojis appear as Chinese characters in Google Docs
     auto shouldAvoidDispatchingKeyPressEvent = [&] {
         auto text = keyPressEvent.text();
-        return !text.isEmpty() && !U_IS_BMP(text.characterStartingAt(0));
+        if (!text.isEmpty() && !U_IS_BMP(text.characterStartingAt(0)))
+            return true;
+
+        // Suppress keypress for command shortcuts (Cmd+key, Ctrl+key).
+        // https://w3c.github.io/uievents/#keypress
+        if (initialKeyEvent.metaKey() || initialKeyEvent.controlKey()) {
+#if PLATFORM(COCOA)
+            return linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::SuppressKeypressForModifierShortcuts);
+#else
+            return true;
+#endif
+        }
+
+        return false;
     };
 
     auto keypress = KeyboardEvent::create(keyPressEvent, &frame->windowProxy());


### PR DESCRIPTION
#### 6e8432fe7c28c46ed29b0862ff2987bf1777dd45
<pre>
Suppress keypress events for Meta+key and Ctrl+key shortcuts
<a href="https://bugs.webkit.org/show_bug.cgi?id=30397">https://bugs.webkit.org/show_bug.cgi?id=30397</a>
<a href="https://rdar.apple.com/4360235">rdar://4360235</a>

Reviewed by Ryosuke Niwa, Aditya Keerthi, and Abrar Rahman Protyasha.

Per the UI Events spec (<a href="https://w3c.github.io/uievents/#keypress)">https://w3c.github.io/uievents/#keypress)</a>, keypress
should only fire for keys that produce a character value. Safari was firing
keypress for modifier shortcuts like Cmd+C and Cmd+V, unlike Chrome and Firefox.

This caused a webcompat bug on tools.usps.com where pasting a ZIP code with
Cmd+V was blocked because the site&apos;s keypress handler saw charCode 118 (&apos;v&apos;),
treated it as a non-digit character, and called preventDefault().

Extend shouldAvoidDispatchingKeyPressEvent in EventHandler::internalKeyEvent to
suppress keypress dispatch when metaKey or controlKey is active. altKey is not
suppressed because Option+key produces characters (e.g. accents).

This is also gated for the future releases to avoid any breakages for
Cocoa applications with this change of behavior, which has existed for a long
time.

Test: imported/w3c/web-platform-tests/uievents/keyboard/keypress-not-fired-for-modifier-shortcuts.html

* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-control-expected.txt:
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-control-expected.txt:
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-expected.txt:
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-option-expected.txt:
* LayoutTests/fast/events/ios/key-events-comprehensive/key-events-meta-shift-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/uievents/keyboard/keypress-not-fired-for-modifier-shortcuts-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/uievents/keyboard/keypress-not-fired-for-modifier-shortcuts.html: Added.
* LayoutTests/platform/ios/TestExpectations:
  We are excluding the test from iOS for now because there are issues in
  the way send_keys() is (not) working on iOS. This should be fixed in a
  followup tests.

* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::internalKeyEvent):

Canonical link: <a href="https://commits.webkit.org/309300@main">https://commits.webkit.org/309300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cc0290e923970c5570861ce6b07173621c77e86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158965 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103685 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26d073c7-c2e9-4d1c-afb5-0a4003038a1e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23134 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115916 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82362 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2209289c-0e2b-4ce5-bead-0de6e5651f00) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96649 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/97b62ce7-994b-4ec6-9831-0f7dade9e00f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17129 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15074 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6810 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142234 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126744 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/12711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161439 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11049 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4567 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14263 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123917 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22811 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124122 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134506 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79152 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23096 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19246 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11263 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181682 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22411 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86211 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46494 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22125 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22277 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22179 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->