### PR TITLE
[Claude PR][RemoteLayerTree] Eagerly send DisplayDidRefresh after layer tree commit

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -431,11 +431,12 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
 
     {
         ProcessState& state = processStateForConnection(connection);
-        if (state.canSendDisplayDidRefresh(*this) && completedCommit.delayState == CommitDelayState::Delayed) {
-            LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree - sending missed didRefreshDisplay");
+        if (state.canSendDisplayDidRefresh(*this)) {
+            // Eagerly send DisplayDidRefresh immediately after processing the commit rather
+            // than waiting for the next vsync tick (~4ms at 120Hz, ~8ms at 60Hz). This
+            // eliminates the idle mach_msg wait in the WebContent main thread.
+            LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree - eagerly sending displayDidRefresh after commit");
             didRefreshDisplay(&connection);
-        } else if (!state.pendingCommits.size()) {
-            LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree all pending commits received, waiting for display did refresh");
         }
         if (completedCommit.delayState != CommitDelayState::Delayed && state.delayedCommits)
             state.delayedCommits--;
@@ -772,7 +773,7 @@ bool ProcessState::canSendDisplayDidRefresh(RemoteLayerTreeDrawingAreaProxy& dra
     if (pendingCommits.size() >= 2)
         return false;
     if (pendingCommits.size() == 1)
-        return drawingArea.allowMultipleCommitLayerTreePending() && pendingCommits[0].pendingMessage == PendingCommitMessage::CommitLayerTree && delayedCommits >= 4;
+        return drawingArea.allowMultipleCommitLayerTreePending() && pendingCommits[0].pendingMessage == PendingCommitMessage::CommitLayerTree && delayedCommits >= 1;
     return true;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -459,10 +459,12 @@ void RemoteLayerTreeDrawingArea::displayDidRefresh(MonotonicTime start)
     }
 
     if (m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap || (m_isScheduled && !m_scheduleRenderingTimer.isActive())) {
-        m_updateStartTime = start;
-        triggerRenderingUpdate();
+        // Clear deferred flags before calling updateRendering() directly, avoiding an extra
+        // runloop wakeup that startRenderingUpdateTimer() would otherwise incur via a 0ms timer.
         m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = false;
         m_isScheduled = false;
+        m_updateStartTime = start;
+        updateRendering();
     } else if (wasWaitingForBackingStoreSwap && m_updateRenderingTimer.isActive())
         m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap = true;
     else


### PR DESCRIPTION
#### a7f5062baac43405dbc5770ee8f7b3b3be2a8902
<pre>
[Claude PR][RemoteLayerTree] Eagerly send DisplayDidRefresh after layer tree commit

Instead of waiting for the next vsync tick after processing a layer tree commit,
send DisplayDidRefresh immediately.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7f5062baac43405dbc5770ee8f7b3b3be2a8902

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149819 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103251 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c1c290cd-ef04-4f0e-8019-3c040b5e1c1f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22988 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115563 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82141 "7 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152779 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17681 "Found 23 new test failures: animations/no-style-recalc-during-accelerated-animation.html animations/steps-transform-rendering-updates.html compositing/cocoa/clip-fixed-element-to-viewport.html compositing/cocoa/clip-nested-sticky-elements.html compositing/ios/clip-nested-fixed-in-sticky-container.html compositing/ios/immediate-scrolling-clip-fixed-element-to-viewport.html compositing/ios/immediate-scrolling-clip-sticky-element-to-viewport.html css3/masking/reference-clip-path-animate-transform-repaint.html editing/deleting/ios/no-autoshift-after-deleting-character-in-word.html editing/editable-region/hit-test-fixed.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134431 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.DragSourceEndedAtCoordinateTransformation (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96303 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe67a254-adba-478e-b032-139e9d55e52b) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16778 "Found 6 new test failures: imported/w3c/web-platform-tests/css/css-animations/event-dispatch.tentative.html imported/w3c/web-platform-tests/css/css-view-transitions/reset-state-after-scrolled-view-transition.html imported/w3c/web-platform-tests/css/cssom-view/scroll-behavior-main-frame-window.html imported/w3c/web-platform-tests/intersection-observer/grow-height-and-scrolled.html imported/w3c/web-platform-tests/scroll-to-text-fragment/percent-encoding.html imported/w3c/web-platform-tests/web-animations/timing-model/timelines/update-and-send-events.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14704 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6370 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126385 "Found 4 new API test failures: TestWebKitAPI.UnifiedPDF.BackgroundAdaptsToColorScheme, TestWebKitAPI.EditorStateTests.SelectedTextRange_CaretSelectionWithZoom, TestWebKitAPI.ScrollViewScrollabilityTests.ScrollableWithOverflowHiddenWhenZoomed, TestWebKitAPI.VisualViewport.RotationResize (failure)") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161001 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4085 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13904 "Found 9 new test failures: animations/no-style-recalc-during-accelerated-animation.html animations/steps-transform-rendering-updates.html css3/masking/reference-clip-path-animate-transform-repaint.html fast/scrolling/mac/stateless-user-scroll-scrollend.html imported/w3c/web-platform-tests/css/css-animations/event-dispatch.tentative.html imported/w3c/web-platform-tests/uievents/mouse/synthetic-mouse-enter-leave-over-out-button-state-after-target-removed.tentative.html?buttonType=LEFT&button=0&buttons=1 imported/w3c/web-platform-tests/uievents/mouse/synthetic-mouse-enter-leave-over-out-button-state-after-target-removed.tentative.html?buttonType=MIDDLE&button=1&buttons=4 imported/w3c/web-platform-tests/web-animations/timing-model/timelines/update-and-send-events.html svg/animations/css-animation-hover-svg.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123578 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22340 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18746 "Found 4 new test failures: animations/no-style-recalc-during-accelerated-animation.html fast/animation/request-animation-frame-throttling-lowPowerMode.html imported/w3c/web-platform-tests/css/css-overflow/overflow-auto-scrolling-with-margin-and-transform.html imported/w3c/web-platform-tests/import-maps/bare-specifiers.sub.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123783 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134155 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78572 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18944 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10906 "Found 10 new test failures: animations/no-style-recalc-during-accelerated-animation.html animations/steps-transform-rendering-updates.html css3/masking/reference-clip-path-animate-transform-repaint.html fast/scrolling/mac/stateless-user-scroll-scrollend.html imported/w3c/web-platform-tests/css/css-animations/event-dispatch.tentative.html imported/w3c/web-platform-tests/uievents/mouse/synthetic-mouse-enter-leave-over-out-button-state-after-target-removed.tentative.html?buttonType=LEFT&button=0&buttons=1 imported/w3c/web-platform-tests/uievents/mouse/synthetic-mouse-enter-leave-over-out-button-state-after-target-removed.tentative.html?buttonType=MIDDLE&button=1&buttons=4 svg/animations/css-animation-hover-svg.html svg/compositing/transform-change-repainting-no-viewBox.html webanimations/accelerated-animation-slot-invalidation.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21948 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85768 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21678 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21830 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21735 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->