### PR TITLE
[scroll-animations] add a test for 309059@main

### DIFF
--- a/LayoutTests/webanimations/unregister-named-scroll-timeline-crash-expected.txt
+++ b/LayoutTests/webanimations/unregister-named-scroll-timeline-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if this test doesn't crash

--- a/LayoutTests/webanimations/unregister-named-scroll-timeline-crash.html
+++ b/LayoutTests/webanimations/unregister-named-scroll-timeline-crash.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<style>
+
+#outer {
+    overflow: scroll;
+    width: 200px;
+    height: 200px;
+    scroll-timeline-name: --foo;
+}
+
+#inner {
+    overflow: scroll;
+    width: 200px;
+    height: 400px;
+    scroll-timeline-name: --foo;
+}
+
+@keyframes anim {
+    from { opacity: 0 }
+    to { opacity: 1 }
+}
+
+#target {
+    width: 200px;
+    height: 800px;
+
+    animation: anim;
+    animation-timeline: --foo;
+}
+
+</style>
+
+<div id="outer">
+    <div id="inner">
+        <div id="target"></div>
+    </div>
+</div>
+
+<script>
+
+(async function() {
+    window.testRunner?.dumpAsText();
+    window.testRunner?.waitUntilDone();
+
+    // Wait until the animation is ready which guarantees it was associated
+    // with a scroll timeline with #inner as its source.
+    await document.getAnimations()[0].ready;
+
+    // Reset scroll-timeline-name on the #inner element, this will change the
+    // animation timeline to a new scroll timeline with #outer as its source.
+    inner.style.scrollTimelineName = "none";
+
+    // Force a style recalc which would trigger a crash fixed by 309059@main
+    // where we would iterate over the list of animations associated with the
+    // #inner timeline to update those animation's timeline association, which
+    // would change the contents of that list. 
+    getComputedStyle(inner).scrollTimelineName;
+
+    window.testRunner?.notifyDone();
+})();
+
+</script>
+
+<p>PASS if this test doesn't crash</p>


### PR DESCRIPTION
#### 105dc95023539a5cea55723e7a0256d887756752
<pre>
[scroll-animations] add a test for 309059@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=309897">https://bugs.webkit.org/show_bug.cgi?id=309897</a>
<a href="https://rdar.apple.com/172477112">rdar://172477112</a>

Reviewed by Alan Baradlay.

Using AI assistance, demonstrate the speculative fix landed in 309059@main is indeed
fixing a test that reproduced the crash prior to the change. Here&apos;s what would happen
within this test:

1. Two nested scrollable elements (#outer and #inner) both declare scroll-timeline-name: --foo.
   Since #inner is closer in the tree, the #target animation attaches to #inner&apos;s scroll timeline.

2. After the animation is ready, we change #inner to have `scroll-timeline-name: none`. This will
   change the timeline on the #target animation to #outer&apos;s scroll timeline.

3. After forcing style resolution, `StyleOriginatedTimelinesController::unregisterNamedTimeline()`
   is called with `--foo` as the name and `#inner` as the styleable. Inside that function, we get
   the timeline generated by the `--foo` / `#inner` combo registered in m_nameToTimelineMap, remove
   it, and proceed to iterate over that timeline&apos;s animations to ensure their timeline is updated
   after that timeline&apos;s removal.

Prior to 309059@main, we iterated over the animation list by reference, but the timeline update
would change that list, yielding a crash as we attempt to iterate over members that weren&apos;t there
anymore.

With 309059@main, we make a copy of the list, ensuring mutation does not occur to it.

* LayoutTests/webanimations/unregister-named-scroll-timeline-crash-expected.txt: Added.
* LayoutTests/webanimations/unregister-named-scroll-timeline-crash.html: Added.

Canonical link: <a href="https://commits.webkit.org/309210@main">https://commits.webkit.org/309210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07f63d8b4df7de8e4c423b7f19d5b8012e42ce14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22647 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158635 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ebdc5f90-331a-453a-b708-c78119339280) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115645 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152888 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134527 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96384 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6481 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126477 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161112 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14000 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123658 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22449 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123862 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134251 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78697 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23058 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19030 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11003 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22057 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21787 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21939 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21844 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->