### PR TITLE
[DRAFT] REGRESSION(305314@main): Datalist list button obscures text input on iOS

### DIFF
--- a/LayoutTests/fast/forms/datalist/datalist-list-button-no-overlap-ios-expected.txt
+++ b/LayoutTests/fast/forms/datalist/datalist-list-button-no-overlap-ios-expected.txt
@@ -1,0 +1,2 @@
+PASS: The list button does not overlap the text editing area.
+

--- a/LayoutTests/fast/forms/datalist/datalist-list-button-no-overlap-ios.html
+++ b/LayoutTests/fast/forms/datalist/datalist-list-button-no-overlap-ios.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+input {
+    font-size: 16px;
+    width: 300px;
+}
+</style>
+</head>
+<body>
+<!-- Regression test for rdar://168475613: the datalist list button should not
+     overlap the text editing area on iOS. The negative margin (-7px) used for
+     expanding the tap target must not extend the button's inline-start edge
+     into the text area. -->
+<input id="fruit" list="fruits" type="text" value="Test text here">
+<datalist id="fruits">
+    <option>Apple</option>
+    <option>Orange</option>
+    <option>Pear</option>
+</datalist>
+<pre id="output"></pre>
+<script>
+if (window.internals) {
+    var input = document.getElementById("fruit");
+    var shadow = internals.shadowRoot(input);
+    var children = shadow.querySelectorAll("div");
+    var listButton = null;
+    for (var i = 0; i < children.length; i++) {
+        var style = getComputedStyle(children[i]);
+        if (style.position === "relative" && style.cursor === "default")
+            listButton = children[i];
+    }
+    var textArea = internals.innerTextElement(input);
+    if (textArea && listButton) {
+        var textRect = textArea.getBoundingClientRect();
+        var buttonRect = listButton.getBoundingClientRect();
+        var overlaps = buttonRect.left < textRect.right;
+        document.getElementById("output").textContent =
+            (overlaps ? "FAIL" : "PASS") + ": The list button does " + (overlaps ? "" : "not ") + "overlap the text editing area.\n";
+    } else {
+        document.getElementById("output").textContent = "FAIL: Could not find text area or list button in shadow DOM.\n";
+    }
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -707,6 +707,8 @@ input::-webkit-list-button {
     /* Make it easier to hit the button on iOS */
     padding: 7px;
     margin: -7px;
+    /* Prevent the negative start margin from pulling the button over the text editing area */
+    margin-inline-start: 0px;
 #else
     block-size: 100%;
 #endif


### PR DESCRIPTION
#### 35317360d1969e109230e8cd776b5c297266164b
<pre>
[DRAFT] REGRESSION(<a href="https://commits.webkit.org/305314@main">305314@main</a>): Datalist list button obscures text input on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=305719">https://bugs.webkit.org/show_bug.cgi?id=305719</a>
<a href="https://rdar.apple.com/168475613">rdar://168475613</a>

Reviewed by NOBODY (OOPS!).

After <a href="https://commits.webkit.org/305314@main">305314@main</a> removed the fixed `inline-size: 11px` from the iOS list button
CSS, the button width is set to 15.4% by the theme code in
`adjustListButtonStyleForVectorBasedControls`.  Combined with `margin: -7px`
(used to expand the tap target), the button&apos;s start edge extends into the text
editing area, visually obscuring user input.

Fix by resetting `margin-inline-start` to `0px`, which preserves the expanded
tap target on the trailing, block-start, and block-end edges while preventing
the button from overlapping the text area.

* Source/WebCore/css/html.css:
(input::-webkit-list-button): Add `margin-inline-start: 0px` to prevent the list button from extending over the text editing area on iOS.
* LayoutTests/fast/forms/datalist/datalist-list-button-no-overlap-ios.html: Added.
* LayoutTests/fast/forms/datalist/datalist-list-button-no-overlap-ios-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35317360d1969e109230e8cd776b5c297266164b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22705 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158684 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103411 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151850 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22805 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115700 "Found 1 new test failure: fast/forms/datalist/datalist-list-button-no-overlap-ios.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82195 "3 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152937 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17821 "Found 3 new test failures: fast/forms/datalist/datalist-list-button-no-overlap-ios.html fast/forms/datalist/datalist-searchinput-appearance.html fast/forms/datalist/datalist-textinput-appearance.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96428 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/18620ba0-3f92-4f18-8dc3-19b2d00326ab) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16921 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14854 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6530 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126536 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161161 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4243 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14052 "Found 1 new test failure: fast/forms/datalist/datalist-list-button-no-overlap-ios.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123702 "Found 1 new test failure: fast/forms/datalist/datalist-list-button-no-overlap-ios.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22504 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18901 "Found 1 new test failure: fast/forms/datalist/datalist-list-button-no-overlap-ios.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123902 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22509 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134295 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78753 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19057 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11051 "Found 1 new test failure: fast/forms/datalist/datalist-list-button-no-overlap-ios.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22109 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85937 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21839 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21991 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21893 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->