### PR TITLE
REGRESSION(308321@main): [macOS] 2x http/tests/site-isolation/accessibility/hit-test-X-remote-frame.html are constant text failures

### DIFF
--- a/LayoutTests/http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame.html
@@ -1,4 +1,4 @@
-<html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<html><!-- webkit-test-runner [ SiteIsolationEnabled=true runSingly=true ] -->
 <head>
 <script src="/js-test-resources/js-test.js"></script>
 <style>

--- a/LayoutTests/http/tests/site-isolation/accessibility/hit-test-returns-remote-frame.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/hit-test-returns-remote-frame.html
@@ -1,4 +1,4 @@
-<html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<html><!-- webkit-test-runner [ SiteIsolationEnabled=true runSingly=true ] -->
 <head>
 <script src="/js-test-resources/js-test.js"></script>
 <style>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2476,10 +2476,6 @@ webkit.org/b/309525 [ Release ] media/video-webkit-playsinline.html [ Pass Failu
 
 webkit.org/b/307889 http/tests/multipart/multipart-async-image.html [ Pass Failure ]
 
-# webkit.org/b/309308 2x http/tests/site-isolation/accessibility/hit-test-X-remote-frame.html are constant text failures
-http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame.html [ Failure ]
-http/tests/site-isolation/accessibility/hit-test-returns-remote-frame.html [ Failure ]
-
 webkit.org/b/308240 http/tests/site-isolation/inspector/runtime/evaluate-in-cross-origin-iframe.html [ Failure ]
 webkit.org/b/308240 http/tests/site-isolation/inspector/runtime/execution-context-from-frame-target.html [ Failure ]
 webkit.org/b/308240 http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target.html [ Failure ]


### PR DESCRIPTION
#### 7b460ab4b1f882048c01961174c08b6ea98637f5
<pre>
REGRESSION(308321@main): [macOS] 2x http/tests/site-isolation/accessibility/hit-test-X-remote-frame.html are constant text failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=309308">https://bugs.webkit.org/show_bug.cgi?id=309308</a>
<a href="https://rdar.apple.com/171850134">rdar://171850134</a>

Reviewed by Tyler Wilcock.

These tests pass now (likely after the FrameGeometry changes in 308698@main).

* LayoutTests/http/tests/site-isolation/accessibility/hit-test-resolving-remote-frame.html:
* LayoutTests/http/tests/site-isolation/accessibility/hit-test-returns-remote-frame.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/309208@main">https://commits.webkit.org/309208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf0c52d16ac747ffc448cb2a2cb903ccf352647d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22525 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158512 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103238 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115554 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82130 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96294 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16782 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14694 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6357 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126389 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12348 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160988 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13890 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123569 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123774 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33632 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134141 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78559 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18934 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10892 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21935 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21665 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21817 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21722 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->