### PR TITLE
[bmalloc] Disable TZone allocations when MTE is enabled

### DIFF
--- a/Source/bmalloc/bmalloc/TZoneHeap.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeap.cpp
@@ -53,7 +53,8 @@ void* tzoneAllocateNonCompactSlow(size_t requestedSize, const TZoneSpecification
             return tzoneAllocateNonCompactSlow(requestedSize, spec);
         }
 
-        RELEASE_BASSERT(tzoneMallocFallback == TZoneMallocFallback::ForceDebugMalloc);
+        RELEASE_BASSERT(tzoneMallocFallback == TZoneMallocFallback::ForceDebugMalloc
+            || tzoneMallocFallback == TZoneMallocFallback::ForceFastMalloc);
         return api::malloc(requestedSize, CompactAllocationMode::NonCompact);
     }
 
@@ -77,7 +78,8 @@ void* tzoneAllocateCompactSlow(size_t requestedSize, const TZoneSpecification& s
             return tzoneAllocateCompactSlow(requestedSize, spec);
         }
 
-        RELEASE_BASSERT(tzoneMallocFallback == TZoneMallocFallback::ForceDebugMalloc);
+        RELEASE_BASSERT(tzoneMallocFallback == TZoneMallocFallback::ForceDebugMalloc
+            || tzoneMallocFallback == TZoneMallocFallback::ForceFastMalloc);
         return api::malloc(requestedSize, CompactAllocationMode::Compact);
     }
 

--- a/Source/bmalloc/bmalloc/TZoneHeap.h
+++ b/Source/bmalloc/bmalloc/TZoneHeap.h
@@ -123,7 +123,12 @@ namespace api {
 
 enum class TZoneMallocFallback : uint8_t {
     Undecided,
+    // Currently, ForceFastMalloc and ForceDebugMalloc
+    // route to the same place (call into FastMalloc);
+    // however, they are semantically different, and
+    // set for different reasons.
     ForceDebugMalloc,
+    ForceFastMalloc = ForceDebugMalloc,
     DoNotFallBack
 };
 
@@ -334,7 +339,7 @@ public: \
     { \
         if (!s_heapRef || size != sizeof(_type)) [[unlikely]] \
             BMUST_TAIL_CALL return operatorNewSlow(size); \
-        BASSERT(::bmalloc::api::tzoneMallocFallback > TZoneMallocFallback::ForceDebugMalloc); \
+        BASSERT(::bmalloc::api::tzoneMallocFallback == TZoneMallocFallback::DoNotFallBack); \
         if constexpr (::bmalloc::api::compactAllocationMode<_type>() == CompactAllocationMode::Compact) \
             return ::bmalloc::api::tzoneAllocateCompact(s_heapRef); \
         return ::bmalloc::api::tzoneAllocate ## _compactMode(s_heapRef); \

--- a/Source/bmalloc/bmalloc/TZoneHeapInlines.h
+++ b/Source/bmalloc/bmalloc/TZoneHeapInlines.h
@@ -78,7 +78,7 @@ public: \
                 return ::bmalloc::api::tzoneAllocateCompactSlow(size, s_heapSpec); \
             return ::bmalloc::api::tzoneAllocate ## _compactMode ## Slow(size, s_heapSpec); \
         } \
-        BASSERT(::bmalloc::api::tzoneMallocFallback > TZoneMallocFallback::ForceDebugMalloc); \
+        BASSERT(::bmalloc::api::tzoneMallocFallback == TZoneMallocFallback::DoNotFallBack); \
         if constexpr (::bmalloc::api::compactAllocationMode<_type>() == CompactAllocationMode::Compact) \
             return ::bmalloc::api::tzoneAllocateCompact(s_heapRef); \
         return ::bmalloc::api::tzoneAllocate ## _compactMode(s_heapRef); \

--- a/Source/bmalloc/bmalloc/bmalloc.cpp
+++ b/Source/bmalloc/bmalloc/bmalloc.cpp
@@ -141,6 +141,17 @@ bool isEnabled(HeapKind)
     return !Environment::get()->shouldBmallocAllocateThroughSystemHeap();
 }
 
+bool isMTEEnabled(HeapKind kind)
+{
+    BUNUSED_PARAM(kind);
+#if PAS_BMALLOC && defined(PAS_ENABLE_MTE) && PAS_ENABLE_MTE
+    // MTE is not currently enabled for the Gigacage
+    return isEnabled(kind) && kind == HeapKind::Primary && pas_mte_is_mte_enabled();
+#else
+    return false;
+#endif
+}
+
 #if BOS(DARWIN)
 void setScavengerThreadQOSClass(qos_class_t overrideClass)
 {

--- a/Source/bmalloc/bmalloc/bmalloc.h
+++ b/Source/bmalloc/bmalloc/bmalloc.h
@@ -301,6 +301,7 @@ BEXPORT void scavengeThisThread();
 BEXPORT void scavenge();
 
 BEXPORT bool isEnabled(HeapKind kind = HeapKind::Primary);
+BEXPORT bool isMTEEnabled(HeapKind kind = HeapKind::Primary);
 
 // ptr must be aligned to vmPageSizePhysical and size must be divisible 
 // by vmPageSizePhysical.

--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.c
@@ -391,6 +391,16 @@ void pas_bmalloc_force_allocations_into_bitfit_heaps_where_available(void)
     PAS_IGNORE_WARNINGS_END;
 }
 
+bool pas_mte_is_mte_enabled(void)
+{
+    pas_mte_ensure_initialized();
+#if PAS_ENABLE_MTE
+    return PAS_MTE_CONFIG_BYTE(PAS_MTE_ENABLE_FLAG);
+#else
+    return false;
+#endif
+}
+
 void pas_mte_force_nontaggable_user_allocations_into_large_heap(void)
 {
 #if PAS_ENABLE_BMALLOC

--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
@@ -206,6 +206,7 @@ PAS_ALLOW_UNSAFE_BUFFER_USAGE_END;
 #ifdef __cplusplus
 extern "C" {
 #endif
+bool pas_mte_is_mte_enabled(void);
 void pas_mte_ensure_initialized(void);
 void pas_mte_force_nontaggable_user_allocations_into_large_heap(void);
 void pas_bmalloc_force_allocations_into_bitfit_heaps_where_available(void);


### PR DESCRIPTION
#### 174feea3cd590065bce6592bfb26819581f0f7ad
<pre>
[bmalloc] Disable TZone allocations when MTE is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=309913">https://bugs.webkit.org/show_bug.cgi?id=309913</a>
<a href="https://rdar.apple.com/172500381">rdar://172500381</a>

Reviewed by Keith Miller.

This is the final patch in the series achieving retag-on-free for +MTE
processes. It does so by disabling TZoneMalloc, the last pathway which would
allocate segregated-and-MTE-tagged objects, such that FastMalloc will
exclusively allocate objects through bitfit heaps when MTE is enabled.
For an understanding of why this is relevant to retag-on-free, see the previous
patch 309573@main.

The principal justification is that the two features (MTE and TZone) provide
largely the same security guarantees (e.g. protection again UAFs, OoB memory
corruption), with MTE providing strictly stronger guarantees due to its ability
to counter intra-type corruptions.

However, the question of why we don&apos;t keep both enabled (for the
defense-in-depth that that would provide) deserves some further explanation.
Prima facie, it is not kosher to allocate isoheaped objects out of bitfit
heaps: plainly, they&apos;re not type-safe, and allow for intra- object
type-confusion via UAFs on objects aligned at different offsets within a given
bitfit page.
At present, however, the particularities of our configuration technically allow
for this to be done safely:
Specifically, because we
  1. Never use the array-alloc APIs for iso-heaped objects
  2. Never use realloc for iso-heaped objects
  3. Never use shrink for iso-heaped objects
  4. Already size-segregate *before* calling into any pas_heap for
     allocating an iso-heaped object -- thanks to TZoneMalloc.
we can guarantee that in practice, the bitfit heap belonging to any given
iso-heap will only ever see objects of a single size-class.

But in the case that any of these invariants were to be violated, the resulting
security holes would be silent and hard to assert for. This fragility is obviously
undesirable. Consequently, I prefer to disable TZones entirely in +MTE processes,
as this creates a clean boundary and avoids &apos;polluting&apos; either one of the features.

Canonical link: <a href="https://commits.webkit.org/309849@main">https://commits.webkit.org/309849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c17fb938e0d90c436ec48651d1603c5881bdc3a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151918 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24699 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/18271 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160660 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/105375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/25192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/25002 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/117350 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/105375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154878 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/19523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/136332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/98065 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/75f5ab20-2f31-4999-82de-f0c101b28efd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16539 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/8495 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/143924 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/128238 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/14235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/163125 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/12719 "Built successfully and passed tests") | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/125373 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/24498 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125549 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34064 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/24499 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/136031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/81081 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20578 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/183542 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/24116 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46818 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23807 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23967 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23868 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->