### PR TITLE
[JSC][WASM][Debugger] ENABLE(WEBASSEMBLY_DEBUGGER) must not be architecture-dependent to keep IPC MessageNames consistent

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -4413,7 +4413,7 @@ int runJSC(const CommandLine& options, bool isWorker, const Func& func)
             globalObject = GlobalObject::create(vm, GlobalObject::createStructure(vm, jsNull()), options.m_arguments);
             globalObject->setInspectable(options.m_inspectable);
 
-#if ENABLE(WEBASSEMBLY_DEBUGGER)
+#if ENABLE(WEBASSEMBLY_DEBUGGER) && CPU(ARM64)
             if (Options::enableWasmDebugger()) [[unlikely]]
                 Wasm::DebugServer::singleton().start();
 #endif

--- a/Source/JavaScriptCore/wasm/debugger/testwasmdebugger.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/testwasmdebugger.cpp
@@ -289,7 +289,7 @@ static void testWASMVirtualAddressOperators()
     dataLogLn("VirtualAddress operators tests completed");
 }
 
-static int runAllTests()
+[[maybe_unused]] static int runAllTests()
 {
     dataLogLn("Starting WASM Debugger Test Suite");
     dataLogLn("===============================================");
@@ -336,6 +336,8 @@ static int runAllTests()
     return totalFailures;
 }
 
+#if CPU(ARM64)
+
 int main(int argc, char** argv)
 {
     UNUSED_PARAM(argc);
@@ -355,6 +357,19 @@ int main(int argc, char** argv)
     JSC::Options::setOption("enableWasmDebugger=true");
     return runAllTests();
 }
+
+#else // !CPU(ARM64)
+
+int main(int argc, char** argv)
+{
+    UNUSED_PARAM(argc);
+    UNUSED_PARAM(argv);
+
+    dataLogLn("WASM debugger tests are disabled (only supported on ARM64)");
+    return 0;
+}
+
+#endif // CPU(ARM64)
 
 #if OS(WINDOWS)
 extern "C" __declspec(dllexport) int WINAPI dllLauncherEntryPoint(int argc, const char* argv[])

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -853,8 +853,8 @@
 #endif
 
 /* WebAssembly Debugger - GDB Remote Protocol debugging for WebAssembly.
- * Restricted to macOS ARM64 only. Supports JSC shell TCP socket mode and WebKit RWI integration. */
-#if !defined(ENABLE_WEBASSEMBLY_DEBUGGER) && PLATFORM(MAC) && CPU(ARM64) && ENABLE(WEBASSEMBLY)
+ * Restricted to macOS only. Supports JSC shell TCP socket mode and WebKit RWI integration. */
+#if !defined(ENABLE_WEBASSEMBLY_DEBUGGER) && PLATFORM(MAC) && ENABLE(WEBASSEMBLY)
 #define ENABLE_WEBASSEMBLY_DEBUGGER 1
 #endif
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -756,7 +756,7 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
     m_shouldInitializeAccessibility = parameters.shouldInitializeAccessibility;
 #endif
 
-#if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
+#if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR) && CPU(ARM64)
     if (JSC::Options::enableWasmDebugger()) [[unlikely]] {
         bool success = JSC::Wasm::DebugServer::singleton().startRWI([](const String& response) {
             return WebKit::WebProcess::singleton().send(Messages::WebProcessProxy::SendWasmDebuggerResponse(response), 0);


### PR DESCRIPTION
#### 5f233ab494317a4a25569e364dc5f5d1b284b667
<pre>
[JSC][WASM][Debugger] ENABLE(WEBASSEMBLY_DEBUGGER) must not be architecture-dependent to keep IPC MessageNames consistent
<a href="https://bugs.webkit.org/show_bug.cgi?id=309905">https://bugs.webkit.org/show_bug.cgi?id=309905</a>
<a href="https://rdar.apple.com/172097502">rdar://172097502</a>

Reviewed by Yusuke Suzuki and Mark Lam.

Safari crashes under Rosetta because ENABLE(WEBASSEMBLY_DEBUGGER) was gated on CPU(ARM64),
causing the SendWasmDebuggerResponse IPC message to be absent from the MessageNames enum on
x86_64 builds. ARM64 WebContent processes and the Intel Safari UI process then disagree on
message indices, causing Safari to kill the sender upon receiving an &quot;invalid&quot; message.

Fix by removing CPU(ARM64) from ENABLE_WEBASSEMBLY_DEBUGGER in PlatformEnable.h so the IPC
plumbing compiles on all Mac architectures. The debugger engine itself is still restricted to
ARM64 by guarding the DebugServer::start() and startRWI() call sites with CPU(ARM64), and
testwasmdebugger skips all tests on non-ARM64.

Canonical link: <a href="https://commits.webkit.org/309253@main">https://commits.webkit.org/309253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/294f08c89d166c135040dfe9c09d2e81bc60a2f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158683 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103410 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1962f137-b91a-44b4-82ef-4d4407ad5834) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115709 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134569 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96427 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5b4e33d-1169-4c3a-bf73-13ca2a99786f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16913 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14853 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6529 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/141969 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126528 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161160 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10784 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123705 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22503 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123912 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33660 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134288 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78752 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19058 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11044 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181406 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22108 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85936 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46449 "Found 1 new JSC stress test failure: Too many failures: 28777 jsc tests failed (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21838 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21990 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21898 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->