### PR TITLE
Move pointer-events to fast-path inherited properties

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7770,7 +7770,8 @@
                 "computed-style-storage-container": "struct",
                 "computed-style-storage-kind": "enum",
                 "computed-style-type": "PointerEvents",
-                "parser-grammar": "<<values>>"
+                "parser-grammar": "<<values>>",
+                "fast-path-inherited": true
             },
             "specification": {
                 "category": "svg",

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -94,6 +94,7 @@ void ComputedStyle::fastPathInheritFrom(const ComputedStyle& inheritParent)
     // FIXME: Use this mechanism for other properties too, like variables.
     m_inheritedFlags.visibility = inheritParent.m_inheritedFlags.visibility;
     m_inheritedFlags.hasExplicitlySetColor = inheritParent.m_inheritedFlags.hasExplicitlySetColor;
+    m_inheritedFlags.pointerEvents = inheritParent.m_inheritedFlags.pointerEvents;
 
     if (m_inheritedData.ptr() != inheritParent.m_inheritedData.ptr()) {
         if (m_inheritedData->nonFastPathInheritedEqual(*inheritParent.m_inheritedData)) {
@@ -159,6 +160,8 @@ bool ComputedStyle::fastPathInheritedEqual(const ComputedStyle& other) const
         return false;
     if (m_inheritedFlags.hasExplicitlySetColor != other.m_inheritedFlags.hasExplicitlySetColor)
         return false;
+    if (m_inheritedFlags.pointerEvents != other.m_inheritedFlags.pointerEvents)
+        return false;
     if (m_inheritedData.ptr() == other.m_inheritedData.ptr())
         return true;
     return m_inheritedData->fastPathInheritedEqual(*other.m_inheritedData);
@@ -169,6 +172,7 @@ bool ComputedStyle::nonFastPathInheritedEqual(const ComputedStyle& other) const
     auto withoutFastPathFlags = [](auto flags) {
         flags.visibility = { };
         flags.hasExplicitlySetColor = { };
+        flags.pointerEvents = { };
         return flags;
     };
     if (withoutFastPathFlags(m_inheritedFlags) != withoutFastPathFlags(other.m_inheritedFlags))


### PR DESCRIPTION
#### 8c8e6ff5a697f2acf931268b7a47534529cc2f5c
<pre>
Move pointer-events to fast-path inherited properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=309851">https://bugs.webkit.org/show_bug.cgi?id=309851</a>
<a href="https://rdar.apple.com/172426982">rdar://172426982</a>

Reviewed by NOBODY (OOPS!).

When pointer-events changes on a parent element (like during a
mousedown on GitHub&apos;s resize bar in the file list), WebKit treats it as a
Change::Inherited, triggering full style resolution for all
children. But pointer-events is an inherited enum that can
be propagated by copying the value from the parent, the same way
visibility and color already work.

Add pointer-events to the fast-path inherited property set. Mark
it as fast-path-inherited in CSSProperties.json. Add it to
fastPathInheritFrom(), fastPathInheritedEqual(), and exclude it
from nonFastPathInheritedEqual() so changes produce
Change::FastPathInherited instead of Change::Inherited. This
allows children to use the fast-path inherit resolution type
(clone and copy) instead of full style resolution.

This is safe because pointer-events does not affect the computed
value of any other property. Changing pointer-events on a parent only
changes pointer-events on children that inherit it, and the
fast-path copies that value directly.

This improves real world site performance.

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
(WebCore::Style::ComputedStyle::fastPathInheritFrom):
(WebCore::Style::ComputedStyle::fastPathInheritedEqual const):
(WebCore::Style::ComputedStyle::nonFastPathInheritedEqual const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c8e6ff5a697f2acf931268b7a47534529cc2f5c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22535 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158522 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103248 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/726511a1-5c7d-4f3a-b28c-68f17e245874) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115560 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82180 "4 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134430 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96300 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6bec8523-7a65-4c77-9d69-45219103b367) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16775 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14703 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6367 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160998 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4082 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123577 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123782 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134154 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78569 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18939 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10905 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21945 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85765 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21675 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21827 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21732 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->