### PR TITLE
[DRAFT] Invalidate old repaint rects when layer transitions from visible descendants to fully hidden

### DIFF
--- a/LayoutTests/compositing/repaint/visibility-hidden-child-becomes-hidden-expected.txt
+++ b/LayoutTests/compositing/repaint/visibility-hidden-child-becomes-hidden-expected.txt
@@ -1,0 +1,4 @@
+This text should be repainted away
+(repaint rects
+  (rect 8 13 100 100)
+)

--- a/LayoutTests/compositing/repaint/visibility-hidden-child-becomes-hidden.html
+++ b/LayoutTests/compositing/repaint/visibility-hidden-child-becomes-hidden.html
@@ -1,0 +1,42 @@
+<!doctype HTML>
+<html>
+
+  <div id=parent style="visibility:hidden; position:absolute; transform: translateX(0px)">
+    <div id=child style="visibility:visible; width: 100px; height: 100px; background: green; position:relative">This text should be repainted away</div>
+  </div>
+
+<pre id=result></pre>
+
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function timerAfterRAF(callback) {
+    return requestAnimationFrame(() => setTimeout(callback, 0));
+}
+
+function runTest() {
+    // First ensure the child is rendered visible.
+    timerAfterRAF(() => {
+        // Now hide the child and track repaints for the transition.
+        if (window.internals)
+            internals.startTrackingRepaints();
+
+        child.style.visibility = 'hidden';
+
+        timerAfterRAF(() => {
+            if (window.internals) {
+                result.innerText = internals.repaintRectsAsText();
+                internals.stopTrackingRepaints();
+            }
+            if (window.testRunner)
+                testRunner.notifyDone();
+        });
+    });
+}
+
+window.addEventListener('load', () => {
+    timerAfterRAF(runTest);
+}, false);

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1315,6 +1315,13 @@ void RenderLayer::recursiveUpdateLayerPositions(OptionSet<UpdateLayerPositionsFl
             auto needsFullRepaint = repaintStatus() == RepaintStatus::NeedsFullRepaint ? RequiresFullRepaint::Yes : RequiresFullRepaint::No;
             auto resolvedOldRects = valueOrDefault(oldRects);
             renderer().repaintAfterLayoutIfNeeded(WTF::move(repaintContainer), needsFullRepaint, resolvedOldRects, *newRects);
+        } else if (checkForRepaint && shouldRepaintAfterLayout() && oldRects && !newRects) {
+            // The layer transitioned from having tracked repaint rects to being fully hidden
+            // (isSubtreeVisibilityHiddenOrOpacityZero() now returns true). This happens when a
+            // visibility:hidden layer had visible descendant layers that subsequently became hidden.
+            // Invalidate the old region to clear visual artifacts from previously-visible content.
+            if (!oldRects->clippedOverflowRect.isEmpty())
+                renderer().repaintUsingContainer(repaintContainer.get(), oldRects->clippedOverflowRect);
         }
     };
 


### PR DESCRIPTION
#### 90c5f7d80d1dda011b7bc8d7e14866bf72cf79e9
<pre>
Invalidate old repaint rects when layer transitions from visible descendants to fully hidden
<a href="https://bugs.webkit.org/show_bug.cgi?id=XXXXX">https://bugs.webkit.org/show_bug.cgi?id=XXXXX</a>
<a href="https://rdar.apple.com/169112402">rdar://169112402</a>

Reviewed by NOBODY (OOPS!).

Commit 4d0d8131db61 changed computeRepaintRects() to use
isSubtreeVisibilityHiddenOrOpacityZero() instead of isVisibilityHiddenOrOpacityZero().
This correctly allows visibility:hidden layers with visible descendant layers to
track repaint rects. However, when those descendants subsequently become hidden, the
layer&apos;s repaint rects transition from valid to nullopt and the repaintIfNecessary
lambda&apos;s `&amp;&amp; newRects` check skips repaintAfterLayoutIfNeeded entirely, leaving the
previously-visible area uninvalidated.

Fix by adding an else-if branch that invalidates the old clipped overflow rect when
the layer transitions from having tracked repaint rects to being fully hidden.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::recursiveUpdateLayerPositions):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90c5f7d80d1dda011b7bc8d7e14866bf72cf79e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158505 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103231 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/276b670e-ad7f-4f9e-8cd5-9a7da807d922) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151672 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22618 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115547 "Found 2 new test failures: compositing/repaint/repaint-on-layer-grouping-change.html compositing/repaint/visibility-hidden-child-becomes-hidden.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82127 "4 flakes 1 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5e8b4a09-b4bb-4c38-86c9-302ecd9de892) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152759 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17667 "Found 2 new test failures: compositing/repaint/repaint-on-layer-grouping-change.html compositing/repaint/visibility-hidden-child-becomes-hidden.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134414 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96287 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e4ec2200-0ea7-48c7-9ac1-375a1c7790ae) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16764 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14690 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6350 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160981 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4065 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13887 "Found 1 new test failure: compositing/repaint/visibility-hidden-child-becomes-hidden.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123567 "Found 2 new test failures: compositing/repaint/repaint-on-layer-grouping-change.html compositing/repaint/visibility-hidden-child-becomes-hidden.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22320 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18732 "Found 1 new test failure: compositing/repaint/visibility-hidden-child-becomes-hidden.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123772 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22327 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134138 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78552 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18932 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10889 "Found 1 new test failure: compositing/repaint/visibility-hidden-child-becomes-hidden.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21928 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85748 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21658 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21810 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21715 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->