### PR TITLE
[DRAFT] REGRESSION(308037@main): fast/ruby/ruby-expansion-cjk-4.html is a consistent image failure on CheerE+

### DIFF
--- a/LayoutTests/fast/text/bidi-glyph-overflow-inflation-expected.html
+++ b/LayoutTests/fast/text/bidi-glyph-overflow-inflation-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+.test {
+    font-family: Ahem;
+    font-size: 40px;
+    -webkit-font-smoothing: none;
+    line-height: 1;
+    overflow: hidden;
+    width: 400px;
+    background: white;
+    margin: 10px 0;
+}
+</style>
+</head>
+<body>
+<!-- Reference: Same content rendered without bidi context to show expected
+     non-inflated rendering. The overflow:hidden should not clip any content
+     because glyph overflow should be minimal (near-zero deltas). -->
+<div class="test">abc</div>
+<div class="test" dir="rtl">&#x62a; abc &#x62a;</div>
+<div class="test">abc</div>
+</body>
+</html>

--- a/LayoutTests/fast/text/bidi-glyph-overflow-inflation.html
+++ b/LayoutTests/fast/text/bidi-glyph-overflow-inflation.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<style>
+.test {
+    font-family: Ahem;
+    font-size: 40px;
+    -webkit-font-smoothing: none;
+    line-height: 1;
+    overflow: hidden;
+    width: 400px;
+    background: white;
+    margin: 10px 0;
+}
+</style>
+</head>
+<body>
+<!-- Test that bidi text with fallback fonts does not produce inflated glyph overflow.
+     The Arabic character U+62A is not in Ahem, so it uses a system fallback font.
+     The dir="rtl" triggers contentRequiresVisualReordering(), which uses
+     computeInlineTextItemWidthsAndTextSpacing() for glyph overflow computation.
+     Without the fix, raw glyph bounds are stored as overflow deltas, causing
+     ~32px of spurious vertical ink overflow inflation per character.
+     With the fix, the overflow deltas are correctly computed as raw_bound minus
+     font_metric, producing near-zero overflow for normal glyphs. -->
+<div class="test">abc</div>
+<div class="test" dir="rtl">&#x62a; abc &#x62a;</div>
+<div class="test">abc</div>
+</body>
+</html>

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp
@@ -27,6 +27,7 @@
 #include "InlineItemsBuilder.h"
 
 #include "FontCascade.h"
+#include "InlineFormattingUtils.h"
 #include "InlineSoftLineBreakItem.h"
 #include "RenderObjectInlines.h"
 #include "RenderStyle+GettersInlines.h"
@@ -830,6 +831,12 @@ void InlineItemsBuilder::computeInlineTextItemWidthsAndTextSpacing(InlineItemLis
                     GlyphOverflow glyphOverflow;
                     glyphOverflow.computeBounds = true;
                     width = TextUtil::width(*inlineTextItem, fontCascade.get(), start, start + inlineTextItem->length(), { }, TextUtil::UseTrailingWhitespaceMeasuringOptimization::Yes, spacingState, &glyphOverflow);
+                    // Convert raw glyph bounds to overflow deltas (extent beyond font metrics).
+                    // This mirrors the conversion in nonWhitespaceContentWidth().
+                    auto& fontMetrics = fontCascade->metricsOfPrimaryFont();
+                    auto& inlineTextBox = inlineTextItem->inlineTextBox();
+                    glyphOverflow.top = std::max(0.f, InlineFormattingUtils::snapToInt(glyphOverflow.top, inlineTextBox) - InlineFormattingUtils::ascent(fontMetrics, FontBaseline::Alphabetic, inlineTextBox));
+                    glyphOverflow.bottom = std::max(0.f, InlineFormattingUtils::snapToInt(glyphOverflow.bottom, inlineTextBox) - InlineFormattingUtils::descent(fontMetrics, FontBaseline::Alphabetic, inlineTextBox));
                     inlineTextItem->setGlyphOverflow(std::clamp(glyphOverflow.top, 0_lu, 31_lu), std::clamp(glyphOverflow.bottom, 0_lu, 7_lu));
                 } else
                     width = TextUtil::width(*inlineTextItem, fontCascade.get(), start, start + inlineTextItem->length(), { }, TextUtil::UseTrailingWhitespaceMeasuringOptimization::Yes, spacingState);


### PR DESCRIPTION
#### 7646fd195a910917d64b70fecea12a565049c30b
<pre>
[DRAFT] REGRESSION(<a href="https://commits.webkit.org/308037@main">308037@main</a>): fast/ruby/ruby-expansion-cjk-4.html is a consistent image failure on CheerE+
<a href="https://bugs.webkit.org/show_bug.cgi?id=309620">https://bugs.webkit.org/show_bug.cgi?id=309620</a>
<a href="https://rdar.apple.com/172107254">rdar://172107254</a>

Reviewed by NOBODY (OOPS!).

Commit <a href="https://commits.webkit.org/308037@main">308037@main</a> introduced glyph overflow tracking in
computeInlineTextItemWidthsAndTextSpacing() but stored raw glyph bounds
instead of overflow deltas (extent beyond font metrics). The consumer
(InlineDisplayContentBuilder::appendTextDisplayBox) expects delta values and
uses them to inflate ink overflow, causing massive over-inflation (~32px for
a 40px font) for text using fallback fonts in bidi-reordering content.

Add the same raw-to-delta conversion that already exists in
nonWhitespaceContentWidth(), which correctly subtracts the font&apos;s
ascent/descent from the raw glyph bounds before storing.

* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::InlineItemsBuilder::computeInlineTextItemWidthsAndTextSpacing):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7646fd195a910917d64b70fecea12a565049c30b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16266 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158669 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103396 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2bc44a30-d21a-45b4-8db7-80799a2be3ab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23135 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115676 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82193 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ca236f4-6a09-4e74-af7c-fa68d8a58fce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134564 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96413 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a2f8c0e-0839-45dc-8dd8-1204fe401d3f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16905 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14838 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6515 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126520 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161146 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14040 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123686 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22493 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123888 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134282 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78738 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19053 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11039 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22100 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85931 "Found 1 new failure in layout/formattingContexts/inline/InlineItemsBuilder.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21821 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21976 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21878 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->