### PR TITLE
[YARR] Greedy/non-greedy non-BMP character class should not advance index past end-of-input

### DIFF
--- a/JSTests/stress/regexp-unicode-nonbmp-fixed-width-charclass-index-overshoot.js
+++ b/JSTests/stress/regexp-unicode-nonbmp-fixed-width-charclass-index-overshoot.js
@@ -1,0 +1,74 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`FAIL: ${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function shouldBeArray(actual, expected, msg) {
+    if (actual === null || expected === null) {
+        if (actual !== expected)
+            throw new Error(`FAIL: ${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+        return;
+    }
+    if (actual.length !== expected.length)
+        throw new Error(`FAIL: ${msg}: length mismatch: expected ${expected.length}, got ${actual.length}`);
+    for (let i = 0; i < expected.length; i++) {
+        if (actual[i] !== expected[i])
+            throw new Error(`FAIL: ${msg}: index ${i}: expected ${JSON.stringify(expected[i])}, got ${JSON.stringify(actual[i])}`);
+    }
+}
+
+let emoji = "\u{1F600}";
+let emoji2 = "\u{1F601}";
+let emoji3 = "\u{1F602}";
+
+function makeSubstring(codeUnits, sliceLength) {
+    let parent = String.fromCharCode(...codeUnits);
+    return parent.slice(0, sliceLength);
+}
+
+let slice1A = makeSubstring([0xD83D, 0xDE00, 0x41], 2);
+let slice1X = makeSubstring([0xD83D, 0xDE00, 0x58], 2);
+let slice2Q = makeSubstring([0xD83D, 0xDE00, 0xD83D, 0xDE01, 0x51], 4);
+let slice3Z = makeSubstring([0xD83D, 0xDE00, 0xD83D, 0xDE01, 0xD83D, 0xDE02, 0x5A], 6);
+
+let full1A = emoji + "A";
+let full2Q = emoji + emoji2 + "Q";
+let full3Z = emoji + emoji2 + emoji3 + "Z";
+
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBe(/[\u{1F600}-\u{1F64F}]*A/u.exec(slice1A), null, "Greedy* range 1x slice");
+    shouldBe(/[\u{1F600}-\u{1F64F}]*Z/u.exec(slice3Z), null, "Greedy* range 3x slice");
+    shouldBe(/[\u{1F600}]*X/u.exec(slice1X), null, "Greedy* single-char-class slice");
+    shouldBe(/[\u{1F600}-\u{1F64F}]+A/u.exec(slice1A), null, "Greedy+ range slice");
+    shouldBe(/[\u{1F600}-\u{1F64F}]{1,3}A/u.exec(slice1A), null, "Greedy{1,3} range slice");
+    shouldBe(/[\u{1F600}-\u{1F64F}]{0,5}Z/u.exec(slice3Z), null, "Greedy{0,5} range 3x slice");
+
+    shouldBe(/[\u{1F600}-\u{1F64F}]*?Q/u.exec(slice2Q), null, "NonGreedy*? range 2x slice");
+    shouldBe(/[\u{1F600}-\u{1F64F}]+?Q/u.exec(slice2Q), null, "NonGreedy+? range 2x slice");
+    shouldBe(/[\u{1F600}]*?X/u.exec(slice1X), null, "NonGreedy*? single-char-class slice");
+
+    shouldBe(/[\u{1F600}-\u{1F64F}]*A/v.exec(slice1A), null, "Greedy* range slice /v flag");
+    shouldBe(/[\u{1F600}-\u{1F64F}]*?Q/v.exec(slice2Q), null, "NonGreedy*? range slice /v flag");
+
+    shouldBe(/[a\u{1F600}]*A/u.exec(slice1A), null, "mixed-width class Greedy (slow path)");
+    shouldBe(/[a\u{1F600}]*?Q/u.exec(slice2Q), null, "mixed-width class NonGreedy (slow path)");
+    shouldBe(/[^a-z]*A/u.exec(slice1A), null, "inverted class Greedy (slow path)");
+
+    shouldBeArray(/[\u{1F600}-\u{1F64F}]*A/u.exec(full1A), [emoji + "A"], "Greedy* full input match");
+    shouldBeArray(/[\u{1F600}-\u{1F64F}]*Z/u.exec(full3Z), [emoji + emoji2 + emoji3 + "Z"], "Greedy* 3x full input match");
+    shouldBeArray(/[\u{1F600}-\u{1F64F}]*/u.exec(emoji + emoji2), [emoji + emoji2], "Greedy* 2x no trailing");
+    shouldBeArray(/[\u{1F600}-\u{1F64F}]*/u.exec(emoji + emoji2 + emoji3), [emoji + emoji2 + emoji3], "Greedy* 3x no trailing");
+    shouldBeArray(/[\u{1F600}-\u{1F64F}]+A/u.exec(full1A), [emoji + "A"], "Greedy+ full input match");
+    shouldBeArray(/[\u{1F600}-\u{1F64F}]{1,3}Z/u.exec(full3Z), [emoji + emoji2 + emoji3 + "Z"], "Greedy{1,3} full input match");
+    shouldBeArray(/[\u{1F600}-\u{1F64F}]*?Q/u.exec(full2Q), [emoji + emoji2 + "Q"], "NonGreedy*? full input match");
+    shouldBeArray(/[\u{1F600}-\u{1F64F}]*?$/u.exec(emoji + emoji2), [emoji + emoji2], "NonGreedy*? anchor 2x");
+    shouldBeArray(/[\u{1F600}-\u{1F64F}]+?$/u.exec(emoji + emoji2 + emoji3), [emoji + emoji2 + emoji3], "NonGreedy+? anchor 3x");
+
+    shouldBeArray(/[\u{1F600}-\u{1F64F}]*/u.exec(emoji + "B"), [emoji], "Greedy* stop at BMP");
+    shouldBeArray(/[\u{1F600}-\u{1F64F}]*B/u.exec(emoji + "B"), [emoji + "B"], "Greedy* + trailing BMP");
+    shouldBe(/[\u{1F600}-\u{1F64F}]*C/u.exec(emoji + "B"), null, "Greedy* + trailing BMP mismatch");
+
+    shouldBeArray(/[\u{1F600}]*$/u.exec(emoji), [emoji], "Greedy* end anchor 1x");
+    shouldBeArray(/[\u{1F600}]*$/u.exec(emoji + emoji), [emoji + emoji], "Greedy* end anchor 2x");
+
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1219,10 +1219,13 @@ class YarrGenerator final : public YarrJITInfo {
     {
         ASSERT(term->type == PatternTerm::Type::CharacterClass);
 
-        if (term->isFixedWidthCharacterClass() && !term->invert())
-            m_jit.add32(MacroAssembler::TrustedImm32(term->characterClass->hasNonBMPCharacters() ? 2 : 1), m_regs.index);
-        else {
-            m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
+        m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
+        if (term->isFixedWidthCharacterClass()) {
+            if (term->characterClass->hasNonBMPCharacters()) {
+                failuresAfterIncrementingIndex.append(atEndOfInput());
+                m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
+            }
+        } else {
             MacroAssembler::Jump isBMPChar = m_jit.branch32(MacroAssembler::LessThan, character, MacroAssembler::TrustedImm32(0x10000));
             failuresAfterIncrementingIndex.append(atEndOfInput());
             m_jit.add32(MacroAssembler::TrustedImm32(1), m_regs.index);
@@ -3037,13 +3040,7 @@ class YarrGenerator final : public YarrJITInfo {
         MacroAssembler::JumpList failures;
         MacroAssembler::JumpList failuresDecrementIndex;
         MacroAssembler::Label loop(&m_jit);
-#if ENABLE(YARR_JIT_UNICODE_EXPRESSIONS)
-        if (term->isFixedWidthCharacterClass() && term->characterClass->hasNonBMPCharacters()) {
-            m_jit.move(MacroAssembler::TrustedImm32(1), character);
-            failures.append(checkNotEnoughInput(character));
-        } else
-#endif
-            failures.append(atEndOfInput());
+        failures.append(atEndOfInput());
 
         readCharacter(op.m_checkedOffset - term->inputPosition, character);
 


### PR DESCRIPTION
#### ca5992c5df2153d9b5e79310e988834b702ff5ee
<pre>
[YARR] Greedy/non-greedy non-BMP character class should not advance index past end-of-input
<a href="https://bugs.webkit.org/show_bug.cgi?id=309870">https://bugs.webkit.org/show_bug.cgi?id=309870</a>

Reviewed by Yusuke Suzuki.

advanceIndexAfterCharacterClassTermMatch&apos;s fixed-width fast path
adds 2 to the index unconditionally for non-BMP-only classes, which
can leave index at length+1 after the last iteration. A subsequent
fixed-character term then reads one unit past the end of input.

The mixed-width else branch already splits this into
+1 -&gt; atEndOfInput -&gt; +1; do the same here. Both callers already
roll back via failuresAfterIncrementingIndex. This also makes
generateCharacterClassGreedy&apos;s checkNotEnoughInput(1) pre-check
redundant.

Also drop a redundant !term-&gt;invert() already covered by
isFixedWidthCharacterClass().

Test: JSTests/stress/regexp-unicode-nonbmp-fixed-width-charclass-index-overshoot.js

* JSTests/stress/regexp-unicode-nonbmp-fixed-width-charclass-index-overshoot.js: Added.
(shouldBe):
(makeSubstring):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/309968@main">https://commits.webkit.org/309968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6707169aef5e32faef7cdfc71dc7b79c9a21294b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149855 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16157 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158561 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103287 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22676 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115594 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82150 "5 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17716 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96333 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16813 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14741 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6408 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141831 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126420 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161037 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10649 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4121 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13943 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123608 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18783 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123813 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34148 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22383 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134194 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78608 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18972 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10946 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181284 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21984 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85804 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46426 "Found 1 new JSC stress test failure: Too many failures: 29438 jsc tests failed (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21714 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21866 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->