### PR TITLE
[GTK][WPE] Non-composited mode renders more than 1 frame per vblank

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.cpp
@@ -59,9 +59,6 @@ void FrameRenderer::scheduleRenderingUpdateRunLoopObserver()
 
     tracePoint(RenderingUpdateRunLoopObserverStart);
     m_renderingUpdateRunLoopObserver->schedule();
-
-    // Avoid running any more tasks before the runloop observer fires.
-    WindowEventLoop::breakToAllowRenderingUpdate();
 }
 
 void FrameRenderer::invalidateRenderingUpdateRunLoopObserver()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.h
@@ -83,7 +83,7 @@ protected:
     virtual bool canUpdateRendering() const = 0;
     virtual void updateRendering() = 0;
 
-    void scheduleRenderingUpdateRunLoopObserver();
+    virtual void scheduleRenderingUpdateRunLoopObserver();
     void invalidateRenderingUpdateRunLoopObserver();
     void renderingUpdateRunLoopObserverFired();
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -130,6 +130,14 @@ void LayerTreeHost::scheduleRenderingUpdate()
     scheduleRenderingUpdateRunLoopObserver();
 }
 
+void LayerTreeHost::scheduleRenderingUpdateRunLoopObserver()
+{
+    FrameRenderer::scheduleRenderingUpdateRunLoopObserver();
+
+    // Avoid running any more tasks before the runloop observer fires.
+    WindowEventLoop::breakToAllowRenderingUpdate();
+}
+
 bool LayerTreeHost::canUpdateRendering() const
 {
     return !m_isWaitingForRenderer;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -107,6 +107,7 @@ private:
     uint64_t surfaceID() const override;
     void updateRenderingWithForcedRepaint() override;
     void scheduleRenderingUpdate() override;
+    void scheduleRenderingUpdateRunLoopObserver() override;
     bool canUpdateRendering() const override;
     void updateRendering() override;
     void suspend() override;


### PR DESCRIPTION
#### 24e3f79f3812ebb364d2d323df2a547bd353867f
<pre>
[GTK][WPE] Non-composited mode renders more than 1 frame per vblank
<a href="https://bugs.webkit.org/show_bug.cgi?id=309888">https://bugs.webkit.org/show_bug.cgi?id=309888</a>

Reviewed by Carlos Garcia Campos.

This change ensures the vblank notifications in web process will get
processed before non-composited frame rendering happens and hence will
get compressed if there were many pending in the queue. With that,
non-composited frame renderer is guaranteed not to render more than 1
frame per vblank anymore.

Canonical link: <a href="https://commits.webkit.org/309199@main">https://commits.webkit.org/309199@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df5c22cacaa2b110e6a7357c6401275cb9c18d80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16200 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158604 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22721 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115623 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152857 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134505 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96362 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6450 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161079 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13978 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123639 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123843 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134229 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78650 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23054 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19011 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10981 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22026 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85846 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21756 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21908 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21813 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->