### PR TITLE
[JSC] FTL `CompareStrictEq(Untyped)` should use DFG's JSValue bit-trick fast path

### DIFF
--- a/JSTests/microbenchmarks/compare-strict-eq-untyped-fast-only.js
+++ b/JSTests/microbenchmarks/compare-strict-eq-untyped-fast-only.js
@@ -1,0 +1,31 @@
+function eq(a, b) {
+    return a === b;
+}
+noInline(eq);
+
+var o1 = {};
+var o2 = {};
+for (var i = 0; i < 1e6; ++i) {
+    eq(1.5, 2.5);
+    eq(null, null);
+    eq(undefined, undefined);
+    eq(true, false);
+    eq(5, 7);
+    eq(o1, o2);
+}
+
+var N = 1e6;
+var acc = 0;
+var a = null;
+var b = undefined;
+var c = true;
+var d = false;
+for (var i = 0; i < N; ++i) {
+    if (eq(a, a)) acc++;
+    if (eq(b, b)) acc++;
+    if (eq(a, b)) acc++;
+    if (eq(c, c)) acc++;
+    if (eq(c, d)) acc++;
+}
+if (acc !== N * 3)
+    throw new Error("bad acc: " + acc);

--- a/JSTests/microbenchmarks/compare-strict-eq-untyped-mixed.js
+++ b/JSTests/microbenchmarks/compare-strict-eq-untyped-mixed.js
@@ -1,0 +1,70 @@
+function eq(a, b) {
+    return a === b;
+}
+noInline(eq);
+
+var obj1 = {};
+var obj2 = {};
+var str1 = "hello" + Math.random().toString().slice(2);
+var str2 = "hello" + Math.random().toString().slice(2);
+
+var pairs = [
+    [null, null, true],
+    [undefined, undefined, true],
+    [null, undefined, false],
+    [undefined, null, false],
+    [true, true, true],
+    [false, false, true],
+    [true, false, false],
+    [null, 0, false],
+    [null, false, false],
+    [undefined, 0, false],
+    [5, 5, true],
+    [5, 7, false],
+    [0, 0, true],
+    [-0, 0, true],
+    [obj1, obj1, true],
+    [obj1, obj2, false],
+    [obj1, null, false],
+    [obj1, 42, false],
+    [1.5, 1.5, true],
+    [1.5, 2.5, false],
+    [NaN, NaN, false],
+    [0.1 + 0.2, 0.3, false],
+    [str1, str1, true],
+    [str1, str2, false],
+    ["ab" + "c", "abc", true],
+    [1n, 1n, true],
+    [1n, 2n, false],
+    [Symbol.iterator, Symbol.iterator, true],
+];
+
+for (var iter = 0; iter < 1e6; ++iter) {
+    for (var i = 0; i < pairs.length; ++i) {
+        var p = pairs[i];
+        var got = eq(p[0], p[1]);
+        if (got !== p[2])
+            throw new Error("iter " + iter + " pair " + i + ": eq(" + String(p[0]) + ", " + String(p[1]) + ") = " + got + ", expected " + p[2]);
+    }
+}
+
+var fastPairs = [
+    [null, null, true],
+    [undefined, undefined, true],
+    [null, undefined, false],
+    [true, false, false],
+    [obj1, obj1, true],
+    [obj1, obj2, false],
+    [5, 5, true],
+    [5, 7, false],
+];
+var acc = 0;
+for (var iter = 0; iter < 1e6; ++iter) {
+    for (var i = 0; i < fastPairs.length; ++i) {
+        var p = fastPairs[i];
+        if (eq(p[0], p[1]))
+            acc++;
+    }
+}
+if (acc !== 1e6 * 4)
+    throw new Error("fastPairs acc mismatch: " + acc);

--- a/JSTests/stress/compare-strict-eq-untyped-bit-trick-edges.js
+++ b/JSTests/stress/compare-strict-eq-untyped-bit-trick-edges.js
@@ -1,0 +1,223 @@
+//@ runDefault
+//@ runFTLNoCJIT
+
+function eq(a, b) {
+    return a === b;
+}
+noInline(eq);
+
+var poison1 = [1.5, null, {}, "x", true, 0, undefined];
+var poison2 = [2.5, undefined, [], "y", false, 1, null];
+for (var i = 0; i < testLoopCount; ++i) {
+    for (var j = 0; j < poison1.length; ++j)
+        eq(poison1[j], poison2[j]);
+}
+
+var failures = [];
+function check(a, b, expected, label) {
+    var got = eq(a, b);
+    if (got !== expected)
+        failures.push(label + ": eq(" + String(a) + ", " + String(b) + ") = " + got + ", expected " + expected);
+}
+
+check(0.0, 0.0, true, "double-zero-vs-double-zero");
+check(0.0, null, false, "double-zero-vs-null");
+check(null, 0.0, false, "null-vs-double-zero");
+check(0.0, 0, true, "double-zero-vs-int-zero");
+check(0, 0.0, true, "int-zero-vs-double-zero");
+
+check(-0.0, -0.0, true, "neg-zero-vs-neg-zero");
+check(-0.0, 0.0, true, "neg-zero-vs-pos-zero");
+check(-0.0, 0, true, "neg-zero-vs-int-zero");
+
+check(5e-324, 5e-324, true, "denormal-vs-denormal");
+check(5e-324, 0.0, false, "denormal-vs-zero");
+check(5e-324, 0, false, "denormal-vs-int-zero");
+check(-5e-324, -5e-324, true, "neg-denormal-vs-neg-denormal");
+check(-5e-324, 5e-324, false, "neg-denormal-vs-pos-denormal");
+
+check(NaN, NaN, false, "nan-vs-nan");
+check(NaN, 0.0, false, "nan-vs-zero");
+check(NaN, null, false, "nan-vs-null");
+check(NaN, undefined, false, "nan-vs-undefined");
+check(NaN, 0, false, "nan-vs-int-zero");
+check(NaN, {}, false, "nan-vs-object");
+
+check(Infinity, Infinity, true, "inf-vs-inf");
+check(-Infinity, -Infinity, true, "neg-inf-vs-neg-inf");
+check(Infinity, -Infinity, false, "inf-vs-neg-inf");
+check(Infinity, Number.MAX_VALUE, false, "inf-vs-max-value");
+
+check(Number.MAX_VALUE, Number.MAX_VALUE, true, "max-value-vs-max-value");
+check(Number.MAX_VALUE, Number.MAX_VALUE - 1e300, false, "max-value-vs-smaller");
+
+check(2147483648.0, 2147483648.0, true, "2^31-double-vs-self");
+check(-2147483649.0, -2147483649.0, true, "below-int32-min-double-vs-self");
+check(4294967296.0, 4294967296.0, true, "2^32-double-vs-self");
+
+var others = [null, undefined, true, false];
+var otherExpected = [
+    [true, false, false, false],
+    [false, true, false, false],
+    [false, false, true, false],
+    [false, false, false, true],
+];
+for (var i = 0; i < 4; ++i)
+    for (var j = 0; j < 4; ++j)
+        check(others[i], others[j], otherExpected[i][j], "other-" + i + "-vs-" + j);
+
+check(0, 0, true, "int-zero-vs-int-zero");
+check(-1, -1, true, "int-neg1-vs-int-neg1");
+check(2147483647, 2147483647, true, "int32-max-vs-int32-max");
+check(-2147483648, -2147483648, true, "int32-min-vs-int32-min");
+check(2147483647, -2147483648, false, "int32-max-vs-int32-min");
+check(0, 1, false, "int-zero-vs-int-one");
+check(0, -1, false, "int-zero-vs-int-neg1");
+
+check(0, null, false, "int-zero-vs-null");
+check(0, undefined, false, "int-zero-vs-undefined");
+check(0, false, false, "int-zero-vs-false");
+check(1, true, false, "int-one-vs-true");
+check(2, null, false, "int-two-vs-null");
+check(6, false, false, "int-six-vs-false");
+check(7, true, false, "int-seven-vs-true");
+check(10, undefined, false, "int-ten-vs-undefined");
+
+check(5, 5.0, true, "int5-vs-double5");
+check(0, 0.0, true, "int0-vs-double0");
+check(-1, -1.0, true, "int-neg1-vs-double-neg1");
+check(2147483647, 2147483647.0, true, "int32-max-vs-double-same");
+check(-2147483648, -2147483648.0, true, "int32-min-vs-double-same");
+
+check(5, 5.5, false, "int5-vs-double5.5");
+check(5, 5.0000000001, false, "int5-vs-double-almost5");
+
+var objA = {};
+var objB = {};
+check(objA, objA, true, "obj-vs-self");
+check(objA, objB, false, "obj-vs-other-obj");
+check(objA, null, false, "obj-vs-null");
+check(objA, undefined, false, "obj-vs-undefined");
+check(objA, true, false, "obj-vs-true");
+check(objA, false, false, "obj-vs-false");
+check(objA, 0, false, "obj-vs-int-zero");
+check(objA, 42, false, "obj-vs-int-42");
+check(null, objA, false, "null-vs-obj");
+check(42, objA, false, "int-42-vs-obj");
+
+var strA = "hello" + Math.random().toString();
+var strB = "hello" + Math.random().toString();
+var strC = "world";
+var strD = "wor" + "ld";
+check(strA, strA, true, "string-vs-self");
+check(strA, strB, false, "string-vs-diff-string");
+check(strC, strD, true, "atom-vs-folded-atom");
+check(strA, null, false, "string-vs-null");
+check(strA, 0, false, "string-vs-int-zero");
+check("", "", true, "empty-string-vs-empty-string");
+check("", null, false, "empty-string-vs-null");
+
+function makeString(s) { return s + ""; }
+noInline(makeString);
+var same1 = makeString("same content here");
+var same2 = makeString("same content here");
+check(same1, same2, true, "same-content-diff-cells-maybe");
+
+var symA = Symbol("a");
+var symB = Symbol("a");
+check(symA, symA, true, "symbol-vs-self");
+check(symA, symB, false, "symbol-vs-diff-symbol");
+check(symA, null, false, "symbol-vs-null");
+check(symA, "a", false, "symbol-vs-string");
+check(Symbol.iterator, Symbol.iterator, true, "wellknown-symbol-vs-self");
+
+var fnA = function() {};
+var fnB = function() {};
+check(fnA, fnA, true, "fn-vs-self");
+check(fnA, fnB, false, "fn-vs-diff-fn");
+check(fnA, objA, false, "fn-vs-obj");
+
+var arrA = [];
+var arrB = [];
+check(arrA, arrA, true, "arr-vs-self");
+check(arrA, arrB, false, "arr-vs-diff-arr");
+
+check(1n, 1n, true, "bigint-1-vs-bigint-1");
+check(1n, 2n, false, "bigint-1-vs-bigint-2");
+check(0n, 0n, true, "bigint-0-vs-bigint-0");
+check(-1n, -1n, true, "bigint-neg1-vs-bigint-neg1");
+check(12345678901234567890n, 12345678901234567890n, true, "bigint-large-vs-same");
+check(12345678901234567890n, 12345678901234567891n, false, "bigint-large-vs-diff");
+check(1n, 1, false, "bigint-vs-int");
+check(1n, 1.0, false, "bigint-vs-double");
+check(1n, "1", false, "bigint-vs-string");
+check(1n, true, false, "bigint-vs-true");
+check(0n, false, false, "bigint-0-vs-false");
+check(0n, null, false, "bigint-0-vs-null");
+check(0n, 0, false, "bigint-0-vs-int-0");
+check(0n, 0.0, false, "bigint-0-vs-double-0");
+
+check(1.5, null, false, "double-vs-null");
+check(1.5, undefined, false, "double-vs-undefined");
+check(1.5, true, false, "double-vs-true");
+check(1.5, false, false, "double-vs-false");
+check(1.5, objA, false, "double-vs-obj");
+check(1.5, strA, false, "double-vs-string");
+check(1.5, symA, false, "double-vs-symbol");
+check(1.5, 1n, false, "double-vs-bigint");
+
+for (var iter = 0; iter < testLoopCount; ++iter) {
+    check(null, null, true, "loop-null-null");
+    check(null, undefined, false, "loop-null-undefined");
+    check(true, false, false, "loop-true-false");
+    check(5, 5, true, "loop-5-5");
+    check(objA, objA, true, "loop-obj-self");
+    check(objA, objB, false, "loop-obj-diff");
+    check(objA, null, false, "loop-obj-null");
+    check(1.5, 1.5, true, "loop-double-double");
+    check(NaN, NaN, false, "loop-nan-nan");
+    check(0, -0.0, true, "loop-int0-neg0");
+    check(1n, 1n, true, "loop-bigint");
+    check(strA, strA, true, "loop-string-self");
+    check(6, false, false, "loop-int6-false");
+    check(symA, symB, false, "loop-symbol-diff");
+}
+
+function neq(a, b) {
+    return a !== b;
+}
+noInline(neq);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    for (var j = 0; j < poison1.length; ++j)
+        neq(poison1[j], poison2[j]);
+}
+
+function checkNeq(a, b, expected, label) {
+    var got = neq(a, b);
+    if (got !== expected)
+        failures.push("neq " + label + ": " + got + " expected " + expected);
+}
+
+for (var iter = 0; iter < testLoopCount; ++iter) {
+    checkNeq(null, null, false, "null-null");
+    checkNeq(null, undefined, true, "null-undefined");
+    checkNeq(true, true, false, "true-true");
+    checkNeq(true, false, true, "true-false");
+    checkNeq(5, 5, false, "5-5");
+    checkNeq(5, 7, true, "5-7");
+    checkNeq(objA, objA, false, "obj-self");
+    checkNeq(objA, objB, true, "obj-diff");
+    checkNeq(objA, null, true, "obj-null");
+    checkNeq(1.5, 1.5, false, "1.5-1.5");
+    checkNeq(NaN, NaN, true, "nan-nan");
+    checkNeq(0, -0.0, false, "int0-neg0");
+    checkNeq(0.0, 0, false, "double0-int0");
+    checkNeq(1n, 1n, false, "bigint-1-1");
+    checkNeq(1n, 2n, true, "bigint-1-2");
+    checkNeq(strA, strA, false, "string-self");
+    checkNeq(6, false, true, "int6-false");
+}
+
+if (failures.length)
+    throw new Error("FAILURES:\n" + failures.join("\n"));

--- a/JSTests/stress/compare-strict-eq-untyped-verify-path.js
+++ b/JSTests/stress/compare-strict-eq-untyped-verify-path.js
@@ -1,0 +1,120 @@
+//@ if isFTLEnabled then runFTLNoCJIT else skip end
+//@ requireOptions("--useDollarVM=1")
+
+let ftlTrue = $vm.ftlTrue;
+
+function eq(a, b) {
+    return a === b;
+}
+noInline(eq);
+
+var mix = [1.5, null, {}, "x", true, 0, Symbol(), 1n, undefined, -0.0, NaN];
+for (var i = 0; i < testLoopCount; ++i)
+    eq(mix[i % mix.length], mix[(i + 3) % mix.length]);
+
+var values = [
+    0, 1, -1, 2, 6, 7, 10, 42, 2147483647, -2147483648, 0x7FFFFFFF, -0x80000000,
+    0.0, -0.0, 0.5, -0.5, 1.0, -1.0, 1.5, 5.0,
+    5e-324,
+    -5e-324,
+    2.2250738585072014e-308,
+    1.7976931348623157e308,
+    Infinity, -Infinity, NaN, 0/0, Infinity - Infinity,
+    2147483647.0, -2147483648.0,
+    2147483648.0, -2147483649.0,
+    4294967295.0, 4294967296.0,
+    9007199254740992.0,
+    null, undefined, true, false,
+    {}, {}, [], [], function(){}, function(){},
+    "", "a", "a" + "", "hello",
+    Symbol(), Symbol(), Symbol.iterator, Symbol.for("x"), Symbol.for("x"),
+    0n, 0n, 1n, -1n, 12345678901234567890n, BigInt("12345678901234567890"),
+    new Proxy({}, {}),
+    Object(1), Object("x"), Object(true),
+    /regex/, new Date(0),
+];
+
+values.push("runtime-" + Math.random().toString(36).slice(2));
+values.push("runtime-" + Math.random().toString(36).slice(2));
+
+var dyn = "same-content-" + Date.now();
+values.push(dyn);
+values.push(dyn.split("").join(""));
+
+var N = values.length;
+
+var ref = new Array(N * N);
+for (var a = 0; a < N; ++a)
+    for (var b = 0; b < N; ++b)
+        ref[a * N + b] = (values[a] === values[b]);
+
+var errors = [];
+var didFTLCompile = false;
+
+function runMatrix() {
+    didFTLCompile = ftlTrue();
+    for (var a = 0; a < N; ++a) {
+        for (var b = 0; b < N; ++b) {
+            var got = eq(values[a], values[b]);
+            if (got !== ref[a * N + b]) {
+                errors.push("[" + a + "," + b + "] eq(" + typeof values[a] + ":" +
+                    String(values[a]) + ", " + typeof values[b] + ":" + String(values[b]) +
+                    ") = " + got + ", expected " + ref[a * N + b]);
+            }
+        }
+    }
+}
+noInline(runMatrix);
+
+for (var iter = 0; iter < testLoopCount; ++iter) {
+    runMatrix();
+    if (errors.length)
+        break;
+}
+
+if (!didFTLCompile)
+    throw new Error("runMatrix never reached FTL");
+
+if (errors.length)
+    throw new Error("FAILURES (" + errors.length + " total, first 20):\n" + errors.slice(0, 20).join("\n"));
+
+function stressCheck(a, b, expected, label) {
+    for (var i = 0; i < testLoopCount; ++i) {
+        if (eq(a, b) !== expected)
+            throw new Error("stressCheck " + label + " failed at i=" + i);
+    }
+}
+
+stressCheck(0.0, null, false, "double-zero-vs-null");
+stressCheck(null, 0.0, false, "null-vs-double-zero");
+stressCheck(0.0, 0.0, true, "double-zero-both");
+stressCheck(0.0, 0, true, "double-zero-vs-int-zero");
+
+stressCheck(2147483647, 2147483647, true, "int32-max-bits-equal");
+stressCheck(-2147483648, -2147483648, true, "int32-min-bits-equal");
+stressCheck(2147483647, -2147483648, false, "int32-max-vs-min");
+
+var o = {};
+stressCheck(o, null, false, "cell-or-null");
+stressCheck(o, undefined, false, "cell-or-undefined");
+stressCheck(o, true, false, "cell-or-true");
+stressCheck(o, false, false, "cell-or-false");
+stressCheck(o, 0, false, "cell-or-int");
+
+var o2 = {};
+stressCheck(o, o2, false, "cell-or-cell-diff");
+stressCheck(o, o, true, "cell-self-bits-equal");
+
+var s1 = ("content-equal-test" + Math.random()).slice(0, 18);
+var s2 = s1.split("").join("");
+stressCheck(s1, s2, s1 === s2, "string-content-compare");
+
+stressCheck(99999999999999999999n, 99999999999999999999n, true, "bigint-content-equal");
+stressCheck(99999999999999999999n, 99999999999999999998n, false, "bigint-content-diff");
+
+stressCheck(NaN, NaN, false, "nan-self");
+stressCheck(NaN, 0.0, false, "nan-vs-zero");
+stressCheck(NaN, null, false, "nan-vs-null");
+
+stressCheck(-0.0, 0.0, true, "neg-zero-pos-zero");
+stressCheck(-0.0, 0, true, "neg-zero-int-zero");

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -12535,13 +12535,59 @@ IGNORE_CLANG_WARNINGS_END
             return;
         }
 
-        // FIXME: we can do something much smarter here, see the DFGSpeculativeJIT approach in e.g. SpeculativeJIT::nonSpeculativePeepholeStrictEq
         DFG_ASSERT(m_graph, m_node, m_node->isBinaryUseKind(UntypedUse), m_node->child1().useKind(), m_node->child2().useKind());
-        genericJSValueCompare(
-            [&] (LValue left, LValue right) {
-                return m_out.equal(left, right);
-            },
-            operationCompareStrictEq);
+
+        // Same bit-trick as DFG's SpeculativeJIT::genericJSValueNonPeepholeStrictEq:
+        // At a high level:
+        //   if (left is Double || right is Double) goto slowPath;
+        //   if (left == right) return true;  // covers Int32, Boolean, null, undefined, identical cells
+        //   if (both are cells) goto slowPath;  // String===String, HeapBigInt===HeapBigInt
+        //   return false;
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        LValue left = lowJSValue(m_node->child1(), ManualOperandSpeculation);
+        LValue right = lowJSValue(m_node->child2(), ManualOperandSpeculation);
+        speculate(m_node->child1());
+        speculate(m_node->child2());
+
+        LBasicBlock notDoubleCase = m_out.newBlock();
+        LBasicBlock checkCellCase = m_out.newBlock();
+        LBasicBlock slowPath = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        // If a JSValue is an Int32, then adding 1<<49 will overflow, leaving all high bits at 0.
+        // If it is not a number at all (Cell/Other), then 1<<49 will be its only high bit set.
+        // Only Doubles end up above or equal to 1<<50 after this transformation.
+        // This lets us detect "either is Double" with a single branch instead of four.
+        LValue lowestOfHighBits = m_out.constInt64(JSValue::LowestOfHighBits);
+        LValue leftAdjusted = m_out.add(left, lowestOfHighBits);
+        LValue rightAdjusted = m_out.add(right, lowestOfHighBits);
+        LValue combined = m_out.bitOr(leftAdjusted, rightAdjusted);
+        m_out.branch(
+            m_out.aboveOrEqual(combined, m_out.constInt64(JSValue::LowestOfHighBits << 1)),
+            rarely(slowPath), usually(notDoubleCase));
+
+        LBasicBlock lastNext = m_out.appendTo(notDoubleCase, checkCellCase);
+        ValueFromBlock fastTrue = m_out.anchor(m_out.booleanTrue);
+        m_out.branch(m_out.equal(left, right), unsure(continuation), unsure(checkCellCase));
+
+        m_out.appendTo(checkCellCase, slowPath);
+        // At this point neither operand is a Double, and their JSValue bits are not equal.
+        // We only need the slow path when values could still be strictly equal, which after
+        // ruling out Doubles means two cells (String===String or HeapBigInt===HeapBigInt).
+        // (left is Cell && right is Cell) is equivalent to ((left | right) is Cell): a Cell
+        // has all NotCellMask bits clear (high bits and OtherTag), and OR preserves that
+        // only when both sides are Cells.
+        LValue cellCheck = m_out.bitOr(left, right);
+        ValueFromBlock fastFalse = m_out.anchor(m_out.booleanFalse);
+        m_out.branch(isCell(cellCheck), rarely(slowPath), usually(continuation));
+
+        m_out.appendTo(slowPath, continuation);
+        ValueFromBlock slowResult = m_out.anchor(m_out.notNull(vmCall(
+            pointerType(), operationCompareStrictEq, weakPointer(globalObject), left, right)));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        setBoolean(m_out.phi(Int32, fastTrue, fastFalse, slowResult));
     }
 
     void compileStringToUntypedStrictEquality(Edge stringEdge, Edge untypedEdge)


### PR DESCRIPTION
#### 089c67d2ead9aa2f3bae6677cba0698b1b7b529a
<pre>
[JSC] FTL `CompareStrictEq(Untyped)` should use DFG&apos;s JSValue bit-trick fast path
<a href="https://bugs.webkit.org/show_bug.cgi?id=309884">https://bugs.webkit.org/show_bug.cgi?id=309884</a>

Reviewed by Yusuke Suzuki.

FTL&apos;s compileCompareStrictEq for UntypedUse went through genericJSValueCompare,
which only has a fast path for the Int32-vs-Int32 case and falls back to a C++
call (operationCompareStrictEq) for everything else. DFG&apos;s
genericJSValueNonPeepholeStrictEq has long had a smarter fast path that handles
most non-Double pairs inline using a JSValue tagging bit-trick:

    1. (left + 1&lt;&lt;49) | (right + 1&lt;&lt;49) &gt;= 1&lt;&lt;50 detects &quot;either is Double&quot; in
       a single branch: Int32&apos;s NumberTag wraps to zero, Cell/Other gain only
       bit 49, and the smallest encoded Double (0.0 = 0x0002...) lands exactly
       at the 1&lt;&lt;50 threshold.
    2. If the 64-bit JSValue encodings are equal, the result is true. This
       covers Int32==Int32, true==true, null==null, undefined==undefined, and
       same-Cell.
    3. (left | right) is Cell detects &quot;both are Cells&quot;, the only remaining case
       where bit-unequal values can still be strictly equal (String content
       compare, HeapBigInt content compare).
    4. Otherwise false.

This patch ports that trick to FTL in B3 IR, replacing the genericJSValueCompare
call. The FTL code was previously slower than DFG for patterns like
`x === null`, `a === undefined`, or `obj === obj` when type prediction was
mixed enough to leave UntypedUse -- a tier-up regression.

                                             TipOfTree                  Patched

compare-strict-eq-untyped-mixed          166.8733+-9.4982     ^    138.8151+-5.3950        ^ definitely 1.2021x faster
compare-strict-eq-untyped-fast-only       40.0483+-6.0252     ^     20.1260+-0.3528        ^ definitely 1.9899x faster

Tests: JSTests/microbenchmarks/compare-strict-eq-untyped-fast-only.js
       JSTests/microbenchmarks/compare-strict-eq-untyped-mixed.js
       JSTests/stress/compare-strict-eq-untyped-bit-trick-edges.js
       JSTests/stress/compare-strict-eq-untyped-verify-path.js

* JSTests/microbenchmarks/compare-strict-eq-untyped-fast-only.js: Added.
(eq):
* JSTests/microbenchmarks/compare-strict-eq-untyped-mixed.js: Added.
(eq):
* JSTests/stress/compare-strict-eq-untyped-bit-trick-edges.js: Added.
(eq):
(makeString):
(fnA):
(fnB):
(neq):
(checkNeq):
* JSTests/stress/compare-strict-eq-untyped-verify-path.js: Added.
(eq):
(runMatrix):
(stressCheck):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/309285@main">https://commits.webkit.org/309285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b10987438280095203aca1acf993a4a9414824ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158586 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103312 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115615 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82168 "2 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134496 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96354 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16839 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14763 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6433 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141856 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126446 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161062 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10674 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4146 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123632 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22401 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18805 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123836 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33687 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22408 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134220 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78633 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18997 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10972 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181309 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22009 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85829 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46433 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; jscore-tests (cancelled)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21739 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21891 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21796 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->