### PR TITLE
Re-import html/semantics/the-button-element/command-and-commandfor tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/popover-top-layer-nesting.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/popover-top-layer-nesting.js
@@ -21,8 +21,7 @@ function createTopLayerElement(t,topLayerType) {
   t.add_cleanup(() => element.remove());
   return {element,show,showing};
 }
-function runTopLayerTests(testCases, testAnchorAttribute) {
-  testAnchorAttribute = testAnchorAttribute || false;
+function runTopLayerTests(testCases) {
   testCases.forEach(test => {
     const description = test.firstChild.data.trim();
     assert_equals(test.querySelectorAll('.target').length,1,'There should be exactly one target');
@@ -85,24 +84,6 @@ function runTopLayerTests(testCases, testAnchorAttribute) {
           }
         }
       },`${description} with ${topLayerType}, top layer element *is* a popover`);
-
-      if (testAnchorAttribute) {
-        promise_test(async t => {
-          const {element,show,showing} = createTopLayerElement(t,topLayerType);
-          element.anchorElement = target;
-          document.body.appendChild(element);
-
-          // Show the popovers.
-          t.add_cleanup(() => popovers.forEach(popover => popover.hidePopover()));
-          popovers.forEach(popover => popover.showPopover());
-          popovers.forEach(popover => assert_true(popover.matches(':popover-open'),'All popovers should be open'));
-
-          // Activate the top layer element.
-          await show(popovers[popovers.length-1]);
-          assert_true(showing());
-          popovers.forEach(popover => assert_equals(popover.matches(':popover-open'),popover.dataset.stayOpen==='true','Incorrect behavior'));
-        },`${description} with ${topLayerType}, anchor attribute`);
-      }
     });
   });
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/toggle-event-source-test.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/toggle-event-source-test.js
@@ -25,8 +25,7 @@ function createToggleEventSourceTest({
     });
 
     await openFunc();
-    await new Promise(requestAnimationFrame);
-    await new Promise(requestAnimationFrame);
+    await new Promise(resolve => step_timeout(resolve, 0));
     if (!skipBeforetoggle) {
       assert_true(!!beforetoggleEvent,
         'An opening beforetoggle event should have been fired.');
@@ -51,8 +50,7 @@ function createToggleEventSourceTest({
     toggleDuplicate = false;
 
     await closeFunc();
-    await new Promise(requestAnimationFrame);
-    await new Promise(requestAnimationFrame);
+    await new Promise(resolve => step_timeout(resolve, 0));
 
     if (!skipBeforetoggle) {
       assert_true(!!beforetoggleEvent,

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: invoker-commands
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch-expected.txt
@@ -20,16 +20,22 @@ PASS setting custom command property to --show-picker (must include dash) sets e
 PASS setting custom command attribute to --show-picker (must include dash) sets event command
 PASS setting custom command property to -foo (no dash) did not dispatch an event
 PASS setting custom command attribute to -foo (no dash) did not dispatch an event
+PASS setting command attribute to -foo (no dash) did not dispatch an event with an svg target
 PASS setting custom command property to -foo- (no dash) did not dispatch an event
 PASS setting custom command attribute to -foo- (no dash) did not dispatch an event
+PASS setting command attribute to -foo- (no dash) did not dispatch an event with an svg target
 PASS setting custom command property to foo-bar (no dash) did not dispatch an event
 PASS setting custom command attribute to foo-bar (no dash) did not dispatch an event
+PASS setting command attribute to foo-bar (no dash) did not dispatch an event with an svg target
 PASS setting custom command property to -foo bar (no dash) did not dispatch an event
 PASS setting custom command attribute to -foo bar (no dash) did not dispatch an event
+PASS setting command attribute to -foo bar (no dash) did not dispatch an event with an svg target
 PASS setting custom command property to —-emdash (no dash) did not dispatch an event
 PASS setting custom command attribute to —-emdash (no dash) did not dispatch an event
+PASS setting command attribute to —-emdash (no dash) did not dispatch an event with an svg target
 PASS setting custom command property to hidedocument (no dash) did not dispatch an event
 PASS setting custom command attribute to hidedocument (no dash) did not dispatch an event
+PASS setting command attribute to hidedocument (no dash) did not dispatch an event with an svg target
 PASS event does not dispatch if click:preventDefault is called
 PASS event does not dispatch on input[type=button]
 PASS event does not dispatch if invoker is disabled
@@ -38,5 +44,17 @@ PASS event does NOT dispatch if button is form associated, with explicit type=in
 PASS event dispatches if button is form associated, with explicit type=button
 PASS event does NOT dispatch if button is form associated, with explicit type=submit
 PASS event does NOT dispatch if button is form associated, with explicit type=reset
-PASS event dispatches if invokee is non-HTML Element
+PASS event dispatches if invokee is non-HTML Element and command is custom
+PASS setting command to show-modal did not dispatch an event for invalid element
+PASS setting command to show-modal did not dispatch an event for svg element
+PASS setting command to close did not dispatch an event for invalid element
+PASS setting command to close did not dispatch an event for svg element
+PASS setting command to request-close did not dispatch an event for invalid element
+PASS setting command to request-close did not dispatch an event for svg element
+PASS setting command to show-popover did dispatch an event for element without popover attribute
+PASS setting command to show-popover did not dispatch an event for svg element
+PASS setting command to hide-popover did dispatch an event for element without popover attribute
+PASS setting command to hide-popover did not dispatch an event for svg element
+PASS setting command to toggle-popover did dispatch an event for element without popover attribute
+PASS setting command to toggle-popover did not dispatch an event for svg element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html
@@ -11,6 +11,7 @@
 <button id="invokerbutton" commandfor="invokee" command="--custom-command"></button>
 <input type="button" id="invalidbutton" commandfor="invokee" command="--custom-command">
 <form id="aform"></form>
+<svg id="svgInvokee"></svg>
 
 <script>
   aform.addEventListener('submit', (e) => (e.preventDefault()));
@@ -110,6 +111,18 @@
       invokerbutton.click();
       assert_equals(event, null, "event should not have fired");
     }, `setting custom command attribute to ${command} (no dash) did not dispatch an event`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      assert_false(svgInvokee instanceof HTMLElement);
+      assert_true(svgInvokee instanceof Element);
+      let command_event_fired = false;
+      svgInvokee.addEventListener("command", () => (command_event_fired = true), {signal: t.get_signal()});
+      invokerbutton.setAttribute("commandfor", "svgInvokee");
+      invokerbutton.setAttribute("command", command);
+      invokerbutton.click();
+      assert_false(command_event_fired, "command event fired");
+    }, `setting command attribute to ${command} (no dash) did not dispatch an event with an svg target`);
   });
 
   test(function (t) {
@@ -206,15 +219,12 @@
   }, "event does NOT dispatch if button is form associated, with explicit type=reset");
 
   test(function (t) {
-    svgInvokee = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-    svgInvokee.setAttribute("id", "svg-invokee");
     t.add_cleanup(resetState);
-    document.body.append(svgInvokee);
     assert_false(svgInvokee instanceof HTMLElement);
     assert_true(svgInvokee instanceof Element);
     let event = null;
-    svgInvokee.addEventListener("command", (e) => (event = e), { once: true });
-    invokerbutton.setAttribute("commandfor", "svg-invokee");
+    svgInvokee.addEventListener("command", (e) => (event = e), { once: true, signal: t.get_signal() });
+    invokerbutton.setAttribute("commandfor", "svgInvokee");
     invokerbutton.setAttribute("command", "--custom-command");
     assert_equals(invokerbutton.commandForElement, svgInvokee);
     invokerbutton.click();
@@ -222,5 +232,53 @@
     assert_true(event instanceof CommandEvent, "event is CommandEvent");
     assert_equals(event.source, invokerbutton, "event.invoker is set to right element");
     assert_equals(event.target, svgInvokee, "event.target is set to right element");
-  }, "event dispatches if invokee is non-HTML Element");
+  }, "event dispatches if invokee is non-HTML Element and command is custom");
+
+  // known commands with incompatible target
+  ["show-modal", "close", "request-close"].forEach((command) => {
+    test(function (t) {
+      t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      invokerbutton.command = command;
+      invokerbutton.click();
+      assert_false(command_event_fired, "command event fired");
+    }, `setting command to ${command} did not dispatch an event for invalid element`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      assert_false(svgInvokee instanceof HTMLElement);
+      assert_true(svgInvokee instanceof Element);
+      let command_event_fired = false;
+      svgInvokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      invokerbutton.setAttribute("commandfor", "svgInvokee");
+      invokerbutton.setAttribute("command", command);
+      invokerbutton.click();
+      assert_false(command_event_fired, "command event fired");
+    }, `setting command to ${command} did not dispatch an event for svg element`);
+  });
+
+  // popover commands
+  ["show-popover", "hide-popover", "toggle-popover"].forEach((command) => {
+    test(function (t) {
+      t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      invokerbutton.command = command;
+      invokerbutton.click();
+      assert_true(command_event_fired, "command event fired");
+    }, `setting command to ${command} did dispatch an event for element without popover attribute`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      assert_false(svgInvokee instanceof HTMLElement);
+      assert_true(svgInvokee instanceof Element);
+      let command_event_fired = false;
+      svgInvokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      invokerbutton.setAttribute("commandfor", "svgInvokee");
+      invokerbutton.setAttribute("command", command);
+      invokerbutton.click();
+      assert_false(command_event_fired, "command event fired");
+    }, `setting command to ${command} did not dispatch an event for svg element`);
+  });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-close-target-non-dialog-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-close-target-non-dialog-crash.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>button command=close targeting non-dialog should not crash</title>
+<meta name="author" title="Peng Zhou" href="mailto:pengzhou@chromium.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element">
+<link rel="help" href="https://crbug.com/490727227">
+<p>Pass if no crash.</p>
+<input type="text" id="target">
+<button id="button" commandfor="target" command="close">Click me</button>
+<script>
+  document.getElementById('button').click();
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<meta name="timeout" content="long" />
+<meta charset="utf-8" />
+<meta name="author" href="mailto:masonf@chromium.org" />
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/invoker-utils.js"></script>
+<script src="/html/resources/common.js"></script>
+
+<meta name=variant content=?command=--custom-event&half=first>
+<meta name=variant content=?command=--custom-event&half=second>
+<meta name=variant content=?command=show-popover&half=first>
+<meta name=variant content=?command=show-popover&half=second>
+<meta name=variant content=?command=show-modal&half=first>
+<meta name=variant content=?command=show-modal&half=second>
+
+<div id="invokee"></div>
+
+<script>
+  // The command parameter is provided by variants, to
+  // effectively split this (slow) test into multiple runs.
+  const urlParams = new URLSearchParams(window.location.search);
+  command = urlParams.get('command');
+  half = urlParams.get('half');
+  const firstHalf = half === 'first';
+  assert_true(firstHalf || half === 'second');
+
+  const allowed = ['button','menuitem'];
+  const allTags = HTML5_ELEMENTS.filter(el => (!allowed.includes(el)));
+  const midpoint = Math.floor(allTags.length / 2);
+  const tags = firstHalf ? allTags.slice(0,midpoint) : allTags.slice(midpoint);
+  let gotEvent = false;
+  invokee.addEventListener('command',() => (gotEvent = true));
+  for(const tag of tags) {
+    promise_test(async () => {
+      gotEvent = false;
+      const element = document.createElement(tag);
+      element.setAttribute('commandfor','invokee');
+      element.setAttribute('command',command);
+      element.style.display = 'block'; // For normally invisible elements
+      document.body.appendChild(element);
+      // Click two ways
+      element.click();
+      await clickOn(element);
+      assert_false(gotEvent,'Command should not be fired');
+    },`command/commandfor on <${tag}> with command=${command} should not function`);
+  }
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=--custom-event&half=first-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=--custom-event&half=first-expected.txt
@@ -1,0 +1,59 @@
+
+
+
+
+PASS command/commandfor on <a> with command=--custom-event should not function
+PASS command/commandfor on <abbr> with command=--custom-event should not function
+PASS command/commandfor on <address> with command=--custom-event should not function
+PASS command/commandfor on <area> with command=--custom-event should not function
+PASS command/commandfor on <article> with command=--custom-event should not function
+PASS command/commandfor on <aside> with command=--custom-event should not function
+PASS command/commandfor on <audio> with command=--custom-event should not function
+PASS command/commandfor on <b> with command=--custom-event should not function
+PASS command/commandfor on <base> with command=--custom-event should not function
+PASS command/commandfor on <bdi> with command=--custom-event should not function
+PASS command/commandfor on <bdo> with command=--custom-event should not function
+PASS command/commandfor on <blockquote> with command=--custom-event should not function
+PASS command/commandfor on <body> with command=--custom-event should not function
+PASS command/commandfor on <br> with command=--custom-event should not function
+PASS command/commandfor on <canvas> with command=--custom-event should not function
+PASS command/commandfor on <caption> with command=--custom-event should not function
+PASS command/commandfor on <cite> with command=--custom-event should not function
+PASS command/commandfor on <code> with command=--custom-event should not function
+PASS command/commandfor on <col> with command=--custom-event should not function
+PASS command/commandfor on <colgroup> with command=--custom-event should not function
+PASS command/commandfor on <data> with command=--custom-event should not function
+PASS command/commandfor on <datalist> with command=--custom-event should not function
+PASS command/commandfor on <dd> with command=--custom-event should not function
+PASS command/commandfor on <del> with command=--custom-event should not function
+PASS command/commandfor on <details> with command=--custom-event should not function
+PASS command/commandfor on <dfn> with command=--custom-event should not function
+PASS command/commandfor on <dialog> with command=--custom-event should not function
+PASS command/commandfor on <div> with command=--custom-event should not function
+PASS command/commandfor on <dl> with command=--custom-event should not function
+PASS command/commandfor on <dt> with command=--custom-event should not function
+PASS command/commandfor on <em> with command=--custom-event should not function
+PASS command/commandfor on <embed> with command=--custom-event should not function
+PASS command/commandfor on <fieldset> with command=--custom-event should not function
+PASS command/commandfor on <figcaption> with command=--custom-event should not function
+PASS command/commandfor on <figure> with command=--custom-event should not function
+PASS command/commandfor on <footer> with command=--custom-event should not function
+PASS command/commandfor on <form> with command=--custom-event should not function
+PASS command/commandfor on <h1> with command=--custom-event should not function
+PASS command/commandfor on <h2> with command=--custom-event should not function
+PASS command/commandfor on <h3> with command=--custom-event should not function
+PASS command/commandfor on <h4> with command=--custom-event should not function
+PASS command/commandfor on <h5> with command=--custom-event should not function
+PASS command/commandfor on <h6> with command=--custom-event should not function
+PASS command/commandfor on <head> with command=--custom-event should not function
+PASS command/commandfor on <header> with command=--custom-event should not function
+PASS command/commandfor on <hr> with command=--custom-event should not function
+PASS command/commandfor on <html> with command=--custom-event should not function
+PASS command/commandfor on <i> with command=--custom-event should not function
+PASS command/commandfor on <iframe> with command=--custom-event should not function
+PASS command/commandfor on <img> with command=--custom-event should not function
+PASS command/commandfor on <input> with command=--custom-event should not function
+PASS command/commandfor on <ins> with command=--custom-event should not function
+PASS command/commandfor on <kbd> with command=--custom-event should not function
+PASS command/commandfor on <label> with command=--custom-event should not function
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=--custom-event&half=second-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=--custom-event&half=second-expected.txt
@@ -1,0 +1,65 @@
+
+
+
+
+
+
+
+
+
+PASS command/commandfor on <legend> with command=--custom-event should not function
+PASS command/commandfor on <li> with command=--custom-event should not function
+PASS command/commandfor on <link> with command=--custom-event should not function
+PASS command/commandfor on <main> with command=--custom-event should not function
+PASS command/commandfor on <map> with command=--custom-event should not function
+PASS command/commandfor on <mark> with command=--custom-event should not function
+PASS command/commandfor on <menu> with command=--custom-event should not function
+PASS command/commandfor on <meta> with command=--custom-event should not function
+PASS command/commandfor on <meter> with command=--custom-event should not function
+PASS command/commandfor on <nav> with command=--custom-event should not function
+PASS command/commandfor on <noscript> with command=--custom-event should not function
+PASS command/commandfor on <object> with command=--custom-event should not function
+PASS command/commandfor on <ol> with command=--custom-event should not function
+PASS command/commandfor on <optgroup> with command=--custom-event should not function
+PASS command/commandfor on <option> with command=--custom-event should not function
+PASS command/commandfor on <output> with command=--custom-event should not function
+PASS command/commandfor on <p> with command=--custom-event should not function
+PASS command/commandfor on <param> with command=--custom-event should not function
+PASS command/commandfor on <pre> with command=--custom-event should not function
+PASS command/commandfor on <progress> with command=--custom-event should not function
+PASS command/commandfor on <q> with command=--custom-event should not function
+PASS command/commandfor on <rp> with command=--custom-event should not function
+PASS command/commandfor on <rt> with command=--custom-event should not function
+PASS command/commandfor on <ruby> with command=--custom-event should not function
+PASS command/commandfor on <s> with command=--custom-event should not function
+PASS command/commandfor on <samp> with command=--custom-event should not function
+PASS command/commandfor on <script> with command=--custom-event should not function
+PASS command/commandfor on <section> with command=--custom-event should not function
+PASS command/commandfor on <select> with command=--custom-event should not function
+PASS command/commandfor on <slot> with command=--custom-event should not function
+PASS command/commandfor on <small> with command=--custom-event should not function
+PASS command/commandfor on <source> with command=--custom-event should not function
+PASS command/commandfor on <span> with command=--custom-event should not function
+PASS command/commandfor on <strong> with command=--custom-event should not function
+PASS command/commandfor on <style> with command=--custom-event should not function
+PASS command/commandfor on <sub> with command=--custom-event should not function
+PASS command/commandfor on <sup> with command=--custom-event should not function
+PASS command/commandfor on <summary> with command=--custom-event should not function
+PASS command/commandfor on <table> with command=--custom-event should not function
+PASS command/commandfor on <tbody> with command=--custom-event should not function
+PASS command/commandfor on <td> with command=--custom-event should not function
+PASS command/commandfor on <template> with command=--custom-event should not function
+PASS command/commandfor on <textarea> with command=--custom-event should not function
+PASS command/commandfor on <tfoot> with command=--custom-event should not function
+PASS command/commandfor on <th> with command=--custom-event should not function
+PASS command/commandfor on <thead> with command=--custom-event should not function
+PASS command/commandfor on <time> with command=--custom-event should not function
+PASS command/commandfor on <title> with command=--custom-event should not function
+PASS command/commandfor on <tr> with command=--custom-event should not function
+PASS command/commandfor on <track> with command=--custom-event should not function
+PASS command/commandfor on <u> with command=--custom-event should not function
+PASS command/commandfor on <ul> with command=--custom-event should not function
+PASS command/commandfor on <var> with command=--custom-event should not function
+PASS command/commandfor on <video> with command=--custom-event should not function
+PASS command/commandfor on <wbr> with command=--custom-event should not function
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=--custom-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=--custom-event-expected.txt
@@ -1,0 +1,4 @@
+
+Harness Error (FAIL), message = Error: assert_true: expected true got false
+
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=show-modal&half=first-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=show-modal&half=first-expected.txt
@@ -1,0 +1,59 @@
+
+
+
+
+PASS command/commandfor on <a> with command=show-modal should not function
+PASS command/commandfor on <abbr> with command=show-modal should not function
+PASS command/commandfor on <address> with command=show-modal should not function
+PASS command/commandfor on <area> with command=show-modal should not function
+PASS command/commandfor on <article> with command=show-modal should not function
+PASS command/commandfor on <aside> with command=show-modal should not function
+PASS command/commandfor on <audio> with command=show-modal should not function
+PASS command/commandfor on <b> with command=show-modal should not function
+PASS command/commandfor on <base> with command=show-modal should not function
+PASS command/commandfor on <bdi> with command=show-modal should not function
+PASS command/commandfor on <bdo> with command=show-modal should not function
+PASS command/commandfor on <blockquote> with command=show-modal should not function
+PASS command/commandfor on <body> with command=show-modal should not function
+PASS command/commandfor on <br> with command=show-modal should not function
+PASS command/commandfor on <canvas> with command=show-modal should not function
+PASS command/commandfor on <caption> with command=show-modal should not function
+PASS command/commandfor on <cite> with command=show-modal should not function
+PASS command/commandfor on <code> with command=show-modal should not function
+PASS command/commandfor on <col> with command=show-modal should not function
+PASS command/commandfor on <colgroup> with command=show-modal should not function
+PASS command/commandfor on <data> with command=show-modal should not function
+PASS command/commandfor on <datalist> with command=show-modal should not function
+PASS command/commandfor on <dd> with command=show-modal should not function
+PASS command/commandfor on <del> with command=show-modal should not function
+PASS command/commandfor on <details> with command=show-modal should not function
+PASS command/commandfor on <dfn> with command=show-modal should not function
+PASS command/commandfor on <dialog> with command=show-modal should not function
+PASS command/commandfor on <div> with command=show-modal should not function
+PASS command/commandfor on <dl> with command=show-modal should not function
+PASS command/commandfor on <dt> with command=show-modal should not function
+PASS command/commandfor on <em> with command=show-modal should not function
+PASS command/commandfor on <embed> with command=show-modal should not function
+PASS command/commandfor on <fieldset> with command=show-modal should not function
+PASS command/commandfor on <figcaption> with command=show-modal should not function
+PASS command/commandfor on <figure> with command=show-modal should not function
+PASS command/commandfor on <footer> with command=show-modal should not function
+PASS command/commandfor on <form> with command=show-modal should not function
+PASS command/commandfor on <h1> with command=show-modal should not function
+PASS command/commandfor on <h2> with command=show-modal should not function
+PASS command/commandfor on <h3> with command=show-modal should not function
+PASS command/commandfor on <h4> with command=show-modal should not function
+PASS command/commandfor on <h5> with command=show-modal should not function
+PASS command/commandfor on <h6> with command=show-modal should not function
+PASS command/commandfor on <head> with command=show-modal should not function
+PASS command/commandfor on <header> with command=show-modal should not function
+PASS command/commandfor on <hr> with command=show-modal should not function
+PASS command/commandfor on <html> with command=show-modal should not function
+PASS command/commandfor on <i> with command=show-modal should not function
+PASS command/commandfor on <iframe> with command=show-modal should not function
+PASS command/commandfor on <img> with command=show-modal should not function
+PASS command/commandfor on <input> with command=show-modal should not function
+PASS command/commandfor on <ins> with command=show-modal should not function
+PASS command/commandfor on <kbd> with command=show-modal should not function
+PASS command/commandfor on <label> with command=show-modal should not function
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=show-modal&half=second-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=show-modal&half=second-expected.txt
@@ -1,0 +1,65 @@
+
+
+
+
+
+
+
+
+
+PASS command/commandfor on <legend> with command=show-modal should not function
+PASS command/commandfor on <li> with command=show-modal should not function
+PASS command/commandfor on <link> with command=show-modal should not function
+PASS command/commandfor on <main> with command=show-modal should not function
+PASS command/commandfor on <map> with command=show-modal should not function
+PASS command/commandfor on <mark> with command=show-modal should not function
+PASS command/commandfor on <menu> with command=show-modal should not function
+PASS command/commandfor on <meta> with command=show-modal should not function
+PASS command/commandfor on <meter> with command=show-modal should not function
+PASS command/commandfor on <nav> with command=show-modal should not function
+PASS command/commandfor on <noscript> with command=show-modal should not function
+PASS command/commandfor on <object> with command=show-modal should not function
+PASS command/commandfor on <ol> with command=show-modal should not function
+PASS command/commandfor on <optgroup> with command=show-modal should not function
+PASS command/commandfor on <option> with command=show-modal should not function
+PASS command/commandfor on <output> with command=show-modal should not function
+PASS command/commandfor on <p> with command=show-modal should not function
+PASS command/commandfor on <param> with command=show-modal should not function
+PASS command/commandfor on <pre> with command=show-modal should not function
+PASS command/commandfor on <progress> with command=show-modal should not function
+PASS command/commandfor on <q> with command=show-modal should not function
+PASS command/commandfor on <rp> with command=show-modal should not function
+PASS command/commandfor on <rt> with command=show-modal should not function
+PASS command/commandfor on <ruby> with command=show-modal should not function
+PASS command/commandfor on <s> with command=show-modal should not function
+PASS command/commandfor on <samp> with command=show-modal should not function
+PASS command/commandfor on <script> with command=show-modal should not function
+PASS command/commandfor on <section> with command=show-modal should not function
+PASS command/commandfor on <select> with command=show-modal should not function
+PASS command/commandfor on <slot> with command=show-modal should not function
+PASS command/commandfor on <small> with command=show-modal should not function
+PASS command/commandfor on <source> with command=show-modal should not function
+PASS command/commandfor on <span> with command=show-modal should not function
+PASS command/commandfor on <strong> with command=show-modal should not function
+PASS command/commandfor on <style> with command=show-modal should not function
+PASS command/commandfor on <sub> with command=show-modal should not function
+PASS command/commandfor on <sup> with command=show-modal should not function
+PASS command/commandfor on <summary> with command=show-modal should not function
+PASS command/commandfor on <table> with command=show-modal should not function
+PASS command/commandfor on <tbody> with command=show-modal should not function
+PASS command/commandfor on <td> with command=show-modal should not function
+PASS command/commandfor on <template> with command=show-modal should not function
+PASS command/commandfor on <textarea> with command=show-modal should not function
+PASS command/commandfor on <tfoot> with command=show-modal should not function
+PASS command/commandfor on <th> with command=show-modal should not function
+PASS command/commandfor on <thead> with command=show-modal should not function
+PASS command/commandfor on <time> with command=show-modal should not function
+PASS command/commandfor on <title> with command=show-modal should not function
+PASS command/commandfor on <tr> with command=show-modal should not function
+PASS command/commandfor on <track> with command=show-modal should not function
+PASS command/commandfor on <u> with command=show-modal should not function
+PASS command/commandfor on <ul> with command=show-modal should not function
+PASS command/commandfor on <var> with command=show-modal should not function
+PASS command/commandfor on <video> with command=show-modal should not function
+PASS command/commandfor on <wbr> with command=show-modal should not function
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=show-popover&half=first-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=show-popover&half=first-expected.txt
@@ -1,0 +1,59 @@
+
+
+
+
+PASS command/commandfor on <a> with command=show-popover should not function
+PASS command/commandfor on <abbr> with command=show-popover should not function
+PASS command/commandfor on <address> with command=show-popover should not function
+PASS command/commandfor on <area> with command=show-popover should not function
+PASS command/commandfor on <article> with command=show-popover should not function
+PASS command/commandfor on <aside> with command=show-popover should not function
+PASS command/commandfor on <audio> with command=show-popover should not function
+PASS command/commandfor on <b> with command=show-popover should not function
+PASS command/commandfor on <base> with command=show-popover should not function
+PASS command/commandfor on <bdi> with command=show-popover should not function
+PASS command/commandfor on <bdo> with command=show-popover should not function
+PASS command/commandfor on <blockquote> with command=show-popover should not function
+PASS command/commandfor on <body> with command=show-popover should not function
+PASS command/commandfor on <br> with command=show-popover should not function
+PASS command/commandfor on <canvas> with command=show-popover should not function
+PASS command/commandfor on <caption> with command=show-popover should not function
+PASS command/commandfor on <cite> with command=show-popover should not function
+PASS command/commandfor on <code> with command=show-popover should not function
+PASS command/commandfor on <col> with command=show-popover should not function
+PASS command/commandfor on <colgroup> with command=show-popover should not function
+PASS command/commandfor on <data> with command=show-popover should not function
+PASS command/commandfor on <datalist> with command=show-popover should not function
+PASS command/commandfor on <dd> with command=show-popover should not function
+PASS command/commandfor on <del> with command=show-popover should not function
+PASS command/commandfor on <details> with command=show-popover should not function
+PASS command/commandfor on <dfn> with command=show-popover should not function
+PASS command/commandfor on <dialog> with command=show-popover should not function
+PASS command/commandfor on <div> with command=show-popover should not function
+PASS command/commandfor on <dl> with command=show-popover should not function
+PASS command/commandfor on <dt> with command=show-popover should not function
+PASS command/commandfor on <em> with command=show-popover should not function
+PASS command/commandfor on <embed> with command=show-popover should not function
+PASS command/commandfor on <fieldset> with command=show-popover should not function
+PASS command/commandfor on <figcaption> with command=show-popover should not function
+PASS command/commandfor on <figure> with command=show-popover should not function
+PASS command/commandfor on <footer> with command=show-popover should not function
+PASS command/commandfor on <form> with command=show-popover should not function
+PASS command/commandfor on <h1> with command=show-popover should not function
+PASS command/commandfor on <h2> with command=show-popover should not function
+PASS command/commandfor on <h3> with command=show-popover should not function
+PASS command/commandfor on <h4> with command=show-popover should not function
+PASS command/commandfor on <h5> with command=show-popover should not function
+PASS command/commandfor on <h6> with command=show-popover should not function
+PASS command/commandfor on <head> with command=show-popover should not function
+PASS command/commandfor on <header> with command=show-popover should not function
+PASS command/commandfor on <hr> with command=show-popover should not function
+PASS command/commandfor on <html> with command=show-popover should not function
+PASS command/commandfor on <i> with command=show-popover should not function
+PASS command/commandfor on <iframe> with command=show-popover should not function
+PASS command/commandfor on <img> with command=show-popover should not function
+PASS command/commandfor on <input> with command=show-popover should not function
+PASS command/commandfor on <ins> with command=show-popover should not function
+PASS command/commandfor on <kbd> with command=show-popover should not function
+PASS command/commandfor on <label> with command=show-popover should not function
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=show-popover&half=second-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=show-popover&half=second-expected.txt
@@ -1,0 +1,65 @@
+
+
+
+
+
+
+
+
+
+PASS command/commandfor on <legend> with command=show-popover should not function
+PASS command/commandfor on <li> with command=show-popover should not function
+PASS command/commandfor on <link> with command=show-popover should not function
+PASS command/commandfor on <main> with command=show-popover should not function
+PASS command/commandfor on <map> with command=show-popover should not function
+PASS command/commandfor on <mark> with command=show-popover should not function
+PASS command/commandfor on <menu> with command=show-popover should not function
+PASS command/commandfor on <meta> with command=show-popover should not function
+PASS command/commandfor on <meter> with command=show-popover should not function
+PASS command/commandfor on <nav> with command=show-popover should not function
+PASS command/commandfor on <noscript> with command=show-popover should not function
+PASS command/commandfor on <object> with command=show-popover should not function
+PASS command/commandfor on <ol> with command=show-popover should not function
+PASS command/commandfor on <optgroup> with command=show-popover should not function
+PASS command/commandfor on <option> with command=show-popover should not function
+PASS command/commandfor on <output> with command=show-popover should not function
+PASS command/commandfor on <p> with command=show-popover should not function
+PASS command/commandfor on <param> with command=show-popover should not function
+PASS command/commandfor on <pre> with command=show-popover should not function
+PASS command/commandfor on <progress> with command=show-popover should not function
+PASS command/commandfor on <q> with command=show-popover should not function
+PASS command/commandfor on <rp> with command=show-popover should not function
+PASS command/commandfor on <rt> with command=show-popover should not function
+PASS command/commandfor on <ruby> with command=show-popover should not function
+PASS command/commandfor on <s> with command=show-popover should not function
+PASS command/commandfor on <samp> with command=show-popover should not function
+PASS command/commandfor on <script> with command=show-popover should not function
+PASS command/commandfor on <section> with command=show-popover should not function
+PASS command/commandfor on <select> with command=show-popover should not function
+PASS command/commandfor on <slot> with command=show-popover should not function
+PASS command/commandfor on <small> with command=show-popover should not function
+PASS command/commandfor on <source> with command=show-popover should not function
+PASS command/commandfor on <span> with command=show-popover should not function
+PASS command/commandfor on <strong> with command=show-popover should not function
+PASS command/commandfor on <style> with command=show-popover should not function
+PASS command/commandfor on <sub> with command=show-popover should not function
+PASS command/commandfor on <sup> with command=show-popover should not function
+PASS command/commandfor on <summary> with command=show-popover should not function
+PASS command/commandfor on <table> with command=show-popover should not function
+PASS command/commandfor on <tbody> with command=show-popover should not function
+PASS command/commandfor on <td> with command=show-popover should not function
+PASS command/commandfor on <template> with command=show-popover should not function
+PASS command/commandfor on <textarea> with command=show-popover should not function
+PASS command/commandfor on <tfoot> with command=show-popover should not function
+PASS command/commandfor on <th> with command=show-popover should not function
+PASS command/commandfor on <thead> with command=show-popover should not function
+PASS command/commandfor on <time> with command=show-popover should not function
+PASS command/commandfor on <title> with command=show-popover should not function
+PASS command/commandfor on <tr> with command=show-popover should not function
+PASS command/commandfor on <track> with command=show-popover should not function
+PASS command/commandfor on <u> with command=show-popover should not function
+PASS command/commandfor on <ul> with command=show-popover should not function
+PASS command/commandfor on <var> with command=show-popover should not function
+PASS command/commandfor on <video> with command=show-popover should not function
+PASS command/commandfor on <wbr> with command=show-popover should not function
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-invalid-behavior-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-invalid-behavior-expected.txt
@@ -20,22 +20,22 @@ PASS invoking (as showmodal) on dialog does nothing
 PASS invoking (as showmodal) on open dialog does nothing
 PASS invoking (as showmodal) on open modal dialog does nothing
 PASS invoking (as showmodal) on open modal while changing the attributer does nothing
-PASS invoking (as show-popover) on dialog does nothing
-PASS invoking (as show-popover) on open dialog does nothing
-PASS invoking (as show-popover) on open modal dialog does nothing
-PASS invoking (as show-popover) on open modal while changing the attributer does nothing
-PASS invoking (as hide-popover) on dialog does nothing
-PASS invoking (as hide-popover) on open dialog does nothing
-PASS invoking (as hide-popover) on open modal dialog does nothing
-PASS invoking (as hide-popover) on open modal while changing the attributer does nothing
-PASS invoking (as toggle-popover) on dialog does nothing
-PASS invoking (as toggle-popover) on open dialog does nothing
-PASS invoking (as toggle-popover) on open modal dialog does nothing
-PASS invoking (as toggle-popover) on open modal while changing the attributer does nothing
 PASS invoking (as show-picker) on dialog does nothing
 PASS invoking (as show-picker) on open dialog does nothing
 PASS invoking (as show-picker) on open modal dialog does nothing
 PASS invoking (as show-picker) on open modal while changing the attributer does nothing
+PASS invoking (as show-popover) on dialog fires event
+PASS invoking (as show-popover) on open dialog fires event
+PASS invoking (as show-popover) on open modal dialog fires event
+PASS invoking (as show-popover) on open modal while changing the attributer does nothing
+PASS invoking (as hide-popover) on dialog fires event
+PASS invoking (as hide-popover) on open dialog fires event
+PASS invoking (as hide-popover) on open modal dialog fires event
+PASS invoking (as hide-popover) on open modal while changing the attributer does nothing
+PASS invoking (as toggle-popover) on dialog fires event
+PASS invoking (as toggle-popover) on open dialog fires event
+PASS invoking (as toggle-popover) on open modal dialog fires event
+PASS invoking (as toggle-popover) on open modal while changing the attributer does nothing
 PASS invoking (as show-modal) dialog as open popover=manual is noop
 PASS invoking (as show-modal) dialog as open popover=auto is noop
 PASS invoking (as close) dialog as open popover=manual is noop

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-invalid-behavior.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-invalid-behavior.html
@@ -28,23 +28,25 @@
     "foo-bar",
     "auto",
     "showmodal",
-    "show-popover",
-    "hide-popover",
-    "toggle-popover",
     "show-picker",
   ].forEach((action) => {
     test(function (t) {
       t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
       invokerbutton.setAttribute("command", action);
       assert_false(invokee.open, "invokee.open");
       assert_false(invokee.matches(":modal"), "invokee :modal");
       invokerbutton.click();
       assert_false(invokee.open, "invokee.open");
       assert_false(invokee.matches(":modal"), "invokee :modal");
+      assert_false(command_event_fired, "command event fired");
     }, `invoking (as ${action}) on dialog does nothing`);
 
     test(function (t) {
       t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
       containedinvoker.setAttribute("command", action);
       invokee.show();
       assert_true(invokee.open, "invokee.open");
@@ -52,10 +54,13 @@
       containedinvoker.click();
       assert_true(invokee.open, "invokee.open");
       assert_false(invokee.matches(":modal"), "invokee :modal");
+      assert_false(command_event_fired, "command event fired");
     }, `invoking (as ${action}) on open dialog does nothing`);
 
     test(function (t) {
       t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
       containedinvoker.setAttribute("command", action);
       invokee.showModal();
       assert_true(invokee.open, "invokee.open");
@@ -63,7 +68,74 @@
       containedinvoker.click();
       assert_true(invokee.open, "invokee.open");
       assert_true(invokee.matches(":modal"), "invokee :modal");
+      assert_false(command_event_fired, "command event fired");
     }, `invoking (as ${action}) on open modal dialog does nothing`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      containedinvoker.setAttribute("command", action);
+      invokee.showModal();
+      assert_true(invokee.open, "invokee.open");
+      assert_true(invokee.matches(":modal"), "invokee :modal");
+      invokee.addEventListener(
+        "command",
+        (e) => {
+          containedinvoker.setAttribute("command", "");
+        },
+        { once: true },
+      );
+      containedinvoker.click();
+      assert_true(invokee.open, "invokee.open");
+      assert_true(invokee.matches(":modal"), "invokee :modal");
+    }, `invoking (as ${action}) on open modal while changing the attributer does nothing`);
+  });
+
+  // popover commands on dialog
+  [
+    "show-popover",
+    "hide-popover",
+    "toggle-popover",
+  ].forEach((action) => {
+    test(function (t) {
+      t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      invokerbutton.setAttribute("command", action);
+      assert_false(invokee.open, "invokee.open");
+      assert_false(invokee.matches(":modal"), "invokee :modal");
+      invokerbutton.click();
+      assert_false(invokee.open, "invokee.open");
+      assert_false(invokee.matches(":modal"), "invokee :modal");
+      assert_true(command_event_fired, "command event fired");
+    }, `invoking (as ${action}) on dialog fires event`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      containedinvoker.setAttribute("command", action);
+      invokee.show();
+      assert_true(invokee.open, "invokee.open");
+      assert_false(invokee.matches(":modal"), "invokee :modal");
+      containedinvoker.click();
+      assert_true(invokee.open, "invokee.open");
+      assert_false(invokee.matches(":modal"), "invokee :modal");
+      assert_true(command_event_fired, "command event fired");
+    }, `invoking (as ${action}) on open dialog fires event`);
+
+    test(function (t) {
+      t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
+      containedinvoker.setAttribute("command", action);
+      invokee.showModal();
+      assert_true(invokee.open, "invokee.open");
+      assert_true(invokee.matches(":modal"), "invokee :modal");
+      containedinvoker.click();
+      assert_true(invokee.open, "invokee.open");
+      assert_true(invokee.matches(":modal"), "invokee :modal");
+      assert_true(command_event_fired, "command event fired");
+    }, `invoking (as ${action}) on open modal dialog fires event`);
 
     test(function (t) {
       t.add_cleanup(resetState);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-popover-invalid-behavior.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-popover-invalid-behavior.html
@@ -26,19 +26,25 @@
   [null, "", "foo-bar", "showpopover", "show-modal", "show-picker", "open", "close"].forEach((command) => {
     test(function (t) {
       t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
       invokerbutton.command = command;
       assert_false(invokee.matches(":popover-open"));
       invokerbutton.click();
       assert_false(invokee.matches(":popover-open"));
+      assert_false(command_event_fired, "command event fired");
     }, `invoking (as ${command}) on popover does nothing`);
 
     test(function (t) {
       t.add_cleanup(resetState);
+      let command_event_fired = false;
+      invokee.addEventListener("command", () => (command_event_fired = true), { signal: t.get_signal() });
       invokerbutton.command = command;
       invokee.showPopover();
       assert_true(invokee.matches(":popover-open"));
       invokerbutton.click();
       assert_true(invokee.matches(":popover-open"));
+      assert_false(command_event_fired, "command event fired");
     }, `invoking (as ${command}) on open popover does nothing`);
   });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-scroll-behavior.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-scroll-behavior.tentative-expected.txt
@@ -1,0 +1,43 @@
+Page Up Page Down Page Left Page Right
+Page Left Page Right
+Page Up Page Down
+Block Start Block End Inline Start Inline End
+Inline Start (RTL) Inline End (RTL)
+Block Start (VW) Block End (VW)
+
+FAIL page-up command scrolls up assert_less_than: Scroll position should decrease expected a number less than 400 but got 400
+FAIL page-down command scrolls down assert_greater_than: Scroll position should increase expected a number greater than 0 but got 0
+FAIL page-left command scrolls left assert_less_than: Scroll position should decrease expected a number less than 400 but got 400
+FAIL page-right command scrolls right assert_greater_than: Scroll position should increase expected a number greater than 0 but got 0
+PASS page-up command doesn't affect horizontal scroll
+PASS page-left command doesn't affect vertical scroll
+FAIL page-right works on horizontal-only container assert_greater_than: Horizontal scroll should increase expected a number greater than 0 but got 0
+FAIL page-down works on vertical-only container assert_greater_than: Vertical scroll should increase expected a number greater than 0 but got 0
+FAIL page-block-end scrolls down in horizontal writing mode assert_greater_than: Scroll position should increase expected a number greater than 0 but got 0
+FAIL page-block-start scrolls up in horizontal writing mode assert_less_than: Scroll position should decrease expected a number less than 400 but got 400
+FAIL page-inline-end scrolls right in LTR assert_greater_than: Scroll position should increase expected a number greater than 0 but got 0
+FAIL page-inline-start scrolls left in LTR assert_less_than: Scroll position should decrease expected a number less than 400 but got 400
+FAIL page-inline-end works in RTL container assert_not_equals: Scroll position should change got disallowed value 0
+FAIL scroll command is case-insensitive: page-up assert_less_than: Scroll should work with page-up expected a number less than 400 but got 400
+FAIL scroll command is case-insensitive: PAGE-UP assert_less_than: Scroll should work with PAGE-UP expected a number less than 400 but got 400
+FAIL scroll command is case-insensitive: PaGe-Up assert_less_than: Scroll should work with PaGe-Up expected a number less than 400 but got 400
+PASS preventDefault stops scroll command
+PASS scroll command requires valid commandfor target
+PASS scroll command on non-scrollable element does nothing
+FAIL scroll amount is approximately one page assert_greater_than: Scroll distance should be approximately one page expected a number greater than 148 but got 0
+PASS scroll command with non-existent commandfor target doesn't throw
+PASS scroll command with empty commandfor doesn't throw
+PASS scroll command with whitespace commandfor doesn't throw
+PASS scroll command with disconnected target element doesn't throw
+PASS scroll command targeting self doesn't throw
+PASS scroll command on display:none element does nothing
+PASS scroll command handles elements with unusual document state
+PASS disabled button doesn't trigger scroll command
+FAIL multiple buttons can target same scroll container assert_greater_than: First button should scroll expected a number greater than 0 but got 0
+PASS scroll command at top boundary doesn't throw
+PASS scroll command at bottom boundary doesn't throw
+PASS invalid scroll command value doesn't trigger scroll
+PASS empty command attribute doesn't trigger scroll
+PASS scroll command on overflow:visible element does nothing
+PASS scroll command on overflow:clip element does nothing
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-scroll-behavior.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-scroll-behavior.tentative.html
@@ -1,0 +1,543 @@
+<!doctype html>
+<meta charset="utf-8" />
+<meta name="author" title="Chromium" href="https://chromium.org" />
+<meta name="timeout" content="long" />
+<link rel="help" href="https://open-ui.org/components/invokers.explainer/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/invoker-utils.js"></script>
+
+<style>
+  .scroll-container {
+    width: 200px;
+    height: 200px;
+    overflow: auto;
+    border: 1px solid black;
+  }
+
+  .scroll-content {
+    width: 1000px;
+    height: 1000px;
+    background: linear-gradient(to bottom right, red, blue);
+  }
+
+  .scroll-container-horizontal {
+    width: 200px;
+    height: 100px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    border: 1px solid black;
+  }
+
+  .scroll-content-horizontal {
+    width: 1000px;
+    height: 100px;
+    background: linear-gradient(to right, red, blue);
+  }
+
+  .scroll-container-vertical {
+    width: 100px;
+    height: 200px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    border: 1px solid black;
+  }
+
+  .scroll-content-vertical {
+    width: 100px;
+    height: 1000px;
+    background: linear-gradient(to bottom, red, blue);
+  }
+
+  .rtl {
+    direction: rtl;
+  }
+
+  .vertical-writing {
+    writing-mode: vertical-rl;
+  }
+</style>
+
+<!-- Basic scroll container -->
+<div id="scrollcontainer" class="scroll-container">
+  <div class="scroll-content"></div>
+</div>
+<button id="pageup" commandfor="scrollcontainer" command="page-up">Page Up</button>
+<button id="pagedown" commandfor="scrollcontainer" command="page-down">Page Down</button>
+<button id="pageleft" commandfor="scrollcontainer" command="page-left">Page Left</button>
+<button id="pageright" commandfor="scrollcontainer" command="page-right">Page Right</button>
+
+<!-- Horizontal only scroll container -->
+<div id="horizontalcontainer" class="scroll-container-horizontal">
+  <div class="scroll-content-horizontal"></div>
+</div>
+<button id="hpageleft" commandfor="horizontalcontainer" command="page-left">Page Left</button>
+<button id="hpageright" commandfor="horizontalcontainer" command="page-right">Page Right</button>
+
+<!-- Vertical only scroll container -->
+<div id="verticalcontainer" class="scroll-container-vertical">
+  <div class="scroll-content-vertical"></div>
+</div>
+<button id="vpageup" commandfor="verticalcontainer" command="page-up">Page Up</button>
+<button id="vpagedown" commandfor="verticalcontainer" command="page-down">Page Down</button>
+
+<!-- Logical direction tests -->
+<div id="logicalcontainer" class="scroll-container">
+  <div class="scroll-content"></div>
+</div>
+<button id="blockstart" commandfor="logicalcontainer" command="page-block-start">Block Start</button>
+<button id="blockend" commandfor="logicalcontainer" command="page-block-end">Block End</button>
+<button id="inlinestart" commandfor="logicalcontainer" command="page-inline-start">Inline Start</button>
+<button id="inlineend" commandfor="logicalcontainer" command="page-inline-end">Inline End</button>
+
+<!-- RTL container -->
+<div id="rtlcontainer" class="scroll-container rtl">
+  <div class="scroll-content"></div>
+</div>
+<button id="rtlinlinestart" commandfor="rtlcontainer" command="page-inline-start">Inline Start (RTL)</button>
+<button id="rtlinlineend" commandfor="rtlcontainer" command="page-inline-end">Inline End (RTL)</button>
+
+<!-- Vertical writing mode container -->
+<div id="verticalwritingcontainer" class="scroll-container vertical-writing">
+  <div class="scroll-content"></div>
+</div>
+<button id="vwblockstart" commandfor="verticalwritingcontainer" command="page-block-start">Block Start (VW)</button>
+<button id="vwblockend" commandfor="verticalwritingcontainer" command="page-block-end">Block End (VW)</button>
+
+<script>
+  function resetScrollPosition(container) {
+    container.scrollTop = 0;
+    container.scrollLeft = 0;
+  }
+
+  // Test page-up command
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    scrollcontainer.scrollTop = 400;
+    const initialScrollTop = scrollcontainer.scrollTop;
+    pageup.click();
+    assert_less_than(scrollcontainer.scrollTop, initialScrollTop, "Scroll position should decrease");
+  }, "page-up command scrolls up");
+
+  // Test page-down command
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    const initialScrollTop = scrollcontainer.scrollTop;
+    pagedown.click();
+    assert_greater_than(scrollcontainer.scrollTop, initialScrollTop, "Scroll position should increase");
+  }, "page-down command scrolls down");
+
+  // Test page-left command
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    scrollcontainer.scrollLeft = 400;
+    const initialScrollLeft = scrollcontainer.scrollLeft;
+    pageleft.click();
+    assert_less_than(scrollcontainer.scrollLeft, initialScrollLeft, "Scroll position should decrease");
+  }, "page-left command scrolls left");
+
+  // Test page-right command
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    const initialScrollLeft = scrollcontainer.scrollLeft;
+    pageright.click();
+    assert_greater_than(scrollcontainer.scrollLeft, initialScrollLeft, "Scroll position should increase");
+  }, "page-right command scrolls right");
+
+  // Test that page-up doesn't scroll horizontally
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    scrollcontainer.scrollTop = 400;
+    scrollcontainer.scrollLeft = 200;
+    const initialScrollLeft = scrollcontainer.scrollLeft;
+    pageup.click();
+    assert_equals(scrollcontainer.scrollLeft, initialScrollLeft, "Horizontal scroll should not change");
+  }, "page-up command doesn't affect horizontal scroll");
+
+  // Test that page-left doesn't scroll vertically
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    scrollcontainer.scrollTop = 200;
+    scrollcontainer.scrollLeft = 400;
+    const initialScrollTop = scrollcontainer.scrollTop;
+    pageleft.click();
+    assert_equals(scrollcontainer.scrollTop, initialScrollTop, "Vertical scroll should not change");
+  }, "page-left command doesn't affect vertical scroll");
+
+  // Test horizontal-only container
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(horizontalcontainer));
+    const initialScrollLeft = horizontalcontainer.scrollLeft;
+    hpageright.click();
+    assert_greater_than(horizontalcontainer.scrollLeft, initialScrollLeft, "Horizontal scroll should increase");
+    assert_equals(horizontalcontainer.scrollTop, 0, "Vertical scroll should remain 0");
+  }, "page-right works on horizontal-only container");
+
+  // Test vertical-only container
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(verticalcontainer));
+    const initialScrollTop = verticalcontainer.scrollTop;
+    vpagedown.click();
+    assert_greater_than(verticalcontainer.scrollTop, initialScrollTop, "Vertical scroll should increase");
+    assert_equals(verticalcontainer.scrollLeft, 0, "Horizontal scroll should remain 0");
+  }, "page-down works on vertical-only container");
+
+  // Test page-block-end (should scroll down in horizontal writing mode)
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(logicalcontainer));
+    const initialScrollTop = logicalcontainer.scrollTop;
+    blockend.click();
+    assert_greater_than(logicalcontainer.scrollTop, initialScrollTop, "Scroll position should increase");
+  }, "page-block-end scrolls down in horizontal writing mode");
+
+  // Test page-block-start (should scroll up in horizontal writing mode)
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(logicalcontainer));
+    logicalcontainer.scrollTop = 400;
+    const initialScrollTop = logicalcontainer.scrollTop;
+    blockstart.click();
+    assert_less_than(logicalcontainer.scrollTop, initialScrollTop, "Scroll position should decrease");
+  }, "page-block-start scrolls up in horizontal writing mode");
+
+  // Test page-inline-end (should scroll right in LTR)
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(logicalcontainer));
+    const initialScrollLeft = logicalcontainer.scrollLeft;
+    inlineend.click();
+    assert_greater_than(logicalcontainer.scrollLeft, initialScrollLeft, "Scroll position should increase");
+  }, "page-inline-end scrolls right in LTR");
+
+  // Test page-inline-start (should scroll left in LTR)
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(logicalcontainer));
+    logicalcontainer.scrollLeft = 400;
+    const initialScrollLeft = logicalcontainer.scrollLeft;
+    inlinestart.click();
+    assert_less_than(logicalcontainer.scrollLeft, initialScrollLeft, "Scroll position should decrease");
+  }, "page-inline-start scrolls left in LTR");
+
+  // Test RTL inline directions
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(rtlcontainer));
+    // In RTL, inline-end should scroll left (in the visual sense)
+    const initialScrollLeft = rtlcontainer.scrollLeft;
+    rtlinlineend.click();
+    // Note: RTL scrolling behavior can vary, but the command should work
+    assert_not_equals(rtlcontainer.scrollLeft, initialScrollLeft, "Scroll position should change");
+  }, "page-inline-end works in RTL container");
+
+  // Test case insensitivity
+  ["page-up", "PAGE-UP", "PaGe-Up"].forEach((command) => {
+    test(function (t) {
+      t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+      const button = document.createElement("button");
+      button.setAttribute("commandfor", "scrollcontainer");
+      button.setAttribute("command", command);
+      document.body.appendChild(button);
+      t.add_cleanup(() => button.remove());
+
+      scrollcontainer.scrollTop = 400;
+      const initialScrollTop = scrollcontainer.scrollTop;
+      button.click();
+      assert_less_than(scrollcontainer.scrollTop, initialScrollTop, "Scroll should work with " + command);
+    }, `scroll command is case-insensitive: ${command}`);
+  });
+
+  // Test preventDefault
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    scrollcontainer.addEventListener("command", (e) => e.preventDefault(), { once: true });
+    const initialScrollTop = scrollcontainer.scrollTop;
+    pagedown.click();
+    assert_equals(scrollcontainer.scrollTop, initialScrollTop, "Scroll should not change when prevented");
+  }, "preventDefault stops scroll command");
+
+  // Test that scroll doesn't happen if commandfor is invalid
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "nonexistent");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    const initialScrollTop = scrollcontainer.scrollTop;
+    button.click();
+    assert_equals(scrollcontainer.scrollTop, initialScrollTop, "Scroll should not happen with invalid commandfor");
+  }, "scroll command requires valid commandfor target");
+
+  // Test that scroll doesn't happen on non-scrollable element
+  test(function (t) {
+    const nonscrollable = document.createElement("div");
+    nonscrollable.id = "nonscrollable";
+    nonscrollable.textContent = "Not scrollable";
+    document.body.appendChild(nonscrollable);
+    t.add_cleanup(() => nonscrollable.remove());
+
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "nonscrollable");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    // Should not throw or cause issues
+    button.click();
+    assert_equals(nonscrollable.scrollTop, 0, "Non-scrollable element should remain at 0");
+  }, "scroll command on non-scrollable element does nothing");
+
+  // Test scroll amount is reasonable (approximately one page)
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    const initialScrollTop = scrollcontainer.scrollTop;
+    const containerHeight = scrollcontainer.clientHeight;
+    pagedown.click();
+    const scrollDistance = scrollcontainer.scrollTop - initialScrollTop;
+
+    // Scroll should be at least 80% of container height (allowing for some overlap)
+    assert_greater_than(scrollDistance, containerHeight * 0.8,
+      "Scroll distance should be approximately one page");
+    // And not more than 1.2x container height
+    assert_less_than(scrollDistance, containerHeight * 1.2,
+      "Scroll distance should not be much more than one page");
+  }, "scroll amount is approximately one page");
+
+  // Edge case: commandfor references non-existent element
+  test(function (t) {
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "this-element-does-not-exist");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    // Should not throw
+    assert_equals(button.click(), undefined, "Click should not throw");
+  }, "scroll command with non-existent commandfor target doesn't throw");
+
+  // Edge case: commandfor is empty string
+  test(function (t) {
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    // Should not throw
+    assert_equals(button.click(), undefined, "Click should not throw");
+  }, "scroll command with empty commandfor doesn't throw");
+
+  // Edge case: commandfor is whitespace
+  test(function (t) {
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "   ");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    // Should not throw
+    assert_equals(button.click(), undefined, "Click should not throw");
+  }, "scroll command with whitespace commandfor doesn't throw");
+
+  // Edge case: target element is disconnected
+  test(function (t) {
+    const disconnected = document.createElement("div");
+    disconnected.id = "disconnected";
+    disconnected.className = "scroll-container";
+    disconnected.innerHTML = '<div class="scroll-content"></div>';
+
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "disconnected");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    // Should not throw
+    assert_equals(button.click(), undefined, "Click should not throw for disconnected target");
+  }, "scroll command with disconnected target element doesn't throw");
+
+  // Edge case: target element is button itself
+  test(function (t) {
+    const button = document.createElement("button");
+    button.id = "selfbutton";
+    button.setAttribute("commandfor", "selfbutton");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    // Should not throw
+    assert_equals(button.click(), undefined, "Click should not throw when targeting self");
+  }, "scroll command targeting self doesn't throw");
+
+  // Edge case: target element is display:none
+  test(function (t) {
+    const hidden = document.createElement("div");
+    hidden.id = "hiddenscroll";
+    hidden.className = "scroll-container";
+    hidden.style.display = "none";
+    hidden.innerHTML = '<div class="scroll-content"></div>';
+    document.body.appendChild(hidden);
+    t.add_cleanup(() => hidden.remove());
+
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "hiddenscroll");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    // Should not throw
+    assert_equals(button.click(), undefined, "Click should not throw for hidden target");
+    assert_equals(hidden.scrollTop, 0, "Hidden element should not scroll");
+  }, "scroll command on display:none element does nothing");
+
+  // Edge case: target element has no computed style (e.g., in detached document)
+  test(function (t) {
+    const newDoc = document.implementation.createHTMLDocument();
+    const container = newDoc.createElement("div");
+    container.id = "detachedcontainer";
+    container.className = "scroll-container";
+    newDoc.body.appendChild(container);
+
+    // Add the container to main document so commandfor can find it
+    document.body.appendChild(container);
+    t.add_cleanup(() => container.remove());
+
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "detachedcontainer");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    // Should not throw
+    assert_equals(button.click(), undefined, "Click should not throw");
+  }, "scroll command handles elements with unusual document state");
+
+  // Edge case: button is disabled
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "scrollcontainer");
+    button.setAttribute("command", "page-down");
+    button.disabled = true;
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    const initialScrollTop = scrollcontainer.scrollTop;
+    button.click();
+    // Disabled buttons should not trigger commands
+    assert_equals(scrollcontainer.scrollTop, initialScrollTop, "Disabled button should not trigger scroll");
+  }, "disabled button doesn't trigger scroll command");
+
+  // Edge case: multiple buttons targeting same element
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    const button1 = document.createElement("button");
+    button1.setAttribute("commandfor", "scrollcontainer");
+    button1.setAttribute("command", "page-down");
+    document.body.appendChild(button1);
+    t.add_cleanup(() => button1.remove());
+
+    const button2 = document.createElement("button");
+    button2.setAttribute("commandfor", "scrollcontainer");
+    button2.setAttribute("command", "page-down");
+    document.body.appendChild(button2);
+    t.add_cleanup(() => button2.remove());
+
+    const initialScrollTop = scrollcontainer.scrollTop;
+    button1.click();
+    const afterFirst = scrollcontainer.scrollTop;
+    assert_greater_than(afterFirst, initialScrollTop, "First button should scroll");
+
+    button2.click();
+    assert_greater_than(scrollcontainer.scrollTop, afterFirst, "Second button should also scroll");
+  }, "multiple buttons can target same scroll container");
+
+  // Edge case: scroll at boundary (can't scroll further up)
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    scrollcontainer.scrollTop = 0;
+
+    // Should not throw
+    pageup.click();
+    assert_equals(scrollcontainer.scrollTop, 0, "Should remain at top");
+  }, "scroll command at top boundary doesn't throw");
+
+  // Edge case: scroll at boundary (can't scroll further down)
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    scrollcontainer.scrollTop = scrollcontainer.scrollHeight - scrollcontainer.clientHeight;
+    const maxScroll = scrollcontainer.scrollTop;
+
+    // Should not throw
+    pagedown.click();
+    assert_equals(scrollcontainer.scrollTop, maxScroll, "Should remain at bottom");
+  }, "scroll command at bottom boundary doesn't throw");
+
+  // Edge case: invalid command value
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "scrollcontainer");
+    button.setAttribute("command", "invalid-scroll-command");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    const initialScrollTop = scrollcontainer.scrollTop;
+    button.click();
+    assert_equals(scrollcontainer.scrollTop, initialScrollTop, "Invalid command should not scroll");
+  }, "invalid scroll command value doesn't trigger scroll");
+
+  // Edge case: command attribute is empty
+  test(function (t) {
+    t.add_cleanup(() => resetScrollPosition(scrollcontainer));
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "scrollcontainer");
+    button.setAttribute("command", "");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    const initialScrollTop = scrollcontainer.scrollTop;
+    button.click();
+    assert_equals(scrollcontainer.scrollTop, initialScrollTop, "Empty command should not scroll");
+  }, "empty command attribute doesn't trigger scroll");
+
+  // Edge case: target has overflow:visible (not scrollable)
+  test(function (t) {
+    const visible = document.createElement("div");
+    visible.id = "visibleoverflow";
+    visible.style.width = "200px";
+    visible.style.height = "200px";
+    visible.style.overflow = "visible";
+    visible.innerHTML = '<div style="width: 1000px; height: 1000px;"></div>';
+    document.body.appendChild(visible);
+    t.add_cleanup(() => visible.remove());
+
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "visibleoverflow");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    button.click();
+    assert_equals(visible.scrollTop, 0, "overflow:visible element should not scroll");
+  }, "scroll command on overflow:visible element does nothing");
+
+  // Edge case: target has overflow:clip
+  test(function (t) {
+    const clipped = document.createElement("div");
+    clipped.id = "clippedoverflow";
+    clipped.style.width = "200px";
+    clipped.style.height = "200px";
+    clipped.style.overflow = "clip";
+    clipped.innerHTML = '<div style="width: 1000px; height: 1000px;"></div>';
+    document.body.appendChild(clipped);
+    t.add_cleanup(() => clipped.remove());
+
+    const button = document.createElement("button");
+    button.setAttribute("commandfor", "clippedoverflow");
+    button.setAttribute("command", "page-down");
+    document.body.appendChild(button);
+    t.add_cleanup(() => button.remove());
+
+    button.click();
+    assert_equals(clipped.scrollTop, 0, "overflow:clip element should not scroll");
+  }, "scroll command on overflow:clip element does nothing");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting-expected.txt
@@ -1,0 +1,6 @@
+popover 3show popover 3
+
+PASS CommandEvent.source should be retargeted during and after event dispatch.
+PASS CommandEvent.source should be retargeted when manually dispatched with composed set to true.
+PASS CommandEvent.source should not be set to null after dispatch without ShadowDOM.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.html
@@ -17,7 +17,7 @@ promise_test(async () => {
   const shadowButton = host.shadowRoot.getElementById('shadow-button');
   shadowButton.commandForElement = popover;
 
-  const eventNames = ['beforetoggle', 'toggle', 'command'];
+  const eventNames = ['command'];
   const eventNameToEvent = {};
   const eventNameToCaptureSource = {};
   const eventNameToBubbleSource = {};
@@ -33,8 +33,7 @@ promise_test(async () => {
   }
 
   shadowButton.click();
-  await new Promise(requestAnimationFrame);
-  await new Promise(requestAnimationFrame);
+  await new Promise(resolve => step_timeout(resolve, 0));
 
   for (const eventName of eventNames) {
     const event = eventNameToEvent[eventName];
@@ -48,7 +47,7 @@ promise_test(async () => {
     assert_equals(event.source, host,
       `${eventName}.source after dispatch.`);
   }
-}, 'CommandEvent.source and ToggleEvent.source should be retargeted during and after event dispatch.');
+}, 'CommandEvent.source should be retargeted during and after event dispatch.');
 </script>
 
 <div id=host2>
@@ -63,7 +62,6 @@ promise_test(async () => {
 </div>
 
 <script>
-// This does not test ToggleEvent because ToggleEventInit does not have a source attribute.
 promise_test(async () => {
   const host2 = document.getElementById('host2');
   const source = host2.shadowRoot.getElementById('source');
@@ -110,7 +108,7 @@ promise_test(async () => {
   const button = document.getElementById('button3');
   const popover = document.getElementById('popover3');
 
-  const eventNames = ['beforetoggle', 'toggle', 'command'];
+  const eventNames = ['command'];
   const eventNameToEvent = {};
   for (const eventName of eventNames) {
     popover.addEventListener(eventName, event => {
@@ -119,8 +117,7 @@ promise_test(async () => {
   }
 
   button.click();
-  await new Promise(requestAnimationFrame);
-  await new Promise(requestAnimationFrame);
+  await new Promise(resolve => step_timeout(resolve, 0));
 
   for (const eventName of eventNames) {
     const event = eventNameToEvent[eventName];
@@ -128,5 +125,5 @@ promise_test(async () => {
     assert_equals(event.source, button,
       `${eventName}.source should be the invoker button after dispatch.`);
   }
-}, 'CommandEvent.source and ToggleEvent.source should not be set to null after dispatch without ShadowDOM.');
+}, 'CommandEvent.source should not be set to null after dispatch without ShadowDOM.');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.tentative-expected.txt
@@ -1,6 +1,0 @@
-popover 3show popover 3
-
-PASS CommandEvent.source and ToggleEvent.source should be retargeted during and after event dispatch.
-PASS CommandEvent.source should be retargeted when manually dispatched with composed set to true.
-PASS CommandEvent.source and ToggleEvent.source should not be set to null after dispatch without ShadowDOM.
-

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/toggleevent-source-attribute-retargeting-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/toggleevent-source-attribute-retargeting-expected.txt
@@ -1,0 +1,6 @@
+popover 3show popover 3
+
+PASS ToggleEvent.source should be retargeted during and after event dispatch.
+PASS Toggle.source should be retargeted when manually dispatched with composed set to true.
+PASS ToggleEvent.source should not be set to null after dispatch without ShadowDOM.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/toggleevent-source-attribute-retargeting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/toggleevent-source-attribute-retargeting.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id=popover popover=auto>popover</div>
+<div id=host>
+  <template shadowrootmode=open>
+    <button id=shadow-button command=show-popover>button in shadowroot</button>
+  </template>
+</div>
+
+<script>
+promise_test(async () => {
+  const popover = document.getElementById('popover');
+  const host = document.getElementById('host');
+  const shadowButton = host.shadowRoot.getElementById('shadow-button');
+  shadowButton.commandForElement = popover;
+
+  const eventNames = ['beforetoggle', 'toggle'];
+  const eventNameToEvent = {};
+  const eventNameToCaptureSource = {};
+  const eventNameToBubbleSource = {};
+
+  for (const eventName of eventNames) {
+    popover.addEventListener(eventName, event => {
+      eventNameToEvent[eventName] = event;
+      eventNameToBubbleSource[eventName] = event.source;
+    });
+    popover.addEventListener(eventName, event => {
+      eventNameToCaptureSource[eventName] = event.source;
+    }, {capture: true});
+  }
+
+  shadowButton.click();
+  await new Promise(resolve => step_timeout(resolve, 0));
+
+  for (const eventName of eventNames) {
+    const event = eventNameToEvent[eventName];
+    assert_true(!!event, `A ${eventName} event should have been fired.`);
+    assert_equals(eventNameToCaptureSource[eventName], host,
+      `${eventName}.source during capture.`);
+    assert_equals(eventNameToBubbleSource[eventName], host,
+      `${eventName}.source during bubble.`);
+    assert_not_equals(event.source, shadowButton,
+      `${eventName}.source shouldn't leak the shadow button.`);
+    assert_equals(event.source, host,
+      `${eventName}.source after dispatch.`);
+  }
+}, 'ToggleEvent.source should be retargeted during and after event dispatch.');
+</script>
+
+<div id=host2>
+  <template shadowrootmode=open>
+    <div id=source>source</div>
+    <div id=innerhost>
+      <template shadowrootmode=open>
+        <div id=target>target</div>
+      </template>
+    </div>
+  </template>
+</div>
+
+<script>
+promise_test(async () => {
+  const host2 = document.getElementById('host2');
+  const source = host2.shadowRoot.getElementById('source');
+  const innerhost = host2.shadowRoot.getElementById('innerhost');
+  const target = innerhost.shadowRoot.getElementById('target');
+
+  const targets = [host2, innerhost, target];
+  const targetToEvent = new Map();
+  const targetToCaptureSource = new Map();
+  const targetToBubbleSource = new Map();
+
+  for (const target of targets) {
+    target.addEventListener('toggle', event => {
+      targetToEvent.set(target, event);
+      targetToBubbleSource.set(target, event.source);
+    });
+    target.addEventListener('toggle', event => {
+      targetToCaptureSource.set(target, event.source);
+    }, {capture: true});
+  }
+
+  const toggleEvent = new ToggleEvent('toggle', {composed: true, source});
+  target.dispatchEvent(toggleEvent);
+
+  for (const target of targets) {
+    const expectedSource = target == host2 ? host2 : source;
+    assert_true(targetToEvent.has(target),
+      `${target.id}: event should have fired.`);
+    assert_equals(targetToCaptureSource.get(target), expectedSource,
+      `${target.id}: event.source at capture.`);
+    assert_equals(targetToBubbleSource.get(target), expectedSource,
+      `${target.id}: event.source at bubble.`);
+    assert_equals(targetToEvent.get(target).source, host2,
+      `${target.id}: event.source after dispatch.`);
+  }
+}, 'Toggle.source should be retargeted when manually dispatched with composed set to true.');
+</script>
+
+<div id=popover3 popover=auto>popover 3</div>
+<button id=button3 commandfor=popover3 command=show-popover>show popover 3</button>
+
+<script>
+promise_test(async () => {
+  const button = document.getElementById('button3');
+  const popover = document.getElementById('popover3');
+
+  const eventNames = ['beforetoggle', 'toggle'];
+  const eventNameToEvent = {};
+  for (const eventName of eventNames) {
+    popover.addEventListener(eventName, event => {
+      eventNameToEvent[eventName] = event;
+    });
+  }
+
+  button.click();
+  await new Promise(resolve => step_timeout(resolve, 0));
+
+  for (const eventName of eventNames) {
+    const event = eventNameToEvent[eventName];
+    assert_true(!!event, `${eventName} should have been fired.`);
+    assert_equals(event.source, button,
+      `${eventName}.source should be the invoker button after dispatch.`);
+  }
+}, 'ToggleEvent.source should not be set to null after dispatch without ShadowDOM.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/w3c-import.log
@@ -14,16 +14,19 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch-content-attribute.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-behavior.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-type-reflection.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-close-target-non-dialog-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-reflection.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/event-dispatch-shadow.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/event-interface.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/fullscreen-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/generic-eventtarget-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/interface.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-audio-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-audio-invalid-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-details-behavior.tentative.html
@@ -35,5 +38,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-popover-behavior.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-popover-disconnect.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-popover-invalid-behavior.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-scroll-behavior.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-video-behavior.tentative.html
-/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.tentative.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.html
+/LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/toggleevent-source-attribute-retargeting.html

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -4325,6 +4325,9 @@
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/fullscreen-behavior.tentative.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-audio-behavior.tentative.html": [
         "slow"
     ],
@@ -4335,9 +4338,6 @@
         "slow"
     ],
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-details-invalid-behavior.tentative.html": [
-        "slow"
-    ],
-    "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior-request-close.tentative.html": [
         "slow"
     ],
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-behavior.html": [
@@ -4356,6 +4356,9 @@
         "slow"
     ],
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-popover-invalid-behavior.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-scroll-behavior.tentative.html": [
         "slow"
     ],
     "imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-video-behavior.tentative.html": [


### PR DESCRIPTION
#### a99700f6ed1ac27cd5e262d58d98f4bf13072fea
<pre>
Re-import html/semantics/the-button-element/command-and-commandfor tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=309903">https://bugs.webkit.org/show_bug.cgi?id=309903</a>

Reviewed by Anne van Kesteren.

Also re-import &apos;html/semantics/popovers/resources&apos;.

The goal is to fetch the changes from
<a href="https://github.com/web-platform-tests/wpt/pull/58451">https://github.com/web-platform-tests/wpt/pull/58451</a>, which makes
several WPT tests non flaky for WPE.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/popover-top-layer-nesting.js:
(runTopLayerTests):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/popover-utils.js:
(async clickOn):
(async verifyFocusOrder):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/resources/toggle-event-source-test.js:
(createToggleEventSourceTest):
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/button-event-dispatch.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/command-close-target-non-dialog-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=--custom-event&amp;half=first-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=--custom-event&amp;half=second-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=--custom-event-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=show-modal&amp;half=first-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=show-modal&amp;half=second-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=show-popover&amp;half=first-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/invalid-element-types_command=show-popover&amp;half=second-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-invalid-behavior-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-dialog-invalid-behavior.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-popover-invalid-behavior.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-scroll-behavior.tentative-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/on-scroll-behavior.tentative.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.html: Copied from LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.tentative.html.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.tentative-expected.txt: Removed.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/toggleevent-source-attribute-retargeting-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/toggleevent-source-attribute-retargeting.html: Renamed from LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/source-attribute-retargeting.tentative.html.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/the-button-element/command-and-commandfor/w3c-import.log:
* LayoutTests/tests-options.json:

Canonical link: <a href="https://commits.webkit.org/309305@main">https://commits.webkit.org/309305@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78832417f1106c7124e23d64c2dede4d7dc50791

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22713 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158698 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103421 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22819 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115707 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82201 "2 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134580 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96435 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16919 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14863 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6544 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126534 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161172 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14056 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123713 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18910 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123914 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134299 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78763 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23097 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19062 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11055 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22119 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21849 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22001 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->