### PR TITLE
Can't seek in webm while content is loading

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h
@@ -127,24 +127,24 @@ private:
     bool playAtHostTime(const MonotonicTime&) final;
     bool pauseAtHostTime(const MonotonicTime&) final;
 
-    FloatSize naturalSize() const final { return m_naturalSize; }
+    FloatSize naturalSize() const final;
 
     bool performTaskAtTime(Function<void(const MediaTime&)>&&, const MediaTime&) final;
     void audioOutputDeviceChanged() final;
 
-    bool hasVideo() const final { return m_hasVideo; }
-    bool hasAudio() const final { return m_hasAudio; }
+    bool hasVideo() const final { return m_hasVideo.load(std::memory_order_relaxed); }
+    bool hasAudio() const final { return m_hasAudio.load(std::memory_order_relaxed); }
 
     void setPageIsVisible(bool) final;
 
     MediaTime timeFudgeFactor() const { return { 1, 10 }; }
     MediaTime currentTime() const final;
-    MediaTime duration() const final { return m_duration; }
+    MediaTime duration() const final;
     MediaTime startTime() const final { return MediaTime::zeroTime(); }
     MediaTime initialTime() const final { return MediaTime::zeroTime(); }
 
     void setRateDouble(double) final;
-    double rate() const final { return m_rate; }
+    double rate() const final;
     double effectiveRate() const final;
 
     void setVolume(float) final;
@@ -178,7 +178,7 @@ private:
     void setHasAudio(bool);
     void setHasVideo(bool);
     void setHasAvailableVideoFrame(bool);
-    bool hasAvailableVideoFrame() const final { return m_hasAvailableVideoFrame; }
+    bool hasAvailableVideoFrame() const final;
     void setDuration(MediaTime);
     void setNetworkState(MediaPlayer::NetworkState);
     void setReadyState(MediaPlayer::ReadyState);
@@ -239,11 +239,11 @@ private:
 
     void addTrackBuffer(TrackID, RefPtr<MediaDescription>&&);
 
-    void clearTracks();
+    void clearTracks(); // Called from destructor (main thread) or running queue
 
     void startVideoFrameMetadataGathering() final;
     void stopVideoFrameMetadataGathering() final;
-    std::optional<VideoFrameMetadata> videoFrameMetadata() final { return std::exchange(m_videoFrameMetadata, { }); }
+    std::optional<VideoFrameMetadata> videoFrameMetadata() final;
     void setResourceOwner(const ProcessIdentity&) final;
 
     void checkNewVideoFrameMetadata(const MediaTime& presentationTime, double displayTime);
@@ -252,7 +252,7 @@ private:
     void setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit) final;
     void playerContentBoxRectChanged(const LayoutRect&) final;
     void setShouldMaintainAspectRatio(bool) final;
-    bool m_shouldMaintainAspectRatio { true };
+    bool m_shouldMaintainAspectRatio WTF_GUARDED_BY_CAPABILITY(mainThread) { true };
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     String defaultSpatialTrackingLabel() const final;
@@ -308,88 +308,96 @@ private:
 
     static Ref<AudioVideoRenderer> createRenderer(LoggerHelper&, HTMLMediaElementIdentifier, MediaPlayerIdentifier);
 
-    URL m_assetURL;
-    MediaPlayer::Preload m_preload { MediaPlayer::Preload::Auto };
+    URL m_assetURL WTF_GUARDED_BY_CAPABILITY(mainThread);
+    std::atomic<MediaPlayer::Preload> m_preload { MediaPlayer::Preload::Auto };
     ThreadSafeWeakPtr<MediaPlayer> m_player;
-    RefPtr<VideoFrame> m_lastVideoFrame;
-    RefPtr<NativeImage> m_lastImage;
-    RefPtr<WebMResourceClient> m_resourceClient;
-    bool m_needsResourceClient { true };
+    RefPtr<VideoFrame> m_lastVideoFrame WTF_GUARDED_BY_CAPABILITY(mainThread);
+    RefPtr<NativeImage> m_lastImage WTF_GUARDED_BY_CAPABILITY(mainThread);
+    RefPtr<WebMResourceClient> m_resourceClient WTF_GUARDED_BY_CAPABILITY(mainThread);
+    bool m_needsResourceClient WTF_GUARDED_BY_CAPABILITY(mainThread) { true };
 
-    Vector<RefPtr<VideoTrackPrivateWebM>> m_videoTracks;
-    Vector<RefPtr<AudioTrackPrivateWebM>> m_audioTracks;
-    StdUnorderedMap<TrackID, TrackIdentifier> m_trackIdentifiers;
-    StdUnorderedMap<TrackID, UniqueRef<TrackBuffer>> m_trackBufferMap;
-    StdUnorderedMap<TrackID, bool> m_readyForMoreSamplesMap;
-    StdUnorderedMap<TrackID, bool> m_requestReadyForMoreSamplesSetMap;
-    PlatformTimeRanges m_buffered;
+    Vector<RefPtr<VideoTrackPrivateWebM>> m_videoTracks WTF_GUARDED_BY_CAPABILITY(runningQueue()); // or in destructor
+    Vector<RefPtr<AudioTrackPrivateWebM>> m_audioTracks WTF_GUARDED_BY_CAPABILITY(runningQueue()); // or in destructor
+    StdUnorderedMap<TrackID, TrackIdentifier> m_trackIdentifiers WTF_GUARDED_BY_CAPABILITY(runningQueue());
+    StdUnorderedMap<TrackID, UniqueRef<TrackBuffer>> m_trackBufferMap WTF_GUARDED_BY_CAPABILITY(runningQueue());
+    StdUnorderedMap<TrackID, bool> m_readyForMoreSamplesMap WTF_GUARDED_BY_CAPABILITY(runningQueue());
+    StdUnorderedMap<TrackID, bool> m_requestReadyForMoreSamplesSetMap WTF_GUARDED_BY_CAPABILITY(runningQueue());
+    PlatformTimeRanges m_buffered WTF_GUARDED_BY_CAPABILITY(runningQueue());
+    PlatformTimeRanges m_bufferedMainThread WTF_GUARDED_BY_CAPABILITY(mainThread);
 
     const Ref<SourceBufferParserWebM> m_parser;
     const Ref<WTF::WorkQueue> m_appendQueue;
 
-    MediaPlayer::NetworkState m_networkState { MediaPlayer::NetworkState::Empty };
-    MediaPlayer::ReadyState m_readyState { MediaPlayer::ReadyState::HaveNothing };
+    std::atomic<MediaPlayer::NetworkState> m_networkState { MediaPlayer::NetworkState::Empty };
+    std::atomic<MediaPlayer::ReadyState> m_readyState { MediaPlayer::ReadyState::HaveNothing };
 
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
-    RefPtr<MediaPlaybackTarget> m_playbackTarget;
-    bool m_shouldPlayToTarget { false };
+    RefPtr<MediaPlaybackTarget> m_playbackTarget WTF_GUARDED_BY_CAPABILITY(mainThread);
+    bool m_shouldPlayToTarget WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
 #endif
     const Ref<const Logger> m_logger;
     const uint64_t m_logIdentifier;
 
-    bool m_isGatheringVideoFrameMetadata { false };
-    std::optional<VideoFrameMetadata> m_videoFrameMetadata;
-    uint64_t m_lastConvertedSampleCount { 0 };
+    bool m_isGatheringVideoFrameMetadata WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    std::optional<VideoFrameMetadata> m_videoFrameMetadata WTF_GUARDED_BY_CAPABILITY(mainThread);
+    uint64_t m_lastConvertedSampleCount WTF_GUARDED_BY_CAPABILITY(mainThread) { 0 };
 
-    FloatSize m_naturalSize;
-    MediaTime m_currentTime;
-    MediaTime m_duration { MediaTime::indefiniteTime() };
-    double m_rate { 1 };
+    FloatSize m_naturalSize WTF_GUARDED_BY_CAPABILITY(mainThread);
+    MediaTime m_duration WTF_GUARDED_BY_CAPABILITY(runningQueue()) { MediaTime::indefiniteTime() };
+    MediaTime m_durationMainThread WTF_GUARDED_BY_CAPABILITY(mainThread) { MediaTime::indefiniteTime() };
+    double m_rate WTF_GUARDED_BY_CAPABILITY(mainThread) { 1 };
 
     bool NODELETE isEnabledVideoTrackID(TrackID) const;
     bool NODELETE hasSelectedVideo() const;
-    std::optional<TrackID> m_enabledVideoTrackID;
+    std::optional<TrackID> m_enabledVideoTrackID WTF_GUARDED_BY_CAPABILITY(runningQueue());
     std::atomic<uint32_t> m_abortCalled { 0 };
-    size_t m_contentLength { 0 };
-    size_t m_contentReceived { 0 };
-    uint32_t m_pendingAppends { 0 };
-    bool m_layerRequiresFlush { false };
+    size_t m_contentLength WTF_GUARDED_BY_CAPABILITY(mainThread) { 0 };
+    size_t m_contentReceived WTF_GUARDED_BY_CAPABILITY(mainThread) { 0 };
+    uint32_t m_pendingAppends WTF_GUARDED_BY_CAPABILITY(runningQueue()) { 0 };
+    bool m_layerRequiresFlush WTF_GUARDED_BY_CAPABILITY(runningQueue()) { false };
 #if PLATFORM(IOS_FAMILY)
-    bool m_applicationIsActive { true };
+    std::atomic<bool> m_applicationIsActive { true };
 #endif
-    bool m_hasAudio { false };
-    bool m_hasVideo { false };
-    bool m_hasAvailableVideoFrame { false };
-    bool m_readyStateIsWaitingForAvailableFrame { true };
-    bool m_visible { false };
-    mutable bool m_loadingProgressed { false };
-    bool m_loadFinished { false };
-    bool m_errored { false };
-    bool m_processingInitializationSegment { false };
+    std::atomic<bool> m_hasAudio { false };
+    std::atomic<bool> m_hasVideo { false };
+    bool m_hasAvailableVideoFrame WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    bool m_readyStateIsWaitingForAvailableFrame WTF_GUARDED_BY_CAPABILITY(mainThread) { true };
+    bool m_visible WTF_GUARDED_BY_CAPABILITY(mainThread) { false };
+    mutable std::atomic<bool> m_loadingProgressed { false };
+    bool m_loadFinished WTF_GUARDED_BY_CAPABILITY(runningQueue()) { false };
+    std::atomic<bool> m_errored { false };
+    std::atomic<bool> m_processingInitializationSegment { false };
 
     // Seek logic support
     void seekToTarget(const SeekTarget&) final;
     bool seeking() const final;
     void seekInternal();
-    void cancelPendingSeek();
+    void cancelPendingSeek(); // Called from destructor or running queue
     void startSeek(const MediaTime&);
     void completeSeek(const MediaTime&);
     Ref<GenericPromise> waitForTimeBuffered(const MediaTime&);
+    void resolveWaitForTimeBufferedPromiseIfPossible();
     bool shouldBePlaying() const;
 
-    bool m_isPlaying { false };
-    Timer m_seekTimer;
-    MediaTime m_lastSeekTime;
-    std::optional<SeekTarget> m_pendingSeek;
-    std::optional<GenericPromise::Producer> m_waitForTimeBufferedPromise;
+    // WorkQueue on which the player is running.
+    WorkQueue& runningQueue() const { return m_runningQueue.get(); }
+    void ensureOnRunningQueue(Function<void()>&&);
+    MediaTime durationOnRunningQueue() const;
+
+    Timer m_seekTimer WTF_GUARDED_BY_CAPABILITY(mainThread);
+    MediaTime m_lastSeekTime WTF_GUARDED_BY_CAPABILITY(runningQueue());
+    std::optional<SeekTarget> m_pendingSeek WTF_GUARDED_BY_CAPABILITY(mainThread);
+    std::atomic<bool> m_hasPendingSeek { false };
+    std::optional<GenericPromise::Producer> m_waitForTimeBufferedPromise WTF_GUARDED_BY_CAPABILITY(runningQueue());
     const Ref<NativePromiseRequest> m_rendererSeekRequest;
-    bool m_seeking { false };
+    std::atomic<bool> m_seeking { false };
 #if HAVE(SPATIAL_TRACKING_LABEL)
-    String m_defaultSpatialTrackingLabel;
-    String m_spatialTrackingLabel;
+    String m_defaultSpatialTrackingLabel WTF_GUARDED_BY_CAPABILITY(mainThread);
+    String m_spatialTrackingLabel WTF_GUARDED_BY_CAPABILITY(mainThread);
 #endif
     const MediaPlayerIdentifier m_playerIdentifier;
     const Ref<AudioVideoRenderer> m_renderer;
+    const Ref<WorkQueue> m_runningQueue;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -104,9 +104,16 @@ MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer& player)
     , m_rendererSeekRequest(NativePromiseRequest::create())
     , m_playerIdentifier(MediaPlayerIdentifier::generate())
     , m_renderer(createRenderer(*this, player.clientIdentifier(), m_playerIdentifier))
+    , m_runningQueue(hasPlatformStrategies() && platformStrategies()->mediaStrategy()->hasRemoteRendererFor(MediaPlayerMediaEngineIdentifier::CocoaWebM) ? m_appendQueue.get() : WorkQueue::mainSingleton())
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     m_parser->setLogger(m_logger, m_logIdentifier);
+    m_parser->setCallOnClientThreadCallback([runningQueue = m_runningQueue](auto&& function) {
+        if (runningQueue->isCurrent())
+            function();
+        else
+            runningQueue->dispatch(WTF::move(function));
+    });
     m_parser->setDidParseInitializationDataCallback([weakThis = ThreadSafeWeakPtr { *this }, this] (InitializationSegment&& segment) {
         if (RefPtr protectedThis = weakThis.get())
             didParseInitializationData(WTF::move(segment));
@@ -123,7 +130,10 @@ MediaPlayerPrivateWebM::MediaPlayerPrivateWebM(MediaPlayer& player)
 #endif
 }
 
-MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM()
+// Destructor runs on main thread (DestructionThread::Main). At this point all running-queue
+// work has drained, so accessing running-queue-guarded members is safe at runtime even though
+// the static analyzer cannot prove it.
+MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
@@ -163,16 +173,18 @@ MediaPlayer::SupportsType MediaPlayerPrivateWebM::supportsType(const MediaEngine
 
 void MediaPlayerPrivateWebM::setPreload(MediaPlayer::Preload preload)
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER, " - ", static_cast<int>(preload));
-    if (preload == std::exchange(m_preload, preload))
+    if (preload == m_preload.exchange(preload))
         return;
     doPreload();
 }
 
 void MediaPlayerPrivateWebM::doPreload()
 {
+    assertIsMainThread();
     if (m_assetURL.isEmpty() || m_networkState >= MediaPlayerNetworkState::FormatError) {
-        INFO_LOG(LOGIDENTIFIER, " - hasURL = ", static_cast<int>(m_assetURL.isEmpty()), " networkState = ", static_cast<int>(m_networkState));
+        INFO_LOG(LOGIDENTIFIER, " - hasURL = ", static_cast<int>(m_assetURL.isEmpty()), " networkState = ", static_cast<int>(m_networkState.load()));
         return;
     }
 
@@ -197,13 +209,19 @@ void MediaPlayerPrivateWebM::doPreload()
     }
 
     if (m_preload > MediaPlayer::Preload::MetaData) {
-        for (auto it = m_readyForMoreSamplesMap.begin(); it != m_readyForMoreSamplesMap.end(); ++it)
-            notifyClientWhenReadyForMoreSamples(it->first);
+        ensureOnRunningQueue([weakThis = ThreadSafeWeakPtr { *this }] {
+            if (RefPtr protectedThis = weakThis.get()) {
+                assertIsCurrent(protectedThis->runningQueue());
+                for (auto& [trackId, ignored] : protectedThis->m_readyForMoreSamplesMap)
+                    protectedThis->notifyClientWhenReadyForMoreSamples(trackId);
+            }
+        });
     }
 }
 
 void MediaPlayerPrivateWebM::load(const URL& url, const LoadOptions& options)
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER);
 
     setReadyState(MediaPlayer::ReadyState::HaveNothing);
@@ -235,10 +253,12 @@ void MediaPlayerPrivateWebM::load(const URL& url, const LoadOptions& options)
     });
 
     m_renderer->notifyWhenRequiresFlushToResume([weakThis = ThreadSafeWeakPtr { *this }] {
-        ensureOnMainThread([weakThis] {
-            if (RefPtr protectedThis = weakThis.get())
-                protectedThis->setLayerRequiresFlush();
-        });
+        if (RefPtr protectedThis = weakThis.get()) {
+            protectedThis->ensureOnRunningQueue([weakThis] {
+                if (RefPtr protectedThis = weakThis.get())
+                    protectedThis->setLayerRequiresFlush();
+            });
+        }
     });
 
     m_renderer->notifyRenderingModeChanged([weakThis = ThreadSafeWeakPtr { *this }] {
@@ -294,11 +314,13 @@ void MediaPlayerPrivateWebM::load(const URL& url, const LoadOptions& options)
 
 bool MediaPlayerPrivateWebM::needsResourceClient() const
 {
+    assertIsMainThread();
     return !m_resourceClient && m_needsResourceClient;
 }
 
 bool MediaPlayerPrivateWebM::createResourceClientIfNeeded()
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER);
 
     ASSERT(needsResourceClient());
@@ -327,6 +349,7 @@ bool MediaPlayerPrivateWebM::createResourceClientIfNeeded()
 #if ENABLE(MEDIA_SOURCE)
 void MediaPlayerPrivateWebM::load(const URL&, const LoadOptions&, MediaSourcePrivateClient&)
 {
+    assertIsMainThread();
     ERROR_LOG(LOGIDENTIFIER, "tried to load as mediasource");
 
     setNetworkState(MediaPlayer::NetworkState::FormatError);
@@ -336,6 +359,7 @@ void MediaPlayerPrivateWebM::load(const URL&, const LoadOptions&, MediaSourcePri
 #if ENABLE(MEDIA_STREAM)
 void MediaPlayerPrivateWebM::load(MediaStreamPrivate&)
 {
+    assertIsMainThread();
     ERROR_LOG(LOGIDENTIFIER, "tried to load as mediastream");
 
     setNetworkState(MediaPlayer::NetworkState::FormatError);
@@ -344,7 +368,8 @@ void MediaPlayerPrivateWebM::load(MediaStreamPrivate&)
 
 void MediaPlayerPrivateWebM::dataLengthReceived(size_t length)
 {
-    callOnMainThread([protectedThis = Ref { *this }, length] {
+    ensureOnMainThread([protectedThis = Ref { *this }, length] {
+        assertIsMainThread();
         protectedThis->m_contentLength = length;
     });
 }
@@ -353,15 +378,20 @@ void MediaPlayerPrivateWebM::dataReceived(const SharedBuffer& buffer)
 {
     ALWAYS_LOG(LOGIDENTIFIER, "data length = ", buffer.size());
 
-    callOnMainThread([protectedThis = Ref { *this }, this, size = buffer.size()] {
-        setNetworkState(MediaPlayer::NetworkState::Loading);
-        m_pendingAppends++;
-        m_contentReceived += size;
+    ensureOnMainThread([protectedThis = Ref { *this }, size = buffer.size()] {
+        assertIsMainThread();
+        protectedThis->m_contentReceived += size;
+    });
+
+    ensureOnRunningQueue([protectedThis = Ref { *this }] {
+        assertIsCurrent(protectedThis->runningQueue());
+        protectedThis->setNetworkState(MediaPlayer::NetworkState::Loading);
+        protectedThis->m_pendingAppends++;
     });
 
     invokeAsync(m_appendQueue, [buffer = Ref { buffer }, parser = m_parser]() mutable {
         return MediaPromise::createAndSettle(parser->appendData(WTF::move(buffer)));
-    })->whenSettled(RunLoop::mainSingleton(), [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
+    })->whenSettled(m_runningQueue, [weakThis = ThreadSafeWeakPtr { *this }](auto&& result) {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->appendCompleted(!!result);
     });
@@ -370,7 +400,7 @@ void MediaPlayerPrivateWebM::dataReceived(const SharedBuffer& buffer)
 void MediaPlayerPrivateWebM::loadFailed(const ResourceError& error)
 {
     ERROR_LOG(LOGIDENTIFIER, "resource failed to load with code ", error.errorCode());
-    callOnMainThread([protectedThis = Ref { *this }] {
+    ensureOnMainThread([protectedThis = Ref { *this }] {
         protectedThis->setNetworkState(MediaPlayer::NetworkState::NetworkError);
     });
 }
@@ -378,7 +408,8 @@ void MediaPlayerPrivateWebM::loadFailed(const ResourceError& error)
 void MediaPlayerPrivateWebM::loadFinished()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    callOnMainThread([protectedThis = Ref { *this }] {
+    ensureOnRunningQueue([protectedThis = Ref { *this }] {
+        assertIsCurrent(protectedThis->runningQueue());
         protectedThis->m_loadFinished = true;
         protectedThis->maybeFinishLoading();
     });
@@ -386,6 +417,7 @@ void MediaPlayerPrivateWebM::loadFinished()
 
 void MediaPlayerPrivateWebM::cancelLoad()
 {
+    assertIsMainThread();
     if (RefPtr resourceClient = m_resourceClient) {
         resourceClient->stop();
         m_resourceClient = nullptr;
@@ -399,18 +431,21 @@ PlatformLayer* MediaPlayerPrivateWebM::platformLayer() const
 
 void MediaPlayerPrivateWebM::prepareToPlay()
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER);
     setPreload(MediaPlayer::Preload::Auto);
 }
 
 void MediaPlayerPrivateWebM::play()
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER);
     playInternal();
 }
 
 void MediaPlayerPrivateWebM::pause()
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER);
     m_renderer->pause();
 }
@@ -422,6 +457,7 @@ bool MediaPlayerPrivateWebM::paused() const
 
 bool MediaPlayerPrivateWebM::playAtHostTime(const MonotonicTime& hostTime)
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER);
     playInternal(hostTime);
     return true;
@@ -429,6 +465,7 @@ bool MediaPlayerPrivateWebM::playAtHostTime(const MonotonicTime& hostTime)
 
 bool MediaPlayerPrivateWebM::pauseAtHostTime(const MonotonicTime& hostTime)
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER);
     m_renderer->pause(hostTime);
     return true;
@@ -436,20 +473,28 @@ bool MediaPlayerPrivateWebM::pauseAtHostTime(const MonotonicTime& hostTime)
 
 void MediaPlayerPrivateWebM::playInternal(std::optional<MonotonicTime> hostTime)
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER);
-    flushVideoIfNeeded();
-
-    m_renderer->play(hostTime);
-
-    if (!shouldBePlaying())
-        return;
-
-    if (currentTime() >= duration())
-        seekToTarget(SeekTarget::zero());
+    ensureOnRunningQueue([weakThis = ThreadSafeWeakPtr { *this }, hostTime] {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        protectedThis->flushVideoIfNeeded();
+        protectedThis->m_renderer->play(hostTime);
+        if (!protectedThis->shouldBePlaying())
+            return;
+        if (protectedThis->currentTime() >= protectedThis->durationOnRunningQueue()) {
+            ensureOnMainThread([weakThis] {
+                if (RefPtr protectedThis = weakThis.get())
+                    protectedThis->seekToTarget(SeekTarget::zero());
+            });
+        }
+    });
 }
 
 bool MediaPlayerPrivateWebM::performTaskAtTime(Function<void(const MediaTime&)>&& task, const MediaTime& time)
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER, time);
 
     m_renderer->performTaskAtTime(time, [task = WTF::move(task)](const MediaTime& time) mutable {
@@ -462,6 +507,7 @@ bool MediaPlayerPrivateWebM::performTaskAtTime(Function<void(const MediaTime&)>&
 
 void MediaPlayerPrivateWebM::audioOutputDeviceChanged()
 {
+    assertIsMainThread();
 #if HAVE(AUDIO_OUTPUT_DEVICE_UNIQUE_ID)
     if (RefPtr player = m_player.get())
         m_renderer->setOutputDeviceId(player->audioOutputDeviceId());
@@ -475,6 +521,7 @@ bool MediaPlayerPrivateWebM::timeIsProgressing() const
 
 void MediaPlayerPrivateWebM::setPageIsVisible(bool visible)
 {
+    assertIsMainThread();
     if (m_visible == visible)
         return;
 
@@ -492,11 +539,49 @@ MediaTime MediaPlayerPrivateWebM::currentTime() const
     return m_renderer->currentTime();
 }
 
+MediaTime MediaPlayerPrivateWebM::duration() const
+{
+    assertIsMainThread();
+    return m_durationMainThread;
+}
+
+MediaTime MediaPlayerPrivateWebM::durationOnRunningQueue() const
+{
+    assertIsCurrent(runningQueue());
+    return m_duration;
+}
+
+FloatSize MediaPlayerPrivateWebM::naturalSize() const
+{
+    assertIsMainThread();
+    return m_naturalSize;
+}
+
+double MediaPlayerPrivateWebM::rate() const
+{
+    assertIsMainThread();
+    return m_rate;
+}
+
+bool MediaPlayerPrivateWebM::hasAvailableVideoFrame() const
+{
+    assertIsMainThread();
+    return m_hasAvailableVideoFrame;
+}
+
+std::optional<VideoFrameMetadata> MediaPlayerPrivateWebM::videoFrameMetadata()
+{
+    assertIsMainThread();
+    return std::exchange(m_videoFrameMetadata, { });
+}
+
 void MediaPlayerPrivateWebM::seekToTarget(const SeekTarget& target)
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER, "time = ", target.time, ", negativeThreshold = ", target.negativeThreshold, ", positiveThreshold = ", target.positiveThreshold);
 
     m_pendingSeek = target;
+    m_hasPendingSeek = true;
 
     if (m_seekTimer.isActive())
         m_seekTimer.stop();
@@ -505,30 +590,38 @@ void MediaPlayerPrivateWebM::seekToTarget(const SeekTarget& target)
 
 void MediaPlayerPrivateWebM::seekInternal()
 {
+    assertIsMainThread();
     if (!m_pendingSeek)
         return;
 
     ALWAYS_LOG(LOGIDENTIFIER, m_pendingSeek->time);
 
-    auto pendingSeek = std::exchange(m_pendingSeek, { }).value();
-    m_lastSeekTime = pendingSeek.time;
+    auto seekTarget = std::exchange(m_pendingSeek, { }).value();
+    m_hasPendingSeek = false;
 
-    cancelPendingSeek();
-
-    m_seeking = true;
-
-    m_renderer->prepareToSeek();
-
-    waitForTimeBuffered(m_lastSeekTime)->whenSettled(RunLoop::mainSingleton(), [weakThis = ThreadSafeWeakPtr { *this }, seekTime = m_lastSeekTime](auto&& result) {
+    ensureOnRunningQueue([weakThis = ThreadSafeWeakPtr { *this }, seekTarget] {
         RefPtr protectedThis = weakThis.get();
-        if (!result || !protectedThis)
-            return; // seek cancelled.
+        if (!protectedThis)
+            return;
 
-        return protectedThis->startSeek(seekTime);
+        assertIsCurrent(protectedThis->runningQueue());
+        auto seekTime = seekTarget.time;
+        protectedThis->m_lastSeekTime = seekTime;
+        protectedThis->cancelPendingSeek();
+        protectedThis->m_seeking = true;
+        protectedThis->m_renderer->prepareToSeek();
+
+        protectedThis->waitForTimeBuffered(seekTime)->whenSettled(protectedThis->m_runningQueue, [weakThis, seekTime](auto&& result) {
+            RefPtr protectedThis = weakThis.get();
+            if (!result || !protectedThis)
+                return; // seek cancelled.
+
+            return protectedThis->startSeek(seekTime);
+        });
     });
 }
 
-void MediaPlayerPrivateWebM::cancelPendingSeek()
+void MediaPlayerPrivateWebM::cancelPendingSeek() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     if (m_rendererSeekRequest->hasCallback())
         m_rendererSeekRequest->disconnect();
@@ -538,7 +631,9 @@ void MediaPlayerPrivateWebM::cancelPendingSeek()
 
 void MediaPlayerPrivateWebM::startSeek(const MediaTime& seekTime)
 {
-    m_renderer->seekTo(seekTime)->whenSettled(RunLoop::mainSingleton(), [weakThis = ThreadSafeWeakPtr { *this }, seekTime](auto&& result) {
+    assertIsCurrent(runningQueue());
+    ALWAYS_LOG(LOGIDENTIFIER, seekTime);
+    m_renderer->seekTo(seekTime)->whenSettled(m_runningQueue, [weakThis = ThreadSafeWeakPtr { *this }, seekTime](auto&& result) {
         if (!result && result.error() != PlatformMediaError::RequiresFlushToResume)
             return; // cancelled.
 
@@ -561,20 +656,26 @@ void MediaPlayerPrivateWebM::startSeek(const MediaTime& seekTime)
 
 void MediaPlayerPrivateWebM::completeSeek(const MediaTime& seekedTime)
 {
+    assertIsCurrent(runningQueue());
     ALWAYS_LOG(LOGIDENTIFIER, "");
 
     m_seeking = false;
 
     monitorReadyState();
 
-    if (RefPtr player = m_player.get()) {
-        player->seeked(seekedTime);
-        player->timeChanged();
-    }
+    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }, seekedTime] {
+        if (RefPtr protectedThis = weakThis.get()) {
+            if (RefPtr player = protectedThis->m_player.get()) {
+                player->seeked(seekedTime);
+                player->timeChanged();
+            }
+        }
+    });
 }
 
 Ref<GenericPromise> MediaPlayerPrivateWebM::waitForTimeBuffered(const MediaTime& time)
 {
+    assertIsCurrent(runningQueue());
     ASSERT(!m_waitForTimeBufferedPromise);
 
     if (m_buffered.containWithEpsilon(time, timeFudgeFactor())) {
@@ -582,16 +683,29 @@ Ref<GenericPromise> MediaPlayerPrivateWebM::waitForTimeBuffered(const MediaTime&
         return GenericPromise::createAndResolve();
     }
 
-    setReadyState(MediaPlayer::ReadyState::HaveMetadata);
+    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->setReadyState(MediaPlayer::ReadyState::HaveMetadata);
+    });
 
     ALWAYS_LOG(LOGIDENTIFIER, "buffered doesn't contain seektime waiting");
     m_waitForTimeBufferedPromise.emplace();
     return m_waitForTimeBufferedPromise->promise();
 }
 
+void MediaPlayerPrivateWebM::resolveWaitForTimeBufferedPromiseIfPossible()
+{
+    assertIsCurrent(runningQueue());
+    if (!m_waitForTimeBufferedPromise || !m_buffered.containWithEpsilon(m_lastSeekTime, timeFudgeFactor()))
+        return;
+    ALWAYS_LOG(LOGIDENTIFIER, "can continue seeking data is now buffered");
+    m_waitForTimeBufferedPromise->resolve();
+    m_waitForTimeBufferedPromise.reset();
+}
+
 bool MediaPlayerPrivateWebM::seeking() const
 {
-    return m_pendingSeek || m_seeking;
+    return m_hasPendingSeek || m_seeking;
 }
 
 bool MediaPlayerPrivateWebM::shouldBePlaying() const
@@ -601,6 +715,7 @@ bool MediaPlayerPrivateWebM::shouldBePlaying() const
 
 void MediaPlayerPrivateWebM::setRateDouble(double rate)
 {
+    assertIsMainThread();
     if (rate == m_rate)
         return;
 
@@ -619,34 +734,45 @@ double MediaPlayerPrivateWebM::effectiveRate() const
 
 void MediaPlayerPrivateWebM::setVolume(float volume)
 {
+    assertIsMainThread();
     m_renderer->setVolume(volume);
 }
 
 void MediaPlayerPrivateWebM::setMuted(bool muted)
 {
+    assertIsMainThread();
     m_renderer->setMuted(muted);
 }
 
-const PlatformTimeRanges& MediaPlayerPrivateWebM::buffered() const
+const PlatformTimeRanges& MediaPlayerPrivateWebM::buffered() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
-    return m_buffered;
+    assertIsMainThread();
+    return m_bufferedMainThread;
 }
 
 void MediaPlayerPrivateWebM::setBufferedRanges(PlatformTimeRanges timeRanges)
 {
+    assertIsCurrent(runningQueue());
     if (m_buffered == timeRanges)
         return;
     m_buffered = WTF::move(timeRanges);
-    if (RefPtr player = m_player.get()) {
-        player->bufferedTimeRangesChanged();
-        player->seekableTimeRangesChanged();
-    }
+    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }, bufferedCopy = m_buffered] mutable {
+        assertIsMainThread();
+        if (RefPtr protectedThis = weakThis.get()) {
+            protectedThis->m_bufferedMainThread = WTF::move(bufferedCopy);
+            if (RefPtr player = protectedThis->m_player.get()) {
+                player->bufferedTimeRangesChanged();
+                player->seekableTimeRangesChanged();
+            }
+        }
+    });
 
     monitorReadyState();
 }
 
 void MediaPlayerPrivateWebM::updateBufferedFromTrackBuffers(bool ended)
 {
+    assertIsCurrent(runningQueue());
     MediaTime highestEndTime = MediaTime::negativeInfiniteTime();
     for (auto& pair : m_trackBufferMap) {
         auto& trackBuffer = pair.second;
@@ -682,6 +808,7 @@ void MediaPlayerPrivateWebM::updateBufferedFromTrackBuffers(bool ended)
 
 void MediaPlayerPrivateWebM::updateDurationFromTrackBuffers()
 {
+    assertIsCurrent(runningQueue());
     ASSERT(m_loadFinished);
     MediaTime highestEndTime = MediaTime::zeroTime();
     for (auto& pair : m_trackBufferMap) {
@@ -702,17 +829,20 @@ void MediaPlayerPrivateWebM::setLoadingProgresssed(bool loadingProgressed)
 
 bool MediaPlayerPrivateWebM::didLoadingProgress() const
 {
-    return std::exchange(m_loadingProgressed, false);
+    assertIsMainThread();
+    return m_loadingProgressed.exchange(false);
 }
 
 RefPtr<NativeImage> MediaPlayerPrivateWebM::nativeImageForCurrentTime()
 {
+    assertIsMainThread();
     updateLastImage();
     return m_lastImage;
 }
 
 bool MediaPlayerPrivateWebM::updateLastVideoFrame()
 {
+    assertIsMainThread();
     RefPtr videoFrame = m_renderer->currentVideoFrame();
     if (!videoFrame)
         return false;
@@ -724,6 +854,7 @@ bool MediaPlayerPrivateWebM::updateLastVideoFrame()
 
 bool MediaPlayerPrivateWebM::updateLastImage()
 {
+    assertIsMainThread();
     if (m_isGatheringVideoFrameMetadata) {
         auto metrics = m_renderer->videoPlaybackQualityMetrics();
         auto sampleCount = metrics ? metrics->displayCompositedVideoFrames : 0;
@@ -737,16 +868,19 @@ bool MediaPlayerPrivateWebM::updateLastImage()
 
 void MediaPlayerPrivateWebM::paint(GraphicsContext& context, const FloatRect& rect)
 {
+    assertIsMainThread();
     paintCurrentFrameInContext(context, rect);
 }
 
 void MediaPlayerPrivateWebM::paintCurrentFrameInContext(GraphicsContext& context, const FloatRect& outputRect)
 {
+    assertIsMainThread();
     m_renderer->paintCurrentVideoFrameInContext(context, outputRect);
 }
 
 RefPtr<VideoFrame> MediaPlayerPrivateWebM::videoFrameForCurrentTime()
 {
+    assertIsMainThread();
     if (!m_isGatheringVideoFrameMetadata)
         updateLastVideoFrame();
     return m_lastVideoFrame;
@@ -754,6 +888,7 @@ RefPtr<VideoFrame> MediaPlayerPrivateWebM::videoFrameForCurrentTime()
 
 DestinationColorSpace MediaPlayerPrivateWebM::colorSpace()
 {
+    assertIsMainThread();
     updateLastImage();
     RefPtr lastImage = m_lastImage;
     return lastImage ? lastImage->colorSpace() : DestinationColorSpace::SRGB();
@@ -761,11 +896,13 @@ DestinationColorSpace MediaPlayerPrivateWebM::colorSpace()
 
 Ref<MediaPlayer::BitmapImagePromise> MediaPlayerPrivateWebM::bitmapImageForCurrentTime()
 {
+    assertIsMainThread();
     return m_renderer->currentBitmapImage();
 }
 
 void MediaPlayerPrivateWebM::setNaturalSize(FloatSize size)
 {
+    assertIsMainThread();
     auto oldSize = m_naturalSize;
     m_naturalSize = size;
     if (oldSize != m_naturalSize) {
@@ -777,6 +914,7 @@ void MediaPlayerPrivateWebM::setNaturalSize(FloatSize size)
 
 void MediaPlayerPrivateWebM::effectiveRateChanged()
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER, effectiveRate());
     if (RefPtr player = m_player.get())
         player->rateChanged();
@@ -784,6 +922,7 @@ void MediaPlayerPrivateWebM::effectiveRateChanged()
 
 void MediaPlayerPrivateWebM::setHasAudio(bool hasAudio)
 {
+    assertIsCurrent(runningQueue());
     if (hasAudio == m_hasAudio)
         return;
 
@@ -793,6 +932,7 @@ void MediaPlayerPrivateWebM::setHasAudio(bool hasAudio)
 
 void MediaPlayerPrivateWebM::setHasVideo(bool hasVideo)
 {
+    assertIsCurrent(runningQueue());
     if (hasVideo == m_hasVideo)
         return;
 
@@ -802,6 +942,7 @@ void MediaPlayerPrivateWebM::setHasVideo(bool hasVideo)
 
 void MediaPlayerPrivateWebM::setHasAvailableVideoFrame(bool hasAvailableVideoFrame)
 {
+    assertIsMainThread();
     if (m_hasAvailableVideoFrame == hasAvailableVideoFrame)
         return;
 
@@ -829,6 +970,7 @@ void MediaPlayerPrivateWebM::setHasAvailableVideoFrame(bool hasAvailableVideoFra
 
 void MediaPlayerPrivateWebM::setDuration(MediaTime duration)
 {
+    assertIsCurrent(runningQueue());
     if (duration == m_duration)
         return;
 
@@ -843,8 +985,14 @@ void MediaPlayerPrivateWebM::setDuration(MediaTime duration)
     });
 
     m_duration = WTF::move(duration);
-    if (RefPtr player = m_player.get())
-        player->durationChanged();
+    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }, durationCopy = m_duration] {
+        assertIsMainThread();
+        if (RefPtr protectedThis = weakThis.get()) {
+            protectedThis->m_durationMainThread = durationCopy;
+            if (RefPtr player = protectedThis->m_player.get())
+                player->durationChanged();
+        }
+    });
 
     if (m_readyState < MediaPlayerReadyState::HaveMetadata)
         return;
@@ -859,12 +1007,17 @@ void MediaPlayerPrivateWebM::setNetworkState(MediaPlayer::NetworkState state)
 
     ALWAYS_LOG(LOGIDENTIFIER, state);
     m_networkState = state;
-    if (RefPtr player = m_player.get())
-        player->networkStateChanged();
+    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get()) {
+            if (RefPtr player = protectedThis->m_player.get())
+                player->networkStateChanged();
+        }
+    });
 }
 
 void MediaPlayerPrivateWebM::setReadyState(MediaPlayer::ReadyState state)
 {
+    assertIsMainThread();
     if (state == m_readyState)
         return;
 
@@ -882,19 +1035,27 @@ void MediaPlayerPrivateWebM::setReadyState(MediaPlayer::ReadyState state)
 
 void MediaPlayerPrivateWebM::characteristicsChanged()
 {
-    if (RefPtr player = m_player.get())
-        player->characteristicChanged();
+    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get()) {
+            if (RefPtr player = protectedThis->m_player.get())
+                player->characteristicChanged();
+        }
+    });
 }
 
 void MediaPlayerPrivateWebM::errorOccurred()
 {
     m_errored = true;
     setNetworkState(MediaPlayer::NetworkState::DecodeError);
-    setReadyState(MediaPlayer::ReadyState::HaveNothing);
+    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->setReadyState(MediaPlayer::ReadyState::HaveNothing);
+    });
 }
 
 void MediaPlayerPrivateWebM::setPreservesPitch(bool preservesPitch)
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER, preservesPitch);
     if (RefPtr player = m_player.get())
         m_renderer->setPreservesPitchAndCorrectionAlgorithm(preservesPitch, player->pitchCorrectionAlgorithm());
@@ -902,37 +1063,44 @@ void MediaPlayerPrivateWebM::setPreservesPitch(bool preservesPitch)
 
 void MediaPlayerPrivateWebM::setPresentationSize(const IntSize& newSize)
 {
+    assertIsMainThread();
     m_renderer->setPresentationSize(newSize);
 }
 
 void MediaPlayerPrivateWebM::acceleratedRenderingStateChanged()
 {
+    assertIsMainThread();
     RefPtr player = m_player.get();
     m_renderer->renderingCanBeAcceleratedChanged(player ? player->renderingCanBeAccelerated() : false);
 }
 
 RetainPtr<PlatformLayer> MediaPlayerPrivateWebM::createVideoFullscreenLayer()
 {
+    assertIsMainThread();
     return adoptNS([[CALayer alloc] init]);
 }
 
 void MediaPlayerPrivateWebM::setVideoFullscreenLayer(PlatformLayer *videoFullscreenLayer, WTF::Function<void()>&& completionHandler)
 {
+    assertIsMainThread();
     m_renderer->setVideoFullscreenLayer(videoFullscreenLayer, WTF::move(completionHandler));
 }
 
 void MediaPlayerPrivateWebM::setVideoFullscreenFrame(const FloatRect& frame)
 {
+    assertIsMainThread();
     m_renderer->setVideoFullscreenFrame(frame);
 }
 
 void MediaPlayerPrivateWebM::syncTextTrackBounds()
 {
+    assertIsMainThread();
     m_renderer->syncTextTrackBounds();
 }
 
 void MediaPlayerPrivateWebM::setTextTrackRepresentation(TextTrackRepresentation* representation)
 {
+    assertIsMainThread();
     m_renderer->setTextTrackRepresentation(representation);
 }
 
@@ -945,12 +1113,14 @@ String MediaPlayerPrivateWebM::engineDescription() const
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 void MediaPlayerPrivateWebM::setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&& target)
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER);
     m_playbackTarget = WTF::move(target);
 }
 
 void MediaPlayerPrivateWebM::setShouldPlayToPlaybackTarget(bool shouldPlayToTarget)
 {
+    assertIsMainThread();
     if (shouldPlayToTarget == m_shouldPlayToTarget)
         return;
 
@@ -963,6 +1133,7 @@ void MediaPlayerPrivateWebM::setShouldPlayToPlaybackTarget(bool shouldPlayToTarg
 
 bool MediaPlayerPrivateWebM::isCurrentPlaybackTargetWireless() const
 {
+    assertIsMainThread();
     RefPtr playbackTarget = m_playbackTarget;
     if (!playbackTarget)
         return false;
@@ -975,6 +1146,7 @@ bool MediaPlayerPrivateWebM::isCurrentPlaybackTargetWireless() const
 
 void MediaPlayerPrivateWebM::enqueueSample(Ref<MediaSample>&& sample, TrackID trackId)
 {
+    assertIsCurrent(runningQueue());
     auto logSiteIdentifier = LOGIDENTIFIER;
     DEBUG_LOG(logSiteIdentifier, "track ID = ", trackId, ", sample = ", sample.get());
 
@@ -1009,14 +1181,19 @@ void MediaPlayerPrivateWebM::enqueueSample(Ref<MediaSample>&& sample, TrackID tr
         return;
     }
 
-    if (m_readyState < MediaPlayer::ReadyState::HaveEnoughData && !m_enabledVideoTrackID)
-        setReadyState(MediaPlayer::ReadyState::HaveEnoughData);
+    if (m_readyState < MediaPlayer::ReadyState::HaveEnoughData && !m_enabledVideoTrackID) {
+        ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->setReadyState(MediaPlayer::ReadyState::HaveEnoughData);
+        });
+    }
 
     m_renderer->enqueueSample(trackIdentifierFor(trackId), WTF::move(sample));
 }
 
 void MediaPlayerPrivateWebM::reenqueSamples(TrackID trackId, NeedsFlush needsFlush)
 {
+    assertIsCurrent(runningQueue());
     auto it = m_trackBufferMap.find(trackId);
     if (it == m_trackBufferMap.end())
         return;
@@ -1027,6 +1204,7 @@ void MediaPlayerPrivateWebM::reenqueSamples(TrackID trackId, NeedsFlush needsFlu
 
 void MediaPlayerPrivateWebM::reenqueueMediaForTime(const MediaTime& time)
 {
+    assertIsCurrent(runningQueue());
     for (auto& trackBufferPair : m_trackBufferMap) {
         TrackBuffer& trackBuffer = trackBufferPair.second;
         auto trackId = trackBufferPair.first;
@@ -1036,6 +1214,7 @@ void MediaPlayerPrivateWebM::reenqueueMediaForTime(const MediaTime& time)
 
 void MediaPlayerPrivateWebM::reenqueueMediaForTime(TrackBuffer& trackBuffer, TrackID trackId, const MediaTime& time, NeedsFlush needsFlush)
 {
+    assertIsCurrent(runningQueue());
     if (needsFlush == NeedsFlush::Yes)
         m_renderer->flushTrack(trackIdentifierFor(trackId));
 
@@ -1045,6 +1224,7 @@ void MediaPlayerPrivateWebM::reenqueueMediaForTime(TrackBuffer& trackBuffer, Tra
 
 void MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples(TrackID trackId)
 {
+    assertIsCurrent(runningQueue());
     if (m_requestReadyForMoreSamplesSetMap[trackId])
         return;
     m_requestReadyForMoreSamplesSetMap[trackId] = true;
@@ -1052,7 +1232,7 @@ void MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples(TrackID trackId
     auto trackIdentifier = maybeTrackIdentifierFor(trackId);
     if (!trackIdentifier)
         return; // track hasn't been enabled yet.
-    m_renderer->requestMediaDataWhenReady(*trackIdentifier)->whenSettled(RunLoop::mainSingleton(), [weakThis = ThreadSafeWeakPtr { *this }, trackId](auto&& result) {
+    m_renderer->requestMediaDataWhenReady(*trackIdentifier)->whenSettled(m_runningQueue, [weakThis = ThreadSafeWeakPtr { *this }, trackId](auto&& result) {
         if (RefPtr protectedThis = weakThis.get(); protectedThis && result)
             protectedThis->didBecomeReadyForMoreSamples(trackId);
     });
@@ -1060,12 +1240,14 @@ void MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples(TrackID trackId
 
 bool MediaPlayerPrivateWebM::isReadyForMoreSamples(TrackID trackId)
 {
+    assertIsCurrent(runningQueue());
     auto trackIdentifier = maybeTrackIdentifierFor(trackId);
     return trackIdentifier && m_renderer->isReadyForMoreSamples(*trackIdentifier);
 }
 
 void MediaPlayerPrivateWebM::didBecomeReadyForMoreSamples(TrackID trackId)
 {
+    assertIsCurrent(runningQueue());
     INFO_LOG(LOGIDENTIFIER, trackId);
 
     m_requestReadyForMoreSamplesSetMap[trackId] = false;
@@ -1075,31 +1257,30 @@ void MediaPlayerPrivateWebM::didBecomeReadyForMoreSamples(TrackID trackId)
 
 void MediaPlayerPrivateWebM::appendCompleted(bool success)
 {
-    assertIsMainThread();
+    assertIsCurrent(runningQueue());
 
     ASSERT(m_pendingAppends > 0);
     m_pendingAppends--;
     INFO_LOG(LOGIDENTIFIER, "pending appends = ", m_pendingAppends, " success = ", success);
     setLoadingProgresssed(true);
-    m_errored |= !success;
+    m_errored = m_errored || !success;
     if (!m_errored)
         updateBufferedFromTrackBuffers(m_loadFinished && !m_pendingAppends);
-
-    if (m_waitForTimeBufferedPromise && m_buffered.containWithEpsilon(m_lastSeekTime, timeFudgeFactor())) {
-        ALWAYS_LOG(LOGIDENTIFIER, "can continue seeking data is now buffered");
-        m_waitForTimeBufferedPromise->resolve();
-        m_waitForTimeBufferedPromise.reset();
-    }
+    resolveWaitForTimeBufferedPromiseIfPossible();
     maybeFinishLoading();
 }
 
 void MediaPlayerPrivateWebM::maybeFinishLoading()
 {
+    assertIsCurrent(runningQueue());
     if (m_loadFinished && !m_pendingAppends) {
         if (!m_hasVideo && !m_hasAudio) {
             ERROR_LOG(LOGIDENTIFIER, "could not load audio or video tracks");
             setNetworkState(MediaPlayer::NetworkState::FormatError);
-            setReadyState(MediaPlayer::ReadyState::HaveNothing);
+            ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+                if (RefPtr protectedThis = weakThis.get())
+                    protectedThis->setReadyState(MediaPlayer::ReadyState::HaveNothing);
+            });
             return;
         }
         if (m_errored) {
@@ -1115,12 +1296,14 @@ void MediaPlayerPrivateWebM::maybeFinishLoading()
 
 void MediaPlayerPrivateWebM::provideMediaData(TrackID trackId)
 {
+    assertIsCurrent(runningQueue());
     if (auto it = m_trackBufferMap.find(trackId); it != m_trackBufferMap.end())
         provideMediaData(it->second, trackId);
 }
 
 void MediaPlayerPrivateWebM::provideMediaData(TrackBuffer& trackBuffer, TrackID trackId)
 {
+    assertIsCurrent(runningQueue());
     if (m_errored)
         return;
 
@@ -1150,6 +1333,7 @@ void MediaPlayerPrivateWebM::provideMediaData(TrackBuffer& trackBuffer, TrackID 
 
 void MediaPlayerPrivateWebM::trackDidChangeSelected(VideoTrackPrivate& track, bool selected)
 {
+    assertIsCurrent(runningQueue());
     auto trackId = track.id();
 
     if (!m_trackBufferMap.contains(trackId))
@@ -1181,6 +1365,7 @@ void MediaPlayerPrivateWebM::trackDidChangeSelected(VideoTrackPrivate& track, bo
 
 void MediaPlayerPrivateWebM::trackDidChangeEnabled(AudioTrackPrivate& track, bool enabled)
 {
+    assertIsCurrent(runningQueue());
     auto trackId = track.id();
 
     if (!m_trackBufferMap.contains(trackId))
@@ -1201,10 +1386,12 @@ void MediaPlayerPrivateWebM::trackDidChangeEnabled(AudioTrackPrivate& track, boo
             characteristicsChanged();
         }
         m_renderer->notifyTrackNeedsReenqueuing(*trackIdentifier, [weakThis = ThreadSafeWeakPtr { *this }, trackId](TrackIdentifier, const MediaTime&) {
-            ensureOnMainThread([weakThis, trackId] {
-                if (RefPtr protectedThis = weakThis.get())
-                    protectedThis->reenqueSamples(trackId, NeedsFlush::No);
-            });
+            if (RefPtr protectedThis = weakThis.get()) {
+                protectedThis->ensureOnRunningQueue([weakThis, trackId] {
+                    if (RefPtr protectedThis = weakThis.get())
+                        protectedThis->reenqueSamples(trackId, NeedsFlush::No);
+                });
+            }
         });
         return;
     }
@@ -1216,14 +1403,18 @@ void MediaPlayerPrivateWebM::trackDidChangeEnabled(AudioTrackPrivate& track, boo
 
 void MediaPlayerPrivateWebM::didParseInitializationData(InitializationSegment&& segment)
 {
+    assertIsCurrent(runningQueue());
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    if (m_preload == MediaPlayer::Preload::MetaData && !m_loadFinished)
-        cancelLoad();
+    if (m_preload == MediaPlayer::Preload::MetaData && !m_loadFinished) {
+        ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->cancelLoad();
+        });
+    }
 
     clearTracks();
 
-    RefPtr player = m_player.get();
     for (auto videoTrackInfo : segment.videoTracks) {
         if (videoTrackInfo.track) {
             // FIXME: Use downcast instead.
@@ -1241,25 +1432,31 @@ void MediaPlayerPrivateWebM::didParseInitializationData(InitializationSegment&& 
                 if (!protectedThis)
                     return;
 
-                auto videoTrackSelectedChanged = [weakThis, trackRef = Ref { track }, selected] {
-                    if (RefPtr protectedThis = weakThis.get())
-                        protectedThis->trackDidChangeSelected(trackRef, selected);
-                };
-
                 if (!protectedThis->m_processingInitializationSegment) {
-                    videoTrackSelectedChanged();
+                    protectedThis->ensureOnRunningQueue([weakThis, trackRef = Ref { track }, selected] {
+                        if (RefPtr protectedThis = weakThis.get())
+                            protectedThis->trackDidChangeSelected(trackRef, selected);
+                    });
                     return;
                 }
             });
 
             if (m_videoTracks.isEmpty()) {
-                setNaturalSize({ float(track->width()), float(track->height()) });
+                FloatSize size { float(track->width()), float(track->height()) };
+                ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }, size] {
+                    if (RefPtr protectedThis = weakThis.get())
+                        protectedThis->setNaturalSize(size);
+                });
                 track->setSelected(true);
             }
 
             m_videoTracks.append(track);
-            if (player)
-                player->addVideoTrack(*track);
+            ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }, trackRef = Ref { *track }] {
+                if (RefPtr protectedThis = weakThis.get()) {
+                    if (RefPtr player = protectedThis->m_player.get())
+                        player->addVideoTrack(trackRef.get());
+                }
+            });
         }
     }
 
@@ -1274,13 +1471,11 @@ void MediaPlayerPrivateWebM::didParseInitializationData(InitializationSegment&& 
                 if (!protectedThis)
                     return;
 
-                auto audioTrackEnabledChanged = [weakThis, trackRef = Ref { track }, enabled] {
-                    if (RefPtr protectedThis = weakThis.get())
-                        protectedThis->trackDidChangeEnabled(trackRef, enabled);
-                };
-
                 if (!protectedThis->m_processingInitializationSegment) {
-                    audioTrackEnabledChanged();
+                    protectedThis->ensureOnRunningQueue([weakThis, trackRef = Ref { track }, enabled] {
+                        if (RefPtr protectedThis = weakThis.get())
+                            protectedThis->trackDidChangeEnabled(trackRef, enabled);
+                    });
                     return;
                 }
             });
@@ -1289,19 +1484,27 @@ void MediaPlayerPrivateWebM::didParseInitializationData(InitializationSegment&& 
                 track->setEnabled(true);
 
             m_audioTracks.append(track);
-            if (player)
-                player->addAudioTrack(*track);
+            ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }, trackRef = Ref { *track }] {
+                if (RefPtr protectedThis = weakThis.get()) {
+                    if (RefPtr player = protectedThis->m_player.get())
+                        player->addAudioTrack(trackRef.get());
+                }
+            });
         }
     }
 
     if (segment.duration.isValid())
         setDuration(WTF::move(segment.duration));
 
-    setReadyState(MediaPlayer::ReadyState::HaveMetadata);
+    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->setReadyState(MediaPlayer::ReadyState::HaveMetadata);
+    });
 }
 
 void MediaPlayerPrivateWebM::didProvideMediaDataForTrackId(Ref<MediaSampleAVFObjC>&& sample, TrackID trackId, const String& mediaType)
 {
+    assertIsCurrent(runningQueue());
     UNUSED_PARAM(mediaType);
 
     auto it = m_trackBufferMap.find(trackId);
@@ -1310,6 +1513,15 @@ void MediaPlayerPrivateWebM::didProvideMediaDataForTrackId(Ref<MediaSampleAVFObj
     TrackBuffer& trackBuffer = it->second;
 
     trackBuffer.addSample(sample);
+
+    // appendCompleted() fires only once per network buffer, so if the file is delivered in large
+    // chunks (or a single chunk), the seek promise would not be checked until all samples in that
+    // chunk are demuxed. Instead, check eagerly here: if this track's buffered range now covers
+    // the seek time, recompute the full intersection and potentially resolve the promise early.
+    if (m_waitForTimeBufferedPromise && trackBuffer.buffered().containWithEpsilon(m_lastSeekTime, timeFudgeFactor())) {
+        updateBufferedFromTrackBuffers(false);
+        resolveWaitForTimeBufferedPromiseIfPossible();
+    }
 
     if (m_preload <= MediaPlayer::Preload::MetaData) {
         m_readyForMoreSamplesMap[trackId] = true;
@@ -1322,13 +1534,18 @@ void MediaPlayerPrivateWebM::didProvideMediaDataForTrackId(Ref<MediaSampleAVFObj
 
 void MediaPlayerPrivateWebM::flush()
 {
+    assertIsCurrent(runningQueue());
     m_renderer->flush();
-    setHasAvailableVideoFrame(false);
+    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->setHasAvailableVideoFrame(false);
+    });
     setAllTracksForReenqueuing();
 }
 
 void MediaPlayerPrivateWebM::setAllTracksForReenqueuing()
 {
+    assertIsCurrent(runningQueue());
     for (auto& trackBufferPair : m_trackBufferMap) {
         TrackBuffer& trackBuffer = trackBufferPair.second;
         trackBuffer.setNeedsReenqueueing(true);
@@ -1337,6 +1554,7 @@ void MediaPlayerPrivateWebM::setAllTracksForReenqueuing()
 
 void MediaPlayerPrivateWebM::setTrackForReenqueuing(TrackID trackId)
 {
+    assertIsCurrent(runningQueue());
     if (auto it = m_trackBufferMap.find(trackId); it != m_trackBufferMap.end()) {
         TrackBuffer& trackBuffer = it->second;
         trackBuffer.setNeedsReenqueueing(true);
@@ -1345,6 +1563,7 @@ void MediaPlayerPrivateWebM::setTrackForReenqueuing(TrackID trackId)
 
 void MediaPlayerPrivateWebM::flushVideoIfNeeded()
 {
+    assertIsCurrent(runningQueue());
     ALWAYS_LOG(LOGIDENTIFIER, "layerRequiresFlush: ", m_layerRequiresFlush);
     if (!m_layerRequiresFlush)
         return;
@@ -1357,6 +1576,7 @@ void MediaPlayerPrivateWebM::flushVideoIfNeeded()
 
 void MediaPlayerPrivateWebM::addTrackBuffer(TrackID trackId, RefPtr<MediaDescription>&& description)
 {
+    assertIsCurrent(runningQueue());
     ASSERT(!m_trackBufferMap.contains(trackId));
 
     setHasAudio(m_hasAudio || description->isAudio());
@@ -1368,26 +1588,34 @@ void MediaPlayerPrivateWebM::addTrackBuffer(TrackID trackId, RefPtr<MediaDescrip
     m_requestReadyForMoreSamplesSetMap[trackId] = false;
 }
 
-void MediaPlayerPrivateWebM::clearTracks()
+void MediaPlayerPrivateWebM::clearTracks() WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
-    RefPtr player = m_player.get();
     for (auto& track : m_videoTracks) {
         track->setSelectedChangedCallback(nullptr);
-        if (player)
-            player->removeVideoTrack(*track);
+        ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }, trackRef = Ref { *track }] {
+            if (RefPtr protectedThis = weakThis.get()) {
+                if (RefPtr player = protectedThis->m_player.get())
+                    player->removeVideoTrack(trackRef.get());
+            }
+        });
     }
     m_videoTracks.clear();
 
     for (auto& track : m_audioTracks) {
         track->setEnabledChangedCallback(nullptr);
-        if (player)
-            player->removeAudioTrack(*track);
+        ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }, trackRef = Ref { *track }] {
+            if (RefPtr protectedThis = weakThis.get()) {
+                if (RefPtr player = protectedThis->m_player.get())
+                    player->removeAudioTrack(trackRef.get());
+            }
+        });
     }
     m_audioTracks.clear();
 }
 
 void MediaPlayerPrivateWebM::startVideoFrameMetadataGathering()
 {
+    assertIsMainThread();
     m_isGatheringVideoFrameMetadata = true;
     m_renderer->notifyWhenHasAvailableVideoFrame([weakThis = ThreadSafeWeakPtr { *this }](const MediaTime& presentationTime, double displayTime) {
         ensureOnMainThread([weakThis, presentationTime, displayTime] {
@@ -1399,6 +1627,7 @@ void MediaPlayerPrivateWebM::startVideoFrameMetadataGathering()
 
 void MediaPlayerPrivateWebM::stopVideoFrameMetadataGathering()
 {
+    assertIsMainThread();
     m_isGatheringVideoFrameMetadata = false;
     m_videoFrameMetadata = { };
     m_renderer->notifyWhenHasAvailableVideoFrame(nullptr);
@@ -1406,6 +1635,7 @@ void MediaPlayerPrivateWebM::stopVideoFrameMetadataGathering()
 
 void MediaPlayerPrivateWebM::checkNewVideoFrameMetadata(const MediaTime& presentationTime, double displayTime)
 {
+    assertIsMainThread();
     RefPtr player = m_player.get();
     if (!player)
         return;
@@ -1436,6 +1666,7 @@ void MediaPlayerPrivateWebM::checkNewVideoFrameMetadata(const MediaTime& present
 
 void MediaPlayerPrivateWebM::setResourceOwner(const ProcessIdentity& resourceOwner)
 {
+    assertIsMainThread();
     m_renderer->setResourceOwner(resourceOwner);
 }
 
@@ -1486,42 +1717,50 @@ bool MediaPlayerPrivateWebM::isAvailable()
 
 bool MediaPlayerPrivateWebM::isEnabledVideoTrackID(TrackID trackID) const
 {
+    assertIsCurrent(runningQueue());
     return m_enabledVideoTrackID && *m_enabledVideoTrackID == trackID;
 }
 
 bool MediaPlayerPrivateWebM::hasSelectedVideo() const
 {
+    assertIsCurrent(runningQueue());
     return !!m_enabledVideoTrackID;
 }
 
 void MediaPlayerPrivateWebM::setShouldDisableHDR(bool shouldDisable)
 {
+    assertIsMainThread();
     m_renderer->setShouldDisableHDR(shouldDisable);
 }
 
 void MediaPlayerPrivateWebM::setPlatformDynamicRangeLimit(PlatformDynamicRangeLimit platformDynamicRangeLimit)
 {
+    assertIsMainThread();
     m_renderer->setPlatformDynamicRangeLimit(platformDynamicRangeLimit);
 }
 
 void MediaPlayerPrivateWebM::playerContentBoxRectChanged(const LayoutRect& newRect)
 {
+    assertIsMainThread();
     m_renderer->contentBoxRectChanged(newRect);
 }
 
 void MediaPlayerPrivateWebM::setShouldMaintainAspectRatio(bool shouldMaintainAspectRatio)
 {
+    assertIsMainThread();
     m_renderer->setShouldMaintainAspectRatio(shouldMaintainAspectRatio);
 }
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
 String MediaPlayerPrivateWebM::defaultSpatialTrackingLabel() const
 {
+    assertIsMainThread();
     return m_defaultSpatialTrackingLabel;
 }
 
 void MediaPlayerPrivateWebM::setDefaultSpatialTrackingLabel(const String& defaultSpatialTrackingLabel)
 {
+    assertIsMainThread();
     if (m_defaultSpatialTrackingLabel == defaultSpatialTrackingLabel)
         return;
     m_defaultSpatialTrackingLabel = defaultSpatialTrackingLabel;
@@ -1530,11 +1769,13 @@ void MediaPlayerPrivateWebM::setDefaultSpatialTrackingLabel(const String& defaul
 
 String MediaPlayerPrivateWebM::spatialTrackingLabel() const
 {
+    assertIsMainThread();
     return m_spatialTrackingLabel;
 }
 
 void MediaPlayerPrivateWebM::setSpatialTrackingLabel(const String& spatialTrackingLabel)
 {
+    assertIsMainThread();
     if (m_spatialTrackingLabel == spatialTrackingLabel)
         return;
     m_spatialTrackingLabel = spatialTrackingLabel;
@@ -1543,6 +1784,7 @@ void MediaPlayerPrivateWebM::setSpatialTrackingLabel(const String& spatialTracki
 
 void MediaPlayerPrivateWebM::updateSpatialTrackingLabel()
 {
+    assertIsMainThread();
 #if HAVE(SPATIAL_AUDIO_EXPERIENCE)
     RefPtr player = m_player.get();
     m_renderer->setSpatialTrackingInfo(player && player->prefersSpatialAudioExperience(), player ? player->soundStageSize() : MediaPlayer::SoundStageSize::Auto, player ? player->sceneIdentifier() : emptyString(), m_defaultSpatialTrackingLabel, m_spatialTrackingLabel);
@@ -1555,6 +1797,7 @@ void MediaPlayerPrivateWebM::updateSpatialTrackingLabel()
 #if ENABLE(LINEAR_MEDIA_PLAYER)
 void MediaPlayerPrivateWebM::setVideoTarget(const PlatformVideoTarget& videoTarget)
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER, !!videoTarget);
     m_renderer->setVideoTarget(videoTarget);
 }
@@ -1563,6 +1806,7 @@ void MediaPlayerPrivateWebM::setVideoTarget(const PlatformVideoTarget& videoTarg
 #if PLATFORM(IOS_FAMILY)
 void MediaPlayerPrivateWebM::sceneIdentifierDidChange()
 {
+    assertIsMainThread();
 #if HAVE(SPATIAL_TRACKING_LABEL)
     updateSpatialTrackingLabel();
 #endif
@@ -1570,6 +1814,7 @@ void MediaPlayerPrivateWebM::sceneIdentifierDidChange()
 
 void MediaPlayerPrivateWebM::applicationWillResignActive()
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER);
     m_renderer->applicationWillResignActive();
     m_applicationIsActive = false;
@@ -1577,19 +1822,25 @@ void MediaPlayerPrivateWebM::applicationWillResignActive()
 
 void MediaPlayerPrivateWebM::applicationDidBecomeActive()
 {
+    assertIsMainThread();
     ALWAYS_LOG(LOGIDENTIFIER);
     m_applicationIsActive = true;
-    flushVideoIfNeeded();
+    ensureOnRunningQueue([weakThis = ThreadSafeWeakPtr { *this }] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->flushVideoIfNeeded();
+    });
 }
 #endif
 
 void MediaPlayerPrivateWebM::isInFullscreenOrPictureInPictureChanged(bool isInFullscreenOrPictureInPicture)
 {
+    assertIsMainThread();
     m_renderer->isInFullscreenOrPictureInPictureChanged(isInFullscreenOrPictureInPicture);
 }
 
 AudioVideoRenderer::TrackIdentifier MediaPlayerPrivateWebM::trackIdentifierFor(TrackID trackID) const
 {
+    assertIsCurrent(runningQueue());
     auto it = m_trackIdentifiers.find(trackID);
     ASSERT(it != m_trackIdentifiers.end());
     return it->second;
@@ -1597,6 +1848,7 @@ AudioVideoRenderer::TrackIdentifier MediaPlayerPrivateWebM::trackIdentifierFor(T
 
 std::optional<AudioVideoRenderer::TrackIdentifier> MediaPlayerPrivateWebM::maybeTrackIdentifierFor(TrackID trackID) const
 {
+    assertIsCurrent(runningQueue());
     if (auto it = m_trackIdentifiers.find(trackID); it != m_trackIdentifiers.end())
         return it->second;
     return { };
@@ -1604,41 +1856,57 @@ std::optional<AudioVideoRenderer::TrackIdentifier> MediaPlayerPrivateWebM::maybe
 
 void MediaPlayerPrivateWebM::setLayerRequiresFlush()
 {
+    assertIsCurrent(runningQueue());
     ALWAYS_LOG(LOGIDENTIFIER);
     m_layerRequiresFlush = true;
 #if PLATFORM(IOS_FAMILY)
-    if (m_applicationIsActive)
-        flushVideoIfNeeded();
-#else
-    flushVideoIfNeeded();
+    if (!m_applicationIsActive)
+        return;
 #endif
+    flushVideoIfNeeded();
 }
 
 std::optional<VideoPlaybackQualityMetrics> MediaPlayerPrivateWebM::videoPlaybackQualityMetrics()
 {
+    assertIsMainThread();
     return m_renderer->videoPlaybackQualityMetrics();
 }
 
 WebCore::HostingContext MediaPlayerPrivateWebM::hostingContext() const
 {
+    assertIsMainThread();
     return m_renderer->hostingContext();
 }
 
 void MediaPlayerPrivateWebM::setVideoLayerSizeFenced(const WebCore::FloatSize& size, WTF::MachSendRightAnnotated&& sendRightAnnotated)
 {
+    assertIsMainThread();
     m_renderer->setVideoLayerSizeFenced(size, WTF::move(sendRightAnnotated));
 }
 
 void MediaPlayerPrivateWebM::monitorReadyState()
 {
+    assertIsCurrent(runningQueue());
     if (!m_buffered.length())
         return;
     // If we have data up to 3s ahead, we can assume that we can play without interruption.
     constexpr double kHaveEnoughDataThreshold = 3;
     auto currentTime = this->currentTime();
-    MediaTime aheadTime = std::min(duration(), currentTime + MediaTime::createWithDouble(kHaveEnoughDataThreshold));
+    MediaTime aheadTime = std::min(durationOnRunningQueue(), currentTime + MediaTime::createWithDouble(kHaveEnoughDataThreshold));
     PlatformTimeRanges neededBufferedRange { currentTime, std::max(currentTime, aheadTime) };
-    setReadyState(m_buffered.containWithEpsilon(neededBufferedRange, MediaTime(2002, 24000)) ? MediaPlayer::ReadyState::HaveEnoughData : MediaPlayer::ReadyState::HaveFutureData);
+    auto newState = m_buffered.containWithEpsilon(neededBufferedRange, MediaTime(2002, 24000)) ? MediaPlayer::ReadyState::HaveEnoughData : MediaPlayer::ReadyState::HaveFutureData;
+    ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }, newState] {
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->setReadyState(newState);
+    });
+}
+
+void MediaPlayerPrivateWebM::ensureOnRunningQueue(Function<void()>&& function)
+{
+    if (runningQueue().isCurrent())
+        function();
+    else
+        runningQueue().dispatch(WTF::move(function));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -611,13 +611,9 @@ Status WebMParser::OnElementBegin(const ElementMetadata& metadata, Action* actio
 
     if ((m_state == State::None && metadata.id != Id::kEbml && metadata.id != Id::kSegment)
         || (m_state == State::ReadingSegment && metadata.id != Id::kInfo && metadata.id != Id::kTracks && metadata.id != Id::kCluster)) {
-        INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, "state(", m_state, "), id(", metadata.id, "), position(", metadata.position, "), headerSize(", metadata.header_size, "), size(", metadata.size, "), skipping");
-
         *action = Action::kSkip;
         return Status(Status::kOkCompleted);
     }
-
-    auto oldState = m_state;
 
     if (metadata.id == Id::kEbml)
         m_state = State::ReadingEbml;
@@ -631,8 +627,6 @@ Status WebMParser::OnElementBegin(const ElementMetadata& metadata, Action* actio
         m_state = State::ReadingTrack;
     else if (metadata.id == Id::kCluster)
         m_state = State::ReadingCluster;
-
-    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, "state(", oldState, "->", m_state, "), id(", metadata.id, "), position(", metadata.position, "), headerSize(", metadata.header_size, "), size(", metadata.size, ")");
 
     // Apply some sanity check; libwebm::StringParser will read the content into a std::string and ByteParser into a std::vector
     std::optional<size_t> maxElementSizeAllowed;
@@ -672,18 +666,12 @@ Status WebMParser::OnElementBegin(const ElementMetadata& metadata, Action* actio
 
 Status WebMParser::OnElementEnd(const ElementMetadata& metadata)
 {
-    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-
-    auto oldState = m_state;
-
     if (metadata.id == Id::kEbml || metadata.id == Id::kSegment)
         m_state = State::None;
     else if (metadata.id == Id::kInfo || metadata.id == Id::kTracks || metadata.id == Id::kCluster)
         m_state = State::ReadingSegment;
     else if (metadata.id == Id::kTrackEntry)
         m_state = State::ReadingTracks;
-
-    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, "state(", oldState, "->", m_state, "), id(", metadata.id, "), size(", metadata.size, ")");
 
     if (metadata.id == Id::kTracks) {
         if (!m_keyIds.isEmpty() && !m_callback.canDecrypt()) {
@@ -709,8 +697,6 @@ Status WebMParser::OnElementEnd(const ElementMetadata& metadata)
 
 Status WebMParser::OnEbml(const ElementMetadata&, const Ebml& ebml)
 {
-    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-
     if (ebml.doc_type.is_present() && (ebml.doc_type.value().compare("webm") && ebml.doc_type.value().compare("matroska")))
         return Status(Status::Code(ErrorCode::InvalidDocType));
 
@@ -732,8 +718,6 @@ Status WebMParser::OnEbml(const ElementMetadata&, const Ebml& ebml)
 
 Status WebMParser::OnSegmentBegin(const ElementMetadata&, Action* action)
 {
-    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-
     if (!m_initializationSegmentEncountered) {
         ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "Encountered Segment before Embl");
         return Status(Status::Code(ErrorCode::InvalidInitSegment));
@@ -749,8 +733,6 @@ Status WebMParser::OnSegmentBegin(const ElementMetadata&, Action* action)
 
 Status WebMParser::OnInfo(const ElementMetadata&, const Info& info)
 {
-    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-
     if (!m_initializationSegmentEncountered || !m_initializationSegment) {
         ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "Encountered Info outside Segment");
         return Status(Status::Code(ErrorCode::InvalidInitSegment));
@@ -765,8 +747,6 @@ Status WebMParser::OnInfo(const ElementMetadata&, const Info& info)
 
 Status WebMParser::OnClusterBegin(const ElementMetadata&, const Cluster& cluster, Action* action)
 {
-    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-
     ASSERT(action);
     if (!action)
         return Status(Status::kNotEnoughMemory);
@@ -875,8 +855,6 @@ Status WebMParser::OnTrackEntry(const ElementMetadata&, const TrackEntry& trackE
 
 webm::Status WebMParser::OnBlockBegin(const ElementMetadata&, const Block& block, Action* action)
 {
-    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-
     ASSERT(action);
     if (!action)
         return Status(Status::kNotEnoughMemory);
@@ -890,8 +868,6 @@ webm::Status WebMParser::OnBlockBegin(const ElementMetadata&, const Block& block
 
 webm::Status WebMParser::OnBlockEnd(const ElementMetadata&, const Block&)
 {
-    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-
     m_currentBlock = std::nullopt;
 
     return Status(Status::kOkCompleted);
@@ -899,8 +875,6 @@ webm::Status WebMParser::OnBlockEnd(const ElementMetadata&, const Block&)
 
 webm::Status WebMParser::OnSimpleBlockBegin(const ElementMetadata&, const SimpleBlock& block, Action* action)
 {
-    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-
     ASSERT(action);
     if (!action)
         return Status(Status::kNotEnoughMemory);
@@ -915,8 +889,6 @@ webm::Status WebMParser::OnSimpleBlockBegin(const ElementMetadata&, const Simple
 
 webm::Status WebMParser::OnSimpleBlockEnd(const ElementMetadata&, const SimpleBlock&)
 {
-    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-
     m_currentBlock = std::nullopt;
     m_currentDuration = MediaTime::zeroTime();
 
@@ -925,8 +897,6 @@ webm::Status WebMParser::OnSimpleBlockEnd(const ElementMetadata&, const SimpleBl
 
 webm::Status WebMParser::OnBlockGroupBegin(const webm::ElementMetadata&, webm::Action* action)
 {
-    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-
     ASSERT(action);
     if (!action)
         return Status(Status::kNotEnoughMemory);
@@ -956,8 +926,6 @@ webm::Status WebMParser::OnBlockGroupEnd(const webm::ElementMetadata&, const web
         ERROR_LOG_IF_POSSIBLE(LOGIDENTIFIER, "Ignoring unknown track number ", trackNumber);
         return Status(Status::kOkCompleted);
     }
-
-    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER);
 
     if (blockGroup.discard_padding.is_present()
         && trackData->track().track_uid.is_present()


### PR DESCRIPTION
#### 8f635b34ec3090727755ee926b805af8b5b6e4ba
<pre>
Can&apos;t seek in webm while content is loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=309867">https://bugs.webkit.org/show_bug.cgi?id=309867</a>
<a href="https://rdar.apple.com/172473039">rdar://172473039</a>

Reviewed by Youenn Fablet.

We had several issues at play.
1- When the MediaPlayerPrivateWebM runs in the content process, the media parser
would return each individual MediaSample by queueing a task on the main thread
to handle that unique MediaSample. It was pegging the main thread and would delay
the UI process seeking task sent to the video element.
2- When reading a file, where data is provided through a single chunk through
`dataReceived()`, as the buffered range wasn&apos;t updated until all data was demuxed
and all MediaSamples processed, we wouldn&apos;t resolve the m_waitForTimeBufferedPromise until
a possibly extensive period of time had lapsed.
3- Logging in the WebMParser was extensive, generating thousands line of logs
should Media logging was set to `info`. This also prevented, particularly on
debug build, the HTMLMediaElement::seekTask() to run.

1- We now run all media buffering, playback, seeking and feeding data to the AudioVideoRenderer
on the same queue used by the SourceBufferParserWebM when the AudioVideoRendererRemote is in use.
We avoid dispatching one task per sample, and instead immediately append them to their respective
TrackBuffer.
2- We now check eagerly if the track&apos;s buffered range now covers the seek time,
recompute the full intersection and potentially resolve the promise early.
3- We remove most logging from the WebMParser. The WebMParser has been mature
for a long time now and the logging has become unnecessary.

Manually tested, CPU usage in the content process while the media is being demuxed
has dropped to a couple of % instead of 100+% before. File can be seeked into
almost immediately even in debug builds.

Covered by existing tests.

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.h:
(WebCore::MediaPlayerPrivateWebM::WTF_GUARDED_BY_CAPABILITY):
(WebCore::MediaPlayerPrivateWebM::runningQueue const):
* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::MediaPlayerPrivateWebM):
(WebCore::MediaPlayerPrivateWebM::setPreload):
(WebCore::MediaPlayerPrivateWebM::doPreload):
(WebCore::MediaPlayerPrivateWebM::load):
(WebCore::MediaPlayerPrivateWebM::needsResourceClient const):
(WebCore::MediaPlayerPrivateWebM::createResourceClientIfNeeded):
(WebCore::MediaPlayerPrivateWebM::dataLengthReceived):
(WebCore::MediaPlayerPrivateWebM::dataReceived):
(WebCore::MediaPlayerPrivateWebM::loadFinished):
(WebCore::MediaPlayerPrivateWebM::cancelLoad):
(WebCore::MediaPlayerPrivateWebM::prepareToPlay):
(WebCore::MediaPlayerPrivateWebM::play):
(WebCore::MediaPlayerPrivateWebM::pause):
(WebCore::MediaPlayerPrivateWebM::playAtHostTime):
(WebCore::MediaPlayerPrivateWebM::pauseAtHostTime):
(WebCore::MediaPlayerPrivateWebM::playInternal):
(WebCore::MediaPlayerPrivateWebM::performTaskAtTime):
(WebCore::MediaPlayerPrivateWebM::audioOutputDeviceChanged):
(WebCore::MediaPlayerPrivateWebM::setPageIsVisible):
(WebCore::MediaPlayerPrivateWebM::duration const):
(WebCore::MediaPlayerPrivateWebM::durationOnRunningQueue const):
(WebCore::MediaPlayerPrivateWebM::naturalSize const):
(WebCore::MediaPlayerPrivateWebM::rate const):
(WebCore::MediaPlayerPrivateWebM::hasAvailableVideoFrame const):
(WebCore::MediaPlayerPrivateWebM::videoFrameMetadata):
(WebCore::MediaPlayerPrivateWebM::seekToTarget):
(WebCore::MediaPlayerPrivateWebM::seekInternal):
(WebCore::MediaPlayerPrivateWebM::startSeek):
(WebCore::MediaPlayerPrivateWebM::completeSeek):
(WebCore::MediaPlayerPrivateWebM::waitForTimeBuffered):
(WebCore::MediaPlayerPrivateWebM::resolveWaitForTimeBufferedPromiseIfPossible):
(WebCore::MediaPlayerPrivateWebM::seeking const):
(WebCore::MediaPlayerPrivateWebM::setRateDouble):
(WebCore::MediaPlayerPrivateWebM::setVolume):
(WebCore::MediaPlayerPrivateWebM::setMuted):
(WebCore::MediaPlayerPrivateWebM::setBufferedRanges):
(WebCore::MediaPlayerPrivateWebM::updateBufferedFromTrackBuffers):
(WebCore::MediaPlayerPrivateWebM::updateDurationFromTrackBuffers):
(WebCore::MediaPlayerPrivateWebM::didLoadingProgress const):
(WebCore::MediaPlayerPrivateWebM::nativeImageForCurrentTime):
(WebCore::MediaPlayerPrivateWebM::updateLastVideoFrame):
(WebCore::MediaPlayerPrivateWebM::updateLastImage):
(WebCore::MediaPlayerPrivateWebM::paint):
(WebCore::MediaPlayerPrivateWebM::paintCurrentFrameInContext):
(WebCore::MediaPlayerPrivateWebM::videoFrameForCurrentTime):
(WebCore::MediaPlayerPrivateWebM::colorSpace):
(WebCore::MediaPlayerPrivateWebM::bitmapImageForCurrentTime):
(WebCore::MediaPlayerPrivateWebM::setNaturalSize):
(WebCore::MediaPlayerPrivateWebM::effectiveRateChanged):
(WebCore::MediaPlayerPrivateWebM::setHasAudio):
(WebCore::MediaPlayerPrivateWebM::setHasVideo):
(WebCore::MediaPlayerPrivateWebM::setHasAvailableVideoFrame):
(WebCore::MediaPlayerPrivateWebM::setDuration):
(WebCore::MediaPlayerPrivateWebM::setNetworkState):
(WebCore::MediaPlayerPrivateWebM::setReadyState):
(WebCore::MediaPlayerPrivateWebM::characteristicsChanged):
(WebCore::MediaPlayerPrivateWebM::errorOccurred):
(WebCore::MediaPlayerPrivateWebM::setPreservesPitch):
(WebCore::MediaPlayerPrivateWebM::setPresentationSize):
(WebCore::MediaPlayerPrivateWebM::acceleratedRenderingStateChanged):
(WebCore::MediaPlayerPrivateWebM::createVideoFullscreenLayer):
(WebCore::MediaPlayerPrivateWebM::setVideoFullscreenLayer):
(WebCore::MediaPlayerPrivateWebM::setVideoFullscreenFrame):
(WebCore::MediaPlayerPrivateWebM::syncTextTrackBounds):
(WebCore::MediaPlayerPrivateWebM::setTextTrackRepresentation):
(WebCore::MediaPlayerPrivateWebM::setWirelessPlaybackTarget):
(WebCore::MediaPlayerPrivateWebM::setShouldPlayToPlaybackTarget):
(WebCore::MediaPlayerPrivateWebM::isCurrentPlaybackTargetWireless const):
(WebCore::MediaPlayerPrivateWebM::enqueueSample):
(WebCore::MediaPlayerPrivateWebM::reenqueSamples):
(WebCore::MediaPlayerPrivateWebM::reenqueueMediaForTime):
(WebCore::MediaPlayerPrivateWebM::notifyClientWhenReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::isReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::didBecomeReadyForMoreSamples):
(WebCore::MediaPlayerPrivateWebM::appendCompleted):
(WebCore::MediaPlayerPrivateWebM::maybeFinishLoading):
(WebCore::MediaPlayerPrivateWebM::provideMediaData):
(WebCore::MediaPlayerPrivateWebM::trackDidChangeSelected):
(WebCore::MediaPlayerPrivateWebM::trackDidChangeEnabled):
(WebCore::MediaPlayerPrivateWebM::didParseInitializationData):
(WebCore::MediaPlayerPrivateWebM::didProvideMediaDataForTrackId):
(WebCore::MediaPlayerPrivateWebM::flush):
(WebCore::MediaPlayerPrivateWebM::setAllTracksForReenqueuing):
(WebCore::MediaPlayerPrivateWebM::setTrackForReenqueuing):
(WebCore::MediaPlayerPrivateWebM::flushVideoIfNeeded):
(WebCore::MediaPlayerPrivateWebM::addTrackBuffer):
(WebCore::MediaPlayerPrivateWebM::startVideoFrameMetadataGathering):
(WebCore::MediaPlayerPrivateWebM::stopVideoFrameMetadataGathering):
(WebCore::MediaPlayerPrivateWebM::checkNewVideoFrameMetadata):
(WebCore::MediaPlayerPrivateWebM::setResourceOwner):
(WebCore::MediaPlayerPrivateWebM::isEnabledVideoTrackID const):
(WebCore::MediaPlayerPrivateWebM::hasSelectedVideo const):
(WebCore::MediaPlayerPrivateWebM::setShouldDisableHDR):
(WebCore::MediaPlayerPrivateWebM::setPlatformDynamicRangeLimit):
(WebCore::MediaPlayerPrivateWebM::playerContentBoxRectChanged):
(WebCore::MediaPlayerPrivateWebM::setShouldMaintainAspectRatio):
(WebCore::MediaPlayerPrivateWebM::defaultSpatialTrackingLabel const):
(WebCore::MediaPlayerPrivateWebM::setDefaultSpatialTrackingLabel):
(WebCore::MediaPlayerPrivateWebM::spatialTrackingLabel const):
(WebCore::MediaPlayerPrivateWebM::setSpatialTrackingLabel):
(WebCore::MediaPlayerPrivateWebM::updateSpatialTrackingLabel):
(WebCore::MediaPlayerPrivateWebM::setVideoTarget):
(WebCore::MediaPlayerPrivateWebM::sceneIdentifierDidChange):
(WebCore::MediaPlayerPrivateWebM::applicationWillResignActive):
(WebCore::MediaPlayerPrivateWebM::applicationDidBecomeActive):
(WebCore::MediaPlayerPrivateWebM::isInFullscreenOrPictureInPictureChanged):
(WebCore::MediaPlayerPrivateWebM::trackIdentifierFor const):
(WebCore::MediaPlayerPrivateWebM::maybeTrackIdentifierFor const):
(WebCore::MediaPlayerPrivateWebM::setLayerRequiresFlush):
(WebCore::MediaPlayerPrivateWebM::videoPlaybackQualityMetrics):
(WebCore::MediaPlayerPrivateWebM::hostingContext const):
(WebCore::MediaPlayerPrivateWebM::setVideoLayerSizeFenced):
(WebCore::MediaPlayerPrivateWebM::monitorReadyState):
(WebCore::MediaPlayerPrivateWebM::ensureOnRunningQueue):
(WebCore::MediaPlayerPrivateWebM::~MediaPlayerPrivateWebM): Deleted.
(WebCore::MediaPlayerPrivateWebM::cancelPendingSeek): Deleted.
(WebCore::MediaPlayerPrivateWebM::buffered const): Deleted.
(WebCore::MediaPlayerPrivateWebM::clearTracks): Deleted.
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
(WebCore::WebMParser::OnElementBegin):
(WebCore::WebMParser::OnElementEnd):
(WebCore::WebMParser::OnEbml):
(WebCore::WebMParser::OnSegmentBegin):
(WebCore::WebMParser::OnInfo):
(WebCore::WebMParser::OnClusterBegin):
(WebCore::WebMParser::OnBlockBegin):
(WebCore::WebMParser::OnBlockEnd):
(WebCore::WebMParser::OnSimpleBlockBegin):
(WebCore::WebMParser::OnSimpleBlockEnd):
(WebCore::WebMParser::OnBlockGroupBegin):
(WebCore::WebMParser::OnBlockGroupEnd):

Canonical link: <a href="https://commits.webkit.org/309373@main">https://commits.webkit.org/309373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c2464111cbe4c045e15eadf73d1d3ff4aee1666

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158808 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103531 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/82de5f76-19f3-48da-9271-6ede915d889f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23285 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22954 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115785 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82250 "3 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3740d0a7-34f0-48b5-9fd7-86ac847447af) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134663 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96514 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74f51132-844a-45b3-a885-e77af0d14c30) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16996 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14947 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6654 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126611 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161282 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4373 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14139 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123788 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123990 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33746 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22644 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134382 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78873 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19112 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11139 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86057 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21971 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22123 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22025 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->