### PR TITLE
Limit length of @counter-style padding

### DIFF
--- a/LayoutTests/fast/css/counters/counter-style-pad-length-limit-expected.txt
+++ b/LayoutTests/fast/css/counters/counter-style-pad-length-limit-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Pad under limit generates padded text
+PASS Pad over limit falls back to decimal
+PASS Pad with long symbol under limit generates padded text
+PASS Pad with long symbol over limit falls back to decimal
+

--- a/LayoutTests/fast/css/counters/counter-style-pad-length-limit.html
+++ b/LayoutTests/fast/css/counters/counter-style-pad-length-limit.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<style>
+@counter-style pad {
+    system: extends decimal;
+    pad: 150 "0";
+}
+
+@counter-style pad-over-limit {
+    system: extends decimal;
+    pad: 300 "0";
+}
+
+@counter-style symbol {
+    system: extends decimal;
+    pad: 10 "0123456789abcde";
+}
+
+@counter-style symbol-over-limit {
+    system: extends decimal;
+    pad: 20 "0123456789abcde";
+}
+</style>
+</head>
+<body>
+<ol><li id="pad" style="list-style-type: pad"></li></ol>
+<ol><li id="pad-over-limit" style="list-style-type: pad-over-limit"></li></ol>
+<ol><li id="symbol" style="list-style-type: symbol"></li></ol>
+<ol><li id="symbol-over-limit" style="list-style-type: symbol-over-limit"></li></ol>
+<script>
+test(function() {
+    const text = internals.markerTextForListItem(document.getElementById('pad'));
+    assert_equals(text, '0'.repeat(149) + '1');
+}, 'Pad under limit generates padded text');
+
+test(function() {
+    const text = internals.markerTextForListItem(document.getElementById('pad-over-limit'));
+    assert_equals(text, '1');
+}, 'Pad over limit falls back to decimal');
+
+test(function() {
+    const text = internals.markerTextForListItem(document.getElementById('symbol'));
+    assert_equals(text, '0123456789abcde'.repeat(9) + '1');
+}, 'Pad with long symbol under limit generates padded text');
+
+test(function() {
+    const text = internals.markerTextForListItem(document.getElementById('symbol-over-limit'));
+    assert_equals(text, '1');
+}, 'Pad with long symbol over limit falls back to decimal');
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/CSSCounterStyle.cpp
+++ b/Source/WebCore/css/CSSCounterStyle.cpp
@@ -30,6 +30,7 @@
 #include "CSSCounterStyleRegistry.h"
 #include <cmath>
 #include <wtf/Assertions.h>
+#include <wtf/CheckedArithmetic.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/TextBreakIterator.h>
@@ -411,7 +412,8 @@ String CSSCounterStyle::text(int value, WritingMode writingMode)
     auto result = initialRepresentation(value, writingMode);
     if (result.isNull())
         return fallbackText(value, writingMode);
-    applyPadSymbols(result, value);
+    if (!applyPadSymbols(result, value))
+        return fallbackText(value, writingMode);
     if (shouldApplyNegativeSymbols(value))
         applyNegativeSymbols(result);
 
@@ -429,20 +431,34 @@ void CSSCounterStyle::applyNegativeSymbols(String& text) const
     text = negative().m_suffix.text.isEmpty() ? makeString(negative().m_prefix.text, text) : makeString(negative().m_prefix.text, text, negative().m_suffix.text);
 }
 
-void CSSCounterStyle::applyPadSymbols(String& text, int value) const
+bool CSSCounterStyle::applyPadSymbols(String& text, int value) const
 {
-    // FIXME: should we cap pad minimum length?
+    // We limit the max UTF-16 padding length to 150 to match Firefox. This complies with CSS
+    // Counter Styles Level 3, which requires us to support counter representations of at least 60
+    // code points before using the fallback representation.
+    static constexpr unsigned maxPadLength = 150;
+
     if (pad().m_padMinimumLength <= 0)
-        return;
+        return true;
 
     int numberOfSymbolsToAdd = static_cast<int>(pad().m_padMinimumLength - WTF::numGraphemeClusters(text));
     if (shouldApplyNegativeSymbols(value))
         numberOfSymbolsToAdd -= static_cast<int>(WTF::numGraphemeClusters(negative().m_prefix.text) + WTF::numGraphemeClusters(negative().m_suffix.text));
 
-    String padText;
+    if (numberOfSymbolsToAdd <= 0)
+        return true;
+
+    auto totalPadLength = checkedProduct<unsigned>(numberOfSymbolsToAdd, pad().m_padSymbol.text.length());
+    if (totalPadLength.hasOverflowed() || totalPadLength.value() > maxPadLength)
+        return false;
+
+    StringBuilder result;
+    result.reserveCapacity(totalPadLength + text.length());
     for (int i = 0; i < numberOfSymbolsToAdd; ++i)
-        padText = makeString(padText, pad().m_padSymbol.text);
-    text = makeString(padText, text);
+        result.append(pad().m_padSymbol.text);
+    result.append(text);
+    text = result.toString();
+    return true;
 }
 
 bool CSSCounterStyle::isInRange(int value) const

--- a/Source/WebCore/css/CSSCounterStyle.h
+++ b/Source/WebCore/css/CSSCounterStyle.h
@@ -100,7 +100,7 @@ private:
     WeakPtr<CSSCounterStyle> fallback() const { return m_fallbackReference; };
     String fallbackText(int, WritingMode);
     // Generates a CSSCounterStyle object as it was defined by a 'decimal' descriptor. It is used as a last-resource in case we can't resolve fallback references.
-    void applyPadSymbols(String&, int) const;
+    bool applyPadSymbols(String&, int) const;
     void applyNegativeSymbols(String&) const;
     // Initial text representation for the counter, before applying pad and/or negative symbols. Suffix and Prefix are also not considered as described by https://www.w3.org/TR/css-counter-styles-3/#counter-styles.
     String initialRepresentation(int, WritingMode) const;


### PR DESCRIPTION
#### 1e7932ecb00da4b22c15182d9ef18f1f7e63d30a
<pre>
Limit length of @counter-style padding
<a href="https://bugs.webkit.org/show_bug.cgi?id=309875">https://bugs.webkit.org/show_bug.cgi?id=309875</a>
<a href="https://rdar.apple.com/172044856">rdar://172044856</a>

Reviewed by Antti Koivisto.

We should limit the length of padding in a @counter-style rule. CSS Counter Styles Level 3
explicitly allows this, and Chrome and Firefox already apply a length limit of 120 and 150
respectively. This patch applies a limit of 150 to match Firefox.

Test: fast/css/counters/counter-style-pad-length-limit.html
* LayoutTests/fast/css/counters/counter-style-pad-length-limit-expected.txt: Added.
* LayoutTests/fast/css/counters/counter-style-pad-length-limit.html: Added.
* Source/WebCore/css/CSSCounterStyle.cpp:
(WebCore::CSSCounterStyle::text):
(WebCore::CSSCounterStyle::applyPadSymbols const):
* Source/WebCore/css/CSSCounterStyle.h:

Canonical link: <a href="https://commits.webkit.org/309228@main">https://commits.webkit.org/309228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/933ac209f35f05f4a97d5685a10db683b5558c1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16168 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158571 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103297 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23034 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22687 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115602 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82158 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba6affca-c9cc-4648-82da-97cde220b227) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17724 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96341 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16821 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14749 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6418 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161047 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13949 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123618 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123823 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33648 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134200 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78618 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18980 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10952 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21994 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85814 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21724 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21876 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21781 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->