### PR TITLE
[JSC] IPInt PC move should be recorded one for prefixed opcodes

### DIFF
--- a/JSTests/wasm/stress/ipint-variable-length-gc-opcodes.js
+++ b/JSTests/wasm/stress/ipint-variable-length-gc-opcodes.js
@@ -1,0 +1,569 @@
+import * as assert from "../assert.js";
+
+/*
+ * Test for IPInt variable-length LEB128 sub-opcode handling.
+ *
+ * This test validates the fix for a bug where certain WebAssembly GC opcodes
+ * incorrectly assumed fixed-length instruction encoding. The bug occurred because:
+ * - GC opcodes use a two-level encoding: base opcode (0xFB) + sub-opcode (LEB128)
+ * - LEB128 allows the same number to be represented multiple ways (e.g., 15 can be 0x0F or 0x8F 0x00)
+ * - Some opcodes used advancePC(2) (constant) instead of dynamic length tracking
+ * - This caused IPInt to advance by the wrong number of bytes with redundant encodings
+ *
+ * The test manually constructs WASM binaries with redundantly-encoded sub-opcodes
+ * to verify IPInt handles variable-length encodings correctly.
+ *
+ * Fixed opcodes tested:
+ * - ref.i31 (0x1C), i31.get_s (0x1D), i31.get_u (0x1E)
+ * - array.len (0x0F), array.fill (0x10), array.copy (0x11)
+ * - any.convert_extern (0x1A), extern.convert_any (0x1B)
+ */
+
+// Helper function to create redundant LEB128 encoding of a value
+// For values < 128, we can add redundant continuation bytes
+function createRedundantLEB128(value, totalBytes) {
+    if (totalBytes === 1) {
+        return [value];
+    }
+
+    // Create redundant encoding by adding continuation bytes
+    let result = [];
+    for (let i = 0; i < totalBytes - 1; i++) {
+        if (i === 0) {
+            result.push(value | 0x80);  // First byte with continuation bit
+        } else {
+            result.push(0x80);  // Middle bytes: just continuation bit
+        }
+    }
+    result.push(0x00);  // Final byte: no continuation bit, value 0
+
+    return result;
+}
+
+// Helper to calculate LEB128 size for section sizes
+function encodeVarUInt32(value) {
+    let result = [];
+    do {
+        let byte = value & 0x7F;
+        value >>>= 7;
+        if (value !== 0) {
+            byte |= 0x80;
+        }
+        result.push(byte);
+    } while (value !== 0);
+    return result;
+}
+
+// ========================================
+// ref.i31 Tests
+// ========================================
+
+function testRefI31RedundantEncoding() {
+    // Test ref.i31 with normal encoding (1 byte sub-opcode)
+    {
+        let extendedOp = [0x1C];  // ref.i31 normal
+        let codeBody = [
+            0x00,  // 0 locals
+            0x41, 0x2A,  // i32.const 42
+            0xFB, ...extendedOp,  // ref.i31
+            0x0B  // end
+        ];
+
+        let codeSectionSize = encodeVarUInt32(1 + encodeVarUInt32(codeBody.length).length + codeBody.length);
+
+        let bytes = new Uint8Array([
+            // WASM header
+            0x00, 0x61, 0x73, 0x6D,  // Magic
+            0x01, 0x00, 0x00, 0x00,  // Version
+
+            // Type section [type 0: () -> i31ref]
+            0x01,  // Section ID
+            0x05,  // Section size
+            0x01,  // 1 type
+            0x60,  // Function type
+            0x00,  // 0 params
+            0x01,  // 1 return
+            0x6C,  // i31ref (ref null i31)
+
+            // Function section [function 0 uses type 0]
+            0x03,  // Section ID
+            0x02,  // Section size
+            0x01,  // 1 function
+            0x00,  // Type index 0
+
+            // Export section
+            0x07,  // Section ID
+            0x05,  // Section size
+            0x01,  // 1 export
+            0x01, 0x66,  // Name length=1, name="f"
+            0x00,  // Export kind: function
+            0x00,  // Function index 0
+
+            // Code section
+            0x0A,  // Section ID
+            ...codeSectionSize,
+            0x01,  // 1 function body
+            ...encodeVarUInt32(codeBody.length),
+            ...codeBody
+        ]);
+
+        let module = new WebAssembly.Module(bytes);
+        let instance = new WebAssembly.Instance(module);
+        assert.eq(instance.exports.f(), 42);
+    }
+
+    // Test ref.i31 with 2-byte redundant encoding
+    {
+        let extendedOp = createRedundantLEB128(0x1C, 2);  // ref.i31 redundant: [0x9C, 0x00]
+        let codeBody = [
+            0x00,  // 0 locals
+            0x41, 0x2A,  // i32.const 42
+            0xFB, ...extendedOp,  // ref.i31 with redundant encoding
+            0x0B  // end
+        ];
+
+        let codeSectionSize = encodeVarUInt32(1 + encodeVarUInt32(codeBody.length).length + codeBody.length);
+
+        let bytes = new Uint8Array([
+            // WASM header
+            0x00, 0x61, 0x73, 0x6D,  // Magic
+            0x01, 0x00, 0x00, 0x00,  // Version
+
+            // Type section [type 0: () -> i31ref]
+            0x01,  // Section ID
+            0x05,  // Section size
+            0x01,  // 1 type
+            0x60,  // Function type
+            0x00,  // 0 params
+            0x01,  // 1 return
+            0x6C,  // i31ref (ref null i31)
+
+            // Function section [function 0 uses type 0]
+            0x03,  // Section ID
+            0x02,  // Section size
+            0x01,  // 1 function
+            0x00,  // Type index 0
+
+            // Export section
+            0x07,  // Section ID
+            0x05,  // Section size
+            0x01,  // 1 export
+            0x01, 0x66,  // Name length=1, name="f"
+            0x00,  // Export kind: function
+            0x00,  // Function index 0
+
+            // Code section
+            0x0A,  // Section ID
+            ...codeSectionSize,
+            0x01,  // 1 function body
+            ...encodeVarUInt32(codeBody.length),
+            ...codeBody
+        ]);
+
+        let module = new WebAssembly.Module(bytes);
+        let instance = new WebAssembly.Instance(module);
+        assert.eq(instance.exports.f(), 42);
+    }
+
+    // Test ref.i31 with 3-byte redundant encoding
+    {
+        let extendedOp = createRedundantLEB128(0x1C, 3);  // ref.i31 redundant: [0x9C, 0x80, 0x00]
+        let codeBody = [
+            0x00,  // 0 locals
+            0x41, 0x2A,  // i32.const 42
+            0xFB, ...extendedOp,  // ref.i31 with extra redundant encoding
+            0x0B  // end
+        ];
+
+        let codeSectionSize = encodeVarUInt32(1 + encodeVarUInt32(codeBody.length).length + codeBody.length);
+
+        let bytes = new Uint8Array([
+            // WASM header
+            0x00, 0x61, 0x73, 0x6D,  // Magic
+            0x01, 0x00, 0x00, 0x00,  // Version
+
+            // Type section [type 0: () -> i31ref]
+            0x01,  // Section ID
+            0x05,  // Section size
+            0x01,  // 1 type
+            0x60,  // Function type
+            0x00,  // 0 params
+            0x01,  // 1 return
+            0x6C,  // i31ref (ref null i31)
+
+            // Function section [function 0 uses type 0]
+            0x03,  // Section ID
+            0x02,  // Section size
+            0x01,  // 1 function
+            0x00,  // Type index 0
+
+            // Export section
+            0x07,  // Section ID
+            0x05,  // Section size
+            0x01,  // 1 export
+            0x01, 0x66,  // Name length=1, name="f"
+            0x00,  // Export kind: function
+            0x00,  // Function index 0
+
+            // Code section
+            0x0A,  // Section ID
+            ...codeSectionSize,
+            0x01,  // 1 function body
+            ...encodeVarUInt32(codeBody.length),
+            ...codeBody
+        ]);
+
+        let module = new WebAssembly.Module(bytes);
+        let instance = new WebAssembly.Instance(module);
+        assert.eq(instance.exports.f(), 42);
+    }
+}
+
+// ========================================
+// i31.get_s and i31.get_u Tests
+// ========================================
+
+function testI31GetRedundantEncoding() {
+    // Test i31.get_s with 2-byte redundant encoding
+    {
+        let extendedOp1 = [0x1C];  // ref.i31 normal
+        let extendedOp2 = createRedundantLEB128(0x1D, 2);  // i31.get_s redundant
+        let codeBody = [
+            0x00,  // 0 locals
+            0x41, 0x2A,  // i32.const 42
+            0xFB, ...extendedOp1,  // ref.i31
+            0xFB, ...extendedOp2,  // i31.get_s with redundant encoding
+            0x0B  // end
+        ];
+
+        let codeSectionSize = encodeVarUInt32(1 + encodeVarUInt32(codeBody.length).length + codeBody.length);
+
+        let bytes = new Uint8Array([
+            0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+            0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7F,  // Type: () -> i32
+            0x03, 0x02, 0x01, 0x00,
+            0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00,
+            0x0A, ...codeSectionSize, 0x01, ...encodeVarUInt32(codeBody.length), ...codeBody
+        ]);
+
+        let module = new WebAssembly.Module(bytes);
+        let instance = new WebAssembly.Instance(module);
+        assert.eq(instance.exports.f(), 42);
+    }
+
+    // Test i31.get_u with 3-byte redundant encoding
+    {
+        let extendedOp1 = [0x1C];  // ref.i31 normal
+        let extendedOp2 = createRedundantLEB128(0x1E, 3);  // i31.get_u redundant
+        let codeBody = [
+            0x00,  // 0 locals
+            0x41, 0x2A,  // i32.const 42
+            0xFB, ...extendedOp1,  // ref.i31
+            0xFB, ...extendedOp2,  // i31.get_u with extra redundant encoding
+            0x0B  // end
+        ];
+
+        let codeSectionSize = encodeVarUInt32(1 + encodeVarUInt32(codeBody.length).length + codeBody.length);
+
+        let bytes = new Uint8Array([
+            0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+            0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7F,  // Type: () -> i32
+            0x03, 0x02, 0x01, 0x00,
+            0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00,
+            0x0A, ...codeSectionSize, 0x01, ...encodeVarUInt32(codeBody.length), ...codeBody
+        ]);
+
+        let module = new WebAssembly.Module(bytes);
+        let instance = new WebAssembly.Instance(module);
+        assert.eq(instance.exports.f(), 42);
+    }
+}
+
+// Run tests
+testRefI31RedundantEncoding();
+testI31GetRedundantEncoding();
+
+// ========================================
+// array.len Tests
+// ========================================
+
+function testArrayLenRedundantEncoding() {
+    // Test array.len with 2-byte redundant encoding
+    {
+        let extendedOp1 = [0x07];  // array.new_default normal
+        let extendedOp2 = createRedundantLEB128(0x0F, 2);  // array.len redundant
+        let codeBody = [
+            0x00,  // 0 locals
+            0x41, 0x05,  // i32.const 5
+            0xFB, ...extendedOp1, 0x00,  // array.new_default type_index=0
+            0xFB, ...extendedOp2,  // array.len with redundant encoding
+            0x0B  // end
+        ];
+
+        let codeSectionSize = encodeVarUInt32(1 + encodeVarUInt32(codeBody.length).length + codeBody.length);
+
+        let bytes = new Uint8Array([
+            0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+
+            // Type section: 2 types
+            0x01, 0x08, 0x02,
+            0x5E, 0x7F, 0x01,  // Type 0: (array i32 mutable)
+            0x60, 0x00, 0x01, 0x7F,  // Type 1: () -> i32
+
+            // Function section
+            0x03, 0x02, 0x01, 0x01,
+
+            // Export section
+            0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00,
+
+            // Code section
+            0x0A, ...codeSectionSize, 0x01, ...encodeVarUInt32(codeBody.length), ...codeBody
+        ]);
+
+        let module = new WebAssembly.Module(bytes);
+        let instance = new WebAssembly.Instance(module);
+        assert.eq(instance.exports.f(), 5);
+    }
+
+    // Test array.len with 3-byte redundant encoding
+    {
+        let extendedOp1 = [0x07];  // array.new_default normal
+        let extendedOp2 = createRedundantLEB128(0x0F, 3);  // array.len extra redundant
+        let codeBody = [
+            0x00,  // 0 locals
+            0x41, 0x0A,  // i32.const 10
+            0xFB, ...extendedOp1, 0x00,  // array.new_default type_index=0
+            0xFB, ...extendedOp2,  // array.len with extra redundant encoding
+            0x0B  // end
+        ];
+
+        let codeSectionSize = encodeVarUInt32(1 + encodeVarUInt32(codeBody.length).length + codeBody.length);
+
+        let bytes = new Uint8Array([
+            0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+
+            // Type section: 2 types
+            0x01, 0x08, 0x02,
+            0x5E, 0x7F, 0x01,  // Type 0: (array i32 mutable)
+            0x60, 0x00, 0x01, 0x7F,  // Type 1: () -> i32
+
+            // Function section
+            0x03, 0x02, 0x01, 0x01,
+
+            // Export section
+            0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00,
+
+            // Code section
+            0x0A, ...codeSectionSize, 0x01, ...encodeVarUInt32(codeBody.length), ...codeBody
+        ]);
+
+        let module = new WebAssembly.Module(bytes);
+        let instance = new WebAssembly.Instance(module);
+        assert.eq(instance.exports.f(), 10);
+    }
+}
+
+// ========================================
+// array.fill Tests
+// ========================================
+
+function testArrayFillRedundantEncoding() {
+    // Test array.fill with 2-byte redundant encoding
+    {
+        let extendedOp1 = [0x07];  // array.new_default normal
+        let extendedOp2 = createRedundantLEB128(0x10, 2);  // array.fill redundant
+        let extendedOp3 = [0x0B];  // array.get normal
+        let codeBody = [
+            0x01, 0x01, 0x63, 0x00,  // 1 local: (ref null 0) = arrayref
+            // Create array
+            0x41, 0x05,  // i32.const 5
+            0xFB, ...extendedOp1, 0x00,  // array.new_default type_index=0
+            0x21, 0x00,  // local.set 0
+            // Fill array
+            0x20, 0x00,  // local.get 0
+            0x41, 0x00,  // i32.const 0 (start index)
+            0x41, 0x2A,  // i32.const 42 (value)
+            0x41, 0x05,  // i32.const 5 (count)
+            0xFB, ...extendedOp2, 0x00,  // array.fill with redundant encoding, type_index=0
+            // Get and return first element
+            0x20, 0x00,  // local.get 0
+            0x41, 0x00,  // i32.const 0
+            0xFB, ...extendedOp3, 0x00,  // array.get type_index=0
+            0x0B  // end
+        ];
+
+        let codeSectionSize = encodeVarUInt32(1 + encodeVarUInt32(codeBody.length).length + codeBody.length);
+
+        let bytes = new Uint8Array([
+            0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+
+            // Type section: 2 types
+            0x01, 0x08, 0x02,
+            0x5E, 0x7F, 0x01,  // Type 0: (array i32 mutable)
+            0x60, 0x00, 0x01, 0x7F,  // Type 1: () -> i32
+
+            // Function section
+            0x03, 0x02, 0x01, 0x01,
+
+            // Export section
+            0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00,
+
+            // Code section
+            0x0A, ...codeSectionSize, 0x01, ...encodeVarUInt32(codeBody.length), ...codeBody
+        ]);
+
+        let module = new WebAssembly.Module(bytes);
+        let instance = new WebAssembly.Instance(module);
+        assert.eq(instance.exports.f(), 42);
+    }
+}
+
+// ========================================
+// array.copy Tests
+// ========================================
+
+function testArrayCopyRedundantEncoding() {
+    // Test array.copy with 2-byte redundant encoding
+    {
+        let extendedOp1 = [0x06];  // array.new normal
+        let extendedOp2 = [0x07];  // array.new_default normal
+        let extendedOp3 = createRedundantLEB128(0x11, 2);  // array.copy redundant
+        let extendedOp4 = [0x0B];  // array.get normal
+        let codeBody = [
+            0x01, 0x02, 0x63, 0x00,  // 1 local declaration: 2 locals of type (ref null 0) = arrayref
+            // Create source array with value 99
+            0x41, 0xE3, 0x00,  // i32.const 99 (LEB128 encoded)
+            0x41, 0x03,  // i32.const 3 (size)
+            0xFB, ...extendedOp1, 0x00,  // array.new type_index=0
+            0x21, 0x00,  // local.set 0 (source array)
+            // Create destination array
+            0x41, 0x03,  // i32.const 3
+            0xFB, ...extendedOp2, 0x00,  // array.new_default type_index=0
+            0x21, 0x01,  // local.set 1 (dest array)
+            // Copy from source to dest
+            0x20, 0x01,  // local.get 1 (dest)
+            0x41, 0x00,  // i32.const 0 (dest index)
+            0x20, 0x00,  // local.get 0 (source)
+            0x41, 0x00,  // i32.const 0 (source index)
+            0x41, 0x03,  // i32.const 3 (count)
+            0xFB, ...extendedOp3, 0x00, 0x00,  // array.copy with redundant encoding, dest_type=0, src_type=0
+            // Get and return first element of dest
+            0x20, 0x01,  // local.get 1
+            0x41, 0x00,  // i32.const 0
+            0xFB, ...extendedOp4, 0x00,  // array.get type_index=0
+            0x0B  // end
+        ];
+
+        let codeSectionSize = encodeVarUInt32(1 + encodeVarUInt32(codeBody.length).length + codeBody.length);
+
+        let bytes = new Uint8Array([
+            0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+
+            // Type section: 2 types
+            0x01, 0x08, 0x02,
+            0x5E, 0x7F, 0x01,  // Type 0: (array i32 mutable)
+            0x60, 0x00, 0x01, 0x7F,  // Type 1: () -> i32
+
+            // Function section
+            0x03, 0x02, 0x01, 0x01,
+
+            // Export section
+            0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00,
+
+            // Code section
+            0x0A, ...codeSectionSize, 0x01, ...encodeVarUInt32(codeBody.length), ...codeBody
+        ]);
+
+        let module = new WebAssembly.Module(bytes);
+        let instance = new WebAssembly.Instance(module);
+        assert.eq(instance.exports.f(), 99);
+    }
+}
+
+// ========================================
+// any.convert_extern and extern.convert_any Tests
+// ========================================
+
+function testExternAnyConvertRedundantEncoding() {
+    // Test extern.convert_any with 2-byte redundant encoding
+    {
+        let extendedOp1 = [0x1C];  // ref.i31 normal
+        let extendedOp2 = createRedundantLEB128(0x1B, 2);  // extern.convert_any redundant
+        let codeBody = [
+            0x00,  // 0 locals
+            0x41, 0x2A,  // i32.const 42
+            0xFB, ...extendedOp1,  // ref.i31
+            0xFB, ...extendedOp2,  // extern.convert_any with redundant encoding
+            0xD1,  // ref.is_null
+            0x45,  // i32.eqz (invert: return 1 if not null, 0 if null)
+            0x0B  // end
+        ];
+
+        let codeSectionSize = encodeVarUInt32(1 + encodeVarUInt32(codeBody.length).length + codeBody.length);
+
+        let bytes = new Uint8Array([
+            0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+
+            // Type section
+            0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7F,  // Type: () -> i32
+
+            // Function section
+            0x03, 0x02, 0x01, 0x00,
+
+            // Export section
+            0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00,
+
+            // Code section
+            0x0A, ...codeSectionSize, 0x01, ...encodeVarUInt32(codeBody.length), ...codeBody
+        ]);
+
+        let module = new WebAssembly.Module(bytes);
+        let instance = new WebAssembly.Instance(module);
+        assert.eq(instance.exports.f(), 1);  // Should return 1 (not null)
+    }
+
+    // Test any.convert_extern with 2-byte redundant encoding
+    {
+        let extendedOp1 = [0x1C];  // ref.i31 normal
+        let extendedOp2 = [0x1B];  // extern.convert_any normal
+        let extendedOp3 = createRedundantLEB128(0x1A, 2);  // any.convert_extern redundant
+        let codeBody = [
+            0x00,  // 0 locals
+            0x41, 0x2A,  // i32.const 42
+            0xFB, ...extendedOp1,  // ref.i31
+            0xFB, ...extendedOp2,  // extern.convert_any
+            0xFB, ...extendedOp3,  // any.convert_extern with redundant encoding
+            0xD1,  // ref.is_null
+            0x45,  // i32.eqz (invert: return 1 if not null, 0 if null)
+            0x0B  // end
+        ];
+
+        let codeSectionSize = encodeVarUInt32(1 + encodeVarUInt32(codeBody.length).length + codeBody.length);
+
+        let bytes = new Uint8Array([
+            0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00,
+
+            // Type section
+            0x01, 0x05, 0x01, 0x60, 0x00, 0x01, 0x7F,  // Type: () -> i32
+
+            // Function section
+            0x03, 0x02, 0x01, 0x00,
+
+            // Export section
+            0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00,
+
+            // Code section
+            0x0A, ...codeSectionSize, 0x01, ...encodeVarUInt32(codeBody.length), ...codeBody
+        ]);
+
+        let module = new WebAssembly.Module(bytes);
+        let instance = new WebAssembly.Instance(module);
+        assert.eq(instance.exports.f(), 1);  // Should return 1 (not null)
+    }
+}
+
+// Run tests
+testArrayLenRedundantEncoding();
+testArrayFillRedundantEncoding();
+testArrayCopyRedundantEncoding();
+testExternAnyConvertRedundantEncoding();

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter64.asm
@@ -3444,7 +3444,9 @@ ipintOp(_array_len, macro()
     bqeq t0, ValueNull, .nullArray
     loadi JSWebAssemblyArray::m_size[t0], t0
     pushInt32(t0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 
 .nullArray:
@@ -3457,9 +3459,9 @@ ipintOp(_array_fill, macro()
 
     addp StackValueSize * 4, sp
 
-    loadb IPInt::ArrayFillMetadata::length[MC], t0
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
     advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::ArrayFillMetadata)))
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -3469,9 +3471,9 @@ ipintOp(_array_copy, macro()
 
     addp StackValueSize * 5, sp
 
-    loadb IPInt::ArrayFillMetadata::length[MC], t0
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
     advancePCByReg(t0)
-    advanceMC(constexpr (sizeof(IPInt::ArrayCopyMetadata)))
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -3597,13 +3599,17 @@ ipintOp(_any_convert_extern, macro()
     popQuad(a1)
     operationCall(macro() cCall2(_ipint_extern_any_convert_extern) end)
     pushQuad(r0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
 ipintOp(_extern_convert_any, macro()
     # do nothing
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -3614,7 +3620,9 @@ ipintOp(_ref_i31, macro()
     orq TagNumber, t0
     pushQuad(t0)
 
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -3623,7 +3631,9 @@ ipintOp(_i31_get_s, macro()
     bqeq t0, ValueNull, .i31_get_throw
     pushInt32(t0)
 
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 .i31_get_throw:
     throwException(NullI31Get)
@@ -3635,7 +3645,9 @@ ipintOp(_i31_get_u, macro()
     andq 0x7fffffff, t0
     pushInt32(t0)
 
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 .i31_get_throw:
     throwException(NullI31Get)
@@ -4260,7 +4272,9 @@ ipintOp(_simd_v128_const, macro()
     # v128.const
     loadv 2[PC], v0
     pushVec(v0)
-    advancePC(18)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4313,7 +4327,9 @@ ipintOp(_simd_i8x16_shuffle, macro()
         addp 2 * V128ISize, sp            # Pop temp result and right vector
     end
 
-    advancePC(18)  # 2 bytes opcode + 16 bytes immediate
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4340,7 +4356,9 @@ ipintOp(_simd_i8x16_swizzle, macro()
     end
 
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4361,7 +4379,9 @@ ipintOp(_simd_i8x16_splat, macro()
     end
 
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4381,7 +4401,9 @@ ipintOp(_simd_i16x8_splat, macro()
     end
 
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4400,7 +4422,9 @@ ipintOp(_simd_i32x4_splat, macro()
     end
 
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4419,7 +4443,9 @@ ipintOp(_simd_i64x2_splat, macro()
     end
 
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4437,7 +4463,9 @@ ipintOp(_simd_f32x4_splat, macro()
     end
 
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4455,7 +4483,9 @@ ipintOp(_simd_f64x2_splat, macro()
     end
 
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4467,7 +4497,9 @@ ipintOp(_simd_i8x16_extract_lane_s, macro()
     loadbsi [sp, t0], t0
     addp V128ISize, sp
     pushInt32(t0)
-    advancePC(3)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4478,7 +4510,9 @@ ipintOp(_simd_i8x16_extract_lane_u, macro()
     loadb [sp, t0], t0
     addp V128ISize, sp
     pushInt32(t0)
-    advancePC(3)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4488,7 +4522,9 @@ ipintOp(_simd_i8x16_replace_lane, macro()
     andi ImmLaneIdx16Mask, t0
     popInt32(t1)  # value to replace with
     storeb t1, [sp, t0]  # replace the byte at lane index
-    advancePC(3)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4499,7 +4535,9 @@ ipintOp(_simd_i16x8_extract_lane_s, macro()
     loadhsi [sp, t0, 2], t0
     addp V128ISize, sp
     pushInt32(t0)
-    advancePC(3)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4510,7 +4548,9 @@ ipintOp(_simd_i16x8_extract_lane_u, macro()
     loadh [sp, t0, 2], t0
     addp V128ISize, sp
     pushInt32(t0)
-    advancePC(3)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4520,7 +4560,9 @@ ipintOp(_simd_i16x8_replace_lane, macro()
     andi ImmLaneIdx8Mask, t0
     popInt32(t1)  # value to replace with
     storeh t1, [sp, t0, 2]  # replace the 16-bit value at lane index
-    advancePC(3)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4531,7 +4573,9 @@ ipintOp(_simd_i32x4_extract_lane, macro()
     loadi [sp, t0, 4], t0
     addp V128ISize, sp
     pushInt32(t0)
-    advancePC(3)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4541,7 +4585,9 @@ ipintOp(_simd_i32x4_replace_lane, macro()
     andi ImmLaneIdx4Mask, t0
     popInt32(t1)  # value to replace with
     storei t1, [sp, t0, 4]  # replace the 32-bit value at lane index
-    advancePC(3)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4552,7 +4598,9 @@ ipintOp(_simd_i64x2_extract_lane, macro()
     loadq [sp, t0, 8], t0
     addp V128ISize, sp
     pushInt64(t0)
-    advancePC(3)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4562,7 +4610,9 @@ ipintOp(_simd_i64x2_replace_lane, macro()
     andi ImmLaneIdx2Mask, t0
     popInt64(t1)  # value to replace with
     storeq t1, [sp, t0, 8]  # replace the 64-bit value at lane index
-    advancePC(3)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4573,7 +4623,9 @@ ipintOp(_simd_f32x4_extract_lane, macro()
     loadf [sp, t0, 4], ft0
     addp V128ISize, sp
     pushFloat32(ft0)
-    advancePC(3)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4583,7 +4635,9 @@ ipintOp(_simd_f32x4_replace_lane, macro()
     andi ImmLaneIdx4Mask, t0
     popFloat32(ft0)  # value to replace with
     storef ft0, [sp, t0, 4]  # replace the 32-bit float at lane index
-    advancePC(3)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4594,7 +4648,9 @@ ipintOp(_simd_f64x2_extract_lane, macro()
     loadd [sp, t0, 8], ft0
     addp V128ISize, sp
     pushFloat64(ft0)
-    advancePC(3)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4604,7 +4660,9 @@ ipintOp(_simd_f64x2_replace_lane, macro()
     andi ImmLaneIdx2Mask, t0
     popFloat64(ft0)  # value to replace with
     stored ft0, [sp, t0, 8]  # replace the 64-bit float at lane index
-    advancePC(3)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4621,7 +4679,9 @@ ipintOp(_simd_i8x16_eq, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4642,7 +4702,9 @@ ipintOp(_simd_i8x16_ne, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4660,7 +4722,9 @@ ipintOp(_simd_i8x16_lt_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4681,7 +4745,9 @@ ipintOp(_simd_i8x16_lt_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4697,7 +4763,9 @@ ipintOp(_simd_i8x16_gt_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4717,7 +4785,9 @@ ipintOp(_simd_i8x16_gt_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4737,7 +4807,9 @@ ipintOp(_simd_i8x16_le_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4756,7 +4828,9 @@ ipintOp(_simd_i8x16_le_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4775,7 +4849,9 @@ ipintOp(_simd_i8x16_ge_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4793,7 +4869,9 @@ ipintOp(_simd_i8x16_ge_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4811,7 +4889,9 @@ ipintOp(_simd_i16x8_eq, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4831,7 +4911,9 @@ ipintOp(_simd_i16x8_ne, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4849,7 +4931,9 @@ ipintOp(_simd_i16x8_lt_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4870,7 +4954,9 @@ ipintOp(_simd_i16x8_lt_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4886,7 +4972,9 @@ ipintOp(_simd_i16x8_gt_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4906,7 +4994,9 @@ ipintOp(_simd_i16x8_gt_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4926,7 +5016,9 @@ ipintOp(_simd_i16x8_le_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4945,7 +5037,9 @@ ipintOp(_simd_i16x8_le_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4964,7 +5058,9 @@ ipintOp(_simd_i16x8_ge_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4982,7 +5078,9 @@ ipintOp(_simd_i16x8_ge_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -4999,7 +5097,9 @@ ipintOp(_simd_i32x4_eq, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5019,7 +5119,9 @@ ipintOp(_simd_i32x4_ne, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5037,7 +5139,9 @@ ipintOp(_simd_i32x4_lt_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5058,7 +5162,9 @@ ipintOp(_simd_i32x4_lt_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5074,7 +5180,9 @@ ipintOp(_simd_i32x4_gt_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5094,7 +5202,9 @@ ipintOp(_simd_i32x4_gt_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5114,7 +5224,9 @@ ipintOp(_simd_i32x4_le_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5133,7 +5245,9 @@ ipintOp(_simd_i32x4_le_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5152,7 +5266,9 @@ ipintOp(_simd_i32x4_ge_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5170,7 +5286,9 @@ ipintOp(_simd_i32x4_ge_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5187,7 +5305,9 @@ ipintOp(_simd_f32x4_eq, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5204,7 +5324,9 @@ ipintOp(_simd_f32x4_ne, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5221,7 +5343,9 @@ ipintOp(_simd_f32x4_lt, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5237,7 +5361,9 @@ ipintOp(_simd_f32x4_gt, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5254,7 +5380,9 @@ ipintOp(_simd_f32x4_le, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5270,7 +5398,9 @@ ipintOp(_simd_f32x4_ge, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5287,7 +5417,9 @@ ipintOp(_simd_f64x2_eq, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5304,7 +5436,9 @@ ipintOp(_simd_f64x2_ne, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5321,7 +5455,9 @@ ipintOp(_simd_f64x2_lt, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5337,7 +5473,9 @@ ipintOp(_simd_f64x2_gt, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5354,7 +5492,9 @@ ipintOp(_simd_f64x2_le, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5370,7 +5510,9 @@ ipintOp(_simd_f64x2_ge, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5388,7 +5530,9 @@ ipintOp(_simd_v128_not, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5404,7 +5548,9 @@ ipintOp(_simd_v128_and, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5420,7 +5566,9 @@ ipintOp(_simd_v128_andnot, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5436,7 +5584,9 @@ ipintOp(_simd_v128_or, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5452,7 +5602,9 @@ ipintOp(_simd_v128_xor, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5477,7 +5629,9 @@ ipintOp(_simd_v128_bitselect, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5500,7 +5654,9 @@ ipintOp(_simd_v128_any_true, macro()
         break # Not implemented
     end
     pushInt32(t0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5748,7 +5904,9 @@ ipintOp(_simd_f32x4_demote_f64x2_zero, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5763,7 +5921,9 @@ ipintOp(_simd_f64x2_promote_low_f32x4, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5780,7 +5940,9 @@ ipintOp(_simd_i8x16_abs, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5797,7 +5959,9 @@ ipintOp(_simd_i8x16_neg, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5839,7 +6003,9 @@ ipintOp(_simd_i8x16_popcnt, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5864,7 +6030,9 @@ ipintOp(_simd_i8x16_all_true, macro()
         break # Not implemented
     end
     pushInt32(t0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5892,7 +6060,9 @@ ipintOp(_simd_i8x16_bitmask, macro()
 
     addp V128ISize, sp  # Pop the vector
     pushInt32(t0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5910,7 +6080,9 @@ ipintOp(_simd_i8x16_narrow_i16x8_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5928,7 +6100,9 @@ ipintOp(_simd_i8x16_narrow_i16x8_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5945,7 +6119,9 @@ ipintOp(_simd_f32x4_ceil, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5960,7 +6136,9 @@ ipintOp(_simd_f32x4_floor, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5975,7 +6153,9 @@ ipintOp(_simd_f32x4_trunc, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -5990,7 +6170,9 @@ ipintOp(_simd_f32x4_nearest, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6038,7 +6220,9 @@ ipintOp(_simd_i8x16_shl, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6080,7 +6264,9 @@ ipintOp(_simd_i8x16_shr_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6122,7 +6308,9 @@ ipintOp(_simd_i8x16_shr_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6138,7 +6326,9 @@ ipintOp(_simd_i8x16_add, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6154,7 +6344,9 @@ ipintOp(_simd_i8x16_add_sat_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6170,7 +6362,9 @@ ipintOp(_simd_i8x16_add_sat_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6186,7 +6380,9 @@ ipintOp(_simd_i8x16_sub, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6202,7 +6398,9 @@ ipintOp(_simd_i8x16_sub_sat_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6218,7 +6416,9 @@ ipintOp(_simd_i8x16_sub_sat_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6235,7 +6435,9 @@ ipintOp(_simd_f64x2_ceil, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6250,7 +6452,9 @@ ipintOp(_simd_f64x2_floor, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6267,7 +6471,9 @@ ipintOp(_simd_i8x16_min_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6283,7 +6489,9 @@ ipintOp(_simd_i8x16_min_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6299,7 +6507,9 @@ ipintOp(_simd_i8x16_max_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6315,7 +6525,9 @@ ipintOp(_simd_i8x16_max_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6332,7 +6544,9 @@ ipintOp(_simd_f64x2_trunc, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6350,7 +6564,9 @@ ipintOp(_simd_i8x16_avgr_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6370,7 +6586,9 @@ ipintOp(_simd_i16x8_extadd_pairwise_i8x16_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6388,7 +6606,9 @@ ipintOp(_simd_i16x8_extadd_pairwise_i8x16_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6406,7 +6626,9 @@ ipintOp(_simd_i32x4_extadd_pairwise_i16x8_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6423,7 +6645,9 @@ ipintOp(_simd_i32x4_extadd_pairwise_i16x8_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6440,7 +6664,9 @@ ipintOp(_simd_i16x8_abs, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6457,7 +6683,9 @@ ipintOp(_simd_i16x8_neg, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6481,7 +6709,9 @@ ipintOp(_simd_i16x8_q15mulr_sat_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6508,7 +6738,9 @@ ipintOp(_simd_i16x8_all_true, macro()
         break # Not implemented
     end
     pushInt32(t0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6536,7 +6768,9 @@ ipintOp(_simd_i16x8_bitmask, macro()
 
     addp V128ISize, sp  # Pop the vector
     pushInt32(t0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6554,7 +6788,9 @@ ipintOp(_simd_i16x8_narrow_i32x4_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6572,7 +6808,9 @@ ipintOp(_simd_i16x8_narrow_i32x4_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6587,7 +6825,9 @@ ipintOp(_simd_i16x8_extend_low_i8x16_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6604,7 +6844,9 @@ ipintOp(_simd_i16x8_extend_high_i8x16_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6619,7 +6861,9 @@ ipintOp(_simd_i16x8_extend_low_i8x16_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6636,7 +6880,9 @@ ipintOp(_simd_i16x8_extend_high_i8x16_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6661,7 +6907,9 @@ ipintOp(_simd_i16x8_shl, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6688,7 +6936,9 @@ ipintOp(_simd_i16x8_shr_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6713,7 +6963,9 @@ ipintOp(_simd_i16x8_shr_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6729,7 +6981,9 @@ ipintOp(_simd_i16x8_add, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6745,7 +6999,9 @@ ipintOp(_simd_i16x8_add_sat_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6761,7 +7017,9 @@ ipintOp(_simd_i16x8_add_sat_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6777,7 +7035,9 @@ ipintOp(_simd_i16x8_sub, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6793,7 +7053,9 @@ ipintOp(_simd_i16x8_sub_sat_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6809,7 +7071,9 @@ ipintOp(_simd_i16x8_sub_sat_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6826,7 +7090,9 @@ ipintOp(_simd_f64x2_nearest, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6844,7 +7110,9 @@ ipintOp(_simd_i16x8_mul, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6860,7 +7128,9 @@ ipintOp(_simd_i16x8_min_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6876,7 +7146,9 @@ ipintOp(_simd_i16x8_min_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6892,7 +7164,9 @@ ipintOp(_simd_i16x8_max_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6908,7 +7182,9 @@ ipintOp(_simd_i16x8_max_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6925,7 +7201,9 @@ ipintOp(_simd_i16x8_avgr_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6944,7 +7222,9 @@ ipintOp(_simd_i16x8_extmul_low_i8x16_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6965,7 +7245,9 @@ ipintOp(_simd_i16x8_extmul_high_i8x16_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -6984,7 +7266,9 @@ ipintOp(_simd_i16x8_extmul_low_i8x16_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7004,7 +7288,9 @@ ipintOp(_simd_i16x8_extmul_high_i8x16_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7021,7 +7307,9 @@ ipintOp(_simd_i32x4_abs, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7038,7 +7326,9 @@ ipintOp(_simd_i32x4_neg, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7067,7 +7357,9 @@ ipintOp(_simd_i32x4_all_true, macro()
         break # Not implemented
     end
     pushInt32(t0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7095,7 +7387,9 @@ ipintOp(_simd_i32x4_bitmask, macro()
 
     addp V128ISize, sp  # Pop the vector
     pushInt32(t0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7113,7 +7407,9 @@ ipintOp(_simd_i32x4_extend_low_i16x8_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7130,7 +7426,9 @@ ipintOp(_simd_i32x4_extend_high_i16x8_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7145,7 +7443,9 @@ ipintOp(_simd_i32x4_extend_low_i16x8_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7162,7 +7462,9 @@ ipintOp(_simd_i32x4_extend_high_i16x8_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7185,7 +7487,9 @@ ipintOp(_simd_i32x4_shl, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7210,7 +7514,9 @@ ipintOp(_simd_i32x4_shr_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7235,7 +7541,9 @@ ipintOp(_simd_i32x4_shr_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7251,7 +7559,9 @@ ipintOp(_simd_i32x4_add, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7270,7 +7580,9 @@ ipintOp(_simd_i32x4_sub, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7290,7 +7602,9 @@ ipintOp(_simd_i32x4_mul, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7306,7 +7620,9 @@ ipintOp(_simd_i32x4_min_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7322,7 +7638,9 @@ ipintOp(_simd_i32x4_min_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7338,7 +7656,9 @@ ipintOp(_simd_i32x4_max_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7354,7 +7674,9 @@ ipintOp(_simd_i32x4_max_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7375,7 +7697,9 @@ ipintOp(_simd_i32x4_dot_i16x8_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 reservedOpcode(0xfdbb01)
@@ -7395,7 +7719,9 @@ ipintOp(_simd_i32x4_extmul_low_i16x8_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7414,7 +7740,9 @@ ipintOp(_simd_i32x4_extmul_high_i16x8_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7433,7 +7761,9 @@ ipintOp(_simd_i32x4_extmul_low_i16x8_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7452,7 +7782,9 @@ ipintOp(_simd_i32x4_extmul_high_i16x8_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7474,7 +7806,9 @@ ipintOp(_simd_i64x2_abs, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7491,7 +7825,9 @@ ipintOp(_simd_i64x2_neg, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7520,7 +7856,9 @@ ipintOp(_simd_i64x2_all_true, macro()
         break # Not implemented
     end
     pushInt32(t0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7550,7 +7888,9 @@ ipintOp(_simd_i64x2_bitmask, macro()
 
 .bitmask_i64x2_done:
     pushInt32(t2)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7568,7 +7908,9 @@ ipintOp(_simd_i64x2_extend_low_i32x4_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7585,7 +7927,9 @@ ipintOp(_simd_i64x2_extend_high_i32x4_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7600,7 +7944,9 @@ ipintOp(_simd_i64x2_extend_low_i32x4_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7617,7 +7963,9 @@ ipintOp(_simd_i64x2_extend_high_i32x4_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7640,7 +7988,9 @@ ipintOp(_simd_i64x2_shl, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7658,7 +8008,9 @@ ipintOp(_simd_i64x2_shr_s, macro()
     rshiftq t0, t1
     storeq t1, [sp]
 
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7683,7 +8035,9 @@ ipintOp(_simd_i64x2_shr_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7699,7 +8053,9 @@ ipintOp(_simd_i64x2_add, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7718,7 +8074,9 @@ ipintOp(_simd_i64x2_sub, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7743,7 +8101,9 @@ ipintOp(_simd_i64x2_mul, macro()
 
     # Pop vector1, result in vector0
     addp V128ISize, sp        # Remove first vector from stack, leaving result
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7759,7 +8119,9 @@ ipintOp(_simd_i64x2_eq, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7779,7 +8141,9 @@ ipintOp(_simd_i64x2_ne, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7797,7 +8161,9 @@ ipintOp(_simd_i64x2_lt_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7813,7 +8179,9 @@ ipintOp(_simd_i64x2_gt_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7833,7 +8201,9 @@ ipintOp(_simd_i64x2_le_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7852,7 +8222,9 @@ ipintOp(_simd_i64x2_ge_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7871,7 +8243,9 @@ ipintOp(_simd_i64x2_extmul_low_i32x4_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7890,7 +8264,9 @@ ipintOp(_simd_i64x2_extmul_high_i32x4_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7909,7 +8285,9 @@ ipintOp(_simd_i64x2_extmul_low_i32x4_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7928,7 +8306,9 @@ ipintOp(_simd_i64x2_extmul_high_i32x4_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7949,7 +8329,9 @@ ipintOp(_simd_f32x4_abs, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7968,7 +8350,9 @@ ipintOp(_simd_f32x4_neg, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -7985,7 +8369,9 @@ ipintOp(_simd_f32x4_sqrt, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8001,7 +8387,9 @@ ipintOp(_simd_f32x4_add, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8017,7 +8405,9 @@ ipintOp(_simd_f32x4_sub, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8033,7 +8423,9 @@ ipintOp(_simd_f32x4_mul, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8049,7 +8441,9 @@ ipintOp(_simd_f32x4_div, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8078,7 +8472,9 @@ ipintOp(_simd_f32x4_min, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8112,7 +8508,9 @@ ipintOp(_simd_f32x4_max, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8132,7 +8530,9 @@ ipintOp(_simd_f32x4_pmin, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8152,7 +8552,9 @@ ipintOp(_simd_f32x4_pmax, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8173,7 +8575,9 @@ ipintOp(_simd_f64x2_abs, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8192,7 +8596,9 @@ ipintOp(_simd_f64x2_neg, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8209,7 +8615,9 @@ ipintOp(_simd_f64x2_sqrt, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8225,7 +8633,9 @@ ipintOp(_simd_f64x2_add, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8241,7 +8651,9 @@ ipintOp(_simd_f64x2_sub, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8257,7 +8669,9 @@ ipintOp(_simd_f64x2_mul, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8273,7 +8687,9 @@ ipintOp(_simd_f64x2_div, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8302,7 +8718,9 @@ ipintOp(_simd_f64x2_min, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8336,7 +8754,9 @@ ipintOp(_simd_f64x2_max, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8356,7 +8776,9 @@ ipintOp(_simd_f64x2_pmin, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8376,7 +8798,9 @@ ipintOp(_simd_f64x2_pmax, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8405,7 +8829,9 @@ ipintOp(_simd_i32x4_trunc_sat_f32x4_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8439,7 +8865,9 @@ ipintOp(_simd_i32x4_trunc_sat_f32x4_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8454,7 +8882,9 @@ ipintOp(_simd_f32x4_convert_i32x4_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8477,7 +8907,9 @@ ipintOp(_simd_f32x4_convert_i32x4_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8506,7 +8938,9 @@ ipintOp(_simd_i32x4_trunc_sat_f64x2_s_zero, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8541,7 +8975,9 @@ ipintOp(_simd_i32x4_trunc_sat_f64x2_u_zero, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8558,7 +8994,9 @@ ipintOp(_simd_f64x2_convert_low_i32x4_s, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 
@@ -8590,7 +9028,9 @@ ipintOp(_simd_f64x2_convert_low_i32x4_u, macro()
         break # Not implemented
     end
     pushVec(v0)
-    advancePC(2)
+    loadb IPInt::InstructionLengthMetadata::length[MC], t0
+    advancePCByReg(t0)
+    advanceMC(constexpr (sizeof(IPInt::InstructionLengthMetadata)))
     nextIPIntInstruction()
 end)
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -2095,11 +2095,11 @@ public:
 
     void materializeVectorConstant(v128_t, Location);
 
-    ExpressionType addConstant(v128_t);
+    ExpressionType addSIMDConstant(v128_t);
 
-    PartialResult addExtractLane(SIMDInfo, uint8_t, Value, Value&);
+    PartialResult addSIMDExtractLane(SIMDInfo, uint8_t, Value, Value&);
 
-    PartialResult addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&);
+    PartialResult addSIMDReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&);
 
     PartialResult addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&);
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp
@@ -1,0 +1,3517 @@
+/*
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WasmBBQJIT32_64.h"
+
+#include "WasmBBQJIT.h"
+
+#if ENABLE(WEBASSEMBLY_BBQJIT)
+#if USE(JSVALUE32_64)
+
+#include "B3Common.h"
+#include "B3ValueRep.h"
+#include "BinarySwitch.h"
+#include "BytecodeStructs.h"
+#include "CCallHelpers.h"
+#include "CPU.h"
+#include "CompilerTimingScope.h"
+#include "GPRInfo.h"
+#include "JSCast.h"
+#include "JSWebAssemblyArray.h"
+#include "JSWebAssemblyException.h"
+#include "JSWebAssemblyStruct.h"
+#include "MacroAssembler.h"
+#include "RegisterSet.h"
+#include "WasmBBQDisassembler.h"
+#include "WasmCallingConvention.h"
+#include "WasmCompilationMode.h"
+#include "WasmFormat.h"
+#include "WasmFunctionParser.h"
+#include "WasmIRGeneratorHelpers.h"
+#include "WasmMemoryInformation.h"
+#include "WasmModule.h"
+#include "WasmModuleInformation.h"
+#include "WasmOMGIRGenerator.h"
+#include "WasmOperations.h"
+#include "WasmOps.h"
+#include "WasmThunks.h"
+#include "WasmTypeDefinition.h"
+#include <bit>
+#include <wtf/Assertions.h>
+#include <wtf/Compiler.h>
+#include <wtf/HashFunctions.h>
+#include <wtf/HashMap.h>
+#include <wtf/MathExtras.h>
+#include <wtf/PlatformRegisters.h>
+#include <wtf/SmallSet.h>
+#include <wtf/StdLibExtras.h>
+
+namespace JSC { namespace Wasm { namespace BBQJITImpl {
+
+Location Location::fromArgumentLocation(ArgumentLocation argLocation, TypeKind type)
+{
+    switch (argLocation.location.kind()) {
+    case ValueLocation::Kind::GPRRegister:
+        if (typeNeedsGPR2(type))
+            return Location::fromGPR2(argLocation.location.jsr().tagGPR(), argLocation.location.jsr().payloadGPR());
+        return Location::fromGPR(argLocation.location.jsr().payloadGPR());
+    case ValueLocation::Kind::FPRRegister:
+        return Location::fromFPR(argLocation.location.fpr());
+    case ValueLocation::Kind::StackArgument:
+        return Location::fromStackArgument(argLocation.location.offsetFromSP());
+    case ValueLocation::Kind::Stack:
+        return Location::fromStack(argLocation.location.offsetFromFP());
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+Location Location::fromGPR2(GPRReg hi, GPRReg lo)
+{
+    ASSERT(hi != lo);
+
+    // we canonicalize hi and lo to avoid a dreadful situation of having two
+    // GPR2 locations (x, y) and (y, x) which we can't easliy generate a move between
+
+    Location loc;
+    loc.m_kind = Gpr2;
+    if (hi > lo) {
+        loc.m_gprhi = hi;
+        loc.m_gprlo = lo;
+    } else {
+        loc.m_gprhi = lo;
+        loc.m_gprlo = hi;
+    }
+    return loc;
+}
+
+bool Location::isRegister() const
+{
+    return isGPR() || isGPR2() || isFPR();
+}
+
+bool BBQJIT::typeNeedsGPR2(TypeKind type)
+{
+    return toValueKind(type) == TypeKind::I64;
+}
+
+uint32_t BBQJIT::sizeOfType(TypeKind type)
+{
+    switch (type) {
+    case TypeKind::I32:
+    case TypeKind::F32:
+        // NB: size in memory (on JSVALUE32_64 we represent even four-byte values as EncodedJSValue)
+        return sizeof(EncodedJSValue);
+    case TypeKind::I64:
+    case TypeKind::F64:
+        return 8;
+    case TypeKind::V128:
+        return 16;
+    case TypeKind::I31ref:
+    case TypeKind::Func:
+    case TypeKind::Funcref:
+    case TypeKind::Ref:
+    case TypeKind::RefNull:
+    case TypeKind::Rec:
+    case TypeKind::Sub:
+    case TypeKind::Subfinal:
+    case TypeKind::Struct:
+    case TypeKind::Structref:
+    case TypeKind::Exnref:
+    case TypeKind::Externref:
+    case TypeKind::Array:
+    case TypeKind::Arrayref:
+    case TypeKind::Eqref:
+    case TypeKind::Anyref:
+    case TypeKind::Noexnref:
+    case TypeKind::Noneref:
+    case TypeKind::Nofuncref:
+    case TypeKind::Noexternref:
+        return sizeof(EncodedJSValue);
+    case TypeKind::Void:
+        return 0;
+    }
+    return 0;
+}
+
+int32_t Value::asI64hi() const
+{
+    ASSERT(m_kind == Const);
+    return m_i32_pair.hi;
+}
+
+int32_t Value::asI64lo() const
+{
+    ASSERT(m_kind == Const);
+    return m_i32_pair.lo;
+}
+
+// This function is intentionally not using implicitSlots since arguments and results should not include implicit slot.
+Location ControlData::allocateArgumentOrResult(BBQJIT& generator, TypeKind type, unsigned i, RegisterSet& remainingGPRs, RegisterSet& remainingFPRs)
+{
+    switch (type) {
+    case TypeKind::V128:
+    case TypeKind::F32:
+    case TypeKind::F64: {
+        if (remainingFPRs.isEmpty())
+            return generator.canonicalSlot(Value::fromTemp(type, this->enclosedHeight() + i));
+        auto reg = *remainingFPRs.begin();
+        remainingFPRs.remove(reg);
+        return Location::fromFPR(reg.fpr());
+    }
+    default:
+        if (typeNeedsGPR2(type)) {
+            auto next = remainingGPRs.begin();
+            if (next != remainingGPRs.end()) {
+                auto lo = (*next);
+                if (++next != remainingGPRs.end()) {
+                    auto hi = (*next);
+                    remainingGPRs.remove(lo);
+                    remainingGPRs.remove(hi);
+                    return Location::fromGPR2(hi.gpr(), lo.gpr());
+                }
+            }
+            return generator.canonicalSlot(Value::fromTemp(type, this->enclosedHeight() + i));
+        }
+        if (remainingGPRs.isEmpty())
+            return generator.canonicalSlot(Value::fromTemp(type, this->enclosedHeight() + i));
+        auto reg = *remainingGPRs.begin();
+        remainingGPRs.remove(reg);
+        return Location::fromGPR(reg.gpr());
+    }
+}
+
+Value BBQJIT::instanceValue()
+{
+    return Value::pinned(TypeKind::I32, Location::fromGPR(GPRInfo::wasmContextInstancePointer));
+}
+
+// Tables
+WARN_UNUSED_RETURN PartialResult BBQJIT::addTableGet(unsigned tableIndex, Value index, Value& result)
+{
+    // FIXME: Emit this inline <https://bugs.webkit.org/show_bug.cgi?id=198506>.
+    ASSERT(index.type() == TypeKind::I32);
+    TypeKind returnType = m_info.tables[tableIndex].wasmType().kind;
+    ASSERT(typeKindSizeInBytes(returnType) == 8);
+
+    Vector<Value, 8> arguments = {
+        instanceValue(),
+        Value::fromI32(tableIndex),
+        index
+    };
+    result = topValue(returnType);
+    emitCCall(&operationGetWasmTableElement, arguments, result);
+    Location resultLocation = loadIfNecessary(result);
+
+    LOG_INSTRUCTION("TableGet", tableIndex, index, RESULT(result));
+
+    m_jit.or32(resultLocation.asGPRhi(), resultLocation.asGPRlo(), wasmScratchGPR);
+    recordJumpToThrowException(ExceptionType::OutOfBoundsTableAccess, m_jit.branchTest32(ResultCondition::Zero, wasmScratchGPR));
+
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::getGlobal(uint32_t index, Value& result)
+{
+    const Wasm::GlobalInformation& global = m_info.globals[index];
+    Type type = global.type;
+
+    int32_t offset = JSWebAssemblyInstance::offsetOfGlobal(m_info, index);
+    Value globalValue = Value::pinned(type.kind, Location::fromGlobal(offset));
+
+    switch (global.bindingMode) {
+    case Wasm::GlobalInformation::BindingMode::EmbeddedInInstance:
+        result = topValue(type.kind);
+        emitLoad(globalValue, loadIfNecessary(result));
+        break;
+    case Wasm::GlobalInformation::BindingMode::Portable:
+        ASSERT(global.mutability == Wasm::Mutability::Mutable);
+        m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, offset), wasmScratchGPR);
+        result = topValue(type.kind);
+        Location resultLocation = allocate(result);
+        switch (type.kind) {
+        case TypeKind::I32:
+            m_jit.load32(Address(wasmScratchGPR), resultLocation.asGPR());
+            break;
+        case TypeKind::I31ref:
+            m_jit.load32(Address(wasmScratchGPR), resultLocation.asGPRlo());
+            m_jit.move(TrustedImm32(JSValue::Int32Tag), resultLocation.asGPRhi());
+            break;
+        case TypeKind::I64:
+            m_jit.loadPair32(Address(wasmScratchGPR), resultLocation.asGPRlo(), resultLocation.asGPRhi());
+            break;
+        case TypeKind::F32:
+            m_jit.loadFloat(Address(wasmScratchGPR), resultLocation.asFPR());
+            break;
+        case TypeKind::F64:
+            m_jit.loadDouble(Address(wasmScratchGPR), resultLocation.asFPR());
+            break;
+        case TypeKind::V128:
+            m_jit.loadVector(Address(wasmScratchGPR), resultLocation.asFPR());
+            break;
+        case TypeKind::Func:
+        case TypeKind::Funcref:
+        case TypeKind::Ref:
+        case TypeKind::RefNull:
+        case TypeKind::Rec:
+        case TypeKind::Sub:
+        case TypeKind::Subfinal:
+        case TypeKind::Struct:
+        case TypeKind::Structref:
+        case TypeKind::Exnref:
+        case TypeKind::Externref:
+        case TypeKind::Array:
+        case TypeKind::Arrayref:
+        case TypeKind::Eqref:
+        case TypeKind::Anyref:
+        case TypeKind::Noexnref:
+        case TypeKind::Noneref:
+        case TypeKind::Nofuncref:
+        case TypeKind::Noexternref:
+            m_jit.loadPair32(Address(wasmScratchGPR), resultLocation.asGPRlo(), resultLocation.asGPRhi());
+            break;
+        case TypeKind::Void:
+            break;
+        }
+        break;
+    }
+
+    LOG_INSTRUCTION("GetGlobal", index, RESULT(result));
+
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::setGlobal(uint32_t index, Value value)
+{
+    const Wasm::GlobalInformation& global = m_info.globals[index];
+    Type type = global.type;
+
+    int32_t offset = JSWebAssemblyInstance::offsetOfGlobal(m_info, index);
+    Location valueLocation = locationOf(value);
+
+    switch (global.bindingMode) {
+    case Wasm::GlobalInformation::BindingMode::EmbeddedInInstance: {
+        emitMove(value, Location::fromGlobal(offset));
+        consume(value);
+        if (isRefType(type))
+            emitWriteBarrier(GPRInfo::wasmContextInstancePointer);
+        break;
+    }
+    case Wasm::GlobalInformation::BindingMode::Portable: {
+        ASSERT(global.mutability == Wasm::Mutability::Mutable);
+        m_jit.loadPtr(Address(GPRInfo::wasmContextInstancePointer, offset), wasmScratchGPR);
+
+        Location valueLocation;
+        if (value.isConst() && value.isFloat()) {
+            ScratchScope<0, 1> scratches(*this);
+            valueLocation = Location::fromFPR(scratches.fpr(0));
+            emitMoveConst(value, valueLocation);
+        } else if (value.isConst()) {
+            if (typeNeedsGPR2(value.type())) {
+                ScratchScope<2, 0> scratches(*this);
+                valueLocation = Location::fromGPR2(scratches.gpr(1), scratches.gpr(0));
+            } else {
+                ScratchScope<1, 0> scratches(*this);
+                valueLocation = Location::fromGPR(scratches.gpr(0));
+            }
+            emitMoveConst(value, valueLocation);
+        } else
+            valueLocation = loadIfNecessary(value);
+        ASSERT(valueLocation.isRegister());
+        consume(value);
+
+        switch (type.kind) {
+        case TypeKind::I32:
+            m_jit.store32(valueLocation.asGPR(), Address(wasmScratchGPR));
+            break;
+        case TypeKind::I64:
+            m_jit.storePair32(valueLocation.asGPRlo(), valueLocation.asGPRhi(), Address(wasmScratchGPR));
+            break;
+        case TypeKind::F32:
+            m_jit.storeFloat(valueLocation.asFPR(), Address(wasmScratchGPR));
+            break;
+        case TypeKind::F64:
+            m_jit.storeDouble(valueLocation.asFPR(), Address(wasmScratchGPR));
+            break;
+        case TypeKind::V128:
+            m_jit.storeVector(valueLocation.asFPR(), Address(wasmScratchGPR));
+            break;
+        case TypeKind::I31ref:
+        case TypeKind::Func:
+        case TypeKind::Funcref:
+        case TypeKind::Ref:
+        case TypeKind::RefNull:
+        case TypeKind::Rec:
+        case TypeKind::Sub:
+        case TypeKind::Subfinal:
+        case TypeKind::Struct:
+        case TypeKind::Structref:
+        case TypeKind::Exnref:
+        case TypeKind::Externref:
+        case TypeKind::Array:
+        case TypeKind::Arrayref:
+        case TypeKind::Eqref:
+        case TypeKind::Anyref:
+        case TypeKind::Noexnref:
+        case TypeKind::Noneref:
+        case TypeKind::Nofuncref:
+        case TypeKind::Noexternref:
+            m_jit.storePair32(valueLocation.asGPRlo(), valueLocation.asGPRhi(), Address(wasmScratchGPR));
+            break;
+        case TypeKind::Void:
+            break;
+        }
+        if (isRefType(type)) {
+            m_jit.loadPtr(Address(wasmScratchGPR, Wasm::Global::offsetOfOwner() - Wasm::Global::offsetOfValue()), wasmScratchGPR);
+            emitWriteBarrier(wasmScratchGPR);
+        }
+        break;
+    }
+    }
+
+    LOG_INSTRUCTION("SetGlobal", index, value, valueLocation);
+
+    return { };
+}
+
+// Memory
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::load(LoadOpType loadOp, Value pointer, Value& result, uint32_t uoffset)
+{
+    if (sumOverflows<uint32_t>(uoffset, sizeOfLoadOp(loadOp))) [[unlikely]] {
+        // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
+        emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
+        consume(pointer);
+
+        // Unreachable at runtime, so we just add a constant that makes the types work out.
+        switch (loadOp) {
+        case LoadOpType::I32Load8S:
+        case LoadOpType::I32Load16S:
+        case LoadOpType::I32Load:
+        case LoadOpType::I32Load16U:
+        case LoadOpType::I32Load8U:
+            result = Value::fromI32(0);
+            break;
+        case LoadOpType::I64Load8S:
+        case LoadOpType::I64Load8U:
+        case LoadOpType::I64Load16S:
+        case LoadOpType::I64Load32U:
+        case LoadOpType::I64Load32S:
+        case LoadOpType::I64Load:
+        case LoadOpType::I64Load16U:
+            result = Value::fromI64(0);
+            break;
+        case LoadOpType::F32Load:
+            result = Value::fromF32(0);
+            break;
+        case LoadOpType::F64Load:
+            result = Value::fromF64(0);
+            break;
+        }
+    } else {
+        result = emitCheckAndPrepareAndMaterializePointerApply(pointer, uoffset, sizeOfLoadOp(loadOp), [&](auto location) -> Value {
+            consume(pointer);
+            Value result = topValue(typeOfLoadOp(loadOp));
+            Location resultLocation = allocate(result);
+
+            switch (loadOp) {
+            case LoadOpType::I32Load8S:
+                m_jit.load8SignedExtendTo32(location, resultLocation.asGPR());
+                break;
+            case LoadOpType::I64Load8S:
+                m_jit.load8SignedExtendTo32(location, resultLocation.asGPRlo());
+                m_jit.rshift32(resultLocation.asGPRlo(), TrustedImm32(31), resultLocation.asGPRhi());
+                break;
+            case LoadOpType::I32Load8U:
+                m_jit.load8(location, resultLocation.asGPR());
+                break;
+            case LoadOpType::I64Load8U:
+                m_jit.load8(location, resultLocation.asGPRlo());
+                m_jit.xor32(resultLocation.asGPRhi(), resultLocation.asGPRhi());
+                break;
+            case LoadOpType::I32Load16S:
+                m_jit.load16SignedExtendTo32(location, resultLocation.asGPR());
+                break;
+            case LoadOpType::I64Load16S:
+                m_jit.load16SignedExtendTo32(location, resultLocation.asGPRlo());
+                m_jit.rshift32(resultLocation.asGPRlo(), TrustedImm32(31), resultLocation.asGPRhi());
+                break;
+            case LoadOpType::I32Load16U:
+                m_jit.load16(location, resultLocation.asGPR());
+                break;
+            case LoadOpType::I64Load16U:
+                m_jit.load16(location, resultLocation.asGPRlo());
+                m_jit.xor32(resultLocation.asGPRhi(), resultLocation.asGPRhi());
+                break;
+            case LoadOpType::I32Load:
+                m_jit.load32(location, resultLocation.asGPR());
+                break;
+            case LoadOpType::I64Load32U:
+                m_jit.load32(location, resultLocation.asGPRlo());
+                m_jit.xor32(resultLocation.asGPRhi(), resultLocation.asGPRhi());
+                break;
+            case LoadOpType::I64Load32S:
+                m_jit.load32(location, resultLocation.asGPRlo());
+                m_jit.rshift32(resultLocation.asGPRlo(), TrustedImm32(31), resultLocation.asGPRhi());
+                break;
+            case LoadOpType::I64Load:
+                m_jit.loadPair32(location, resultLocation.asGPRlo(), resultLocation.asGPRhi());
+                break;
+            case LoadOpType::F32Load:
+                m_jit.load32(location, wasmScratchGPR);
+                m_jit.move32ToFloat(wasmScratchGPR, resultLocation.asFPR());
+                break;
+            case LoadOpType::F64Load:
+                m_jit.loadPair32(location, wasmScratchGPR, wasmScratchGPR2);
+                m_jit.move64ToDouble(wasmScratchGPR2, wasmScratchGPR, resultLocation.asFPR());
+                break;
+            }
+
+            return result;
+        });
+    }
+
+    LOG_INSTRUCTION(LOAD_OP_NAMES[(unsigned)loadOp - (unsigned)I32Load], pointer, uoffset, RESULT(result));
+
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::store(StoreOpType storeOp, Value pointer, Value value, uint32_t uoffset)
+{
+    Location valueLocation = locationOf(value);
+    if (sumOverflows<uint32_t>(uoffset, sizeOfStoreOp(storeOp))) [[unlikely]] {
+        // FIXME: Same issue as in AirIRGenerator::load(): https://bugs.webkit.org/show_bug.cgi?id=166435
+        emitThrowException(ExceptionType::OutOfBoundsMemoryAccess);
+        consume(pointer);
+        consume(value);
+    } else {
+        emitCheckAndPrepareAndMaterializePointerApply(pointer, uoffset, sizeOfStoreOp(storeOp), [&](auto location) -> void {
+            Location valueLocation;
+            if (value.isConst() && value.isFloat()) {
+                ScratchScope<0, 1> scratches(*this);
+                valueLocation = Location::fromFPR(scratches.fpr(0));
+                emitMoveConst(value, valueLocation);
+            } else if (!value.isConst()) {
+                valueLocation = loadIfNecessary(value);
+                ASSERT(valueLocation.isRegister());
+            }
+
+            consume(value);
+            consume(pointer);
+
+            switch (storeOp) {
+            case StoreOpType::I64Store8:
+                if (value.isConst())
+                    m_jit.store8(TrustedImm32(static_cast<int32_t>(value.asI64())), location);
+                else
+                    m_jit.store8(valueLocation.asGPRlo(), location);
+                return;
+            case StoreOpType::I32Store8:
+                if (value.isConst())
+                    m_jit.store8(TrustedImm32(value.asI32()), location);
+                else
+                    m_jit.store8(valueLocation.asGPR(), location);
+                return;
+            case StoreOpType::I64Store16:
+                if (value.isConst())
+                    m_jit.store16(TrustedImm32(static_cast<int32_t>(value.asI64())), location);
+                else
+                    m_jit.store16(valueLocation.asGPRlo(), location);
+                return;
+            case StoreOpType::I32Store16:
+                if (value.isConst())
+                    m_jit.store16(TrustedImm32(value.asI32()), location);
+                else
+                    m_jit.store16(valueLocation.asGPR(), location);
+                return;
+            case StoreOpType::I64Store32:
+                if (value.isConst())
+                    m_jit.store32(TrustedImm32(static_cast<int32_t>(value.asI64())), location);
+                else
+                    m_jit.store32(valueLocation.asGPRlo(), location);
+                return;
+            case StoreOpType::I32Store:
+                if (value.isConst())
+                    m_jit.store32(TrustedImm32(value.asI32()), location);
+                else
+                    m_jit.store32(valueLocation.asGPR(), location);
+                return;
+            case StoreOpType::I64Store:
+                if (value.isConst()) {
+                    int64_t val = value.asI64();
+                    m_jit.storePair32(TrustedImm32(static_cast<int32_t>(val)), TrustedImm32(static_cast<int32_t>(val >> 32)), location);
+                } else
+                    m_jit.storePair32(valueLocation.asGPRlo(), valueLocation.asGPRhi(), location);
+                return;
+            case StoreOpType::F32Store: {
+                ScratchScope<1, 0> scratches(*this);
+                m_jit.moveFloatTo32(valueLocation.asFPR(), scratches.gpr(0));
+                m_jit.store32(scratches.gpr(0), location);
+                return;
+            }
+            case StoreOpType::F64Store: {
+                ScratchScope<1, 0> scratches(*this);
+                m_jit.moveDoubleTo64(valueLocation.asFPR(), wasmScratchGPR2, scratches.gpr(0));
+                m_jit.storePair32(scratches.gpr(0), wasmScratchGPR2, location);
+                return;
+            }
+            }
+        });
+    }
+
+    LOG_INSTRUCTION(STORE_OP_NAMES[(unsigned)storeOp - (unsigned)I32Store], pointer, uoffset, value, valueLocation);
+
+    return { };
+}
+
+void BBQJIT::emitSanitizeAtomicResult(ExtAtomicOpType op, TypeKind resultType, Location source, Location dest)
+{
+    switch (resultType) {
+    case TypeKind::I64: {
+        switch (accessWidth(op)) {
+        case Width8:
+            m_jit.zeroExtend8To32(source.asGPR(), dest.asGPRlo());
+            m_jit.xor32(dest.asGPRhi(), dest.asGPRhi());
+            return;
+        case Width16:
+            m_jit.zeroExtend16To32(source.asGPR(), dest.asGPRlo());
+            m_jit.xor32(dest.asGPRhi(), dest.asGPRhi());
+            return;
+        case Width32:
+            m_jit.zeroExtend32ToWord(source.asGPR(), dest.asGPRlo());
+            m_jit.xor32(dest.asGPRhi(), dest.asGPRhi());
+            return;
+        case Width64:
+            ASSERT(dest.asGPRlo() != source.asGPRhi());
+            m_jit.move(source.asGPRlo(), dest.asGPRlo());
+            m_jit.move(source.asGPRhi(), dest.asGPRhi());
+            return;
+        case Width128:
+            RELEASE_ASSERT_NOT_REACHED();
+            return;
+        }
+        return;
+    }
+    case TypeKind::I32:
+        switch (accessWidth(op)) {
+        case Width8:
+            m_jit.zeroExtend8To32(source.asGPR(), dest.asGPR());
+            return;
+        case Width16:
+            m_jit.zeroExtend16To32(source.asGPR(), dest.asGPR());
+            return;
+        case Width32:
+            m_jit.move(source.asGPR(), dest.asGPR());
+            return;
+        case Width64:
+            m_jit.move(source.asGPRlo(), dest.asGPR());
+            return;
+        case Width128:
+            RELEASE_ASSERT_NOT_REACHED();
+            return;
+        }
+        return;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        return;
+    }
+}
+
+void BBQJIT::emitSanitizeAtomicOperand(ExtAtomicOpType op, TypeKind operandType, Location source, Location dest)
+{
+    switch (operandType) {
+    case TypeKind::I64:
+        switch (accessWidth(op)) {
+        case Width8:
+            m_jit.zeroExtend8To32(source.asGPRlo(), dest.asGPR());
+            return;
+        case Width16:
+            m_jit.zeroExtend16To32(source.asGPRlo(), dest.asGPR());
+            return;
+        case Width32:
+            m_jit.move(source.asGPRlo(), dest.asGPR());
+            return;
+        case Width64:
+            ASSERT(dest.asGPRlo() != source.asGPRhi());
+            m_jit.move(source.asGPRlo(), dest.asGPRlo());
+            m_jit.move(source.asGPRhi(), dest.asGPRhi());
+            return;
+        case Width128:
+            RELEASE_ASSERT_NOT_REACHED();
+            return;
+        }
+        return;
+    case TypeKind::I32:
+        switch (accessWidth(op)) {
+        case Width8:
+            m_jit.zeroExtend8To32(source.asGPR(), dest.asGPR());
+            return;
+        case Width16:
+            m_jit.zeroExtend16To32(source.asGPR(), dest.asGPR());
+            return;
+        case Width32:
+            m_jit.move(source.asGPR(), dest.asGPR());
+            return;
+        case Width64:
+            m_jit.move(source.asGPR(), dest.asGPRlo());
+            m_jit.xor32(dest.asGPRhi(), dest.asGPRhi());
+            return;
+        case Width128:
+            RELEASE_ASSERT_NOT_REACHED();
+            return;
+        }
+        return;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        return;
+    }
+
+}
+
+Location BBQJIT::emitMaterializeAtomicOperand(Value value)
+{
+    Location valueLocation;
+
+    if (value.isConst()) {
+        switch (value.type()) {
+        case TypeKind::I64: {
+            ScratchScope<2, 0> scratches(*this);
+            valueLocation = Location::fromGPR2(scratches.gpr(1), scratches.gpr(0));
+            break;
+        }
+        case TypeKind::I32: {
+            ScratchScope<1, 0> scratches(*this);
+            valueLocation = Location::fromGPR(scratches.gpr(0));
+            break;
+        }
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        emitMoveConst(value, valueLocation);
+    } else
+        valueLocation = loadIfNecessary(value);
+    ASSERT(valueLocation.isRegister());
+
+    consume(value);
+
+    return valueLocation;
+}
+
+template<typename Functor>
+void BBQJIT::emitAtomicOpGeneric(ExtAtomicOpType op, Address address, Location old, Location cur, const Functor& functor)
+{
+    Width accessWidth = this->accessWidth(op);
+
+    // We need a CAS loop or a LL/SC loop. Using prepare/attempt jargon, we want:
+    //
+    // Block #reloop:
+    //     Prepare
+    //     Operation
+    //     Attempt
+    //   Successors: Then:#done, Else:#reloop
+    // Block #done:
+    //     Move oldValue, result
+
+    // Prepare
+    auto reloopLabel = m_jit.label();
+    switch (accessWidth) {
+    case Width8:
+        m_jit.loadLink8(address, old.asGPR());
+        break;
+    case Width16:
+        m_jit.loadLink16(address, old.asGPR());
+        break;
+    case Width32:
+        m_jit.loadLink32(address, old.asGPR());
+        break;
+    case Width64:
+        m_jit.loadLinkPair32(address, old.asGPRlo(), old.asGPRhi());
+        break;
+    case Width128:
+        RELEASE_ASSERT_NOT_REACHED();
+        break;
+    }
+
+    // Operation
+    functor(old, cur);
+
+    switch (accessWidth) {
+    case Width8:
+        m_jit.storeCond8(cur.asGPR(), address, wasmScratchGPR2);
+        break;
+    case Width16:
+        m_jit.storeCond16(cur.asGPR(), address, wasmScratchGPR2);
+        break;
+    case Width32:
+        m_jit.storeCond32(cur.asGPR(), address, wasmScratchGPR2);
+        break;
+    case Width64:
+        m_jit.storeCondPair32(cur.asGPRlo(), cur.asGPRhi(), address, wasmScratchGPR2);
+        break;
+    case Width128:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+    m_jit.branchTest32(ResultCondition::NonZero, wasmScratchGPR2).linkTo(reloopLabel, &m_jit);
+}
+
+WARN_UNUSED_RETURN Value BBQJIT::emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint32_t uoffset)
+{
+    ASSERT(pointer.isGPR());
+
+    // For Atomic access, we need SimpleAddress (uoffset = 0).
+    if (uoffset)
+        m_jit.addPtr(TrustedImmPtr(static_cast<int64_t>(uoffset)), pointer.asGPR());
+    Address address = Address(pointer.asGPR());
+
+    if (accessWidth(loadOp) != Width8)
+        recordJumpToThrowException(ExceptionType::UnalignedMemoryAccess, m_jit.branchTest32(ResultCondition::NonZero, pointer.asGPR(), TrustedImm32(sizeOfAtomicOpMemoryAccess(loadOp) - 1)));
+
+    Value result = topValue(valueType.kind);
+    Location resultLocation;
+    Location old, cur;
+
+    switch (valueType.kind) {
+    case TypeKind::I64:
+        switch (canonicalWidth(accessWidth(loadOp))) {
+        case Width32: {
+            resultLocation = allocate(result);
+            cur = Location::fromGPR(resultLocation.asGPRlo());
+            ScratchScope<1, 0> scratches(*this);
+            old = Location::fromGPR(scratches.gpr(0));
+            break;
+        }
+        case Width64: {
+            resultLocation = allocate(result);
+            cur = resultLocation;
+            ScratchScope<2, 0> scratches(*this);
+            old = Location::fromGPR2(scratches.gpr(1), scratches.gpr(0));
+            break;
+        }
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        break;
+    case TypeKind::I32:
+        switch (canonicalWidth(accessWidth(loadOp))) {
+        case Width32: {
+            resultLocation = allocate(result);
+            cur = resultLocation;
+            ScratchScope<1, 0> scratches(*this);
+            old = Location::fromGPR(scratches.gpr(0));
+            break;
+        }
+        case Width64: {
+            ScratchScope<4, 0> scratches(*this);
+            cur = Location::fromGPR2(scratches.gpr(1), scratches.gpr(0));
+            resultLocation = Location::fromGPR(scratches.gpr(0));
+            ASSERT(resultLocation == allocateWithHint(result, resultLocation));
+            old = Location::fromGPR2(scratches.gpr(3), scratches.gpr(2));
+            break;
+        }
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    emitAtomicOpGeneric(loadOp, address, old, cur, [&](Location old, Location cur) {
+        if (old.isGPR2()) {
+            ASSERT(cur.asGPRlo() != old.asGPRhi());
+            m_jit.move(old.asGPRlo(), cur.asGPRlo());
+            m_jit.move(old.asGPRhi(), cur.asGPRhi());
+        } else
+            m_jit.move(old.asGPR(), cur.asGPR());
+    });
+    emitSanitizeAtomicResult(loadOp, valueType.kind, cur, resultLocation);
+
+    return result;
+}
+
+void BBQJIT::emitAtomicStoreOp(ExtAtomicOpType storeOp, Type, Location pointer, Value value, uint32_t uoffset)
+{
+    ASSERT(pointer.isGPR());
+
+    // For Atomic access, we need SimpleAddress (uoffset = 0).
+    if (uoffset)
+        m_jit.addPtr(TrustedImmPtr(static_cast<int64_t>(uoffset)), pointer.asGPR());
+    Address address = Address(pointer.asGPR());
+
+    if (accessWidth(storeOp) != Width8)
+        recordJumpToThrowException(ExceptionType::UnalignedMemoryAccess, m_jit.branchTest32(ResultCondition::NonZero, pointer.asGPR(), TrustedImm32(sizeOfAtomicOpMemoryAccess(storeOp) - 1)));
+
+    Location source, old, cur;
+    switch (canonicalWidth(accessWidth(storeOp))) {
+    case Width32: {
+        Location valueLocation = emitMaterializeAtomicOperand(value);
+        ScratchScope<1, 0> scratchSource(*this);
+        source = Location::fromGPR(scratchSource.gpr(0));
+        emitSanitizeAtomicOperand(storeOp, value.type(), valueLocation, source);
+        ScratchScope<2, 0> scratchTmp(*this);
+        old = Location::fromGPR(scratchTmp.gpr(0));
+        cur = Location::fromGPR(scratchTmp.gpr(1));
+        break;
+    }
+    case Width64: {
+        Location valueLocation = emitMaterializeAtomicOperand(value);
+        ScratchScope<2, 0> scratchSource(*this);
+        source = Location::fromGPR2(scratchSource.gpr(1), scratchSource.gpr(0));
+        emitSanitizeAtomicOperand(storeOp, value.type(), valueLocation, source);
+        ScratchScope<4, 0> scratchTmp(*this);
+        old = Location::fromGPR2(scratchTmp.gpr(1), scratchTmp.gpr(0));
+        cur = Location::fromGPR2(scratchTmp.gpr(3), scratchTmp.gpr(2));
+        break;
+    }
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    emitAtomicOpGeneric(storeOp, address, old, cur, [&](Location, Location cur) {
+        if (source.isGPR2()) {
+            ASSERT(cur.asGPRlo() != source.asGPRhi());
+            m_jit.move(source.asGPRlo(), cur.asGPRlo());
+            m_jit.move(source.asGPRhi(), cur.asGPRhi());
+        } else
+            m_jit.move(source.asGPR(), cur.asGPR());
+    });
+}
+
+Value BBQJIT::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location pointer, Value value, uint32_t uoffset)
+{
+    ASSERT(pointer.isGPR());
+
+    // For Atomic access, we need SimpleAddress (uoffset = 0).
+    if (uoffset)
+        m_jit.addPtr(TrustedImmPtr(static_cast<int64_t>(uoffset)), pointer.asGPR());
+    Address address = Address(pointer.asGPR());
+
+    if (accessWidth(op) != Width8)
+        recordJumpToThrowException(ExceptionType::UnalignedMemoryAccess, m_jit.branchTest32(ResultCondition::NonZero, pointer.asGPR(), TrustedImm32(sizeOfAtomicOpMemoryAccess(op) - 1)));
+
+    Value result = topValue(valueType.kind);
+    Location resultLocation;
+    Location operand, old, cur;
+
+    switch (valueType.kind) {
+    case TypeKind::I64:
+        switch (canonicalWidth(accessWidth(op))) {
+        case Width32: {
+            resultLocation = allocate(result);
+            old = Location::fromGPR(resultLocation.asGPRlo());
+            Location valueLocation = emitMaterializeAtomicOperand(value);
+            ScratchScope<1, 0> scratchOperand(*this, old);
+            operand = Location::fromGPR(scratchOperand.gpr(0));
+            emitSanitizeAtomicOperand(op, value.type(), valueLocation, operand);
+            ScratchScope<1, 0> scratchTmp(*this, old);
+            cur = Location::fromGPR(scratchTmp.gpr(0));
+            break;
+        }
+        case Width64: {
+            resultLocation = allocate(result);
+            old = resultLocation;
+            Location valueLocation = emitMaterializeAtomicOperand(value);
+            ScratchScope<2, 0> scratchOperand(*this, old);
+            operand = Location::fromGPR2(scratchOperand.gpr(1), scratchOperand.gpr(0));
+            emitSanitizeAtomicOperand(op, value.type(), valueLocation, operand);
+            ScratchScope<2, 0> scratchTmp(*this, old);
+            cur = Location::fromGPR2(scratchTmp.gpr(1), scratchTmp.gpr(0));
+            break;
+        }
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        break;
+    case TypeKind::I32:
+        switch (canonicalWidth(accessWidth(op))) {
+        case Width32: {
+            resultLocation = allocate(result);
+            old = resultLocation;
+            Location valueLocation = emitMaterializeAtomicOperand(value);
+            ScratchScope<1, 0> scratchOperand(*this, old);
+            operand = Location::fromGPR(scratchOperand.gpr(0));
+            emitSanitizeAtomicOperand(op, value.type(), valueLocation, operand);
+            ScratchScope<1, 0> scratchTmp(*this, old);
+            cur = Location::fromGPR(scratchTmp.gpr(0));
+            break;
+        }
+        case Width64: {
+            ScratchScope<2, 0> scratchResult(*this);
+            old = Location::fromGPR2(scratchResult.gpr(1), scratchResult.gpr(0));
+            resultLocation = Location::fromGPR(scratchResult.gpr(0));
+            ASSERT(resultLocation == allocateWithHint(result, resultLocation));
+            Location valueLocation = emitMaterializeAtomicOperand(value);
+            ScratchScope<2, 0> scratchOperand(*this);
+            operand = Location::fromGPR2(scratchOperand.gpr(1), scratchOperand.gpr(0));
+            emitSanitizeAtomicOperand(op, value.type(), valueLocation, operand);
+            ScratchScope<2, 0> scratchTmp(*this);
+            cur = Location::fromGPR2(scratchTmp.gpr(1), scratchTmp.gpr(0));
+            break;
+        }
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    emitAtomicOpGeneric(op, address, old, cur, [&](Location old, Location cur) {
+        switch (op) {
+        case ExtAtomicOpType::I32AtomicRmw16AddU:
+        case ExtAtomicOpType::I32AtomicRmw8AddU:
+        case ExtAtomicOpType::I32AtomicRmwAdd:
+        case ExtAtomicOpType::I64AtomicRmw8AddU:
+        case ExtAtomicOpType::I64AtomicRmw16AddU:
+        case ExtAtomicOpType::I64AtomicRmw32AddU:
+            m_jit.add32(old.asGPR(), operand.asGPR(), cur.asGPR());
+            break;
+        case ExtAtomicOpType::I64AtomicRmwAdd:
+            m_jit.add64(old.asGPRhi(), old.asGPRlo(),
+                operand.asGPRhi(), operand.asGPRlo(),
+                cur.asGPRhi(), cur.asGPRlo());
+            break;
+        case ExtAtomicOpType::I32AtomicRmw8SubU:
+        case ExtAtomicOpType::I32AtomicRmw16SubU:
+        case ExtAtomicOpType::I32AtomicRmwSub:
+        case ExtAtomicOpType::I64AtomicRmw8SubU:
+        case ExtAtomicOpType::I64AtomicRmw16SubU:
+        case ExtAtomicOpType::I64AtomicRmw32SubU:
+            m_jit.sub32(old.asGPR(), operand.asGPR(), cur.asGPR());
+            break;
+        case ExtAtomicOpType::I64AtomicRmwSub:
+            m_jit.sub64(old.asGPRhi(), old.asGPRlo(),
+                operand.asGPRhi(), operand.asGPRlo(),
+                cur.asGPRhi(), cur.asGPRlo());
+            break;
+        case ExtAtomicOpType::I32AtomicRmw8AndU:
+        case ExtAtomicOpType::I32AtomicRmw16AndU:
+        case ExtAtomicOpType::I32AtomicRmwAnd:
+        case ExtAtomicOpType::I64AtomicRmw8AndU:
+        case ExtAtomicOpType::I64AtomicRmw16AndU:
+        case ExtAtomicOpType::I64AtomicRmw32AndU:
+            m_jit.and32(old.asGPR(), operand.asGPR(), cur.asGPR());
+            break;
+        case ExtAtomicOpType::I64AtomicRmwAnd:
+            m_jit.and32(old.asGPRhi(), operand.asGPRhi(), cur.asGPRhi());
+            m_jit.and32(old.asGPRlo(), operand.asGPRlo(), cur.asGPRlo());
+            break;
+        case ExtAtomicOpType::I32AtomicRmw8OrU:
+        case ExtAtomicOpType::I32AtomicRmw16OrU:
+        case ExtAtomicOpType::I32AtomicRmwOr:
+        case ExtAtomicOpType::I64AtomicRmw8OrU:
+        case ExtAtomicOpType::I64AtomicRmw16OrU:
+        case ExtAtomicOpType::I64AtomicRmw32OrU:
+            m_jit.or32(old.asGPR(), operand.asGPR(), cur.asGPR());
+            break;
+        case ExtAtomicOpType::I64AtomicRmwOr:
+            m_jit.or32(old.asGPRhi(), operand.asGPRhi(), cur.asGPRhi());
+            m_jit.or32(old.asGPRlo(), operand.asGPRlo(), cur.asGPRlo());
+            break;
+        case ExtAtomicOpType::I32AtomicRmw8XorU:
+        case ExtAtomicOpType::I32AtomicRmw16XorU:
+        case ExtAtomicOpType::I32AtomicRmwXor:
+        case ExtAtomicOpType::I64AtomicRmw8XorU:
+        case ExtAtomicOpType::I64AtomicRmw16XorU:
+        case ExtAtomicOpType::I64AtomicRmw32XorU:
+            m_jit.xor32(old.asGPR(), operand.asGPR(), cur.asGPR());
+            break;
+        case ExtAtomicOpType::I64AtomicRmwXor:
+            m_jit.xor32(old.asGPRhi(), operand.asGPRhi(), cur.asGPRhi());
+            m_jit.xor32(old.asGPRlo(), operand.asGPRlo(), cur.asGPRlo());
+            break;
+        case ExtAtomicOpType::I32AtomicRmw8XchgU:
+        case ExtAtomicOpType::I32AtomicRmw16XchgU:
+        case ExtAtomicOpType::I32AtomicRmwXchg:
+        case ExtAtomicOpType::I64AtomicRmw8XchgU:
+        case ExtAtomicOpType::I64AtomicRmw16XchgU:
+        case ExtAtomicOpType::I64AtomicRmw32XchgU:
+            m_jit.move(operand.asGPR(), cur.asGPR());
+            break;
+        case ExtAtomicOpType::I64AtomicRmwXchg:
+            ASSERT(cur.asGPRlo() != operand.asGPRhi());
+            m_jit.move(operand.asGPRlo(), cur.asGPRlo());
+            m_jit.move(operand.asGPRhi(), cur.asGPRhi());
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
+    });
+    emitSanitizeAtomicResult(op, valueType.kind, old, resultLocation);
+
+    return result;
+}
+
+WARN_UNUSED_RETURN Value BBQJIT::emitAtomicCompareExchange(ExtAtomicOpType op, Type valueType, Location pointer, Value expected, Value value, uint32_t uoffset)
+{
+    ASSERT(pointer.isGPR());
+
+    // For Atomic access, we need SimpleAddress (uoffset = 0).
+    if (uoffset)
+        m_jit.addPtr(TrustedImmPtr(static_cast<int64_t>(uoffset)), pointer.asGPR());
+    Address address = Address(pointer.asGPR());
+
+    if (accessWidth(op) != Width8)
+        recordJumpToThrowException(ExceptionType::UnalignedMemoryAccess, m_jit.branchTest32(ResultCondition::NonZero, pointer.asGPR(), TrustedImm32(sizeOfAtomicOpMemoryAccess(op) - 1)));
+
+    Value result = topValue(valueType.kind);
+    Location resultLocation;
+    Location a, b, old, cur;
+
+    switch (valueType.kind) {
+    case TypeKind::I64:
+        switch (canonicalWidth(accessWidth(op))) {
+        case Width32: {
+            resultLocation = allocate(result);
+            old = Location::fromGPR(resultLocation.asGPRlo());
+            Location aLocation = emitMaterializeAtomicOperand(expected);
+            ScratchScope<1, 0> scratchA(*this, old);
+            a = Location::fromGPR(scratchA.gpr(0));
+            emitSanitizeAtomicOperand(op, value.type(), aLocation, a);
+            Location bLocation = emitMaterializeAtomicOperand(value);
+            ScratchScope<1, 0> scratchB(*this, old);
+            b = Location::fromGPR(scratchB.gpr(0));
+            emitSanitizeAtomicOperand(op, value.type(), bLocation, b);
+            cur = old;
+            break;
+        }
+        case Width64: {
+            resultLocation = allocate(result);
+            old = resultLocation;
+            Location aLocation = emitMaterializeAtomicOperand(expected);
+            ScratchScope<2, 0> scratchA(*this, old);
+            a = Location::fromGPR2(scratchA.gpr(1), scratchA.gpr(0));
+            emitSanitizeAtomicOperand(op, value.type(), aLocation, a);
+            Location bLocation = emitMaterializeAtomicOperand(value);
+            ScratchScope<2, 0> scratchB(*this, old);
+            b = Location::fromGPR2(scratchB.gpr(1), scratchB.gpr(0));
+            emitSanitizeAtomicOperand(op, value.type(), bLocation, b);
+            cur = old;
+            break;
+        }
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        break;
+    case TypeKind::I32:
+        switch (canonicalWidth(accessWidth(op))) {
+        case Width32: {
+            resultLocation = allocate(result);
+            old = resultLocation;
+            Location aLocation = emitMaterializeAtomicOperand(expected);
+            ScratchScope<1, 0> scratchA(*this, old);
+            a = Location::fromGPR(scratchA.gpr(0));
+            emitSanitizeAtomicOperand(op, value.type(), aLocation, a);
+            Location bLocation = emitMaterializeAtomicOperand(value);
+            ScratchScope<1, 0> scratchB(*this, old);
+            b = Location::fromGPR(scratchB.gpr(0));
+            emitSanitizeAtomicOperand(op, value.type(), bLocation, b);
+            cur = old;
+            break;
+        }
+        case Width64: {
+            ScratchScope<2, 0> scratchResult(*this);
+            old = Location::fromGPR2(scratchResult.gpr(1), scratchResult.gpr(0));
+            resultLocation = Location::fromGPR(scratchResult.gpr(0));
+            ASSERT(resultLocation == allocateWithHint(result, resultLocation));
+            Location aLocation = emitMaterializeAtomicOperand(expected);
+            ScratchScope<2, 0> scratchA(*this);
+            a = Location::fromGPR2(scratchA.gpr(1), scratchA.gpr(0));
+            emitSanitizeAtomicOperand(op, value.type(), aLocation, a);
+            Location bLocation = emitMaterializeAtomicOperand(value);
+            ScratchScope<2, 0> scratchB(*this);
+            b = Location::fromGPR2(scratchB.gpr(1), scratchB.gpr(0));
+            emitSanitizeAtomicOperand(op, value.type(), bLocation, b);
+            cur = old;
+            break;
+        }
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    JumpList failure;
+
+    emitAtomicOpGeneric(op, address, old, cur, [&](Location old, Location cur) {
+        emitSanitizeAtomicResult(op, valueType.kind, old, resultLocation);
+        if (old.isGPR2()) {
+            failure.append(m_jit.branch32(RelationalCondition::NotEqual, old.asGPRlo(), a.asGPRlo()));
+            failure.append(m_jit.branch32(RelationalCondition::NotEqual, old.asGPRhi(), a.asGPRhi()));
+            m_jit.move(b.asGPRlo(), cur.asGPRlo());
+            m_jit.move(b.asGPRhi(), cur.asGPRhi());
+        } else {
+            failure.append(m_jit.branch32(RelationalCondition::NotEqual, old.asGPR(), a.asGPR()));
+            m_jit.move(b.asGPR(), cur.asGPR());
+        }
+    });
+    emitSanitizeAtomicResult(op, valueType.kind, a, resultLocation);
+    failure.link(&m_jit);
+
+    return result;
+}
+
+void BBQJIT::truncInBounds(TruncationKind truncationKind, Location operandLocation, Location resultLocation, FPRReg scratch1FPR, FPRReg scratch2FPR)
+{
+    switch (truncationKind) {
+    case TruncationKind::I32TruncF32S:
+        m_jit.truncateFloatToInt32(operandLocation.asFPR(), resultLocation.asGPR());
+        break;
+    case TruncationKind::I32TruncF64S:
+        m_jit.truncateDoubleToInt32(operandLocation.asFPR(), resultLocation.asGPR());
+        break;
+    case TruncationKind::I32TruncF32U:
+        m_jit.truncateFloatToUint32(operandLocation.asFPR(), resultLocation.asGPR());
+        break;
+    case TruncationKind::I32TruncF64U:
+        m_jit.truncateDoubleToUint32(operandLocation.asFPR(), resultLocation.asGPR());
+        break;
+    case TruncationKind::I64TruncF32S: {
+        m_jit.truncateFloatToInt64(operandLocation.asFPR(), resultLocation.asGPRlo(), resultLocation.asGPRhi(), scratch1FPR, scratch2FPR);
+        break;
+    }
+    case TruncationKind::I64TruncF64S: {
+        m_jit.truncateDoubleToInt64(operandLocation.asFPR(), resultLocation.asGPRlo(), resultLocation.asGPRhi(), scratch1FPR, scratch2FPR);
+        break;
+    }
+    case TruncationKind::I64TruncF32U: {
+        m_jit.truncateFloatToUint64(operandLocation.asFPR(), resultLocation.asGPRlo(), resultLocation.asGPRhi(), scratch1FPR, scratch2FPR);
+        break;
+    }
+    case TruncationKind::I64TruncF64U: {
+        m_jit.truncateDoubleToUint64(operandLocation.asFPR(), resultLocation.asGPRlo(), resultLocation.asGPRhi(), scratch1FPR, scratch2FPR);
+        break;
+    }
+    }
+}
+
+// GC
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefI31(ExpressionType value, ExpressionType& result)
+{
+    if (value.isConst()) {
+        uint32_t lo32 = (value.asI32() << 1) >> 1;
+        result = Value::fromI64(JSValue::encode(JSValue(JSValue::Int32Tag, lo32)));
+        LOG_INSTRUCTION("RefI31", value, RESULT(result));
+        return { };
+    }
+
+    Location initialValue = loadIfNecessary(value);
+    consume(value);
+
+    result = topValue(TypeKind::I64);
+    Location resultLocation = allocateWithHint(result, initialValue);
+
+    LOG_INSTRUCTION("RefI31", value, RESULT(result));
+
+    m_jit.lshift32(TrustedImm32(1), resultLocation.asGPRlo());
+    m_jit.rshift32(TrustedImm32(1), resultLocation.asGPRlo());
+    m_jit.move(TrustedImm32(JSValue::Int32Tag), resultLocation.asGPRhi());
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI31GetS(TypedExpression typedValue, ExpressionType& result)
+{
+    auto value = typedValue.value();
+    if (value.isConst()) {
+        if (JSValue::decode(value.asI64()).isNumber())
+            result = Value::fromI32((value.asI64() << 33) >> 33);
+        else {
+            emitThrowException(ExceptionType::NullI31Get);
+            result = Value::fromI32(0);
+        }
+
+        LOG_INSTRUCTION("I31GetS", value, RESULT(result));
+
+        return { };
+    }
+
+
+    Location initialValue = loadIfNecessary(value);
+    if (typedValue.type().isNullable())
+        emitThrowOnNullReference(ExceptionType::NullI31Get, initialValue);
+    consume(value);
+
+    result = topValue(TypeKind::I32);
+    Location resultLocation = allocateWithHint(result, initialValue);
+
+    LOG_INSTRUCTION("I31GetS", value, RESULT(result));
+
+    m_jit.move(initialValue.asGPRlo(), resultLocation.asGPR());
+
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI31GetU(TypedExpression typedValue, ExpressionType& result)
+{
+    auto value = typedValue.value();
+    if (value.isConst()) {
+        if (JSValue::decode(value.asI64()).isNumber())
+            result = Value::fromI32(value.asI64() & 0x7fffffffu);
+        else {
+            emitThrowException(ExceptionType::NullI31Get);
+            result = Value::fromI32(0);
+        }
+
+        LOG_INSTRUCTION("I31GetU", value, RESULT(result));
+
+        return { };
+    }
+
+
+    Location initialValue = loadIfNecessary(value);
+    if (typedValue.type().isNullable())
+        emitThrowOnNullReference(ExceptionType::NullI31Get, initialValue);
+    consume(value);
+
+    result = topValue(TypeKind::I32);
+    Location resultLocation = allocateWithHint(result, initialValue);
+
+    LOG_INSTRUCTION("I31GetU", value, RESULT(result));
+
+    m_jit.and32(TrustedImm32(0x7fffffff), initialValue.asGPRlo(), resultLocation.asGPR());
+
+    return { };
+}
+
+// This will replace the existing value with a new value. Note that if this is an F32 then the top bits may be garbage but that's ok for our current usage.
+Value BBQJIT::marshallToI64(Value value)
+{
+    ASSERT(!value.isLocal());
+    if (value.isConst()) {
+        switch (value.type()) {
+        case TypeKind::F64:
+            return Value::fromI64(std::bit_cast<uint64_t>(value.asF64()));
+        case TypeKind::F32:
+        case TypeKind::I32:
+            return Value::fromI64(std::bit_cast<uint32_t>(value.asI32()));
+        default:
+            return value;
+        }
+    }
+    switch (value.type()) {
+    case TypeKind::F64:
+        flushValue(value);
+        return Value::fromTemp(TypeKind::I64, value.asTemp());
+    case TypeKind::F32:
+    case TypeKind::I32: {
+        flushValue(value);
+        Location slot = canonicalSlot(value);
+        m_jit.store32(TrustedImm32(0), slot.asAddress().withOffset(4));
+        return Value::fromTemp(TypeKind::I64, value.asTemp());
+    }
+    default:
+        return value;
+    }
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType initValue, ExpressionType& result)
+{
+    result = topValue(TypeKind::Arrayref);
+
+    initValue = marshallToI64(initValue);
+
+    Vector<Value, 8> arguments = {
+        instanceValue(),
+        Value::fromI32(typeIndex),
+        size,
+        initValue,
+    };
+    emitCCall(operationWasmArrayNew, arguments, result);
+
+    Location resultLocation = loadIfNecessary(result);
+    emitThrowOnNullReference(ExceptionType::BadArrayNew, resultLocation);
+
+    LOG_INSTRUCTION("ArrayNew", typeIndex, size, initValue, RESULT(result));
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewFixed(uint32_t typeIndex, ArgumentList& args, ExpressionType& result)
+{
+    // Allocate an uninitialized array whose length matches the argument count
+    // FIXME: inline the allocation.
+    // https://bugs.webkit.org/show_bug.cgi?id=244388
+    Vector<Value, 8> arguments = {
+        instanceValue(),
+        Value::fromI32(typeIndex),
+        Value::fromI32(args.size()),
+    };
+    Value allocationResult = Value::fromTemp(TypeKind::Arrayref, currentControlData().enclosedHeight() + currentControlData().implicitSlots() + m_parser->expressionStack().size() + args.size());
+    emitCCall(operationWasmArrayNewEmpty, arguments, allocationResult);
+
+    Location allocationResultLocation = loadIfNecessary(allocationResult);
+    emitThrowOnNullReference(ExceptionType::BadArrayNew, allocationResultLocation);
+
+    for (uint32_t i = 0; i < args.size(); ++i) {
+        // Emit the array set code -- note that this omits the bounds check, since
+        // if operationWasmArrayNewEmpty() returned a non-null value, it's an array of the right size
+        allocationResultLocation = loadIfNecessary(allocationResult);
+        Value pinnedResult = Value::pinned(TypeKind::I64, allocationResultLocation);
+        emitArraySetUnchecked(typeIndex, pinnedResult, Value::fromI32(i), args[i]);
+        consume(pinnedResult);
+    }
+
+    result = topValue(TypeKind::Arrayref);
+    Location resultLocation;
+
+    // If args.isEmpty() then allocationResult.asTemp() == result.asTemp() so we will consume our result.
+    if (args.size()) {
+        consume(allocationResult);
+        resultLocation = allocate(result);
+        emitMove(allocationResult.type(), allocationResultLocation, resultLocation);
+        if (isRefType(getArrayElementType(typeIndex).unpacked()))
+            emitWriteBarrier(resultLocation.asGPRlo());
+    } else {
+        RELEASE_ASSERT(result.asTemp() == allocationResult.asTemp());
+        resultLocation = allocationResultLocation;
+    }
+
+    LOG_INSTRUCTION("ArrayNewFixed", typeIndex, args.size(), RESULT(result));
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result)
+{
+    Vector<Value, 8> arguments = {
+        instanceValue(),
+        Value::fromI32(typeIndex),
+        size,
+    };
+    result = topValue(TypeKind::Arrayref);
+    emitCCall(&operationWasmArrayNewEmpty, arguments, result);
+
+    Location resultLocation = loadIfNecessary(result);
+    emitThrowOnNullReference(ExceptionType::BadArrayNew, resultLocation);
+
+    LOG_INSTRUCTION("ArrayNewDefault", typeIndex, size, RESULT(result));
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType& result)
+{
+    auto arrayref = typedArray.value();
+    StorageType elementType = getArrayElementType(typeIndex);
+    Type resultType = elementType.unpacked();
+
+    if (arrayref.isConst()) {
+        ASSERT(arrayref.asI64() == JSValue::encode(jsNull()));
+        emitThrowException(ExceptionType::NullAccess);
+        result = topValue(resultType.kind);
+        return { };
+    }
+
+    Location arrayLocation = loadIfNecessary(arrayref);
+    if (typedArray.type().isNullable())
+        emitThrowOnNullReference(ExceptionType::NullAccess, arrayLocation);
+
+    Location indexLocation;
+    if (index.isConst()) {
+        m_jit.load32(MacroAssembler::Address(arrayLocation.asGPRlo(), JSWebAssemblyArray::offsetOfSize()), wasmScratchGPR);
+        recordJumpToThrowException(ExceptionType::OutOfBoundsArrayGet,
+            m_jit.branch32(MacroAssembler::BelowOrEqual, wasmScratchGPR, TrustedImm32(index.asI32())));
+    } else {
+        indexLocation = loadIfNecessary(index);
+        recordJumpToThrowException(ExceptionType::OutOfBoundsArrayGet,
+            m_jit.branch32(MacroAssembler::AboveOrEqual, indexLocation.asGPR(), MacroAssembler::Address(arrayLocation.asGPRlo(), JSWebAssemblyArray::offsetOfSize())));
+    }
+
+    emitArrayGetPayload(elementType, arrayLocation.asGPRlo(), wasmScratchGPR);
+
+    consume(arrayref);
+    result = topValue(resultType.kind);
+    Location resultLocation = allocate(result);
+
+    if (index.isConst()) {
+        auto fieldAddress = MacroAssembler::Address(wasmScratchGPR, elementType.elementSize() * index.asI32());
+
+        if (elementType.is<PackedType>()) {
+            switch (elementType.as<Wasm::PackedType>()) {
+            case Wasm::PackedType::I8:
+                m_jit.load8(fieldAddress, resultLocation.asGPR());
+                break;
+            case Wasm::PackedType::I16:
+                m_jit.load16(fieldAddress, resultLocation.asGPR());
+                break;
+            }
+        } else {
+            ASSERT(elementType.is<Type>());
+            switch (result.type()) {
+            case TypeKind::I32: {
+                m_jit.load32(fieldAddress, resultLocation.asGPR());
+                break;
+            }
+            case TypeKind::I64:
+                m_jit.loadPair32(fieldAddress, resultLocation.asGPRlo(), resultLocation.asGPRhi());
+                break;
+            case TypeKind::F32:
+                m_jit.loadFloat(fieldAddress, resultLocation.asFPR());
+                break;
+            case TypeKind::F64:
+                m_jit.loadDouble(fieldAddress, resultLocation.asFPR());
+                break;
+            default:
+                RELEASE_ASSERT_NOT_REACHED();
+                break;
+            }
+        }
+    } else {
+        auto scale = static_cast<MacroAssembler::Scale>(std::bit_width(elementType.elementSize()) - 1);
+        auto fieldBaseIndex = MacroAssembler::BaseIndex(wasmScratchGPR, indexLocation.asGPR(), scale);
+
+        if (elementType.is<PackedType>()) {
+            switch (elementType.as<Wasm::PackedType>()) {
+            case Wasm::PackedType::I8:
+                m_jit.load8(fieldBaseIndex, resultLocation.asGPR());
+                break;
+            case Wasm::PackedType::I16:
+                m_jit.load16(fieldBaseIndex, resultLocation.asGPR());
+                break;
+            }
+        } else {
+            ASSERT(elementType.is<Type>());
+            switch (result.type()) {
+            case TypeKind::I32:
+                m_jit.load32(fieldBaseIndex, resultLocation.asGPR());
+                break;
+            case TypeKind::I64:
+                m_jit.loadPair32(fieldBaseIndex, resultLocation.asGPRlo(), resultLocation.asGPRhi());
+                break;
+            case TypeKind::F32:
+                m_jit.loadFloat(fieldBaseIndex, resultLocation.asFPR());
+                break;
+            case TypeKind::F64:
+                m_jit.loadDouble(fieldBaseIndex, resultLocation.asFPR());
+                break;
+            default:
+                RELEASE_ASSERT_NOT_REACHED();
+                break;
+            }
+        }
+    }
+
+    consume(index);
+
+    if (result.type() == TypeKind::I32) {
+        switch (arrayGetKind) {
+        case ExtGCOpType::ArrayGet:
+            break;
+        case ExtGCOpType::ArrayGetU:
+            LOG_INSTRUCTION("ArrayGetU", typeIndex, arrayref, index, RESULT(result));
+            return { };
+        case ExtGCOpType::ArrayGetS: {
+            ASSERT(resultType.kind == TypeKind::I32);
+            uint8_t bitShift = (sizeof(uint32_t) - elementType.elementSize()) * 8;
+
+            m_jit.lshift32(TrustedImm32(bitShift), resultLocation.asGPR());
+            m_jit.rshift32(TrustedImm32(bitShift), resultLocation.asGPR());
+            LOG_INSTRUCTION("ArrayGetS", typeIndex, arrayref, index, RESULT(result));
+            return { };
+        }
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            return { };
+        }
+    }
+
+    LOG_INSTRUCTION("ArrayGet", typeIndex, arrayref, index, RESULT(result));
+
+    return { };
+}
+
+void BBQJIT::emitArraySetUnchecked(uint32_t typeIndex, Value arrayref, Value index, Value value)
+{
+    StorageType elementType = getArrayElementType(typeIndex);
+
+    Location arrayLocation;
+    if (arrayref.isPinned())
+        arrayLocation = locationOf(arrayref);
+    else
+        arrayLocation = loadIfNecessary(arrayref);
+    ScratchScope<1, 0> tmp(*this);
+    auto payloadGPR = tmp.gpr(0);
+    emitArrayGetPayload(elementType, arrayLocation.asGPRlo(), payloadGPR);
+    if (index.isConst()) {
+        ScratchScope<1, 0> scratches(*this);
+        auto fieldAddress = MacroAssembler::Address(payloadGPR, elementType.elementSize() * index.asI32());
+
+        Location valueLocation;
+        if (value.isConst() && value.isFloat()) {
+            ScratchScope<0, 1> scratches(*this);
+            valueLocation = Location::fromFPR(scratches.fpr(0));
+            // Materialize the constant to ensure constant blinding.
+            emitMoveConst(value, valueLocation);
+        } else if (value.isConst() && typeNeedsGPR2(value.type())) {
+            ScratchScope<2, 0> scratches(*this);
+            valueLocation = Location::fromGPR2(scratches.gpr(1), scratches.gpr(0));
+            // Materialize the constant to ensure constant blinding.
+            emitMoveConst(value, valueLocation);
+        } else if (value.isConst()) {
+            ScratchScope<1, 0> scratches(*this);
+            valueLocation = Location::fromGPR(scratches.gpr(0));
+            // Materialize the constant to ensure constant blinding.
+            emitMoveConst(value, valueLocation);
+        } else
+            valueLocation = loadIfNecessary(value);
+        ASSERT(valueLocation.isRegister());
+
+        if (elementType.is<PackedType>()) {
+            switch (elementType.as<Wasm::PackedType>()) {
+            case Wasm::PackedType::I8:
+                m_jit.store8(valueLocation.asGPR(), fieldAddress);
+                break;
+            case Wasm::PackedType::I16:
+                m_jit.store16(valueLocation.asGPR(), fieldAddress);
+                break;
+            }
+        } else {
+            ASSERT(elementType.is<Type>());
+            switch (value.type()) {
+            case TypeKind::I32:
+                m_jit.store32(valueLocation.asGPR(), fieldAddress);
+                break;
+            case TypeKind::I64:
+                m_jit.storePair32(valueLocation.asGPRlo(), valueLocation.asGPRhi(), fieldAddress);
+                break;
+            case TypeKind::F32:
+                m_jit.storeFloat(valueLocation.asFPR(), fieldAddress);
+                break;
+            case TypeKind::F64:
+                m_jit.storeDouble(valueLocation.asFPR(), fieldAddress);
+                break;
+            default:
+                RELEASE_ASSERT_NOT_REACHED();
+                break;
+            }
+        }
+    } else {
+        Location indexLocation = loadIfNecessary(index);
+        auto scale = static_cast<MacroAssembler::Scale>(std::bit_width(elementType.elementSize()) - 1);
+        auto fieldBaseIndex = MacroAssembler::BaseIndex(payloadGPR, indexLocation.asGPR(), scale);
+
+        Location valueLocation;
+        if (value.isConst() && value.isFloat()) {
+            ScratchScope<0, 1> scratches(*this);
+            valueLocation = Location::fromFPR(scratches.fpr(0));
+            emitMoveConst(value, valueLocation);
+        } else if (value.isConst() && typeNeedsGPR2(value.type())) {
+            ScratchScope<2, 0> scratches(*this);
+            valueLocation = Location::fromGPR2(scratches.gpr(1), scratches.gpr(0));
+            emitMoveConst(value, valueLocation);
+        } else if (value.isConst()) {
+            ScratchScope<1, 0> scratches(*this);
+            valueLocation = Location::fromGPR(scratches.gpr(0));
+            emitMoveConst(value, valueLocation);
+        } else
+            valueLocation = loadIfNecessary(value);
+        ASSERT(valueLocation.isRegister());
+
+        if (elementType.is<PackedType>()) {
+            switch (elementType.as<Wasm::PackedType>()) {
+            case Wasm::PackedType::I8:
+                m_jit.store8(valueLocation.asGPR(), fieldBaseIndex);
+                break;
+            case Wasm::PackedType::I16:
+                m_jit.store16(valueLocation.asGPR(), fieldBaseIndex);
+                break;
+            }
+        } else {
+            ASSERT(elementType.is<Type>());
+            switch (value.type()) {
+            case TypeKind::I32:
+                m_jit.store32(valueLocation.asGPR(), fieldBaseIndex);
+                break;
+            case TypeKind::I64:
+                m_jit.storePair32(valueLocation.asGPRlo(), valueLocation.asGPRhi(), fieldBaseIndex);
+                break;
+            case TypeKind::F32:
+                m_jit.storeFloat(valueLocation.asFPR(), fieldBaseIndex);
+                break;
+            case TypeKind::F64:
+                m_jit.storeDouble(valueLocation.asFPR(), fieldBaseIndex);
+                break;
+            default:
+                RELEASE_ASSERT_NOT_REACHED();
+                break;
+            }
+        }
+    }
+
+    consume(index);
+    consume(value);
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArraySet(uint32_t typeIndex, TypedExpression typedArray, ExpressionType index, ExpressionType value)
+{
+    auto arrayref = typedArray.value();
+    if (arrayref.isConst()) {
+        ASSERT(arrayref.asI64() == JSValue::encode(jsNull()));
+
+        LOG_INSTRUCTION("ArraySet", typeIndex, arrayref, index, value);
+        consume(value);
+        emitThrowException(ExceptionType::NullAccess);
+        return { };
+    }
+
+    Location arrayLocation = loadIfNecessary(arrayref);
+    if (typedArray.type().isNullable())
+        emitThrowOnNullReference(ExceptionType::NullAccess, arrayLocation);
+
+    if (index.isConst()) {
+        m_jit.load32(MacroAssembler::Address(arrayLocation.asGPRlo(), JSWebAssemblyArray::offsetOfSize()), wasmScratchGPR);
+        recordJumpToThrowException(ExceptionType::OutOfBoundsArraySet,
+            m_jit.branch32(MacroAssembler::BelowOrEqual, wasmScratchGPR, TrustedImm32(index.asI32())));
+    } else {
+        Location indexLocation = loadIfNecessary(index);
+        recordJumpToThrowException(ExceptionType::OutOfBoundsArraySet,
+            m_jit.branch32(MacroAssembler::AboveOrEqual, indexLocation.asGPR(), MacroAssembler::Address(arrayLocation.asGPRlo(), JSWebAssemblyArray::offsetOfSize())));
+    }
+
+    emitArraySetUnchecked(typeIndex, arrayref, index, value);
+
+    if (isRefType(getArrayElementType(typeIndex).unpacked()))
+        emitWriteBarrier(arrayLocation.asGPRlo());
+    consume(arrayref);
+
+    LOG_INSTRUCTION("ArraySet", typeIndex, arrayref, index, value);
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayLen(TypedExpression typedArray, ExpressionType& result)
+{
+    auto arrayref = typedArray.value();
+    if (arrayref.isConst()) {
+        ASSERT(arrayref.asI64() == JSValue::encode(jsNull()));
+        emitThrowException(ExceptionType::NullAccess);
+        result = Value::fromI32(0);
+        LOG_INSTRUCTION("ArrayLen", arrayref, RESULT(result), "Exception");
+        return { };
+    }
+
+    Location arrayLocation = loadIfNecessary(arrayref);
+    consume(arrayref);
+    if (typedArray.type().isNullable())
+        emitThrowOnNullReference(ExceptionType::NullAccess, arrayLocation);
+
+    result = topValue(TypeKind::I32);
+    Location resultLocation = allocateWithHint(result, arrayLocation);
+    m_jit.load32(MacroAssembler::Address(arrayLocation.asGPRlo(), JSWebAssemblyArray::offsetOfSize()), resultLocation.asGPR());
+
+    LOG_INSTRUCTION("ArrayLen", arrayref, RESULT(result));
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addArrayFill(uint32_t typeIndex, TypedExpression typedArray, ExpressionType offset, ExpressionType value, ExpressionType size)
+{
+    auto arrayref = typedArray.value();
+    if (arrayref.isConst()) {
+        ASSERT(arrayref.asI64() == JSValue::encode(jsNull()));
+
+        LOG_INSTRUCTION("ArrayFill", typeIndex, arrayref, offset, value, size);
+
+        consume(offset);
+        consume(value);
+        consume(size);
+        emitThrowException(ExceptionType::NullArrayFill);
+        return { };
+    }
+
+    if (typedArray.type().isNullable())
+        emitThrowOnNullReference(ExceptionType::NullArrayFill, loadIfNecessary(arrayref));
+
+    Value shouldThrow = topValue(TypeKind::I32);
+    value = marshallToI64(value);
+    Vector<Value, 8> arguments = {
+        instanceValue(),
+        arrayref,
+        offset,
+        value,
+        size
+    };
+    emitCCall(&operationWasmArrayFill, arguments, shouldThrow);
+    Location shouldThrowLocation = loadIfNecessary(shouldThrow);
+
+    LOG_INSTRUCTION("ArrayFill", typeIndex, arrayref, offset, value, size);
+
+    recordJumpToThrowException(ExceptionType::OutOfBoundsArrayFill, m_jit.branchTest32(ResultCondition::Zero, shouldThrowLocation.asGPR()));
+
+    consume(shouldThrow);
+
+    return { };
+}
+
+bool BBQJIT::emitStructSet(GPRReg structGPR, const StructType& structType, uint32_t fieldIndex, Value value)
+{
+    unsigned fieldOffset = JSWebAssemblyStruct::offsetOfData() + structType.offsetOfFieldInPayload(fieldIndex);
+    RELEASE_ASSERT((std::numeric_limits<int32_t>::max() & fieldOffset) == fieldOffset);
+
+    StorageType storageType = structType.field(fieldIndex).type;
+    TypeKind kind = toValueKind(storageType.unpacked().kind);
+    if (value.isConst()) {
+        switch (kind) {
+        case TypeKind::I32:
+            if (structType.field(fieldIndex).type.is<PackedType>()) {
+                ScratchScope<1, 0> scratches(*this);
+                // If it's a packed type, we materialize the constant to ensure constant blinding.
+                emitMoveConst(Value::fromI32(value.asI32()), Location::fromGPR(scratches.gpr(0)));
+                switch (storageType.as<PackedType>()) {
+                case PackedType::I8:
+                    m_jit.store8(scratches.gpr(0), MacroAssembler::Address(structGPR, fieldOffset));
+                    break;
+                case PackedType::I16:
+                    m_jit.store16(scratches.gpr(0), MacroAssembler::Address(structGPR, fieldOffset));
+                    break;
+                }
+                break;
+            }
+            m_jit.store32(MacroAssembler::Imm32(value.asI32()), MacroAssembler::Address(structGPR, fieldOffset));
+            break;
+        case TypeKind::F32:
+            m_jit.store32(MacroAssembler::Imm32(value.asI32()), MacroAssembler::Address(structGPR, fieldOffset));
+            break;
+        case TypeKind::I64:
+        case TypeKind::F64:
+            m_jit.storePair32(TrustedImm32(value.asI64lo()), TrustedImm32(value.asI64hi()), MacroAssembler::Address(structGPR, fieldOffset));
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
+
+        ASSERT_IMPLIES(isRefType(storageType.unpacked()), !JSValue::decode(value.asI32()).isCell());
+        return false;
+    }
+
+    Location valueLocation = loadIfNecessary(value);
+    switch (kind) {
+    case TypeKind::I32:
+        if (structType.field(fieldIndex).type.is<PackedType>()) {
+            switch (structType.field(fieldIndex).type.as<PackedType>()) {
+            case PackedType::I8:
+                m_jit.store8(valueLocation.asGPR(), MacroAssembler::Address(structGPR, fieldOffset));
+                break;
+            case PackedType::I16:
+                m_jit.store16(valueLocation.asGPR(), MacroAssembler::Address(structGPR, fieldOffset));
+                break;
+            }
+            break;
+        }
+        m_jit.store32(valueLocation.asGPR(), MacroAssembler::Address(structGPR, fieldOffset));
+        break;
+    case TypeKind::I64:
+        m_jit.storePair32(valueLocation.asGPRlo(), valueLocation.asGPRhi(), MacroAssembler::Address(structGPR, fieldOffset));
+        break;
+    case TypeKind::F32:
+        m_jit.storeFloat(valueLocation.asFPR(), MacroAssembler::Address(structGPR, fieldOffset));
+        break;
+    case TypeKind::F64:
+        m_jit.storeDouble(valueLocation.asFPR(), MacroAssembler::Address(structGPR, fieldOffset));
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        break;
+    }
+    consume(value);
+    return isRefType(storageType.unpacked());
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addStructNewDefault(uint32_t typeIndex, ExpressionType& result)
+{
+
+    Vector<Value, 8> arguments = {
+        instanceValue(),
+        Value::fromI32(typeIndex),
+    };
+    result = topValue(TypeKind::I64);
+    emitCCall(operationWasmStructNewEmpty, arguments, result);
+
+    const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
+    Location structLocation = loadIfNecessary(result);
+    emitThrowOnNullReference(ExceptionType::BadStructNew, structLocation);
+    bool needsWriteBarrier = false;
+    for (StructFieldCount i = 0; i < structType.fieldCount(); ++i) {
+        if (Wasm::isRefType(structType.field(i).type))
+            needsWriteBarrier |= emitStructSet(structLocation.asGPRlo(), structType, i, Value::fromRef(TypeKind::RefNull, JSValue::encode(jsNull())));
+        else
+            needsWriteBarrier |= emitStructSet(structLocation.asGPRlo(), structType, i, Value::fromI64(0));
+    }
+
+    // No write barrier needed here as all fields are set to constants.
+    ASSERT_UNUSED(needsWriteBarrier, !needsWriteBarrier);
+
+    LOG_INSTRUCTION("StructNewDefault", typeIndex, RESULT(result));
+
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addStructNew(uint32_t typeIndex, ArgumentList& args, Value& result)
+{
+    Vector<Value, 8> arguments = {
+        instanceValue(),
+        Value::fromI32(typeIndex),
+    };
+    // Note: using topValue here would be wrong because args[0] would be clobbered by the result.
+    Value allocationResult = Value::fromTemp(TypeKind::Structref, currentControlData().enclosedHeight() + currentControlData().implicitSlots() + m_parser->expressionStack().size() + args.size());
+    emitCCall(operationWasmStructNewEmpty, arguments, allocationResult);
+
+    const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
+    Location structLocation = loadIfNecessary(allocationResult);
+    emitThrowOnNullReference(ExceptionType::BadStructNew, structLocation);
+    bool needsWriteBarrier = false;
+    for (uint32_t i = 0; i < args.size(); ++i)
+        needsWriteBarrier |= emitStructSet(structLocation.asGPRlo(), structType, i, args[i]);
+
+    if (needsWriteBarrier)
+        emitWriteBarrier(structLocation.asGPRlo());
+
+    result = topValue(TypeKind::Structref);
+    Location resultLocation;
+    // If args.isEmpty() then allocationResult.asTemp() == result.asTemp() so we will consume our result.
+    if (args.size()) {
+        consume(allocationResult);
+        resultLocation = allocate(result);
+        emitMove(allocationResult.type(), structLocation, resultLocation);
+    } else {
+        RELEASE_ASSERT(result.asTemp() == allocationResult.asTemp());
+        resultLocation = structLocation;
+    }
+
+    LOG_INSTRUCTION("StructNew", typeIndex, args, RESULT(result));
+
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addStructGet(ExtGCOpType structGetKind, TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value& result)
+{
+    auto structValue = typedStruct.value();
+    TypeKind resultKind = structType.field(fieldIndex).type.unpacked().kind;
+    if (structValue.isConst()) {
+        // This is the only constant struct currently possible.
+        ASSERT(JSValue::decode(structValue.asRef()).isNull());
+        emitThrowException(ExceptionType::NullAccess);
+        result = topValue(resultKind);
+        LOG_INSTRUCTION("StructGet", structValue, fieldIndex, "Exception");
+        return { };
+    }
+
+    Location structLocation = loadIfNecessary(structValue);
+    if (typedStruct.type().isNullable())
+        emitThrowOnNullReference(ExceptionType::NullAccess, structLocation);
+
+    unsigned fieldOffset = JSWebAssemblyStruct::offsetOfData() + structType.offsetOfFieldInPayload(fieldIndex);
+    RELEASE_ASSERT((std::numeric_limits<int32_t>::max() & fieldOffset) == fieldOffset);
+
+    consume(structValue);
+    result = topValue(resultKind);
+    Location resultLocation = allocate(result);
+
+    switch (result.type()) {
+    case TypeKind::I32:
+        if (structType.field(fieldIndex).type.is<PackedType>()) {
+            switch (structType.field(fieldIndex).type.as<PackedType>()) {
+            case PackedType::I8:
+                m_jit.load8(MacroAssembler::Address(structLocation.asGPRlo(), fieldOffset), resultLocation.asGPR());
+                break;
+            case PackedType::I16:
+                m_jit.load16(MacroAssembler::Address(structLocation.asGPRlo(), fieldOffset), resultLocation.asGPR());
+                break;
+            }
+            switch (structGetKind) {
+            case ExtGCOpType::StructGetU:
+                LOG_INSTRUCTION("StructGetU", structValue, fieldIndex, RESULT(result));
+                return { };
+            case ExtGCOpType::StructGetS: {
+                uint8_t bitShift = (sizeof(uint32_t) - structType.field(fieldIndex).type.elementSize()) * 8;
+                m_jit.lshift32(TrustedImm32(bitShift), resultLocation.asGPR());
+                m_jit.rshift32(TrustedImm32(bitShift), resultLocation.asGPR());
+                LOG_INSTRUCTION("StructGetS", structValue, fieldIndex, RESULT(result));
+                return { };
+            }
+            default:
+                RELEASE_ASSERT_NOT_REACHED();
+                return { };
+            }
+        }
+        m_jit.load32(MacroAssembler::Address(structLocation.asGPRlo(), fieldOffset), resultLocation.asGPR());
+        break;
+    case TypeKind::I64:
+        m_jit.loadPair32(MacroAssembler::Address(structLocation.asGPRlo(), fieldOffset), resultLocation.asGPRlo(), resultLocation.asGPRhi());
+        break;
+    case TypeKind::F32:
+        m_jit.loadFloat(MacroAssembler::Address(structLocation.asGPRlo(), fieldOffset), resultLocation.asFPR());
+        break;
+    case TypeKind::F64:
+        m_jit.loadDouble(MacroAssembler::Address(structLocation.asGPRlo(), fieldOffset), resultLocation.asFPR());
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+        break;
+    }
+
+    LOG_INSTRUCTION("StructGet", structValue, fieldIndex, RESULT(result));
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addStructSet(TypedExpression typedStruct, const StructType& structType, uint32_t fieldIndex, Value value)
+{
+    auto structValue = typedStruct.value();
+    if (structValue.isConst()) {
+        // This is the only constant struct currently possible.
+        ASSERT(JSValue::decode(structValue.asRef()).isNull());
+
+        LOG_INSTRUCTION("StructSet", structValue, fieldIndex, value, "Exception");
+        consume(value);
+        emitThrowException(ExceptionType::NullAccess);
+        return { };
+    }
+
+    Location structLocation = loadIfNecessary(structValue);
+    if (typedStruct.type().isNullable())
+        emitThrowOnNullReference(ExceptionType::NullAccess, structLocation);
+
+    bool needsWriteBarrier = emitStructSet(structLocation.asGPRlo(), structType, fieldIndex, value);
+    if (needsWriteBarrier)
+        emitWriteBarrier(structLocation.asGPRlo());
+
+    LOG_INSTRUCTION("StructSet", structValue, fieldIndex, value);
+
+    consume(structValue);
+
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefCast(TypedExpression reference, bool allowNull, int32_t heapType, ExpressionType& result)
+{
+    Vector<Value, 8> arguments = {
+        instanceValue(),
+        Value(reference),
+        Value::fromI32(allowNull),
+        Value::fromI32(heapType),
+    };
+    result = topValue(TypeKind::Ref);
+    emitCCall(operationWasmRefCast, arguments, result);
+    Location resultLocation = loadIfNecessary(result);
+
+    recordJumpToThrowException(ExceptionType::CastFailure,
+        m_jit.branch32(MacroAssembler::Equal, resultLocation.asGPRhi(), TrustedImm32(JSValue::EmptyValueTag)));
+
+    LOG_INSTRUCTION("RefCast", reference, allowNull, heapType, RESULT(result));
+
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefTest(TypedExpression reference, bool allowNull, int32_t heapType, bool shouldNegate, ExpressionType& result)
+{
+    Vector<Value, 8> arguments = {
+        instanceValue(),
+        Value(reference),
+        Value::fromI32(allowNull),
+        Value::fromI32(heapType),
+        Value::fromI32(shouldNegate),
+    };
+    result = topValue(TypeKind::I32);
+    emitCCall(operationWasmRefTest, arguments, result);
+
+    LOG_INSTRUCTION("RefTest", reference, allowNull, heapType, shouldNegate, RESULT(result));
+
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Add(Value lhs, Value rhs, Value& result)
+{
+    EMIT_BINARY(
+        "I64Add", TypeKind::I64,
+        BLOCK(Value::fromI64(lhs.asI64() + rhs.asI64())),
+        BLOCK(
+            m_jit.add64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRhi(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo());
+        ),
+        BLOCK(
+            ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
+            emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2));
+            m_jit.add64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRhi(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo());
+        )
+    );
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Sub(Value lhs, Value rhs, Value& result)
+{
+    EMIT_BINARY(
+        "I64Sub", TypeKind::I64,
+        BLOCK(Value::fromI64(lhs.asI64() - rhs.asI64())),
+        BLOCK(
+            m_jit.sub64(
+                lhsLocation.asGPRhi(), lhsLocation.asGPRlo(),
+                rhsLocation.asGPRhi(), rhsLocation.asGPRlo(),
+                resultLocation.asGPRhi(), resultLocation.asGPRlo()
+            );
+        ),
+        BLOCK(
+            ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
+            emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2));
+            m_jit.sub64(
+                lhsLocation.asGPRhi(), lhsLocation.asGPRlo(),
+                rhsLocation.asGPRhi(), rhsLocation.asGPRlo(),
+                resultLocation.asGPRhi(), resultLocation.asGPRlo()
+            );
+        )
+    );
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Mul(Value lhs, Value rhs, Value& result)
+{
+    EMIT_BINARY(
+        "I64Mul", TypeKind::I64,
+        BLOCK(Value::fromI64(lhs.asI64() * rhs.asI64())),
+        BLOCK(
+            m_jit.mul64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRhi(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo());
+        ),
+        BLOCK(
+            ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
+            emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2));
+            m_jit.mul64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRhi(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo());
+        )
+    );
+}
+
+void BBQJIT::emitThrowOnNullReference(ExceptionType type, Location ref)
+{
+    recordJumpToThrowException(type, m_jit.branch32(MacroAssembler::Equal, ref.asGPRhi(), TrustedImm32(JSValue::NullTag)));
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64And(Value lhs, Value rhs, Value& result)
+{
+    EMIT_BINARY(
+        "I64And", TypeKind::I64,
+        BLOCK(Value::fromI64(lhs.asI64() & rhs.asI64())),
+        BLOCK(
+            m_jit.and64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRhi(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo());
+        ),
+        BLOCK(
+            m_jit.move(ImmHelpers::regLocation(lhsLocation, rhsLocation).asGPRhi(), resultLocation.asGPRhi());
+            m_jit.move(ImmHelpers::regLocation(lhsLocation, rhsLocation).asGPRlo(), resultLocation.asGPRlo());
+            m_jit.and32(TrustedImm32(static_cast<int32_t>(ImmHelpers::imm(lhs, rhs).asI64() >> 32)), resultLocation.asGPRhi());
+            m_jit.and32(TrustedImm32(static_cast<int32_t>(ImmHelpers::imm(lhs, rhs).asI64() & 0xffffffff)), resultLocation.asGPRlo());
+        )
+    );
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Xor(Value lhs, Value rhs, Value& result)
+{
+    EMIT_BINARY(
+        "I64Xor", TypeKind::I64,
+        BLOCK(Value::fromI64(lhs.asI64() ^ rhs.asI64())),
+        BLOCK(
+            m_jit.xor64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRhi(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo());
+        ),
+        BLOCK(
+            m_jit.move(ImmHelpers::regLocation(lhsLocation, rhsLocation).asGPRhi(), resultLocation.asGPRhi());
+            m_jit.move(ImmHelpers::regLocation(lhsLocation, rhsLocation).asGPRlo(), resultLocation.asGPRlo());
+            m_jit.xor32(TrustedImm32(static_cast<int32_t>(ImmHelpers::imm(lhs, rhs).asI64() >> 32)), resultLocation.asGPRhi());
+            m_jit.xor32(TrustedImm32(static_cast<int32_t>(ImmHelpers::imm(lhs, rhs).asI64() & 0xffffffff)), resultLocation.asGPRlo());
+        )
+    );
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Or(Value lhs, Value rhs, Value& result)
+{
+    EMIT_BINARY(
+        "I64Or", TypeKind::I64,
+        BLOCK(Value::fromI64(lhs.asI64() | rhs.asI64())),
+        BLOCK(
+            m_jit.or64(lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRhi(), rhsLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo());
+        ),
+        BLOCK(
+            m_jit.move(ImmHelpers::regLocation(lhsLocation, rhsLocation).asGPRhi(), resultLocation.asGPRhi());
+            m_jit.move(ImmHelpers::regLocation(lhsLocation, rhsLocation).asGPRlo(), resultLocation.asGPRlo());
+            m_jit.or32(TrustedImm32(static_cast<int32_t>(ImmHelpers::imm(lhs, rhs).asI64() >> 32)), resultLocation.asGPRhi());
+            m_jit.or32(TrustedImm32(static_cast<int32_t>(ImmHelpers::imm(lhs, rhs).asI64() & 0xffffffff)), resultLocation.asGPRlo());
+        )
+    );
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Shl(Value lhs, Value rhs, Value& result)
+{
+    auto emitI64Shl = [&](Location lhsLocation, Location rhsLocation, Location resultLocation) {
+        ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
+
+        auto shiftReg = rhsLocation.asGPRlo();
+        auto resultLo = resultLocation.asGPRlo();
+        auto resultHi = resultLocation.asGPRhi();
+        auto lhsLo    = lhsLocation.asGPRlo();
+        auto lhsHi    = lhsLocation.asGPRhi();
+
+        auto shift = scratches.gpr(0);
+        auto tmp = scratches.gpr(1);
+
+        m_jit.and32(TrustedImm32(63), shiftReg, shift);
+
+        m_jit.sub32(shift, TrustedImm32(32), tmp);
+        m_jit.lshiftUnchecked(lhsHi, shift, resultHi);
+        m_jit.lshiftUnchecked(lhsLo, tmp, tmp);
+        m_jit.or32(resultHi, tmp, resultHi);
+
+        m_jit.sub32(TrustedImm32(32), shift, tmp);
+        m_jit.urshiftUnchecked(lhsLo, tmp, tmp);
+        m_jit.or32(resultHi, tmp, resultHi);
+        m_jit.lshiftUnchecked(lhsLo, shift, resultLo);
+    };
+
+    EMIT_BINARY(
+        "I64Shl", TypeKind::I64,
+        BLOCK(Value::fromI64(lhs.asI64() << rhs.asI64())),
+        BLOCK(
+            emitI64Shl(lhsLocation, rhsLocation, resultLocation);
+        ),
+        BLOCK(
+            ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
+            emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2));
+            emitI64Shl(lhsLocation, rhsLocation, resultLocation);
+        )
+    );
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ShrS(Value lhs, Value rhs, Value& result)
+{
+    auto emitI64ShrS = [&](Location lhsLocation, Location rhsLocation, Location resultLocation) {
+        ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
+
+        auto shiftReg = rhsLocation.asGPRlo();
+        auto resultLo = resultLocation.asGPRlo();
+        auto resultHi = resultLocation.asGPRhi();
+        auto lhsLo    = lhsLocation.asGPRlo();
+        auto lhsHi    = lhsLocation.asGPRhi();
+
+        auto shift = scratches.gpr(0);
+        auto tmp = scratches.gpr(1);
+
+        m_jit.and32(TrustedImm32(63), shiftReg, shift);
+
+        m_jit.urshiftUnchecked(lhsLo, shift, resultLo);
+
+        m_jit.sub32(TrustedImm32(32), shift, tmp);
+        m_jit.lshiftUnchecked(lhsHi, tmp, tmp);
+        m_jit.or32(tmp, resultLo);
+
+        m_jit.sub32(shift, TrustedImm32(32), tmp);
+        m_jit.rshiftUnchecked(lhsHi, tmp, tmp);
+        m_jit.or32(resultLo, tmp, tmp);
+        m_jit.moveConditionally32(RelationalCondition::AboveOrEqual, shift, TrustedImm32(32), tmp, resultLo, resultLo);
+
+        m_jit.rshiftUnchecked(lhsHi, shift, resultHi);
+    };
+
+    EMIT_BINARY(
+        "I64ShrS", TypeKind::I64,
+        BLOCK(Value::fromI64(lhs.asI64() >> rhs.asI64())),
+        BLOCK(
+            emitI64ShrS(lhsLocation, rhsLocation, resultLocation);
+        ),
+        BLOCK(
+            ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
+            emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2));
+            emitI64ShrS(lhsLocation, rhsLocation, resultLocation);
+        )
+    );
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ShrU(Value lhs, Value rhs, Value& result)
+{
+    auto emitI64ShrU = [&](Location lhsLocation, Location rhsLocation, Location resultLocation) {
+        ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
+
+        auto shiftReg = rhsLocation.asGPRlo();
+        auto resultLo = resultLocation.asGPRlo();
+        auto resultHi = resultLocation.asGPRhi();
+        auto lhsLo    = lhsLocation.asGPRlo();
+        auto lhsHi    = lhsLocation.asGPRhi();
+
+        auto shift = scratches.gpr(0);
+        auto tmp = scratches.gpr(1);
+
+        m_jit.and32(TrustedImm32(63), shiftReg, shift);
+
+        m_jit.urshiftUnchecked(lhsLo, shift, resultLo);
+
+        m_jit.sub32(TrustedImm32(32), shift, tmp);
+        m_jit.lshiftUnchecked(lhsHi, tmp, tmp);
+        m_jit.or32(tmp, resultLo);
+
+        m_jit.sub32(shift, TrustedImm32(32), tmp);
+        m_jit.urshiftUnchecked(lhsHi, tmp, tmp);
+        m_jit.or32(tmp, resultLo);
+
+        m_jit.urshiftUnchecked(lhsHi, shift, resultHi);
+    };
+
+    EMIT_BINARY(
+        "I64ShrU", TypeKind::I64,
+        BLOCK(Value::fromI64(static_cast<uint64_t>(lhs.asI64()) >> static_cast<uint64_t>(rhs.asI64()))),
+        BLOCK(
+            emitI64ShrU(lhsLocation, rhsLocation, resultLocation);
+        ),
+        BLOCK(
+            ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
+            emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2));
+            emitI64ShrU(lhsLocation, rhsLocation, resultLocation);
+        )
+    );
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Rotl(Value lhs, Value rhs, Value& result)
+{
+    PREPARE_FOR_SHIFT;
+    EMIT_BINARY(
+        "I64Rotl", TypeKind::I64,
+        BLOCK(Value::fromI64(B3::rotateLeft(lhs.asI64(), rhs.asI64()))),
+        BLOCK(
+            rotI64Helper(RotI64HelperOp::Left, lhsLocation, rhsLocation, resultLocation);
+        ),
+        BLOCK(
+            ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
+            emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2));
+            rotI64Helper(RotI64HelperOp::Left, lhsLocation, rhsLocation, resultLocation);
+        )
+    );
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Rotr(Value lhs, Value rhs, Value& result)
+{
+    PREPARE_FOR_SHIFT;
+    EMIT_BINARY(
+        "I64Rotr", TypeKind::I64,
+        BLOCK(Value::fromI64(B3::rotateRight(lhs.asI64(), rhs.asI64()))),
+        BLOCK(
+            rotI64Helper(RotI64HelperOp::Right, lhsLocation, rhsLocation, resultLocation);
+        ),
+        BLOCK(
+            ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
+            emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2));
+            rotI64Helper(RotI64HelperOp::Right, lhsLocation, rhsLocation, resultLocation);
+        )
+    );
+}
+
+void BBQJIT::rotI64Helper(RotI64HelperOp op, Location lhsLocation, Location rhsLocation, Location resultLocation)
+{
+    // NB: this only works as long as result is allocated in lhsLocation!
+    auto carry = rhsLocation.asGPRhi();
+    auto shift = rhsLocation.asGPRlo();
+    ScratchScope<2, 0> scratches(*this, lhsLocation, rhsLocation, resultLocation);
+    auto tmpHi = scratches.gpr(0);
+    auto tmpLo = scratches.gpr(1);
+    m_jit.move(lhsLocation.asGPRhi(), resultLocation.asGPRhi());
+    m_jit.move(lhsLocation.asGPRlo(), resultLocation.asGPRlo());
+    m_jit.and32(TrustedImm32(63), shift, shift);
+    auto rotate = m_jit.branch32(RelationalCondition::LessThan, shift, TrustedImm32(32));
+    // swap
+    m_jit.swap(resultLocation.asGPRhi(), resultLocation.asGPRlo());
+    rotate.link(&m_jit);
+    m_jit.and32(TrustedImm32(31), shift, shift);
+    auto zero = m_jit.branch32(RelationalCondition::Equal, shift, TrustedImm32(0));
+    // rotate
+    m_jit.move(TrustedImm32(32), carry);
+    m_jit.sub32(carry, shift, carry);
+    if (op == RotI64HelperOp::Left) {
+        m_jit.urshift32(resultLocation.asGPRhi(), carry, tmpLo);
+        m_jit.urshift32(resultLocation.asGPRlo(), carry, tmpHi);
+        m_jit.lshift32(resultLocation.asGPRhi(), shift, resultLocation.asGPRhi());
+        m_jit.lshift32(resultLocation.asGPRlo(), shift, resultLocation.asGPRlo());
+    } else if (op == RotI64HelperOp::Right) {
+        m_jit.lshift32(resultLocation.asGPRhi(), carry, tmpLo);
+        m_jit.lshift32(resultLocation.asGPRlo(), carry, tmpHi);
+        m_jit.urshift32(resultLocation.asGPRhi(), shift, resultLocation.asGPRhi());
+        m_jit.urshift32(resultLocation.asGPRlo(), shift, resultLocation.asGPRlo());
+    }
+    m_jit.or32(tmpHi, resultLocation.asGPRhi());
+    m_jit.or32(tmpLo, resultLocation.asGPRlo());
+    zero.link(&m_jit);
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Clz(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "I64Clz", TypeKind::I64,
+        BLOCK(Value::fromI64(WTF::clz(operand.asI64()))),
+        BLOCK(
+            m_jit.countLeadingZeros64(operandLocation.asGPRhi(), operandLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo());
+        )
+    );
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Ctz(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "I64Ctz", TypeKind::I64,
+        BLOCK(Value::fromI64(WTF::ctz(operand.asI64()))),
+        BLOCK(
+            m_jit.countTrailingZeros64(operandLocation.asGPRhi(), operandLocation.asGPRlo(), resultLocation.asGPRhi(), resultLocation.asGPRlo());
+        )
+    );
+}
+
+PartialResult BBQJIT::emitCompareI64(const char* opcode, Value& lhs, Value& rhs, Value& result, RelationalCondition condition, bool (*comparator)(int64_t lhs, int64_t rhs))
+{
+    EMIT_BINARY(
+        opcode, TypeKind::I32,
+        BLOCK(Value::fromI32(static_cast<int32_t>(comparator(lhs.asI64(), rhs.asI64())))),
+        BLOCK(
+            m_jit.compare64(condition, lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRhi(), rhsLocation.asGPRlo(), resultLocation.asGPR());
+        ),
+        BLOCK(
+            ImmHelpers::immLocation(lhsLocation, rhsLocation) = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
+            emitMoveConst(ImmHelpers::imm(lhs, rhs), Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2));
+            m_jit.compare64(condition, lhsLocation.asGPRhi(), lhsLocation.asGPRlo(), rhsLocation.asGPRhi(), rhsLocation.asGPRlo(), resultLocation.asGPR());
+        )
+    )
+}
+
+PartialResult BBQJIT::addI32WrapI64(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "I32WrapI64", TypeKind::I32,
+        BLOCK(Value::fromI32(static_cast<int32_t>(operand.asI64()))),
+        BLOCK(
+            m_jit.move(operandLocation.asGPRlo(), resultLocation.asGPR());
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend8S(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "I64Extend8S", TypeKind::I64,
+        BLOCK(Value::fromI64(static_cast<int64_t>(static_cast<int8_t>(operand.asI64())))),
+        BLOCK(
+            GPRReg operandReg = operandLocation.isGPR() ? operandLocation.asGPR() : operandLocation.asGPRlo();
+            m_jit.signExtend8To32(operandReg, resultLocation.asGPRlo());
+            m_jit.rshift32(resultLocation.asGPRlo(), TrustedImm32(31), resultLocation.asGPRhi());
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend16S(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "I64Extend16S", TypeKind::I64,
+        BLOCK(Value::fromI64(static_cast<int64_t>(static_cast<int16_t>(operand.asI64())))),
+        BLOCK(
+            GPRReg operandReg = operandLocation.isGPR() ? operandLocation.asGPR() : operandLocation.asGPRlo();
+            m_jit.signExtend16To32(operandReg, resultLocation.asGPRlo());
+            m_jit.rshift32(resultLocation.asGPRlo(), TrustedImm32(31), resultLocation.asGPRhi());
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Extend32S(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "I64Extend32S", TypeKind::I64,
+        BLOCK(Value::fromI64(static_cast<int64_t>(static_cast<int32_t>(operand.asI64())))),
+        BLOCK(
+            GPRReg operandReg = operandLocation.isGPR() ? operandLocation.asGPR() : operandLocation.asGPRlo();
+            m_jit.move(operandReg, resultLocation.asGPRlo());
+            m_jit.rshift32(resultLocation.asGPRlo(), TrustedImm32(31), resultLocation.asGPRhi());
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ExtendSI32(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "I64ExtendSI32", TypeKind::I64,
+        BLOCK(Value::fromI64(static_cast<int64_t>(operand.asI32()))),
+        BLOCK(
+            GPRReg operandReg = operandLocation.isGPR() ? operandLocation.asGPR() : operandLocation.asGPRlo();
+            m_jit.move(operandReg, resultLocation.asGPRlo());
+            m_jit.rshift32(resultLocation.asGPRlo(), TrustedImm32(31), resultLocation.asGPRhi());
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ExtendUI32(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "I64ExtendUI32", TypeKind::I64,
+        BLOCK(Value::fromI64(static_cast<uint64_t>(static_cast<uint32_t>(operand.asI32())))),
+        BLOCK(
+            GPRReg operandReg = operandLocation.isGPR() ? operandLocation.asGPR() : operandLocation.asGPRlo();
+            m_jit.move(operandReg, resultLocation.asGPRlo());
+            m_jit.xor32(resultLocation.asGPRhi(), resultLocation.asGPRhi());
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64Eqz(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "I64Eqz", TypeKind::I32,
+        BLOCK(Value::fromI32(!operand.asI64())),
+        BLOCK(
+            m_jit.or32(operandLocation.asGPRhi(), operandLocation.asGPRlo(), resultLocation.asGPR());
+            m_jit.test32(ResultCondition::Zero, resultLocation.asGPR(), resultLocation.asGPR(), resultLocation.asGPR());
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addI64ReinterpretF64(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "I64ReinterpretF64", TypeKind::I64,
+        BLOCK(Value::fromI64(std::bit_cast<int64_t>(operand.asF64()))),
+        BLOCK(
+            m_jit.moveDoubleTo64(operandLocation.asFPR(), resultLocation.asGPRhi(), resultLocation.asGPRlo());
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ReinterpretI64(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "F64ReinterpretI64", TypeKind::F64,
+        BLOCK(Value::fromF64(std::bit_cast<double>(operand.asI64()))),
+        BLOCK(
+            m_jit.moveIntsToDouble(operandLocation.asGPRlo(), operandLocation.asGPRhi(), resultLocation.asFPR());
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertUI32(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "F32ConvertUI32", TypeKind::F32,
+        BLOCK(Value::fromF32(static_cast<uint32_t>(operand.asI32()))),
+        BLOCK(
+            m_jit.convertUInt32ToFloat(operandLocation.asGPR(), resultLocation.asFPR());
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertSI64(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "F32ConvertSI64", TypeKind::F32,
+        BLOCK(Value::fromF32(operand.asI64())),
+        BLOCK(
+            auto arg = Value::pinned(TypeKind::I64, operandLocation);
+            consume(result);
+            emitCCall(Math::f32_convert_s_i64, Vector<Value, 8> { arg }, result);
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32ConvertUI64(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "F32ConvertUI64", TypeKind::F32,
+        BLOCK(Value::fromF32(static_cast<uint64_t>(operand.asI64()))),
+        BLOCK(
+            auto arg = Value::pinned(TypeKind::I64, operandLocation);
+            consume(result);
+            emitCCall(Math::f32_convert_u_i64, Vector<Value, 8> { arg }, result);
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertUI32(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "F64ConvertUI32", TypeKind::F64,
+        BLOCK(Value::fromF64(static_cast<uint32_t>(operand.asI32()))),
+        BLOCK(
+            m_jit.convertUInt32ToDouble(operandLocation.asGPR(), resultLocation.asFPR());
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertSI64(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "F64ConvertSI64", TypeKind::F64,
+        BLOCK(Value::fromF64(operand.asI64())),
+        BLOCK(
+            auto arg = Value::pinned(TypeKind::I64, operandLocation);
+            consume(result);
+            emitCCall(Math::f64_convert_s_i64, Vector<Value, 8> { arg }, result);
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64ConvertUI64(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "F64ConvertUI64", TypeKind::F64,
+        BLOCK(Value::fromF64(static_cast<uint64_t>(operand.asI64()))),
+        BLOCK(
+            auto arg = Value::pinned(TypeKind::I64, operandLocation);
+            consume(result);
+            emitCCall(Math::f64_convert_u_i64, Vector<Value, 8> { arg }, result);
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Floor(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "F32Floor", TypeKind::F32,
+        BLOCK(Value::fromF32(Math::floorFloat(operand.asF32()))),
+        BLOCK(
+            auto arg = Value::pinned(TypeKind::F32, operandLocation);
+            consume(result);
+            emitCCall(Math::floorFloat, Vector<Value, 8> { arg }, result);
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Floor(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "F64Floor", TypeKind::F64,
+        BLOCK(Value::fromF64(Math::floorDouble(operand.asF64()))),
+        BLOCK(
+            auto arg = Value::pinned(TypeKind::F64, operandLocation);
+            consume(result);
+            emitCCall(Math::floorDouble, Vector<Value, 8> { arg }, result);
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Ceil(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "F32Ceil", TypeKind::F32,
+        BLOCK(Value::fromF32(Math::ceilFloat(operand.asF32()))),
+        BLOCK(
+            auto arg = Value::pinned(TypeKind::F32, operandLocation);
+            consume(result);
+            emitCCall(Math::ceilFloat, Vector<Value, 8> { arg }, result);
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Ceil(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "F64Ceil", TypeKind::F64,
+        BLOCK(Value::fromF64(Math::ceilDouble(operand.asF64()))),
+        BLOCK(
+            auto arg = Value::pinned(TypeKind::F64, operandLocation);
+            consume(result);
+            emitCCall(Math::ceilDouble, Vector<Value, 8> { arg }, result);
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Nearest(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "F32Nearest", TypeKind::F32,
+        BLOCK(Value::fromF32(std::nearbyintf(operand.asF32()))),
+        BLOCK(
+            auto arg = Value::pinned(TypeKind::F32, operandLocation);
+            consume(result);
+            emitCCall(Math::f32_nearest, Vector<Value, 8> { arg }, result);
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Nearest(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "F64Nearest", TypeKind::F64,
+        BLOCK(Value::fromF64(std::nearbyint(operand.asF64()))),
+        BLOCK(
+            auto arg = Value::pinned(TypeKind::F64, operandLocation);
+            consume(result);
+            emitCCall(Math::f64_nearest, Vector<Value, 8> { arg }, result);
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF32Trunc(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "F32Trunc", TypeKind::F32,
+        BLOCK(Value::fromF32(Math::truncFloat(operand.asF32()))),
+        BLOCK(
+            auto arg = Value::pinned(TypeKind::F32, operandLocation);
+            consume(result);
+            emitCCall(Math::truncFloat, Vector<Value, 8> { arg }, result);
+        )
+    )
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addF64Trunc(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "F64Trunc", TypeKind::F64,
+        BLOCK(Value::fromF64(Math::truncDouble(operand.asF64()))),
+        BLOCK(
+            auto arg = Value::pinned(TypeKind::F64, operandLocation);
+            consume(result);
+            emitCCall(Math::truncDouble, Vector<Value, 8> { arg }, result);
+        )
+    )
+}
+
+// References
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefIsNull(Value operand, Value& result)
+{
+    EMIT_UNARY(
+        "RefIsNull", TypeKind::I32,
+        BLOCK(Value::fromI32(operand.asRef() == JSValue::encode(jsNull()))),
+        BLOCK(
+            m_jit.compare32(RelationalCondition::Equal, operandLocation.asGPRhi(), TrustedImm32(JSValue::NullTag), resultLocation.asGPR());
+        )
+    );
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRefAsNonNull(Value value, Value& result)
+{
+    Location valueLocation;
+    if (value.isConst()) {
+        valueLocation = Location::fromGPR2(wasmScratchGPR, wasmScratchGPR2);
+        emitMoveConst(value, valueLocation);
+    } else
+        valueLocation = loadIfNecessary(value);
+    ASSERT(valueLocation.isGPR2());
+    consume(value);
+
+    result = topValue(TypeKind::Ref);
+    Location resultLocation = allocate(result);
+    recordJumpToThrowException(ExceptionType::NullRefAsNonNull, m_jit.branch32(RelationalCondition::Equal, valueLocation.asGPRhi(), TrustedImm32(JSValue::NullTag)));
+    emitMove(TypeKind::Ref, valueLocation, resultLocation);
+
+    return { };
+}
+
+void BBQJIT::emitCatchPrologue()
+{
+    m_frameSizeLabels.append(m_jit.moveWithPatch(TrustedImmPtr(nullptr), GPRInfo::nonPreservedNonArgumentGPR0));
+    m_jit.subPtr(GPRInfo::callFrameRegister, GPRInfo::nonPreservedNonArgumentGPR0, wasmScratchGPR);
+    m_jit.move(wasmScratchGPR, MacroAssembler::stackPointerRegister);
+
+    static_assert(noOverlap(GPRInfo::nonPreservedNonArgumentGPR0, GPRInfo::returnValueGPR, GPRInfo::returnValueGPR2));
+}
+
+void BBQJIT::emitCatchAllImpl(ControlData& dataCatch)
+{
+    m_catchEntrypoints.append(m_jit.label());
+    emitCatchPrologue();
+    bind(this->exception(dataCatch), Location::fromGPR2(GPRInfo::returnValueGPR2, GPRInfo::returnValueGPR));
+    Stack emptyStack { };
+    dataCatch.startBlock(*this, emptyStack);
+}
+
+void BBQJIT::emitCatchImpl(ControlData& dataCatch, const TypeDefinition& exceptionSignature, ResultList& results)
+{
+    m_catchEntrypoints.append(m_jit.label());
+    emitCatchPrologue();
+    bind(this->exception(dataCatch), Location::fromGPR2(GPRInfo::returnValueGPR2, GPRInfo::returnValueGPR));
+    Stack emptyStack { };
+    dataCatch.startBlock(*this, emptyStack);
+
+    if (exceptionSignature.as<FunctionSignature>()->argumentCount()) {
+        ScratchScope<1, 0> scratches(*this);
+        GPRReg bufferGPR = scratches.gpr(0);
+        m_jit.loadPtr(Address(GPRInfo::returnValueGPR, JSWebAssemblyException::offsetOfPayload() + JSWebAssemblyException::Payload::offsetOfStorage()), bufferGPR);
+        unsigned offset = 0;
+        for (unsigned i = 0; i < exceptionSignature.as<FunctionSignature>()->argumentCount(); ++i) {
+            Type type = exceptionSignature.as<FunctionSignature>()->argumentType(i);
+            Value result = Value::fromTemp(type.kind, dataCatch.enclosedHeight() + dataCatch.implicitSlots() + i);
+            Location slot = canonicalSlot(result);
+            switch (type.kind) {
+            case TypeKind::I32:
+                m_jit.load32(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), wasmScratchGPR);
+                m_jit.store32(wasmScratchGPR, slot.asAddress());
+                break;
+            case TypeKind::I31ref:
+            case TypeKind::I64:
+            case TypeKind::Ref:
+            case TypeKind::RefNull:
+            case TypeKind::Arrayref:
+            case TypeKind::Structref:
+            case TypeKind::Funcref:
+            case TypeKind::Exnref:
+            case TypeKind::Externref:
+            case TypeKind::Eqref:
+            case TypeKind::Anyref:
+            case TypeKind::Noexnref:
+            case TypeKind::Noneref:
+            case TypeKind::Nofuncref:
+            case TypeKind::Noexternref:
+            case TypeKind::Rec:
+            case TypeKind::Sub:
+            case TypeKind::Subfinal:
+            case TypeKind::Array:
+            case TypeKind::Struct:
+            case TypeKind::Func: {
+                m_jit.loadPair32(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), wasmScratchGPR, wasmScratchGPR2);
+                m_jit.storePair32(wasmScratchGPR, wasmScratchGPR2, slot.asAddress());
+                break;
+            }
+            case TypeKind::F32:
+                m_jit.loadFloat(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), wasmScratchFPR);
+                m_jit.storeFloat(wasmScratchFPR, slot.asAddress());
+                break;
+            case TypeKind::F64:
+                m_jit.loadDouble(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), wasmScratchFPR);
+                m_jit.storeDouble(wasmScratchFPR, slot.asAddress());
+                break;
+            case TypeKind::V128:
+                m_jit.loadVector(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), wasmScratchFPR);
+                m_jit.storeVector(wasmScratchFPR, slot.asAddress());
+                break;
+            case TypeKind::Void:
+                RELEASE_ASSERT_NOT_REACHED();
+                break;
+            }
+            bind(result, slot);
+            results.append(result);
+            offset += type.kind == TypeKind::V128 ? 2 : 1;
+        }
+    }
+}
+
+void BBQJIT::emitCatchTableImpl(ControlData& entryData, ControlType::TryTableTarget& target)
+{
+    HandlerType handlerType;
+    switch (target.type) {
+    case CatchKind::Catch:
+        handlerType = HandlerType::TryTableCatch;
+        break;
+    case CatchKind::CatchRef:
+        handlerType = HandlerType::TryTableCatchRef;
+        break;
+    case CatchKind::CatchAll:
+        handlerType = HandlerType::TryTableCatchAll;
+        break;
+    case CatchKind::CatchAllRef:
+        handlerType = HandlerType::TryTableCatchAllRef;
+        break;
+    }
+
+    JIT_COMMENT(m_jit, "catch handler");
+    m_catchEntrypoints.append(m_jit.label());
+    m_exceptionHandlers.append({ handlerType, entryData.tryStart(), m_callSiteIndex, 0, m_tryCatchDepth, target.tag });
+    emitCatchPrologue();
+
+    auto& targetControl = m_parser->resolveControlRef(target.target).controlData;
+    if (target.type == CatchKind::CatchRef || target.type == CatchKind::CatchAllRef) {
+        if (targetControl.targetLocations().last().isGPR())
+            m_jit.move(GPRInfo::returnValueGPR, targetControl.targetLocations().last().asGPR());
+        else if (targetControl.targetLocations().last().isGPR2()) {
+            m_jit.move(GPRInfo::returnValueGPR, targetControl.targetLocations().last().asGPRlo());
+            m_jit.move(GPRInfo::returnValueGPR2, targetControl.targetLocations().last().asGPRhi());
+        } else
+            m_jit.storePtr(GPRInfo::returnValueGPR, targetControl.targetLocations().last().asAddress());
+    }
+
+    if (target.type == CatchKind::Catch || target.type == CatchKind::CatchRef) {
+        auto signature = target.exceptionSignature->template as<FunctionSignature>();
+        if (signature->argumentCount()) {
+            ScratchScope<1, 0> scratches(*this);
+            GPRReg bufferGPR = scratches.gpr(0);
+            m_jit.loadPtr(Address(GPRInfo::returnValueGPR, JSWebAssemblyException::offsetOfPayload() + JSWebAssemblyException::Payload::offsetOfStorage()), bufferGPR);
+            unsigned offset = 0;
+            for (unsigned i = 0; i < signature->argumentCount(); ++i) {
+                Type type = signature->argumentType(i);
+                Location slot = targetControl.targetLocations()[i];
+                switch (type.kind) {
+                case TypeKind::I32:
+                    if (slot.isGPR())
+                        m_jit.load32(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), slot.asGPR());
+                    else
+                        m_jit.transfer32(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), slot.asAddress());
+                    break;
+                case TypeKind::I31ref:
+                case TypeKind::I64:
+                case TypeKind::Ref:
+                case TypeKind::RefNull:
+                case TypeKind::Arrayref:
+                case TypeKind::Structref:
+                case TypeKind::Funcref:
+                case TypeKind::Exnref:
+                case TypeKind::Externref:
+                case TypeKind::Eqref:
+                case TypeKind::Anyref:
+                case TypeKind::Noexnref:
+                case TypeKind::Noneref:
+                case TypeKind::Nofuncref:
+                case TypeKind::Noexternref:
+                case TypeKind::Rec:
+                case TypeKind::Sub:
+                case TypeKind::Subfinal:
+                case TypeKind::Array:
+                case TypeKind::Struct:
+                case TypeKind::Func:
+                    if (slot.isGPR2())
+                        m_jit.loadPair32(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), slot.asGPRlo(), slot.asGPRhi());
+                    else {
+                        m_jit.loadPair32(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), wasmScratchGPR, wasmScratchGPR2);
+                        m_jit.storePair32(wasmScratchGPR, wasmScratchGPR2, slot.asAddress());
+                    }
+                    break;
+                case TypeKind::F32:
+                    if (slot.isFPR())
+                        m_jit.loadFloat(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), slot.asFPR());
+                    else {
+                        m_jit.loadFloat(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), wasmScratchFPR);
+                        m_jit.storeFloat(wasmScratchFPR, slot.asAddress());
+                    }
+                    break;
+                case TypeKind::F64:
+                    if (slot.isFPR())
+                        m_jit.loadDouble(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), slot.asFPR());
+                    else {
+                        m_jit.loadDouble(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), wasmScratchFPR);
+                        m_jit.storeDouble(wasmScratchFPR, slot.asAddress());
+                    }
+                    break;
+                case TypeKind::V128:
+                    m_jit.loadVector(Address(bufferGPR, JSWebAssemblyException::Payload::Storage::offsetOfData() + offset * sizeof(uint64_t)), wasmScratchFPR);
+                    m_jit.storeVector(wasmScratchFPR, slot.asAddress());
+                    break;
+                case TypeKind::Void:
+                    RELEASE_ASSERT_NOT_REACHED();
+                    break;
+                }
+                offset += type.kind == TypeKind::V128 ? 2 : 1;
+            }
+        }
+    }
+
+    // jump to target
+    targetControl.addBranch(m_jit.jump());
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addThrowRef(Value exception, Stack&)
+{
+    LOG_INSTRUCTION("ThrowRef", exception);
+
+    emitMove(exception, Location::fromGPR2(GPRInfo::argumentGPR2, GPRInfo::argumentGPR3));
+    consume(exception);
+
+    ++m_callSiteIndex;
+    if (m_profiledCallee.hasExceptionHandlers()) {
+        m_jit.store32(CCallHelpers::TrustedImm32(m_callSiteIndex), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
+        flushRegisters();
+    }
+
+    // Check for a null exception
+    auto noexnref = m_jit.branch32(CCallHelpers::Equal, GPRInfo::argumentGPR2, TrustedImm32(JSValue::NullTag));
+
+    m_jit.move(GPRInfo::wasmContextInstancePointer, GPRInfo::argumentGPR0);
+    emitThrowRefImpl(m_jit);
+
+    noexnref.linkTo(m_jit.label(), &m_jit);
+
+    emitThrowException(ExceptionType::NullExnrefReference);
+
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addRethrow(unsigned, ControlType& data)
+{
+    LOG_INSTRUCTION("Rethrow", exception(data));
+
+    ++m_callSiteIndex;
+    if (m_profiledCallee.hasExceptionHandlers()) {
+        m_jit.store32(CCallHelpers::TrustedImm32(m_callSiteIndex), CCallHelpers::tagFor(CallFrameSlot::argumentCountIncludingThis));
+        flushRegisters();
+    }
+    emitMove(this->exception(data), Location::fromGPR2(GPRInfo::argumentGPR3, GPRInfo::argumentGPR2));
+    m_jit.move(GPRInfo::wasmContextInstancePointer, GPRInfo::argumentGPR0);
+    emitThrowRefImpl(m_jit);
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addBranchNull(ControlData& data, ExpressionType reference, Stack& returnValues, bool shouldNegate, ExpressionType& result)
+{
+    if (reference.isConst() && (reference.asRef() == JSValue::encode(jsNull())) == shouldNegate) {
+        // If branch is known to be not-taken, exit early.
+        if (!shouldNegate)
+            result = reference;
+        return { };
+    }
+
+    // The way we use referenceLocation is a little tricky, here's the breakdown:
+    //
+    //  - For a br_on_null, we discard the reference when the branch is taken. In
+    //    this case, we consume the reference as if it was popped (since it was),
+    //    but use its referenceLocation after the branch. This is safe, because
+    //    in the case we don't take the branch, the only operations between
+    //    materializing the ref and writing the result are (1) flushing at the
+    //    block boundary, which can't overwrite non-scratch registers, and (2)
+    //    emitting the branch, which uses the ref but doesn't clobber it. So the
+    //    ref will be live in the same register if we didn't take the branch.
+    //
+    //  - For a br_on_non_null, we discard the reference when we don't take the
+    //    branch. Because the ref is on the expression stack in this case when we
+    //    emit the branch, we don't want to eagerly consume() it - it's not used
+    //    until it's passed as a parameter to the branch target. So, we don't
+    //    consume the value, and rely on block parameter passing logic to ensure
+    //    it's left in the right place.
+    //
+    // Between these cases, we ensure that the reference value is live in
+    // referenceLocation by the time we reach its use.
+
+    Location referenceLocation;
+    if (!reference.isConst())
+        referenceLocation = loadIfNecessary(reference);
+    if (!shouldNegate)
+        consume(reference);
+
+    LOG_INSTRUCTION(shouldNegate ? "BrOnNonNull" : "BrOnNull", reference);
+
+    if (reference.isConst()) {
+        // If we didn't exit early, the branch must be always-taken.
+        currentControlData().flushAndSingleExit(*this, data, returnValues, false, false);
+        data.addBranch(m_jit.jump());
+    } else {
+        ASSERT(referenceLocation.isGPR2());
+        currentControlData().flushAtBlockBoundary(*this, 0, returnValues, false);
+        Jump ifNotTaken = m_jit.branch32(shouldNegate ? CCallHelpers::Equal : CCallHelpers::NotEqual, referenceLocation.asGPRhi(), TrustedImm32(JSValue::NullTag));
+        currentControlData().addExit(*this, data.targetLocations(), returnValues);
+        data.addBranch(m_jit.jump());
+        ifNotTaken.link(&m_jit);
+        currentControlData().finalizeBlock(*this, data.targetLocations().size(), returnValues, true);
+    }
+
+    if (!shouldNegate) {
+        result = topValue(reference.type());
+        Location resultLocation = allocate(result);
+        if (reference.isConst())
+            emitMoveConst(reference, resultLocation);
+        else
+            emitMove(reference.type(), referenceLocation, resultLocation);
+    }
+
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addBranchCast(ControlData& data, ExpressionType reference, Stack& returnValues, bool allowNull, int32_t heapType, bool shouldNegate)
+{
+    Value condition;
+    if (reference.isConst()) {
+        JSValue refValue = JSValue::decode(reference.asRef());
+        ASSERT(refValue.isNull() || refValue.isNumber());
+        if (refValue.isNull())
+            condition = Value::fromI32(static_cast<uint32_t>(shouldNegate ? !allowNull : allowNull));
+        else {
+            bool matches = isSubtype(Type { TypeKind::Ref, static_cast<TypeIndex>(TypeKind::I31ref) }, Type { TypeKind::Ref, static_cast<TypeIndex>(heapType) });
+            condition = Value::fromI32(shouldNegate ? !matches : matches);
+        }
+    } else {
+        // Use an indirection for the reference to avoid it getting consumed here.
+        Value tempReference = Value::pinned(TypeKind::Ref, Location::fromGPR2(wasmScratchGPR2, wasmScratchGPR));
+        emitMove(reference, locationOf(tempReference));
+
+        Vector<Value, 8> arguments = {
+            instanceValue(),
+            tempReference,
+            Value::fromI32(allowNull),
+            Value::fromI32(heapType),
+            Value::fromI32(shouldNegate),
+        };
+        condition = topValue(TypeKind::I32);
+        emitCCall(operationWasmRefTest, arguments, condition);
+    }
+
+    WASM_FAIL_IF_HELPER_FAILS(addBranch(data, condition, returnValues));
+
+    LOG_INSTRUCTION("BrOnCast/CastFail", reference);
+
+    return { };
+}
+
+int BBQJIT::alignedFrameSize(int frameSize) const
+{
+    // On armv7 account for misalignment due to of saved {FP, PC}
+    constexpr int misalignment = 4 + 4;
+    return WTF::roundUpToMultipleOf<stackAlignmentBytes()>(frameSize + misalignment) - misalignment;
+}
+
+void BBQJIT::restoreWebAssemblyGlobalState()
+{
+    restoreWebAssemblyContextInstance();
+}
+
+void BBQJIT::restoreWebAssemblyGlobalStateAfterWasmCall()
+{
+    restoreWebAssemblyGlobalState();
+}
+
+// SIMD
+
+void BBQJIT::notifyFunctionUsesSIMD()
+{
+    m_usesSIMD = false;
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoad(ExpressionType, uint32_t, ExpressionType&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDStore(ExpressionType, ExpressionType, uint32_t)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadSplat(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t, ExpressionType&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+void BBQJIT::materializeVectorConstant(v128_t, Location)
+{
+    UNREACHABLE_FOR_PLATFORM();
+}
+
+ExpressionType BBQJIT::addSIMDConstant(v128_t)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDExtractLane(SIMDInfo, uint8_t, Value, Value&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addSIMDRelaxedFMA(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
+{
+    UNREACHABLE_FOR_PLATFORM();
+    return { };
+
+}
+
+void BBQJIT::emitStoreConst(Value constant, Location loc)
+{
+    LOG_INSTRUCTION("Store", constant, RESULT(loc));
+
+    ASSERT(constant.isConst());
+    ASSERT(loc.isMemory());
+
+    switch (constant.type()) {
+    case TypeKind::I32:
+    case TypeKind::F32:
+        m_jit.store32(Imm32(constant.asI32()), loc.asAddress());
+        break;
+    case TypeKind::Ref:
+    case TypeKind::Funcref:
+    case TypeKind::Arrayref:
+    case TypeKind::Structref:
+    case TypeKind::RefNull:
+    case TypeKind::Exnref:
+    case TypeKind::Externref:
+    case TypeKind::Eqref:
+    case TypeKind::Anyref:
+    case TypeKind::Noexnref:
+    case TypeKind::Noneref:
+    case TypeKind::Nofuncref:
+    case TypeKind::Noexternref:
+        m_jit.storePair32(TrustedImm32(constant.asI64lo()), TrustedImm32(constant.asI64hi()), loc.asAddress());
+        break;
+    case TypeKind::I64:
+    case TypeKind::F64:
+        m_jit.storePair32(TrustedImm32(constant.asI64lo()), TrustedImm32(constant.asI64hi()), loc.asAddress());
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unimplemented constant typekind.");
+        break;
+    }
+}
+
+void BBQJIT::emitMoveConst(Value constant, Location loc)
+{
+    ASSERT(constant.isConst());
+
+    if (loc.isMemory())
+        return emitStoreConst(constant, loc);
+
+    ASSERT(loc.isRegister());
+    ASSERT(loc.isFPR() == constant.isFloat());
+
+    if (!isScratch(loc))
+        LOG_INSTRUCTION("Move", constant, RESULT(loc));
+
+    switch (constant.type()) {
+    case TypeKind::I32:
+        m_jit.move(Imm32(constant.asI32()), loc.asGPR());
+        break;
+    case TypeKind::I64:
+        m_jit.move(Imm32(constant.asI64hi()), loc.asGPRhi());
+        m_jit.move(Imm32(constant.asI64lo()), loc.asGPRlo());
+        break;
+    case TypeKind::Ref:
+    case TypeKind::Funcref:
+    case TypeKind::Arrayref:
+    case TypeKind::Structref:
+    case TypeKind::RefNull:
+    case TypeKind::Exnref:
+    case TypeKind::Externref:
+    case TypeKind::Eqref:
+    case TypeKind::Anyref:
+    case TypeKind::Noexnref:
+    case TypeKind::Noneref:
+    case TypeKind::Nofuncref:
+    case TypeKind::Noexternref:
+        m_jit.move(Imm32(constant.asI64hi()), loc.asGPRhi());
+        m_jit.move(Imm32(constant.asI64lo()), loc.asGPRlo());
+        break;
+    case TypeKind::F32:
+        m_jit.move32ToFloat(Imm32(constant.asI32()), loc.asFPR());
+        break;
+    case TypeKind::F64:
+        m_jit.move64ToDouble(Imm64(constant.asI64()), loc.asFPR());
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unimplemented constant typekind.");
+        break;
+    }
+}
+
+void BBQJIT::emitStore(TypeKind type, Location src, Location dst)
+{
+    ASSERT(dst.isMemory());
+    ASSERT(src.isRegister());
+
+    switch (type) {
+    case TypeKind::I32:
+        m_jit.store32(src.asGPR(), dst.asAddress());
+        break;
+    case TypeKind::I31ref:
+        m_jit.store32(src.asGPRlo(), dst.asAddress());
+        m_jit.store32(TrustedImm32(JSValue::Int32Tag), dst.asAddress().withOffset(4));
+        break;
+    case TypeKind::I64:
+        m_jit.storePair32(src.asGPRlo(), src.asGPRhi(), dst.asAddress());
+        break;
+    case TypeKind::F32:
+        m_jit.storeFloat(src.asFPR(), dst.asAddress());
+        break;
+    case TypeKind::F64:
+        m_jit.storeDouble(src.asFPR(), dst.asAddress());
+        break;
+    case TypeKind::Exnref:
+    case TypeKind::Externref:
+    case TypeKind::Ref:
+    case TypeKind::RefNull:
+    case TypeKind::Funcref:
+    case TypeKind::Arrayref:
+    case TypeKind::Structref:
+    case TypeKind::Eqref:
+    case TypeKind::Anyref:
+    case TypeKind::Noexnref:
+    case TypeKind::Noneref:
+    case TypeKind::Nofuncref:
+    case TypeKind::Noexternref:
+        m_jit.storePair32(src.asGPRlo(), src.asGPRhi(), dst.asAddress());
+        break;
+    case TypeKind::V128:
+        m_jit.storeVector(src.asFPR(), dst.asAddress());
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unimplemented type kind store.");
+    }
+}
+
+void BBQJIT::emitMoveMemory(TypeKind type, Location src, Location dst)
+{
+    ASSERT(dst.isMemory());
+    ASSERT(src.isMemory());
+
+    if (src == dst)
+        return;
+
+    switch (type) {
+    case TypeKind::I32:
+        m_jit.transfer32(src.asAddress(), dst.asAddress());
+        break;
+    case TypeKind::I31ref:
+        m_jit.transfer32(src.asAddress(), dst.asAddress());
+        m_jit.store32(TrustedImm32(JSValue::Int32Tag), dst.asAddress().withOffset(4));
+        break;
+    case TypeKind::F32:
+        m_jit.transfer32(src.asAddress(), dst.asAddress());
+        break;
+    case TypeKind::I64:
+        m_jit.transfer32(src.asAddress().withOffset(0), dst.asAddress().withOffset(0));
+        m_jit.transfer32(src.asAddress().withOffset(4), dst.asAddress().withOffset(4));
+        break;
+    case TypeKind::F64:
+        m_jit.transferDouble(src.asAddress(), dst.asAddress());
+        break;
+    case TypeKind::Exnref:
+    case TypeKind::Externref:
+    case TypeKind::Ref:
+    case TypeKind::RefNull:
+    case TypeKind::Funcref:
+    case TypeKind::Structref:
+    case TypeKind::Arrayref:
+    case TypeKind::Eqref:
+    case TypeKind::Anyref:
+    case TypeKind::Noexnref:
+    case TypeKind::Noneref:
+    case TypeKind::Nofuncref:
+    case TypeKind::Noexternref:
+        m_jit.transfer32(src.asAddress().withOffset(0), dst.asAddress().withOffset(0));
+        m_jit.transfer32(src.asAddress().withOffset(4), dst.asAddress().withOffset(4));
+        break;
+    case TypeKind::V128:
+        m_jit.transferVector(src.asAddress(), dst.asAddress());
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unimplemented type kind move.");
+    }
+}
+
+void BBQJIT::emitMoveRegister(TypeKind type, Location src, Location dst)
+{
+    ASSERT(dst.isRegister());
+    ASSERT(src.isRegister());
+
+    if (src == dst)
+        return;
+
+    switch (type) {
+    case TypeKind::I32:
+        m_jit.move(src.asGPR(), dst.asGPR());
+        break;
+    case TypeKind::I31ref:
+    case TypeKind::I64:
+    case TypeKind::Exnref:
+    case TypeKind::Externref:
+    case TypeKind::Ref:
+    case TypeKind::RefNull:
+    case TypeKind::Funcref:
+    case TypeKind::Arrayref:
+    case TypeKind::Structref:
+    case TypeKind::Eqref:
+    case TypeKind::Anyref:
+    case TypeKind::Noexnref:
+    case TypeKind::Noneref:
+    case TypeKind::Nofuncref:
+    case TypeKind::Noexternref:
+        if (dst.asGPRlo() == src.asGPRhi()) {
+            ASSERT(dst.asGPRhi() != src.asGPRlo());
+            m_jit.move(src.asGPRhi(), dst.asGPRhi());
+            m_jit.move(src.asGPRlo(), dst.asGPRlo());
+            break;
+        }
+        m_jit.move(src.asGPRlo(), dst.asGPRlo());
+        m_jit.move(src.asGPRhi(), dst.asGPRhi());
+        break;
+    case TypeKind::F32:
+    case TypeKind::F64:
+        m_jit.moveDouble(src.asFPR(), dst.asFPR());
+        break;
+    case TypeKind::V128:
+        m_jit.moveVector(src.asFPR(), dst.asFPR());
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unimplemented type kind move.");
+    }
+}
+
+void BBQJIT::emitLoad(TypeKind type, Location src, Location dst)
+{
+    ASSERT(dst.isRegister());
+    ASSERT(src.isMemory());
+
+    switch (type) {
+    case TypeKind::I32:
+        m_jit.load32(src.asAddress(), dst.asGPR());
+        break;
+    case TypeKind::I31ref:
+    case TypeKind::I64:
+        m_jit.loadPair32(src.asAddress(), dst.asGPRlo(), dst.asGPRhi());
+        break;
+    case TypeKind::F32:
+        m_jit.loadFloat(src.asAddress(), dst.asFPR());
+        break;
+    case TypeKind::F64:
+        m_jit.loadDouble(src.asAddress(), dst.asFPR());
+        break;
+    case TypeKind::Ref:
+    case TypeKind::RefNull:
+    case TypeKind::Exnref:
+    case TypeKind::Externref:
+    case TypeKind::Funcref:
+    case TypeKind::Arrayref:
+    case TypeKind::Structref:
+    case TypeKind::Eqref:
+    case TypeKind::Anyref:
+    case TypeKind::Noexnref:
+    case TypeKind::Noneref:
+    case TypeKind::Nofuncref:
+    case TypeKind::Noexternref:
+        m_jit.loadPair32(src.asAddress(), dst.asGPRlo(), dst.asGPRhi());
+        break;
+    case TypeKind::V128:
+        m_jit.loadVector(src.asAddress(), dst.asFPR());
+        break;
+    default:
+        RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Unimplemented type kind load.");
+    }
+}
+
+WARN_UNUSED_RETURN PartialResult BBQJIT::addCallRef(unsigned callProfileIndex, const TypeDefinition& originalSignature, ArgumentList& args, ResultList& results, CallType callType)
+{
+    emitIncrementCallProfileCount(callProfileIndex);
+    Value callee = args.takeLast();
+    const TypeDefinition& signature = originalSignature.expand();
+    ASSERT(signature.as<FunctionSignature>()->argumentCount() == args.size());
+
+    CallInformation callInfo = wasmCallingConvention().callInformationFor(signature, CallRole::Caller);
+    Checked<int32_t> calleeStackSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(callInfo.headerAndArgumentStackSizeInBytes);
+    m_maxCalleeStackSize = std::max<int>(calleeStackSize, m_maxCalleeStackSize);
+
+    GPRReg importableFunction = GPRInfo::nonPreservedNonArgumentGPR1;
+    {
+        clobber(importableFunction);
+        ScratchScope<0, 0> importableFunctionScope(*this, importableFunction);
+        static_assert(GPRInfo::nonPreservedNonArgumentGPR0 == wasmScratchGPR);
+        {
+            ScratchScope<2, 0> otherScratch(*this);
+
+            Location calleeLocation;
+            if (callee.isConst()) {
+                ASSERT(callee.asI64() == JSValue::encode(jsNull()));
+                // This is going to throw anyway. It's suboptimial but probably won't happen in practice anyway.
+                emitMoveConst(callee, calleeLocation = Location::fromGPR2(otherScratch.gpr(1), otherScratch.gpr(0)));
+            } else
+                calleeLocation = loadIfNecessary(callee);
+            consume(callee);
+            emitThrowOnNullReference(ExceptionType::NullReference, calleeLocation);
+
+            GPRReg calleePtr = calleeLocation.asGPRlo();
+            m_jit.addPtr(TrustedImm32(WebAssemblyFunctionBase::offsetOfImportableFunction()), calleePtr, importableFunction);
+        }
+    }
+
+    if (callType == CallType::Call)
+        emitIndirectCall("CallRef", callProfileIndex, callee, importableFunction, signature, args, results);
+    else
+        emitIndirectTailCall("ReturnCallRef", callee, importableFunction, signature, args);
+    return { };
+}
+
+} } } // namespace JSC::Wasm::BBQJITImpl
+
+#endif // USE(JSVALUE32_64)
+#endif // ENABLE(WEBASSEMBLY_BBQJIT)

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -3827,7 +3827,7 @@ void BBQJIT::materializeVectorConstant(v128_t value, Location result)
     m_jit.move128ToVector(value, result.asFPR());
 }
 
-[[nodiscard]] ExpressionType BBQJIT::addConstant(v128_t value)
+[[nodiscard]] ExpressionType BBQJIT::addSIMDConstant(v128_t value)
 {
     // We currently don't track constant Values for V128s, since folding them seems like a lot of work that might not be worth it.
     // Maybe we can look into this eventually?
@@ -3840,7 +3840,7 @@ void BBQJIT::materializeVectorConstant(v128_t value, Location result)
 
 // SIMD generated
 
-[[nodiscard]] PartialResult BBQJIT::addExtractLane(SIMDInfo info, uint8_t lane, Value value, Value& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDExtractLane(SIMDInfo info, uint8_t lane, Value value, Value& result)
 {
     Location valueLocation = loadIfNecessary(value);
     consume(value);
@@ -3856,7 +3856,7 @@ void BBQJIT::materializeVectorConstant(v128_t value, Location result)
     return { };
 }
 
-[[nodiscard]] PartialResult BBQJIT::addReplaceLane(SIMDInfo info, uint8_t lane, ExpressionType vector, ExpressionType scalar, ExpressionType& result)
+[[nodiscard]] PartialResult BBQJIT::addSIMDReplaceLane(SIMDInfo info, uint8_t lane, ExpressionType vector, ExpressionType scalar, ExpressionType& result)
 {
     Location vectorLocation = loadIfNecessary(vector);
     Location scalarLocation;

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -697,15 +697,15 @@ public:
     [[nodiscard]] PartialResult addSIMDStoreLane(SIMDLaneOperation, ExpressionType, ExpressionType, uint32_t, uint8_t) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&) CONST_EXPR_STUB
-    [[nodiscard]] ExpressionType addConstant(v128_t vector)
+    [[nodiscard]] ExpressionType addSIMDConstant(v128_t vector)
     {
         RELEASE_ASSERT(Options::useWasmSIMD());
         if (m_mode == Mode::Evaluate)
             return ConstExprValue(vector);
         return { };
     }
-    [[nodiscard]] PartialResult addExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&) CONST_EXPR_STUB
-    [[nodiscard]] PartialResult addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&) CONST_EXPR_STUB
+    [[nodiscard]] PartialResult addSIMDReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&) CONST_EXPR_STUB
     [[nodiscard]] PartialResult addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&) CONST_EXPR_STUB

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -1021,7 +1021,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
             return { };
 
         if (Context::tierSupportsSIMD()) {
-            m_expressionStack.constructAndAppend(Types::V128, m_context.addConstant(constant));
+            m_expressionStack.constructAndAppend(Types::V128, m_context.addSIMDConstant(constant));
             return { };
         }
         return pushUnreachable(Types::V128);
@@ -1304,7 +1304,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
 
         if (Context::tierSupportsSIMD()) {
             ExpressionType result;
-            WASM_TRY_ADD_TO_CONTEXT(addExtractLane(SIMDInfo { lane, signMode }, laneIdx, v, result));
+            WASM_TRY_ADD_TO_CONTEXT(addSIMDExtractLane(SIMDInfo { lane, signMode }, laneIdx, v, result));
             m_expressionStack.constructAndAppend(simdScalarType(lane), result);
             return { };
         }
@@ -1326,7 +1326,7 @@ auto FunctionParser<Context>::simd(SIMDLaneOperation op, SIMDLane lane, SIMDSign
 
         if (Context::tierSupportsSIMD()) {
             ExpressionType result;
-            WASM_TRY_ADD_TO_CONTEXT(addReplaceLane(SIMDInfo { lane, signMode }, laneIdx, v, s, result));
+            WASM_TRY_ADD_TO_CONTEXT(addSIMDReplaceLane(SIMDInfo { lane, signMode }, laneIdx, v, s, result));
             m_expressionStack.constructAndAppend(Types::V128, result);
             return { };
         }

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -258,12 +258,12 @@ public:
     [[nodiscard]] PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&);
     [[nodiscard]] PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType, uint32_t, ExpressionType&);
 
-    ExpressionType addConstant(v128_t);
+    ExpressionType addSIMDConstant(v128_t);
 
     // SIMD generated
 
-    [[nodiscard]] PartialResult addExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&);
-    [[nodiscard]] PartialResult addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&);
+    [[nodiscard]] PartialResult addSIMDReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&);
     [[nodiscard]] PartialResult addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&);
     [[nodiscard]] PartialResult addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&);
     [[nodiscard]] PartialResult addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&);
@@ -719,24 +719,28 @@ Value IPIntGenerator::addConstant(Type type, uint64_t value)
 
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDSplat(SIMDLane, ExpressionType, ExpressionType&)
 {
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDShuffle(v128_t, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDShift(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDExtmul(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
@@ -769,36 +773,42 @@ Value IPIntGenerator::addConstant(Type type, uint64_t value)
     return addSIMDLoad(pointer, offset, result);
 }
 
-IPIntGenerator::ExpressionType IPIntGenerator::addConstant(v128_t)
+IPIntGenerator::ExpressionType IPIntGenerator::addSIMDConstant(v128_t)
 {
     changeStackSize(1);
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDExtractLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType&)
 {
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
-[[nodiscard]] PartialResult IPIntGenerator::addReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&)
+[[nodiscard]] PartialResult IPIntGenerator::addSIMDReplaceLane(SIMDInfo, uint8_t, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1);
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDI_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
 {
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDV_V(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType&)
 {
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDBitwiseSelect(ExpressionType, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-2); // 3 operands, 1 result
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
@@ -806,6 +816,7 @@ IPIntGenerator::ExpressionType IPIntGenerator::addConstant(v128_t)
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDRelOp(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, B3::Air::Arg, ExpressionType&)
 {
     changeStackSize(-1);
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 #endif
@@ -813,6 +824,7 @@ IPIntGenerator::ExpressionType IPIntGenerator::addConstant(v128_t)
 [[nodiscard]] PartialResult IPIntGenerator::addSIMDV_VV(SIMDLaneOperation, SIMDInfo, ExpressionType, ExpressionType, ExpressionType&)
 {
     changeStackSize(-1); // Pop two v128 values, push one v128 value
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
@@ -1183,16 +1195,19 @@ IPIntGenerator::ExpressionType IPIntGenerator::addConstant(v128_t)
 
 [[nodiscard]] PartialResult IPIntGenerator::addRefI31(ExpressionType, ExpressionType&)
 {
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addI31GetS(ExpressionType, ExpressionType&)
 {
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addI31GetU(ExpressionType, ExpressionType&)
 {
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
@@ -1270,25 +1285,21 @@ IPIntGenerator::ExpressionType IPIntGenerator::addConstant(v128_t)
 
 [[nodiscard]] PartialResult IPIntGenerator::addArrayLen(ExpressionType, ExpressionType&)
 {
-    // no metadata
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addArrayFill(uint32_t, ExpressionType, ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-4);
-    m_metadata->appendMetadata<IPInt::ArrayFillMetadata>({
-        static_cast<uint8_t>(getCurrentInstructionLength())
-    });
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addArrayCopy(uint32_t, ExpressionType, ExpressionType, uint32_t, ExpressionType, ExpressionType, ExpressionType)
 {
     changeStackSize(-5);
-    m_metadata->appendMetadata<IPInt::ArrayCopyMetadata>({
-        static_cast<uint8_t>(getCurrentInstructionLength())
-    });
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
@@ -1373,11 +1384,13 @@ IPIntGenerator::ExpressionType IPIntGenerator::addConstant(v128_t)
 
 [[nodiscard]] PartialResult IPIntGenerator::addAnyConvertExtern(ExpressionType, ExpressionType&)
 {
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 
 [[nodiscard]] PartialResult IPIntGenerator::addExternConvertAny(ExpressionType, ExpressionType&)
 {
+    m_metadata->addLength(getCurrentInstructionLength());
     return { };
 }
 

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.h
@@ -343,14 +343,6 @@ struct ArrayGetSetMetadata {
     uint8_t length;
 };
 
-struct ArrayFillMetadata {
-    uint8_t length;
-};
-
-struct ArrayCopyMetadata {
-    uint8_t length;
-};
-
 struct ArrayInitDataMetadata {
     uint32_t dataSegmentIndex;
     uint8_t length;

--- a/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp
@@ -491,7 +491,7 @@ public:
     [[nodiscard]] PartialResult addSIMDLoadExtend(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
     [[nodiscard]] PartialResult addSIMDLoadPad(SIMDLaneOperation, ExpressionType pointer, uint32_t offset, ExpressionType& result);
 
-    [[nodiscard]] ExpressionType addConstant(v128_t value)
+    [[nodiscard]] ExpressionType addSIMDConstant(v128_t value)
     {
         return push(constant(B3::V128, value));
     }
@@ -505,7 +505,7 @@ public:
     B3::Opcode b3Op = B3::Oops; \
     if (false) { }
 
-    auto addExtractLane(SIMDInfo info, uint8_t lane, ExpressionType v, ExpressionType& result) -> PartialResult
+    auto addSIMDExtractLane(SIMDInfo info, uint8_t lane, ExpressionType v, ExpressionType& result) -> PartialResult
     {
         result = push(m_currentBlock->appendNew<SIMDValue>(m_proc, origin(), B3::VectorExtractLane, toB3Type(simdScalarType(info.lane)), info,
             lane,
@@ -513,7 +513,7 @@ public:
         return { };
     }
 
-    auto addReplaceLane(SIMDInfo info, uint8_t lane, ExpressionType v, ExpressionType s, ExpressionType& result) -> PartialResult
+    auto addSIMDReplaceLane(SIMDInfo info, uint8_t lane, ExpressionType v, ExpressionType s, ExpressionType& result) -> PartialResult
     {
         result = push(m_currentBlock->appendNew<SIMDValue>(m_proc, origin(), B3::VectorReplaceLane, B3::V128, info,
             lane,


### PR DESCRIPTION
#### 0acf64e0c0c305a120676415b888dd3d70cad1ae
<pre>
[JSC] IPInt PC move should be recorded one for prefixed opcodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=305813">https://bugs.webkit.org/show_bug.cgi?id=305813</a>
<a href="https://rdar.apple.com/168478682">rdar://168478682</a>

Reviewed by Keith Miller and Dan Hecht.

Prefixed opcodes in IPInt (GC, SIMD, etc.) have subsequent sub-opcode to
dispatch actual instruction. However this sub-opcode is encoded via
VarUInt32 LEB. This means that opcode can have multiple different ways
to be encoded (e.g. one value can be represeted via 2 byte, 3 byte,
etc.). As a result, we should not use advancePC(constant) since
instruction is variable-length. This patch fixes the issue using
advancePC(constant).

Test: JSTests/wasm/stress/ipint-variable-length-gc-opcodes.js

* JSTests/wasm/stress/ipint-variable-length-gc-opcodes.js: Added.
(createRedundantLEB128):
(encodeVarUInt32):
(testRefI31RedundantEncoding):
(testI31GetRedundantEncoding):
(testArrayLenRedundantEncoding):
(testArrayFillRedundantEncoding):
(testArrayCopyRedundantEncoding):
(testExternAnyConvertRedundantEncoding):
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:
* Source/JavaScriptCore/wasm/WasmBBQJIT.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT32_64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDConstant):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDExtractLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDReplaceLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addConstant): Deleted.
(JSC::Wasm::BBQJITImpl::BBQJIT::addExtractLane): Deleted.
(JSC::Wasm::BBQJITImpl::BBQJIT::addReplaceLane): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDConstant):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDExtractLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDReplaceLane):
(JSC::Wasm::BBQJITImpl::BBQJIT::addConstant): Deleted.
(JSC::Wasm::BBQJITImpl::BBQJIT::addExtractLane): Deleted.
(JSC::Wasm::BBQJITImpl::BBQJIT::addReplaceLane): Deleted.
* Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp:
(JSC::Wasm::ConstExprGenerator::addSIMDConstant):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::simd):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addSIMDSplat):
(JSC::Wasm::IPIntGenerator::addSIMDShuffle):
(JSC::Wasm::IPIntGenerator::addSIMDShift):
(JSC::Wasm::IPIntGenerator::addSIMDExtmul):
(JSC::Wasm::IPIntGenerator::addSIMDConstant):
(JSC::Wasm::IPIntGenerator::addSIMDExtractLane):
(JSC::Wasm::IPIntGenerator::addSIMDReplaceLane):
(JSC::Wasm::IPIntGenerator::addSIMDI_V):
(JSC::Wasm::IPIntGenerator::addSIMDV_V):
(JSC::Wasm::IPIntGenerator::addSIMDBitwiseSelect):
(JSC::Wasm::IPIntGenerator::addSIMDRelOp):
(JSC::Wasm::IPIntGenerator::addSIMDV_VV):
(JSC::Wasm::IPIntGenerator::addRefI31):
(JSC::Wasm::IPIntGenerator::addI31GetS):
(JSC::Wasm::IPIntGenerator::addI31GetU):
(JSC::Wasm::IPIntGenerator::addArrayLen):
(JSC::Wasm::IPIntGenerator::addArrayFill):
(JSC::Wasm::IPIntGenerator::addArrayCopy):
(JSC::Wasm::IPIntGenerator::addAnyConvertExtern):
(JSC::Wasm::IPIntGenerator::addExternConvertAny):
(JSC::Wasm::IPIntGenerator::addExtractLane): Deleted.
(JSC::Wasm::IPIntGenerator::addReplaceLane): Deleted.
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.h:
* Source/JavaScriptCore/wasm/WasmOMGIRGenerator.cpp:
(JSC::Wasm::OMGIRGenerator::addSIMDConstant):
(JSC::Wasm::OMGIRGenerator::addSIMDExtractLane):
(JSC::Wasm::OMGIRGenerator::addSIMDReplaceLane):
(JSC::Wasm::OMGIRGenerator::addExtractLane): Deleted.
(JSC::Wasm::OMGIRGenerator::addReplaceLane): Deleted.

Originally-landed-as: 301765.432@safari-7623-branch (37d2b52a42b9). <a href="https://rdar.apple.com/170270707">rdar://170270707</a>
Canonical link: <a href="https://commits.webkit.org/309247@main">https://commits.webkit.org/309247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/beba71c56c9cc83e7ef01a995e64a0ef498ca577

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22752 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158737 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23199 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22877 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115729 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152986 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96458 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c2d107a-ea5a-4db3-9195-b1b6dbf95280) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6583 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142009 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/12529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161211 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10824 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14081 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123731 "Passed tests") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/22553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123932 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/22558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134324 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23077 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/11080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181457 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22158 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85986 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/46454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/21888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/22040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/21946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->