### PR TITLE
Test case for rdar://146806902 (StabilityTracer: com.apple.WebKit.WebContent at WebCore:  WebCore::JSVMClientData::overrideSourceURL const)

### DIFF
--- a/LayoutTests/js/async-stack-trace-capture-after-jettison-expected.txt
+++ b/LayoutTests/js/async-stack-trace-capture-after-jettison-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that Error.captureStackTrace works correctly with async stack frames whose CodeBlock has been jettisoned. See https://bugs.webkit.org/show_bug.cgi?id=308997.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Error.captureStackTrace did not crash with jettisoned async CodeBlock
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/js/async-stack-trace-capture-after-jettison.html
+++ b/LayoutTests/js/async-stack-trace-capture-after-jettison.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html><!-- webkit-test-runner [ jscOptions=--useAsyncStackTrace=true,--forceCodeBlockToJettisonDueToOldAge=true ] -->
+<html>
+<head>
+<script src="../resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description("This test verifies that Error.captureStackTrace works correctly with async stack frames whose CodeBlock has been jettisoned. See https://bugs.webkit.org/show_bug.cgi?id=308997.");
+
+jsTestIsAsync = true;
+
+async function outer() {
+    await inner();
+}
+
+async function inner() {
+    // Suspend execution so both outer and inner are off the call stack.
+    // When inner resumes via microtask, outer's CodeBlock is no longer
+    // on any stack and can be jettisoned.
+    await Promise.resolve();
+
+    // Force GC to jettison outer's CodeBlock. With
+    // --forceCodeBlockToJettisonDueToOldAge=true, any CodeBlock not currently
+    // on the stack will be jettisoned.
+    if (window.GCController) {
+        GCController.collect();
+        GCController.collect();
+    }
+
+    // Error.captureStackTrace walks the async stack frames. The frame for
+    // outer() now has no CodeBlock (it was jettisoned). This previously
+    // crashed in WebCore::JSVMClientData::overrideSourceURL due to a
+    // RELEASE_ASSERT(codeBlock) that didn't account for async frames.
+    var obj = {};
+    Error.captureStackTrace(obj);
+
+    testPassed("Error.captureStackTrace did not crash with jettisoned async CodeBlock");
+    finishJSTest();
+}
+
+outer();
+</script>
+<script src="../resources/js-test-post.js"></script>
+</body>
+</html>


### PR DESCRIPTION
#### c726f7f47723cdb5f8d4d0902fab712ee5cd4f2f
<pre>
Test case for <a href="https://rdar.apple.com/146806902">rdar://146806902</a> (StabilityTracer: com.apple.WebKit.WebContent at WebCore:  WebCore::JSVMClientData::overrideSourceURL const)
<a href="https://rdar.apple.com/172448998">rdar://172448998</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309873">https://bugs.webkit.org/show_bug.cgi?id=309873</a>

Reviewed by Yusuke Suzuki.

The fix in 308486@main had no test. This test suspends an async
function via await, forces GC to jettison its CodeBlock, then calls
Error.captureStackTrace() which triggers overrideSourceURL on the
async frame.

* LayoutTests/js/async-stack-trace-capture-after-jettison-expected.txt: Added.
* LayoutTests/js/async-stack-trace-capture-after-jettison.html: Added.

Canonical link: <a href="https://commits.webkit.org/309263@main">https://commits.webkit.org/309263@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb016060d2f3c967ac37d764ae2a1fcc1fd9dd3e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158578 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103304 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115609 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82167 "8 flakes 2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17730 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134485 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96348 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16827 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14756 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6425 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141848 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126434 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161054 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10666 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13958 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123624 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22393 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18798 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123828 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33665 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22400 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134209 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78625 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18987 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10961 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181301 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22001 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46432 "Found 1 new JSC stress test failure: Too many failures: 29422 jsc tests failed (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21731 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21883 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21788 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->