### PR TITLE
[DRAFT] Fix regression from 289517@main that can cause stale text to be shown

### DIFF
--- a/LayoutTests/fast/repaint/replace-formatted-text-invalidation-expected.txt
+++ b/LayoutTests/fast/repaint/replace-formatted-text-invalidation-expected.txt
@@ -1,0 +1,5 @@
+
+(repaint rects
+  (rect 8 8 784 20)
+)
+

--- a/LayoutTests/fast/repaint/replace-formatted-text-invalidation.html
+++ b/LayoutTests/fast/repaint/replace-formatted-text-invalidation.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<!--
+ Tests that replacing innerHTML in a contenteditable div containing bold/underline
+ formatted text produces a repaint rect covering the area previously occupied by
+ the formatted text. Regression test for rdar://158963215, where RenderText::
+ localRectsForRepaint() returned an empty rect when the text had no line boxes
+ (during content replacement), leaving stale composited tile content visible.
+-->
+<style>
+body {
+    font-family: Ahem;
+    font-size: 20px;
+}
+</style>
+<script src="resources/text-based-repaint.js"></script>
+<script>
+function repaintTest()
+{
+    document.getElementById("editor").innerHTML = "";
+}
+onload = runRepaintTest;
+</script>
+<div id="editor" contenteditable="true"><b><u>Hello formatted world</u></b></div>

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1952,7 +1952,16 @@ auto RenderText::localRectsForRepaint(RepaintOutlineBounds) const -> RepaintRect
     LayoutRect overflowRect = linesBoundingBox();
     // FIXME: layoutDelta needs to be applied in parts before/after transforms and
     // repaint containers. https://bugs.webkit.org/show_bug.cgi?id=23308
-    overflowRect.move(view().frameView().layoutContext().layoutDelta());
+    if (!overflowRect.isEmpty())
+        overflowRect.move(view().frameView().layoutContext().layoutDelta());
+    else if (auto* block = containingBlock()) {
+        // When the text has no line boxes (e.g., content is being replaced and the new
+        // text hasn't been laid out yet), fall back to the containing block's visual
+        // overflow rect. Without this, the repaint rect is empty and stale composited
+        // content from the previous text may remain visible (rdar://158963215).
+        overflowRect = block->visualOverflowRect();
+        overflowRect.move(view().frameView().layoutContext().layoutDelta());
+    }
 
     return RepaintRects { overflowRect };
 }


### PR DESCRIPTION
#### 6d6c7bc0435dce65f5080ad196e015c847ddb33c
<pre>
Fix regression from <a href="https://commits.webkit.org/289517@main">289517@main</a> that can cause stale text to be shown
<a href="https://bugs.webkit.org/show_bug.cgi?id=309904">https://bugs.webkit.org/show_bug.cgi?id=309904</a>
<a href="https://rdar.apple.com/158963215">rdar://158963215</a>

Reviewed by: NOBODY (OOPS!).

RenderText::localRectsForRepaint() returns the text&apos;s linesBoundingBox(),
which is empty when the text has no inline line boxes. This can happen
during content replacement transitions. The empty repaint rect causes
no invalidation of the area previously occupied by the old text, leaving
stale composited content visible until the next layout forces a repaint.

Before <a href="https://commits.webkit.org/289517@main">289517@main</a>, RenderText::clippedOverflowRect() delegated to the
containing block, which always produced a non-empty rect covering the
text&apos;s area. Fix by falling back to the containing block&apos;s visual
overflow rect when linesBoundingBox() is empty.

* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::localRectsForRepaint): Fall back to containing
block&apos;s visualOverflowRect when the text has no line boxes.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d6c7bc0435dce65f5080ad196e015c847ddb33c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158666 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103393 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec80faf9-799e-404f-9fb8-568ac631d895) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151832 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22786 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115674 "Found 1 new test failure: fast/repaint/replace-formatted-text-invalidation.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82192 "3 flakes 1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6605e9e6-750e-4c23-b5d2-b7b3ea51d245) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17804 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96411 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16904 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14833 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6512 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161143 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4225 "Build is in progress. Recent messages:") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14038 "Found 1 new test failure: fast/repaint/replace-formatted-text-invalidation.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123685 "Found 1 new test failure: fast/repaint/replace-formatted-text-invalidation.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22491 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18884 "Found 1 new test failure: fast/repaint/replace-formatted-text-invalidation.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123887 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22491 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134280 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78735 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19051 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11037 "Found 1 new test failure: fast/repaint/replace-formatted-text-invalidation.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22088 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85929 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21818 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21973 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21875 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->