### PR TITLE
RemoteBuffer allows to write non-writable buffers, leading to shader's OOB accesses

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp
@@ -62,15 +62,21 @@ void RemoteBuffer::stopListeningForIPC()
 
 void RemoteBuffer::mapAsync(WebCore::WebGPU::MapModeFlags mapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size, CompletionHandler<void(bool)>&& callback)
 {
-    m_isMapped = true;
-    m_mapModeFlags = mapModeFlags;
+    if (m_pendingMap) {
+        callback(false);
+        return;
+    }
 
-    protect(m_backing)->mapAsync(mapModeFlags, offset, size, [protectedThis = Ref<RemoteBuffer>(*this), callback = WTF::move(callback)] (bool success) mutable {
+    m_pendingMap = true;
+
+    protect(m_backing)->mapAsync(mapModeFlags, offset, size, [protectedThis = Ref<RemoteBuffer>(*this), callback = WTF::move(callback), mapModeFlags] (bool success) mutable {
         if (!success) {
             callback(false);
             return;
         }
 
+        protectedThis->m_isMapped = true;
+        protectedThis->m_mapModeFlags = mapModeFlags;
         callback(true);
     });
 }
@@ -93,7 +99,7 @@ void RemoteBuffer::unmap()
 
 void RemoteBuffer::copyWithCopy(Vector<uint8_t>&& data, uint64_t offset)
 {
-    if (!m_isMapped || !m_mapModeFlags.contains(WebCore::WebGPU::MapMode::Write))
+    if (m_pendingMap || !m_isMapped || !m_mapModeFlags.contains(WebCore::WebGPU::MapMode::Write))
         return;
 
     auto buffer = protect(m_backing)->getBufferContents();
@@ -110,9 +116,14 @@ void RemoteBuffer::copyWithCopy(Vector<uint8_t>&& data, uint64_t offset)
 
 void RemoteBuffer::copy(std::optional<WebCore::SharedMemoryHandle>&& dataHandle, uint64_t offset, CompletionHandler<void(bool)>&& completionHandler)
 {
+    if (m_pendingMap || !m_isMapped || !m_mapModeFlags.contains(WebCore::WebGPU::MapMode::Write)) {
+        completionHandler(false);
+        return;
+    }
+
     auto sharedData = dataHandle ? WebCore::SharedMemory::map(WTF::move(*dataHandle), WebCore::SharedMemory::Protection::ReadOnly) : nullptr;
     auto data = sharedData ? sharedData->span() : std::span<const uint8_t> { };
-    if (!m_isMapped || !m_mapModeFlags.contains(WebCore::WebGPU::MapMode::Write) || data.size() <= WebGPU::maxCrossProcessResourceCopySize) {
+    if (data.size() <= WebGPU::maxCrossProcessResourceCopySize) {
         completionHandler(false);
         return;
     }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
@@ -103,6 +103,7 @@ private:
     WeakRef<RemoteGPU> m_gpu;
     WebGPUIdentifier m_identifier;
     bool m_isMapped { false };
+    bool m_pendingMap { false };
     WebCore::WebGPU::MapModeFlags m_mapModeFlags;
 };
 


### PR DESCRIPTION
#### 3aed028b8f7bf1bb1ca8857170f1d9ffb99b90e3
<pre>
RemoteBuffer allows to write non-writable buffers, leading to shader&apos;s OOB accesses
<a href="https://bugs.webkit.org/show_bug.cgi?id=304612">https://bugs.webkit.org/show_bug.cgi?id=304612</a>
<a href="https://rdar.apple.com/166211693">rdar://166211693</a>

Reviewed by Tadeu Zagallo.

From the JS level we prevent certain buffer operations from occurring when
a buffer is mapped, but this was not enforced in the GPU process which
allows a compromised web content process to write to buffers in unexpected
states.

This would for instance give the ability to perform a CPU side write after
index validation occurs, leading to OOB reads from vertex buffers on the
shader cores.

* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp:
(WebKit::RemoteBuffer::mapAsync):
(WebKit::RemoteBuffer::copyWithCopy):
(WebKit::RemoteBuffer::copy):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h:

Originally-landed-as: 301765.412@safari-7623-branch (49e07206b401). <a href="https://rdar.apple.com/171556187">rdar://171556187</a>
Canonical link: <a href="https://commits.webkit.org/309852@main">https://commits.webkit.org/309852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf0403321b46bea324de9baffe30d84d84ce3160

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16993 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159386 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104098 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/34aac23a-559f-4a93-ad1e-c900a75b8bce) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23854 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116277 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82587 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/849b355f-3368-4ae7-84a7-40307d66795b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135158 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97005 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17489 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15432 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7234 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127103 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161860 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4980 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14636 "Found 8 new test failures: http/tests/webgpu/webgpu/api/operation/buffers/map.html http/tests/webgpu/webgpu/api/operation/command_buffer/queries/occlusionQuery.html http/tests/webgpu/webgpu/api/operation/resource_init/buffer.html http/tests/webgpu/webgpu/api/validation/buffer/mapping.html http/tests/webgpu/webgpu/shader/execution/memory_model/atomicity.html http/tests/webgpu/webgpu/shader/execution/memory_model/barrier.html http/tests/webgpu/webgpu/shader/execution/memory_model/coherence.html http/tests/webgpu/webgpu/shader/execution/memory_model/weak.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124274 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23224 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19479 "Found 8 new test failures: http/tests/webgpu/webgpu/api/operation/buffers/map.html http/tests/webgpu/webgpu/api/operation/command_buffer/queries/occlusionQuery.html http/tests/webgpu/webgpu/api/operation/resource_init/buffer.html http/tests/webgpu/webgpu/api/validation/buffer/mapping.html http/tests/webgpu/webgpu/shader/execution/memory_model/atomicity.html http/tests/webgpu/webgpu/shader/execution/memory_model/barrier.html http/tests/webgpu/webgpu/shader/execution/memory_model/coherence.html http/tests/webgpu/webgpu/shader/execution/memory_model/weak.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124472 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134877 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79601 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23321 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19557 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11639 "Found 2 new test failures: http/tests/webgpu/webgpu/api/operation/buffers/map.html http/tests/webgpu/webgpu/api/validation/buffer/mapping.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22826 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86625 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22538 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22690 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22592 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->