### PR TITLE
REGRESSION(303042@main): MotionMark regression on some subtests.

### DIFF
--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -42,6 +42,7 @@
 #include "RenderTextFragment.h"
 #include "RenderTreeUpdater.h"
 #include "RenderView.h"
+#include "StyleOriginatedTimelinesController.h"
 #include "StyleTreeResolver.h"
 #include "WritingSuggestionData.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -199,11 +200,17 @@ void RenderTreeUpdater::GeneratedContent::updateBeforeOrAfterPseudoElement(Eleme
     // cancel any animations that were on it so we do not end up thinking we need to keep
     // the renderer around. We cannot completely rely on needsPseudoElement because
     // we may need to animate a box with display: none.
-    if (!updateStyle)
-        Styleable { current, Style::PseudoElementIdentifier { pseudoElementType } }.cancelStyleOriginatedAnimations();
+
+    bool mayHaveKeyframeEffects = current.mayHaveKeyframeEffects();
+    if (!updateStyle) {
+        if (mayHaveKeyframeEffects)
+            Styleable { current, Style::PseudoElementIdentifier { pseudoElementType } }.cancelStyleOriginatedAnimations();
+        else if (CheckedPtr styleOriginatedTimelinesController = current.document().styleOriginatedTimelinesController())
+            styleOriginatedTimelinesController->unregisterNamedTimelinesAssociatedWithElement(Styleable { current, Style::PseudoElementIdentifier { pseudoElementType } });
+    }
 
     ASSERT(!is<PseudoElement>(current));
-    if (!needsPseudoElement(updateStyle) && !needsPseudoElementForAnimation(current, pseudoElementType)) {
+    if (!needsPseudoElement(updateStyle) && (!mayHaveKeyframeEffects || !needsPseudoElementForAnimation(current, pseudoElementType))) {
         if (pseudoElement) {
             if (pseudoElementType == PseudoElementType::Before)
                 removeBeforePseudoElement(current, m_updater.m_builder);


### PR DESCRIPTION
#### 362a1f9f947dda9dc48b2b85c72795362590d321
<pre>
REGRESSION(<a href="https://commits.webkit.org/303042@main">303042@main</a>): MotionMark regression on some subtests.
<a href="https://rdar.apple.com/171888738">rdar://171888738</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309796">https://bugs.webkit.org/show_bug.cgi?id=309796</a>

Reviewed by NOBODY (OOPS!).

In <a href="https://commits.webkit.org/303042@main">303042@main</a>, we added a fix to address some stale before/after pseudo
content that we were seeing on GitHub, which was resulting in an
unexpected display of this content. This was done by trying to cancel
any style-originated animations within the render tree updating code for
this type of content.

However, it seems like this resulted in a small perf regression within
the Multiply and Leaves subtests. An investigation revealed that we were
hitting this for content which did not have any before/after pseudo
elements or style-originated animations, neither of which seem to be
tested on MotionMark.

Prior to <a href="https://commits.webkit.org/303042@main">303042@main</a>, what was happening for this type of content was
that we were hitting the early return within the logic that checked for
!needsPseudoElement &amp;&amp; !needsPseudoElementForAnimation. For the content
in MotionMark, we were returning very early from needsPseudoElement
since updateStyle was nullptr and were returning from needsPseudoElementForAnimation
because there were no animations associated with the content.

After the patch, we still run the same logic described above, but we also
will end up calling into the logic to cancel any style-associated
animations. However, since the content in the benchmark does not have
any animations, we will end up bailing out when we end up realizing that.

Since the only additional code that runs after the patch with respect to
the MotionMark content is related to checking if there are any
animations, it seems like the perf regression must be coming from the
overhead that results from the additional rare data access.

We can attempt to recover from this by checking to see if the content
even has any animation-related rare data, which is already done when we
check needsPseudoElementForAnimation. If there is no animation rare data,
then there is no point trying to cancel any animations. Similarly, there
is no need to check for needsPseudoElementForAnimation since that should
also already be covered. This change should bring the number of rare
data accesses back to the same as before <a href="https://commits.webkit.org/303042@main">303042@main</a>.

One thing to note is that cancelling any animations from style could
have potentially triggered unregistering named timelines even without
animations so we should carry over that logic as well so that there is
no behavior change.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/362a1f9f947dda9dc48b2b85c72795362590d321

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23847 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159813 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104521 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d860f5e-bbe8-41d4-9c11-bde6c118a81a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24072 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116642 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82803 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9719149-4b79-4f38-9cc4-e1b02196d8c5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18762 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97363 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0871c6c0-9102-4376-8ecd-b64ddf949ccf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17855 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15809 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7659 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127473 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162286 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5411 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124649 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23649 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124837 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23639 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135274 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80083 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19901 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12039 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23249 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87543 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22961 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23113 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23015 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->