### PR TITLE
[iOS] Video does not render after exiting from AVExperienceController fullscreen

### DIFF
--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -261,6 +261,7 @@ protected:
     virtual bool willRenderToLayer() const = 0;
     virtual void transferVideoViewToFullscreen() { }
     WEBCORE_EXPORT virtual void returnVideoView();
+    WEBCORE_EXPORT virtual bool shouldCreateWindow() const;
 
 #if PLATFORM(WATCHOS)
     bool m_waitingForPreparedToExit { false };

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm
@@ -298,6 +298,11 @@ void VideoPresentationInterfaceIOS::preparedToReturnToInline(bool visible, const
     }
 }
 
+bool VideoPresentationInterfaceIOS::shouldCreateWindow() const
+{
+    return ![[m_parentView window] _isHostedInAnotherProcess] && !m_window && !PAL::currentUserInterfaceIdiomIsVision();
+}
+
 void VideoPresentationInterfaceIOS::doSetup()
 {
     if (m_currentMode.hasVideo() && m_targetMode.hasVideo()) {
@@ -321,7 +326,7 @@ void VideoPresentationInterfaceIOS::doSetup()
     [CATransaction setDisableActions:YES];
 
 #if !PLATFORM(WATCHOS)
-    if (![[m_parentView window] _isHostedInAnotherProcess] && !m_window && !PAL::currentUserInterfaceIdiomIsVision()) {
+    if (shouldCreateWindow()) {
         m_window = adoptNS([PAL::allocUIWindowInstance() initWithWindowScene:[[m_parentView window] windowScene]]);
         [m_window setBackgroundColor:clearUIColor()];
         if (!m_viewController)

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.h
@@ -31,6 +31,7 @@
 #include <wtf/TZoneMalloc.h>
 
 OBJC_CLASS WKSExperienceController;
+OBJC_CLASS WKExperienceControllerDelegate;
 
 namespace WebKit {
 
@@ -47,6 +48,8 @@ public:
 
 private:
     VideoPresentationInterfaceAVKit(WebCore::PlaybackSessionInterfaceIOS&);
+
+    WebAVPlayerLayer *fullscreenPlayerLayer();
 
     // VideoPresentationInterfaceIOS overrides
     bool pictureInPictureWasStartedWhenEnteringBackground() const final { return false; }
@@ -78,8 +81,11 @@ private:
     void setSpatialImmersive(bool) final { }
     void transferVideoViewToFullscreen() final { }
     void returnVideoView() final { }
+    bool shouldCreateWindow() const final { return false; }
 
     RetainPtr<WKSExperienceController> m_experienceController;
+    RetainPtr<WKExperienceControllerDelegate> m_experienceControllerDelegate;
+    RetainPtr<WebAVPlayerLayerView> m_fullscreenPlayerLayerView;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.mm
@@ -32,14 +32,48 @@
 #import "WKSExperienceController.h"
 #import <AVKit/AVPlayerViewControllerContentSource.h>
 #import <WebCore/WebAVPlayerLayer.h>
+#import <WebCore/WebAVPlayerLayerView.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/TZoneMallocInlines.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
 
 #import "WebKitSwiftSoftLink.h"
 #import <pal/cf/CoreMediaSoftLink.h>
 
 SOFTLINK_AVKIT_FRAMEWORK()
 SOFT_LINK_CLASS_OPTIONAL(AVKit, AVPlayerViewControllerContentSource)
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface WKExperienceControllerDelegate: NSObject <WKSExperienceControllerDelegate>
++ (instancetype)new NS_UNAVAILABLE;
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithModel:(WebCore::PlaybackSessionModel&)model NS_DESIGNATED_INITIALIZER;
+@end
+
+@implementation WKExperienceControllerDelegate {
+    WeakPtr<WebCore::PlaybackSessionModel> _model;
+}
+
+- (instancetype)initWithModel:(WebCore::PlaybackSessionModel&)model
+{
+    self = [super init];
+    if (!self)
+        return nil;
+
+    _model = model;
+    return self;
+}
+
+- (void)experienceControllerDidExitFullscreen:(nonnull WKSExperienceController *)experienceController
+{
+    if (CheckedPtr model = _model.get())
+        model->exitFullscreen();
+}
+
+@end
+
+NS_ASSUME_NONNULL_END
 
 namespace WebKit {
 
@@ -52,10 +86,16 @@ Ref<VideoPresentationInterfaceAVKit> VideoPresentationInterfaceAVKit::create(Web
 
 VideoPresentationInterfaceAVKit::VideoPresentationInterfaceAVKit(WebCore::PlaybackSessionInterfaceIOS& playbackSessionInterface)
     : VideoPresentationInterfaceIOS { playbackSessionInterface }
+    , m_experienceControllerDelegate { adoptNS([[WKExperienceControllerDelegate alloc] initWithModel:*playbackSessionInterface.playbackSessionModel()]) }
 {
 }
 
 VideoPresentationInterfaceAVKit::~VideoPresentationInterfaceAVKit() = default;
+
+WebAVPlayerLayer *VideoPresentationInterfaceAVKit::fullscreenPlayerLayer()
+{
+    return checked_objc_cast<WebAVPlayerLayer>([m_fullscreenPlayerLayerView playerLayer]);
+}
 
 void VideoPresentationInterfaceAVKit::setupFullscreen(const WebCore::FloatRect& initialRect, const WebCore::FloatSize& videoDimensions, UIView *parentView, WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode, bool allowsPictureInPicturePlayback, bool standby, bool blocksReturnToFullscreenFromPictureInPicture)
 {
@@ -73,17 +113,27 @@ void VideoPresentationInterfaceAVKit::finalizeSetup()
 
 void VideoPresentationInterfaceAVKit::setupPlayerViewController()
 {
-    RetainPtr contentSource = playbackSessionInterface().contentSource();
-    if (!m_experienceController) {
-        RetainPtr platformContentSource = [allocAVPlayerViewControllerContentSourceInstance() initWithVideoPlaybackControllable:contentSource.get()];
-        m_experienceController = [allocWKSExperienceControllerInstance() initWithContentSource:platformContentSource.get()];
-    }
+    if (m_experienceController)
+        return;
 
-    [contentSource setVideoLayer:playerLayer()];
+    m_fullscreenPlayerLayerView = adoptNS([WebCore::allocWebAVPlayerLayerViewInstance() init]);
+    [fullscreenPlayerLayer() setPresentationModel:videoPresentationModel()];
+    [playerLayerView() transferVideoViewTo:m_fullscreenPlayerLayerView.get()];
+
+    RetainPtr contentSource = playbackSessionInterface().contentSource();
+    [contentSource setVideoLayer:fullscreenPlayerLayer()];
+
+    RetainPtr platformContentSource = [allocAVPlayerViewControllerContentSourceInstance() initWithVideoPlaybackControllable:contentSource.get()];
+    m_experienceController = [allocWKSExperienceControllerInstance() initWithContentSource:platformContentSource.get()];
+    [m_experienceController setDelegate:m_experienceControllerDelegate.get()];
 }
 
 void VideoPresentationInterfaceAVKit::invalidatePlayerViewController()
 {
+    [m_fullscreenPlayerLayerView transferVideoViewTo:playerLayerView()];
+    [fullscreenPlayerLayer() setPresentationModel:nullptr];
+    m_fullscreenPlayerLayerView = nil;
+    [m_experienceController setDelegate:nil];
     m_experienceController = nil;
 }
 

--- a/Source/WebKit/WebKitSwift/AVKit/WKSExperienceController.h
+++ b/Source/WebKit/WebKitSwift/AVKit/WKSExperienceController.h
@@ -30,12 +30,19 @@
 NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class AVPlayerViewControllerContentSource;
+@class WKSExperienceController;
+
+@protocol WKSExperienceControllerDelegate <NSObject>
+- (void)experienceControllerDidExitFullscreen:(WKSExperienceController *)experienceController;
+@end
 
 NS_SWIFT_MAIN_ACTOR
 @interface WKSExperienceController : NSObject
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithContentSource:(AVPlayerViewControllerContentSource *)contentSource NS_DESIGNATED_INITIALIZER;
+
+@property (nonatomic, weak) id<WKSExperienceControllerDelegate> delegate;
 
 - (void)enterFullscreenWithCompletionHandler:(NS_SWIFT_UI_ACTOR NS_SWIFT_SENDABLE void (^)(BOOL))completionHandler;
 - (void)exitFullscreenWithCompletionHandler:(NS_SWIFT_UI_ACTOR NS_SWIFT_SENDABLE void (^)(BOOL))completionHandler;

--- a/Source/WebKit/WebKitSwift/AVKit/WKSExperienceController.swift
+++ b/Source/WebKit/WebKitSwift/AVKit/WKSExperienceController.swift
@@ -25,19 +25,28 @@
 
 import AVKit
 import AVKit_Private
+import os
 @_spi(AVExperienceController) import AVKit
+
+extension Logger {
+    static let experienceController = Logger(subsystem: "com.apple.WebKit", category: "Fullscreen")
+}
 
 @MainActor
 @objc
 @implementation
 extension WKSExperienceController {
+    weak var delegate: (any WKSExperienceControllerDelegate)?
+
     @nonobjc
     final let experienceController: AVExperienceController
 
     @objc(initWithContentSource:)
     init(contentSource: AVPlayerViewControllerContentSource) {
-        self.experienceController = AVExperienceController(contentSource: contentSource)
+        experienceController = AVExperienceController(contentSource: contentSource)
         super.init()
+        experienceController.delegate = self
+        Logger.experienceController.log("\(#function)")
     }
 
     @objc(enterFullscreenWithCompletionHandler:)


### PR DESCRIPTION
#### d6e13005bc64e29c6caae02f4e5515b88500d6ba
<pre>
[iOS] Video does not render after exiting from AVExperienceController fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=309878">https://bugs.webkit.org/show_bug.cgi?id=309878</a>
<a href="https://rdar.apple.com/172452254">rdar://172452254</a>

Reviewed by Eric Carlson.

Fixed several problems related to exiting video fullscreen when using AVExperienceController:
1. Stopped creating an unnecessary UIWindow when entering fullscreen that prevented interacting
   with the web view after exiting fullscreen.
2. Created a WebAVPlayerLayerView in VideoPresentationInterfaceAVKit and properly transfered the
   video view to/from it when entering/exiting fullscreen.
3. Implemented the WKSExperienceControllerDelegate method that is called when exiting fullscreen
   and wired it up to PlaybackSessionModel::exitFullscreen.

* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.mm:
(WebCore::VideoPresentationInterfaceIOS::shouldCreateWindow const):
(WebCore::VideoPresentationInterfaceIOS::doSetup):
* Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.mm:
(-[WKExperienceControllerDelegate initWithModel:]):
(-[WKExperienceControllerDelegate experienceControllerDidExitFullscreen:]):
(WebKit::VideoPresentationInterfaceAVKit::fullscreenPlayerLayer):
(WebKit::VideoPresentationInterfaceAVKit::setupPlayerViewController):
(WebKit::VideoPresentationInterfaceAVKit::invalidatePlayerViewController):
* Source/WebKit/WebKitSwift/AVKit/WKSExperienceController.h:
* Source/WebKit/WebKitSwift/AVKit/WKSExperienceController.swift:
(WKSExperienceController.delegate):

Canonical link: <a href="https://commits.webkit.org/309236@main">https://commits.webkit.org/309236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aead5fa03501a1c02fc89c1301947e01293e47cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149967 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158674 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/127ec860-9ff8-497e-9dfc-5ca8ed9ebba9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22796 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115683 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3d374fb8-ef50-4521-b35b-3b2457076645) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152927 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134561 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96420 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/55b5a073-82a3-4d22-9985-01171bfdd169) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16909 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14844 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6520 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161151 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123697 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123893 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33654 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22499 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134278 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78743 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19055 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11036 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22096 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85932 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21826 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21981 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21883 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->