### PR TITLE
[Swift in WebKit] Use `if let` and `guard let` in CommandEncoder.swift now that it no longer causes a compiler crash

### DIFF
--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -1196,8 +1196,7 @@ extension WebGPU.CommandEncoder {
                 mtlAttachment.level = 0
                 mtlAttachment.slice = 0
                 var depthSliceOrArrayLayer: UInt64 = 0
-                // FIMXE: (rdar://170907318) This should be changed to `if let` when possible.
-                if var depthSlice = Optional(fromCxx: attachment.depthSlice) {
+                if let depthSlice = Optional(fromCxx: attachment.depthSlice) {
                     if !texture.is3DTexture() {
                         return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "depthSlice specified on 2D texture")
                     }
@@ -1255,8 +1254,7 @@ extension WebGPU.CommandEncoder {
                     }
                     resolveTarget.setCommandEncoder(self)
                     let resolveTexture = resolveTarget.texture()
-                    // FIMXE: (rdar://170907318) This should be changed to `guard let` when possible.
-                    guard var resolveTexture, var mtlTexture else {
+                    guard let resolveTexture, let mtlTexture else {
                         return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "resolveTexture/mtlTexture is nil")
                     }
 
@@ -1285,18 +1283,15 @@ extension WebGPU.CommandEncoder {
                     compositorTextureSlice = compositorTexture.parentRelativeSlice()
                 }
 
-                // FIMXE: (rdar://170907318) This should be changed to `if let` when possible.
-                if var textureToClear {
+                if let textureToClear {
                     let textureWithResolve = TextureAndClearColor(texture: textureToClear)
                     attachmentsToClear[i as NSNumber] = textureWithResolve
                     texture.setPreviouslyCleared()
-                    // FIMXE: (rdar://170907318) This should be changed to `if let` when possible.
-                    if var resolveTarget = attachment.resolveTarget {
+                    if let resolveTarget = attachment.resolveTarget {
                         // FIXME: rdar://138042799 remove default argument.
                         WebGPU.fromAPI(resolveTarget).setPreviouslyCleared(0, 0)
                     }
-                    // FIMXE: (rdar://170907318) This should be changed to `if let` when possible.
-                    if var resolveTexture = attachment.resolveTexture {
+                    if let resolveTexture = attachment.resolveTexture {
                         WebGPU.fromAPI(resolveTexture).setPreviouslyCleared()
                     }
                 }
@@ -1386,8 +1381,7 @@ extension WebGPU.CommandEncoder {
             }
 
             if zeroColorTargets {
-                // FIMXE: (rdar://170907318) This should be changed to `guard let` when possible.
-                guard var metalDepthStencilTexture, metalDepthStencilTexture.sampleCount > 0 else {
+                guard let metalDepthStencilTexture, metalDepthStencilTexture.sampleCount > 0 else {
                     return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "no color targets and depth-stencil texture is nil")
                 }
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -1196,8 +1196,7 @@ extension WebGPU.CommandEncoder {
                 mtlAttachment.level = 0
                 mtlAttachment.slice = 0
                 var depthSliceOrArrayLayer: UInt64 = 0
-                // FIMXE: (rdar://170907318) This should be changed to `if let` when possible.
-                if var depthSlice = Optional(fromCxx: attachment.depthSlice) {
+                if let depthSlice = Optional(fromCxx: attachment.depthSlice) {
                     if !texture.is3DTexture() {
                         return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "depthSlice specified on 2D texture")
                     }
@@ -1258,8 +1257,7 @@ extension WebGPU.CommandEncoder {
                     }
                     resolveTarget.setCommandEncoder(self)
                     let resolveTexture = resolveTarget.texture()
-                    // FIMXE: (rdar://170907318) This should be changed to `guard let` when possible.
-                    guard var resolveTexture, var mtlTexture else {
+                    guard let resolveTexture, let mtlTexture else {
                         return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "resolveTexture/mtlTexture is nil")
                     }
 
@@ -1288,18 +1286,15 @@ extension WebGPU.CommandEncoder {
                     compositorTextureSlice = compositorTexture.parentRelativeSlice()
                 }
 
-                // FIMXE: (rdar://170907318) This should be changed to `if let` when possible.
-                if var textureToClear {
+                if let textureToClear {
                     let textureWithResolve = TextureAndClearColor(texture: textureToClear)
                     attachmentsToClear[i as NSNumber] = textureWithResolve
                     texture.setPreviouslyCleared()
-                    // FIMXE: (rdar://170907318) This should be changed to `if let` when possible.
-                    if var resolveTarget = attachment.resolveTarget {
+                    if let resolveTarget = attachment.resolveTarget {
                         // FIXME: rdar://138042799 remove default argument.
                         WebGPU.fromAPI(resolveTarget).setPreviouslyCleared(0, 0)
                     }
-                    // FIMXE: (rdar://170907318) This should be changed to `if let` when possible.
-                    if var resolveTexture = attachment.resolveTexture {
+                    if let resolveTexture = attachment.resolveTexture {
                         WebGPU.fromAPI(resolveTexture).setPreviouslyCleared()
                     }
                 }
@@ -1389,8 +1384,7 @@ extension WebGPU.CommandEncoder {
             }
 
             if zeroColorTargets {
-                // FIMXE: (rdar://170907318) This should be changed to `guard let` when possible.
-                guard var metalDepthStencilTexture, metalDepthStencilTexture.sampleCount > 0 else {
+                guard let metalDepthStencilTexture, metalDepthStencilTexture.sampleCount > 0 else {
                     return WebGPU.RenderPassEncoder.createInvalid(self, m_device.ptr(), "no color targets and depth-stencil texture is nil")
                 }
 


### PR DESCRIPTION
#### ea3f4245aa4c26b9fb1bc6fa67cbff8ea7882daf
<pre>
[Swift in WebKit] Use `if let` and `guard let` in CommandEncoder.swift now that it no longer causes a compiler crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=309862">https://bugs.webkit.org/show_bug.cgi?id=309862</a>
<a href="https://rdar.apple.com/172438993">rdar://172438993</a>

Reviewed by NOBODY (OOPS!).

The bug that prevented this has since been fixed.

* Source/WebGPU/WebGPU/CommandEncoder.swift:
(WebGPU.beginRenderPass(_:)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea3f4245aa4c26b9fb1bc6fa67cbff8ea7882daf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164213 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30916 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173242 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121465 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/91feaaeb-984b-4db4-acd7-6405d4a329ea) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38031 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37697 "Hash ea3f4245 for PR 60533 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127574 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89758 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/62f50285-ee59-4eb0-9557-45f86557439a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147614 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108122 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/585f6a93-a84d-4760-9004-0d37bcffa604) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28918 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/37697 "Hash ea3f4245 for PR 60533 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21006 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138820 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175768 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28589 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26999 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135885 "Passed tests") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37367 "Hash ea3f4245 for PR 60533 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/37697 "Hash ea3f4245 for PR 60533 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135855 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147126 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100464 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31166 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23982 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36963 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110008 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36360 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2037 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36610 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36510 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->