### PR TITLE
[DRAFT] Avoid full compositing requirements traversal for page and composited scrolling

### DIFF
--- a/LayoutTests/compositing/scrolling/no-full-compositing-traversal-on-page-scroll-expected.txt
+++ b/LayoutTests/compositing/scrolling/no-full-compositing-traversal-on-page-scroll-expected.txt
@@ -1,0 +1,10 @@
+Test that page scrolling does not trigger a full compositing requirements traversal.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS updateCount is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/compositing/scrolling/no-full-compositing-traversal-on-page-scroll.html
+++ b/LayoutTests/compositing/scrolling/no-full-compositing-traversal-on-page-scroll.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+    <style>
+        body {
+            height: 4000px;
+            margin: 0;
+        }
+
+        .fixed {
+            position: fixed;
+            top: 10px;
+            left: 10px;
+            width: 100px;
+            height: 100px;
+            background-color: green;
+        }
+
+        .composited {
+            transform: translateZ(0);
+            width: 200px;
+            height: 200px;
+            margin: 20px;
+            background-color: blue;
+        }
+
+        .scroller {
+            overflow: auto;
+            width: 300px;
+            height: 200px;
+            margin: 20px;
+            border: 1px solid black;
+        }
+
+        .tall-content {
+            height: 2000px;
+            background: linear-gradient(to bottom, red, yellow);
+        }
+    </style>
+    <script src="../../resources/js-test-pre.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        description('Test that page scrolling does not trigger a full compositing requirements traversal.');
+        window.jsTestIsAsync = true;
+
+        var updateCount;
+
+        async function runTest()
+        {
+            // Wait for initial compositing to settle.
+            await UIHelper.renderingUpdate();
+            await UIHelper.renderingUpdate();
+
+            internals.startTrackingCompositingUpdates();
+
+            // Perform a page scroll.
+            window.scrollTo(0, 200);
+            await UIHelper.renderingUpdate();
+
+            updateCount = internals.compositingUpdateCount();
+            shouldBe('updateCount', '0');
+
+            finishJSTest();
+        }
+
+        window.addEventListener('load', runTest);
+    </script>
+</head>

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1101,8 +1101,13 @@ bool RenderLayerCompositor::updateCompositingLayers(CompositingUpdateType update
             }
         }
 
-        // Scrolling can affect overlap. FIXME: avoid for page scrolling.
-        updateRoot->setDescendantsNeedCompositingRequirementsTraversal();
+        // Scrolling can affect overlap, but only non-composited overflow scrolling
+        // can change overlap relationships in a way that requires recomputing
+        // compositing requirements. Page scrolling moves the viewport without
+        // changing content-relative overlap, and composited scrolling is handled
+        // by the compositor thread without affecting the layer hierarchy.
+        if (updateType == CompositingUpdateType::OnScroll && !isPageScroll)
+            updateRoot->setDescendantsNeedCompositingRequirementsTraversal();
     }
 
     if (updateType == CompositingUpdateType::AfterLayout) {


### PR DESCRIPTION
#### 7c3e594900437c24f7cc5c3ae8e8a4462cabbd51
<pre>
[DRAFT] Avoid full compositing requirements traversal for page and composited scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=309902">https://bugs.webkit.org/show_bug.cgi?id=309902</a>
<a href="https://rdar.apple.com/166488863">rdar://166488863</a>

Reviewed by NOBODY (OOPS!).

On each scroll event, updateCompositingLayers() unconditionally called
setDescendantsNeedCompositingRequirementsTraversal() on the root render layer,
forcing a complete recomputation of compositing requirements for every layer in
the tree. This caused severe performance degradation on complex pages like
GitHub PR diffs, where the deeply nested DOM led to expensive recursive
traversals in computeCompositingRequirements().

The fix limits the full compositing requirements traversal to cases where
overlap relationships can actually change: non-composited overflow scrolling.
For page scrolling, the viewport moves uniformly and content-relative overlap
does not change; fixed/sticky elements are already handled by targeted
setNeedsCompositingGeometryUpdate() calls. For composited scrolling, the
scroll is managed by the compositor thread and the compositing hierarchy
remains unchanged.

* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateCompositingLayers):
Only trigger full compositing requirements traversal for non-composited,
non-page overflow scrolling (CompositingUpdateType::OnScroll with a
non-root updateRootArg), where overlap relationships can genuinely change.
Skip for page scrolling (per existing FIXME) and composited scrolling
(OnCompositedScroll) where the compositor thread handles the scroll
without affecting the layer hierarchy.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c3e594900437c24f7cc5c3ae8e8a4462cabbd51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158664 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103391 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/540c698d-615a-49da-b444-b51071becca6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151830 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23127 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22784 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115673 "Found 1 new test failure: compositing/scrolling/no-full-compositing-traversal-on-page-scroll.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82191 "3 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c1fa3c2-cd71-4aa8-8228-3c9d7ac2c57f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152917 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17803 "Found 1 new test failure: compositing/scrolling/no-full-compositing-traversal-on-page-scroll.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134552 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96410 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16903 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14834 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6510 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161141 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14037 "Found 1 new test failure: compositing/scrolling/no-full-compositing-traversal-on-page-scroll.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123684 "Found 1 new test failure: compositing/scrolling/no-full-compositing-traversal-on-page-scroll.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22478 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18885 "Found 1 new test failure: compositing/scrolling/no-full-compositing-traversal-on-page-scroll.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123886 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22489 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134276 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78733 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19049 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11034 "Found 1 new test failure: compositing/scrolling/no-full-compositing-traversal-on-page-scroll.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22086 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85906 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21816 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21971 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21873 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->