### PR TITLE
Parallelize xcfilelist-copy subprocesses

### DIFF
--- a/Source/WebKitLegacy/scripts/xcfilelist-copy.py
+++ b/Source/WebKitLegacy/scripts/xcfilelist-copy.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import concurrent.futures
 import os
 import shutil
 import subprocess
@@ -32,41 +33,60 @@ def pattern_match(path, pattern):
     return all(fnmatch(path_component, pattern_component) for path_component, pattern_component in components_to_match)
 
 
-for file_number in range(int(os.environ["SCRIPT_OUTPUT_FILE_LIST_COUNT"])):
-    input_file_list = os.environ[f"SCRIPT_INPUT_FILE_LIST_{file_number}"]
-    output_file_list = os.environ[f"SCRIPT_OUTPUT_FILE_LIST_{file_number}"]
-    if not input_file_list and not output_file_list:
-        # Empty string indicates a filelist which is present in other build
-        # configurations only.
-        continue
-    for input_file, output_file in zip(open(input_file_list), open(output_file_list)):
-        input_file = Path(input_file.rstrip())
-        output_file = Path(output_file.rstrip())
+def migrate_file(input_file, output_file):
+    task_env = postprocess_rule_env.copy()
+    task_env["INPUT_FILE_PATH"] = str(input_file)
+    task_env["INPUT_FILE_NAME"] = input_file.name
+    task_env["SCRIPT_OUTPUT_FILE_0"] = str(output_file)
+    if "PrivateHeaders" in output_file.parts:
+        task_env["SCRIPT_HEADER_VISIBILITY"] = "private"
+    elif "Headers" in output_file.parts:
+        task_env["SCRIPT_HEADER_VISIBILITY"] = "public"
+    print("RuleScriptExecution", output_file, input_file, file=sys.stderr)
+    subprocess.check_call((migrate_rule), env=task_env)
 
-        if input_file.name != output_file.name and (input_file.name, output_file.name) not in allowed_renames:
-            sys.exit(f"error: Trying to copy {input_file} to {output_file}, but the file names don't match. "
-                     "Files should always have the same name when copied. "
-                     "Ensure that the paths in this script phase's input and output xcfilelists match.")
 
-        if any(pattern_match(input_file, pattern) for pattern in excluded_patterns) \
-                and not any(pattern_match(input_file, pattern) for pattern in included_patterns):
+def copy_file(input_file, output_file):
+    print(output_file, "->", input_file, file=sys.stderr)
+    shutil.copy(input_file, output_file)
+
+
+with concurrent.futures.ThreadPoolExecutor(max_workers=os.cpu_count()) as executor:
+    futures = []
+    for file_number in range(int(os.environ["SCRIPT_OUTPUT_FILE_LIST_COUNT"])):
+        input_file_list = os.environ[f"SCRIPT_INPUT_FILE_LIST_{file_number}"]
+        output_file_list = os.environ[f"SCRIPT_OUTPUT_FILE_LIST_{file_number}"]
+        if not input_file_list and not output_file_list:
+            # Empty string indicates a filelist which is present in other build
+            # configurations only.
             continue
+        for input_file, output_file in zip(open(input_file_list), open(output_file_list)):
+            input_file = Path(input_file.rstrip())
+            output_file = Path(output_file.rstrip())
 
-        if migrate_rule:
-            postprocess_rule_env["INPUT_FILE_PATH"] = input_file
-            postprocess_rule_env["INPUT_FILE_NAME"] = input_file.name
-            postprocess_rule_env["SCRIPT_OUTPUT_FILE_0"] = output_file
-            if "PrivateHeaders" in output_file.parts:
-                postprocess_rule_env["SCRIPT_HEADER_VISIBILITY"] = "private"
-            elif "Headers" in output_file.parts:
-                postprocess_rule_env["SCRIPT_HEADER_VISIBILITY"] = "public"
-            print("RuleScriptExecution", output_file, input_file, file=sys.stderr)
-            subprocess.check_call((migrate_rule), env=postprocess_rule_env)
-        elif os.path.exists(input_file):
-            print(output_file, "->", input_file, file=sys.stderr)
-            shutil.copy(input_file, output_file)
-        else:
-            print("Skipping ", input_file, " (does not exist)", file=sys.stderr)
+            if input_file.name != output_file.name and (input_file.name, output_file.name) not in allowed_renames:
+                sys.exit(f"error: Trying to copy {input_file} to {output_file}, but the file names don't match. "
+                         "Files should always have the same name when copied. "
+                         "Ensure that the paths in this script phase's input and output xcfilelists match.")
+
+            if any(pattern_match(input_file, pattern) for pattern in excluded_patterns) \
+                    and not any(pattern_match(input_file, pattern) for pattern in included_patterns):
+                continue
+
+            if migrate_rule:
+                futures.append(executor.submit(migrate_file, input_file, output_file))
+            elif os.path.exists(input_file):
+                futures.append(executor.submit(copy_file, input_file, output_file))
+            else:
+                print("Skipping ", input_file, " (does not exist)", file=sys.stderr)
+
+    for future in concurrent.futures.as_completed(futures):
+        try:
+            future.result()
+        except Exception as e:
+            for f in futures:
+                f.cancel()
+            sys.exit(f"error: {e}")
 
 if timestamp:
     Path(timestamp).touch()


### PR DESCRIPTION
#### 9027b69e10bff22f94802950002b05414844fdaf
<pre>
Parallelize xcfilelist-copy subprocesses
<a href="https://bugs.webkit.org/show_bug.cgi?id=309871">https://bugs.webkit.org/show_bug.cgi?id=309871</a>
<a href="https://rdar.apple.com/172447888">rdar://172447888</a>

Reviewed by Elliott Williams and Richard Robinson.

* Source/WebKitLegacy/scripts/xcfilelist-copy.py:
(migrate_file):
(copy_file):
In local clean builds, xcfilelist-copy hangs over into time in which xcbuild is
not performing work in parallel, so internally parallelizing the copies/migration
results in better utilization.

On my machine this is a ~12 second clean build win.

Canonical link: <a href="https://commits.webkit.org/309260@main">https://commits.webkit.org/309260@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9de4f4128b83efd56e6a8614507a6b8b83244782

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158563 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103289 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d176807c-48b2-4927-8825-ae9015497e48) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22678 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115596 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82153 "3 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96335 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32a1969c-fb4d-45af-91ff-37fe8ea490ca) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16820 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14742 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6410 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161039 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4123 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123611 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123816 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33663 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22385 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134196 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78610 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18973 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10948 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21986 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85806 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21716 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21868 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21773 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->