### PR TITLE
Skip unnecessary relayout for nowrap content during width changes

### DIFF
--- a/PerformanceTests/Layout/flexbox-sidebar-resize.html
+++ b/PerformanceTests/Layout/flexbox-sidebar-resize.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/runner.js"></script>
+<style>
+    .outer { display: flex; height: 600px; }
+    .right { flex: 1; overflow: hidden; }
+    .line { display: flex; }
+    #left { width: 300px; }
+    #handle { width: 8px; }
+</style>
+</head>
+<body>
+<div class="outer">
+    <div id="left"></div>
+    <div id="handle"></div>
+    <div class="right" id="right"></div>
+</div>
+<script>
+var right = document.getElementById("right");
+for (var i = 0; i < 3000; i++)
+    right.insertAdjacentHTML("beforeend", '<div class="line"><span>' + i + '</span><span>x</span></div>');
+
+// Force initial layout.
+document.body.offsetHeight;
+
+var left = document.getElementById("left");
+var numberOfIterations = 20;
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+    customIterationCount: numberOfIterations,
+    unit: 'ms',
+    done: function () {
+        PerfTestRunner.gc();
+    }
+});
+
+function startIteration() {
+    var startTime = PerfTestRunner.now();
+
+    // Simulate a drag gesture: 50 incremental width changes, like dragging a sidebar handle.
+    for (var x = 200; x <= 400; x += 4) {
+        left.style.width = x + "px";
+        document.body.offsetHeight;
+    }
+
+    // Reset for next iteration.
+    left.style.width = "300px";
+    document.body.offsetHeight;
+
+    if (!PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime))
+        return;
+
+    setTimeout(startIteration, 0);
+}
+
+startIteration();
+</script>
+</body>
+</html>

--- a/PerformanceTests/Layout/nowrap-text-sidebar-resize.html
+++ b/PerformanceTests/Layout/nowrap-text-sidebar-resize.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/runner.js"></script>
+<style>
+    .outer { display: flex; height: 600px; }
+    .right { flex: 1; overflow: hidden; }
+    .row { white-space: nowrap; }
+    #left { width: 300px; }
+</style>
+</head>
+<body>
+<div class="outer">
+    <div id="left"></div>
+    <div class="right" id="right"></div>
+</div>
+<script>
+var right = document.getElementById("right");
+for (var i = 0; i < 3000; i++)
+    right.insertAdjacentHTML("beforeend", '<div class="row">Item ' + i + ' — some nowrap text content here</div>');
+
+// Force initial layout.
+document.body.offsetHeight;
+
+var left = document.getElementById("left");
+var numberOfIterations = 20;
+
+PerfTestRunner.prepareToMeasureValuesAsync({
+    customIterationCount: numberOfIterations,
+    unit: 'ms',
+    done: function () {
+        PerfTestRunner.gc();
+    }
+});
+
+function startIteration() {
+    var startTime = PerfTestRunner.now();
+
+    // Simulate a drag gesture: 50 incremental width changes, like dragging a sidebar handle.
+    for (var x = 200; x <= 400; x += 4) {
+        left.style.width = x + "px";
+        document.body.offsetHeight;
+    }
+
+    // Reset for next iteration.
+    left.style.width = "300px";
+    document.body.offsetHeight;
+
+    if (!PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime))
+        return;
+
+    setTimeout(startIteration, 0);
+}
+
+startIteration();
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -390,6 +390,23 @@ bool RenderBlockFlow::recomputeLogicalWidthAndColumnWidth()
     return changed || oldColumnWidth != computedColumnWidth();
 }
 
+bool RenderBlockFlow::canSkipInlineRelayoutOnWidthChange() const
+{
+    if (!childrenInline())
+        return false;
+
+    if (style().textWrapMode() != TextWrapMode::NoWrap)
+        return false;
+
+    if (containsFloats())
+        return false;
+
+    if (multiColumnFlow())
+        return false;
+
+    return true;
+}
+
 LayoutUnit RenderBlockFlow::columnGap() const
 {
     if (style().columnGap().isNormal())
@@ -544,8 +561,10 @@ void RenderBlockFlow::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit 
 
     LayoutRepainter repainter(*this);
 
-    if (recomputeLogicalWidthAndColumnWidth())
-        relayoutChildren = RelayoutChildren::Yes;
+    if (recomputeLogicalWidthAndColumnWidth()) {
+        if (!canSkipInlineRelayoutOnWidthChange())
+            relayoutChildren = RelayoutChildren::Yes;
+    }
 
     if (auto* layoutState = view().frameView().layoutContext().layoutState(); layoutState && layoutState->legacyLineClamp() && !isFieldset())
         relayoutChildren = RelayoutChildren::Yes;

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -442,6 +442,7 @@ protected:
 
 private:
     bool recomputeLogicalWidthAndColumnWidth();
+    bool canSkipInlineRelayoutOnWidthChange() const;
     LayoutUnit columnGap() const;
     
     RenderBlockFlow* previousSiblingWithOverhangingFloats(bool& parentHasFloats) const;

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -2379,6 +2379,47 @@ bool RenderFlexibleBox::flexItemHasPercentHeightDescendants(const RenderBox& ren
     return false;
 }
 
+bool RenderFlexibleBox::canSkipFlexItemLayoutForWidthChange(const RenderBox& flexItem) const
+{
+    if (!mainAxisIsFlexItemInlineAxis(flexItem))
+        return false;
+
+    if (flexItem.selfNeedsLayout())
+        return false;
+
+    if (!flexItem.everHadLayout())
+        return false;
+
+    for (auto* child = flexItem.firstChild(); child; child = child->nextSibling()) {
+        if (child->needsLayout())
+            return false;
+    }
+
+    if (flexItemHasPercentHeightDescendants(flexItem))
+        return false;
+
+    if (flexItem.hasRelativeLogicalHeight())
+        return false;
+
+    auto& childStyle = flexItem.style();
+
+    if (childStyle.aspectRatio().hasRatio())
+        return false;
+
+    if (flexItem.isHorizontalWritingMode() != isHorizontalWritingMode())
+        return false;
+
+    if (is<RenderFlexibleBox>(flexItem)) {
+        if (childStyle.flexWrap() != FlexWrap::NoWrap)
+            return false;
+    }
+
+    if (flexItem.isRenderReplaced() || is<RenderTable>(flexItem))
+        return false;
+
+    return true;
+}
+
 static LayoutUnit contentAlignmentStartOverflow(LayoutUnit availableFreeSpace, ContentPosition position, ContentDistribution distribution, OverflowAlignment safety, bool isReverse)
 {
     if (availableFreeSpace >= 0 || safety == OverflowAlignment::Safe)
@@ -2483,11 +2524,26 @@ void RenderFlexibleBox::layoutAndPlaceFlexItems(LayoutUnit& crossAxisOffset, Fle
         updateFlexItemDirtyBitsBeforeLayout(forceFlexItemRelayout, flexItem);
         if (!flexItem.needsLayout())
             flexItem.markForPaginationRelayoutIfNeeded();
-        if (flexItem.needsLayout())
-            m_relaidOutFlexItems.add(flexItem);
-        {
-            auto flexLayoutScope = SetForScope(m_afterMainAxisItemSizing, true);
-            flexItem.layoutIfNeeded();
+
+        bool skippedLayout = false;
+        if (flexItem.needsLayout() && !forceFlexItemRelayout
+            && canSkipFlexItemLayoutForWidthChange(flexItem)) {
+            auto newBorderBoxMain = flexLayoutItem.flexedContentSize + flexLayoutItem.mainAxisBorderAndPadding;
+            if (isHorizontalFlow())
+                flexItem.setWidth(newBorderBoxMain);
+            else
+                flexItem.setHeight(newBorderBoxMain);
+            flexItem.clearNeedsLayout();
+            skippedLayout = true;
+        }
+
+        if (!skippedLayout) {
+            if (flexItem.needsLayout())
+                m_relaidOutFlexItems.add(flexItem);
+            {
+                auto flexLayoutScope = SetForScope(m_afterMainAxisItemSizing, true);
+                flexItem.layoutIfNeeded();
+            }
         }
         if (!flexLayoutItem.everHadLayout && flexItem.checkForRepaintDuringLayout()) {
             flexItem.repaint();

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -279,6 +279,8 @@ private:
 
     bool flexItemHasPercentHeightDescendants(const RenderBox&) const;
 
+    bool canSkipFlexItemLayoutForWidthChange(const RenderBox& flexItem) const;
+
     void resetHasDefiniteHeight() { m_hasDefiniteHeight = SizeDefiniteness::Unknown; }
     const RenderBox* flexItemForFirstBaseline() const;
     const RenderBox* flexItemForLastBaseline() const;


### PR DESCRIPTION
#### 92a851f7ad99632538cfb46eed4709d2eb994653
<pre>
Skip unnecessary relayout for nowrap content during width changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=309914">https://bugs.webkit.org/show_bug.cgi?id=309914</a>
<a href="https://rdar.apple.com/172501037">rdar://172501037</a>

Reviewed by NOBODY (OOPS!).

When a flex container's width changes, all of its children get                                            
marked dirty and laid out from scratch, even when their heights
cannot change. The cost scales linearly with the number of children and
is dominated by redundant layout work that produces identical
results.

Add two optimizations that reduce unnecessary work during
width-only changes.

First, in RenderBlockFlow::layoutBlock, skip setting
relayoutChildren when the block&apos;s width changes but its inline
content cannot reflow. A block with nowrap text, no floats, and
no multi-column layout produces identical line layout regardless
of available width, so its children do not need to be
force-dirtied.

Second, in RenderFlexibleBox::layoutAndPlaceFlexItems, skip the
full internal layout of individual flex items whose height is
independent of their width. The flex algorithm still runs to
compute positions and distribute space, but when it reaches the
point of laying out an item&apos;s subtree, it sets the item&apos;s new
border-box size directly from the already-computed flexed content
size and clears its dirty bit. This is restricted to items where
the main axis is the inline axis, the item was not self-dirty, no
direct children need layout, and the item has no percent-height
descendants, relative heights, or aspect ratios. Nested flex
containers are only skipped if they are nowrap.

Add two performance tests. nowrap-text-sidebar-resize.html
measures the cost of resizing a flex panel whose sibling contains
3000 block divs with nowrap text, simulating 50 incremental width
changes per iteration. This targets the first optimization.
flexbox-sidebar-resize.html measures the same resize pattern but
with 3000 nowrap flex rows each containing two span children,
targeting the second optimization. Results on a local build:
nowrap-text-sidebar-resize improved from 175ms to 3ms per
iteration (58x), flexbox-sidebar-resize improved from 4383ms to
3ms per iteration (1461x).

* PerformanceTests/Layout/flexbox-sidebar-resize.html: Added.
* PerformanceTests/Layout/nowrap-text-sidebar-resize.html: Added.
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::canSkipInlineRelayoutOnWidthChange const):
(WebCore::RenderBlockFlow::layoutBlock):
* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::canSkipFlexItemLayoutForWidthChange const):
(WebCore::RenderFlexibleBox::layoutAndPlaceFlexItems):
* Source/WebCore/rendering/RenderFlexibleBox.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92a851f7ad99632538cfb46eed4709d2eb994653

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150027 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16346 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158738 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103461 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44cca0f8-4cfd-40c3-a3a4-40f9e47779fb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22878 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115728 "Found 5 new test failures: editing/undo/redo-after-detach.html fast/forms/range/input-appearance-range.html imported/w3c/web-platform-tests/css/css-flexbox/dynamic-stretch-change.html imported/w3c/web-platform-tests/css/css-flexbox/relayout-align-items.html imported/w3c/web-platform-tests/css/css-grid/dynamic-grid-within-flexbox.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82212 "3 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/266da201-b121-4359-8766-f399f65832ee) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152987 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17838 "Found 3 new test failures: fast/attachment/cocoa/wide-attachment-save-event.html fast/forms/password-scrolled-after-caps-lock-toggled.html fast/forms/range/input-appearance-range.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96457 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1382f827-2c59-4464-b254-d1db3e96f437) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16938 "Found 4 new test failures: imported/w3c/web-platform-tests/css/css-flexbox/align-items-008.html imported/w3c/web-platform-tests/css/css-flexbox/dynamic-stretch-change.html imported/w3c/web-platform-tests/css/css-flexbox/relayout-align-items.html imported/w3c/web-platform-tests/css/css-grid/dynamic-grid-within-flexbox.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14887 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6584 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126553 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161212 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4303 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14075 "Found 10 new test failures: fast/attachment/cocoa/wide-attachment-save-event.html fast/attachment/mac/wide-attachment-image-controls-basic.html fast/attachment/mac/wide-attachment-title-with-rtl.html fast/forms/datalist/input-appearance-range-with-datalist-rtl.html fast/forms/range/input-appearance-range.html fast/repaint/placeholder-after-caps-lock-hidden.html imported/w3c/web-platform-tests/css/css-flexbox/align-items-008.html imported/w3c/web-platform-tests/css/css-flexbox/dynamic-stretch-change.html imported/w3c/web-platform-tests/css/css-flexbox/relayout-align-items.html imported/w3c/web-platform-tests/css/css-grid/dynamic-grid-within-flexbox.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123730 "Found 3 new test failures: editing/undo/redo-after-detach.html fast/forms/range/input-appearance-range.html imported/w3c/web-platform-tests/css/css-flexbox/relayout-align-items.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22554 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18934 "Found 11 new test failures: editing/execCommand/remove-formatting-from-iframe-in-button.html fast/attachment/cocoa/wide-attachment-save-event.html fast/attachment/mac/wide-attachment-image-controls-basic.html fast/attachment/mac/wide-attachment-title-with-rtl.html fast/forms/range/input-appearance-range.html fast/inline/contenteditable-with-leading-whitespace-crash.html fast/repaint/placeholder-after-caps-lock-hidden.html imported/w3c/web-platform-tests/css/css-flexbox/align-items-008.html imported/w3c/web-platform-tests/css/css-flexbox/dynamic-stretch-change.html imported/w3c/web-platform-tests/css/css-flexbox/relayout-align-items.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123931 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134318 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78803 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19078 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11074 "Found 10 new test failures: fast/attachment/cocoa/wide-attachment-save-event.html fast/attachment/mac/wide-attachment-image-controls-basic.html fast/attachment/mac/wide-attachment-title-with-rtl.html fast/forms/datalist/input-appearance-range-with-datalist-rtl.html fast/forms/range/input-appearance-range.html fast/repaint/placeholder-after-caps-lock-hidden.html imported/w3c/web-platform-tests/css/css-flexbox/align-items-008.html imported/w3c/web-platform-tests/css/css-flexbox/dynamic-stretch-change.html imported/w3c/web-platform-tests/css/css-flexbox/relayout-align-items.html imported/w3c/web-platform-tests/css/css-grid/dynamic-grid-within-flexbox.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22159 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85987 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21889 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22041 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21947 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->