### PR TITLE
Fix typo in API test logging

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache.cpp
@@ -79,7 +79,7 @@ TEST(WebKit, DidRemoveFrameFromHiearchyInBackForwardCache)
     PlatformWebView webView(context.get());
 
     if (!isUsingBackForwardCache(static_cast<WKWebView*>(webView.platformView()))) {
-        WTFLogAlways("WebKit.DidRemoveFrameFromHiearchyInBackForwardCache: Test is skipped as backfoward cache is disabled");
+        WTFLogAlways("WebKit.DidRemoveFrameFromHiearchyInBackForwardCache: Test is skipped as backforward cache is disabled");
         return;
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm
@@ -1141,7 +1141,7 @@ TEST(ProcessSwap, SuspendedPagesInActivityMonitor)
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     if (!isUsingBackForwardCache(webView.get())) {
-        NSLog(@"ProcessSwap.SuspendedPagesInActivityMonitor: Test is skipped as backfoward cache is disabled");
+        NSLog(@"ProcessSwap.SuspendedPagesInActivityMonitor: Test is skipped as backforward cache is disabled");
         return;
     }
     auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
@@ -3498,7 +3498,7 @@ TEST(ProcessSwap, PageCache1)
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     if (!isUsingBackForwardCache(webView.get())) {
-        NSLog(@"ProcessSwap.PageCache1: Test is skipped as backfoward cache is disabled");
+        NSLog(@"ProcessSwap.PageCache1: Test is skipped as backforward cache is disabled");
         return;
     }
 
@@ -3732,7 +3732,7 @@ TEST(ProcessSwap, PageCacheAfterProcessSwapByClient)
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     if (!isUsingBackForwardCache(webView.get())) {
-        NSLog(@"ProcessSwap.PageCacheAfterProcessSwapByClient: Test is skipped as backfoward cache is disabled");
+        NSLog(@"ProcessSwap.PageCacheAfterProcessSwapByClient: Test is skipped as backforward cache is disabled");
         return;
     }
     auto delegate = adoptNS([[PSONNavigationDelegate alloc] init]);
@@ -3812,7 +3812,7 @@ TEST(ProcessSwap, PageCacheWhenNavigatingFromJS)
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     if (!isUsingBackForwardCache(webView.get())) {
-        NSLog(@"ProcessSwap.PageCacheWhenNavigatingFromJS: Test is skipped as backfoward cache is disabled");
+        NSLog(@"ProcessSwap.PageCacheWhenNavigatingFromJS: Test is skipped as backforward cache is disabled");
         return;
     }
 
@@ -6820,7 +6820,7 @@ TEST(ProcessSwap, GoBackToSuspendedPageWithMainFrameIDThatIsNotOne)
 
     auto webView1 = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:webViewConfiguration.get()]);
     if (!isUsingBackForwardCache(webView1.get())) {
-        NSLog(@"ProcessSwap.GoBackToSuspendedPageWithMainFrameIDThatIsNotOne: Test is skipped as backfoward cache is disabled");
+        NSLog(@"ProcessSwap.GoBackToSuspendedPageWithMainFrameIDThatIsNotOne: Test is skipped as backforward cache is disabled");
         return;
     }
 


### PR DESCRIPTION
#### e33f99f0fc5494db4d8c5ea30c774f2e5d939733
<pre>
Fix typo in API test logging
<a href="https://bugs.webkit.org/show_bug.cgi?id=309899">https://bugs.webkit.org/show_bug.cgi?id=309899</a>
<a href="https://rdar.apple.com/172482518">rdar://172482518</a>

Reviewed by NOBODY (OOPS!).

* Tools/TestWebKitAPI/Tests/WebKit/DidRemoveFrameFromHiearchyInPageCache.cpp:
(TestWebKitAPI::TEST(WebKit, DidRemoveFrameFromHiearchyInBackForwardCache)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:
((ProcessSwap, SuspendedPagesInActivityMonitor)):
((ProcessSwap, PageCache1)):
((ProcessSwap, PageCacheAfterProcessSwapByClient)):
((ProcessSwap, PageCacheWhenNavigatingFromJS)):
((ProcessSwap, GoBackToSuspendedPageWithMainFrameIDThatIsNotOne)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e33f99f0fc5494db4d8c5ea30c774f2e5d939733

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149938 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158645 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78a5df09-4f0a-47f4-8909-4e5caa407339) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151811 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22765 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115656 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dad43007-12b7-44ea-a8a1-464425198b16) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152898 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/17785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/134534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96394 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6491 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/12465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161122 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/14007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/123666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22459 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123870 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22466 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/134258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78707 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/19037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/11010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22067 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21797 "Built successfully") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21949 "Failed to checkout and rebase branch from PR 60561") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21854 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->