### PR TITLE
Add "InGCThread" suffix to `visit*(Visitor&)` functions in WebCore

### DIFF
--- a/Source/JavaScriptCore/heap/SlotVisitorMacros.h
+++ b/Source/JavaScriptCore/heap/SlotVisitorMacros.h
@@ -110,11 +110,11 @@ public: \
 #define DEFINE_VISIT_OUTPUT_CONSTRAINTS(className) \
     DEFINE_VISIT_OUTPUT_CONSTRAINTS_WITH_MODIFIER(UNUSED_MODIFIER_ARGUMENT, className)
 
-// Macros for visitAdditionalChildren().
+// Macros for visitAdditionalChildrenInGCThread().
 
-#define DEFINE_VISIT_ADDITIONAL_CHILDREN(className) \
-    template void className::visitAdditionalChildren(JSC::AbstractSlotVisitor&); \
-    template void className::visitAdditionalChildren(JSC::SlotVisitor&)
+#define DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(className) \
+    template void className::visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor&); \
+    template void className::visitAdditionalChildrenInGCThread(JSC::SlotVisitor&)
 
 } // namespace JSC
 

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -740,7 +740,7 @@ void IDBObjectStore::rollbackForVersionChangeAbort()
 }
 
 template<typename Visitor>
-void IDBObjectStore::visitReferencedIndexesConcurrently(Visitor& visitor) const
+void IDBObjectStore::visitReferencedIndexesInGCThread(Visitor& visitor) const
 {
     Locker locker { m_referencedIndexLock };
     for (auto& index : m_referencedIndexes.values()) {
@@ -753,8 +753,8 @@ void IDBObjectStore::visitReferencedIndexesConcurrently(Visitor& visitor) const
     }
 }
 
-template void IDBObjectStore::visitReferencedIndexesConcurrently(AbstractSlotVisitor&) const;
-template void IDBObjectStore::visitReferencedIndexesConcurrently(SlotVisitor&) const;
+template void IDBObjectStore::visitReferencedIndexesInGCThread(AbstractSlotVisitor&) const;
+template void IDBObjectStore::visitReferencedIndexesInGCThread(SlotVisitor&) const;
 
 void IDBObjectStore::renameReferencedIndex(IDBIndex& index, const String& newName)
 {

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.h
@@ -118,7 +118,7 @@ public:
     void NODELETE ref() const final;
     void deref() const final;
 
-    template<typename Visitor> void visitReferencedIndexesConcurrently(Visitor&) const;
+    template<typename Visitor> void visitReferencedIndexesInGCThread(Visitor&) const;
     void renameReferencedIndex(IDBIndex&, const String& newName);
 
 private:

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -1497,7 +1497,7 @@ void IDBTransaction::connectionClosedFromServer(const IDBError& error)
 }
 
 template<typename Visitor>
-void IDBTransaction::visitReferencedObjectStores(Visitor& visitor) const
+void IDBTransaction::visitReferencedObjectStoresInGCThread(Visitor& visitor) const
 {
     Locker locker { m_objectStoresLock };
     for (auto& objectStore : m_referencedObjectStores.values())
@@ -1506,8 +1506,8 @@ void IDBTransaction::visitReferencedObjectStores(Visitor& visitor) const
         SUPPRESS_UNCHECKED_ARG addWebCoreOpaqueRoot(visitor, objectStore.get());
 }
 
-template void IDBTransaction::visitReferencedObjectStores(JSC::AbstractSlotVisitor&) const;
-template void IDBTransaction::visitReferencedObjectStores(JSC::SlotVisitor&) const;
+template void IDBTransaction::visitReferencedObjectStoresInGCThread(JSC::AbstractSlotVisitor&) const;
+template void IDBTransaction::visitReferencedObjectStoresInGCThread(JSC::SlotVisitor&) const;
 
 void IDBTransaction::handlePendingOperations()
 {

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -152,7 +152,7 @@ public:
     void connectionClosedFromServer(const IDBError&);
     void generateIndexKeyForRecord(const IDBResourceIdentifier& requestIdentifier, const IDBIndexInfo&, const std::optional<IDBKeyPath>&, const IDBKeyData&, const IDBValue&, std::optional<int64_t> recordID);
 
-    template<typename Visitor> void visitReferencedObjectStores(Visitor&) const;
+    template<typename Visitor> void visitReferencedObjectStoresInGCThread(Visitor&) const;
 
     WEBCORE_EXPORT static std::atomic<unsigned> numberOfIDBTransactions;
 

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -95,7 +95,7 @@ public:
 
     void callActionHandler(const MediaSessionActionDetails&, DOMPromiseDeferred<void>&&);
 
-    template <typename Visitor> void visitActionHandlers(Visitor&) const;
+    template <typename Visitor> void visitActionHandlersInGCThread(Visitor&) const;
 
     ExceptionOr<void> setPositionState(std::optional<MediaPositionState>&&);
     std::optional<MediaPositionState> positionState() const { return m_positionState; }
@@ -221,12 +221,12 @@ inline bool MediaSession::hasActiveActionHandlers() const
 }
 
 template <typename Visitor>
-void MediaSession::visitActionHandlers(Visitor& visitor) const
+void MediaSession::visitActionHandlersInGCThread(Visitor& visitor) const
 {
     Locker lock { m_actionHandlersLock };
     for (auto& actionHandler : m_actionHandlers) {
         // We are not ref'ing here as this function may get called from a GC thread.
-        SUPPRESS_UNCOUNTED_ARG actionHandler.value->visitJSFunction(visitor);
+        SUPPRESS_UNCOUNTED_ARG actionHandler.value->visitJSFunctionInGCThread(visitor);
     }
 }
 

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
@@ -1007,33 +1007,33 @@ void ReadableByteStreamController::handleSourcePromise(JSDOMGlobalObject& global
 }
 
 template<typename Visitor>
-void ReadableByteStreamController::visitDirectChildren(Visitor& visitor)
+void ReadableByteStreamController::visitDirectChildrenInGCThread(Visitor& visitor)
 {
-    m_underlyingSource.visit(visitor);
-    m_storedError.visit(visitor);
+    m_underlyingSource.visitInGCThread(visitor);
+    m_storedError.visitInGCThread(visitor);
 
     Locker lock(m_gcLock);
     if (m_pullAlgorithm)
-        SUPPRESS_UNCOUNTED_ARG m_pullAlgorithm->visitJSFunction(visitor);
+        SUPPRESS_UNCOUNTED_ARG m_pullAlgorithm->visitJSFunctionInGCThread(visitor);
     if (m_cancelAlgorithm)
-        SUPPRESS_UNCOUNTED_ARG m_cancelAlgorithm->visitJSFunction(visitor);
+        SUPPRESS_UNCOUNTED_ARG m_cancelAlgorithm->visitJSFunctionInGCThread(visitor);
 }
 
 template<typename Visitor>
-void ReadableByteStreamController::visitAdditionalChildren(Visitor& visitor)
+void ReadableByteStreamController::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    SUPPRESS_UNCOUNTED_ARG m_stream->visitAdditionalChildren(visitor);
+    SUPPRESS_UNCOUNTED_ARG m_stream->visitAdditionalChildrenInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(ReadableByteStreamController);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(ReadableByteStreamController);
 
 template<typename Visitor>
-void JSReadableByteStreamController::visitAdditionalChildren(Visitor& visitor)
+void JSReadableByteStreamController::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     // Do not ref `wrapped()` here since this function may get called on a GC thread.
-    SUPPRESS_UNCOUNTED_ARG wrapped().visitAdditionalChildren(visitor);
+    SUPPRESS_UNCOUNTED_ARG wrapped().visitAdditionalChildrenInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSReadableByteStreamController);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSReadableByteStreamController);
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.h
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.h
@@ -101,8 +101,8 @@ public:
 
     bool isPulling() const { return m_pulling; }
 
-    template<typename Visitor> void visitAdditionalChildren(Visitor&);
-    template<typename Visitor> void visitDirectChildren(Visitor&);
+    template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);
+    template<typename Visitor> void visitDirectChildrenInGCThread(Visitor&);
 
     using PullAlgorithm = Function<Ref<DOMPromise>(JSDOMGlobalObject&, ReadableByteStreamController&)>;
     using CancelAlgorithm = Function<Ref<DOMPromise>(JSDOMGlobalObject&, ReadableByteStreamController&, std::optional<JSC::JSValue>&&)>;

--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -643,7 +643,7 @@ JSC::JSValue ReadableStream::storedError(JSDOMGlobalObject& globalObject) const
     return m_controller->storedError();
 }
 
-void ReadableStream::visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor, VisitTeedChildren visitTeedChildren)
+void ReadableStream::visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor, VisitTeedChildren visitTeedChildren)
 {
     {
         Locker lock(m_gcLock);
@@ -661,7 +661,7 @@ void ReadableStream::visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor, 
         m_dependencyToVisit->visit(visitor);
 
     if (m_controller)
-        m_controller->visitDirectChildren(visitor);
+        m_controller->visitDirectChildrenInGCThread(visitor);
 }
 
 void ReadableStream::setTeedBranches(ReadableStream& branch0, ReadableStream& branch1)
@@ -852,11 +852,11 @@ ExceptionOr<Ref<ReadableStream>> ReadableStream::runTransferReceivingSteps(JSDOM
 }
 
 template<typename Visitor>
-void JSReadableStream::visitAdditionalChildren(Visitor& visitor)
+void JSReadableStream::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    SUPPRESS_UNCOUNTED_ARG wrapped().visitAdditionalChildren(visitor, ReadableStream::VisitTeedChildren::Yes);
+    SUPPRESS_UNCOUNTED_ARG wrapped().visitAdditionalChildrenInGCThread(visitor, ReadableStream::VisitTeedChildren::Yes);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSReadableStream);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSReadableStream);
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -139,7 +139,7 @@ public:
 
     bool isReachableFromOpaqueRoots() const { return m_isSourceReachableFromOpaqueRoot && m_state == State::Readable; }
     enum class VisitTeedChildren : bool { No, Yes };
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor&, VisitTeedChildren = VisitTeedChildren::No);
+    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor&, VisitTeedChildren = VisitTeedChildren::No);
     void setTeedBranches(ReadableStream&, ReadableStream&);
     void NODELETE setSourceTeedStream(ReadableStream&);
 

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp
@@ -289,19 +289,19 @@ bool JSReadableStreamBYOBReaderOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC
 }
 
 template<typename Visitor>
-void ReadableStreamBYOBReader::visitAdditionalChildren(Visitor& visitor)
+void ReadableStreamBYOBReader::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     if (m_stream)
-        SUPPRESS_UNCOUNTED_ARG m_stream->visitAdditionalChildren(visitor);
+        SUPPRESS_UNCOUNTED_ARG m_stream->visitAdditionalChildrenInGCThread(visitor);
 }
 
 template<typename Visitor>
-void JSReadableStreamBYOBReader::visitAdditionalChildren(Visitor& visitor)
+void JSReadableStreamBYOBReader::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     // Do not ref `wrapped()` here since this function may get called on a GC thread.
-    SUPPRESS_UNCOUNTED_ARG wrapped().visitAdditionalChildren(visitor);
+    SUPPRESS_UNCOUNTED_ARG wrapped().visitAdditionalChildrenInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSReadableStreamBYOBReader);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSReadableStreamBYOBReader);
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h
@@ -75,7 +75,7 @@ public:
     void read(JSDOMGlobalObject&, JSC::ArrayBufferView&, uint64_t, Ref<ReadableStreamReadIntoRequest>&&);
 
     bool NODELETE isReachableFromOpaqueRoots() const;
-    template<typename Visitor> void visitAdditionalChildren(Visitor&);
+    template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);
 
 private:
     explicit ReadableStreamBYOBReader(Ref<DOMPromise>&&, Ref<DeferredPromise>&&);

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.cpp
@@ -83,21 +83,21 @@ void ReadableStreamBYOBRequest::setView(JSC::ArrayBufferView* view)
 }
 
 template<typename Visitor>
-void ReadableStreamBYOBRequest::visitAdditionalChildren(Visitor& visitor)
+void ReadableStreamBYOBRequest::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     if (m_controller)
-        SUPPRESS_UNCOUNTED_ARG m_controller->stream().visitAdditionalChildren(visitor);
+        SUPPRESS_UNCOUNTED_ARG m_controller->stream().visitAdditionalChildrenInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(ReadableStreamBYOBRequest);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(ReadableStreamBYOBRequest);
 
 template<typename Visitor>
-void JSReadableStreamBYOBRequest::visitAdditionalChildren(Visitor& visitor)
+void JSReadableStreamBYOBRequest::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     // Do not ref `wrapped()` here since this function may get called on a GC thread.
-    SUPPRESS_UNCOUNTED_ARG wrapped().visitAdditionalChildren(visitor);
+    SUPPRESS_UNCOUNTED_ARG wrapped().visitAdditionalChildrenInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSReadableStreamBYOBRequest);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSReadableStreamBYOBRequest);
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.h
@@ -49,7 +49,7 @@ public:
     void NODELETE setController(ReadableByteStreamController*);
     void NODELETE setView(JSC::ArrayBufferView*);
 
-    template<typename Visitor> void visitAdditionalChildren(Visitor&);
+    template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);
 
 private:
     ReadableStreamBYOBRequest();

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
@@ -395,19 +395,19 @@ bool JSReadableStreamDefaultReaderOwner::isReachableFromOpaqueRoots(JSC::Handle<
 }
 
 template<typename Visitor>
-void ReadableStreamDefaultReader::visitAdditionalChildren(Visitor& visitor)
+void ReadableStreamDefaultReader::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     if (m_stream)
-        SUPPRESS_UNCOUNTED_ARG m_stream->visitAdditionalChildren(visitor);
+        SUPPRESS_UNCOUNTED_ARG m_stream->visitAdditionalChildrenInGCThread(visitor);
 }
 
 template<typename Visitor>
-void JSReadableStreamDefaultReader::visitAdditionalChildren(Visitor& visitor)
+void JSReadableStreamDefaultReader::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     // Do not ref `wrapped()` here since this function may get called on a GC thread.
-    wrapped().visitAdditionalChildren(visitor);
+    wrapped().visitAdditionalChildrenInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSReadableStreamDefaultReader);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSReadableStreamDefaultReader);
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h
@@ -73,7 +73,7 @@ public:
     void onClosedPromiseResolution(Function<void()>&&);
 
     bool NODELETE isReachableFromOpaqueRoots() const;
-    template<typename Visitor> void visitAdditionalChildren(Visitor&);
+    template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);
 
     ReadableStream* stream() { return m_stream.get(); }
 

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -88,9 +88,9 @@ public:
     }
     void visit(JSC::AbstractSlotVisitor& visitor) final
     {
-        m_branch1Reason.visit(visitor);
-        m_branch2Reason.visit(visitor);
-        m_stream->visitAdditionalChildren(visitor);
+        m_branch1Reason.visitInGCThread(visitor);
+        m_branch2Reason.visitInGCThread(visitor);
+        m_stream->visitAdditionalChildrenInGCThread(visitor);
     }
     void NODELETE clearReasons()
     {

--- a/Source/WebCore/Modules/streams/TransformStream.cpp
+++ b/Source/WebCore/Modules/streams/TransformStream.cpp
@@ -164,11 +164,11 @@ ExceptionOr<CreateInternalTransformStreamResult> createInternalTransformStream(J
 }
 
 template<typename Visitor>
-void JSTransformStream::visitAdditionalChildren(Visitor& visitor)
+void JSTransformStream::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().internalTransformStream().visit(visitor);
+    wrapped().internalTransformStream().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSTransformStream);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSTransformStream);
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.cpp
@@ -199,15 +199,15 @@ ExceptionOr<JSC::JSValue> AudioBuffer::getChannelData(JSDOMGlobalObject& globalO
 }
 
 template<typename Visitor>
-void AudioBuffer::visitChannelWrappers(Visitor& visitor)
+void AudioBuffer::visitChannelWrappersInGCThread(Visitor& visitor)
 {
     Locker locker { m_channelsLock };
     for (auto& channelWrapper : m_channelWrappers)
-        channelWrapper.visit(visitor);
+        channelWrapper.visitInGCThread(visitor);
 }
 
-template void AudioBuffer::visitChannelWrappers(JSC::AbstractSlotVisitor&);
-template void AudioBuffer::visitChannelWrappers(JSC::SlotVisitor&);
+template void AudioBuffer::visitChannelWrappersInGCThread(JSC::AbstractSlotVisitor&);
+template void AudioBuffer::visitChannelWrappersInGCThread(JSC::SlotVisitor&);
 
 RefPtr<Float32Array> AudioBuffer::channelData(unsigned channelIndex)
 {

--- a/Source/WebCore/Modules/webaudio/AudioBuffer.h
+++ b/Source/WebCore/Modules/webaudio/AudioBuffer.h
@@ -83,7 +83,7 @@ public:
 
     size_t memoryCost() const;
 
-    template<typename Visitor> void visitChannelWrappers(Visitor&);
+    template<typename Visitor> void visitChannelWrappersInGCThread(Visitor&);
 
     bool copyTo(AudioBuffer&) const;
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
@@ -220,7 +220,7 @@ void AudioWorkletGlobalScope::processorIsNoLongerNeeded(AudioWorkletProcessor& p
     m_processors.remove(processor);
 }
 
-void AudioWorkletGlobalScope::visitProcessors(JSC::AbstractSlotVisitor& visitor)
+void AudioWorkletGlobalScope::visitProcessorsInGCThread(JSC::AbstractSlotVisitor& visitor)
 {
     m_processors.forEach([&](auto& processor) {
         addWebCoreOpaqueRoot(visitor, processor);

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h
@@ -58,7 +58,7 @@ public:
     ExceptionOr<void> registerProcessor(String&& name, Ref<JSAudioWorkletProcessorConstructor>&&);
     RefPtr<AudioWorkletProcessor> createProcessor(const String& name, TransferredMessagePort, Ref<SerializedScriptValue>&& options);
     void processorIsNoLongerNeeded(AudioWorkletProcessor&);
-    void visitProcessors(JSC::AbstractSlotVisitor&);
+    void visitProcessorsInGCThread(JSC::AbstractSlotVisitor&);
 
     size_t currentFrame() const { return m_currentFrame; }
 

--- a/Source/WebCore/bindings/js/JSAbortSignalCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAbortSignalCustom.cpp
@@ -66,11 +66,11 @@ bool JSAbortSignalOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> ha
 }
 
 template<typename Visitor>
-void JSAbortSignal::visitAdditionalChildren(Visitor& visitor)
+void JSAbortSignal::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().reason().visit(visitor);
+    wrapped().reason().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSAbortSignal);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSAbortSignal);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSAttrCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAttrCustom.cpp
@@ -35,12 +35,12 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSAttr::visitAdditionalChildren(Visitor& visitor)
+void JSAttr::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     if (SUPPRESS_UNCHECKED_LOCAL auto* element = wrapped().ownerElement())
         addWebCoreOpaqueRoot(visitor, *element);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSAttr);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSAttr);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSAudioBufferCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAudioBufferCustom.cpp
@@ -36,12 +36,12 @@ namespace WebCore {
 using namespace JSC;
 
 template<typename Visitor>
-void JSAudioBuffer::visitAdditionalChildren(Visitor& visitor)
+void JSAudioBuffer::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().visitChannelWrappers(visitor);
+    wrapped().visitChannelWrappersInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSAudioBuffer);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSAudioBuffer);
 
 } // namespace WebCore
 

--- a/Source/WebCore/bindings/js/JSAudioBufferSourceNodeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAudioBufferSourceNodeCustom.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 using namespace JSC;
 
 template<typename Visitor>
-void JSAudioBufferSourceNode::visitAdditionalChildren(Visitor& visitor)
+void JSAudioBufferSourceNode::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     Locker locker { wrapped().processLock() };
     // The AudioBufferSourceNode's buffer may hold on to a large amount of memory. This memory is
@@ -44,7 +44,7 @@ void JSAudioBufferSourceNode::visitAdditionalChildren(Visitor& visitor)
     addWebCoreOpaqueRoot(visitor, wrapped().buffer());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSAudioBufferSourceNode);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSAudioBufferSourceNode);
 
 } // namespace WebCore
 

--- a/Source/WebCore/bindings/js/JSAudioWorkletGlobalScopeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAudioWorkletGlobalScopeCustom.cpp
@@ -35,14 +35,14 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSAudioWorkletGlobalScope::visitAdditionalChildren(Visitor& visitor)
+void JSAudioWorkletGlobalScope::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     // This function may get called on a GC thread so we cannot ref the object.
     SUPPRESS_UNCOUNTED_ARG addWebCoreOpaqueRoot(visitor, static_cast<ScriptExecutionContext&>(wrapped()));
-    SUPPRESS_UNCOUNTED_ARG wrapped().visitProcessors(visitor);
+    SUPPRESS_UNCOUNTED_ARG wrapped().visitProcessorsInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSAudioWorkletGlobalScope);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSAudioWorkletGlobalScope);
 
 } // namespace WebCore
 

--- a/Source/WebCore/bindings/js/JSAudioWorkletProcessorCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAudioWorkletProcessorCustom.cpp
@@ -31,15 +31,15 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSAudioWorkletProcessor::visitAdditionalChildren(Visitor& visitor)
+void JSAudioWorkletProcessor::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     auto& processor = wrapped();
-    processor.jsInputsWrapper().visit(visitor);
-    processor.jsOutputsWrapper().visit(visitor);
-    processor.jsParamValuesWrapper().visit(visitor);
+    processor.jsInputsWrapper().visitInGCThread(visitor);
+    processor.jsOutputsWrapper().visitInGCThread(visitor);
+    processor.jsParamValuesWrapper().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSAudioWorkletProcessor);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSAudioWorkletProcessor);
 
 } // namespace WebCore
 

--- a/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSRuleCustom.cpp
@@ -81,11 +81,11 @@ namespace WebCore {
 using namespace JSC;
 
 template<typename Visitor>
-void JSCSSRule::visitAdditionalChildren(Visitor& visitor)
+void JSCSSRule::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, wrapped());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSCSSRule);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSCSSRule);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSCSSStyleDeclarationCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCSSStyleDeclarationCustom.cpp
@@ -62,11 +62,11 @@ WebCoreOpaqueRoot root(CSSStyleDeclaration* style)
 }
 
 template<typename Visitor>
-void JSCSSStyleDeclaration::visitAdditionalChildren(Visitor& visitor)
+void JSCSSStyleDeclaration::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, wrapped());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSCSSStyleDeclaration);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSCSSStyleDeclaration);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSCallbackData.cpp
+++ b/Source/WebCore/bindings/js/JSCallbackData.cpp
@@ -101,12 +101,12 @@ JSValue JSCallbackData::invokeCallback(JSDOMGlobalObject& globalObject, JSObject
 }
 
 template<typename Visitor>
-void JSCallbackData::visitJSFunction(Visitor& visitor)
+void JSCallbackData::visitJSFunctionInGCThread(Visitor& visitor)
 {
     visitor.append(m_callback);
 }
 
-template void JSCallbackData::visitJSFunction(JSC::AbstractSlotVisitor&);
-template void JSCallbackData::visitJSFunction(JSC::SlotVisitor&);
+template void JSCallbackData::visitJSFunctionInGCThread(JSC::AbstractSlotVisitor&);
+template void JSCallbackData::visitJSFunctionInGCThread(JSC::SlotVisitor&);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSCallbackData.h
+++ b/Source/WebCore/bindings/js/JSCallbackData.h
@@ -65,7 +65,7 @@ public:
     JSDOMGlobalObject* globalObject() { return m_globalObject.get(); }
     JSC::JSObject* callback() { return m_callback.get(); }
 
-    template<typename Visitor> void visitJSFunction(Visitor&);
+    template<typename Visitor> void visitJSFunctionInGCThread(Visitor&);
 
     WEBCORE_EXPORT static JSC::JSValue invokeCallback(JSDOMGlobalObject&, JSC::JSObject* callback, JSC::JSValue thisValue, JSC::MarkedArgumentBuffer&, CallbackType, JSC::PropertyName functionName, NakedPtr<JSC::Exception>& returnedException);
 

--- a/Source/WebCore/bindings/js/JSCanvasRenderingContext2DCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCanvasRenderingContext2DCustom.cpp
@@ -35,11 +35,11 @@ bool JSCanvasRenderingContext2DOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC
 }
 
 template<typename Visitor>
-void JSCanvasRenderingContext2D::visitAdditionalChildren(Visitor& visitor)
+void JSCanvasRenderingContext2D::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, wrapped().canvas());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSCanvasRenderingContext2D);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSCanvasRenderingContext2D);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.cpp
@@ -451,7 +451,7 @@ ScriptExecutionContext* JSCustomElementInterface::scriptExecutionContext() const
 }
 
 template<typename Visitor>
-void JSCustomElementInterface::visitJSFunctions(Visitor& visitor) const
+void JSCustomElementInterface::visitJSFunctionsInGCThread(Visitor& visitor) const
 {
     visitor.append(m_constructor);
     visitor.append(m_connectedCallback);
@@ -464,7 +464,7 @@ void JSCustomElementInterface::visitJSFunctions(Visitor& visitor) const
     visitor.append(m_formStateRestoreCallback);
 }
 
-template void JSCustomElementInterface::visitJSFunctions(JSC::AbstractSlotVisitor&) const;
-template void JSCustomElementInterface::visitJSFunctions(JSC::SlotVisitor&) const;
+template void JSCustomElementInterface::visitJSFunctionsInGCThread(JSC::AbstractSlotVisitor&) const;
+template void JSCustomElementInterface::visitJSFunctionsInGCThread(JSC::SlotVisitor&) const;
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.h
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.h
@@ -123,7 +123,7 @@ public:
 
     virtual ~JSCustomElementInterface();
 
-    template<typename Visitor> void visitJSFunctions(Visitor&) const;
+    template<typename Visitor> void visitJSFunctionsInGCThread(Visitor&) const;
 private:
     JSCustomElementInterface(const QualifiedName&, JSC::JSObject* callback, JSDOMGlobalObject*);
 

--- a/Source/WebCore/bindings/js/JSCustomElementRegistryCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCustomElementRegistryCustom.cpp
@@ -251,11 +251,11 @@ JSValue JSCustomElementRegistry::whenDefined(JSGlobalObject& lexicalGlobalObject
 }
 
 template<typename Visitor>
-void JSCustomElementRegistry::visitAdditionalChildren(Visitor& visitor)
+void JSCustomElementRegistry::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     wrapped().visitJSCustomElementInterfacesInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSCustomElementRegistry);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSCustomElementRegistry);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSCustomEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSCustomEventCustom.cpp
@@ -43,12 +43,12 @@ JSC::JSValue JSCustomEvent::detail(JSC::JSGlobalObject& lexicalGlobalObject) con
 }
 
 template<typename Visitor>
-void JSCustomEvent::visitAdditionalChildren(Visitor& visitor)
+void JSCustomEvent::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().detail().visit(visitor);
-    wrapped().cachedDetail().visit(visitor);
+    wrapped().detail().visitInGCThread(visitor);
+    wrapped().cachedDetail().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSCustomEvent);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSCustomEvent);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -457,7 +457,7 @@ void JSDOMGlobalObject::visitChildrenImpl(JSCell* cell, Visitor& visitor)
             visitor.append(structure);
 
         for (auto& guarded : thisObject->m_guardedObjects)
-            guarded->visitAggregate(visitor);
+            guarded->visitAggregateInGCThread(visitor);
     }
 
     if (thisObject->m_readableStreamByteStrategySize)

--- a/Source/WebCore/bindings/js/JSDOMGuardedObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGuardedObject.h
@@ -44,7 +44,7 @@ public:
 
     bool isSuspended() const { return !m_guarded || !canInvokeCallback(); } // The wrapper world has gone away or active DOM objects have been suspended.
 
-    template<typename Visitor> void visitAggregate(Visitor& visitor) { visitor.append(m_guarded); }
+    template<typename Visitor> void visitAggregateInGCThread(Visitor& visitor) { visitor.append(m_guarded); }
 
     JSC::JSValue guardedObject() const { return m_guarded.get(); }
     JSDOMGlobalObject* globalObject() const { return m_globalObject.get(); }

--- a/Source/WebCore/bindings/js/JSDOMQuadCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMQuadCustom.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 using namespace JSC;
 
 template<typename Visitor>
-void JSDOMQuad::visitAdditionalChildren(Visitor& visitor)
+void JSDOMQuad::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, const_cast<DOMPoint*>(&wrapped().p1()));
     addWebCoreOpaqueRoot(visitor, const_cast<DOMPoint*>(&wrapped().p2()));
@@ -42,6 +42,6 @@ void JSDOMQuad::visitAdditionalChildren(Visitor& visitor)
     addWebCoreOpaqueRoot(visitor, const_cast<DOMPoint*>(&wrapped().p4()));
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSDOMQuad);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSDOMQuad);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -75,17 +75,17 @@ static JSC_DECLARE_CUSTOM_GETTER(jsDOMWindow_webkit);
 #endif
 
 template<typename Visitor>
-void JSDOMWindow::visitAdditionalChildren(Visitor& visitor)
+void JSDOMWindow::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     SUPPRESS_UNCOUNTED_ARG addWebCoreOpaqueRoot(visitor, wrapped());
 
-    // Normally JSEventTargetCustom.cpp's JSEventTarget::visitAdditionalChildren() would call this. But
+    // Normally JSEventTargetCustom.cpp's JSEventTarget::visitAdditionalChildrenInGCThread() would call this. But
     // even though DOMWindow is an EventTarget, JSDOMWindow does not subclass JSEventTarget, so we need
     // to do this here.
-    SUPPRESS_UNCOUNTED_ARG wrapped().visitJSEventListeners(visitor);
+    SUPPRESS_UNCOUNTED_ARG wrapped().visitJSEventListenersInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSDOMWindow);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSDOMWindow);
 
 #if ENABLE(USER_MESSAGE_HANDLERS)
 JSC_DEFINE_CUSTOM_GETTER(jsDOMWindow_webkit, (JSGlobalObject* lexicalGlobalObject, EncodedJSValue thisValue, PropertyName))

--- a/Source/WebCore/bindings/js/JSDocumentCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDocumentCustom.cpp
@@ -88,13 +88,13 @@ void JSDocument::setAdoptedStyleSheets(JSC::JSGlobalObject& lexicalGlobalObject,
 }
 
 template<typename Visitor>
-void JSDocument::visitAdditionalChildren(Visitor& visitor)
+void JSDocument::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     // This may get called on a GC thread so we cannot ref this object.
     SUPPRESS_UNCOUNTED_ARG addWebCoreOpaqueRoot(visitor, static_cast<ScriptExecutionContext&>(wrapped()));
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSDocument);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSDocument);
 
 void JSDocument::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 {

--- a/Source/WebCore/bindings/js/JSErrorEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSErrorEventCustom.cpp
@@ -30,11 +30,11 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSErrorEvent::visitAdditionalChildren(Visitor& visitor)
+void JSErrorEvent::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().originalError().visit(visitor);
+    wrapped().originalError().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSErrorEvent);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSErrorEvent);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSEventListener.cpp
@@ -107,7 +107,7 @@ JSValue eventHandlerAttribute(EventTarget& eventTarget, const AtomString& eventT
 }
 
 template<typename Visitor>
-inline void JSEventListener::visitJSFunctionImpl(Visitor& visitor)
+inline void JSEventListener::visitJSFunctionImplInGCThread(Visitor& visitor)
 {
     // If m_wrapper is null, we are not keeping m_jsFunction alive.
     if (!m_wrapper)
@@ -116,8 +116,8 @@ inline void JSEventListener::visitJSFunctionImpl(Visitor& visitor)
     visitor.append(m_jsFunction);
 }
 
-void JSEventListener::visitJSFunction(AbstractSlotVisitor& visitor) { visitJSFunctionImpl(visitor); }
-void JSEventListener::visitJSFunction(SlotVisitor& visitor) { visitJSFunctionImpl(visitor); }
+void JSEventListener::visitJSFunctionInGCThread(AbstractSlotVisitor& visitor) { visitJSFunctionImplInGCThread(visitor); }
+void JSEventListener::visitJSFunctionInGCThread(SlotVisitor& visitor) { visitJSFunctionImplInGCThread(visitor); }
 
 static void handleBeforeUnloadEventReturnValue(BeforeUnloadEvent& event, const String& returnValue)
 {

--- a/Source/WebCore/bindings/js/JSEventListener.h
+++ b/Source/WebCore/bindings/js/JSEventListener.h
@@ -73,9 +73,9 @@ public:
 private:
     virtual JSC::JSObject* initializeJSFunction(ScriptExecutionContext&) const;
 
-    template<typename Visitor> void visitJSFunctionImpl(Visitor&);
-    void visitJSFunction(JSC::AbstractSlotVisitor&) final;
-    void visitJSFunction(JSC::SlotVisitor&) final;
+    template<typename Visitor> void visitJSFunctionImplInGCThread(Visitor&);
+    void visitJSFunctionInGCThread(JSC::AbstractSlotVisitor&) final;
+    void visitJSFunctionInGCThread(JSC::SlotVisitor&) final;
     virtual String code() const { return String(); }
 
     // JSVMClientDataClient
@@ -160,7 +160,7 @@ inline JSC::JSObject* JSEventListener::ensureJSFunction(ScriptExecutionContext& 
     // m_wrapper and m_jsFunction are Weak<>. nullptr of these fields do not mean that this event-listener is not initialized yet.
     // If this is initialized once, m_isInitialized should be true, and then m_wrapper and m_jsFunction must be alive. m_wrapper's
     // liveness should be kept correctly by using ActiveDOMObject, output-constraints, etc. And m_jsFunction must be alive if m_wrapper
-    // is alive since JSEventListener marks m_jsFunction in JSEventListener::visitJSFunction if m_wrapper is alive.
+    // is alive since JSEventListener marks m_jsFunction in JSEventListener::visitJSFunctionInGCThread if m_wrapper is alive.
     // If the event-listener is not initialized yet, we should skip invoking this event-listener.
     if (!m_isInitialized)
         return nullptr;

--- a/Source/WebCore/bindings/js/JSEventTargetCustom.cpp
+++ b/Source/WebCore/bindings/js/JSEventTargetCustom.cpp
@@ -74,11 +74,11 @@ JSEventTargetWrapper jsEventTargetCast(VM& vm, JSValue thisValue)
 }
 
 template<typename Visitor>
-void JSEventTarget::visitAdditionalChildren(Visitor& visitor)
+void JSEventTarget::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().visitJSEventListeners(visitor);
+    wrapped().visitJSEventListenersInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSEventTarget);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSEventTarget);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSExtendableMessageEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSExtendableMessageEventCustom.cpp
@@ -68,12 +68,12 @@ JSC::JSValue JSExtendableMessageEvent::ports(JSC::JSGlobalObject& lexicalGlobalO
 }
 
 template<typename Visitor>
-void JSExtendableMessageEvent::visitAdditionalChildren(Visitor& visitor)
+void JSExtendableMessageEvent::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().data().visit(visitor);
-    wrapped().cachedPorts().visit(visitor);
+    wrapped().data().visitInGCThread(visitor);
+    wrapped().cachedPorts().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSExtendableMessageEvent);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSExtendableMessageEvent);
 
 }

--- a/Source/WebCore/bindings/js/JSFetchEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSFetchEventCustom.cpp
@@ -32,11 +32,11 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSFetchEvent::visitAdditionalChildren(Visitor& visitor)
+void JSFetchEvent::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, wrapped().request());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSFetchEvent);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSFetchEvent);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSHTMLCanvasElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLCanvasElementCustom.cpp
@@ -33,11 +33,11 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSHTMLCanvasElement::visitAdditionalChildren(Visitor& visitor)
+void JSHTMLCanvasElement::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, static_cast<CanvasBase&>(wrapped()));
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSHTMLCanvasElement);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSHTMLCanvasElement);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSHTMLTemplateElementCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLTemplateElementCustom.cpp
@@ -40,12 +40,12 @@ namespace WebCore {
 using namespace JSC;
 
 template<typename Visitor>
-void JSHTMLTemplateElement::visitAdditionalChildren(Visitor& visitor)
+void JSHTMLTemplateElement::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     if (SUPPRESS_UNCHECKED_LOCAL auto* content = wrapped().contentIfAvailable())
         addWebCoreOpaqueRoot(visitor, *content);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSHTMLTemplateElement);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSHTMLTemplateElement);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSHistoryCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHistoryCustom.cpp
@@ -50,11 +50,11 @@ JSValue JSHistory::state(JSGlobalObject& lexicalGlobalObject) const
 }
 
 template<typename Visitor>
-void JSHistory::visitAdditionalChildren(Visitor& visitor)
+void JSHistory::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().cachedStateForGC().visit(visitor);
+    wrapped().cachedStateForGC().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSHistory);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSHistory);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSIDBCursorCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBCursorCustom.cpp
@@ -51,15 +51,15 @@ JSC::JSValue JSIDBCursor::primaryKey(JSC::JSGlobalObject& lexicalGlobalObject) c
 }
 
 template<typename Visitor>
-void JSIDBCursor::visitAdditionalChildren(Visitor& visitor)
+void JSIDBCursor::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     auto& cursor = wrapped();
     if (auto* request = cursor.request())
         addWebCoreOpaqueRoot(visitor, *request);
-    cursor.keyWrapper().visit(visitor);
-    cursor.primaryKeyWrapper().visit(visitor);
+    cursor.keyWrapper().visitInGCThread(visitor);
+    cursor.primaryKeyWrapper().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSIDBCursor);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSIDBCursor);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSIDBCursorWithValueCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBCursorWithValueCustom.cpp
@@ -43,12 +43,12 @@ JSC::JSValue JSIDBCursorWithValue::value(JSC::JSGlobalObject& lexicalGlobalObjec
 }
 
 template<typename Visitor>
-void JSIDBCursorWithValue::visitAdditionalChildren(Visitor& visitor)
+void JSIDBCursorWithValue::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    JSIDBCursor::visitAdditionalChildren(visitor);
-    wrapped().valueWrapper().visit(visitor);
+    JSIDBCursor::visitAdditionalChildrenInGCThread(visitor);
+    wrapped().valueWrapper().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSIDBCursorWithValue);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSIDBCursorWithValue);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSIDBObjectStoreCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBObjectStoreCustom.cpp
@@ -36,11 +36,11 @@ namespace WebCore {
 using namespace JSC;
 
 template<typename Visitor>
-void JSIDBObjectStore::visitAdditionalChildren(Visitor& visitor)
+void JSIDBObjectStore::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    static_cast<IDBObjectStore&>(wrapped()).visitReferencedIndexesConcurrently(visitor);
+    static_cast<IDBObjectStore&>(wrapped()).visitReferencedIndexesInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSIDBObjectStore);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSIDBObjectStore);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSIDBRequestCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBRequestCustom.cpp
@@ -106,12 +106,12 @@ JSC::JSValue JSIDBRequest::result(JSC::JSGlobalObject& lexicalGlobalObject) cons
 }
 
 template<typename Visitor>
-void JSIDBRequest::visitAdditionalChildren(Visitor& visitor)
+void JSIDBRequest::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     auto& request = wrapped();
-    request.resultWrapper().visit(visitor);
+    request.resultWrapper().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSIDBRequest);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSIDBRequest);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSIDBTransactionCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIDBTransactionCustom.cpp
@@ -33,11 +33,11 @@ namespace WebCore {
 using namespace JSC;
 
 template<typename Visitor>
-void JSIDBTransaction::visitAdditionalChildren(Visitor& visitor)
+void JSIDBTransaction::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    static_cast<IDBTransaction&>(wrapped()).visitReferencedObjectStores(visitor);
+    static_cast<IDBTransaction&>(wrapped()).visitReferencedObjectStoresInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSIDBTransaction);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSIDBTransaction);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSIntersectionObserverCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIntersectionObserverCustom.cpp
@@ -34,14 +34,14 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSIntersectionObserver::visitAdditionalChildren(Visitor& visitor)
+void JSIntersectionObserver::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     if (auto* callback = wrapped().callbackConcurrently())
-        callback->visitJSFunction(visitor);
+        callback->visitJSFunctionInGCThread(visitor);
     addWebCoreOpaqueRoot(visitor, wrapped().root());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSIntersectionObserver);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSIntersectionObserver);
 
 bool JSIntersectionObserverOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, JSC::AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {

--- a/Source/WebCore/bindings/js/JSIntersectionObserverEntryCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIntersectionObserverEntryCustom.cpp
@@ -33,7 +33,7 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSIntersectionObserverEntry::visitAdditionalChildren(Visitor& visitor)
+void JSIntersectionObserverEntry::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, wrapped().target());
     addWebCoreOpaqueRoot(visitor, wrapped().boundingClientRect());
@@ -41,6 +41,6 @@ void JSIntersectionObserverEntry::visitAdditionalChildren(Visitor& visitor)
     addWebCoreOpaqueRoot(visitor, wrapped().rootBounds());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSIntersectionObserverEntry);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSIntersectionObserverEntry);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSLocationCustom.cpp
+++ b/Source/WebCore/bindings/js/JSLocationCustom.cpp
@@ -200,12 +200,12 @@ bool JSLocation::preventExtensions(JSObject*, JSGlobalObject*)
 }
 
 template<typename Visitor>
-void JSLocation::visitAdditionalChildren(Visitor& visitor)
+void JSLocation::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     if (auto* ancestorOrigins = wrapped().cachedAncestorOrigins())
         addWebCoreOpaqueRoot(visitor, WebCoreOpaqueRoot(ancestorOrigins));
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSLocation);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSLocation);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSMediaControlsHostCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMediaControlsHostCustom.cpp
@@ -44,12 +44,12 @@ void JSMediaControlsHost::setController(JSC::JSGlobalObject& lexicalGlobalObject
 }
 
 template<typename Visitor>
-void JSMediaControlsHost::visitAdditionalChildren(Visitor& visitor)
+void JSMediaControlsHost::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().controllerWrapper().visit(visitor);
+    wrapped().controllerWrapper().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSMediaControlsHost);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSMediaControlsHost);
 
 } // namespace WebCore
 

--- a/Source/WebCore/bindings/js/JSMediaSessionCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMediaSessionCustom.cpp
@@ -34,12 +34,12 @@
 namespace WebCore {
 
 template <typename Visitor>
-void JSMediaSession::visitAdditionalChildren(Visitor& visitor)
+void JSMediaSession::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    SUPPRESS_UNCOUNTED_ARG wrapped().visitActionHandlers(visitor);
+    SUPPRESS_UNCOUNTED_ARG wrapped().visitActionHandlersInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSMediaSession);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSMediaSession);
 
 }
 

--- a/Source/WebCore/bindings/js/JSMessageChannelCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMessageChannelCustom.cpp
@@ -35,12 +35,12 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSMessageChannel::visitAdditionalChildren(Visitor& visitor)
+void JSMessageChannel::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, wrapped().port1());
     addWebCoreOpaqueRoot(visitor, wrapped().port2());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSMessageChannel);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSMessageChannel);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSMessageEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMessageEventCustom.cpp
@@ -67,13 +67,13 @@ JSC::JSValue JSMessageEvent::data(JSC::JSGlobalObject& lexicalGlobalObject) cons
 }
 
 template<typename Visitor>
-void JSMessageEvent::visitAdditionalChildren(Visitor& visitor)
+void JSMessageEvent::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().jsData().visit(visitor);
-    wrapped().cachedData().visit(visitor);
-    wrapped().cachedPorts().visit(visitor);
+    wrapped().jsData().visitInGCThread(visitor);
+    wrapped().cachedData().visitInGCThread(visitor);
+    wrapped().cachedPorts().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSMessageEvent);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSMessageEvent);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSMessagePortCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMessagePortCustom.cpp
@@ -32,13 +32,13 @@ namespace WebCore {
 using namespace JSC;
 
 template<typename Visitor>
-void JSMessagePort::visitAdditionalChildren(Visitor& visitor)
+void JSMessagePort::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     // If we have a locally entangled port, we can directly mark it as reachable. Ports that are remotely entangled are marked in-use by markActiveObjectsForContext().
     if (auto* port = wrapped().locallyEntangledPort())
         addWebCoreOpaqueRoot(visitor, *port);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSMessagePort);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSMessagePort);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSMutationObserverCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMutationObserverCustom.cpp
@@ -40,12 +40,12 @@ namespace WebCore {
 using namespace JSC;
 
 template<typename Visitor>
-void JSMutationObserver::visitAdditionalChildren(Visitor& visitor)
+void JSMutationObserver::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().callback().visitJSFunction(visitor);
+    wrapped().callback().visitJSFunctionInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSMutationObserver);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSMutationObserver);
 
 bool JSMutationObserverOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {

--- a/Source/WebCore/bindings/js/JSMutationRecordCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMutationRecordCustom.cpp
@@ -31,11 +31,11 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSMutationRecord::visitAdditionalChildren(Visitor& visitor)
+void JSMutationRecord::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().visitNodesConcurrently(visitor);
+    wrapped().visitNodesInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSMutationRecord);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSMutationRecord);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSNavigateEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNavigateEventCustom.cpp
@@ -29,13 +29,13 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSNavigateEvent::visitAdditionalChildren(Visitor& visitor)
+void JSNavigateEvent::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     auto& event = wrapped();
-    event.infoWrapper().visit(visitor);
+    event.infoWrapper().visitInGCThread(visitor);
     addWebCoreOpaqueRoot(visitor, &event.signal());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSNavigateEvent);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSNavigateEvent);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSNavigationCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNavigationCustom.cpp
@@ -32,14 +32,14 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSNavigation::visitAdditionalChildren(Visitor& visitor)
+void JSNavigation::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     // We cannot ref the event on a GC thread.
     SUPPRESS_UNCOUNTED_ARG if (auto* event = wrapped().ongoingNavigateEvent())
         addWebCoreOpaqueRoot(visitor, event);
-    SUPPRESS_UNCOUNTED_ARG wrapped().visitAdditionalChildren(visitor);
+    SUPPRESS_UNCOUNTED_ARG wrapped().visitAdditionalChildrenInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSNavigation);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSNavigation);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSNavigatorCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNavigatorCustom.cpp
@@ -35,12 +35,12 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSNavigator::visitAdditionalChildren(Visitor& visitor)
+void JSNavigator::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, static_cast<NavigatorBase&>(wrapped()));
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSNavigator);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSNavigator);
 
 #if ENABLE(MEDIA_STREAM)
 JSC::JSValue JSNavigator::getUserMedia(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame& callFrame)

--- a/Source/WebCore/bindings/js/JSNodeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeCustom.cpp
@@ -85,12 +85,12 @@ bool JSNodeOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, v
 }
 
 template<typename Visitor>
-void JSNode::visitAdditionalChildren(Visitor& visitor)
+void JSNode::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, wrapped());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSNode);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSNode);
 
 static ALWAYS_INLINE JSValue createWrapperInline(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, Ref<Node>&& node)
 {

--- a/Source/WebCore/bindings/js/JSNodeIteratorCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeIteratorCustom.cpp
@@ -27,12 +27,12 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSNodeIterator::visitAdditionalChildren(Visitor& visitor)
+void JSNodeIterator::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     if (auto filter = wrapped().filter())
         addWebCoreOpaqueRoot(visitor, *filter);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSNodeIterator);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSNodeIterator);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSOffscreenCanvasRenderingContext2DCustom.cpp
+++ b/Source/WebCore/bindings/js/JSOffscreenCanvasRenderingContext2DCustom.cpp
@@ -42,12 +42,12 @@ bool JSOffscreenCanvasRenderingContext2DOwner::isReachableFromOpaqueRoots(JSC::H
 }
 
 template<typename Visitor>
-void JSOffscreenCanvasRenderingContext2D::visitAdditionalChildren(Visitor& visitor)
+void JSOffscreenCanvasRenderingContext2D::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, wrapped().canvas());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSOffscreenCanvasRenderingContext2D);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSOffscreenCanvasRenderingContext2D);
 
 } // namespace WebCore
 

--- a/Source/WebCore/bindings/js/JSPaintRenderingContext2DCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPaintRenderingContext2DCustom.cpp
@@ -48,11 +48,11 @@ bool JSPaintRenderingContext2DOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC:
 }
 
 template<typename Visitor>
-void JSPaintRenderingContext2D::visitAdditionalChildren(Visitor& visitor)
+void JSPaintRenderingContext2D::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, wrapped().canvas());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSPaintRenderingContext2D);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSPaintRenderingContext2D);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSPaintWorkletGlobalScopeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPaintWorkletGlobalScopeCustom.cpp
@@ -30,15 +30,15 @@ namespace WebCore {
 using namespace JSC;
 
 template<typename Visitor>
-void JSPaintWorkletGlobalScope::visitAdditionalChildren(Visitor& visitor)
+void JSPaintWorkletGlobalScope::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     Locker locker { wrapped().paintDefinitionLock() };
     for (auto& registered : wrapped().paintDefinitionMap().values()) {
-        registered->paintCallback->visitJSFunction(visitor);
+        registered->paintCallback->visitJSFunctionInGCThread(visitor);
         visitor.appendUnbarriered(registered->paintConstructor);
     }
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSPaintWorkletGlobalScope);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSPaintWorkletGlobalScope);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSPaymentMethodChangeEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPaymentMethodChangeEventCustom.cpp
@@ -43,17 +43,17 @@ JSC::JSValue JSPaymentMethodChangeEvent::methodDetails(JSC::JSGlobalObject& lexi
 }
 
 template<typename Visitor>
-void JSPaymentMethodChangeEvent::visitAdditionalChildren(Visitor& visitor)
+void JSPaymentMethodChangeEvent::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     WTF::switchOn(wrapped().methodDetails(), [&visitor](const JSValueInWrappedObject& methodDetails) {
-        methodDetails.visit(visitor);
+        methodDetails.visitInGCThread(visitor);
     }, [](const PaymentMethodChangeEvent::MethodDetailsFunction&) {
     });
 
-    wrapped().cachedMethodDetails().visit(visitor);
+    wrapped().cachedMethodDetails().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSPaymentMethodChangeEvent);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSPaymentMethodChangeEvent);
 
 } // namespace WebCore
 

--- a/Source/WebCore/bindings/js/JSPaymentResponseCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPaymentResponseCustom.cpp
@@ -39,12 +39,12 @@ JSC::JSValue JSPaymentResponse::details(JSC::JSGlobalObject& lexicalGlobalObject
 }
 
 template<typename Visitor>
-void JSPaymentResponse::visitAdditionalChildren(Visitor& visitor)
+void JSPaymentResponse::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().cachedDetails().visit(visitor);
+    wrapped().cachedDetails().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSPaymentResponse);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSPaymentResponse);
 
 } // namespace WebCore
 

--- a/Source/WebCore/bindings/js/JSPerformanceObserverCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPerformanceObserverCustom.cpp
@@ -32,12 +32,12 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSPerformanceObserver::visitAdditionalChildren(Visitor& visitor)
+void JSPerformanceObserver::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().callback().visitJSFunction(visitor);
+    wrapped().callback().visitJSFunctionInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSPerformanceObserver);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSPerformanceObserver);
 
 bool JSPerformanceObserverOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, JSC::AbstractSlotVisitor&, ASCIILiteral* reason)
 {

--- a/Source/WebCore/bindings/js/JSPopStateEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPopStateEventCustom.cpp
@@ -93,11 +93,11 @@ JSValue JSPopStateEvent::state(JSGlobalObject& lexicalGlobalObject) const
 }
 
 template<typename Visitor>
-void JSPopStateEvent::visitAdditionalChildren(Visitor& visitor)
+void JSPopStateEvent::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().state().visit(visitor);
+    wrapped().state().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSPopStateEvent);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSPopStateEvent);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSPromiseRejectionEventCustom.cpp
+++ b/Source/WebCore/bindings/js/JSPromiseRejectionEventCustom.cpp
@@ -34,11 +34,11 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSPromiseRejectionEvent::visitAdditionalChildren(Visitor& visitor)
+void JSPromiseRejectionEvent::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().reason().visit(visitor);
+    wrapped().reason().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSPromiseRejectionEvent);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSPromiseRejectionEvent);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSRangeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSRangeCustom.cpp
@@ -32,11 +32,11 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSRange::visitAdditionalChildren(Visitor& visitor)
+void JSRange::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().visitNodesConcurrently(visitor);
+    wrapped().visitNodesInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSRange);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSRange);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSReportingObserverCustom.cpp
+++ b/Source/WebCore/bindings/js/JSReportingObserverCustom.cpp
@@ -33,12 +33,12 @@
 namespace WebCore {
 
 template <typename Visitor>
-void JSReportingObserver::visitAdditionalChildren(Visitor& visitor)
+void JSReportingObserver::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     // Do not ref `wrapped()` here since this function may get called on a GC thread.
-    SUPPRESS_UNCOUNTED_ARG wrapped().callbackConcurrently().visitJSFunction(visitor);
+    SUPPRESS_UNCOUNTED_ARG wrapped().callbackConcurrently().visitJSFunctionInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSReportingObserver);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSReportingObserver);
 
 }

--- a/Source/WebCore/bindings/js/JSResizeObserverCustom.cpp
+++ b/Source/WebCore/bindings/js/JSResizeObserverCustom.cpp
@@ -35,11 +35,11 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSResizeObserver::visitAdditionalChildren(Visitor& visitor)
+void JSResizeObserver::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     ResizeObserverCallback* callback = wrapped().callbackConcurrently();
     if (callback)
-        callback->visitJSFunction(visitor);
+        callback->visitJSFunctionInGCThread(visitor);
 
     Locker locker { wrapped().observationTargetsLock() };
 
@@ -54,7 +54,7 @@ void JSResizeObserver::visitAdditionalChildren(Visitor& visitor)
     }
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSResizeObserver);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSResizeObserver);
 
 bool JSResizeObserverOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, JSC::AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {

--- a/Source/WebCore/bindings/js/JSResizeObserverEntryCustom.cpp
+++ b/Source/WebCore/bindings/js/JSResizeObserverEntryCustom.cpp
@@ -33,12 +33,12 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSResizeObserverEntry::visitAdditionalChildren(Visitor& visitor)
+void JSResizeObserverEntry::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, wrapped().target());
     addWebCoreOpaqueRoot(visitor, wrapped().contentRect());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSResizeObserverEntry);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSResizeObserverEntry);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSSVGViewSpecCustom.cpp
+++ b/Source/WebCore/bindings/js/JSSVGViewSpecCustom.cpp
@@ -32,12 +32,12 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSSVGViewSpec::visitAdditionalChildren(Visitor& visitor)
+void JSSVGViewSpec::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     ASSERT(wrapped().contextElementConcurrently());
     addWebCoreOpaqueRoot(visitor, wrapped().contextElementConcurrently());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSSVGViewSpec);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSSVGViewSpec);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSServiceWorkerGlobalScopeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSServiceWorkerGlobalScopeCustom.cpp
@@ -36,12 +36,12 @@ namespace WebCore {
 using namespace JSC;
 
 template<typename Visitor>
-void JSServiceWorkerGlobalScope::visitAdditionalChildren(Visitor& visitor)
+void JSServiceWorkerGlobalScope::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, wrapped().clients());
     addWebCoreOpaqueRoot(visitor, wrapped().registration());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSServiceWorkerGlobalScope);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSServiceWorkerGlobalScope);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSStaticRangeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSStaticRangeCustom.cpp
@@ -31,11 +31,11 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSStaticRange::visitAdditionalChildren(Visitor& visitor)
+void JSStaticRange::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().visitNodesConcurrently(visitor);
+    wrapped().visitNodesInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSStaticRange);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSStaticRange);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSStylePropertyMapReadOnlyCustom.cpp
+++ b/Source/WebCore/bindings/js/JSStylePropertyMapReadOnlyCustom.cpp
@@ -32,11 +32,11 @@
 namespace WebCore {
 
 template <typename Visitor>
-void JSStylePropertyMapReadOnly::visitAdditionalChildren(Visitor& visitor)
+void JSStylePropertyMapReadOnly::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     if (auto* computedStylePropertyMap = dynamicDowncast<ComputedStylePropertyMapReadOnly>(wrapped()))
         addWebCoreOpaqueRoot(visitor, computedStylePropertyMap->elementConcurrently());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSStylePropertyMapReadOnly);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSStylePropertyMapReadOnly);
 }

--- a/Source/WebCore/bindings/js/JSStyleSheetCustom.cpp
+++ b/Source/WebCore/bindings/js/JSStyleSheetCustom.cpp
@@ -32,11 +32,11 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSStyleSheet::visitAdditionalChildren(Visitor& visitor)
+void JSStyleSheet::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, wrapped());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSStyleSheet);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSStyleSheet);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSSubscriberCustom.cpp
+++ b/Source/WebCore/bindings/js/JSSubscriberCustom.cpp
@@ -31,14 +31,14 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSSubscriber::visitAdditionalChildren(Visitor& visitor)
+void JSSubscriber::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     for (auto* teardown : wrapped().teardownCallbacksConcurrently())
-        teardown->visitJSFunction(visitor);
+        teardown->visitJSFunctionInGCThread(visitor);
 
-    wrapped().observerConcurrently()->visitAdditionalChildren(visitor);
+    wrapped().observerConcurrently()->visitAdditionalChildrenInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSSubscriber);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSSubscriber);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp
@@ -61,13 +61,13 @@ bool JSTextTrackCueOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> h
 }
 
 template<typename Visitor>
-void JSTextTrackCue::visitAdditionalChildren(Visitor& visitor)
+void JSTextTrackCue::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     if (auto* textTrack = wrapped().track())
         addWebCoreOpaqueRoot(visitor, *textTrack);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSTextTrackCue);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSTextTrackCue);
 
 } // namespace WebCore
 

--- a/Source/WebCore/bindings/js/JSTreeWalkerCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTreeWalkerCustom.cpp
@@ -27,12 +27,12 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSTreeWalker::visitAdditionalChildren(Visitor& visitor)
+void JSTreeWalker::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     if (auto filter = wrapped().filter())
         addWebCoreOpaqueRoot(visitor, *filter);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSTreeWalker);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSTreeWalker);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSTrustedTypePolicyCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTrustedTypePolicyCustom.cpp
@@ -31,7 +31,7 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSTrustedTypePolicy::visitAdditionalChildren(Visitor& visitor)
+void JSTrustedTypePolicy::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     SUPPRESS_UNCOUNTED_LOCAL CreateHTMLCallback* createHTML = nullptr;
     SUPPRESS_UNCOUNTED_LOCAL CreateScriptCallback* createScript = nullptr;
@@ -43,13 +43,13 @@ void JSTrustedTypePolicy::visitAdditionalChildren(Visitor& visitor)
         createScriptURL = wrapped().options().createScriptURL.get();
     }
     if (createHTML)
-        SUPPRESS_UNCOUNTED_ARG createHTML->visitJSFunction(visitor);
+        SUPPRESS_UNCOUNTED_ARG createHTML->visitJSFunctionInGCThread(visitor);
     if (createScript)
-        SUPPRESS_UNCOUNTED_ARG createScript->visitJSFunction(visitor);
+        SUPPRESS_UNCOUNTED_ARG createScript->visitJSFunctionInGCThread(visitor);
     if (createScriptURL)
-        SUPPRESS_UNCOUNTED_ARG createScriptURL->visitJSFunction(visitor);
+        SUPPRESS_UNCOUNTED_ARG createScriptURL->visitJSFunctionInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSTrustedTypePolicy);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSTrustedTypePolicy);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSTrustedTypePolicyFactoryCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTrustedTypePolicyFactoryCustom.cpp
@@ -32,11 +32,11 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSTrustedTypePolicyFactory::visitAdditionalChildren(Visitor& visitor)
+void JSTrustedTypePolicyFactory::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, wrapped().defaultPolicyConcurrently());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSTrustedTypePolicyFactory);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSTrustedTypePolicyFactory);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSUndoItemCustom.cpp
+++ b/Source/WebCore/bindings/js/JSUndoItemCustom.cpp
@@ -32,13 +32,13 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSUndoItem::visitAdditionalChildren(Visitor& visitor)
+void JSUndoItem::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().undoHandler().visitJSFunction(visitor);
-    wrapped().redoHandler().visitJSFunction(visitor);
+    wrapped().undoHandler().visitJSFunctionInGCThread(visitor);
+    wrapped().redoHandler().visitJSFunctionInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSUndoItem);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSUndoItem);
 
 bool JSUndoItemOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handle, void*, JSC::AbstractSlotVisitor& visitor, ASCIILiteral* reason)
 {

--- a/Source/WebCore/bindings/js/JSValueInWrappedObject.h
+++ b/Source/WebCore/bindings/js/JSValueInWrappedObject.h
@@ -42,14 +42,14 @@ public:
     JSValueInWrappedObject(JSC::JSValue = { });
 
     explicit operator bool() const;
-    template<typename Visitor> void visit(Visitor&) const;
+    template<typename Visitor> void visitInGCThread(Visitor&) const;
     void clear();
 
     // If you expect the value you store to be returned by getValue and not cleared under you, you *MUST* use set not setWeakly.
     // The owner parameter is typically the wrapper of the DOM node this class is embedded into but can be any GCed object that
-    // will visit this JSValueInWrappedObject via visitAdditionalChildren/isReachableFromOpaqueRoots.
+    // will visit this JSValueInWrappedObject via visitAdditionalChildrenInGCThread/isReachableFromOpaqueRoots.
     void set(JSC::VM&, const JSC::JSCell* owner, JSC::JSValue);
-    // Only use this if you actually expect this value to be weakly held. If you call visit on this value *DONT* set using setWeakly
+    // Only use this if you actually expect this value to be weakly held. If you call visitInGCThread on this value *DONT* set using setWeakly
     // use set instead. The GC might or might not keep your value around in that case.
     void setWeakly(JSC::JSValue);
     JSC::JSValue getValue(JSC::JSValue nullValue = JSC::jsUndefined()) const;
@@ -80,13 +80,13 @@ inline JSValueInWrappedObject::operator bool() const
 }
 
 template<typename Visitor>
-inline void JSValueInWrappedObject::visit(Visitor& visitor) const
+inline void JSValueInWrappedObject::visitInGCThread(Visitor& visitor) const
 {
     visitor.append(m_cell);
 }
 
-template void JSValueInWrappedObject::visit(JSC::AbstractSlotVisitor&) const;
-template void JSValueInWrappedObject::visit(JSC::SlotVisitor&) const;
+template void JSValueInWrappedObject::visitInGCThread(JSC::AbstractSlotVisitor&) const;
+template void JSValueInWrappedObject::visitInGCThread(JSC::SlotVisitor&) const;
 
 inline void JSValueInWrappedObject::setWeakly(JSC::JSValue value)
 {

--- a/Source/WebCore/bindings/js/JSWebCodecsAudioDecoderCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebCodecsAudioDecoderCustom.cpp
@@ -36,13 +36,13 @@
 namespace WebCore {
 
 template <typename Visitor>
-void JSWebCodecsAudioDecoder::visitAdditionalChildren(Visitor& visitor)
+void JSWebCodecsAudioDecoder::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().outputCallbackConcurrently().visitJSFunction(visitor);
-    wrapped().errorCallbackConcurrently().visitJSFunction(visitor);
+    wrapped().outputCallbackConcurrently().visitJSFunctionInGCThread(visitor);
+    wrapped().errorCallbackConcurrently().visitJSFunctionInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSWebCodecsAudioDecoder);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSWebCodecsAudioDecoder);
 
 }
 

--- a/Source/WebCore/bindings/js/JSWebCodecsAudioEncoderCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebCodecsAudioEncoderCustom.cpp
@@ -36,13 +36,13 @@
 namespace WebCore {
 
 template <typename Visitor>
-void JSWebCodecsAudioEncoder::visitAdditionalChildren(Visitor& visitor)
+void JSWebCodecsAudioEncoder::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().outputCallbackConcurrently().visitJSFunction(visitor);
-    wrapped().errorCallbackConcurrently().visitJSFunction(visitor);
+    wrapped().outputCallbackConcurrently().visitJSFunctionInGCThread(visitor);
+    wrapped().errorCallbackConcurrently().visitJSFunctionInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSWebCodecsAudioEncoder);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSWebCodecsAudioEncoder);
 
 }
 

--- a/Source/WebCore/bindings/js/JSWebCodecsVideoDecoderCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebCodecsVideoDecoderCustom.cpp
@@ -36,13 +36,13 @@
 namespace WebCore {
 
 template <typename Visitor>
-void JSWebCodecsVideoDecoder::visitAdditionalChildren(Visitor& visitor)
+void JSWebCodecsVideoDecoder::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().outputCallbackConcurrently().visitJSFunction(visitor);
-    wrapped().errorCallbackConcurrently().visitJSFunction(visitor);
+    wrapped().outputCallbackConcurrently().visitJSFunctionInGCThread(visitor);
+    wrapped().errorCallbackConcurrently().visitJSFunctionInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSWebCodecsVideoDecoder);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSWebCodecsVideoDecoder);
 
 }
 

--- a/Source/WebCore/bindings/js/JSWebCodecsVideoEncoderCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebCodecsVideoEncoderCustom.cpp
@@ -36,13 +36,13 @@
 namespace WebCore {
 
 template <typename Visitor>
-void JSWebCodecsVideoEncoder::visitAdditionalChildren(Visitor& visitor)
+void JSWebCodecsVideoEncoder::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().outputCallbackConcurrently().visitJSFunction(visitor);
-    wrapped().errorCallbackConcurrently().visitJSFunction(visitor);
+    wrapped().outputCallbackConcurrently().visitJSFunctionInGCThread(visitor);
+    wrapped().errorCallbackConcurrently().visitJSFunctionInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSWebCodecsVideoEncoder);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSWebCodecsVideoEncoder);
 
 }
 

--- a/Source/WebCore/bindings/js/JSWebGL2RenderingContextCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebGL2RenderingContextCustom.cpp
@@ -35,13 +35,13 @@ namespace WebCore {
 using namespace JSC;
 
 template<typename Visitor>
-void JSWebGL2RenderingContext::visitAdditionalChildren(Visitor& visitor)
+void JSWebGL2RenderingContext::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, wrapped());
     wrapped().addMembersToOpaqueRoots(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSWebGL2RenderingContext);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSWebGL2RenderingContext);
 
 } // namespace WebCore
 

--- a/Source/WebCore/bindings/js/JSWebGLRenderingContextCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebGLRenderingContextCustom.cpp
@@ -35,13 +35,13 @@ namespace WebCore {
 using namespace JSC;
 
 template<typename Visitor>
-void JSWebGLRenderingContext::visitAdditionalChildren(Visitor& visitor)
+void JSWebGLRenderingContext::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, wrapped());
     wrapped().addMembersToOpaqueRoots(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSWebGLRenderingContext);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSWebGLRenderingContext);
 
 } // namespace WebCore
 

--- a/Source/WebCore/bindings/js/JSWebXRRigidTransformCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebXRRigidTransformCustom.cpp
@@ -44,12 +44,12 @@ JSC::JSValue JSWebXRRigidTransform::matrix(JSC::JSGlobalObject& lexicalGlobalObj
 }
 
 template<typename Visitor>
-void JSWebXRRigidTransform::visitAdditionalChildren(Visitor& visitor)
+void JSWebXRRigidTransform::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().cachedMatrix().visit(visitor);
+    wrapped().cachedMatrix().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSWebXRRigidTransform);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSWebXRRigidTransform);
 
 } // namespace WebCore
 

--- a/Source/WebCore/bindings/js/JSWebXRSessionCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebXRSessionCustom.cpp
@@ -32,12 +32,12 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSWebXRSession::visitAdditionalChildren(Visitor& visitor)
+void JSWebXRSession::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, wrapped());
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSWebXRSession);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSWebXRSession);
 
 } // namespace WebCore
 

--- a/Source/WebCore/bindings/js/JSWebXRViewCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWebXRViewCustom.cpp
@@ -44,12 +44,12 @@ JSC::JSValue JSWebXRView::projectionMatrix(JSC::JSGlobalObject& lexicalGlobalObj
 }
 
 template<typename Visitor>
-void JSWebXRView::visitAdditionalChildren(Visitor& visitor)
+void JSWebXRView::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().cachedProjectionMatrix().visit(visitor);
+    wrapped().cachedProjectionMatrix().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSWebXRView);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSWebXRView);
 
 } // namespace WebCore
 

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp
@@ -38,7 +38,7 @@ namespace WebCore {
 using namespace JSC;
 
 template<typename Visitor>
-void JSWorkerGlobalScope::visitAdditionalChildren(Visitor& visitor)
+void JSWorkerGlobalScope::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     if (auto* location = wrapped().optionalLocation())
         addWebCoreOpaqueRoot(visitor, *location);
@@ -48,13 +48,13 @@ void JSWorkerGlobalScope::visitAdditionalChildren(Visitor& visitor)
     // We cannot ref the object here as this may get called on a GC thread.
     SUPPRESS_UNCOUNTED_ARG addWebCoreOpaqueRoot(visitor, static_cast<ScriptExecutionContext&>(wrapped()));
     
-    // Normally JSEventTargetCustom.cpp's JSEventTarget::visitAdditionalChildren() would call this. But
+    // Normally JSEventTargetCustom.cpp's JSEventTarget::visitAdditionalChildrenInGCThread() would call this. But
     // even though WorkerGlobalScope is an EventTarget, JSWorkerGlobalScope does not subclass
     // JSEventTarget, so we need to do this here.
-    wrapped().visitJSEventListeners(visitor);
+    wrapped().visitJSEventListenersInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSWorkerGlobalScope);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSWorkerGlobalScope);
 
 JSValue JSWorkerGlobalScope::queueMicrotask(JSGlobalObject& lexicalGlobalObject, CallFrame& callFrame)
 {

--- a/Source/WebCore/bindings/js/JSWorkerNavigatorCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerNavigatorCustom.cpp
@@ -32,11 +32,11 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSWorkerNavigator::visitAdditionalChildren(Visitor& visitor)
+void JSWorkerNavigator::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     addWebCoreOpaqueRoot(visitor, static_cast<NavigatorBase&>(wrapped()));
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSWorkerNavigator);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSWorkerNavigator);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/js/JSXMLHttpRequestCustom.cpp
+++ b/Source/WebCore/bindings/js/JSXMLHttpRequestCustom.cpp
@@ -43,7 +43,7 @@ namespace WebCore {
 using namespace JSC;
 
 template<typename Visitor>
-void JSXMLHttpRequest::visitAdditionalChildren(Visitor& visitor)
+void JSXMLHttpRequest::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     if (auto* upload = wrapped().optionalUpload())
         addWebCoreOpaqueRoot(visitor, *upload);
@@ -52,7 +52,7 @@ void JSXMLHttpRequest::visitAdditionalChildren(Visitor& visitor)
         addWebCoreOpaqueRoot(visitor, *responseDocument);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSXMLHttpRequest);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSXMLHttpRequest);
 
 JSValue JSXMLHttpRequest::response(JSGlobalObject& lexicalGlobalObject) const
 {

--- a/Source/WebCore/bindings/js/JSXPathResultCustom.cpp
+++ b/Source/WebCore/bindings/js/JSXPathResultCustom.cpp
@@ -34,7 +34,7 @@
 namespace WebCore {
 
 template<typename Visitor>
-void JSXPathResult::visitAdditionalChildren(Visitor& visitor)
+void JSXPathResult::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
     auto& value = wrapped().value();
     if (value.isNodeSet()) {
@@ -44,6 +44,6 @@ void JSXPathResult::visitAdditionalChildren(Visitor& visitor)
     }
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSXPathResult);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSXPathResult);
 
 } // namespace WebCore

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -3721,21 +3721,21 @@ sub GenerateHeader
     # visit function
     if ($needsVisitChildren) {
         push(@headerContent, "    DECLARE_VISIT_CHILDREN;\n");
-        push(@headerContent, "    template<typename Visitor> void visitAdditionalChildren(Visitor&);\n") if $interface->extendedAttributes->{JSCustomMarkFunction};
+        push(@headerContent, "    template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);\n") if $interface->extendedAttributes->{JSCustomMarkFunction};
         push(@headerContent, "\n");
 
         if ($interface->extendedAttributes->{JSCustomMarkFunction}) {
-            # We assume that the logic in visitAdditionalChildren is highly volatile, and during a
+            # We assume that the logic in visitAdditionalChildrenInGCThread is highly volatile, and during a
             # concurrent GC or in between eden GCs something may happen that would lead to this
             # logic behaving differently. Since this could mark objects or add opaque roots, this
             # means that after any increment of mutator resumption in a concurrent GC and at least
-            # once during any eden GC we need to re-execute visitAdditionalChildren on any objects
+            # once during any eden GC we need to re-execute visitAdditionalChildrenInGCThread on any objects
             # that we had executed it on before. We do this using the DOM's own MarkingConstraint,
             # which will call visitOutputConstraints on all objects in the DOM's own
             # outputConstraintSubspace. visitOutputConstraints is the name JSC uses for the method
             # that the GC calls to ask an object is it would like to mark anything else after the
             # program resumed since the last call to visitChildren or visitOutputConstraints. Since
-            # this just calls visitAdditionalChildren, you usually don't have to worry about this.
+            # this just calls visitAdditionalChildrenInGCThread, you usually don't have to worry about this.
             push(@headerContent, "    template<typename Visitor> static void visitOutputConstraints(JSCell*, Visitor&);\n");
         }
     }
@@ -5647,7 +5647,7 @@ sub GenerateImplementation
         push(@implContent, "    auto* thisObject = jsCast<${className}*>(cell);\n");
         push(@implContent, "    ASSERT_GC_OBJECT_INHERITS(thisObject, info());\n");
         push(@implContent, "    Base::visitChildren(thisObject, visitor);\n");
-        push(@implContent, "    thisObject->visitAdditionalChildren(visitor);\n") if $interface->extendedAttributes->{JSCustomMarkFunction};
+        push(@implContent, "    thisObject->visitAdditionalChildrenInGCThread(visitor);\n") if $interface->extendedAttributes->{JSCustomMarkFunction};
         if ($interface->extendedAttributes->{GenerateAddOpaqueRoot}) {
             AddToImplIncludes("<wtf/GetPtr.h>");
             AddToImplIncludes("WebCoreOpaqueRootInlines.h");
@@ -5684,7 +5684,7 @@ sub GenerateImplementation
             push(@implContent, "    auto* thisObject = jsCast<${className}*>(cell);\n");
             push(@implContent, "    ASSERT_GC_OBJECT_INHERITS(thisObject, info());\n");
             push(@implContent, "    Base::visitOutputConstraints(thisObject, visitor);\n");
-            push(@implContent, "    thisObject->visitAdditionalChildren(visitor);\n");
+            push(@implContent, "    thisObject->visitAdditionalChildrenInGCThread(visitor);\n");
             push(@implContent, "}\n\n");
             push(@implContent, "template void ${className}::visitOutputConstraints(JSCell*, AbstractSlotVisitor&);\n");
             push(@implContent, "template void ${className}::visitOutputConstraints(JSCell*, SlotVisitor&);\n");
@@ -7417,8 +7417,8 @@ sub GenerateCallbackHeaderContent
     push(@$contentRef, "    bool is${className}() const final { return true; }\n\n");
 
     if (!$generateIsReachable) {
-        push(@$contentRef, "    void visitJSFunction(JSC::AbstractSlotVisitor&) override;\n\n");
-        push(@$contentRef, "    void visitJSFunction(JSC::SlotVisitor&) override;\n\n");
+        push(@$contentRef, "    void visitJSFunctionInGCThread(JSC::AbstractSlotVisitor&) override;\n\n");
+        push(@$contentRef, "    void visitJSFunctionInGCThread(JSC::SlotVisitor&) override;\n\n");
     }
 
     push(@$contentRef, "    JSCallbackData* m_data;\n");
@@ -7657,13 +7657,13 @@ sub GenerateCallbackImplementationContent
     }
 
     if (!$generateIsReachable) {
-        push(@$contentRef, "void ${className}::visitJSFunction(JSC::AbstractSlotVisitor& visitor)\n");
+        push(@$contentRef, "void ${className}::visitJSFunctionInGCThread(JSC::AbstractSlotVisitor& visitor)\n");
         push(@$contentRef, "{\n");
-        push(@$contentRef, "    m_data->visitJSFunction(visitor);\n");
+        push(@$contentRef, "    m_data->visitJSFunctionInGCThread(visitor);\n");
         push(@$contentRef, "}\n\n");
-        push(@$contentRef, "void ${className}::visitJSFunction(JSC::SlotVisitor& visitor)\n");
+        push(@$contentRef, "void ${className}::visitJSFunctionInGCThread(JSC::SlotVisitor& visitor)\n");
         push(@$contentRef, "{\n");
-        push(@$contentRef, "    m_data->visitJSFunction(visitor);\n");
+        push(@$contentRef, "    m_data->visitJSFunctionInGCThread(visitor);\n");
         push(@$contentRef, "}\n\n");
     }
 

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
@@ -116,14 +116,14 @@ CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunction
     return { returnValue.releaseReturnValue() };
 }
 
-void JSTestCallbackFunction::visitJSFunction(JSC::AbstractSlotVisitor& visitor)
+void JSTestCallbackFunction::visitJSFunctionInGCThread(JSC::AbstractSlotVisitor& visitor)
 {
-    m_data->visitJSFunction(visitor);
+    m_data->visitJSFunctionInGCThread(visitor);
 }
 
-void JSTestCallbackFunction::visitJSFunction(JSC::SlotVisitor& visitor)
+void JSTestCallbackFunction::visitJSFunctionInGCThread(JSC::SlotVisitor& visitor)
 {
-    m_data->visitJSFunction(visitor);
+    m_data->visitJSFunctionInGCThread(visitor);
 }
 
 JSC::JSValue toJS(TestCallbackFunction& impl)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h
@@ -51,9 +51,9 @@ private:
 
     bool isJSTestCallbackFunction() const final { return true; }
 
-    void visitJSFunction(JSC::AbstractSlotVisitor&) override;
+    void visitJSFunctionInGCThread(JSC::AbstractSlotVisitor&) override;
 
-    void visitJSFunction(JSC::SlotVisitor&) override;
+    void visitJSFunctionInGCThread(JSC::SlotVisitor&) override;
 
     JSCallbackData* m_data;
 };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
@@ -112,14 +112,14 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackFunction
     return { };
 }
 
-void JSTestCallbackFunctionWithThisObject::visitJSFunction(JSC::AbstractSlotVisitor& visitor)
+void JSTestCallbackFunctionWithThisObject::visitJSFunctionInGCThread(JSC::AbstractSlotVisitor& visitor)
 {
-    m_data->visitJSFunction(visitor);
+    m_data->visitJSFunctionInGCThread(visitor);
 }
 
-void JSTestCallbackFunctionWithThisObject::visitJSFunction(JSC::SlotVisitor& visitor)
+void JSTestCallbackFunctionWithThisObject::visitJSFunctionInGCThread(JSC::SlotVisitor& visitor)
 {
-    m_data->visitJSFunction(visitor);
+    m_data->visitJSFunctionInGCThread(visitor);
 }
 
 JSC::JSValue toJS(TestCallbackFunctionWithThisObject& impl)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h
@@ -51,9 +51,9 @@ private:
 
     bool isJSTestCallbackFunctionWithThisObject() const final { return true; }
 
-    void visitJSFunction(JSC::AbstractSlotVisitor&) override;
+    void visitJSFunctionInGCThread(JSC::AbstractSlotVisitor&) override;
 
-    void visitJSFunction(JSC::SlotVisitor&) override;
+    void visitJSFunctionInGCThread(JSC::SlotVisitor&) override;
 
     JSCallbackData* m_data;
 };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
@@ -114,14 +114,14 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackFunction
     return { };
 }
 
-void JSTestCallbackFunctionWithTypedefs::visitJSFunction(JSC::AbstractSlotVisitor& visitor)
+void JSTestCallbackFunctionWithTypedefs::visitJSFunctionInGCThread(JSC::AbstractSlotVisitor& visitor)
 {
-    m_data->visitJSFunction(visitor);
+    m_data->visitJSFunctionInGCThread(visitor);
 }
 
-void JSTestCallbackFunctionWithTypedefs::visitJSFunction(JSC::SlotVisitor& visitor)
+void JSTestCallbackFunctionWithTypedefs::visitJSFunctionInGCThread(JSC::SlotVisitor& visitor)
 {
-    m_data->visitJSFunction(visitor);
+    m_data->visitJSFunctionInGCThread(visitor);
 }
 
 JSC::JSValue toJS(TestCallbackFunctionWithTypedefs& impl)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h
@@ -51,9 +51,9 @@ private:
 
     bool isJSTestCallbackFunctionWithTypedefs() const final { return true; }
 
-    void visitJSFunction(JSC::AbstractSlotVisitor&) override;
+    void visitJSFunctionInGCThread(JSC::AbstractSlotVisitor&) override;
 
-    void visitJSFunction(JSC::SlotVisitor&) override;
+    void visitJSFunctionInGCThread(JSC::SlotVisitor&) override;
 
     JSCallbackData* m_data;
 };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
@@ -119,14 +119,14 @@ CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunction
     return { returnValue.releaseReturnValue() };
 }
 
-void JSTestCallbackFunctionWithVariadic::visitJSFunction(JSC::AbstractSlotVisitor& visitor)
+void JSTestCallbackFunctionWithVariadic::visitJSFunctionInGCThread(JSC::AbstractSlotVisitor& visitor)
 {
-    m_data->visitJSFunction(visitor);
+    m_data->visitJSFunctionInGCThread(visitor);
 }
 
-void JSTestCallbackFunctionWithVariadic::visitJSFunction(JSC::SlotVisitor& visitor)
+void JSTestCallbackFunctionWithVariadic::visitJSFunctionInGCThread(JSC::SlotVisitor& visitor)
 {
-    m_data->visitJSFunction(visitor);
+    m_data->visitJSFunctionInGCThread(visitor);
 }
 
 JSC::JSValue toJS(TestCallbackFunctionWithVariadic& impl)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h
@@ -53,9 +53,9 @@ private:
 
     bool isJSTestCallbackFunctionWithVariadic() const final { return true; }
 
-    void visitJSFunction(JSC::AbstractSlotVisitor&) override;
+    void visitJSFunctionInGCThread(JSC::AbstractSlotVisitor&) override;
 
-    void visitJSFunction(JSC::SlotVisitor&) override;
+    void visitJSFunctionInGCThread(JSC::SlotVisitor&) override;
 
     JSCallbackData* m_data;
 };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -762,14 +762,14 @@ CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackInterfac
     return { returnValue.releaseReturnValue() };
 }
 
-void JSTestCallbackInterface::visitJSFunction(JSC::AbstractSlotVisitor& visitor)
+void JSTestCallbackInterface::visitJSFunctionInGCThread(JSC::AbstractSlotVisitor& visitor)
 {
-    m_data->visitJSFunction(visitor);
+    m_data->visitJSFunctionInGCThread(visitor);
 }
 
-void JSTestCallbackInterface::visitJSFunction(JSC::SlotVisitor& visitor)
+void JSTestCallbackInterface::visitJSFunctionInGCThread(JSC::SlotVisitor& visitor)
 {
-    m_data->visitJSFunction(visitor);
+    m_data->visitJSFunctionInGCThread(visitor);
 }
 
 JSC::JSValue toJS(TestCallbackInterface& impl)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
@@ -75,9 +75,9 @@ private:
 
     bool isJSTestCallbackInterface() const final { return true; }
 
-    void visitJSFunction(JSC::AbstractSlotVisitor&) override;
+    void visitJSFunctionInGCThread(JSC::AbstractSlotVisitor&) override;
 
-    void visitJSFunction(JSC::SlotVisitor&) override;
+    void visitJSFunctionInGCThread(JSC::SlotVisitor&) override;
 
     JSCallbackData* m_data;
 };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
@@ -114,14 +114,14 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestCallbackWithFunc
     return { };
 }
 
-void JSTestCallbackWithFunctionOrDict::visitJSFunction(JSC::AbstractSlotVisitor& visitor)
+void JSTestCallbackWithFunctionOrDict::visitJSFunctionInGCThread(JSC::AbstractSlotVisitor& visitor)
 {
-    m_data->visitJSFunction(visitor);
+    m_data->visitJSFunctionInGCThread(visitor);
 }
 
-void JSTestCallbackWithFunctionOrDict::visitJSFunction(JSC::SlotVisitor& visitor)
+void JSTestCallbackWithFunctionOrDict::visitJSFunctionInGCThread(JSC::SlotVisitor& visitor)
 {
-    m_data->visitJSFunction(visitor);
+    m_data->visitJSFunctionInGCThread(visitor);
 }
 
 JSC::JSValue toJS(TestCallbackWithFunctionOrDict& impl)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h
@@ -51,9 +51,9 @@ private:
 
     bool isJSTestCallbackWithFunctionOrDict() const final { return true; }
 
-    void visitJSFunction(JSC::AbstractSlotVisitor&) override;
+    void visitJSFunctionInGCThread(JSC::AbstractSlotVisitor&) override;
 
-    void visitJSFunction(JSC::SlotVisitor&) override;
+    void visitJSFunctionInGCThread(JSC::SlotVisitor&) override;
 
     JSCallbackData* m_data;
 };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
@@ -130,14 +130,14 @@ CallbackResult<typename IDLUndefined::CallbackReturnType> JSTestVoidCallbackFunc
     return { };
 }
 
-void JSTestVoidCallbackFunction::visitJSFunction(JSC::AbstractSlotVisitor& visitor)
+void JSTestVoidCallbackFunction::visitJSFunctionInGCThread(JSC::AbstractSlotVisitor& visitor)
 {
-    m_data->visitJSFunction(visitor);
+    m_data->visitJSFunctionInGCThread(visitor);
 }
 
-void JSTestVoidCallbackFunction::visitJSFunction(JSC::SlotVisitor& visitor)
+void JSTestVoidCallbackFunction::visitJSFunctionInGCThread(JSC::SlotVisitor& visitor)
 {
-    m_data->visitJSFunction(visitor);
+    m_data->visitJSFunctionInGCThread(visitor);
 }
 
 JSC::JSValue toJS(TestVoidCallbackFunction& impl)

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h
@@ -53,9 +53,9 @@ private:
 
     bool isJSTestVoidCallbackFunction() const final { return true; }
 
-    void visitJSFunction(JSC::AbstractSlotVisitor&) override;
+    void visitJSFunctionInGCThread(JSC::AbstractSlotVisitor&) override;
 
-    void visitJSFunction(JSC::SlotVisitor&) override;
+    void visitJSFunctionInGCThread(JSC::SlotVisitor&) override;
 
     JSCallbackData* m_data;
 };

--- a/Source/WebCore/dom/AbortController.cpp
+++ b/Source/WebCore/dom/AbortController.cpp
@@ -58,11 +58,11 @@ WebCoreOpaqueRoot AbortController::opaqueRoot()
 }
 
 template<typename Visitor>
-void JSAbortController::visitAdditionalChildren(Visitor& visitor)
+void JSAbortController::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    wrapped().signal().reason().visit(visitor);
+    wrapped().signal().reason().visitInGCThread(visitor);
 }
 
-DEFINE_VISIT_ADDITIONAL_CHILDREN(JSAbortController);
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSAbortController);
 
 }

--- a/Source/WebCore/dom/ActiveDOMCallback.h
+++ b/Source/WebCore/dom/ActiveDOMCallback.h
@@ -57,8 +57,8 @@ public:
     WEBCORE_EXPORT bool activeDOMObjectsAreSuspended() const;
     WEBCORE_EXPORT bool activeDOMObjectAreStopped() const;
     
-    virtual void visitJSFunction(JSC::AbstractSlotVisitor&) { }
-    virtual void visitJSFunction(JSC::SlotVisitor&) { }
+    virtual void visitJSFunctionInGCThread(JSC::AbstractSlotVisitor&) { }
+    virtual void visitJSFunctionInGCThread(JSC::SlotVisitor&) { }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/CustomElementRegistry.cpp
+++ b/Source/WebCore/dom/CustomElementRegistry.cpp
@@ -265,7 +265,7 @@ void CustomElementRegistry::visitJSCustomElementInterfacesInGCThread(Visitor& vi
 {
     Locker locker { m_constructorMapLock };
     for (const auto& iterator : m_constructorMap)
-        iterator.value->visitJSFunctions(visitor);
+        iterator.value->visitJSFunctionsInGCThread(visitor);
 }
 
 template void CustomElementRegistry::visitJSCustomElementInterfacesInGCThread(JSC::AbstractSlotVisitor&) const;

--- a/Source/WebCore/dom/EventListener.h
+++ b/Source/WebCore/dom/EventListener.h
@@ -55,8 +55,8 @@ public:
 
     virtual void handleEvent(ScriptExecutionContext&, Event&) = 0;
 
-    virtual void visitJSFunction(JSC::AbstractSlotVisitor&) { }
-    virtual void visitJSFunction(JSC::SlotVisitor&) { }
+    virtual void visitJSFunctionInGCThread(JSC::AbstractSlotVisitor&) { }
+    virtual void visitJSFunctionInGCThread(JSC::SlotVisitor&) { }
 
     virtual bool isAttribute() const { return false; }
     Type type() const { return m_type; }

--- a/Source/WebCore/dom/EventListenerMap.h
+++ b/Source/WebCore/dom/EventListenerMap.h
@@ -110,7 +110,7 @@ public:
     void removeFirstEventListenerCreatedFromMarkup(const AtomString& eventType);
     void copyEventListenersNotCreatedFromMarkupToTarget(EventTarget*);
     
-    template<typename Visitor> void visitJSEventListeners(Visitor&);
+    template<typename Visitor> void visitJSEventListenersInGCThread(Visitor&);
     Lock& lock() LIFETIME_BOUND { return m_lock; }
 
 private:
@@ -136,12 +136,12 @@ private:
 };
 
 template<typename Visitor>
-void EventListenerMap::visitJSEventListeners(Visitor& visitor)
+void EventListenerMap::visitJSEventListenersInGCThread(Visitor& visitor)
 {
     Locker locker { m_lock };
     for (auto& entry : m_entries) {
         for (auto& eventListener : entry.second)
-            eventListener->callback().visitJSFunction(visitor);
+            eventListener->callback().visitJSFunctionInGCThread(visitor);
     }
 }
 

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -133,7 +133,7 @@ public:
     void fireEventListeners(Event&, EventInvokePhase);
 
     template<typename Visitor>
-    inline void visitJSEventListeners(Visitor&);
+    inline void visitJSEventListenersInGCThread(Visitor&);
     void invalidateJSEventListeners(JSC::JSObject*);
 
     inline const EventTargetData* eventTargetData() const;

--- a/Source/WebCore/dom/EventTargetInlines.h
+++ b/Source/WebCore/dom/EventTargetInlines.h
@@ -121,10 +121,10 @@ inline bool EventTarget::containsMatchingEventListener(NOESCAPE const CallbackTy
 }
 
 template<typename Visitor>
-inline void EventTarget::visitJSEventListeners(Visitor& visitor)
+inline void EventTarget::visitJSEventListenersInGCThread(Visitor& visitor)
 {
     if (auto* data = eventTargetDataConcurrently())
-        data->eventListenerMap.visitJSEventListeners(visitor);
+        data->eventListenerMap.visitJSEventListenersInGCThread(visitor);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/InternalObserver.h
+++ b/Source/WebCore/dom/InternalObserver.h
@@ -50,7 +50,7 @@ public:
 
     virtual void error(JSC::JSValue);
 
-    virtual void visitAdditionalChildren(JSC::AbstractSlotVisitor&) const = 0;
+    virtual void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor&) const = 0;
 
 protected:
     bool m_active { true };

--- a/Source/WebCore/dom/InternalObserverDrop.cpp
+++ b/Source/WebCore/dom/InternalObserverDrop.cpp
@@ -109,9 +109,9 @@ private:
         protect(m_subscriber)->complete();
     }
 
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor) const final
     {
-        m_subscriber->visitAdditionalChildren(visitor);
+        m_subscriber->visitAdditionalChildrenInGCThread(visitor);
     }
 
     InternalObserverDrop(ScriptExecutionContext& context, Ref<Subscriber> subscriber, uint64_t amount)

--- a/Source/WebCore/dom/InternalObserverEvery.cpp
+++ b/Source/WebCore/dom/InternalObserverEvery.cpp
@@ -99,9 +99,9 @@ private:
         m_promise->resolve<IDLBoolean>(true);
     }
 
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor) const final
     {
-        m_callback->visitJSFunction(visitor);
+        m_callback->visitJSFunctionInGCThread(visitor);
     }
 
     InternalObserverEvery(ScriptExecutionContext& context, Ref<PredicateCallback>&& callback, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/InternalObserverFilter.cpp
+++ b/Source/WebCore/dom/InternalObserverFilter.cpp
@@ -134,10 +134,10 @@ private:
         protect(m_subscriber)->complete();
     }
 
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor) const final
     {
-        m_subscriber->visitAdditionalChildren(visitor);
-        m_predicate->visitJSFunction(visitor);
+        m_subscriber->visitAdditionalChildrenInGCThread(visitor);
+        m_predicate->visitJSFunctionInGCThread(visitor);
     }
 
     InternalObserverFilter(ScriptExecutionContext& context, Ref<Subscriber> subscriber, Ref<PredicateCallback> predicate)

--- a/Source/WebCore/dom/InternalObserverFind.cpp
+++ b/Source/WebCore/dom/InternalObserverFind.cpp
@@ -100,9 +100,9 @@ private:
         m_promise->resolve();
     }
 
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor) const final
     {
-        m_callback->visitJSFunction(visitor);
+        m_callback->visitJSFunctionInGCThread(visitor);
     }
 
     InternalObserverFind(ScriptExecutionContext& context, Ref<PredicateCallback>&& callback, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/InternalObserverFirst.cpp
+++ b/Source/WebCore/dom/InternalObserverFirst.cpp
@@ -67,7 +67,7 @@ private:
         protect(m_promise)->reject(Exception { ExceptionCode::RangeError, "No values in Observable"_s });
     }
 
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor&) const final
+    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor&) const final
     {
     }
 

--- a/Source/WebCore/dom/InternalObserverForEach.cpp
+++ b/Source/WebCore/dom/InternalObserverForEach.cpp
@@ -87,9 +87,9 @@ private:
         protect(m_promise)->resolve();
     }
 
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor) const final
     {
-        m_callback->visitJSFunction(visitor);
+        m_callback->visitJSFunctionInGCThread(visitor);
     }
 
     InternalObserverForEach(ScriptExecutionContext& context, Ref<VisitorCallback>&& callback, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/InternalObserverFromScript.cpp
+++ b/Source/WebCore/dom/InternalObserverFromScript.cpp
@@ -70,16 +70,16 @@ void InternalObserverFromScript::complete()
     m_active = false;
 }
 
-void InternalObserverFromScript::visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const
+void InternalObserverFromScript::visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor) const
 {
     if (RefPtr next = m_next)
-        next->visitJSFunction(visitor);
+        next->visitJSFunctionInGCThread(visitor);
 
     if (RefPtr error = m_error)
-        error->visitJSFunction(visitor);
+        error->visitJSFunctionInGCThread(visitor);
 
     if (RefPtr complete = m_complete)
-        complete->visitJSFunction(visitor);
+        complete->visitJSFunctionInGCThread(visitor);
 }
 
 InternalObserverFromScript::InternalObserverFromScript(ScriptExecutionContext& context, RefPtr<JSSubscriptionObserverCallback> callback)

--- a/Source/WebCore/dom/InternalObserverFromScript.h
+++ b/Source/WebCore/dom/InternalObserverFromScript.h
@@ -48,7 +48,7 @@ public:
     void error(JSC::JSValue) final;
     void complete() final;
 
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor&) const final;
+    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor&) const final;
 
 protected:
     // ActiveDOMObject

--- a/Source/WebCore/dom/InternalObserverInspect.cpp
+++ b/Source/WebCore/dom/InternalObserverInspect.cpp
@@ -174,19 +174,19 @@ private:
         protect(m_subscriber)->complete();
     }
 
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor) const final
     {
-        m_subscriber->visitAdditionalChildren(visitor);
+        m_subscriber->visitAdditionalChildrenInGCThread(visitor);
         if (m_inspector.next)
-            SUPPRESS_UNCOUNTED_ARG m_inspector.next->visitJSFunction(visitor);
+            SUPPRESS_UNCOUNTED_ARG m_inspector.next->visitJSFunctionInGCThread(visitor);
         if (m_inspector.error)
-            SUPPRESS_UNCOUNTED_ARG m_inspector.error->visitJSFunction(visitor);
+            SUPPRESS_UNCOUNTED_ARG m_inspector.error->visitJSFunctionInGCThread(visitor);
         if (m_inspector.complete)
-            SUPPRESS_UNCOUNTED_ARG m_inspector.complete->visitJSFunction(visitor);
+            SUPPRESS_UNCOUNTED_ARG m_inspector.complete->visitJSFunctionInGCThread(visitor);
         if (m_inspector.subscribe)
-            SUPPRESS_UNCOUNTED_ARG m_inspector.subscribe->visitJSFunction(visitor);
+            SUPPRESS_UNCOUNTED_ARG m_inspector.subscribe->visitJSFunctionInGCThread(visitor);
         if (m_inspector.abort)
-            SUPPRESS_UNCOUNTED_ARG m_inspector.abort->visitJSFunction(visitor);
+            SUPPRESS_UNCOUNTED_ARG m_inspector.abort->visitJSFunctionInGCThread(visitor);
     }
 
     void removeAbortHandler()

--- a/Source/WebCore/dom/InternalObserverLast.cpp
+++ b/Source/WebCore/dom/InternalObserverLast.cpp
@@ -72,9 +72,9 @@ private:
         protect(m_promise)->resolve<IDLAny>(m_lastValue.getValue());
     }
 
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor) const final
     {
-        m_lastValue.visit(visitor);
+        m_lastValue.visitInGCThread(visitor);
     }
 
     InternalObserverLast(ScriptExecutionContext& context, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/InternalObserverMap.cpp
+++ b/Source/WebCore/dom/InternalObserverMap.cpp
@@ -129,10 +129,10 @@ private:
         protect(m_subscriber)->complete();
     }
 
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor) const final
     {
-        m_subscriber->visitAdditionalChildren(visitor);
-        m_mapper->visitJSFunction(visitor);
+        m_subscriber->visitAdditionalChildrenInGCThread(visitor);
+        m_mapper->visitJSFunctionInGCThread(visitor);
     }
 
     InternalObserverMap(ScriptExecutionContext& context, Ref<Subscriber> subscriber, Ref<MapperCallback> mapper)

--- a/Source/WebCore/dom/InternalObserverReduce.cpp
+++ b/Source/WebCore/dom/InternalObserverReduce.cpp
@@ -100,10 +100,10 @@ private:
         protect(m_promise)->resolve<IDLAny>(m_accumulator.getValue());
     }
 
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor) const final
     {
-        m_callback->visitJSFunction(visitor);
-        m_accumulator.visit(visitor);
+        m_callback->visitJSFunctionInGCThread(visitor);
+        m_accumulator.visitInGCThread(visitor);
     }
 
     InternalObserverReduce(ScriptExecutionContext& context, Ref<AbortSignal>&& signal, Ref<ReducerCallback>&& callback, JSC::JSValue initialValue, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/InternalObserverSome.cpp
+++ b/Source/WebCore/dom/InternalObserverSome.cpp
@@ -99,9 +99,9 @@ private:
         protect(m_promise)->resolve<IDLBoolean>(false);
     }
 
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor) const final
     {
-        m_callback->visitJSFunction(visitor);
+        m_callback->visitJSFunctionInGCThread(visitor);
     }
 
     InternalObserverSome(ScriptExecutionContext& context, Ref<PredicateCallback>&& callback, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/dom/InternalObserverTake.cpp
+++ b/Source/WebCore/dom/InternalObserverTake.cpp
@@ -110,9 +110,9 @@ private:
         protect(m_subscriber)->complete();
     }
 
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor) const final
+    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor) const final
     {
-        m_subscriber->visitAdditionalChildren(visitor);
+        m_subscriber->visitAdditionalChildrenInGCThread(visitor);
     }
 
     InternalObserverTake(ScriptExecutionContext& context, Ref<Subscriber> subscriber, uint64_t amount)

--- a/Source/WebCore/dom/MutationRecord.cpp
+++ b/Source/WebCore/dom/MutationRecord.cpp
@@ -43,7 +43,7 @@ namespace WebCore {
 
 namespace {
 
-static void visitNodeList(JSC::AbstractSlotVisitor& visitor, NodeList& nodeList)
+static void visitNodeListInGCThread(JSC::AbstractSlotVisitor& visitor, NodeList& nodeList)
 {
     ASSERT(!nodeList.isLiveNodeList());
     unsigned length = nodeList.length();
@@ -72,13 +72,13 @@ private:
     Node* previousSibling() override { return m_previousSibling.get(); }
     Node* nextSibling() override { return m_nextSibling.get(); }
 
-    void visitNodesConcurrently(JSC::AbstractSlotVisitor& visitor) const final
+    void visitNodesInGCThread(JSC::AbstractSlotVisitor& visitor) const final
     {
         addWebCoreOpaqueRoot(visitor, m_target.get());
         // We cannot ref m_addedNodes here as this function may get called from a GC thread.
-        SUPPRESS_UNRETAINED_ARG visitNodeList(visitor, m_addedNodes.get());
+        SUPPRESS_UNRETAINED_ARG visitNodeListInGCThread(visitor, m_addedNodes.get());
         // We cannot ref m_removedNodes here as this function may get called from a GC thread.
-        SUPPRESS_UNRETAINED_ARG visitNodeList(visitor, m_removedNodes.get());
+        SUPPRESS_UNRETAINED_ARG visitNodeListInGCThread(visitor, m_removedNodes.get());
     }
     
     const Ref<ContainerNode> m_target;
@@ -109,7 +109,7 @@ private:
         return *nodeList;
     }
 
-    void visitNodesConcurrently(JSC::AbstractSlotVisitor& visitor) const final
+    void visitNodesInGCThread(JSC::AbstractSlotVisitor& visitor) const final
     {
         addWebCoreOpaqueRoot(visitor, m_target.get());
     }
@@ -168,9 +168,9 @@ private:
 
     String oldValue() override { return String(); }
 
-    void visitNodesConcurrently(JSC::AbstractSlotVisitor& visitor) const final
+    void visitNodesInGCThread(JSC::AbstractSlotVisitor& visitor) const final
     {
-        m_record->visitNodesConcurrently(visitor);
+        m_record->visitNodesInGCThread(visitor);
     }
 
     const Ref<MutationRecord> m_record;

--- a/Source/WebCore/dom/MutationRecord.h
+++ b/Source/WebCore/dom/MutationRecord.h
@@ -73,7 +73,7 @@ public:
 
     virtual String oldValue() { return String(); }
 
-    virtual void visitNodesConcurrently(JSC::AbstractSlotVisitor&) const = 0;
+    virtual void visitNodesInGCThread(JSC::AbstractSlotVisitor&) const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -1152,7 +1152,7 @@ RefPtr<Range> createLiveRange(const std::optional<SimpleRange>& range)
     return createLiveRange(*range);
 }
 
-void Range::visitNodesConcurrently(JSC::AbstractSlotVisitor& visitor) const
+void Range::visitNodesInGCThread(JSC::AbstractSlotVisitor& visitor) const
 {
     addWebCoreOpaqueRoot(visitor, m_start.container());
     addWebCoreOpaqueRoot(visitor, m_end.container());

--- a/Source/WebCore/dom/Range.h
+++ b/Source/WebCore/dom/Range.h
@@ -129,7 +129,7 @@ public:
     String debugDescription() const;
 #endif
 
-    void visitNodesConcurrently(JSC::AbstractSlotVisitor&) const;
+    void visitNodesInGCThread(JSC::AbstractSlotVisitor&) const;
 
     enum ActionType : uint8_t { Delete, Extract, Clone };
 

--- a/Source/WebCore/dom/StaticRange.cpp
+++ b/Source/WebCore/dom/StaticRange.cpp
@@ -68,7 +68,7 @@ ExceptionOr<Ref<StaticRange>> StaticRange::create(Init&& init)
     return create({ { WTF::move(init.startContainer), init.startOffset }, { WTF::move(init.endContainer), init.endOffset } });
 }
 
-void StaticRange::visitNodesConcurrently(JSC::AbstractSlotVisitor& visitor) const
+void StaticRange::visitNodesInGCThread(JSC::AbstractSlotVisitor& visitor) const
 {
     addWebCoreOpaqueRoot(visitor, start.container.get());
     addWebCoreOpaqueRoot(visitor, end.container.get());

--- a/Source/WebCore/dom/StaticRange.h
+++ b/Source/WebCore/dom/StaticRange.h
@@ -61,7 +61,7 @@ public:
     // https://dom.spec.whatwg.org/#staticrange-valid
     bool computeValidity() const;
 
-    void visitNodesConcurrently(JSC::AbstractSlotVisitor&) const;
+    void visitNodesInGCThread(JSC::AbstractSlotVisitor&) const;
 
 private:
     explicit StaticRange(SimpleRange&&);

--- a/Source/WebCore/dom/Subscriber.cpp
+++ b/Source/WebCore/dom/Subscriber.cpp
@@ -167,14 +167,14 @@ InternalObserver* Subscriber::observerConcurrently()
     return &m_observer.get();
 }
 
-void Subscriber::visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor)
+void Subscriber::visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor)
 {
     // We cannot ref `teardown` here as this may get called from a GC thread.
     SUPPRESS_UNRETAINED_ARG for (auto* teardown : teardownCallbacksConcurrently())
-        teardown->visitJSFunction(visitor);
+        teardown->visitJSFunctionInGCThread(visitor);
 
     // We cannot ref the observer here as this may get called from a GC thread.
-    SUPPRESS_UNRETAINED_ARG observerConcurrently()->visitAdditionalChildren(visitor);
+    SUPPRESS_UNRETAINED_ARG observerConcurrently()->visitAdditionalChildrenInGCThread(visitor);
 }
 
 Subscriber::~Subscriber() = default;

--- a/Source/WebCore/dom/Subscriber.h
+++ b/Source/WebCore/dom/Subscriber.h
@@ -61,7 +61,7 @@ public:
     // JSCustomMarkFunction; for JSSubscriberCustom
     Vector<VoidCallback*> teardownCallbacksConcurrently();
     InternalObserver* NODELETE observerConcurrently();
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor&);
+    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor&);
 
 private:
     explicit Subscriber(ScriptExecutionContext&, Ref<InternalObserver>&&, const SubscribeOptions&);

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -1359,15 +1359,15 @@ bool Navigation::RateLimiter::navigationAllowed()
     return false;
 }
 
-void Navigation::visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor)
+void Navigation::visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor& visitor)
 {
     Locker locker { m_apiMethodTrackersLock };
     if (m_ongoingAPIMethodTracker)
-        m_ongoingAPIMethodTracker->info.visit(visitor);
+        m_ongoingAPIMethodTracker->info.visitInGCThread(visitor);
     if (m_upcomingNonTraverseMethodTracker)
-        m_upcomingNonTraverseMethodTracker->info.visit(visitor);
+        m_upcomingNonTraverseMethodTracker->info.visitInGCThread(visitor);
     for (auto& tracker : m_upcomingTraverseMethodTrackers.values())
-        tracker->info.visit(visitor);
+        tracker->info.visitInGCThread(visitor);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -174,7 +174,7 @@ public:
     void rejectFinishedPromise(NavigationAPIMethodTracker*);
     NavigationAPIMethodTracker* upcomingTraverseMethodTracker(const String& key) const;
 
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor&);
+    void visitAdditionalChildrenInGCThread(JSC::AbstractSlotVisitor&);
 
     class AbortHandler : public RefCountedAndCanMakeWeakPtr<AbortHandler> {
     public:

--- a/Source/WebCore/page/ResizeObserver.cpp
+++ b/Source/WebCore/page/ResizeObserver.cpp
@@ -165,7 +165,7 @@ void ResizeObserver::deliverObservations()
 
     auto entries = WTF::compactMap(m_activeObservations, [](auto& observation) -> RefPtr<ResizeObserverEntry> {
         RefPtr target = observation->target();
-        ASSERT(target); // The target is supposed to be kept alive via `m_activeObservationTargets` and JSResizeObserver::visitAdditionalChildren().
+        ASSERT(target); // The target is supposed to be kept alive via `m_activeObservationTargets` and JSResizeObserver::visitAdditionalChildrenInGCThread().
         if (!target)
             return nullptr;
         return ResizeObserverEntry::create(target.releaseNonNull(), observation->computeContentRect(), observation->borderBoxSize(), observation->contentBoxSize());
@@ -174,7 +174,7 @@ void ResizeObserver::deliverObservations()
 
     // Use GCReachableRef here to make sure the targets and their JS wrappers are kept alive while we deliver.
     // It is important since m_activeObservationTargets / m_targetsWaitingForFirstObservation will get cleared and
-    // thus JSResizeObserver::visitAdditionalChildren() won't be able to visit them on a GC thread.
+    // thus JSResizeObserver::visitAdditionalChildrenInGCThread() won't be able to visit them on a GC thread.
     Vector<GCReachableRef<Element>> activeObservationTargets;
     Vector<GCReachableRef<Element>> targetsWaitingForFirstObservation;
     {
@@ -182,14 +182,14 @@ void ResizeObserver::deliverObservations()
         activeObservationTargets = WTF::compactMap(m_activeObservationTargets, [](auto& weakTarget) -> std::optional<GCReachableRef<Element>> {
             if (weakTarget)
                 return GCReachableRef<Element> { *weakTarget };
-            ASSERT_NOT_REACHED(); // Targets are supposed to be kept alive via JSResizeObserver::visitAdditionalChildren().
+            ASSERT_NOT_REACHED(); // Targets are supposed to be kept alive via JSResizeObserver::visitAdditionalChildrenInGCThread().
             return std::nullopt;
         });
         m_activeObservationTargets = { };
         targetsWaitingForFirstObservation = WTF::compactMap(m_targetsWaitingForFirstObservation, [](auto& weakTarget) -> std::optional<GCReachableRef<Element>> {
             if (weakTarget)
                 return GCReachableRef<Element> { *weakTarget };
-            ASSERT_NOT_REACHED(); // Targets are supposed to be kept alive via JSResizeObserver::visitAdditionalChildren().
+            ASSERT_NOT_REACHED(); // Targets are supposed to be kept alive via JSResizeObserver::visitAdditionalChildrenInGCThread().
             return std::nullopt;
         });
         m_targetsWaitingForFirstObservation = { };


### PR DESCRIPTION
#### 0caf133589aca128faa3c973b2b4bef34ca9af7f
<pre>
Add &quot;InGCThread&quot; suffix to `visit*(Visitor&amp;)` functions in WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=309869">https://bugs.webkit.org/show_bug.cgi?id=309869</a>

Reviewed by Yusuke Suzuki and Ryosuke Niwa.

Add &quot;InGCThread&quot; suffix to `visit*(Visitor&amp;)` functions in WebCore, to
make it clear that they can be called concurrently on the GC thread
while the main thread is still running. This will hopefully reduce the
chance of engineers introducing thread-safety bugs in these functions.

* Source/JavaScriptCore/heap/SlotVisitorMacros.h:
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::visitReferencedIndexesInGCThread const):
(WebCore::IDBObjectStore::visitReferencedIndexesConcurrently const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBObjectStore.h:
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::visitReferencedObjectStoresInGCThread const):
(WebCore::IDBTransaction::visitReferencedObjectStores const): Deleted.
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:
* Source/WebCore/Modules/mediasession/MediaSession.h:
(WebCore::MediaSession::visitActionHandlersInGCThread const):
(WebCore::MediaSession::visitActionHandlers const): Deleted.
* Source/WebCore/Modules/streams/ReadableByteStreamController.cpp:
(WebCore::ReadableByteStreamController::visitDirectChildrenInGCThread):
(WebCore::ReadableByteStreamController::visitAdditionalChildrenInGCThread):
(WebCore::JSReadableByteStreamController::visitAdditionalChildrenInGCThread):
(WebCore::ReadableByteStreamController::visitDirectChildren): Deleted.
(WebCore::ReadableByteStreamController::visitAdditionalChildren): Deleted.
(WebCore::JSReadableByteStreamController::visitAdditionalChildren): Deleted.
* Source/WebCore/Modules/streams/ReadableByteStreamController.h:
* Source/WebCore/Modules/streams/ReadableStream.cpp:
(WebCore::ReadableStream::visitAdditionalChildrenInGCThread):
(WebCore::JSReadableStream::visitAdditionalChildrenInGCThread):
(WebCore::ReadableStream::visitAdditionalChildren): Deleted.
(WebCore::JSReadableStream::visitAdditionalChildren): Deleted.
* Source/WebCore/Modules/streams/ReadableStream.h:
* Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp:
(WebCore::ReadableStreamBYOBReader::visitAdditionalChildrenInGCThread):
(WebCore::JSReadableStreamBYOBReader::visitAdditionalChildrenInGCThread):
(WebCore::ReadableStreamBYOBReader::visitAdditionalChildren): Deleted.
(WebCore::JSReadableStreamBYOBReader::visitAdditionalChildren): Deleted.
* Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h:
* Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.cpp:
(WebCore::ReadableStreamBYOBRequest::visitAdditionalChildrenInGCThread):
(WebCore::JSReadableStreamBYOBRequest::visitAdditionalChildrenInGCThread):
(WebCore::ReadableStreamBYOBRequest::visitAdditionalChildren): Deleted.
(WebCore::JSReadableStreamBYOBRequest::visitAdditionalChildren): Deleted.
* Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.h:
* Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp:
(WebCore::ReadableStreamDefaultReader::visitAdditionalChildrenInGCThread):
(WebCore::JSReadableStreamDefaultReader::visitAdditionalChildrenInGCThread):
(WebCore::ReadableStreamDefaultReader::visitAdditionalChildren): Deleted.
(WebCore::JSReadableStreamDefaultReader::visitAdditionalChildren): Deleted.
* Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h:
* Source/WebCore/Modules/streams/StreamTeeUtilities.cpp:
* Source/WebCore/Modules/streams/TransformStream.cpp:
(WebCore::JSTransformStream::visitAdditionalChildrenInGCThread):
(WebCore::JSTransformStream::visitAdditionalChildren): Deleted.
* Source/WebCore/Modules/webaudio/AudioBuffer.cpp:
(WebCore::AudioBuffer::visitChannelWrappersInGCThread):
(WebCore::AudioBuffer::visitChannelWrappers): Deleted.
* Source/WebCore/Modules/webaudio/AudioBuffer.h:
* Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp:
(WebCore::AudioWorkletGlobalScope::visitProcessorsInGCThread):
(WebCore::AudioWorkletGlobalScope::visitProcessors): Deleted.
* Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.h:
* Source/WebCore/bindings/js/JSAbortSignalCustom.cpp:
(WebCore::JSAbortSignal::visitAdditionalChildrenInGCThread):
(WebCore::JSAbortSignal::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSAttrCustom.cpp:
(WebCore::JSAttr::visitAdditionalChildrenInGCThread):
(WebCore::JSAttr::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSAudioBufferCustom.cpp:
(WebCore::JSAudioBuffer::visitAdditionalChildrenInGCThread):
(WebCore::JSAudioBuffer::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSAudioBufferSourceNodeCustom.cpp:
(WebCore::JSAudioBufferSourceNode::visitAdditionalChildrenInGCThread):
(WebCore::JSAudioBufferSourceNode::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSAudioWorkletGlobalScopeCustom.cpp:
(WebCore::JSAudioWorkletGlobalScope::visitAdditionalChildrenInGCThread):
(WebCore::JSAudioWorkletGlobalScope::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSAudioWorkletProcessorCustom.cpp:
(WebCore::JSAudioWorkletProcessor::visitAdditionalChildrenInGCThread):
(WebCore::JSAudioWorkletProcessor::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSCSSRuleCustom.cpp:
(WebCore::JSCSSRule::visitAdditionalChildrenInGCThread):
(WebCore::JSCSSRule::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSCSSStyleDeclarationCustom.cpp:
(WebCore::JSCSSStyleDeclaration::visitAdditionalChildrenInGCThread):
(WebCore::JSCSSStyleDeclaration::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSCallbackData.cpp:
(WebCore::JSCallbackData::visitJSFunctionInGCThread):
(WebCore::JSCallbackData::visitJSFunction): Deleted.
* Source/WebCore/bindings/js/JSCallbackData.h:
* Source/WebCore/bindings/js/JSCanvasRenderingContext2DCustom.cpp:
(WebCore::JSCanvasRenderingContext2D::visitAdditionalChildrenInGCThread):
(WebCore::JSCanvasRenderingContext2D::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSCustomElementInterface.cpp:
(WebCore::JSCustomElementInterface::visitJSFunctionsInGCThread const):
(WebCore::JSCustomElementInterface::visitJSFunctions const): Deleted.
* Source/WebCore/bindings/js/JSCustomElementInterface.h:
* Source/WebCore/bindings/js/JSCustomElementRegistryCustom.cpp:
(WebCore::JSCustomElementRegistry::visitAdditionalChildrenInGCThread):
(WebCore::JSCustomElementRegistry::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSCustomEventCustom.cpp:
(WebCore::JSCustomEvent::visitAdditionalChildrenInGCThread):
(WebCore::JSCustomEvent::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::JSDOMGlobalObject::visitChildrenImpl):
* Source/WebCore/bindings/js/JSDOMGuardedObject.h:
* Source/WebCore/bindings/js/JSDOMQuadCustom.cpp:
(WebCore::JSDOMQuad::visitAdditionalChildrenInGCThread):
(WebCore::JSDOMQuad::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSDOMWindowCustom.cpp:
(WebCore::JSDOMWindow::visitAdditionalChildrenInGCThread):
(WebCore::JSDOMWindow::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSDocumentCustom.cpp:
(WebCore::JSDocument::visitAdditionalChildrenInGCThread):
(WebCore::JSDocument::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSErrorEventCustom.cpp:
(WebCore::JSErrorEvent::visitAdditionalChildrenInGCThread):
(WebCore::JSErrorEvent::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSEventListener.cpp:
(WebCore::JSEventListener::visitJSFunctionImplInGCThread):
(WebCore::JSEventListener::visitJSFunctionInGCThread):
(WebCore::JSEventListener::visitJSFunctionImpl): Deleted.
(WebCore::JSEventListener::visitJSFunction): Deleted.
* Source/WebCore/bindings/js/JSEventListener.h:
(WebCore::JSEventListener::ensureJSFunction const):
* Source/WebCore/bindings/js/JSEventTargetCustom.cpp:
(WebCore::JSEventTarget::visitAdditionalChildrenInGCThread):
(WebCore::JSEventTarget::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSExtendableMessageEventCustom.cpp:
(WebCore::JSExtendableMessageEvent::visitAdditionalChildrenInGCThread):
(WebCore::JSExtendableMessageEvent::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSFetchEventCustom.cpp:
(WebCore::JSFetchEvent::visitAdditionalChildrenInGCThread):
(WebCore::JSFetchEvent::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSHTMLCanvasElementCustom.cpp:
(WebCore::JSHTMLCanvasElement::visitAdditionalChildrenInGCThread):
(WebCore::JSHTMLCanvasElement::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSHTMLTemplateElementCustom.cpp:
(WebCore::JSHTMLTemplateElement::visitAdditionalChildrenInGCThread):
(WebCore::JSHTMLTemplateElement::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSHistoryCustom.cpp:
(WebCore::JSHistory::visitAdditionalChildrenInGCThread):
(WebCore::JSHistory::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSIDBCursorCustom.cpp:
(WebCore::JSIDBCursor::visitAdditionalChildrenInGCThread):
(WebCore::JSIDBCursor::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSIDBCursorWithValueCustom.cpp:
(WebCore::JSIDBCursorWithValue::visitAdditionalChildrenInGCThread):
(WebCore::JSIDBCursorWithValue::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSIDBObjectStoreCustom.cpp:
(WebCore::JSIDBObjectStore::visitAdditionalChildrenInGCThread):
(WebCore::JSIDBObjectStore::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSIDBRequestCustom.cpp:
(WebCore::JSIDBRequest::visitAdditionalChildrenInGCThread):
(WebCore::JSIDBRequest::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSIDBTransactionCustom.cpp:
(WebCore::JSIDBTransaction::visitAdditionalChildrenInGCThread):
(WebCore::JSIDBTransaction::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSIntersectionObserverCustom.cpp:
(WebCore::JSIntersectionObserver::visitAdditionalChildrenInGCThread):
(WebCore::JSIntersectionObserver::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSIntersectionObserverEntryCustom.cpp:
(WebCore::JSIntersectionObserverEntry::visitAdditionalChildrenInGCThread):
(WebCore::JSIntersectionObserverEntry::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSLocationCustom.cpp:
(WebCore::JSLocation::visitAdditionalChildrenInGCThread):
(WebCore::JSLocation::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSMediaControlsHostCustom.cpp:
(WebCore::JSMediaControlsHost::visitAdditionalChildrenInGCThread):
(WebCore::JSMediaControlsHost::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSMediaSessionCustom.cpp:
(WebCore::JSMediaSession::visitAdditionalChildrenInGCThread):
(WebCore::JSMediaSession::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSMessageChannelCustom.cpp:
(WebCore::JSMessageChannel::visitAdditionalChildrenInGCThread):
(WebCore::JSMessageChannel::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSMessageEventCustom.cpp:
(WebCore::JSMessageEvent::visitAdditionalChildrenInGCThread):
(WebCore::JSMessageEvent::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSMessagePortCustom.cpp:
(WebCore::JSMessagePort::visitAdditionalChildrenInGCThread):
(WebCore::JSMessagePort::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSMutationObserverCustom.cpp:
(WebCore::JSMutationObserver::visitAdditionalChildrenInGCThread):
(WebCore::JSMutationObserver::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSMutationRecordCustom.cpp:
(WebCore::JSMutationRecord::visitAdditionalChildrenInGCThread):
(WebCore::JSMutationRecord::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSNavigateEventCustom.cpp:
(WebCore::JSNavigateEvent::visitAdditionalChildrenInGCThread):
(WebCore::JSNavigateEvent::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSNavigationCustom.cpp:
(WebCore::JSNavigation::visitAdditionalChildrenInGCThread):
(WebCore::JSNavigation::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSNavigatorCustom.cpp:
(WebCore::JSNavigator::visitAdditionalChildrenInGCThread):
(WebCore::JSNavigator::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSNodeCustom.cpp:
(WebCore::JSNode::visitAdditionalChildrenInGCThread):
(WebCore::JSNode::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSNodeIteratorCustom.cpp:
(WebCore::JSNodeIterator::visitAdditionalChildrenInGCThread):
(WebCore::JSNodeIterator::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSOffscreenCanvasRenderingContext2DCustom.cpp:
(WebCore::JSOffscreenCanvasRenderingContext2D::visitAdditionalChildrenInGCThread):
(WebCore::JSOffscreenCanvasRenderingContext2D::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSPaintRenderingContext2DCustom.cpp:
(WebCore::JSPaintRenderingContext2D::visitAdditionalChildrenInGCThread):
(WebCore::JSPaintRenderingContext2D::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSPaintWorkletGlobalScopeCustom.cpp:
(WebCore::JSPaintWorkletGlobalScope::visitAdditionalChildrenInGCThread):
(WebCore::JSPaintWorkletGlobalScope::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSPaymentMethodChangeEventCustom.cpp:
(WebCore::JSPaymentMethodChangeEvent::visitAdditionalChildrenInGCThread):
(WebCore::JSPaymentMethodChangeEvent::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSPaymentResponseCustom.cpp:
(WebCore::JSPaymentResponse::visitAdditionalChildrenInGCThread):
(WebCore::JSPaymentResponse::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSPerformanceObserverCustom.cpp:
(WebCore::JSPerformanceObserver::visitAdditionalChildrenInGCThread):
(WebCore::JSPerformanceObserver::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSPopStateEventCustom.cpp:
(WebCore::JSPopStateEvent::visitAdditionalChildrenInGCThread):
(WebCore::JSPopStateEvent::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSPromiseRejectionEventCustom.cpp:
(WebCore::JSPromiseRejectionEvent::visitAdditionalChildrenInGCThread):
(WebCore::JSPromiseRejectionEvent::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSRangeCustom.cpp:
(WebCore::JSRange::visitAdditionalChildrenInGCThread):
(WebCore::JSRange::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSReportingObserverCustom.cpp:
(WebCore::JSReportingObserver::visitAdditionalChildrenInGCThread):
(WebCore::JSReportingObserver::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSResizeObserverCustom.cpp:
(WebCore::JSResizeObserver::visitAdditionalChildrenInGCThread):
(WebCore::JSResizeObserver::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSResizeObserverEntryCustom.cpp:
(WebCore::JSResizeObserverEntry::visitAdditionalChildrenInGCThread):
(WebCore::JSResizeObserverEntry::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSSVGViewSpecCustom.cpp:
(WebCore::JSSVGViewSpec::visitAdditionalChildrenInGCThread):
(WebCore::JSSVGViewSpec::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSServiceWorkerGlobalScopeCustom.cpp:
(WebCore::JSServiceWorkerGlobalScope::visitAdditionalChildrenInGCThread):
(WebCore::JSServiceWorkerGlobalScope::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSStaticRangeCustom.cpp:
(WebCore::JSStaticRange::visitAdditionalChildrenInGCThread):
(WebCore::JSStaticRange::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSStylePropertyMapReadOnlyCustom.cpp:
(WebCore::JSStylePropertyMapReadOnly::visitAdditionalChildrenInGCThread):
(WebCore::JSStylePropertyMapReadOnly::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSStyleSheetCustom.cpp:
(WebCore::JSStyleSheet::visitAdditionalChildrenInGCThread):
(WebCore::JSStyleSheet::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSSubscriberCustom.cpp:
(WebCore::JSSubscriber::visitAdditionalChildrenInGCThread):
(WebCore::JSSubscriber::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSTextTrackCueCustom.cpp:
(WebCore::JSTextTrackCue::visitAdditionalChildrenInGCThread):
(WebCore::JSTextTrackCue::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSTreeWalkerCustom.cpp:
(WebCore::JSTreeWalker::visitAdditionalChildrenInGCThread):
(WebCore::JSTreeWalker::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSTrustedTypePolicyCustom.cpp:
(WebCore::JSTrustedTypePolicy::visitAdditionalChildrenInGCThread):
(WebCore::JSTrustedTypePolicy::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSTrustedTypePolicyFactoryCustom.cpp:
(WebCore::JSTrustedTypePolicyFactory::visitAdditionalChildrenInGCThread):
(WebCore::JSTrustedTypePolicyFactory::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSUndoItemCustom.cpp:
(WebCore::JSUndoItem::visitAdditionalChildrenInGCThread):
(WebCore::JSUndoItem::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSValueInWrappedObject.h:
(WebCore::JSValueInWrappedObject::visitInGCThread const):
(WebCore::JSValueInWrappedObject::visit const): Deleted.
* Source/WebCore/bindings/js/JSWebCodecsAudioDecoderCustom.cpp:
(WebCore::JSWebCodecsAudioDecoder::visitAdditionalChildrenInGCThread):
(WebCore::JSWebCodecsAudioDecoder::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSWebCodecsAudioEncoderCustom.cpp:
(WebCore::JSWebCodecsAudioEncoder::visitAdditionalChildrenInGCThread):
(WebCore::JSWebCodecsAudioEncoder::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSWebCodecsVideoDecoderCustom.cpp:
(WebCore::JSWebCodecsVideoDecoder::visitAdditionalChildrenInGCThread):
(WebCore::JSWebCodecsVideoDecoder::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSWebCodecsVideoEncoderCustom.cpp:
(WebCore::JSWebCodecsVideoEncoder::visitAdditionalChildrenInGCThread):
(WebCore::JSWebCodecsVideoEncoder::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSWebGL2RenderingContextCustom.cpp:
(WebCore::JSWebGL2RenderingContext::visitAdditionalChildrenInGCThread):
(WebCore::JSWebGL2RenderingContext::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSWebGLRenderingContextCustom.cpp:
(WebCore::JSWebGLRenderingContext::visitAdditionalChildrenInGCThread):
(WebCore::JSWebGLRenderingContext::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSWebXRRigidTransformCustom.cpp:
(WebCore::JSWebXRRigidTransform::visitAdditionalChildrenInGCThread):
(WebCore::JSWebXRRigidTransform::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSWebXRSessionCustom.cpp:
(WebCore::JSWebXRSession::visitAdditionalChildrenInGCThread):
(WebCore::JSWebXRSession::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSWebXRViewCustom.cpp:
(WebCore::JSWebXRView::visitAdditionalChildrenInGCThread):
(WebCore::JSWebXRView::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp:
(WebCore::JSWorkerGlobalScope::visitAdditionalChildrenInGCThread):
(WebCore::JSWorkerGlobalScope::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSWorkerNavigatorCustom.cpp:
(WebCore::JSWorkerNavigator::visitAdditionalChildrenInGCThread):
(WebCore::JSWorkerNavigator::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSXMLHttpRequestCustom.cpp:
(WebCore::JSXMLHttpRequest::visitAdditionalChildrenInGCThread):
(WebCore::JSXMLHttpRequest::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/js/JSXPathResultCustom.cpp:
(WebCore::JSXPathResult::visitAdditionalChildrenInGCThread):
(WebCore::JSXPathResult::visitAdditionalChildren): Deleted.
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateHeader):
(GenerateImplementation):
(GenerateCallbackHeaderContent):
(GenerateCallbackImplementationContent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp:
(WebCore::JSTestCallbackFunction::visitJSFunctionInGCThread):
(WebCore::JSTestCallbackFunction::visitJSFunction): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp:
(WebCore::JSTestCallbackFunctionWithThisObject::visitJSFunctionInGCThread):
(WebCore::JSTestCallbackFunctionWithThisObject::visitJSFunction): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp:
(WebCore::JSTestCallbackFunctionWithTypedefs::visitJSFunctionInGCThread):
(WebCore::JSTestCallbackFunctionWithTypedefs::visitJSFunction): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp:
(WebCore::JSTestCallbackFunctionWithVariadic::visitJSFunctionInGCThread):
(WebCore::JSTestCallbackFunctionWithVariadic::visitJSFunction): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp:
(WebCore::JSTestCallbackInterface::visitJSFunctionInGCThread):
(WebCore::JSTestCallbackInterface::visitJSFunction): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp:
(WebCore::JSTestCallbackWithFunctionOrDict::visitJSFunctionInGCThread):
(WebCore::JSTestCallbackWithFunctionOrDict::visitJSFunction): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h:
* Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp:
(WebCore::JSTestVoidCallbackFunction::visitJSFunctionInGCThread):
(WebCore::JSTestVoidCallbackFunction::visitJSFunction): Deleted.
* Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h:
* Source/WebCore/dom/AbortController.cpp:
(WebCore::JSAbortController::visitAdditionalChildrenInGCThread):
(WebCore::JSAbortController::visitAdditionalChildren): Deleted.
* Source/WebCore/dom/ActiveDOMCallback.h:
(WebCore::ActiveDOMCallback::visitJSFunctionInGCThread):
(WebCore::ActiveDOMCallback::visitJSFunction): Deleted.
* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::CustomElementRegistry::visitJSCustomElementInterfacesInGCThread const):
* Source/WebCore/dom/EventListener.h:
(WebCore::EventListener::visitJSFunctionInGCThread):
(WebCore::EventListener::visitJSFunction): Deleted.
* Source/WebCore/dom/EventListenerMap.h:
(WebCore::EventListenerMap::visitJSEventListenersInGCThread):
(WebCore::EventListenerMap::visitJSEventListeners): Deleted.
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/EventTargetInlines.h:
(WebCore::EventTarget::visitJSEventListenersInGCThread):
(WebCore::EventTarget::visitJSEventListeners): Deleted.
* Source/WebCore/dom/InternalObserver.h:
* Source/WebCore/dom/InternalObserverDrop.cpp:
* Source/WebCore/dom/InternalObserverEvery.cpp:
* Source/WebCore/dom/InternalObserverFilter.cpp:
* Source/WebCore/dom/InternalObserverFind.cpp:
* Source/WebCore/dom/InternalObserverFirst.cpp:
* Source/WebCore/dom/InternalObserverForEach.cpp:
* Source/WebCore/dom/InternalObserverFromScript.cpp:
(WebCore::InternalObserverFromScript::visitAdditionalChildrenInGCThread const):
(WebCore::InternalObserverFromScript::visitAdditionalChildren const): Deleted.
* Source/WebCore/dom/InternalObserverFromScript.h:
* Source/WebCore/dom/InternalObserverInspect.cpp:
* Source/WebCore/dom/InternalObserverLast.cpp:
* Source/WebCore/dom/InternalObserverMap.cpp:
* Source/WebCore/dom/InternalObserverReduce.cpp:
* Source/WebCore/dom/InternalObserverSome.cpp:
* Source/WebCore/dom/InternalObserverTake.cpp:
* Source/WebCore/dom/MutationRecord.cpp:
* Source/WebCore/dom/MutationRecord.h:
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::visitNodesInGCThread const):
(WebCore::Range::visitNodesConcurrently const): Deleted.
* Source/WebCore/dom/Range.h:
* Source/WebCore/dom/StaticRange.cpp:
(WebCore::StaticRange::visitNodesInGCThread const):
(WebCore::StaticRange::visitNodesConcurrently const): Deleted.
* Source/WebCore/dom/StaticRange.h:
* Source/WebCore/dom/Subscriber.cpp:
(WebCore::Subscriber::visitAdditionalChildrenInGCThread):
(WebCore::Subscriber::visitAdditionalChildren): Deleted.
* Source/WebCore/dom/Subscriber.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::visitAdditionalChildrenInGCThread):
(WebCore::Navigation::visitAdditionalChildren): Deleted.
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/ResizeObserver.cpp:
(WebCore::ResizeObserver::deliverObservations):

Canonical link: <a href="https://commits.webkit.org/309255@main">https://commits.webkit.org/309255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/283611001e4b867904ef87e5d5414a463f367b4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149863 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16166 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158569 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103295 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/af406320-dcea-4694-99b9-3fadc007f9ca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115606 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82156 "3 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d2a9e383-22aa-49b5-b88b-bcca9006eb9a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152823 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134488 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96345 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f65bf362-338e-4b0b-b6fe-bb7d413fa4f5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16830 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14752 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6416 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141839 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126437 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161045 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10657 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4129 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13961 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123621 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22384 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123825 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33662 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22391 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134212 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78616 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18988 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10964 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181292 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21992 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85812 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46428 "Found 1 new JSC stress test failure: Too many failures: 29413 jsc tests failed (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21722 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21874 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21779 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->