### PR TITLE
REGRESSION(300558@main): Sometimes referrer is missing after PSON

### DIFF
--- a/LayoutTests/http/tests/referrer-policy/no-referrer/about-blank-inherits-opener-referrer-policy-expected.txt
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/about-blank-inherits-opener-referrer-policy-expected.txt
@@ -1,0 +1,10 @@
+Tests that about:blank popup inherits the opener's no-referrer referrer policy.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS referrer is ""
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/about-blank-inherits-opener-referrer-policy.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/about-blank-inherits-opener-referrer-policy.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="referrer" content="no-referrer">
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Tests that about:blank popup inherits the opener's no-referrer referrer policy.");
+jsTestIsAsync = true;
+
+window.onmessage = function(event) {
+    referrer = event.data.referrer;
+    // about:blank should inherit no-referrer from opener, so no Referer header is sent.
+    shouldBeEqualToString("referrer", "");
+    w.close();
+    finishJSTest();
+};
+
+var w = window.open("about:blank");
+
+// Define checkReferrer in the popup.
+var s1 = w.document.createElement("script");
+s1.textContent = 'function checkReferrer(r) { opener.postMessage({ referrer: r }, "*"); }';
+w.document.body.appendChild(s1);
+
+// Load script.py to check if Referer header is present.
+var s2 = w.document.createElement("script");
+s2.src = "http://127.0.0.1:8000/referrer-policy/resources/script.py";
+w.document.body.appendChild(s2);
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy-back-navigation-expected.txt
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy-back-navigation-expected.txt
@@ -1,0 +1,10 @@
+Tests that referrer policy does not persist across cross-origin navigations with a back navigation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS referrer is not ''
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy-back-navigation.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy-back-navigation.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="referrer" content="no-referrer">
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Tests that referrer policy does not persist across cross-origin navigations with a back navigation.");
+jsTestIsAsync = true;
+
+const channelName = "referrer-back-navigation-test";
+const bc = new BroadcastChannel(channelName);
+bc.onmessage = function(event) {
+    referrer = event.data.referrer;
+    // Referrer should be present because the no-referrer policy should NOT have persisted.
+    shouldNotBe("referrer", "''");
+    bc.close();
+    finishJSTest();
+};
+
+// Must use noopener to trigger PSON (opener keeps popup in same process).
+window.open("/referrer-policy/no-referrer/resources/navigate-and-go-back.html?channel=" + encodeURIComponent(channelName), "_blank", "noopener");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy-expected.txt
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy-expected.txt
@@ -1,0 +1,10 @@
+Tests that no-referrer referrer policy does not persist across cross-origin PSON navigations.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS referrer is not ''
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="referrer" content="no-referrer">
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Tests that no-referrer referrer policy does not persist across cross-origin PSON navigations.");
+jsTestIsAsync = true;
+
+const channelName = "referrer-policy-test";
+const bc = new BroadcastChannel(channelName);
+bc.onmessage = function(event) {
+    referrer = event.data.referrer;
+    // Referrer should be present because the no-referrer policy should NOT have persisted.
+    shouldNotBe("referrer", "''");
+    bc.close();
+    finishJSTest();
+};
+
+// Open a noopener popup that will navigate cross-origin twice and then check the referrer.
+window.open("/referrer-policy/no-referrer/resources/navigate-cross-origin.html?channel=" + encodeURIComponent(channelName), "_blank", "noopener");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-pson-bfcache-restoration-expected.txt
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-pson-bfcache-restoration-expected.txt
@@ -1,0 +1,13 @@
+Tests that cross-origin PSON with BFCache restoration exercises the suspendedPage path.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+pageshow - not from cache
+pagehide - entering cache
+pageshow - from cache
+PASS Page did enter and was restored from the page cache
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-pson-bfcache-restoration.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-pson-bfcache-restoration.html
@@ -1,0 +1,35 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test-pre.js"></script>
+<script>
+description("Tests that cross-origin PSON with BFCache restoration exercises the suspendedPage path.");
+window.jsTestIsAsync = true;
+
+window.addEventListener("pageshow", function(event) {
+    debug("pageshow - " + (event.persisted ? "" : "not ") + "from cache");
+
+    if (event.persisted) {
+        testPassed("Page did enter and was restored from the page cache");
+        finishJSTest();
+    }
+}, false);
+
+window.addEventListener("pagehide", function(event) {
+    debug("pagehide - " + (event.persisted ? "" : "not ") + "entering cache");
+    if (!event.persisted) {
+        testFailed("Page did not enter the page cache.");
+        finishJSTest();
+    }
+}, false);
+
+window.addEventListener("load", function() {
+    setTimeout(function() {
+        location.href = "http://localhost:8000/navigation/resources/page-cache-helper.html";
+    }, 0);
+}, false);
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/resources/check-referrer-policy-not-inherited.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/resources/check-referrer-policy-not-inherited.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+const params = new URLSearchParams(location.search);
+const channelName = params.get("channel");
+function checkReferrer(referrer) {
+    const bc = new BroadcastChannel(channelName);
+    bc.postMessage({ referrer: referrer });
+    bc.close();
+}
+</script>
+<script src="http://localhost:8000/referrer-policy/resources/script.py"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-and-go-back.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-and-go-back.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+const params = new URLSearchParams(location.search);
+const channel = params.get("channel");
+
+if (!sessionStorage.getItem("navigated_once")) {
+    sessionStorage.setItem("navigated_once", "1");
+    // Navigate cross-origin (PSON #1). The intermediate page navigates
+    // back here for a second visit.
+    location.href = "http://localhost:8000/referrer-policy/no-referrer/resources/navigate-back-cross-origin-for-back-navigation.html?channel=" + encodeURIComponent(channel);
+} else {
+    // Second visit after back navigation. Two PSONs have occurred, so the
+    // fix is in effect. Navigate to check page at same origin (127.0.0.1)
+    // so BroadcastChannel can reach the main test page.
+    location.href = "/referrer-policy/no-referrer/resources/check-referrer-policy-not-inherited.html?channel=" + encodeURIComponent(channel);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-back-cross-origin-for-back-navigation.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-back-cross-origin-for-back-navigation.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+const params = new URLSearchParams(location.search);
+const channel = params.get("channel");
+
+// Navigate back to 127.0.0.1 to complete the second PSON.
+if (history.length > 1)
+    history.back();
+else
+    location.href = "http://127.0.0.1:8000/referrer-policy/no-referrer/resources/navigate-and-go-back.html?channel=" + encodeURIComponent(channel);
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-back-cross-origin.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-back-cross-origin.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+const params = new URLSearchParams(location.search);
+const channel = params.get("channel");
+// Navigate back cross-origin to trigger PSON #2
+location.href = "http://127.0.0.1:8000/referrer-policy/no-referrer/resources/check-referrer-policy-not-inherited.html?channel=" + encodeURIComponent(channel);
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-cross-origin.html
+++ b/LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-cross-origin.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+const params = new URLSearchParams(location.search);
+const channel = params.get("channel");
+// Navigate cross-origin to trigger PSON #1
+location.href = "http://localhost:8000/referrer-policy/no-referrer/resources/navigate-back-cross-origin.html?channel=" + encodeURIComponent(channel);
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/referrer-policy-not-inherited-cross-site-with-opener-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/referrer-policy-not-inherited-cross-site-with-opener-expected.txt
@@ -1,0 +1,10 @@
+Tests that no-referrer referrer policy is not inherited via cross-site navigation with opener under site isolation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS referrer is not ''
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/referrer-policy-not-inherited-cross-site-with-opener.html
+++ b/LayoutTests/http/tests/site-isolation/referrer-policy-not-inherited-cross-site-with-opener.html
@@ -1,0 +1,27 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="referrer" content="no-referrer">
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<script>
+description("Tests that no-referrer referrer policy is not inherited via cross-site navigation with opener under site isolation.");
+jsTestIsAsync = true;
+
+var w = window.open("about:blank");
+
+window.onmessage = function(event) {
+    referrer = event.data.referrer;
+    // Referrer should be present because the no-referrer policy should NOT have persisted.
+    shouldNotBe("referrer", "''");
+    w.close();
+    finishJSTest();
+};
+
+// Navigate the opened window cross-site; triggers PSON with m_shouldReuseMainFrame.
+w.location = "http://localhost:8000/site-isolation/resources/check-and-report-referrer.html";
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/check-and-report-referrer.html
+++ b/LayoutTests/http/tests/site-isolation/resources/check-and-report-referrer.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+function checkReferrer(referrer) {
+    if (window.opener)
+        window.opener.postMessage({ referrer: referrer }, "*");
+}
+</script>
+<script src="http://localhost:8000/referrer-policy/resources/script.py"></script>
+</body>
+</html>

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -529,3 +529,4 @@ svg/custom/svg-image-dark-mode-initial.html [ ImageOnlyFailure ]
 ####################################
 fast/history/page-cache-clearing.html [ Skip ]
 http/tests/navigation/page-cache-video.html [ Skip ]
+http/tests/referrer-policy/no-referrer/cross-origin-pson-bfcache-restoration.html [ Skip ]

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -126,13 +126,15 @@ ProvisionalPageProxy::ProvisionalPageProxy(WebPageProxy& page, Ref<FrameProcess>
         ASSERT(&suspendedPage->process() == process.ptr());
         suspendedPage->unsuspend();
         m_mainFrame = suspendedPage->mainFrame();
+        m_mainFrame->updateReferrerPolicy(ReferrerPolicy::EmptyString);
         m_needsMainFrameObserver = true;
-    } else if (m_shouldReuseMainFrame)
+    } else if (m_shouldReuseMainFrame) {
         m_mainFrame = page.mainFrame();
-    else {
+        m_mainFrame->updateReferrerPolicy(ReferrerPolicy::EmptyString);
+    } else {
         // Passing previous frame's url to restore the main frame's committed URL
         // as some clients may rely on it until the next load is committed.
-        Ref mainFrame = WebFrameProxy::create(page, m_frameProcess, generateFrameIdentifier(), previousMainFrame->effectiveSandboxFlags(), previousMainFrame->effectiveReferrerPolicy(), previousMainFrame->scrollingMode(), nullptr, nullptr, IsMainFrame::Yes, previousMainFrame->url());
+        Ref mainFrame = WebFrameProxy::create(page, m_frameProcess, generateFrameIdentifier(), previousMainFrame->effectiveSandboxFlags(), ReferrerPolicy::EmptyString, previousMainFrame->scrollingMode(), nullptr, nullptr, IsMainFrame::Yes, previousMainFrame->url());
         m_mainFrame = mainFrame.copyRef();
         m_needsMainFrameObserver = true;
         previousMainFrame->transferNavigationCallbackToFrame(mainFrame);


### PR DESCRIPTION
#### 42cc8781b1c3ad89df8e7def9b6f606de7ff3f5f
<pre>
REGRESSION(300558@main): Sometimes referrer is missing after PSON
<a href="https://rdar.apple.com/169006635">rdar://169006635</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309645">https://bugs.webkit.org/show_bug.cgi?id=309645</a>

Reviewed by Sihui Liu.

Commit 300558@main introduced a regression where the referrer policy
from the outgoing page&apos;s WebFrameProxy carries over to the new page
created during PSON. This causes the previous page&apos;s referrer policy to
persist indefinitely across cross-origin navigations, resulting in
unexpected Referer header behavior for subsequent pages.

Fix by resetting the provisional main frame&apos;s referrer policy to
EmptyString in all three ProvisionalPageProxy paths (new WebFrameProxy,
m_shouldReuseMainFrame, and suspendedPage). This resetting is scoped to
PSON frame create and does not alter how referrer policies are inherited
during window.open or about:blank navigations.

Tests: http/tests/referrer-policy/no-referrer/about-blank-inherits-opener-referrer-policy.html
       http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy-back-navigation.html
       http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy.html
       http/tests/referrer-policy/no-referrer/cross-origin-pson-bfcache-restoration.html
       http/tests/site-isolation/referrer-policy-not-inherited-cross-site-with-opener.html

* LayoutTests/http/tests/referrer-policy/no-referrer/about-blank-inherits-opener-referrer-policy-expected.txt: Added.
* LayoutTests/http/tests/referrer-policy/no-referrer/about-blank-inherits-opener-referrer-policy.html: Added.
* LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy-back-navigation-expected.txt: Added.
* LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy-back-navigation.html: Added.
* LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy-expected.txt: Added.
* LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-navigation-does-not-inherit-referrer-policy.html: Added.
* LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-pson-bfcache-restoration-expected.txt: Added.
* LayoutTests/http/tests/referrer-policy/no-referrer/cross-origin-pson-bfcache-restoration.html: Added.
* LayoutTests/http/tests/referrer-policy/no-referrer/resources/check-referrer-policy-not-inherited.html: Added.
* LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-and-go-back.html: Added.
* LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-back-cross-origin-for-back-navigation.html: Added.
* LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-back-cross-origin.html: Added.
* LayoutTests/http/tests/referrer-policy/no-referrer/resources/navigate-cross-origin.html: Added.
* LayoutTests/http/tests/site-isolation/referrer-policy-not-inherited-cross-site-with-opener-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/referrer-policy-not-inherited-cross-site-with-opener.html: Added.
* LayoutTests/http/tests/site-isolation/resources/check-and-report-referrer.html: Added.
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::ProvisionalPageProxy):

Canonical link: <a href="https://commits.webkit.org/309382@main">https://commits.webkit.org/309382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1d88e8ed1ea4e88276718f6be73cbb94c03a8df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159190 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103902 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d657ca1f-8897-47d0-a642-28df53df4d60) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23364 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116103 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82491 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153428 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134977 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96831 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/380a7a14-832a-4b08-9666-6c2905c9073a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17310 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15258 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7038 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126925 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161664 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4784 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14454 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124101 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19305 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124299 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33756 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23015 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134696 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79395 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19412 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11453 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22629 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86428 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22342 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22494 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22396 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->