### PR TITLE
WebKit's Derived Sources build phase does not run when input files from WebKitAdditions change

### DIFF
--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -21110,14 +21110,14 @@
 			);
 			inputFileListPaths = (
 				"$(SRCROOT)/DerivedSources-input.xcfilelist",
-				"$(WK_WEBKIT_INPUT_XCFILELIST_ADDITIONS)",
+				"$(WK_WEBKIT_DERIVEDSOURCES_INPUT_XCFILELIST_ADDITIONS)",
 			);
 			inputPaths = (
 			);
 			name = "Generate Derived Sources";
 			outputFileListPaths = (
 				"$(SRCROOT)/DerivedSources-output.xcfilelist",
-				"$(WK_WEBKIT_OUTPUT_XCFILELIST_ADDITIONS)",
+				"$(WK_WEBKIT_DERIVEDSOURCES_OUTPUT_XCFILELIST_ADDITIONS)",
 			);
 			outputPaths = (
 			);


### PR DESCRIPTION
#### 88c6839bb996ea350cc76539ec9e5d93d2f99ce9
<pre>
WebKit&apos;s Derived Sources build phase does not run when input files from WebKitAdditions change
<a href="https://bugs.webkit.org/show_bug.cgi?id=309911">https://bugs.webkit.org/show_bug.cgi?id=309911</a>
<a href="https://rdar.apple.com/172498641">rdar://172498641</a>

Reviewed by Elliott Williams and Abrar Rahman Protyasha.

WebKit&apos;s xcconfig files define WK_WEBKIT_DERIVEDSOURCES_INPUT_XCFILELIST_ADDITIONS and
WK_WEBKIT_DERIVEDSOURCES_OUTPUT_XCFILELIST_ADDITIONS pointing to .xcfilelists in WebKitAdditions
containing input and output files for the Derived Sources build phase. However, the Derived Sources
build phase specified WK_WEBKIT_INPUT_XCFILELIST_ADDITIONS and WK_WEBKIT_OUTPUT_XCFILELIST_ADDITIONS
(which aren&apos;t defined) as input and output file list paths. Resolved this by specifying the correct
build settings.

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/309240@main">https://commits.webkit.org/309240@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3aa676499435e223a51e1ad601d92bda1431b01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22728 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158713 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/423179a6-fc29-4123-aa60-4a2126373d82) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115716 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59c2786d-4d7a-4354-b7de-db05f3b5cac6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17823 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96443 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c5081df-acd8-48ad-b776-43e76423ed55) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16923 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6559 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126538 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161187 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123716 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22529 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18920 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123917 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33656 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/22534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134307 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11063 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22134 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85962 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/21864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/22016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21922 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->