### PR TITLE
Add missing WTF_GUARDED_BY_LOCK() for IDBTransaction::m_deletedObjectStores

### DIFF
--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -156,7 +156,7 @@ ExceptionOr<Ref<IDBObjectStore>> IDBTransaction::objectStore(const String& objec
     if (isFinishedOrFinishing())
         return Exception { ExceptionCode::InvalidStateError, "Failed to execute 'objectStore' on 'IDBTransaction': The transaction finished."_s };
 
-    Locker locker { m_referencedObjectStoreLock };
+    Locker locker { m_objectStoresLock };
 
     if (RefPtr store = m_referencedObjectStores.get(objectStoreName))
         return store.releaseNonNull();
@@ -233,7 +233,7 @@ void IDBTransaction::abortInternal()
     m_database->willAbortTransaction(*this);
 
     if (isVersionChange()) {
-        Locker locker { m_referencedObjectStoreLock };
+        Locker locker { m_objectStoresLock };
 
         auto& info = m_database->info();
         Vector<IDBObjectStoreIdentifier> identifiersToRemove;
@@ -657,7 +657,7 @@ Ref<IDBObjectStore> IDBTransaction::createObjectStore(const IDBObjectStoreInfo& 
     ASSERT(scriptExecutionContext());
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
 
-    Locker locker { m_referencedObjectStoreLock };
+    Locker locker { m_objectStoresLock };
 
     auto objectStore = IDBObjectStore::create(*protect(scriptExecutionContext()), info, *this);
     Ref objectStoreRef { objectStore.get() };
@@ -693,7 +693,7 @@ void IDBTransaction::renameObjectStore(IDBObjectStore& objectStore, const String
 {
     LOG(IndexedDB, "IDBTransaction::renameObjectStore");
 
-    Locker locker { m_referencedObjectStoreLock };
+    Locker locker { m_objectStoresLock };
 
     ASSERT(isVersionChange());
     ASSERT(scriptExecutionContext());
@@ -781,7 +781,7 @@ void IDBTransaction::didCreateIndexOnServer(const IDBResultData& resultData)
 void IDBTransaction::renameIndex(IDBIndex& index, const String& newName)
 {
     LOG(IndexedDB, "IDBTransaction::renameIndex");
-    Locker locker { m_referencedObjectStoreLock };
+    Locker locker { m_objectStoresLock };
 
     ASSERT(isVersionChange());
     ASSERT(scriptExecutionContext());
@@ -1345,7 +1345,7 @@ void IDBTransaction::deleteObjectStore(const String& objectStoreName)
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
     ASSERT(isVersionChange());
 
-    Locker locker { m_referencedObjectStoreLock };
+    Locker locker { m_objectStoresLock };
 
     if (auto objectStore = m_referencedObjectStores.take(objectStoreName)) {
         objectStore->markAsDeleted();
@@ -1499,7 +1499,7 @@ void IDBTransaction::connectionClosedFromServer(const IDBError& error)
 template<typename Visitor>
 void IDBTransaction::visitReferencedObjectStores(Visitor& visitor) const
 {
-    Locker locker { m_referencedObjectStoreLock };
+    Locker locker { m_objectStoresLock };
     for (auto& objectStore : m_referencedObjectStores.values())
         SUPPRESS_UNCHECKED_ARG addWebCoreOpaqueRoot(visitor, objectStore.get());
     for (auto& objectStore : m_deletedObjectStores.values())

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -261,9 +261,9 @@ private:
     HashMap<Ref<IDBClient::TransactionOperation>, IDBResultData> m_transactionOperationResultMap;
     HashMap<IDBResourceIdentifier, Ref<IDBClient::TransactionOperation>> m_transactionOperationMap;
 
-    mutable Lock m_referencedObjectStoreLock;
-    HashMap<String, std::unique_ptr<IDBObjectStore>> m_referencedObjectStores WTF_GUARDED_BY_LOCK(m_referencedObjectStoreLock);
-    HashMap<IDBObjectStoreIdentifier, std::unique_ptr<IDBObjectStore>> m_deletedObjectStores;
+    mutable Lock m_objectStoresLock;
+    HashMap<String, std::unique_ptr<IDBObjectStore>> m_referencedObjectStores WTF_GUARDED_BY_LOCK(m_objectStoresLock);
+    HashMap<IDBObjectStoreIdentifier, std::unique_ptr<IDBObjectStore>> m_deletedObjectStores WTF_GUARDED_BY_LOCK(m_objectStoresLock);;
 
     HashSet<Ref<IDBRequest>> m_openRequests;
     RefPtr<IDBRequest> m_currentlyCompletingRequest;


### PR DESCRIPTION
#### 0d2b57c4763910fcb007551cfdaf971d664194e8
<pre>
Add missing WTF_GUARDED_BY_LOCK() for IDBTransaction::m_deletedObjectStores
<a href="https://bugs.webkit.org/show_bug.cgi?id=309886">https://bugs.webkit.org/show_bug.cgi?id=309886</a>

Reviewed by Darin Adler.

Add missing WTF_GUARDED_BY_LOCK() for IDBTransaction::m_deletedObjectStores.
IDBTransaction::visitReferencedObjectStores() wouldn&apos;t be safe if
m_deletedObjectStores was modified without holding the lock.

* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::objectStore):
(WebCore::IDBTransaction::abortInternal):
(WebCore::IDBTransaction::createObjectStore):
(WebCore::IDBTransaction::renameObjectStore):
(WebCore::IDBTransaction::renameIndex):
(WebCore::IDBTransaction::deleteObjectStore):
(WebCore::IDBTransaction::visitReferencedObjectStores const):
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:

Canonical link: <a href="https://commits.webkit.org/309206@main">https://commits.webkit.org/309206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1397904ba04fc6878b209a6530b73c69d1b33b29

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149885 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22604 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158591 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151758 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115619 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/86b52415-0469-4bd6-b158-dc6c5f747ec9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152845 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96358 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6438 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161067 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13973 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123634 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123838 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33630 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22413 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134224 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78638 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19000 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10976 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22014 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85834 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21744 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21896 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21801 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->