### PR TITLE
[Site Isolation] Enable back/forward navigation via UIProcess when site isolation is active

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3785,6 +3785,9 @@ void FrameLoader::continueFragmentScrollAfterNavigationPolicy(const ResourceRequ
     // frame to be deallocated.
     Ref frame = m_frame.get();
 
+    // A fragment scroll should cancel any pending async back-forward navigation.
+    cancelPendingAsyncBackForwardNavigation();
+
     // If we have a provisional request for a different document, a fragment scroll should cancel it.
     if (m_provisionalDocumentLoader && !equalIgnoringFragmentIdentifier(m_provisionalDocumentLoader->request().url(), request.url())) {
         protect(m_provisionalDocumentLoader)->stopLoading();
@@ -4689,8 +4692,14 @@ void FrameLoader::setPendingAsyncBackForwardNavigation()
 
 void FrameLoader::cancelPendingAsyncBackForwardNavigation()
 {
-    if (m_asyncBackForwardNavigationState == AsyncBackForwardNavigationState::Pending)
-        m_asyncBackForwardNavigationState = AsyncBackForwardNavigationState::Cancelled;
+    if (m_asyncBackForwardNavigationState != AsyncBackForwardNavigationState::Pending)
+        return;
+
+    m_asyncBackForwardNavigationState = AsyncBackForwardNavigationState::Cancelled;
+
+    Ref frame = m_frame.get();
+    if (RefPtr parentFrame = dynamicDowncast<LocalFrame>(frame->tree().parent()))
+        parentFrame->loader().checkCompleted();
 }
 
 bool FrameLoader::shouldProceedWithAsyncBackForwardNavigation()

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -269,7 +269,7 @@ public:
     void loadDone(LoadCompletionType);
     void subresourceLoadDone(LoadCompletionType);
     void finishedParsing();
-    WEBCORE_EXPORT void checkCompleted();
+    void checkCompleted();
 
     bool isComplete() const { return m_isComplete; }
 

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -312,6 +312,12 @@ public:
 
         UserGestureIndicator gestureIndicator(userGestureToForward());
 
+        // history.go(0) is a reload, not a back-forward navigation.
+        if (!m_steps) {
+            localFrame->loader().changeLocation(localFrame->document()->url(), selfTargetFrameName(), 0, ReferrerPolicy::EmptyString, shouldOpenExternalURLs(), std::nullopt, nullAtom(), std::nullopt, NavigationHistoryBehavior::Reload);
+            return;
+        }
+
         if (page->settings().useUIProcessForBackForwardItemLoading()) {
             localFrame->loader().setPendingAsyncBackForwardNavigation();
             localFrame->loader().client().dispatchGoToBackForwardItemAtIndex(m_steps, FrameLoadType::IndexedBackForward);
@@ -324,11 +330,6 @@ public:
 
         if (!protect(page->backForward())->containsItem(*historyItem))
             return;
-
-        if (RefPtr currentItem = protect(page->backForward())->currentItem(); currentItem && currentItem->itemID() == historyItem->itemID()) {
-            localFrame->loader().changeLocation(localFrame->document()->url(), selfTargetFrameName(), 0, ReferrerPolicy::EmptyString, shouldOpenExternalURLs(), std::nullopt, nullAtom(), std::nullopt, NavigationHistoryBehavior::Reload);
-            return;
-        }
 
         Ref rootFrame = localFrame->rootFrame();
         page->goToItem(rootFrame, *historyItem, FrameLoadType::IndexedBackForward, ShouldTreatAsContinuingLoad::No);

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -764,8 +764,14 @@ FrameState* WebBackForwardList::findFrameStateInItem(WebCore::BackForwardItemIde
         return nullptr;
 
     RefPtr parentFrameItem = targetItem->mainFrameItem().childItemForFrameID(parentFrameID);
-    if (!parentFrameItem)
-        return nullptr;
+    if (!parentFrameItem) {
+        // FIXME: After session restore, the back/forward list's frame identifiers don't match
+        // the current WebView's frames because the original identifiers are unavailable.
+        // Fall back to the mainFrameItem if the parentFrameID isn't found.
+        // This only works correctly for direct children of the main frame; nested frames
+        // (e.g., subframe > nestedframe) will get the wrong FrameState.
+        parentFrameItem = &targetItem->mainFrameItem();
+    }
 
     RefPtr childFrameItem = parentFrameItem->childItemAtIndex(childFrameIndex);
     if (!childFrameItem)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5594,8 +5594,15 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
 
     RefPtr mainFrameInPreviousProcess = m_mainFrame;
     Ref preferences = m_preferences;
-    if (mainFrameInPreviousProcess && preferences->siteIsolationEnabled())
+    if (mainFrameInPreviousProcess && preferences->siteIsolationEnabled()) {
+        // Update the back/forward list so existing entries use the new main frame's FrameIdentifier.
+        // This is needed for back/forward navigations that trigger a process swap, since no new
+        // back/forward list item is added (unlike forward navigations where backForwardAddItemShared
+        // handles the update).
+        if (mainFrameInPreviousProcess->frameID() != frameID)
+            backForwardList().updateFrameIdentifier(mainFrameInPreviousProcess->frameID(), frameID);
         mainFrameInPreviousProcess->removeChildFrames();
+    }
 
     ASSERT(m_legacyMainFrameProcess.ptr() != &provisionalPage->process() || preferences->siteIsolationEnabled());
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1343,6 +1343,8 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
 
     RefPtr relatedPage = pageConfiguration->relatedPage();
     bool siteIsolationEnabled = protect(pageConfiguration->preferences())->siteIsolationEnabled();
+    if (siteIsolationEnabled)
+        protect(pageConfiguration->preferences())->setUseUIProcessForBackForwardItemLoading(true);
     RefPtr preferredBrowsingContextGroup = pageConfiguration->preferredBrowsingContextGroup();
     RefPtr preferredFrameProcess = preferredBrowsingContextGroup ? preferredBrowsingContextGroup->processForSite(pageConfiguration->openedSite()) : nullptr;
     if (auto& openerInfo = pageConfiguration->openerInfo(); openerInfo && siteIsolationEnabled)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -1197,6 +1197,7 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForBackForwardNavigationActi
             if (!localFrame)
                 return;
 
+            // The frame will become a RemoteFrame, which handles parent completion tracking.
             if (action == PolicyAction::LoadWillContinueInAnotherProcess)
                 return;
 
@@ -1204,8 +1205,6 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForBackForwardNavigationActi
                 // Reset the pending async state and re-check completeness
                 // on the parent since this child won't be loading.
                 localFrame->loader().cancelPendingAsyncBackForwardNavigation();
-                if (RefPtr parent = dynamicDowncast<LocalFrame>(localFrame->tree().parent()))
-                    parent->loader().checkCompleted();
                 return;
             }
 
@@ -1213,13 +1212,18 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForBackForwardNavigationActi
             if (!historyItem) {
                 // Fallback: FrameState not found, use normal load path
                 RELEASE_LOG(Loading, "dispatchDecidePolicyForBackForwardNavigationAction: FrameState not found, using fallback normal load path");
-
+                localFrame->loader().cancelPendingAsyncBackForwardNavigation();
                 if (RefPtr parent = dynamicDowncast<LocalFrame>(localFrame->tree().parent()))
                     parent->loader().continueLoadURLIntoChildFrame(URL { url }, referer, *localFrame);
                 return;
             }
 
-            localFrame->loader().loadRequestedHistoryItem(loadType, PolicyAlreadyDecided::Yes);
+            // The async wait is over — UIProcess has resolved the HistoryItem
+            // and the actual loading begins via normal DocumentLoader mechanisms.
+            // Clear the async state so that frame completion tracking behaves
+            // identically to the non-flag path.
+            if (localFrame->loader().shouldProceedWithAsyncBackForwardNavigation())
+                localFrame->loader().loadRequestedHistoryItem(loadType, PolicyAlreadyDecided::Yes);
         }
     );
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -1903,6 +1903,7 @@ TEST(SiteIsolation, NavigationWithIFrames)
 
     [webView goBack];
     [navigationDelegate waitForDidFinishNavigation];
+    [navigationDelegate waitForDidFinishLoadInSubframe];
     checkFrameTreesInProcesses(webView.get(), {
         { "https://domain1.com"_s, { { RemoteFrame } } },
         { RemoteFrame, { { "https://domain2.com"_s } } }
@@ -4151,6 +4152,7 @@ TEST(SiteIsolation, GoBackToPageWithIframe)
 
     [webView goBack];
     [navigationDelegate waitForDidFinishNavigation];
+    [navigationDelegate waitForDidFinishLoadInSubframe];
     checkFrameTreesInProcesses(webView.get(), {
         { "https://a.com"_s,
             { { RemoteFrame } }
@@ -4835,6 +4837,8 @@ TEST(SiteIsolation, ProcessTerminationReason)
 
     kill([webView mainFrame].info._processIdentifier, 9);
     [navigationDelegate waitForDidFinishNavigation];
+    while (server.totalRequests() < 5u)
+        Util::spinRunLoop();
     EXPECT_EQ(server.totalRequests(), 5u);
 }
 

--- a/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h
@@ -40,6 +40,7 @@
 @property (nonatomic, copy) void (^didCommitNavigation)(WKWebView *, WKNavigation *);
 @property (nonatomic, copy) void (^didCommitLoadWithRequestInFrame)(WKWebView *, NSURLRequest *, WKFrameInfo *);
 @property (nonatomic, copy) void (^didFinishNavigation)(WKWebView *, WKNavigation *);
+@property (nonatomic, copy) void (^didFinishLoadWithRequestInFrame)(WKWebView *, NSURLRequest *, WKFrameInfo *);
 @property (nonatomic, copy) void (^didSameDocumentNavigation)(WKWebView *, WKNavigation *);
 @property (nonatomic, copy) void (^renderingProgressDidChange)(WKWebView *, _WKRenderingProgressEvents);
 @property (nonatomic, copy) void (^webContentProcessDidTerminate)(WKWebView *, _WKProcessTerminationReason);
@@ -55,6 +56,7 @@
 - (void)allowAnyTLSCertificate;
 - (void)waitForDidStartProvisionalNavigation;
 - (void)waitForDidFinishNavigation;
+- (void)waitForDidFinishLoadInSubframe;
 - (void)waitForDidFinishNavigationWithPreferences:(WKWebpagePreferences *)preferences;
 - (void)waitForDidSameDocumentNavigation;
 - (_WKProcessTerminationReason)waitForWebContentProcessDidTerminate;

--- a/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm
@@ -95,6 +95,12 @@
         _didFinishNavigation(webView, navigation);
 }
 
+- (void)_webView:(WKWebView *)webView didFinishLoadWithRequest:(NSURLRequest *)request inFrame:(WKFrameInfo *)frame
+{
+    if (_didFinishLoadWithRequestInFrame)
+        _didFinishLoadWithRequestInFrame(webView, request, frame);
+}
+
 - (void)_webView:(WKWebView *)webView navigation:(WKNavigation *)navigation didSameDocumentNavigation:(_WKSameDocumentNavigationType)navigationType
 {
     if (_didSameDocumentNavigation)
@@ -169,6 +175,21 @@
     TestWebKitAPI::Util::run(&finished);
 
     self.didFinishNavigation = nil;
+}
+
+- (void)waitForDidFinishLoadInSubframe
+{
+    EXPECT_FALSE(self.didFinishLoadWithRequestInFrame);
+
+    __block bool finished = false;
+    self.didFinishLoadWithRequestInFrame = ^(WKWebView *, NSURLRequest *, WKFrameInfo *frame) {
+        if (!frame.isMainFrame)
+            finished = true;
+    };
+
+    TestWebKitAPI::Util::run(&finished);
+
+    self.didFinishLoadWithRequestInFrame = nil;
 }
 
 - (void)waitForDidSameDocumentNavigation


### PR DESCRIPTION
#### f57d285d1e5a72ea6f5120ddead75bba72d2b64e
<pre>
[Site Isolation] Enable back/forward navigation via UIProcess when site isolation is active
<a href="https://bugs.webkit.org/show_bug.cgi?id=309907">https://bugs.webkit.org/show_bug.cgi?id=309907</a>
<a href="https://rdar.apple.com/172495046">rdar://172495046</a>

Reviewed by Charlie Wolfe.

Enable useUIProcessForBackForwardItemLoading when site isolation is enabled,
so that the UIProcess resolves back/forward list items and drives process
swaps correctly during history traversals.

Key changes:
- Automatically set useUIProcessForBackForwardItemLoading when
  siteIsolationEnabled is true.
- Handle history.go(0) as a reload early, before entering the async
  back/forward path.
- Cancel pending async back-forward navigation on fragment scrolls.
- Update back/forward list FrameIdentifiers during process swaps in
  commitProvisionalPage so subsequent navigations find the right frames.
- Fall back to mainFrameItem when a parentFrameID lookup fails after
  session restore, where original frame identifiers are unavailable.
- Clear async back-forward navigation state before loading the resolved
  HistoryItem so frame completion tracking works correctly.
- Add waitForAndCheckFrameTreesInProcesses() test helper that polls
  until cross-origin subframe process swaps complete.

No new tests, covered by existing site-isolation back/forward tests.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::continueFragmentScrollAfterNavigationPolicy):
* Source/WebCore/loader/NavigationScheduler.cpp:
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::findFrameStateInItem):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::commitProvisionalPage):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createWebPage):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForBackForwardNavigationAction):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, NavigationWithIFrames)):
(TestWebKitAPI::TEST(SiteIsolation, GoBackToPageWithIframe)):
(TestWebKitAPI::TEST(SiteIsolation, ProcessTerminationReason)):
* Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestNavigationDelegate.mm:
(-[TestNavigationDelegate _webView:didFinishLoadWithRequest:inFrame:]):
(-[TestNavigationDelegate waitForDidFinishLoadInSubframe]):

Canonical link: <a href="https://commits.webkit.org/309525@main">https://commits.webkit.org/309525@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3971e5fc936a8560df6499ff0520a2dca37da728

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159675 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c4bb20e-ec8d-4b45-b45b-f7813b323579) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116526 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/932b00f7-c0cd-464f-8e37-c0329c9d07dd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153907 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97246 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15686 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7521 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127351 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162148 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5273 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14915 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124530 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124717 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33844 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23501 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135141 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79908 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19786 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11906 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23111 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87264 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22823 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22975 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22877 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->