### PR TITLE
Re-import command button WPT tests

### DIFF
--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -381,5 +381,8 @@
     "web-platform-tests/worklets": "import",
     "web-platform-tests/x-frame-options": "import",
     "web-platform-tests/xhr": "import",
-    "web-platform-tests/xml": "import"
+    "web-platform-tests/xml": "import",
+    "web-platform-tests/html/semantics/popovers": "import",
+    "web-platform-tests/html/semantics/popovers/resources": "import",
+    "web-platform-tests/html/semantics/popovers/resources/toggle-event-source-test.js": "import"
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/popover-top-layer-nesting.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/popover-top-layer-nesting.js
@@ -21,8 +21,7 @@ function createTopLayerElement(t,topLayerType) {
   t.add_cleanup(() => element.remove());
   return {element,show,showing};
 }
-function runTopLayerTests(testCases, testAnchorAttribute) {
-  testAnchorAttribute = testAnchorAttribute || false;
+function runTopLayerTests(testCases) {
   testCases.forEach(test => {
     const description = test.firstChild.data.trim();
     assert_equals(test.querySelectorAll('.target').length,1,'There should be exactly one target');
@@ -85,24 +84,6 @@ function runTopLayerTests(testCases, testAnchorAttribute) {
           }
         }
       },`${description} with ${topLayerType}, top layer element *is* a popover`);
-
-      if (testAnchorAttribute) {
-        promise_test(async t => {
-          const {element,show,showing} = createTopLayerElement(t,topLayerType);
-          element.anchorElement = target;
-          document.body.appendChild(element);
-
-          // Show the popovers.
-          t.add_cleanup(() => popovers.forEach(popover => popover.hidePopover()));
-          popovers.forEach(popover => popover.showPopover());
-          popovers.forEach(popover => assert_true(popover.matches(':popover-open'),'All popovers should be open'));
-
-          // Activate the top layer element.
-          await show(popovers[popovers.length-1]);
-          assert_true(showing());
-          popovers.forEach(popover => assert_equals(popover.matches(':popover-open'),popover.dataset.stayOpen==='true','Incorrect behavior'));
-        },`${description} with ${topLayerType}, anchor attribute`);
-      }
     });
   });
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/toggle-event-source-test.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/toggle-event-source-test.js
@@ -25,8 +25,7 @@ function createToggleEventSourceTest({
     });
 
     await openFunc();
-    await new Promise(requestAnimationFrame);
-    await new Promise(requestAnimationFrame);
+    await new Promise(resolve => step_timeout(resolve, 0));
     if (!skipBeforetoggle) {
       assert_true(!!beforetoggleEvent,
         'An opening beforetoggle event should have been fired.');
@@ -51,8 +50,7 @@ function createToggleEventSourceTest({
     toggleDuplicate = false;
 
     await closeFunc();
-    await new Promise(requestAnimationFrame);
-    await new Promise(requestAnimationFrame);
+    await new Promise(resolve => step_timeout(resolve, 0));
 
     if (!skipBeforetoggle) {
       assert_true(!!beforetoggleEvent,

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: invoker-commands
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html
@@ -11,6 +11,7 @@
 <button id="invokerbutton" commandfor="invokee" command="--custom-command"></button>
 <input type="button" id="invalidbutton" commandfor="invokee" command="--custom-command">
 <form id="aform"></form>
+<svg id="svgInvokee"></svg>
 
 <script>
   aform.addEventListener('submit', (e) => (e.preventDefault()));
@@ -110,6 +111,18 @@
       invokerbutton.click();
       assert_equals(event, null, "event should not have fired");
     }, `setting custom command attribute to ${command} (no dash) did not dispatch an event`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      assert_false(svgInvokee instanceof HTMLElement);
+      assert_true(svgInvokee instanceof Element);
+      let command_event_fired = false;
+      svgInvokee.addEventListener("command", () => (command_event_fired = true), {signal: t.get_signal()});
+      invokerbutton.setAttribute("commandfor", "svgInvokee");
+      invokerbutton.setAttribute("command", command);
+      invokerbutton.click();
+      assert_false(command_event_fired, "command event fired");
+    }, `setting command attribute to ${command} (no dash) did not dispatch an event with an svg target`);
   });
 
   test(function (t) {
@@ -206,15 +219,12 @@
   }, "event does NOT dispatch if button is form associated, with explicit type=reset");
 
   test(function (t) {
-    svgInvokee = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    svgInvokee.setAttribute("id", "svg-invokee");
     t.add_cleanup(resetState);
-    document.body.append(svgInvokee);
     assert_false(svgInvokee instanceof HTMLElement);
     assert_true(svgInvokee instanceof Element);
     let event = null;
-    svgInvokee.addEventListener("command", (e) => (event = e), { once: true });
-    invokerbutton.setAttribute("commandfor", "svg-invokee");
+    svgInvokee.addEventListener("command", (e) => (event = e), { once: true, signal: t.get_signal() });
+    invokerbutton.setAttribute("commandfor", "svgInvokee");
     invokerbutton.setAttribute("command", "--custom-command");
     assert_equals(invokerbutton.commandForElement, svgInvokee);
     invokerbutton.click();
@@ -222,5 +232,53 @@
     assert_true(event instanceof CommandEvent, "event is CommandEvent");
     assert_equals(event.source, invokerbutton, "event.invoker is set to right element");
     assert_equals(event.target, svgInvokee, "event.target is set to right element");
-  }, "event dispatches if invokee is non-HTML Element");
+  }, "event dispatches if invokee is non-HTML Element and command is custom");
+
+  // known commands with incompatible target
+  ["show-modal", "close", "request-close"].forEach((command) => {
+    test(function (t) {
+      t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      invokerbutton.command = command;
+      invokerbutton.click();
+      assert_false(command_event_fired, "command event fired");
+    }, `setting command to ${command} did not dispatch an event for invalid element`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      assert_false(svgInvokee instanceof HTMLElement);
+      assert_true(svgInvokee instanceof Element);
+      let command_event_fired = false;
+      svgInvokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      invokerbutton.setAttribute("commandfor", "svgInvokee");
+      invokerbutton.setAttribute("command", command);
+      invokerbutton.click();
+      assert_false(command_event_fired, "command event fired");
+    }, `setting command to ${command} did not dispatch an event for svg element`);
+  });
+
+  // popover commands
+  ["show-popover", "hide-popover", "toggle-popover"].forEach((command) => {
+    test(function (t) {
+      t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      invokerbutton.command = command;
+      invokerbutton.click();
+      assert_true(command_event_fired, "command event fired");
+    }, `setting command to ${command} did dispatch an event for element without popover attribute`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      assert_false(svgInvokee instanceof HTMLElement);
+      assert_true(svgInvokee instanceof Element);
+      let command_event_fired = false;
+      svgInvokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      invokerbutton.setAttribute("commandfor", "svgInvokee");
+      invokerbutton.setAttribute("command", command);
+      invokerbutton.click();
+      assert_false(command_event_fired, "command event fired");
+    }, `setting command to ${command} did not dispatch an event for svg element`);
+  });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-close-target-non-dialog-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-close-target-non-dialog-crash.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>button command=close targeting non-dialog should not crash</title>
+<meta name="author" title="Peng Zhou" href="mailto:pengzhou@chromium.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element">
+<link rel="help" href="https://crbug.com/490727227">
+<p>Pass if no crash.</p>
+<input type="text" id="target">
+<button id="button" commandfor="target" command="close">Click me</button>
+<script>
+  document.getElementById('button').click();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<meta name="timeout" content="long" />
+<meta charset="utf-8" />
+<meta name="author" href="mailto:masonf@chromium.org" />
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+<script src="/html/resources/common.js"></script>
+
+<meta name=variant content=?command=--custom-event&half=first>
+<meta name=variant content=?command=--custom-event&half=second>
+<meta name=variant content=?command=show-popover&half=first>
+<meta name=variant content=?command=show-popover&half=second>
+<meta name=variant content=?command=show-modal&half=first>
+<meta name=variant content=?command=show-modal&half=second>
+
+<div id="invokee"></div>
+
+<script>
+  // The command parameter is provided by variants, to
+  // effectively split this (slow) test into multiple runs.
+  const urlParams = new URLSearchParams(window.location.search);
+  command = urlParams.get('command');
+  half = urlParams.get('half');
+  const firstHalf = half === 'first';
+  assert_true(firstHalf || half === 'second');
+
+  const allowed = ['button','menuitem'];
+  const allTags = HTML5_ELEMENTS.filter(el => (!allowed.includes(el)));
+  const midpoint = Math.floor(allTags.length / 2);
+  const tags = firstHalf ? allTags.slice(0,midpoint) : allTags.slice(midpoint);
+  let gotEvent = false;
+  invokee.addEventListener('command',() => (gotEvent = true));
+  for(const tag of tags) {
+    promise_test(async () => {
+      gotEvent = false;
+      const element = document.createElement(tag);
+      element.setAttribute('commandfor','invokee');
+      element.setAttribute('command',command);
+      element.style.display = 'block'; // For normally invisible elements
+      document.body.appendChild(element);
+      // Click two ways
+      element.click();
+      await clickOn(element);
+      assert_false(gotEvent,'Command should not be fired');
+    },`command/commandfor on <${tag}> with command=${command} should not function`);
+  }
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-invalid-behavior.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-invalid-behavior.html
@@ -28,23 +28,25 @@
     "foo-bar",
     "auto",
     "showmodal",
-    "show-popover",
-    "hide-popover",
-    "toggle-popover",
     "show-picker",
   ].forEach((action) => {
     test(function (t) {
       t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
       invokerbutton.setAttribute("command", action);
       assert_false(invokee.open, "invokee.open");
       assert_false(invokee.matches(":modal"), "invokee :modal");
       invokerbutton.click();
       assert_false(invokee.open, "invokee.open");
       assert_false(invokee.matches(":modal"), "invokee :modal");
+      assert_false(command_event_fired, "command event fired");
     }, `invoking (as ${action}) on dialog does nothing`);
 
     test(function (t) {
       t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
       containedinvoker.setAttribute("command", action);
       invokee.show();
       assert_true(invokee.open, "invokee.open");
@@ -52,10 +54,13 @@
       containedinvoker.click();
       assert_true(invokee.open, "invokee.open");
       assert_false(invokee.matches(":modal"), "invokee :modal");
+      assert_false(command_event_fired, "command event fired");
     }, `invoking (as ${action}) on open dialog does nothing`);
 
     test(function (t) {
       t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
       containedinvoker.setAttribute("command", action);
       invokee.showModal();
       assert_true(invokee.open, "invokee.open");
@@ -63,7 +68,74 @@
       containedinvoker.click();
       assert_true(invokee.open, "invokee.open");
       assert_true(invokee.matches(":modal"), "invokee :modal");
+      assert_false(command_event_fired, "command event fired");
     }, `invoking (as ${action}) on open modal dialog does nothing`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      containedinvoker.setAttribute("command", action);
+      invokee.showModal();
+      assert_true(invokee.open, "invokee.open");
+      assert_true(invokee.matches(":modal"), "invokee :modal");
+      invokee.addEventListener(
+        "command",
+        (e) => {
+          containedinvoker.setAttribute("command", "");
+        },
+        { once: true },
+      );
+      containedinvoker.click();
+      assert_true(invokee.open, "invokee.open");
+      assert_true(invokee.matches(":modal"), "invokee :modal");
+    }, `invoking (as ${action}) on open modal while changing the attributer does nothing`);
+  });
+
+  // popover commands on dialog
+  [
+    "show-popover",
+    "hide-popover",
+    "toggle-popover",
+  ].forEach((action) => {
+    test(function (t) {
+      t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      invokerbutton.setAttribute("command", action);
+      assert_false(invokee.open, "invokee.open");
+      assert_false(invokee.matches(":modal"), "invokee :modal");
+      invokerbutton.click();
+      assert_false(invokee.open, "invokee.open");
+      assert_false(invokee.matches(":modal"), "invokee :modal");
+      assert_true(command_event_fired, "command event fired");
+    }, `invoking (as ${action}) on dialog fires event`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      containedinvoker.setAttribute("command", action);
+      invokee.show();
+      assert_true(invokee.open, "invokee.open");
+      assert_false(invokee.matches(":modal"), "invokee :modal");
+      containedinvoker.click();
+      assert_true(invokee.open, "invokee.open");
+      assert_false(invokee.matches(":modal"), "invokee :modal");
+      assert_true(command_event_fired, "command event fired");
+    }, `invoking (as ${action}) on open dialog fires event`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      containedinvoker.setAttribute("command", action);
+      invokee.showModal();
+      assert_true(invokee.open, "invokee.open");
+      assert_true(invokee.matches(":modal"), "invokee :modal");
+      containedinvoker.click();
+      assert_true(invokee.open, "invokee.open");
+      assert_true(invokee.matches(":modal"), "invokee :modal");
+      assert_true(command_event_fired, "command event fired");
+    }, `invoking (as ${action}) on open modal dialog fires event`);
 
     test(function (t) {
       t.add_cleanup(resetState);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-popover-invalid-behavior.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-popover-invalid-behavior.html
@@ -26,19 +26,25 @@
   [null, "", "foo-bar", "showpopover", "show-modal", "show-picker", "open", "close"].forEach((command) => {
     test(function (t) {
       t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
       invokerbutton.command = command;
       assert_false(invokee.matches(":popover-open"));
       invokerbutton.click();
       assert_false(invokee.matches(":popover-open"));
+      assert_false(command_event_fired, "command event fired");
     }, `invoking (as ${command}) on popover does nothing`);
 
     test(function (t) {
       t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
       invokerbutton.command = command;
       invokee.showPopover();
       assert_true(invokee.matches(":popover-open"));
       invokerbutton.click();
       assert_true(invokee.matches(":popover-open"));
+      assert_false(command_event_fired, "command event fired");
     }, `invoking (as ${command}) on open popover does nothing`);
   });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-scroll-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-scroll-behavior.tentative.html
@@ -1,0 +1,543 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Chromium" href="https://chromium.org" />
+<meta name="timeout" content="long" />
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<style>
+  .scroll-container {
+    width: 200px;
+    height: 200px;
+    overflow: auto;
+    border: 1px solid black;
+  }
+
+  .scroll-content {
+    width: 1000px;
+    height: 1000px;
+    background: linear-gradient(to bottom right, red, blue);
+  }
+
+  .scroll-container-horizontal {
+    width: 200px;
+    height: 100px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    border: 1px solid black;
+  }
+
+  .scroll-content-horizontal {
+    width: 1000px;
+    height: 100px;
+    background: linear-gradient(to right, red, blue);
+  }
+
+  .scroll-container-vertical {
+    width: 100px;
+    height: 200px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    border: 1px solid black;
+  }
+
+  .scroll-content-vertical {
+    width: 100px;
+    height: 1000px;
+    background: linear-gradient(to bottom, red, blue);
+  }
+
+  .rtl {
+    direction: rtl;
+  }
+
+  .vertical-writing {
+    writing-mode: vertical-rl;
+  }
+</style>
+
+<!-- Basic scroll container -->
+<div id="scrollcontainer" class="scroll-container">
+  <div class="scroll-content"></div>
+</div>
+<button id="pageup" commandfor="scrollcontainer" command="page-up">Page Up</button>
+<button id="pagedown" commandfor="scrollcontainer" command="page-down">Page Down</button>
+<button id="pageleft" commandfor="scrollcontainer" command="page-left">Page Left</button>
+<button id="pageright" commandfor="scrollcontainer" command="page-right">Page Right</button>
+
+<!-- Horizontal only scroll container -->
+<div id="horizontalcontainer" class="scroll-container-horizontal">
+  <div class="scroll-content-horizontal"></div>
+</div>
+<button id="hpageleft" commandfor="horizontalcontainer" command="page-left">Page Left</button>
+<button id="hpageright" commandfor="horizontalcontainer" command="page-right">Page Right</button>
+
+<!-- Vertical only scroll container -->
+<div id="verticalcontainer" class="scroll-container-vertical">
+  <div class="scroll-content-vertical"></div>
+</div>
+<button id="vpageup" commandfor="verticalcontainer" command="page-up">Page Up</button>
+<button id="vpagedown" commandfor="verticalcontainer" command="page-down">Page Down</button>
+
+<!-- Logical direction tests -->
+<div id="logicalcontainer" class="scroll-container">
+  <div class="scroll-content"></div>
+</div>
+<button id="blockstart" commandfor="logicalcontainer" command="page-block-start">Block Start</button>
+<button id="blockend" commandfor="logicalcontainer" command="page-block-end">Block End</button>
+<button id="inlinestart" commandfor="logicalcontainer" command="page-inline-start">Inline Start</button>
+<button id="inlineend" commandfor="logicalcontainer" command="page-inline-end">Inline End</button>
+
+<!-- RTL container -->
+<div id="rtlcontainer" class="scroll-container rtl">
+  <div class="scroll-content"></div>
+</div>
+<button id="rtlinlinestart" commandfor="rtlcontainer" command="page-inline-start">Inline Start (RTL)</button>
+<button id="rtlinlineend" commandfor="rtlcontainer" command="page-inline-end">Inline End (RTL)</button>
+
+<!-- Vertical writing mode container -->
+<div id="verticalwritingcontainer" class="scroll-container vertical-writing">
+  <div class="scroll-content"></div>
+</div>
+<button id="vwblockstart" commandfor="verticalwritingcontainer" command="page-block-start">Block Start (VW)</button>
+<button id="vwblockend" commandfor="verticalwritingcontainer" command="page-block-end">Block End (VW)</button>
+
+<script>
+  function resetScrollPosition(container) {
+    container.scrollTop = 0;
+    container.scrollLeft = 0;
+  }
+
+  // Test page-up command
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    scrollcontainer.scrollTop = 400;
+    const initialScrollTop = scrollcontainer.scrollTop;
+    pageup.click();
+    assert_less_than(scrollcontainer.scrollTop, initialScrollTop, "Scroll position should decrease");
+  }, "page-up command scrolls up");
+
+  // Test page-down command
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    const initialScrollTop = scrollcontainer.scrollTop;
+    pagedown.click();
+    assert_greater_than(scrollcontainer.scrollTop, initialScrollTop, "Scroll position should increase");
+  }, "page-down command scrolls down");
+
+  // Test page-left command
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    scrollcontainer.scrollLeft = 400;
+    const initialScrollLeft = scrollcontainer.scrollLeft;
+    pageleft.click();
+    assert_less_than(scrollcontainer.scrollLeft, initialScrollLeft, "Scroll position should decrease");
+  }, "page-left command scrolls left");
+
+  // Test page-right command
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    const initialScrollLeft = scrollcontainer.scrollLeft;
+    pageright.click();
+    assert_greater_than(scrollcontainer.scrollLeft, initialScrollLeft, "Scroll position should increase");
+  }, "page-right command scrolls right");
+
+  // Test that page-up doesn't scroll horizontally
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    scrollcontainer.scrollTop = 400;
+    scrollcontainer.scrollLeft = 200;
+    const initialScrollLeft = scrollcontainer.scrollLeft;
+    pageup.click();
+    assert_equals(scrollcontainer.scrollLeft, initialScrollLeft, "Horizontal scroll should not change");
+  }, "page-up command doesn't affect horizontal scroll");
+
+  // Test that page-left doesn't scroll vertically
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    scrollcontainer.scrollTop = 200;
+    scrollcontainer.scrollLeft = 400;
+    const initialScrollTop = scrollcontainer.scrollTop;
+    pageleft.click();
+    assert_equals(scrollcontainer.scrollTop, initialScrollTop, "Vertical scroll should not change");
+  }, "page-left command doesn't affect vertical scroll");
+
+  // Test horizontal-only container
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(horizontalcontainer));
+    const initialScrollLeft = horizontalcontainer.scrollLeft;
+    hpageright.click();
+    assert_greater_than(horizontalcontainer.scrollLeft, initialScrollLeft, "Horizontal scroll should increase");
+    assert_equals(horizontalcontainer.scrollTop, 0, "Vertical scroll should remain 0");
+  }, "page-right works on horizontal-only container");
+
+  // Test vertical-only container
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(verticalcontainer));
+    const initialScrollTop = verticalcontainer.scrollTop;
+    vpagedown.click();
+    assert_greater_than(verticalcontainer.scrollTop, initialScrollTop, "Vertical scroll should increase");
+    assert_equals(verticalcontainer.scrollLeft, 0, "Horizontal scroll should remain 0");
+  }, "page-down works on vertical-only container");
+
+  // Test page-block-end (should scroll down in horizontal writing mode)
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(logicalcontainer));
+    const initialScrollTop = logicalcontainer.scrollTop;
+    blockend.click();
+    assert_greater_than(logicalcontainer.scrollTop, initialScrollTop, "Scroll position should increase");
+  }, "page-block-end scrolls down in horizontal writing mode");
+
+  // Test page-block-start (should scroll up in horizontal writing mode)
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(logicalcontainer));
+    logicalcontainer.scrollTop = 400;
+    const initialScrollTop = logicalcontainer.scrollTop;
+    blockstart.click();
+    assert_less_than(logicalcontainer.scrollTop, initialScrollTop, "Scroll position should decrease");
+  }, "page-block-start scrolls up in horizontal writing mode");
+
+  // Test page-inline-end (should scroll right in LTR)
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(logicalcontainer));
+    const initialScrollLeft = logicalcontainer.scrollLeft;
+    inlineend.click();
+    assert_greater_than(logicalcontainer.scrollLeft, initialScrollLeft, "Scroll position should increase");
+  }, "page-inline-end scrolls right in LTR");
+
+  // Test page-inline-start (should scroll left in LTR)
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(logicalcontainer));
+    logicalcontainer.scrollLeft = 400;
+    const initialScrollLeft = logicalcontainer.scrollLeft;
+    inlinestart.click();
+    assert_less_than(logicalcontainer.scrollLeft, initialScrollLeft, "Scroll position should decrease");
+  }, "page-inline-start scrolls left in LTR");
+
+  // Test RTL inline directions
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(rtlcontainer));
+    // In RTL, inline-end should scroll left (in the visual sense)
+    const initialScrollLeft = rtlcontainer.scrollLeft;
+    rtlinlineend.click();
+    // Note: RTL scrolling behavior can vary, but the command should work
+    assert_not_equals(rtlcontainer.scrollLeft, initialScrollLeft, "Scroll position should change");
+  }, "page-inline-end works in RTL container");
+
+  // Test case insensitivity
+  ["page-up", "PAGE-UP", "PaGe-Up"].forEach((command) => {
+    test(function (t) {
+      t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+      const button = document.createElement("button");
+      button.setAttribute("commandfor", "scrollcontainer");
+      button.setAttribute("command", command);
+      document.body.appendChild(button);
+      t.add_cleanup(() => button.remove());
+
+      scrollcontainer.scrollTop = 400;
+      const initialScrollTop = scrollcontainer.scrollTop;
+      button.click();
+      assert_less_than(scrollcontainer.scrollTop, initialScrollTop, "Scroll should work with " + command);
+    }, `scroll command is case-insensitive: ${command}`);
+  });
+
+  // Test preventDefault
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    scrollcontainer.addEventListener("command", (e) => e.preventDefault(), { once: true });
+    const initialScrollTop = scrollcontainer.scrollTop;
+    pagedown.click();
+    assert_equals(scrollcontainer.scrollTop, initialScrollTop, "Scroll should not change when prevented");
+  }, "preventDefault stops scroll command");
+
+  // Test that scroll doesn't happen if commandfor is invalid
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "nonexistent");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    const initialScrollTop = scrollcontainer.scrollTop;
+    button.click();
+    assert_equals(scrollcontainer.scrollTop, initialScrollTop, "Scroll should not happen with invalid commandfor");
+  }, "scroll command requires valid commandfor target");
+
+  // Test that scroll doesn't happen on non-scrollable element
+  test(function (t) {
+    const nonscrollable = document.createElement("div");
+    nonscrollable.id = "nonscrollable";
+    nonscrollable.textContent = "Not scrollable";
+    document.body.appendChild(nonscrollable);
+    t.add_cleanup(() => nonscrollable.remove());
+
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "nonscrollable");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    // Should not throw or cause issues
+    button.click();
+    assert_equals(nonscrollable.scrollTop, 0, "Non-scrollable element should remain at 0");
+  }, "scroll command on non-scrollable element does nothing");
+
+  // Test scroll amount is reasonable (approximately one page)
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    const initialScrollTop = scrollcontainer.scrollTop;
+    const containerHeight = scrollcontainer.clientHeight;
+    pagedown.click();
+    const scrollDistance = scrollcontainer.scrollTop - initialScrollTop;
+
+    // Scroll should be at least 80% of container height (allowing for some overlap)
+    assert_greater_than(scrollDistance, containerHeight * 0.8,
+      "Scroll distance should be approximately one page");
+    // And not more than 1.2x container height
+    assert_less_than(scrollDistance, containerHeight * 1.2,
+      "Scroll distance should not be much more than one page");
+  }, "scroll amount is approximately one page");
+
+  // Edge case: commandfor references non-existent element
+  test(function (t) {
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "this-element-does-not-exist");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    // Should not throw
+    assert_equals(button.click(), undefined, "Click should not throw");
+  }, "scroll command with non-existent commandfor target doesn't throw");
+
+  // Edge case: commandfor is empty string
+  test(function (t) {
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    // Should not throw
+    assert_equals(button.click(), undefined, "Click should not throw");
+  }, "scroll command with empty commandfor doesn't throw");
+
+  // Edge case: commandfor is whitespace
+  test(function (t) {
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "   ");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    // Should not throw
+    assert_equals(button.click(), undefined, "Click should not throw");
+  }, "scroll command with whitespace commandfor doesn't throw");
+
+  // Edge case: target element is disconnected
+  test(function (t) {
+    const disconnected = document.createElement("div");
+    disconnected.id = "disconnected";
+    disconnected.className = "scroll-container";
+    disconnected.innerHTML = '<div class="scroll-content"></div>';
+
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "disconnected");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    // Should not throw
+    assert_equals(button.click(), undefined, "Click should not throw for disconnected target");
+  }, "scroll command with disconnected target element doesn't throw");
+
+  // Edge case: target element is button itself
+  test(function (t) {
+    const button = document.createElement("button");
+    button.id = "selfbutton";
+    button.setAttribute("commandfor", "selfbutton");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    // Should not throw
+    assert_equals(button.click(), undefined, "Click should not throw when targeting self");
+  }, "scroll command targeting self doesn't throw");
+
+  // Edge case: target element is display:none
+  test(function (t) {
+    const hidden = document.createElement("div");
+    hidden.id = "hiddenscroll";
+    hidden.className = "scroll-container";
+    hidden.style.display = "none";
+    hidden.innerHTML = '<div class="scroll-content"></div>';
+    document.body.appendChild(hidden);
+    t.add_cleanup(() => hidden.remove());
+
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "hiddenscroll");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    // Should not throw
+    assert_equals(button.click(), undefined, "Click should not throw for hidden target");
+    assert_equals(hidden.scrollTop, 0, "Hidden element should not scroll");
+  }, "scroll command on display:none element does nothing");
+
+  // Edge case: target element has no computed style (e.g., in detached document)
+  test(function (t) {
+    const newDoc = document.implementation.createHTMLDocument();
+    const container = newDoc.createElement("div");
+    container.id = "detachedcontainer";
+    container.className = "scroll-container";
+    newDoc.body.appendChild(container);
+
+    // Add the container to main document so commandfor can find it
+    document.body.appendChild(container);
+    t.add_cleanup(() => container.remove());
+
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "detachedcontainer");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    // Should not throw
+    assert_equals(button.click(), undefined, "Click should not throw");
+  }, "scroll command handles elements with unusual document state");
+
+  // Edge case: button is disabled
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "scrollcontainer");
+    button.setAttribute("command", "page-down");
+    button.disabled = true;
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    const initialScrollTop = scrollcontainer.scrollTop;
+    button.click();
+    // Disabled buttons should not trigger commands
+    assert_equals(scrollcontainer.scrollTop, initialScrollTop, "Disabled button should not trigger scroll");
+  }, "disabled button doesn't trigger scroll command");
+
+  // Edge case: multiple buttons targeting same element
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    const button1 = document.createElement("button");
+    button1.setAttribute("commandfor", "scrollcontainer");
+    button1.setAttribute("command", "page-down");
+    document.body.appendChild(button1);
+    t.add_cleanup(() => button1.remove());
+
+    const button2 = document.createElement("button");
+    button2.setAttribute("commandfor", "scrollcontainer");
+    button2.setAttribute("command", "page-down");
+    document.body.appendChild(button2);
+    t.add_cleanup(() => button2.remove());
+
+    const initialScrollTop = scrollcontainer.scrollTop;
+    button1.click();
+    const afterFirst = scrollcontainer.scrollTop;
+    assert_greater_than(afterFirst, initialScrollTop, "First button should scroll");
+
+    button2.click();
+    assert_greater_than(scrollcontainer.scrollTop, afterFirst, "Second button should also scroll");
+  }, "multiple buttons can target same scroll container");
+
+  // Edge case: scroll at boundary (can't scroll further up)
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    scrollcontainer.scrollTop = 0;
+
+    // Should not throw
+    pageup.click();
+    assert_equals(scrollcontainer.scrollTop, 0, "Should remain at top");
+  }, "scroll command at top boundary doesn't throw");
+
+  // Edge case: scroll at boundary (can't scroll further down)
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    scrollcontainer.scrollTop = scrollcontainer.scrollHeight - scrollcontainer.clientHeight;
+    const maxScroll = scrollcontainer.scrollTop;
+
+    // Should not throw
+    pagedown.click();
+    assert_equals(scrollcontainer.scrollTop, maxScroll, "Should remain at bottom");
+  }, "scroll command at bottom boundary doesn't throw");
+
+  // Edge case: invalid command value
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "scrollcontainer");
+    button.setAttribute("command", "invalid-scroll-command");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    const initialScrollTop = scrollcontainer.scrollTop;
+    button.click();
+    assert_equals(scrollcontainer.scrollTop, initialScrollTop, "Invalid command should not scroll");
+  }, "invalid scroll command value doesn't trigger scroll");
+
+  // Edge case: command attribute is empty
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "scrollcontainer");
+    button.setAttribute("command", "");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    const initialScrollTop = scrollcontainer.scrollTop;
+    button.click();
+    assert_equals(scrollcontainer.scrollTop, initialScrollTop, "Empty command should not scroll");
+  }, "empty command attribute doesn't trigger scroll");
+
+  // Edge case: target has overflow:visible (not scrollable)
+  test(function (t) {
+    const visible = document.createElement("div");
+    visible.id = "visibleoverflow";
+    visible.style.width = "200px";
+    visible.style.height = "200px";
+    visible.style.overflow = "visible";
+    visible.innerHTML = '<div style="width: 1000px; height: 1000px;"></div>';
+    document.body.appendChild(visible);
+    t.add_cleanup(() => visible.remove());
+
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "visibleoverflow");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    button.click();
+    assert_equals(visible.scrollTop, 0, "overflow:visible element should not scroll");
+  }, "scroll command on overflow:visible element does nothing");
+
+  // Edge case: target has overflow:clip
+  test(function (t) {
+    const clipped = document.createElement("div");
+    clipped.id = "clippedoverflow";
+    clipped.style.width = "200px";
+    clipped.style.height = "200px";
+    clipped.style.overflow = "clip";
+    clipped.innerHTML = '<div style="width: 1000px; height: 1000px;"></div>';
+    document.body.appendChild(clipped);
+    t.add_cleanup(() => clipped.remove());
+
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "clippedoverflow");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    button.click();
+    assert_equals(clipped.scrollTop, 0, "overflow:clip element should not scroll");
+  }, "scroll command on overflow:clip element does nothing");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.html
@@ -17,7 +17,7 @@ promise_test(async () => {
   const shadowButton = host.shadowRoot.getElementById('shadow-button');
   shadowButton.commandForElement = popover;
 
-  const eventNames = ['beforetoggle', 'toggle', 'command'];
+  const eventNames = ['command'];
   const eventNameToEvent = {};
   const eventNameToCaptureSource = {};
   const eventNameToBubbleSource = {};
@@ -33,8 +33,7 @@ promise_test(async () => {
   }
 
   shadowButton.click();
-  await new Promise(requestAnimationFrame);
-  await new Promise(requestAnimationFrame);
+  await new Promise(resolve => step_timeout(resolve, 0));
 
   for (const eventName of eventNames) {
     const event = eventNameToEvent[eventName];
@@ -48,7 +47,7 @@ promise_test(async () => {
     assert_equals(event.source, host,
       `${eventName}.source after dispatch.`);
   }
-}, 'CommandEvent.source and ToggleEvent.source should be retargeted during and after event dispatch.');
+}, 'CommandEvent.source should be retargeted during and after event dispatch.');
 </script>
 
 <div id=host2>
@@ -63,7 +62,6 @@ promise_test(async () => {
 </div>
 
 <script>
-// This does not test ToggleEvent because ToggleEventInit does not have a source attribute.
 promise_test(async () => {
   const host2 = document.getElementById('host2');
   const source = host2.shadowRoot.getElementById('source');
@@ -110,7 +108,7 @@ promise_test(async () => {
   const button = document.getElementById('button3');
   const popover = document.getElementById('popover3');
 
-  const eventNames = ['beforetoggle', 'toggle', 'command'];
+  const eventNames = ['command'];
   const eventNameToEvent = {};
   for (const eventName of eventNames) {
     popover.addEventListener(eventName, event => {
@@ -119,8 +117,7 @@ promise_test(async () => {
   }
 
   button.click();
-  await new Promise(requestAnimationFrame);
-  await new Promise(requestAnimationFrame);
+  await new Promise(resolve => step_timeout(resolve, 0));
 
   for (const eventName of eventNames) {
     const event = eventNameToEvent[eventName];
@@ -128,5 +125,5 @@ promise_test(async () => {
     assert_equals(event.source, button,
       `${eventName}.source should be the invoker button after dispatch.`);
   }
-}, 'CommandEvent.source and ToggleEvent.source should not be set to null after dispatch without ShadowDOM.');
+}, 'CommandEvent.source should not be set to null after dispatch without ShadowDOM.');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.tentative-expected.txt
@@ -1,6 +1,0 @@
-popover 3show popover 3
-
-PASS CommandEvent.source and ToggleEvent.source should be retargeted during and after event dispatch.
-PASS CommandEvent.source should be retargeted when manually dispatched with composed set to true.
-PASS CommandEvent.source and ToggleEvent.source should not be set to null after dispatch without ShadowDOM.
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/toggleevent-source-attribute-retargeting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/toggleevent-source-attribute-retargeting.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id=popover popover=auto>popover</div>
+<div id=host>
+  <template shadowrootmode=open>
+    <button id=shadow-button command=show-popover>button in shadowroot</button>
+  </template>
+</div>
+
+<script>
+promise_test(async () => {
+  const popover = document.getElementById('popover');
+  const host = document.getElementById('host');
+  const shadowButton = host.shadowRoot.getElementById('shadow-button');
+  shadowButton.commandForElement = popover;
+
+  const eventNames = ['beforetoggle', 'toggle'];
+  const eventNameToEvent = {};
+  const eventNameToCaptureSource = {};
+  const eventNameToBubbleSource = {};
+
+  for (const eventName of eventNames) {
+    popover.addEventListener(eventName, event => {
+      eventNameToEvent[eventName] = event;
+      eventNameToBubbleSource[eventName] = event.source;
+    });
+    popover.addEventListener(eventName, event => {
+      eventNameToCaptureSource[eventName] = event.source;
+    }, {capture: true});
+  }
+
+  shadowButton.click();
+  await new Promise(resolve => step_timeout(resolve, 0));
+
+  for (const eventName of eventNames) {
+    const event = eventNameToEvent[eventName];
+    assert_true(!!event, `A ${eventName} event should have been fired.`);
+    assert_equals(eventNameToCaptureSource[eventName], host,
+      `${eventName}.source during capture.`);
+    assert_equals(eventNameToBubbleSource[eventName], host,
+      `${eventName}.source during bubble.`);
+    assert_not_equals(event.source, shadowButton,
+      `${eventName}.source shouldn't leak the shadow button.`);
+    assert_equals(event.source, host,
+      `${eventName}.source after dispatch.`);
+  }
+}, 'ToggleEvent.source should be retargeted during and after event dispatch.');
+</script>
+
+<div id=host2>
+  <template shadowrootmode=open>
+    <div id=source>source</div>
+    <div id=innerhost>
+      <template shadowrootmode=open>
+        <div id=target>target</div>
+      </template>
+    </div>
+  </template>
+</div>
+
+<script>
+promise_test(async () => {
+  const host2 = document.getElementById('host2');
+  const source = host2.shadowRoot.getElementById('source');
+  const innerhost = host2.shadowRoot.getElementById('innerhost');
+  const target = innerhost.shadowRoot.getElementById('target');
+
+  const targets = [host2, innerhost, target];
+  const targetToEvent = new Map();
+  const targetToCaptureSource = new Map();
+  const targetToBubbleSource = new Map();
+
+  for (const target of targets) {
+    target.addEventListener('toggle', event => {
+      targetToEvent.set(target, event);
+      targetToBubbleSource.set(target, event.source);
+    });
+    target.addEventListener('toggle', event => {
+      targetToCaptureSource.set(target, event.source);
+    }, {capture: true});
+  }
+
+  const toggleEvent = new ToggleEvent('toggle', {composed: true, source});
+  target.dispatchEvent(toggleEvent);
+
+  for (const target of targets) {
+    const expectedSource = target == host2 ? host2 : source;
+    assert_true(targetToEvent.has(target),
+      `${target.id}: event should have fired.`);
+    assert_equals(targetToCaptureSource.get(target), expectedSource,
+      `${target.id}: event.source at capture.`);
+    assert_equals(targetToBubbleSource.get(target), expectedSource,
+      `${target.id}: event.source at bubble.`);
+    assert_equals(targetToEvent.get(target).source, host2,
+      `${target.id}: event.source after dispatch.`);
+  }
+}, 'Toggle.source should be retargeted when manually dispatched with composed set to true.');
+</script>
+
+<div id=popover3 popover=auto>popover 3</div>
+<button id=button3 commandfor=popover3 command=show-popover>show popover 3</button>
+
+<script>
+promise_test(async () => {
+  const button = document.getElementById('button3');
+  const popover = document.getElementById('popover3');
+
+  const eventNames = ['beforetoggle', 'toggle'];
+  const eventNameToEvent = {};
+  for (const eventName of eventNames) {
+    popover.addEventListener(eventName, event => {
+      eventNameToEvent[eventName] = event;
+    });
+  }
+
+  button.click();
+  await new Promise(resolve => step_timeout(resolve, 0));
+
+  for (const eventName of eventNames) {
+    const event = eventNameToEvent[eventName];
+    assert_true(!!event, `${eventName} should have been fired.`);
+    assert_equals(event.source, button,
+      `${eventName}.source should be the invoker button after dispatch.`);
+  }
+}, 'ToggleEvent.source should not be set to null after dispatch without ShadowDOM.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/w3c-import.log
@@ -14,16 +14,19 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch-content-attribute.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-close-target-non-dialog-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-reflection.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/event-dispatch-shadow.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/event-interface.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/fullscreen-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/generic-eventtarget-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/interface.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-audio-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-audio-invalid-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-details-behavior.tentative.html
@@ -35,5 +38,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-popover-behavior.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-popover-disconnect.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-popover-invalid-behavior.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-scroll-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-video-behavior.tentative.html
-/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/toggleevent-source-attribute-retargeting.html

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -4298,6 +4298,9 @@
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/fullscreen-behavior.tentative.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-audio-behavior.tentative.html": [
         "slow"
     ],
@@ -4308,9 +4311,6 @@
         "slow"
     ],
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-details-invalid-behavior.tentative.html": [
-        "slow"
-    ],
-    "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior-request-close.tentative.html": [
         "slow"
     ],
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior.html": [
@@ -4329,6 +4329,9 @@
         "slow"
     ],
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-popover-invalid-behavior.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-scroll-behavior.tentative.html": [
         "slow"
     ],
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-video-behavior.tentative.html": [


### PR DESCRIPTION
Re-import command button WPT tests https://bugs.webkit.org/show_bug.cgi?id=309903

Reviewed by NOBODY (OOPS!).

Also re-import 'html/semantics/popovers/resources'.

The goal is to fetch the changes from
https://github.com/web-platform-tests/wpt/pull/58451, which makes several WPT tests pass for WPE.

* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/popover-top-layer-nesting.js: (runTopLayerTests):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/popover-utils.js: (async clickOn):
(async verifyFocusOrder):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/toggle-event-source-test.js: (createToggleEventSourceTest):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-invalid-behavior.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-popover-invalid-behavior.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.tentative-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.tentative.html: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/w3c-import.log:
* LayoutTests/tests-options.json:

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8a2c2da4792c90e3999ba186a2d52de2f22d7a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149971 "4 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/22690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/16276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/158678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/23144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22799 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/158678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152931 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/23144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/16276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/158678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/23144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/6524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/23144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/16276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/161155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/16276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/161155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/22498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/18892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/161155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/22503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/16276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78747 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/16276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/22103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/21830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/21985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/21887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->