### PR TITLE
[SaferCPP] Return RefPtr from optional UserAgentStyle accessors

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -670,7 +670,7 @@ style/StyleTreeResolver.cpp
 style/StyleUpdate.cpp
 style/Styleable.cpp
 style/Styleable.h
-style/UserAgentStyle.cpp
+[ iOS ] style/UserAgentStyle.cpp
 style/computed/StyleComputedStyle.cpp
 style/computed/StyleComputedStyleBase.cpp
 style/values/filter-effects/StyleFilterReference.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -118,7 +118,6 @@ style/StyleInvalidationFunctions.h
 style/StyleRelations.cpp
 style/StyleScope.cpp
 [ iOS ] style/StyleScopeRuleSets.cpp
-style/UserAgentStyle.cpp
 style/computed/StyleComputedStyleBase+SettersInlines.h
 style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
 svg/SVGClipPathElement.cpp

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -510,13 +510,13 @@ void ElementRuleCollector::matchUserRules()
 void ElementRuleCollector::matchUARules()
 {
     // First we match rules from the user agent sheet.
-    auto* userAgentStyleSheet = m_isPrintStyle
-        ? UserAgentStyle::defaultPrintStyle : UserAgentStyle::defaultStyle;
-    matchUARules(*userAgentStyleSheet);
+    auto& userAgentStyleSheet = m_isPrintStyle
+        ? UserAgentStyle::defaultPrintStyle() : UserAgentStyle::defaultStyle();
+    matchUARules(userAgentStyleSheet);
 
     // In quirks mode, we match rules from the quirks user agent sheet.
     if (element().document().inQuirksMode())
-        matchUARules(*UserAgentStyle::defaultQuirksStyle);
+        matchUARules(UserAgentStyle::defaultQuirksStyle());
 
     if (m_userAgentMediaQueryStyle)
         matchUARules(*m_userAgentMediaQueryStyle);

--- a/Source/WebCore/style/InspectorCSSOMWrappers.cpp
+++ b/Source/WebCore/style/InspectorCSSOMWrappers.cpp
@@ -129,20 +129,20 @@ void InspectorCSSOMWrappers::maybeCollectFromStyleSheets(const Vector<Ref<CSSSty
 void InspectorCSSOMWrappers::collectDocumentWrappers(ExtensionStyleSheets& extensionStyleSheets)
 {
     if (m_styleRuleToCSSOMWrapperMap.isEmpty()) {
-        collectFromStyleSheetContents(UserAgentStyle::defaultStyleSheet);
-        collectFromStyleSheetContents(UserAgentStyle::quirksStyleSheet);
-        collectFromStyleSheetContents(UserAgentStyle::svgStyleSheet);
-        collectFromStyleSheetContents(UserAgentStyle::mathMLStyleSheet);
-        collectFromStyleSheetContents(UserAgentStyle::mathMLCoreExtrasStyleSheet);
-        collectFromStyleSheetContents(UserAgentStyle::mathMLFontSizeMathStyleSheet);
-        collectFromStyleSheetContents(UserAgentStyle::mathMLLegacyFontSizeMathStyleSheet);
-        collectFromStyleSheetContents(UserAgentStyle::horizontalFormControlsStyleSheet);
-        collectFromStyleSheetContents(UserAgentStyle::viewTransitionsStyleSheet);
-        collectFromStyleSheetContents(UserAgentStyle::htmlSwitchControlStyleSheet);
+        collectFromStyleSheetContents(UserAgentStyle::defaultStyleSheet());
+        collectFromStyleSheetContents(UserAgentStyle::quirksStyleSheet());
+        collectFromStyleSheetContents(UserAgentStyle::svgStyleSheet());
+        collectFromStyleSheetContents(UserAgentStyle::mathMLStyleSheet());
+        collectFromStyleSheetContents(UserAgentStyle::mathMLCoreExtrasStyleSheet());
+        collectFromStyleSheetContents(UserAgentStyle::mathMLFontSizeMathStyleSheet());
+        collectFromStyleSheetContents(UserAgentStyle::mathMLLegacyFontSizeMathStyleSheet());
+        collectFromStyleSheetContents(UserAgentStyle::horizontalFormControlsStyleSheet());
+        collectFromStyleSheetContents(UserAgentStyle::viewTransitionsStyleSheet());
+        collectFromStyleSheetContents(UserAgentStyle::htmlSwitchControlStyleSheet());
 #if ENABLE(FULLSCREEN_API)
-        collectFromStyleSheetContents(UserAgentStyle::fullscreenStyleSheet);
+        collectFromStyleSheetContents(UserAgentStyle::fullscreenStyleSheet());
 #endif
-        collectFromStyleSheetContents(UserAgentStyle::mediaQueryStyleSheet);
+        collectFromStyleSheetContents(UserAgentStyle::mediaQueryStyleSheet());
 
         collect(extensionStyleSheets.pageUserSheet());
         collectFromStyleSheets(extensionStyleSheets.injectedUserStyleSheets());

--- a/Source/WebCore/style/PageRuleCollector.cpp
+++ b/Source/WebCore/style/PageRuleCollector.cpp
@@ -67,7 +67,7 @@ void PageRuleCollector::matchAllPageRules(int pageIndex)
     const bool isFirst = isFirstPage(pageIndex);
     const String page = pageName(pageIndex);
 
-    matchPageRules(UserAgentStyle::defaultPrintStyle, isLeft, isFirst, page);
+    matchPageRules(&UserAgentStyle::defaultPrintStyle(), isLeft, isFirst, page);
     matchPageRules(m_ruleSets.userStyle(), isLeft, isFirst, page);
     // Only consider the global author RuleSet for @page rules, as per the HTML5 spec.
     if (m_ruleSets.isAuthorStyleDefined())

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -70,10 +70,10 @@ RuleSet* ScopeRuleSets::userAgentMediaQueryStyle() const
 
 void ScopeRuleSets::updateUserAgentMediaQueryStyleIfNeeded() const
 {
-    if (!UserAgentStyle::mediaQueryStyleSheet)
+    if (!UserAgentStyle::mediaQueryStyleSheet())
         return;
 
-    auto ruleCount = UserAgentStyle::mediaQueryStyleSheet->ruleCount();
+    auto ruleCount = UserAgentStyle::mediaQueryStyleSheet()->ruleCount();
     if (m_userAgentMediaQueryStyle && ruleCount == m_userAgentMediaQueryRuleCountOnUpdate)
         return;
     m_userAgentMediaQueryRuleCountOnUpdate = ruleCount;
@@ -84,7 +84,7 @@ void ScopeRuleSets::updateUserAgentMediaQueryStyleIfNeeded() const
     m_userAgentMediaQueryStyle = RuleSet::create();
 
     RuleSetBuilder builder(*m_userAgentMediaQueryStyle, mediaQueryEvaluator, &m_styleResolver);
-    builder.addRulesFromSheet(*UserAgentStyle::mediaQueryStyleSheet);
+    builder.addRulesFromSheet(*UserAgentStyle::mediaQueryStyleSheet());
 }
 
 RuleSet* ScopeRuleSets::dynamicViewTransitionsStyle() const
@@ -278,9 +278,9 @@ void ScopeRuleSets::collectFeatures() const
     RELEASE_ASSERT(!m_isInvalidatingStyleWithRuleSets);
 
     m_features.clear();
-    if (UserAgentStyle::defaultStyle)
-        m_features.add(UserAgentStyle::defaultStyle->features());
-    m_defaultStyleVersionOnFeatureCollection = UserAgentStyle::defaultStyleVersion;
+    if (RefPtr defaultStyle = UserAgentStyle::defaultStyleIfExists())
+        m_features.add(defaultStyle->features());
+    m_defaultStyleVersionOnFeatureCollection = UserAgentStyle::defaultStyleVersion();
 
     if (RefPtr userAgentMediaQueryStyle = this->userAgentMediaQueryStyle())
         m_features.add(userAgentMediaQueryStyle->features());

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -146,7 +146,7 @@ private:
 
 inline const RuleFeatureSet& ScopeRuleSets::features() const
 {
-    if (m_defaultStyleVersionOnFeatureCollection < UserAgentStyle::defaultStyleVersion)
+    if (m_defaultStyleVersionOnFeatureCollection < UserAgentStyle::defaultStyleVersion())
         collectFeatures();
     return m_features;
 }
@@ -154,7 +154,7 @@ inline const RuleFeatureSet& ScopeRuleSets::features() const
 // FIXME: There should be just the const version.
 inline RuleFeatureSet& ScopeRuleSets::mutableFeatures()
 {
-    if (m_defaultStyleVersionOnFeatureCollection < UserAgentStyle::defaultStyleVersion)
+    if (m_defaultStyleVersionOnFeatureCollection < UserAgentStyle::defaultStyleVersion())
         collectFeatures();
     return m_features;
 }

--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -71,51 +71,288 @@ namespace Style {
 
 using namespace HTMLNames;
 
-RuleSet* UserAgentStyle::defaultStyle;
-RuleSet* UserAgentStyle::defaultQuirksStyle;
-RuleSet* UserAgentStyle::defaultPrintStyle;
-unsigned UserAgentStyle::defaultStyleVersion;
+namespace {
 
-StyleSheetContents* UserAgentStyle::defaultStyleSheet;
-StyleSheetContents* UserAgentStyle::quirksStyleSheet;
-StyleSheetContents* UserAgentStyle::svgStyleSheet;
-StyleSheetContents* UserAgentStyle::mathMLStyleSheet;
-StyleSheetContents* UserAgentStyle::mathMLCoreExtrasStyleSheet;
-StyleSheetContents* UserAgentStyle::mathMLFontSizeMathStyleSheet;
-StyleSheetContents* UserAgentStyle::mathMLLegacyFontSizeMathStyleSheet;
-StyleSheetContents* UserAgentStyle::mediaQueryStyleSheet;
-StyleSheetContents* UserAgentStyle::popoverStyleSheet;
-StyleSheetContents* UserAgentStyle::horizontalFormControlsStyleSheet;
-StyleSheetContents* UserAgentStyle::htmlSwitchControlStyleSheet;
-StyleSheetContents* UserAgentStyle::counterStylesStyleSheet;
-StyleSheetContents* UserAgentStyle::viewTransitionsStyleSheet;
+struct UserAgentStyleState {
+    RefPtr<RuleSet> defaultStyle;
+    RefPtr<RuleSet> defaultQuirksStyle;
+    RefPtr<RuleSet> defaultPrintStyle;
+    unsigned defaultStyleVersion { 0 };
+
+    RefPtr<StyleSheetContents> defaultStyleSheet;
+    RefPtr<StyleSheetContents> quirksStyleSheet;
+    RefPtr<StyleSheetContents> svgStyleSheet;
+    RefPtr<StyleSheetContents> mathMLStyleSheet;
+    RefPtr<StyleSheetContents> mathMLCoreExtrasStyleSheet;
+    RefPtr<StyleSheetContents> mathMLFontSizeMathStyleSheet;
+    RefPtr<StyleSheetContents> mathMLLegacyFontSizeMathStyleSheet;
+    RefPtr<StyleSheetContents> mediaQueryStyleSheet;
+    RefPtr<StyleSheetContents> popoverStyleSheet;
+    RefPtr<StyleSheetContents> horizontalFormControlsStyleSheet;
+    RefPtr<StyleSheetContents> htmlSwitchControlStyleSheet;
+    RefPtr<StyleSheetContents> counterStylesStyleSheet;
+    RefPtr<StyleSheetContents> viewTransitionsStyleSheet;
 #if ENABLE(FULLSCREEN_API)
-StyleSheetContents* UserAgentStyle::fullscreenStyleSheet;
+    RefPtr<StyleSheetContents> fullscreenStyleSheet;
 #endif
 #if ENABLE(SERVICE_CONTROLS)
-StyleSheetContents* UserAgentStyle::imageControlsStyleSheet;
+    RefPtr<StyleSheetContents> imageControlsStyleSheet;
 #endif
 #if ENABLE(ATTACHMENT_ELEMENT)
-StyleSheetContents* UserAgentStyle::attachmentStyleSheet;
+    RefPtr<StyleSheetContents> attachmentStyleSheet;
+#endif
+};
+
+UserAgentStyleState& userAgentStyleState()
+{
+    static MainThreadNeverDestroyed<UserAgentStyleState> state;
+    return state;
+}
+
+RefPtr<RuleSet>& defaultStyleStorage()
+{
+    return userAgentStyleState().defaultStyle;
+}
+
+RefPtr<RuleSet>& defaultQuirksStyleStorage()
+{
+    return userAgentStyleState().defaultQuirksStyle;
+}
+
+RefPtr<RuleSet>& defaultPrintStyleStorage()
+{
+    return userAgentStyleState().defaultPrintStyle;
+}
+
+RefPtr<StyleSheetContents>& defaultStyleSheetStorage()
+{
+    return userAgentStyleState().defaultStyleSheet;
+}
+
+RefPtr<StyleSheetContents>& quirksStyleSheetStorage()
+{
+    return userAgentStyleState().quirksStyleSheet;
+}
+
+RefPtr<StyleSheetContents>& svgStyleSheetStorage()
+{
+    return userAgentStyleState().svgStyleSheet;
+}
+
+RefPtr<StyleSheetContents>& mathMLStyleSheetStorage()
+{
+    return userAgentStyleState().mathMLStyleSheet;
+}
+
+RefPtr<StyleSheetContents>& mathMLCoreExtrasStyleSheetStorage()
+{
+    return userAgentStyleState().mathMLCoreExtrasStyleSheet;
+}
+
+RefPtr<StyleSheetContents>& mathMLFontSizeMathStyleSheetStorage()
+{
+    return userAgentStyleState().mathMLFontSizeMathStyleSheet;
+}
+
+RefPtr<StyleSheetContents>& mathMLLegacyFontSizeMathStyleSheetStorage()
+{
+    return userAgentStyleState().mathMLLegacyFontSizeMathStyleSheet;
+}
+
+RefPtr<StyleSheetContents>& mediaQueryStyleSheetStorage()
+{
+    return userAgentStyleState().mediaQueryStyleSheet;
+}
+
+RefPtr<StyleSheetContents>& popoverStyleSheetStorage()
+{
+    return userAgentStyleState().popoverStyleSheet;
+}
+
+RefPtr<StyleSheetContents>& horizontalFormControlsStyleSheetStorage()
+{
+    return userAgentStyleState().horizontalFormControlsStyleSheet;
+}
+
+RefPtr<StyleSheetContents>& htmlSwitchControlStyleSheetStorage()
+{
+    return userAgentStyleState().htmlSwitchControlStyleSheet;
+}
+
+RefPtr<StyleSheetContents>& counterStylesStyleSheetStorage()
+{
+    return userAgentStyleState().counterStylesStyleSheet;
+}
+
+RefPtr<StyleSheetContents>& viewTransitionsStyleSheetStorage()
+{
+    return userAgentStyleState().viewTransitionsStyleSheet;
+}
+
+#if ENABLE(FULLSCREEN_API)
+RefPtr<StyleSheetContents>& fullscreenStyleSheetStorage()
+{
+    return userAgentStyleState().fullscreenStyleSheet;
+}
+#endif
+
+#if ENABLE(SERVICE_CONTROLS)
+RefPtr<StyleSheetContents>& imageControlsStyleSheetStorage()
+{
+    return userAgentStyleState().imageControlsStyleSheet;
+}
+#endif
+
+#if ENABLE(ATTACHMENT_ELEMENT)
+RefPtr<StyleSheetContents>& attachmentStyleSheetStorage()
+{
+    return userAgentStyleState().attachmentStyleSheet;
+}
+#endif
+
+} // namespace
+
+RuleSet& UserAgentStyle::defaultStyle()
+{
+    ASSERT(defaultStyleStorage());
+    return *defaultStyleStorage();
+}
+
+RefPtr<RuleSet> UserAgentStyle::defaultStyleIfExists()
+{
+    return defaultStyleStorage();
+}
+
+RuleSet& UserAgentStyle::defaultQuirksStyle()
+{
+    ASSERT(defaultQuirksStyleStorage());
+    return *defaultQuirksStyleStorage();
+}
+
+RefPtr<RuleSet> UserAgentStyle::defaultQuirksStyleIfExists()
+{
+    return defaultQuirksStyleStorage();
+}
+
+RuleSet& UserAgentStyle::defaultPrintStyle()
+{
+    ASSERT(defaultPrintStyleStorage());
+    return *defaultPrintStyleStorage();
+}
+
+RefPtr<RuleSet> UserAgentStyle::defaultPrintStyleIfExists()
+{
+    return defaultPrintStyleStorage();
+}
+
+unsigned UserAgentStyle::defaultStyleVersion()
+{
+    return userAgentStyleState().defaultStyleVersion;
+}
+
+RefPtr<StyleSheetContents> UserAgentStyle::defaultStyleSheet()
+{
+    return defaultStyleSheetStorage();
+}
+
+RefPtr<StyleSheetContents> UserAgentStyle::quirksStyleSheet()
+{
+    return quirksStyleSheetStorage();
+}
+
+RefPtr<StyleSheetContents> UserAgentStyle::svgStyleSheet()
+{
+    return svgStyleSheetStorage();
+}
+
+RefPtr<StyleSheetContents> UserAgentStyle::mathMLStyleSheet()
+{
+    return mathMLStyleSheetStorage();
+}
+
+RefPtr<StyleSheetContents> UserAgentStyle::mathMLCoreExtrasStyleSheet()
+{
+    return mathMLCoreExtrasStyleSheetStorage();
+}
+
+RefPtr<StyleSheetContents> UserAgentStyle::mathMLFontSizeMathStyleSheet()
+{
+    return mathMLFontSizeMathStyleSheetStorage();
+}
+
+RefPtr<StyleSheetContents> UserAgentStyle::mathMLLegacyFontSizeMathStyleSheet()
+{
+    return mathMLLegacyFontSizeMathStyleSheetStorage();
+}
+
+RefPtr<StyleSheetContents> UserAgentStyle::mediaQueryStyleSheet()
+{
+    return mediaQueryStyleSheetStorage();
+}
+
+RefPtr<StyleSheetContents> UserAgentStyle::popoverStyleSheet()
+{
+    return popoverStyleSheetStorage();
+}
+
+RefPtr<StyleSheetContents> UserAgentStyle::horizontalFormControlsStyleSheet()
+{
+    return horizontalFormControlsStyleSheetStorage();
+}
+
+RefPtr<StyleSheetContents> UserAgentStyle::htmlSwitchControlStyleSheet()
+{
+    return htmlSwitchControlStyleSheetStorage();
+}
+
+RefPtr<StyleSheetContents> UserAgentStyle::counterStylesStyleSheet()
+{
+    return counterStylesStyleSheetStorage();
+}
+
+RefPtr<StyleSheetContents> UserAgentStyle::viewTransitionsStyleSheet()
+{
+    return viewTransitionsStyleSheetStorage();
+}
+
+#if ENABLE(FULLSCREEN_API)
+RefPtr<StyleSheetContents> UserAgentStyle::fullscreenStyleSheet()
+{
+    return fullscreenStyleSheetStorage();
+}
+#endif
+
+#if ENABLE(SERVICE_CONTROLS)
+RefPtr<StyleSheetContents> UserAgentStyle::imageControlsStyleSheet()
+{
+    return imageControlsStyleSheetStorage();
+}
+#endif
+
+#if ENABLE(ATTACHMENT_ELEMENT)
+RefPtr<StyleSheetContents> UserAgentStyle::attachmentStyleSheet()
+{
+    return attachmentStyleSheetStorage();
+}
 #endif
 
 static const MQ::MediaQueryEvaluator& screenEval()
 {
-    static NeverDestroyed<const MQ::MediaQueryEvaluator> staticScreenEval(screenAtom());
-    return staticScreenEval;
+    static MainThreadNeverDestroyed<const MQ::MediaQueryEvaluator> screenEvaluator(screenAtom());
+    return screenEvaluator;
 }
 
 static const MQ::MediaQueryEvaluator& printEval()
 {
-    static NeverDestroyed<const MQ::MediaQueryEvaluator> staticPrintEval(printAtom());
-    return staticPrintEval;
+    static MainThreadNeverDestroyed<const MQ::MediaQueryEvaluator> printEvaluator(printAtom());
+    return printEvaluator;
 }
 
-static StyleSheetContents* parseUASheet(const String& str)
+static Ref<StyleSheetContents> parseUASheet(const String& str)
 {
     Ref sheet = StyleSheetContents::create(CSSParserContext(UASheetMode));
     sheet->parseString(str);
-    return &sheet.leakRef();
+    return sheet;
 }
 
 void static addToCounterStyleRegistry(StyleSheetContents& sheet)
@@ -138,10 +375,10 @@ void static addUserAgentKeyframes(StyleSheetContents& sheet)
 
 void UserAgentStyle::addToDefaultStyle(StyleSheetContents& sheet)
 {
-    RuleSetBuilder screenBuilder(*defaultStyle, screenEval());
+    RuleSetBuilder screenBuilder(defaultStyle(), screenEval());
     screenBuilder.addRulesFromSheet(sheet);
 
-    RuleSetBuilder printBuilder(*defaultPrintStyle, printEval());
+    RuleSetBuilder printBuilder(defaultPrintStyle(), printEval());
     printBuilder.addRulesFromSheet(sheet);
 
     // Build a stylesheet consisting of non-trivial media queries seen in default style.
@@ -155,114 +392,114 @@ void UserAgentStyle::addToDefaultStyle(StyleSheetContents& sheet)
             continue;
         if (printEval().evaluate(mediaQuery))
             continue;
-        mediaQueryStyleSheet->parserAppendRule(mediaRule->copy());
+        mediaQueryStyleSheet()->parserAppendRule(mediaRule->copy());
     }
 
-    ++defaultStyleVersion;
+    ++userAgentStyleState().defaultStyleVersion;
 }
 
 void UserAgentStyle::initDefaultStyleSheet()
 {
-    if (defaultStyle)
+    if (defaultStyleIfExists())
         return;
 
-    defaultStyle = &RuleSet::create().leakRef();
-    defaultPrintStyle = &RuleSet::create().leakRef();
-    defaultQuirksStyle = &RuleSet::create().leakRef();
-    mediaQueryStyleSheet = &StyleSheetContents::create(CSSParserContext(UASheetMode)).leakRef();
+    defaultStyleStorage() = RuleSet::create();
+    defaultPrintStyleStorage() = RuleSet::create();
+    defaultQuirksStyleStorage() = RuleSet::create();
+    mediaQueryStyleSheetStorage() = StyleSheetContents::create(CSSParserContext(UASheetMode));
 
     String defaultRules;
-    auto extraDefaultStyleSheet = RenderTheme::singleton().extraDefaultStyleSheet();
-    if (extraDefaultStyleSheet.isEmpty())
+    auto extraDefaultStyleSheetStr = RenderTheme::singleton().extraDefaultStyleSheet();
+    if (extraDefaultStyleSheetStr.isEmpty())
         defaultRules = StringImpl::createWithoutCopying(htmlUserAgentStyleSheet);
     else
-        defaultRules = makeString(std::span { htmlUserAgentStyleSheet }, extraDefaultStyleSheet);
-    defaultStyleSheet = parseUASheet(defaultRules);
-    addToDefaultStyle(*defaultStyleSheet);
+        defaultRules = makeString(std::span { htmlUserAgentStyleSheet }, extraDefaultStyleSheetStr);
+    defaultStyleSheetStorage() = parseUASheet(defaultRules);
+    addToDefaultStyle(*defaultStyleSheet());
 
-    counterStylesStyleSheet = parseUASheet(StringImpl::createWithoutCopying(counterStylesUserAgentStyleSheet));
-    addToCounterStyleRegistry(*counterStylesStyleSheet);
+    counterStylesStyleSheetStorage() = parseUASheet(StringImpl::createWithoutCopying(counterStylesUserAgentStyleSheet));
+    addToCounterStyleRegistry(*counterStylesStyleSheet());
 
-    quirksStyleSheet = parseUASheet(StringImpl::createWithoutCopying(quirksUserAgentStyleSheet));
+    quirksStyleSheetStorage() = parseUASheet(StringImpl::createWithoutCopying(quirksUserAgentStyleSheet));
 
-    RuleSetBuilder quirkBuilder(*defaultQuirksStyle, screenEval());
-    quirkBuilder.addRulesFromSheet(*quirksStyleSheet);
+    RuleSetBuilder quirkBuilder(defaultQuirksStyle(), screenEval());
+    quirkBuilder.addRulesFromSheet(*quirksStyleSheet());
 
-    ++defaultStyleVersion;
+    ++userAgentStyleState().defaultStyleVersion;
 }
 
 void UserAgentStyle::ensureDefaultStyleSheetsForElement(const Element& element)
 {
     if (is<HTMLElement>(element)) {
         if (RefPtr input = dynamicDowncast<HTMLInputElement>(element)) {
-            if (!htmlSwitchControlStyleSheet && input->isSwitch()) {
-                htmlSwitchControlStyleSheet = parseUASheet(StringImpl::createWithoutCopying(htmlSwitchControlUserAgentStyleSheet));
-                addToDefaultStyle(*htmlSwitchControlStyleSheet);
+            if (!htmlSwitchControlStyleSheet() && input->isSwitch()) {
+                htmlSwitchControlStyleSheetStorage() = parseUASheet(StringImpl::createWithoutCopying(htmlSwitchControlUserAgentStyleSheet));
+                addToDefaultStyle(*htmlSwitchControlStyleSheet());
             }
         }
 #if ENABLE(ATTACHMENT_ELEMENT)
-        else if (!attachmentStyleSheet && is<HTMLAttachmentElement>(element)) {
-            attachmentStyleSheet = parseUASheet(RenderTheme::singleton().attachmentStyleSheet());
-            addToDefaultStyle(*attachmentStyleSheet);
+        else if (!attachmentStyleSheet() && is<HTMLAttachmentElement>(element)) {
+            attachmentStyleSheetStorage() = parseUASheet(RenderTheme::singleton().attachmentStyleSheet());
+            addToDefaultStyle(*attachmentStyleSheet());
         }
 #endif // ENABLE(ATTACHMENT_ELEMENT)
 
-        if (!popoverStyleSheet && element.document().settings().popoverAttributeEnabled() && element.hasAttributeWithoutSynchronization(popoverAttr)) {
-            popoverStyleSheet = parseUASheet(StringImpl::createWithoutCopying(popoverUserAgentStyleSheet));
-            addToDefaultStyle(*popoverStyleSheet);
+        if (!popoverStyleSheet() && element.document().settings().popoverAttributeEnabled() && element.hasAttributeWithoutSynchronization(popoverAttr)) {
+            popoverStyleSheetStorage() = parseUASheet(StringImpl::createWithoutCopying(popoverUserAgentStyleSheet));
+            addToDefaultStyle(*popoverStyleSheet());
         }
 
         if (isAnyOf<HTMLFormControlElement, HTMLMeterElement, HTMLProgressElement>(element) && !element.document().settings().verticalFormControlsEnabled()) {
-            if (!horizontalFormControlsStyleSheet) {
-                horizontalFormControlsStyleSheet = parseUASheet(StringImpl::createWithoutCopying(horizontalFormControlsUserAgentStyleSheet));
-                addToDefaultStyle(*horizontalFormControlsStyleSheet);
+            if (!horizontalFormControlsStyleSheet()) {
+                horizontalFormControlsStyleSheetStorage() = parseUASheet(StringImpl::createWithoutCopying(horizontalFormControlsUserAgentStyleSheet));
+                addToDefaultStyle(*horizontalFormControlsStyleSheet());
             }
         }
 
     } else if (is<SVGElement>(element)) {
-        if (!svgStyleSheet) {
-            svgStyleSheet = parseUASheet(StringImpl::createWithoutCopying(svgUserAgentStyleSheet));
-            addToDefaultStyle(*svgStyleSheet);
+        if (!svgStyleSheet()) {
+            svgStyleSheetStorage() = parseUASheet(StringImpl::createWithoutCopying(svgUserAgentStyleSheet));
+            addToDefaultStyle(*svgStyleSheet());
         }
     }
 #if ENABLE(MATHML)
     else if (is<MathMLElement>(element)) {
-        if (!mathMLStyleSheet) {
-            mathMLStyleSheet = parseUASheet(StringImpl::createWithoutCopying(mathmlUserAgentStyleSheet));
-            addToDefaultStyle(*mathMLStyleSheet);
+        if (!mathMLStyleSheet()) {
+            mathMLStyleSheetStorage() = parseUASheet(StringImpl::createWithoutCopying(mathmlUserAgentStyleSheet));
+            addToDefaultStyle(*mathMLStyleSheet());
         }
-        if (!mathMLCoreExtrasStyleSheet && element.document().settings().coreMathMLEnabled()) {
-            mathMLCoreExtrasStyleSheet = parseUASheet(StringImpl::createWithoutCopying(mathmlCoreExtrasUserAgentStyleSheet));
-            addToDefaultStyle(*mathMLCoreExtrasStyleSheet);
+        if (!mathMLCoreExtrasStyleSheet() && element.document().settings().coreMathMLEnabled()) {
+            mathMLCoreExtrasStyleSheetStorage() = parseUASheet(StringImpl::createWithoutCopying(mathmlCoreExtrasUserAgentStyleSheet));
+            addToDefaultStyle(*mathMLCoreExtrasStyleSheet());
         }
         if (element.document().settings().cssMathDepthEnabled()) {
-            if (!mathMLFontSizeMathStyleSheet) {
-                mathMLFontSizeMathStyleSheet = parseUASheet(StringImpl::createWithoutCopying(mathmlFontSizeMathUserAgentStyleSheet));
-                addToDefaultStyle(*mathMLFontSizeMathStyleSheet);
+            if (!mathMLFontSizeMathStyleSheet()) {
+                mathMLFontSizeMathStyleSheetStorage() = parseUASheet(StringImpl::createWithoutCopying(mathmlFontSizeMathUserAgentStyleSheet));
+                addToDefaultStyle(*mathMLFontSizeMathStyleSheet());
             }
         } else {
-            if (!mathMLLegacyFontSizeMathStyleSheet) {
-                mathMLLegacyFontSizeMathStyleSheet = parseUASheet(StringImpl::createWithoutCopying(mathmlLegacyFontSizeMathUserAgentStyleSheet));
-                addToDefaultStyle(*mathMLLegacyFontSizeMathStyleSheet);
+            if (!mathMLLegacyFontSizeMathStyleSheet()) {
+                mathMLLegacyFontSizeMathStyleSheetStorage() = parseUASheet(StringImpl::createWithoutCopying(mathmlLegacyFontSizeMathUserAgentStyleSheet));
+                addToDefaultStyle(*mathMLLegacyFontSizeMathStyleSheet());
             }
         }
     }
 #endif // ENABLE(MATHML)
 
 #if ENABLE(FULLSCREEN_API)
-    if (RefPtr documentFullscreen = element.document().fullscreenIfExists(); !fullscreenStyleSheet && documentFullscreen) {
-        fullscreenStyleSheet = parseUASheet(StringImpl::createWithoutCopying(fullscreenUserAgentStyleSheet));
-        addToDefaultStyle(*fullscreenStyleSheet);
+    if (RefPtr documentFullscreen = element.document().fullscreenIfExists(); !fullscreenStyleSheet() && documentFullscreen) {
+        fullscreenStyleSheetStorage() = parseUASheet(StringImpl::createWithoutCopying(fullscreenUserAgentStyleSheet));
+        addToDefaultStyle(*fullscreenStyleSheet());
     }
 #endif // ENABLE(FULLSCREEN_API)
 
-    if (!viewTransitionsStyleSheet && element.document().settings().viewTransitionsEnabled()) {
-        viewTransitionsStyleSheet = parseUASheet(StringImpl::createWithoutCopying(viewTransitionsUserAgentStyleSheet));
-        addToDefaultStyle(*viewTransitionsStyleSheet);
-        addUserAgentKeyframes(*viewTransitionsStyleSheet);
+    if (!viewTransitionsStyleSheet() && element.document().settings().viewTransitionsEnabled()) {
+        viewTransitionsStyleSheetStorage() = parseUASheet(StringImpl::createWithoutCopying(viewTransitionsUserAgentStyleSheet));
+        addToDefaultStyle(*viewTransitionsStyleSheet());
+        addUserAgentKeyframes(*viewTransitionsStyleSheet());
     }
 
-    ASSERT(defaultStyle->features().idsInRules.isEmpty());
+    ASSERT(defaultStyle().features().idsInRules.isEmpty());
 }
 
 } // namespace Style

--- a/Source/WebCore/style/UserAgentStyle.h
+++ b/Source/WebCore/style/UserAgentStyle.h
@@ -22,6 +22,9 @@
 
 #pragma once
 
+#include <wtf/Forward.h>
+#include <wtf/RefPtr.h>
+
 namespace WebCore {
 
 class Element;
@@ -33,32 +36,35 @@ class RuleSet;
 
 class UserAgentStyle {
 public:
-    static RuleSet* defaultStyle;
-    static RuleSet* defaultQuirksStyle;
-    static RuleSet* defaultPrintStyle;
-    static unsigned defaultStyleVersion;
+    static RuleSet& defaultStyle();
+    static RefPtr<RuleSet> defaultStyleIfExists();
+    static RuleSet& defaultQuirksStyle();
+    static RefPtr<RuleSet> defaultQuirksStyleIfExists();
+    static RuleSet& defaultPrintStyle();
+    static RefPtr<RuleSet> defaultPrintStyleIfExists();
+    static unsigned defaultStyleVersion();
 
-    static StyleSheetContents* defaultStyleSheet;
-    static StyleSheetContents* quirksStyleSheet;
-    static StyleSheetContents* svgStyleSheet;
-    static StyleSheetContents* mathMLStyleSheet;
-    static StyleSheetContents* mathMLCoreExtrasStyleSheet;
-    static StyleSheetContents* mathMLFontSizeMathStyleSheet;
-    static StyleSheetContents* mathMLLegacyFontSizeMathStyleSheet;
-    static StyleSheetContents* mediaQueryStyleSheet;
-    static StyleSheetContents* horizontalFormControlsStyleSheet;
-    static StyleSheetContents* htmlSwitchControlStyleSheet;
-    static StyleSheetContents* popoverStyleSheet;
-    static StyleSheetContents* counterStylesStyleSheet;
-    static StyleSheetContents* viewTransitionsStyleSheet;
+    static RefPtr<StyleSheetContents> defaultStyleSheet();
+    static RefPtr<StyleSheetContents> quirksStyleSheet();
+    static RefPtr<StyleSheetContents> svgStyleSheet();
+    static RefPtr<StyleSheetContents> mathMLStyleSheet();
+    static RefPtr<StyleSheetContents> mathMLCoreExtrasStyleSheet();
+    static RefPtr<StyleSheetContents> mathMLFontSizeMathStyleSheet();
+    static RefPtr<StyleSheetContents> mathMLLegacyFontSizeMathStyleSheet();
+    static RefPtr<StyleSheetContents> mediaQueryStyleSheet();
+    static RefPtr<StyleSheetContents> horizontalFormControlsStyleSheet();
+    static RefPtr<StyleSheetContents> htmlSwitchControlStyleSheet();
+    static RefPtr<StyleSheetContents> popoverStyleSheet();
+    static RefPtr<StyleSheetContents> counterStylesStyleSheet();
+    static RefPtr<StyleSheetContents> viewTransitionsStyleSheet();
 #if ENABLE(FULLSCREEN_API)
-    static StyleSheetContents* fullscreenStyleSheet;
+    static RefPtr<StyleSheetContents> fullscreenStyleSheet();
 #endif
 #if ENABLE(SERVICE_CONTROLS)
-    static StyleSheetContents* imageControlsStyleSheet;
+    static RefPtr<StyleSheetContents> imageControlsStyleSheet();
 #endif
 #if ENABLE(ATTACHMENT_ELEMENT)
-    static StyleSheetContents* attachmentStyleSheet;
+    static RefPtr<StyleSheetContents> attachmentStyleSheet();
 #endif
 
     static void initDefaultStyleSheet();


### PR DESCRIPTION
#### 4cc620fbca59b7316ce59b1b724626cc1048919c
<pre>
[SaferCPP] Return RefPtr from optional UserAgentStyle accessors
<a href="https://bugs.webkit.org/show_bug.cgi?id=309890">https://bugs.webkit.org/show_bug.cgi?id=309890</a>

Reviewed by NOBODY (OOPS!).

Replace UserAgentStyle&apos;s optional RuleSet and StyleSheetContents accessors
that expose storage-backed state as raw pointers with RefPtr-returning
accessors. Keep the guaranteed accessors returning RuleSet&amp;, but simplify
their implementations to dereference the backing storage directly after
asserting it exists. Update ScopeRuleSets to retain the default style while
collecting features.

This keeps the ownership model explicit at the API boundary and avoids
propagating raw pointers from RefPtr-backed global state.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::matchUARules):
* Source/WebCore/style/InspectorCSSOMWrappers.cpp:
(WebCore::Style::InspectorCSSOMWrappers::collectDocumentWrappers):
* Source/WebCore/style/PageRuleCollector.cpp:
(WebCore::Style::PageRuleCollector::matchAllPageRules):
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::updateUserAgentMediaQueryStyleIfNeeded const):
(WebCore::Style::ScopeRuleSets::collectFeatures const):
* Source/WebCore/style/StyleScopeRuleSets.h:
(WebCore::Style::ScopeRuleSets::features const):
(WebCore::Style::ScopeRuleSets::mutableFeatures):
* Source/WebCore/style/UserAgentStyle.cpp:
(WebCore::Style::HTMLNames::userAgentStyleState):
(WebCore::Style::HTMLNames::defaultStyleStorage):
(WebCore::Style::HTMLNames::defaultQuirksStyleStorage):
(WebCore::Style::HTMLNames::defaultPrintStyleStorage):
(WebCore::Style::HTMLNames::defaultStyleSheetStorage):
(WebCore::Style::HTMLNames::quirksStyleSheetStorage):
(WebCore::Style::HTMLNames::svgStyleSheetStorage):
(WebCore::Style::HTMLNames::mathMLStyleSheetStorage):
(WebCore::Style::HTMLNames::mathMLCoreExtrasStyleSheetStorage):
(WebCore::Style::HTMLNames::mathMLFontSizeMathStyleSheetStorage):
(WebCore::Style::HTMLNames::mathMLLegacyFontSizeMathStyleSheetStorage):
(WebCore::Style::HTMLNames::mediaQueryStyleSheetStorage):
(WebCore::Style::HTMLNames::popoverStyleSheetStorage):
(WebCore::Style::HTMLNames::horizontalFormControlsStyleSheetStorage):
(WebCore::Style::HTMLNames::htmlSwitchControlStyleSheetStorage):
(WebCore::Style::HTMLNames::counterStylesStyleSheetStorage):
(WebCore::Style::HTMLNames::viewTransitionsStyleSheetStorage):
(WebCore::Style::HTMLNames::fullscreenStyleSheetStorage):
(WebCore::Style::HTMLNames::imageControlsStyleSheetStorage):
(WebCore::Style::HTMLNames::attachmentStyleSheetStorage):
(WebCore::Style::UserAgentStyle::defaultStyle):
(WebCore::Style::UserAgentStyle::defaultStyleIfExists):
(WebCore::Style::UserAgentStyle::defaultQuirksStyle):
(WebCore::Style::UserAgentStyle::defaultQuirksStyleIfExists):
(WebCore::Style::UserAgentStyle::defaultPrintStyle):
(WebCore::Style::UserAgentStyle::defaultPrintStyleIfExists):
(WebCore::Style::UserAgentStyle::defaultStyleVersion):
(WebCore::Style::UserAgentStyle::defaultStyleSheet):
(WebCore::Style::UserAgentStyle::quirksStyleSheet):
(WebCore::Style::UserAgentStyle::svgStyleSheet):
(WebCore::Style::UserAgentStyle::mathMLStyleSheet):
(WebCore::Style::UserAgentStyle::mathMLCoreExtrasStyleSheet):
(WebCore::Style::UserAgentStyle::mathMLFontSizeMathStyleSheet):
(WebCore::Style::UserAgentStyle::mathMLLegacyFontSizeMathStyleSheet):
(WebCore::Style::UserAgentStyle::mediaQueryStyleSheet):
(WebCore::Style::UserAgentStyle::popoverStyleSheet):
(WebCore::Style::UserAgentStyle::horizontalFormControlsStyleSheet):
(WebCore::Style::UserAgentStyle::htmlSwitchControlStyleSheet):
(WebCore::Style::UserAgentStyle::counterStylesStyleSheet):
(WebCore::Style::UserAgentStyle::viewTransitionsStyleSheet):
(WebCore::Style::UserAgentStyle::fullscreenStyleSheet):
(WebCore::Style::UserAgentStyle::imageControlsStyleSheet):
(WebCore::Style::UserAgentStyle::attachmentStyleSheet):
(WebCore::Style::screenEval):
(WebCore::Style::printEval):
(WebCore::Style::parseUASheet):
(WebCore::Style::UserAgentStyle::addToDefaultStyle):
(WebCore::Style::UserAgentStyle::initDefaultStyleSheet):
(WebCore::Style::UserAgentStyle::ensureDefaultStyleSheetsForElement):
* Source/WebCore/style/UserAgentStyle.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cc620fbca59b7316ce59b1b724626cc1048919c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159498 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104210 "Failed to checkout and rebase branch from PR 60552") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23739 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116373 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/104210 "Failed to checkout and rebase branch from PR 60552") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153736 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97101 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17580 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15530 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7346 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161972 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5093 "Failed to checkout and rebase branch from PR 60552") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124373 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19577 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124571 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23327 "Failed to checkout and rebase branch from PR 60552") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134983 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79713 "Failed to checkout and rebase branch from PR 60552") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/23327 "Failed to checkout and rebase branch from PR 60552") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11745 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22938 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86738 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22650 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22802 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->