### PR TITLE
[JSC] Implement `Iterator.prototype.includes` (disabled by default)

### DIFF
--- a/JSTests/stress/iterator-prototype-includes.js
+++ b/JSTests/stress/iterator-prototype-includes.js
@@ -1,0 +1,524 @@
+//@ requireOptions("--useIteratorIncludes=1")
+
+function sameValue(a, b, testname) {
+    if (a !== b)
+        throw new Error(`${testname}: Expected ${b} but got ${a}`);
+}
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName) {
+        throw new Error(`must specify test case name`);
+    }
+
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw, but succeeded`);
+    } catch (e) {
+        if (!(e instanceof expectedErrorCtor))
+            throw new Error(`${caseName}: Expected to throw ${expectedErrorCtor.name} but got ${e.name}`);
+        if (e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expectedErrorCtor.name} with '${expectedErrorMessage}' but got '${e.message}'`);
+    }
+}
+
+function callTestTargetFunction(iterator, searchElement, skippedElements) {
+    return Iterator.prototype.includes.call(iterator, searchElement, skippedElements);
+}
+
+class TestIterator extends Iterator {
+    value = 0;
+    isClosed = false;
+    isDone = false;
+    constructor(max) {
+        super();
+        if (max < 0) {
+            throw new RangeError('max must be >= 0');
+        }
+        this.max = max;
+    }
+    next() {
+        const value = this.value;
+        if (value > this.max) {
+            this.isDone = true;
+            return {
+                done: true,
+                value: undefined,
+            };
+        }
+
+        this.value += 1;
+        return {
+            done: false,
+            value,
+        };
+    }
+    return() {
+        this.isClosed = true;
+        return {
+            done: true,
+            value: undefined,
+        };
+    }
+}
+
+// without second argument
+
+{
+    const TEST_NAME = `simply include`;
+
+    const gen = function* (num) {
+        for (let i = 0; i <= num; ++i) {
+            yield i;
+        }
+    };
+    const iter = gen(3);
+    sameValue(callTestTargetFunction(iter, 1), true, TEST_NAME);
+}
+
+
+{
+    const TEST_NAME = `simply not include`;
+
+    const gen = function* (len) {
+        for (let i = 0; i < len; ++i) {
+            yield i;
+        }
+    };
+    const iter = gen(3);
+    sameValue(callTestTargetFunction(iter, 4), false, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `iterator is empty`;
+
+    const gen = function* () {};
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, 1), false, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `Use SameValueZero comparison`;
+
+    const gen = function* () {
+        yield +0;
+    };
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, -0), true, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `Use SameValueZero comparison, search NaN`;
+
+    const gen = function* () {
+        yield NaN;
+    };
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, NaN), true, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `Use SameValueZero comparison, search Number.NaN`;
+
+    const gen = function* () {
+        yield NaN;
+    };
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, Number.NaN), true, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `Use SameValueZero comparison, the iteraror yeild NaN but the searching value is anothor one.`;
+
+    const gen = function* () {
+        yield NaN;
+    };
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, 0), false, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `Use SameValueZero comparison, the iteraror yeild Number.NaN but the searching value is anothor one.`;
+
+    const gen = function* () {
+        yield Number.NaN;
+    };
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, 0), false, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `iterator should be closed`;
+
+    const gen = function* () {
+        yield 0;
+        yield 1;
+        yield 2;
+    };
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, 1), true, `${TEST_NAME}: consume once`);
+    sameValue(callTestTargetFunction(iter, 2), false, `${TEST_NAME}: 2nd iteration on consumed iterator would be nothing`);
+}
+
+{
+    const TEST_NAME = `do not iterate all, the actual should be expected`;
+
+    class Unreachable extends Error {
+        constructor(message) {
+            super(message);
+            this.name = new.target.name;
+        }
+    }
+    const gen = function* () {
+        yield 0;
+        throw new Unreachable("do not iterate all after the target was found");
+    };
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, 0), true, TEST_NAME);
+}
+
+{
+    const TEST_NAME = 'calling .includes() should close the iterator if the searched was found';
+
+    const iter = new TestIterator(5);
+    sameValue(callTestTargetFunction(iter, 4), true, `${TEST_NAME}: call`);
+    sameValue(iter.isDone, false, `${TEST_NAME}: iterator should not be done`);
+    sameValue(iter.isClosed, true, `${TEST_NAME}: iterator should be closed`);
+}
+
+{
+    const TEST_NAME = 'calling .includes() should not close the iterator if no matched';
+
+    const iter = new TestIterator(5);
+    sameValue(callTestTargetFunction(iter, -1), false, `${TEST_NAME}: call`);
+    sameValue(iter.isDone, true, `${TEST_NAME}: iterator should be done`);
+    sameValue(iter.isClosed, false, `${TEST_NAME}: iterator should not be closed`);
+}
+
+// with second argument
+
+{
+    const TEST_NAME = `call with 2nd arg: simply include`;
+
+    const gen = function* (len) {
+        for (let i = 0; i < len; ++i) {
+            yield i;
+        }
+    };
+    const iter = gen(3);
+    sameValue(callTestTargetFunction(iter, 2, 2), true, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg is 0: simply include`;
+
+    const gen = function* (len) {
+        for (let i = 0; i < len; ++i) {
+            yield i;
+        }
+    };
+    const iter = gen(3);
+    sameValue(callTestTargetFunction(iter, 2, 2), true, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg: simply include but the target is in skipped range`;
+
+    const gen = function* (len) {
+        for (let i = 0; i < len; ++i) {
+            yield i;
+        }
+    };
+    const iter = gen(3);
+    sameValue(callTestTargetFunction(iter, 2, 3), false, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg: simply include but the skipped range is over than the iterator length`;
+
+    const iter = new TestIterator(3);
+    sameValue(callTestTargetFunction(iter, 2, 100), false, TEST_NAME);
+    sameValue(iter.isDone, true, `${TEST_NAME}: iterator should be done properly`);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg: simply not include`;
+
+    const gen = function* (len) {
+        for (let i = 0; i < len; ++i) {
+            yield i;
+        }
+    };
+    const iter = gen(3);
+    sameValue(callTestTargetFunction(iter, 4, 0), false, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg: iterator is empty`;
+
+    const gen = function* () {};
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, 1, 1), false, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg: Use SameValueZero comparison`;
+
+    const gen = function* () {
+        yield -1;
+        yield +0;
+    };
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, -0, 1), true, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg: Use SameValueZero comparison, search NaN`;
+
+    const gen = function* () {
+        yield -1;
+        yield NaN;
+    };
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, NaN, 1), true, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg: Use SameValueZero comparison, search NaN but the iterator will not return NaN`;
+
+    const gen = function* () {
+        yield -1;
+        yield 0;
+        yield 1;
+    };
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, NaN, 1), false, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg: Use SameValueZero comparison, search Number.NaN`;
+
+    const gen = function* () {
+        yield -1;
+        yield NaN;
+    };
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, Number.NaN, 1), true, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg: Use SameValueZero comparison, search Number.NaN but the iterator will not return NaN`;
+
+    const gen = function* () {
+        yield -1;
+        yield 0;
+        yield 1;
+    };
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, Number.NaN, 1), false, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg: Use SameValueZero comparison, the iterator yield NaN but the searching value is another one`;
+
+    const gen = function* (limit) {
+        for (let i = 0; i < limit; ++i) {
+            yield NaN;
+        }
+    };
+    const iter = gen(10);
+    sameValue(callTestTargetFunction(iter, 0, 1), false, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg: Use SameValueZero comparison, the iterator yield Number.NaN but the searching value is another one`;
+
+    const gen = function* (limit) {
+        for (let i = 0; i < limit; ++i) {
+            yield NaN;
+        }
+    };
+    const iter = gen(10);
+    sameValue(callTestTargetFunction(iter, 0, 1), false, TEST_NAME);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg: iterator should be closed`;
+
+    const gen = function* () {
+        yield 0;
+        yield 1;
+        yield 2;
+    };
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, 1, 1), true, `${TEST_NAME}: consume once`);
+    sameValue(callTestTargetFunction(iter, 2, 1), false, `${TEST_NAME}: 2nd iteration on closed iterator would be nothing`);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg but skipped all: iterator should be closed`;
+
+    const gen = function* () {
+        yield 0;
+        yield 1;
+        yield 2;
+    };
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, 1, 100), false, `${TEST_NAME}: consume once`);
+    sameValue(callTestTargetFunction(iter, 2, 100), false, `${TEST_NAME}: 2nd iteration on closed iterator would be nothing`);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg: do not iterate all`;
+
+    class Unreachable extends Error {
+        constructor(message) {
+            super(`unreachable: ${message}`);
+            this.name = new.target.name;
+        }
+    }
+    const gen = function* () {
+        yield -1;
+        yield 0;
+        throw new Unreachable(`${TEST_NAME}: after the searched was found`);
+    };
+    const iter = gen();
+    sameValue(callTestTargetFunction(iter, 0, 1), true, `${TEST_NAME}: the searched was found`);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg: skipped range throw something`;
+
+    class TestIterator extends Iterator {
+        value = 0;
+        isClosed = false;
+        isDone = false;
+        constructor(max) {
+            super();
+            this.max = max;
+        }
+        next() {
+            const value = this.value;
+            if (value > this.max) {
+                this.isDone = true;
+                return {
+                    done: true,
+                    value: undefined,
+                };
+            }
+
+            throw new Error('this is in skipped range!');
+        }
+        return() {
+            this.isClosed = true;
+            return {
+                done: true,
+                value: undefined,
+            };
+        }
+    }
+
+    const iter = new TestIterator(3);
+    shouldThrow(TEST_NAME, () => {
+        callTestTargetFunction(iter, 1, 100);
+    }, Error, 'this is in skipped range!');
+    sameValue(iter.isDone, false, `${TEST_NAME}: iterator should not be done`);
+    sameValue(iter.isClosed, false, `${TEST_NAME}: iterator should not be closed`);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg: calling .includes() should close the iterator`;
+
+    const iter = new TestIterator(5);
+    sameValue(callTestTargetFunction(iter, 4, 1), true, `${TEST_NAME}: calling .includes()`);
+    sameValue(iter.isDone, false, `${TEST_NAME}: iterator should not be done`);
+    sameValue(iter.isClosed, true, `${TEST_NAME}: iterator should be closed`);
+}
+
+{
+    const TEST_NAME = `call with 2nd arg but skip everything`;
+
+    const iter = new TestIterator(5);
+    sameValue(callTestTargetFunction(iter, 4, 100), false, `${TEST_NAME}: calling .includes()`);
+    sameValue(iter.isDone, true, `${TEST_NAME}: iterator should be done`);
+    sameValue(iter.isClosed, false, `${TEST_NAME}: iterator should not be closed`);
+}
+
+{
+    const valid2ndArgument = [
+        [Number.POSITIVE_INFINITY, `+Infinity`],
+        [Number.MAX_SAFE_INTEGER, `Number.MAX_SAFE_INTEGER`],
+        [Number.MAX_SAFE_INTEGER + 1, `(Number.MAX_SAFE_INTEGER + 1)`],
+        [Number.MAX_VALUE, `Number.MAX_VALUE`],
+    ];
+
+    for (const [skippedElements, label] of valid2ndArgument) {
+        const testName = `call on short iterator with 2nd arg (large number): ${label}`;
+        const iter = new TestIterator(0);
+        sameValue(callTestTargetFunction(iter, 0, skippedElements), false, `${testName}: calling .includes()`);
+        sameValue(iter.isDone, true, `${testName}: iterator should be done`);
+        sameValue(iter.isClosed, false, `${testName}: iterator should not be closed`);
+    }
+}
+
+// invalid
+
+{
+    const invalidIterators = [
+        [1, ],
+        [1n, `1n`],
+        [true, ],
+        [false, ],
+        [null, ],
+        [undefined, ],
+        [Symbol("symbol"), ],
+    ];
+    for (const [invalidIterator, label] of invalidIterators) {
+        const testName = label ?? String(invalidIterator);
+        shouldThrow(`|this| is invalid: ${testName}`, function () {
+            Iterator.prototype.includes.call(invalidIterator);
+        }, TypeError, "Iterator.prototype.includes requires that |this| be an Object.");
+    }
+}
+
+{
+    const invalidSkippedElements = [
+        ['', ],
+        ['1', `'1'`],
+        [true, ],
+        [false, ],
+        [null, ],
+        [1.2, ],
+        [-1.2, ],
+        [1n, `1n`],
+        [-1n, `-1n`],
+        [new Number(0), `new Number`],
+        [NaN, 'NaN'],
+        [Number.NaN, 'Number.NaN'],
+        [Number.MIN_VALUE, `Number.MIN_VALUE`],
+    ];
+
+    for (const [skip, label] of invalidSkippedElements) {
+        const testName = label ?? String(skip);
+        const validIter = new TestIterator(3);
+        shouldThrow(`the 2nd arg is invalid: ${testName}`, function () {
+            callTestTargetFunction(validIter, null, skip);
+        }, TypeError, "Iterator.prototype.includes requires that the second argument is a non-negative integral Number or Infinity.");
+        sameValue(validIter.isClosed, true, 'the given iterator should be closed.');
+    }
+}
+
+{
+    const invalidSkippedElements = [
+        [-1, ],
+        [Number.NEGATIVE_INFINITY, ],
+        [Number.MIN_SAFE_INTEGER, `Number.MIN_SAFE_INTEGER`],
+    ];
+    for (const [skip, label] of invalidSkippedElements) {
+        const testName = label ?? String(skip);
+        const validIter = new TestIterator(3);
+        shouldThrow(`the 2nd arg is not positive integer: ${String(testName)}`, function () {
+            callTestTargetFunction(validIter, null, skip);
+        }, RangeError, "Iterator.prototype.includes requires that the second argument is a non-negative integral Number or Infinity.");
+        sameValue(validIter.isClosed, true, 'the given iterator should be closed.');
+    }
+}

--- a/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp
@@ -30,12 +30,21 @@
 
 #include "BuiltinNames.h"
 #include "CachedCallInlines.h"
+#include "CallData.h"
+#include "ExceptionScope.h"
+#include "ImplementationVisibility.h"
 #include "InterpreterInlines.h"
 #include "IteratorOperations.h"
 #include "JSCBuiltins.h"
 #include "JSCInlines.h"
 #include "JSIteratorConstructor.h"
+#include "MathCommon.h"
+#include "ThrowScope.h"
 #include "VMEntryScopeInlines.h"
+#include <cmath>
+#include <cstdint>
+#include <optional>
+#include <wtf/Assertions.h>
 
 namespace JSC {
 
@@ -48,6 +57,7 @@ static JSC_DECLARE_CUSTOM_GETTER(iteratorProtoToStringTagGetter);
 static JSC_DECLARE_CUSTOM_SETTER(iteratorProtoToStringTagSetter);
 static JSC_DECLARE_HOST_FUNCTION(iteratorProtoFuncToArray);
 static JSC_DECLARE_HOST_FUNCTION(iteratorProtoFuncForEach);
+static JSC_DECLARE_HOST_FUNCTION(iteratorProtoFuncIncludes);
 
 void JSIteratorPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
 {
@@ -88,6 +98,11 @@ void JSIteratorPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
         JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("chunks"_s, jsIteratorPrototypeChunksCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
         // https://tc39.es/proposal-iterator-chunking/#sec-iterator.prototype.windows
         JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("windows"_s, jsIteratorPrototypeWindowsCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    }
+
+    if (Options::useIteratorIncludes()) {
+        // https://tc39.es/proposal-iterator-includes/#sec-iterator.prototype.includes
+        JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().includesPublicName(), iteratorProtoFuncIncludes, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     }
 
     if (Options::useExplicitResourceManagement())
@@ -194,6 +209,115 @@ JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncForEach, (JSGlobalObject* globalObject
 
     RETURN_IF_EXCEPTION(scope, { });
     return JSValue::encode(jsUndefined());
+}
+
+// https://tc39.es/proposal-iterator-includes/#sec-iterator.prototype.includes
+JSC_DEFINE_HOST_FUNCTION(iteratorProtoFuncIncludes, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue thisValue = callFrame->thisValue().toThis(globalObject, ECMAMode::strict());
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!thisValue.isObject()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Iterator.prototype.includes requires that |this| be an Object."_s);
+
+    JSValue skippedElementsArg = callFrame->argument(1);
+    uint64_t toSkip = 0;
+    if (!skippedElementsArg.isUndefined()) {
+        constexpr ASCIILiteral errorMessage = "Iterator.prototype.includes requires that the second argument is a non-negative integral Number or Infinity."_s;
+
+        if (skippedElementsArg.isInt32()) [[likely]] {
+            int32_t skippedAsInt32 = skippedElementsArg.asInt32();
+            if (skippedAsInt32 < 0) {
+                iteratorClose(globalObject, thisValue);
+                TRY_CLEAR_EXCEPTION(scope, { });
+                return throwVMRangeError(globalObject, scope, errorMessage);
+            }
+            toSkip = skippedAsInt32;
+        } else if (skippedElementsArg.isDouble()) {
+            double skippedAsDouble = skippedElementsArg.asDouble();
+            if (isInteger(skippedAsDouble)) {
+                if (skippedAsDouble < 0) {
+                    iteratorClose(globalObject, thisValue);
+                    TRY_CLEAR_EXCEPTION(scope, { });
+                    return throwVMRangeError(globalObject, scope, errorMessage);
+                }
+
+                toSkip = static_cast<uint64_t>(skippedAsDouble);
+            } else if (std::isinf(skippedAsDouble)) {
+                // check -Infinity
+                if (skippedAsDouble < 0) {
+                    iteratorClose(globalObject, thisValue);
+                    TRY_CLEAR_EXCEPTION(scope, { });
+                    return throwVMRangeError(globalObject, scope, errorMessage);
+                }
+
+                // if the 2nd argument is +Infinity, we should consume the iterator to the end.
+                toSkip = std::numeric_limits<uint64_t>::max();
+            } else {
+                iteratorClose(globalObject, thisValue);
+                TRY_CLEAR_EXCEPTION(scope, { });
+                return throwVMTypeError(globalObject, scope, errorMessage);
+            }
+        } else {
+            iteratorClose(globalObject, thisValue);
+            TRY_CLEAR_EXCEPTION(scope, { });
+            return throwVMTypeError(globalObject, scope, errorMessage);
+        }
+    }
+
+    IterationRecord iterationRecord = iteratorDirect(globalObject, thisValue);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    JSValue nextMethod = iterationRecord.nextMethod;
+    CallData callData = getCallDataInline(nextMethod);
+
+    std::optional<CachedCall> cachedCallHolder;
+    CachedCall* cachedCall = nullptr;
+    if (callData.type == CallData::Type::JS) [[likely]] {
+        cachedCallHolder.emplace(globalObject, jsCast<JSFunction*>(nextMethod), 0);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        cachedCall = &cachedCallHolder.value();
+    }
+
+    JSValue searchElement = callFrame->argument(0);
+    uint64_t skipped = 0;
+
+    while (true) {
+        JSValue next;
+        if (cachedCall) [[likely]] {
+            cachedCall->clearArguments();
+            next = iteratorStepWithCachedCall(globalObject, iterationRecord, cachedCall);
+        } else
+            next = iteratorStep(globalObject, iterationRecord);
+
+        RETURN_IF_EXCEPTION(scope, { });
+
+        if (next.isFalse())
+            return JSValue::encode(jsBoolean(false));
+
+        if (skipped < toSkip) {
+            skipped += 1;
+            continue;
+        }
+
+        JSValue nextValue = iteratorValue(globalObject, next);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        bool isEqual = sameValueZero(globalObject, nextValue, searchElement);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        if (isEqual) {
+            iteratorClose(globalObject, iterationRecord.iterator);
+            TRY_CLEAR_EXCEPTION(scope, { });
+            return JSValue::encode(jsBoolean(true));
+        }
+    }
+
+    RELEASE_ASSERT_NOT_REACHED();
+    return { };
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -661,6 +661,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, useImportDefer, false, Normal, "Enable deferred module import."_s) \
     v(Bool, useIteratorChunking, false, Normal, "Expose the Iterator.prototype.chunks and Iterator.prototype.windows methods."_s) \
     v(Bool, useIteratorSequencing, true, Normal, "Expose the Iterator.concat method."_s) \
+    v(Bool, useIteratorIncludes, false, Normal, "Expose the Iterator.includes method."_s) \
     v(Bool, useJSONSourceTextAccess, true, Normal, "Expose JSON source text access feature."_s) \
     v(Bool, useJSPI, true, Normal, "Enable the implementation of JavaScript Promise Integration."_s) \
     v(Bool, useMoreCurrencyDisplayChoices, false, Normal, "Enable more currencyDisplay choices for Intl.NumberFormat"_s) \


### PR DESCRIPTION
#### 7fdc018c4dd77266f919db0a9ff495ebafde757e
<pre>
[JSC] Implement `Iterator.prototype.includes` (disabled by default)
<a href="https://bugs.webkit.org/show_bug.cgi?id=309883">https://bugs.webkit.org/show_bug.cgi?id=309883</a>

Reviewed by Yusuke Suzuki.

This implements Iterator Includes proposal <a href="https://tc39.es/proposal-iterator-includes/">https://tc39.es/proposal-iterator-includes/</a>
that refers rev. March 12, 2026.
<a href="https://github.com/tc39/proposal-iterator-includes/tree/8787f1ae4500fc6c7851f4eccb9557f9d74fa694">https://github.com/tc39/proposal-iterator-includes/tree/8787f1ae4500fc6c7851f4eccb9557f9d74fa694</a>

This feature is behind the flag `--useIteratorIncludes`.

Test: JSTests/stress/iterator-prototype-includes.js

* JSTests/stress/iterator-prototype-includes.js: Added.
* Source/JavaScriptCore/runtime/JSIteratorPrototype.cpp:
* Source/JavaScriptCore/runtime/OptionsList.h:
    This introduces `--useIteratorIncludes` flag.

Canonical link: <a href="https://commits.webkit.org/310769@main">https://commits.webkit.org/310769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5618d974f7523081561a6b899b4624bd80e83070

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/154477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/27735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/20895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163233 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/107946 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/27869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/27585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/119487 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84510 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/157436 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/21765 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/138742 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100184 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/20852 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/18859 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11063 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/146526 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/130514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/16586 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/165705 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/15308 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8912 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18195 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/127586 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/22899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/127731 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27205 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138379 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/83888 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23621 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/22625 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15171 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/186185 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/26896 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/90998 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/47722 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/26476 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/26707 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/26549 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->