### PR TITLE
[JSC] Add MicrotaskCall

### DIFF
--- a/JSTests/stress/microtask-call-caching.js
+++ b/JSTests/stress/microtask-call-caching.js
@@ -1,0 +1,17 @@
+// MicrotaskCall caching: verify correctness for promise chains using the same handler function.
+let results = [];
+const handler = (v) => { results.push(v); };
+
+let promises = [];
+for (let i = 0; i < 1000; i++)
+    promises.push(Promise.resolve(i).then(handler));
+
+Promise.all(promises).then(() => {
+    if (results.length !== 1000)
+        throw new Error("Wrong count: " + results.length);
+    results.sort((a, b) => a - b);
+    for (let i = 0; i < 1000; i++) {
+        if (results[i] !== i)
+            throw new Error("Wrong value at " + i + ": " + results[i]);
+    }
+});

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -913,6 +913,8 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     interpreter/EntryFrame.h
     interpreter/FrameTracers.h
     interpreter/Interpreter.h
+    interpreter/MicrotaskCall.h
+    interpreter/MicrotaskCallInlines.h
     interpreter/ProtoCallFrame.h
     interpreter/ProtoCallFrameInlines.h
     interpreter/Register.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1741,6 +1741,8 @@
 		A7FB61001040C38B0017A286 /* PropertyDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = A7FB604B103F5EAB0017A286 /* PropertyDescriptor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A7FCC26D17A0B6AA00786D1A /* FTLSwitchCase.h in Headers */ = {isa = PBXBuildFile; fileRef = A7FCC26C17A0B6AA00786D1A /* FTLSwitchCase.h */; };
 		AA45D14F2EB82FEB00FCBD16 /* CachedCallInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = AA45D14E2EB82FEB00FCBD16 /* CachedCallInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E30001002EF0001000000004 /* MicrotaskCall.h in Headers */ = {isa = PBXBuildFile; fileRef = E30001002EF0001000000001 /* MicrotaskCall.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E30001002EF0001000000005 /* MicrotaskCallInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E30001002EF0001000000002 /* MicrotaskCallInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		AA785BEB2E77BECA0097F688 /* JSPromiseCombinatorsContext.h in Headers */ = {isa = PBXBuildFile; fileRef = AA785BEA2E77BECA0097F688 /* JSPromiseCombinatorsContext.h */; };
 		AA785BEE2E77BED70097F688 /* JSPromiseCombinatorsContextInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = AA785BED2E77BED70097F688 /* JSPromiseCombinatorsContextInlines.h */; };
 		AD00659E1ECAC812000CA926 /* WasmLimits.h in Headers */ = {isa = PBXBuildFile; fileRef = AD00659D1ECAC7FE000CA926 /* WasmLimits.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5495,6 +5497,9 @@
 		A8E894310CD0602400367179 /* JSCallbackObjectFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSCallbackObjectFunctions.h; sourceTree = "<group>"; };
 		A8E894330CD0603F00367179 /* JSGlobalObject.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSGlobalObject.h; sourceTree = "<group>"; };
 		AA45D14E2EB82FEB00FCBD16 /* CachedCallInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CachedCallInlines.h; sourceTree = "<group>"; };
+		E30001002EF0001000000001 /* MicrotaskCall.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MicrotaskCall.h; sourceTree = "<group>"; };
+		E30001002EF0001000000002 /* MicrotaskCallInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MicrotaskCallInlines.h; sourceTree = "<group>"; };
+		E30001002EF0001000000003 /* MicrotaskCall.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MicrotaskCall.cpp; sourceTree = "<group>"; };
 		AA785BEA2E77BECA0097F688 /* JSPromiseCombinatorsContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSPromiseCombinatorsContext.h; sourceTree = "<group>"; };
 		AA785BEC2E77BECF0097F688 /* JSPromiseCombinatorsContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSPromiseCombinatorsContext.cpp; sourceTree = "<group>"; };
 		AA785BED2E77BED70097F688 /* JSPromiseCombinatorsContextInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSPromiseCombinatorsContextInlines.h; sourceTree = "<group>"; };
@@ -7227,6 +7232,9 @@
 				1429D7D30ED2128200B89619 /* Interpreter.cpp */,
 				1429D77B0ED20D7300B89619 /* Interpreter.h */,
 				E39D9D841D39000600667282 /* InterpreterInlines.h */,
+				E30001002EF0001000000003 /* MicrotaskCall.cpp */,
+				E30001002EF0001000000001 /* MicrotaskCall.h */,
+				E30001002EF0001000000002 /* MicrotaskCallInlines.h */,
 				65FB5115184EE8F800C12B70 /* ProtoCallFrame.h */,
 				FE1D6D742362649D007A5C26 /* ProtoCallFrameInlines.h */,
 				149B24FF0D8AF6D1009CB8C7 /* Register.h */,
@@ -12108,6 +12116,8 @@
 				142F16E021558802003D49C9 /* MetadataTable.h in Headers */,
 				0FB5467B14F5C7E1002C2989 /* MethodOfGettingAValueProfile.h in Headers */,
 				7C008CE7187631B600955C24 /* Microtask.h in Headers */,
+				E30001002EF0001000000004 /* MicrotaskCall.h in Headers */,
+				E30001002EF0001000000005 /* MicrotaskCallInlines.h in Headers */,
 				E36965F32D76E975005BCC77 /* MicrotaskQueue.h in Headers */,
 				E306C1BC2D79000D0011D5AC /* MicrotaskQueueInlines.h in Headers */,
 				FE2A87601F02381600EB31B2 /* MinimumReservedZoneSize.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -628,6 +628,7 @@ interpreter/CachedCall.cpp
 interpreter/CLoopStack.cpp
 interpreter/CallFrame.cpp
 interpreter/Interpreter.cpp
+interpreter/MicrotaskCall.cpp
 interpreter/ShadowChicken.cpp
 interpreter/StackVisitor.cpp
 

--- a/Source/JavaScriptCore/bytecode/CallLinkInfoBase.h
+++ b/Source/JavaScriptCore/bytecode/CallLinkInfoBase.h
@@ -62,6 +62,7 @@ public:
         DirectCall,
 #endif
         CachedCall,
+        MicrotaskCall,
     };
 
     enum CallType : uint8_t {

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -66,6 +66,7 @@
 #include "JSWebAssemblyException.h"
 #include "LLIntThunks.h"
 #include "LiteralParser.h"
+#include "MicrotaskCall.h"
 #include "ModuleProgramCodeBlock.h"
 #include "NativeCallee.h"
 #include "ProgramCodeBlock.h"
@@ -1428,6 +1429,24 @@ CodeBlock* Interpreter::prepareForCachedCall(CachedCall& cachedCall, JSFunction*
 
     cachedCall.m_addressForCall = newCodeBlock->jitCode()->addressForCall();
     newCodeBlock->linkIncomingCall(nullptr, &cachedCall);
+    return newCodeBlock;
+}
+
+CodeBlock* Interpreter::prepareForMicrotaskCall(MicrotaskCall& microtaskCall, JSFunction* function)
+{
+    VM& vm = this->vm();
+    auto throwScope = DECLARE_THROW_SCOPE(vm);
+
+    // Compile the callee:
+    CodeBlock* newCodeBlock;
+    microtaskCall.functionExecutable()->prepareForExecution<FunctionExecutable>(vm, function, function->scope(), CodeSpecializationKind::CodeForCall, newCodeBlock);
+    RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(throwScope, { });
+
+    ASSERT(newCodeBlock);
+    newCodeBlock->m_shouldAlwaysBeInlined = false;
+
+    microtaskCall.m_addressForCall = newCodeBlock->jitCode()->addressForCall();
+    newCodeBlock->linkIncomingCall(nullptr, &microtaskCall);
     return newCodeBlock;
 }
 

--- a/Source/JavaScriptCore/interpreter/Interpreter.h
+++ b/Source/JavaScriptCore/interpreter/Interpreter.h
@@ -57,6 +57,7 @@ using JSOrWasmInstruction = Variant<const JSInstruction*, uintptr_t /* IPIntOffs
 
     class ArgList;
     class CachedCall;
+    class MicrotaskCall;
     class CodeBlock;
     class EvalExecutable;
     class Exception;
@@ -125,6 +126,7 @@ using JSOrWasmInstruction = Variant<const JSInstruction*, uintptr_t /* IPIntOffs
     class Interpreter {
         WTF_MAKE_TZONE_NON_HEAP_ALLOCATABLE(Interpreter);
         friend class CachedCall;
+        friend class MicrotaskCall;
         friend class LLIntOffsetsExtractor;
         friend class JIT;
         friend class VM;
@@ -161,6 +163,7 @@ using JSOrWasmInstruction = Variant<const JSInstruction*, uintptr_t /* IPIntOffs
         enum ExecutionFlag { Normal, InitializeAndReturn };
 
         CodeBlock* prepareForCachedCall(CachedCall&, JSFunction*);
+        CodeBlock* prepareForMicrotaskCall(MicrotaskCall&, JSFunction*);
 
         JSValue executeCachedCall(CachedCall&);
         JSValue executeBoundCall(VM&, JSBoundFunction*, JSCell*, const ArgList&);

--- a/Source/JavaScriptCore/interpreter/MicrotaskCall.cpp
+++ b/Source/JavaScriptCore/interpreter/MicrotaskCall.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,38 +24,50 @@
  */
 
 #include "config.h"
-#include "CallLinkInfoBase.h"
-
-#include "CachedCall.h"
-#include "CallLinkInfo.h"
-#include "JSCJSValueInlines.h"
-#include "JSFunctionInlines.h"
 #include "MicrotaskCall.h"
-#include "PolymorphicCallStubRoutine.h"
+
+#include "CodeBlock.h"
+#include "Interpreter.h"
+#include "JSFunction.h"
+#include "ThrowScope.h"
 
 namespace JSC {
 
-void CallLinkInfoBase::unlinkOrUpgrade(VM& vm, CodeBlock* oldCodeBlock, CodeBlock* newCodeBlock)
+void MicrotaskCall::initialize(VM& vm, JSFunction* function)
 {
-    switch (callSiteType()) {
-    case CallSiteType::CallLinkInfo:
-        static_cast<CallLinkInfo*>(this)->unlinkOrUpgradeImpl(vm, oldCodeBlock, newCodeBlock);
-        break;
-    case CallSiteType::PolymorphicCallNode:
-        static_cast<PolymorphicCallNode*>(this)->unlinkOrUpgradeImpl(vm, oldCodeBlock, newCodeBlock);
-        break;
-#if ENABLE(JIT)
-    case CallSiteType::DirectCall:
-        static_cast<DirectCallLinkInfo*>(this)->unlinkOrUpgradeImpl(vm, oldCodeBlock, newCodeBlock);
-        break;
-#endif
-    case CallSiteType::CachedCall:
-        static_cast<CachedCall*>(this)->unlinkOrUpgradeImpl(vm, oldCodeBlock, newCodeBlock);
-        break;
-    case CallSiteType::MicrotaskCall:
-        static_cast<MicrotaskCall*>(this)->unlinkOrUpgradeImpl(vm, oldCodeBlock, newCodeBlock);
-        break;
+    m_addressForCall = nullptr;
+    m_functionExecutable = function->jsExecutable();
+    relink(vm, function);
+}
+
+void MicrotaskCall::relink(VM& vm, JSFunction* function)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    // Unlink from any prior CodeBlock before we reset state.
+    if (isOnList())
+        remove();
+
+    auto* newCodeBlock = vm.interpreter.prepareForMicrotaskCall(*this, function);
+    RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, void());
+    m_codeBlock = newCodeBlock;
+    m_numParameters = newCodeBlock->numParameters();
+}
+
+void MicrotaskCall::unlinkOrUpgradeImpl(VM&, CodeBlock* oldCodeBlock, CodeBlock* newCodeBlock)
+{
+    if (isOnList())
+        remove();
+
+    if (newCodeBlock && m_codeBlock == oldCodeBlock) {
+        newCodeBlock->m_shouldAlwaysBeInlined = false;
+        m_addressForCall = newCodeBlock->jitCode()->addressForCall();
+        m_codeBlock = newCodeBlock;
+        m_numParameters = newCodeBlock->numParameters();
+        newCodeBlock->linkIncomingCall(nullptr, this);
+        return;
     }
+    m_addressForCall = nullptr;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/interpreter/MicrotaskCall.h
+++ b/Source/JavaScriptCore/interpreter/MicrotaskCall.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/CallLinkInfoBase.h>
+#include <JavaScriptCore/ExceptionHelpers.h>
+#include <JavaScriptCore/JSFunction.h>
+#include <wtf/ForbidHeapAllocation.h>
+
+namespace JSC {
+
+class Interpreter;
+class VM;
+
+class MicrotaskCall final : public CallLinkInfoBase {
+    WTF_MAKE_NONCOPYABLE(MicrotaskCall);
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
+    static constexpr unsigned maxCallArguments = 6;
+
+    explicit MicrotaskCall(VM&)
+        : CallLinkInfoBase(CallSiteType::MicrotaskCall)
+    { }
+
+    ~MicrotaskCall()
+    {
+        m_addressForCall = nullptr;
+    }
+
+    void initialize(VM&, JSFunction*);
+
+    template<typename... Args> requires (std::is_convertible_v<Args, JSValue> && ...)
+    JSValue tryCallWithArguments(VM&, JSFunction*, JSValue thisValue, JSCell* context, Args...);
+
+    bool isInitializedFor(FunctionExecutable* executable) const
+    {
+        return m_functionExecutable == executable;
+    }
+
+    FunctionExecutable* functionExecutable() { return m_functionExecutable; }
+
+    void unlinkOrUpgradeImpl(VM&, CodeBlock* oldCodeBlock, CodeBlock* newCodeBlock);
+    void relink(VM&, JSFunction*);
+
+private:
+    CodeBlock* m_codeBlock { nullptr };
+    FunctionExecutable* m_functionExecutable { nullptr };
+    void* m_addressForCall { nullptr };
+    unsigned m_numParameters { 0 };
+    friend class Interpreter;
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/interpreter/MicrotaskCallInlines.h
+++ b/Source/JavaScriptCore/interpreter/MicrotaskCallInlines.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <JavaScriptCore/LLIntThunks.h>
+#include <JavaScriptCore/MicrotaskCall.h>
+#include <JavaScriptCore/VMTrapsInlines.h>
+#include <wtf/StackStats.h>
+
+#if ASSERT_ENABLED
+#include <JavaScriptCore/IntegrityInlines.h>
+#endif
+
+namespace JSC {
+
+template<typename... Args> requires (std::is_convertible_v<Args, JSValue> && ...)
+ALWAYS_INLINE JSValue MicrotaskCall::tryCallWithArguments(VM& vm, JSFunction* function, JSValue thisValue, JSCell* context, Args... args)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    ASSERT_WITH_MESSAGE(!thisValue.isEmpty(), "Expected thisValue to be non-empty. Use jsUndefined() if you meant to use undefined.");
+#if ASSERT_ENABLED
+    if constexpr (sizeof...(args) > 0) {
+        size_t argIndex = 0;
+        auto checkArg = [&argIndex, &vm](JSValue arg) {
+            ASSERT_WITH_MESSAGE(!arg.isEmpty(), "arguments[%zu] is JSValue(). Use jsUndefined() if you meant to make it undefined.", argIndex);
+            if (arg.isCell())
+                Integrity::auditCell(vm, arg.asCell());
+            ++argIndex;
+        };
+        (checkArg(args), ...);
+    }
+#endif
+
+    ASSERT(!vm.isCollectorBusyOnCurrentThread());
+    ASSERT(vm.currentThreadIsHoldingAPILock());
+
+    constexpr unsigned argumentCountIncludingThis = 1 + sizeof...(args);
+#if CPU(ARM64) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
+    static_assert(argumentCountIncludingThis <= 7);
+    if (m_numParameters <= argumentCountIncludingThis) [[likely]] {
+        auto* entry = m_addressForCall;
+        if (!entry) [[unlikely]] {
+            DeferTraps deferTraps(vm);
+            relink(vm, function);
+            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, { });
+            entry = m_addressForCall;
+        }
+        auto* codeBlock = m_codeBlock;
+        if constexpr (!sizeof...(args))
+            RELEASE_AND_RETURN(scope, JSValue::decode(vmEntryToJavaScriptWith0Arguments(entry, &vm, codeBlock, function, thisValue, context)));
+        else if constexpr (sizeof...(args) == 1)
+            RELEASE_AND_RETURN(scope, JSValue::decode(vmEntryToJavaScriptWith1Arguments(entry, &vm, codeBlock, function, thisValue, context, args...)));
+        else if constexpr (sizeof...(args) == 2)
+            RELEASE_AND_RETURN(scope, JSValue::decode(vmEntryToJavaScriptWith2Arguments(entry, &vm, codeBlock, function, thisValue, context, args...)));
+        else if constexpr (sizeof...(args) == 3)
+            RELEASE_AND_RETURN(scope, JSValue::decode(vmEntryToJavaScriptWith3Arguments(entry, &vm, codeBlock, function, thisValue, context, args...)));
+        else if constexpr (sizeof...(args) == 4)
+            RELEASE_AND_RETURN(scope, JSValue::decode(vmEntryToJavaScriptWith4Arguments(entry, &vm, codeBlock, function, thisValue, context, args...)));
+        else if constexpr (sizeof...(args) == 5)
+            RELEASE_AND_RETURN(scope, JSValue::decode(vmEntryToJavaScriptWith5Arguments(entry, &vm, codeBlock, function, thisValue, context, args...)));
+        else if constexpr (sizeof...(args) == 6)
+            RELEASE_AND_RETURN(scope, JSValue::decode(vmEntryToJavaScriptWith6Arguments(entry, &vm, codeBlock, function, thisValue, context, args...)));
+        else
+            return { };
+    }
+#else
+    UNUSED_PARAM(function);
+    UNUSED_PARAM(thisValue);
+    UNUSED_PARAM(context);
+    UNUSED_VARIABLE(scope);
+    UNUSED_VARIABLE(argumentCountIncludingThis);
+#endif
+
+    return { };
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -36,6 +36,7 @@
 #include "Interpreter.h"
 #include "InterpreterInlines.h"
 #include "IteratorOperations.h"
+#include "MicrotaskCallInlines.h"
 #include "JSArray.h"
 #include "JSAsyncGenerator.h"
 #include "JSFunction.h"
@@ -68,13 +69,13 @@ static ALWAYS_INLINE JSCell* dynamicCastToCell(JSValue value)
 }
 
 template<typename... Args> requires (std::is_convertible_v<Args, JSValue> && ...)
-static JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObject, JSValue thisValue, JSCell* context, ASCIILiteral message, Args... args)
+static JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObject, JSValue thisValue, JSCell* context, ASCIILiteral message, MicrotaskCall* microtaskCall, Args... args)
 {
     NO_TAIL_CALLS();
 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    static_assert(sizeof...(args) <= 6);
+    static_assert(sizeof...(args) <= MicrotaskCall::maxCallArguments);
 
     auto callData = JSC::getCallDataInline(functionObject);
     if (callData.type == CallData::Type::None)
@@ -98,9 +99,22 @@ static JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObjec
     if (isJSCall) {
         functionScope = callData.js.scope;
         functionExecutable = callData.js.functionExecutable;
-        calleeGlobalObject = functionScope->globalObject();
         if (!vm.isSafeToRecurseSoft()) [[unlikely]]
-            return throwStackOverflowError(calleeGlobalObject, scope);
+            return throwStackOverflowError(functionScope->globalObject(), scope);
+
+        if (microtaskCall) [[likely]] {
+            auto* jsFunction = jsCast<JSFunction*>(functionObject.asCell());
+            if (!microtaskCall->isInitializedFor(functionExecutable)) {
+                microtaskCall->initialize(vm, jsFunction);
+                RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, scope.exception());
+            }
+            if (auto result = microtaskCall->tryCallWithArguments(vm, jsFunction, thisValue, context, args...)) [[likely]] {
+                scope.release();
+                return result;
+            }
+            RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, scope.exception());
+        }
+
         {
             DeferTraps deferTraps(vm); // We can't jettison this code if we're about to run it.
 
@@ -132,6 +146,8 @@ static JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObjec
                 return { };
         }
 #endif
+
+        calleeGlobalObject = functionScope->globalObject();
         {
             AssertNoGC assertNoGC; // Ensure no GC happens. GC can replace CodeBlock in Executable.
             jitCode = functionExecutable->generatedJITCodeForCall();
@@ -227,7 +243,7 @@ static void promiseResolveThenableJob(JSGlobalObject* globalObject, JSValue prom
     auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
 
     {
-        callMicrotask(globalObject, then, promise, dynamicCastToCell(then), "|then| is not a function"_s, resolve, reject);
+        callMicrotask(globalObject, then, promise, dynamicCastToCell(then), "|then| is not a function"_s, nullptr, resolve, reject);
         if (!scope.exception()) [[likely]]
             return;
     }
@@ -277,7 +293,7 @@ static void asyncFromSyncIteratorContinueOrDone(JSGlobalObject* globalObject, VM
                 return;
             }
             if (returnMethod.isCallable()) {
-                callMicrotask(globalObject, returnMethod, syncIterator, dynamicCastToCell(returnMethod), "return is not a function"_s);
+                callMicrotask(globalObject, returnMethod, syncIterator, dynamicCastToCell(returnMethod), "return is not a function"_s, nullptr);
                 if (scope.exception()) [[unlikely]]
                     return;
             }
@@ -534,7 +550,7 @@ static bool asyncGeneratorBodyCall(JSGlobalObject* globalObject, JSAsyncGenerato
     JSValue error;
     {
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        value = callMicrotask(globalObject, generatorFunction, generatorThis, generator, "handler is not a function"_s,
+        value = callMicrotask(globalObject, generatorFunction, generatorThis, generator, "handler is not a function"_s, nullptr,
             generator, jsNumber(state >> JSAsyncGenerator::reasonShift), resumeValue, jsNumber(resumeMode), generatorFrame);
         if (scope.exception()) [[unlikely]] {
             error = scope.exception()->value();
@@ -717,7 +733,7 @@ static void promiseFinallyReactionJob(JSGlobalObject* globalObject, VM& vm, JSPr
     JSValue error;
     {
         auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        result = callMicrotask(globalObject, onFinally, jsUndefined(), dynamicCastToCell(onFinally), "onFinally is not a function"_s);
+        result = callMicrotask(globalObject, onFinally, jsUndefined(), dynamicCastToCell(onFinally), "onFinally is not a function"_s, nullptr);
         if (catchScope.exception()) {
             error = catchScope.exception()->value();
             if (!catchScope.clearExceptionExceptTermination()) [[unlikely]] {
@@ -786,7 +802,7 @@ static void promiseFinallyReactionJob(JSGlobalObject* globalObject, VM& vm, JSPr
     promiseResolveThenableJob(globalObject, resolutionObject, then, resolve, reject);
 }
 
-void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotask task, uint8_t payload, std::span<const JSValue, maxMicrotaskArguments> arguments)
+void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotask task, uint8_t payload, std::span<const JSValue, maxMicrotaskArguments> arguments, MicrotaskCall* microtaskCall)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
@@ -897,7 +913,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         JSValue error;
         {
             auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            result = callMicrotask(globalObject, handler, jsUndefined(), dynamicCastToCell(handler), "handler is not a function"_s, arguments[2]);
+            result = callMicrotask(globalObject, handler, jsUndefined(), dynamicCastToCell(handler), "handler is not a function"_s, microtaskCall, arguments[2]);
             if (catchScope.exception()) {
                 if (promiseOrCapability.isUndefinedOrNull()) {
                     scope.release();
@@ -948,7 +964,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
     case InternalMicrotask::InvokeFunctionJob: {
         JSValue handler = arguments[0];
         scope.release();
-        callMicrotask(globalObject, handler, jsUndefined(), nullptr, "handler is not a function"_s);
+        callMicrotask(globalObject, handler, jsUndefined(), nullptr, "handler is not a function"_s, microtaskCall);
         return;
     }
 
@@ -980,7 +996,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         JSValue error;
         {
             auto catchScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-            value = callMicrotask(globalObject, next, thisValue, generator, "handler is not a function"_s,
+            value = callMicrotask(globalObject, next, thisValue, generator, "handler is not a function"_s, microtaskCall,
                 generator, jsNumber(state), resolution, jsNumber(static_cast<int32_t>(resumeMode)), frame);
             if (catchScope.exception()) {
                 error = catchScope.exception()->value();

--- a/Source/JavaScriptCore/runtime/JSMicrotask.h
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.h
@@ -31,6 +31,8 @@
 
 namespace JSC {
 
-void runInternalMicrotask(JSGlobalObject*, VM&, InternalMicrotask, uint8_t, std::span<const JSValue, maxMicrotaskArguments>);
+class MicrotaskCall;
+
+void runInternalMicrotask(JSGlobalObject*, VM&, InternalMicrotask, uint8_t, std::span<const JSValue, maxMicrotaskArguments>, MicrotaskCall* = nullptr);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
+++ b/Source/JavaScriptCore/runtime/MicrotaskQueue.cpp
@@ -34,6 +34,7 @@
 #include "JSMicrotask.h"
 #include "JSMicrotaskDispatcher.h"
 #include "JSObject.h"
+#include "MicrotaskCallInlines.h"
 #include "MicrotaskQueueInlines.h"
 #include "ScriptProfilingScope.h"
 #include "SlotVisitorInlines.h"
@@ -55,9 +56,9 @@ bool QueuedTask::isRunnable() const
     return jsCast<JSGlobalObject*>(dispatcher())->microtaskRunnability() == QueuedTaskResult::Executed;
 }
 
-static bool runMicrotask(JSGlobalObject* globalObject, TopExceptionScope& catchScope, VM& vm, QueuedTask& task)
+static bool runMicrotask(JSGlobalObject* globalObject, TopExceptionScope& catchScope, VM& vm, QueuedTask& task, MicrotaskCall* microtaskCall)
 {
-    runInternalMicrotask(globalObject, vm, task.job(), task.payload(), task.arguments());
+    runInternalMicrotask(globalObject, vm, task.job(), task.payload(), task.arguments(), microtaskCall);
     if (auto* exception = catchScope.exception()) [[unlikely]] {
         if (!catchScope.clearExceptionExceptTermination()) [[unlikely]]
             return false;
@@ -79,7 +80,7 @@ void runMicrotaskWithDebugger(JSGlobalObject* globalObject, VM& vm, QueuedTask& 
             return;
     }
 
-    if (!runMicrotask(globalObject, catchScope, vm, task)) [[unlikely]]
+    if (!runMicrotask(globalObject, catchScope, vm, task, nullptr)) [[unlikely]]
         return;
 
     if (auto* debugger = globalObject->debugger(); debugger && identifier) [[unlikely]] {
@@ -170,6 +171,8 @@ DEFINE_VISIT_AGGREGATE(MarkedMicrotaskDeque);
 template<bool useCallOnEachMicrotask>
 ALWAYS_INLINE std::pair<JSGlobalObject*, bool> MicrotaskQueue::drainImpl(JSGlobalObject* currentGlobalObject, VM& vm, TopExceptionScope& catchScope)
 {
+    MicrotaskCall microtaskCall(vm);
+
     while (!m_queue.isEmpty()) {
         auto& front = m_queue.front();
 
@@ -187,7 +190,7 @@ ALWAYS_INLINE std::pair<JSGlobalObject*, bool> MicrotaskQueue::drainImpl(JSGloba
                 return { globalObject, false };
 
             auto task = m_queue.dequeue();
-            if (!runMicrotask(globalObject, catchScope, vm, task)) [[unlikely]] {
+            if (!runMicrotask(globalObject, catchScope, vm, task, &microtaskCall)) [[unlikely]] {
                 clear();
                 return { nullptr, true };
             }


### PR DESCRIPTION
#### 7a597ba1b58e80eac0e77815d59adc2d618fadc1
<pre>
[JSC] Add MicrotaskCall
<a href="https://bugs.webkit.org/show_bug.cgi?id=309881">https://bugs.webkit.org/show_bug.cgi?id=309881</a>
<a href="https://rdar.apple.com/172458722">rdar://172458722</a>

Reviewed by Yijia Huang.

This patch adds MicrotaskCall, which is similar to CachedCall, but much
more tailored for MicrotaskQueue.

1. This is more aligned to Closure Call in DataOnlyCallLinkInfo. So we
   cache the FunctionExecutable* and based on that, we cache CodeBlock*.
2. Available # of arguments are aligned to microtask.
3. A lot of setup are skipped because it is for microtask invocation.

Test: JSTests/stress/microtask-call-caching.js
* JSTests/stress/microtask-call-caching.js: Added.
(const.handler):
(Promise.all.promises.then):
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/bytecode/CallLinkInfoBase.cpp:
(JSC::CallLinkInfoBase::unlinkOrUpgrade):
* Source/JavaScriptCore/bytecode/CallLinkInfoBase.h:
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::prepareForMicrotaskCall):
* Source/JavaScriptCore/interpreter/Interpreter.h:
* Source/JavaScriptCore/interpreter/MicrotaskCall.cpp: Added.
(JSC::MicrotaskCall::initialize):
(JSC::MicrotaskCall::relink):
(JSC::MicrotaskCall::unlinkOrUpgradeImpl):
* Source/JavaScriptCore/interpreter/MicrotaskCall.h: Added.
(JSC::MicrotaskCall::MicrotaskCall):
(JSC::MicrotaskCall::~MicrotaskCall):
(JSC::MicrotaskCall::isInitializedFor const):
(JSC::MicrotaskCall::functionExecutable):
* Source/JavaScriptCore/interpreter/MicrotaskCallInlines.h: Added.
(JSC::MicrotaskCall::callWithArguments):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::callMicrotask):
(JSC::promiseResolveThenableJob):
(JSC::asyncFromSyncIteratorContinueOrDone):
(JSC::asyncGeneratorBodyCall):
(JSC::promiseFinallyReactionJob):
(JSC::runInternalMicrotask):
* Source/JavaScriptCore/runtime/JSMicrotask.h:
* Source/JavaScriptCore/runtime/MicrotaskQueue.cpp:
(JSC::runMicrotask):
(JSC::runMicrotaskWithDebugger):
(JSC::MicrotaskQueue::drainImpl):

Canonical link: <a href="https://commits.webkit.org/309252@main">https://commits.webkit.org/309252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ed7c3e78dc1d6b983ebeffa104b2fd5a718a6b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158746 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22886 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115738 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02fbc3f7-b46e-46eb-a2cd-20880f56498b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152995 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134609 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96467 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6592 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142018 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126561 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/12533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161220 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10833 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14085 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123735 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22562 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18941 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123937 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/22567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134328 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23080 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11084 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181466 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22167 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85995 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/21897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/22049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/21955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->