### PR TITLE
[JSC] DFG strength reduction should not clobber lastIndex found via SetRegExpObjectLastIndex

### DIFF
--- a/JSTests/stress/dfg-strength-reduction-regexp-new-regexp-last-index-overwrite.js
+++ b/JSTests/stress/dfg-strength-reduction-regexp-new-regexp-last-index-overwrite.js
@@ -1,0 +1,60 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+noInline(shouldBe);
+
+// DFG strength reduction folds RegExpTest/RegExpExec when the RegExp object
+// comes from a NewRegExp node and the input string is constant. It scans
+// backwards to find the most recent SetRegExpObjectLastIndex in the same block.
+// It must not then clobber that discovered value with NewRegExp's initial
+// lastIndex (which is always 0).
+
+function testGlobal() {
+    var re = /a/g;
+    re.lastIndex = 1;
+    // "a".length === 1, so searching from index 1 must fail.
+    return re.test("a");
+}
+noInline(testGlobal);
+
+function testSticky() {
+    var re = /a/y;
+    re.lastIndex = 1;
+    // sticky: must match exactly at index 1, which is out of bounds.
+    return re.test("a");
+}
+noInline(testSticky);
+
+function testExecGlobal() {
+    var re = /a/g;
+    re.lastIndex = 2;
+    // "xa".length === 2, searching from index 2 must return null.
+    return re.exec("xa");
+}
+noInline(testExecGlobal);
+
+function testStickyMidString() {
+    var re = /a/y;
+    re.lastIndex = 1;
+    // index 1 is "b", sticky fails there.
+    return re.test("ab");
+}
+noInline(testStickyMidString);
+
+function testGlobalLastIndexUpdated() {
+    var re = /a/g;
+    re.lastIndex = 1;
+    re.test("aa"); // matches at index 1
+    // lastIndex should be advanced to 2 (end of match), not 1 (end of match from 0).
+    return re.lastIndex;
+}
+noInline(testGlobalLastIndexUpdated);
+
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBe(testGlobal(), false);
+    shouldBe(testSticky(), false);
+    shouldBe(testExecGlobal(), null);
+    shouldBe(testStickyMidString(), false);
+    shouldBe(testGlobalLastIndexUpdated(), 2);
+}

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -822,7 +822,11 @@ private:
                     if (otherNode == regExpObjectNode) {
                         if (regExpObjectNodeIsConstant)
                             break;
-                        lastIndex = 0;
+                        // NewRegExp's child1 is the initial lastIndex. Bytecode emits it as 0, but
+                        // ObjectAllocationSinking materializes it with the tracked lastIndex value.
+                        ASSERT(regExpObjectNode->op() == NewRegExp);
+                        if (regExpObjectNode->child1()->isInt32Constant() && regExpObjectNode->child1()->asInt32() >= 0)
+                            lastIndex = regExpObjectNode->child1()->asUInt32();
                         break;
                     }
                     if (otherNode->op() == SetRegExpObjectLastIndex
@@ -916,9 +920,6 @@ private:
                 m_graph.registerStructure(structure);
 
                 FrozenValue* globalObjectFrozenValue = m_graph.freeze(globalObject);
-
-                if (regExpObjectNode && regExpObjectNode->op() == NewRegExp && regExpObjectNode->child1()->isInt32Constant())
-                    lastIndex = regExpObjectNode->child1()->asUInt32();
 
                 MatchResult result;
                 Vector<int> ovector(regExp->offsetVectorSize());


### PR DESCRIPTION
#### a3789656ce600631840823d5ead9f48fc8ea0773
<pre>
[JSC] DFG strength reduction should not clobber lastIndex found via SetRegExpObjectLastIndex
<a href="https://bugs.webkit.org/show_bug.cgi?id=309857">https://bugs.webkit.org/show_bug.cgi?id=309857</a>

Reviewed by Yusuke Suzuki.

When folding RegExpExec/RegExpTest to a constant, DFG strength reduction
performs a backward scan to discover the lastIndex value at the point of
the operation. If it finds a SetRegExpObjectLastIndex node, it correctly
picks up that value.

However, after the scan, the old code would unconditionally overwrite
lastIndex with NewRegExp&apos;s child1 constant. This destroyed the value
discovered by the scan, causing the fold to use lastIndex=0 even when
the program had assigned a different value.

    var re = /a/g;
    re.lastIndex = 1;
    re.test(&quot;a&quot;); // noDFG: false, DFG/FTL: true

The overwrite existed to correct a different problem: the backward scan
hardcoded lastIndex=0 when reaching the NewRegExp node itself, which is
wrong after ObjectAllocationSinking. That phase materializes NewRegExp
with child1 set to the tracked lastIndex value, not necessarily 0.

Fix by reading child1 at the point where the scan reaches NewRegExp,
instead of hardcoding 0 and correcting it later.

Test: JSTests/stress/dfg-strength-reduction-regexp-new-regexp-last-index-overwrite.js

* JSTests/stress/dfg-strength-reduction-regexp-new-regexp-last-index-overwrite.js: Added.
(shouldBe):
(testGlobal):
(testSticky):
(testExecGlobal):
(testStickyMidString):
(testGlobalLastIndexUpdated):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):

Canonical link: <a href="https://commits.webkit.org/309179@main">https://commits.webkit.org/309179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e30a67f261be7e9abc8fd19670c5b28fc84ece43

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16124 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158529 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115565 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17684 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134433 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96305 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6374 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141799 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161005 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10617 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4089 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123581 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22344 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/18750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123786 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33613 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134157 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78576 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18947 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/10908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181252 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21952 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85772 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46410 "Found 1 new JSC stress test failure: Too many failures: 28843 jsc tests failed (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21682 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21834 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21739 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->