### PR TITLE
LCP: avoid changing LCP candidate over tiny/invisible differences

### DIFF
--- a/Source/WebCore/page/LargestContentfulPaintData.cpp
+++ b/Source/WebCore/page/LargestContentfulPaintData.cpp
@@ -109,13 +109,15 @@ bool LargestContentfulPaintData::canCompareWithLargestPaintArea(const Element& e
 }
 
 // https://w3c.github.io/largest-contentful-paint/#sec-effective-visual-size
-std::optional<float> LargestContentfulPaintData::effectiveVisualArea(const Element& element, CachedImage* image, FloatRect imageLocalRect, FloatRect intersectionRect, FloatSize viewportSize)
+std::optional<EffectiveVisualSizeResult> LargestContentfulPaintData::effectiveVisualSize(const Element& element, CachedImage* image, FloatRect imageLocalRect, FloatRect intersectionRect, FloatSize viewportSize)
 {
     RefPtr frameView = element.document().view();
     if (!frameView)
         return { };
 
-    auto area = intersectionRect.area();
+    auto width = std::ceil(intersectionRect.width());
+    auto height = std::ceil(intersectionRect.height());
+    auto area = width * height;
     if (area >= viewportSize.area())
         return { };
 
@@ -127,20 +129,26 @@ std::optional<float> LargestContentfulPaintData::effectiveVisualArea(const Eleme
         auto absoluteContentRect = renderer->localToAbsoluteQuad(FloatRect(imageLocalRect)).boundingBox();
 
         auto intersectingContentRect = intersection(absoluteContentRect, intersectionRect);
-        area = intersectingContentRect.area();
+        width = std::ceil(intersectingContentRect.width());
+        height = std::ceil(intersectingContentRect.height());
+        area = width * height;
 
         auto naturalSize = image->imageSizeForRenderer(renderer.get(), 1);
         if (naturalSize.isEmpty())
             return { };
 
         auto scaleFactor = absoluteContentRect.area() / FloatSize { naturalSize }.area();
-        if (scaleFactor > 1)
+        if (scaleFactor > 1) {
             area /= scaleFactor;
+            auto linearScaleFactor = std::sqrt(scaleFactor);
+            width = std::ceil(width / linearScaleFactor);
+            height = std::ceil(height / linearScaleFactor);
+        }
 
-        return area;
+        return EffectiveVisualSizeResult { area, width, height };
     }
 
-    return area;
+    return EffectiveVisualSizeResult { area, width, height };
 }
 
 // https://w3c.github.io/largest-contentful-paint/#sec-add-lcp-entry
@@ -176,19 +184,29 @@ void LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry(Eleme
     if (!viewportSize)
         viewportSize = FloatSize { view->visualViewportRect().size() };
 
-    auto elementArea = effectiveVisualArea(element, image, imageLocalRect, intersectionRect, *viewportSize);
-    if (!elementArea)
+    auto result = effectiveVisualSize(element, image, imageLocalRect, intersectionRect, *viewportSize);
+    if (!result)
         return;
 
-    if (*elementArea <= m_largestPaintArea) {
-        LOG_WITH_STREAM(LargestContentfulPaint, stream << " element area " << elementArea << " less than LCP " << m_largestPaintArea);
+    if (result->size <= m_largestPaintArea) {
+        LOG_WITH_STREAM(LargestContentfulPaint, stream << " element area " << result->size << " less than LCP " << m_largestPaintArea);
         return;
     }
 
-    if (!isEligibleForLargestContentfulPaint(element, *elementArea))
+    // https://w3c.github.io/largest-contentful-paint/#sec-report-largest-contentful-paint
+    // If the current size is greater than 0, skip candidates whose width and height each differ
+    // by 3 or fewer pixels from the current largest candidate.
+    if (m_largestPaintArea > 0) {
+        if (result->width - m_largestPaintWidth <= 3 && result->height - m_largestPaintHeight <= 3)
+            return;
+    }
+
+    if (!isEligibleForLargestContentfulPaint(element, result->size))
         return;
 
-    m_largestPaintArea = *elementArea;
+    m_largestPaintArea = result->size;
+    m_largestPaintWidth = result->width;
+    m_largestPaintHeight = result->height;
 
     Ref pendingEntry = LargestContentfulPaint::create(0);
     pendingEntry->setElement(&element);

--- a/Source/WebCore/page/LargestContentfulPaintData.h
+++ b/Source/WebCore/page/LargestContentfulPaintData.h
@@ -52,6 +52,12 @@ struct PerElementImageData {
     bool inContentSet { false };
 };
 
+struct EffectiveVisualSizeResult {
+    float size { 0 };
+    float width { 0 };
+    float height { 0 };
+};
+
 struct ElementLargestContentfulPaintData {
     WTF_MAKE_STRUCT_TZONE_ALLOCATED(ElementLargestContentfulPaintData);
     FloatRect accumulatedTextRect;
@@ -74,7 +80,7 @@ public:
 
 private:
 
-    static std::optional<float> effectiveVisualArea(const Element&, CachedImage*, FloatRect imageLocalRect, FloatRect intersectionRect, FloatSize viewportSize);
+    static std::optional<EffectiveVisualSizeResult> effectiveVisualSize(const Element&, CachedImage*, FloatRect imageLocalRect, FloatRect intersectionRect, FloatSize viewportSize);
 
     static FloatRect computeViewportIntersectionRect(Element&, FloatRect localRect);
     static FloatRect computeViewportIntersectionRectForTextContainer(Element&, const WeakHashSet<Text, WeakPtrImplWithEventTargetData>&);
@@ -87,6 +93,8 @@ private:
     void scheduleRenderingUpdateIfNecessary(Element&);
 
     float m_largestPaintArea { 0 };
+    float m_largestPaintWidth { 0 };
+    float m_largestPaintHeight { 0 };
 
     WeakHashSet<Element, WeakPtrImplWithEventTargetData> m_paintedTextRecords;
     WeakHashMap<Element, Vector<WeakPtr<CachedImage>>, WeakPtrImplWithEventTargetData> m_pendingImageRecords;


### PR DESCRIPTION
#### a925a5b9aacd6980c7b9a25c8b764dc7ec465159
<pre>
LCP: avoid changing LCP candidate over tiny/invisible differences
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/WebCore/page/LargestContentfulPaintData.cpp:
(WebCore::LargestContentfulPaintData::effectiveVisualSize):
(WebCore::LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry):
(WebCore::LargestContentfulPaintData::effectiveVisualArea): Deleted.
* Source/WebCore/page/LargestContentfulPaintData.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a925a5b9aacd6980c7b9a25c8b764dc7ec465159

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16217 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158621 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103348 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151787 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23083 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22739 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115634 "Found 2 new test failures: imported/w3c/web-platform-tests/largest-contentful-paint/image-TAO.sub.html imported/w3c/web-platform-tests/largest-contentful-paint/image-upscaling.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82175 "2 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17769 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134518 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96373 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16887 "Found 2 new test failures: imported/w3c/web-platform-tests/largest-contentful-paint/image-TAO.sub.html imported/w3c/web-platform-tests/largest-contentful-paint/image-upscaling.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14791 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6467 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126472 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12449 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161096 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4180 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13991 "Found 2 new test failures: imported/w3c/web-platform-tests/largest-contentful-paint/image-TAO.sub.html imported/w3c/web-platform-tests/largest-contentful-paint/image-upscaling.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123647 "Found 2 new test failures: imported/w3c/web-platform-tests/largest-contentful-paint/image-TAO.sub.html imported/w3c/web-platform-tests/largest-contentful-paint/image-upscaling.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22435 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18833 "Found 2 new test failures: imported/w3c/web-platform-tests/largest-contentful-paint/image-TAO.sub.html imported/w3c/web-platform-tests/largest-contentful-paint/image-upscaling.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123851 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22442 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134242 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78677 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19021 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10994 "Found 2 new test failures: imported/w3c/web-platform-tests/largest-contentful-paint/image-TAO.sub.html imported/w3c/web-platform-tests/largest-contentful-paint/image-upscaling.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22043 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85863 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21773 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21925 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21830 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->