### PR TITLE
CrashTracer: com.apple.WebKit.WebContent at WebCore: WebCore::Document::~Document

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -878,8 +878,11 @@ Document::~Document()
     if (m_whenWindowLoadEventOrDestroyed)
         m_whenWindowLoadEventOrDestroyed();
 
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_listsInvalidatedAtDocument.isEmpty());
-    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_collectionsInvalidatedAtDocument.isEmpty());
+    // isEmptyIgnoringNullReferences() prunes stale (dangling) WeakPtr
+    // entries. If non-empty after pruning, live LiveNodeLists/HTMLCollections
+    // still reference this dying Document, which should be impossible.
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_listsInvalidatedAtDocument.isEmptyIgnoringNullReferences());
+    RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_collectionsInvalidatedAtDocument.isEmptyIgnoringNullReferences());
 
     for (unsigned count : m_nodeListAndCollectionCounts)
         ASSERT_UNUSED(count, !count);
@@ -6734,7 +6737,7 @@ void Document::registerNodeListForInvalidation(LiveNodeList& list)
         return;
     ASSERT(!list.isRegisteredForInvalidationAtDocument());
     list.setRegisteredForInvalidationAtDocument(true);
-    m_listsInvalidatedAtDocument.add(&list);
+    m_listsInvalidatedAtDocument.add(list);
 }
 
 void Document::unregisterNodeListForInvalidation(LiveNodeList& list)
@@ -6744,15 +6747,15 @@ void Document::unregisterNodeListForInvalidation(LiveNodeList& list)
         return;
 
     list.setRegisteredForInvalidationAtDocument(false);
-    ASSERT(m_listsInvalidatedAtDocument.contains(&list));
-    m_listsInvalidatedAtDocument.remove(&list);
+    ASSERT(m_listsInvalidatedAtDocument.contains(list));
+    m_listsInvalidatedAtDocument.remove(list);
 }
 
 void Document::registerCollection(HTMLCollection& collection)
 {
     m_nodeListAndCollectionCounts[static_cast<unsigned>(collection.invalidationType())]++;
     if (collection.isRootedAtTreeScope())
-        m_collectionsInvalidatedAtDocument.add(&collection);
+        m_collectionsInvalidatedAtDocument.add(collection);
 }
 
 void Document::unregisterCollection(HTMLCollection& collection)
@@ -6762,7 +6765,7 @@ void Document::unregisterCollection(HTMLCollection& collection)
     if (!collection.isRootedAtTreeScope())
         return;
 
-    m_collectionsInvalidatedAtDocument.remove(&collection);
+    m_collectionsInvalidatedAtDocument.remove(collection);
 }
 
 void Document::collectionCachedIdNameMap(const HTMLCollection& collection)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -2386,8 +2386,8 @@ private:
 
     RefPtr<TextResourceDecoder> m_decoder;
 
-    HashSet<LiveNodeList*> m_listsInvalidatedAtDocument;
-    HashSet<HTMLCollection*> m_collectionsInvalidatedAtDocument;
+    WeakHashSet<LiveNodeList> m_listsInvalidatedAtDocument;
+    WeakHashSet<HTMLCollection> m_collectionsInvalidatedAtDocument;
     std::array<unsigned, numNodeListInvalidationTypes> m_nodeListAndCollectionCounts = { };
 
     RefPtr<XPathEvaluator> m_xpathEvaluator;

--- a/Source/WebCore/dom/LiveNodeList.h
+++ b/Source/WebCore/dom/LiveNodeList.h
@@ -44,7 +44,7 @@ enum class LiveNodeListType : uint8_t {
     LabelsNodeList = 2
 };
 
-class LiveNodeList : public NodeList {
+class LiveNodeList : public NodeList, public CanMakeWeakPtr<LiveNodeList> {
     WTF_MAKE_TZONE_NON_HEAP_ALLOCATABLE(LiveNodeList);
 public:
     virtual ~LiveNodeList();

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1051,11 +1051,8 @@ inline bool Document::shouldInvalidateNodeListAndCollectionCachesForAttribute(co
 template <typename InvalidationFunction>
 void Document::invalidateNodeListAndCollectionCaches(InvalidationFunction invalidate)
 {
-    for (RefPtr list : copyToVectorSpecialization<Vector<LiveNodeList*, 8>>(m_listsInvalidatedAtDocument))
-        invalidate(*list);
-
-    for (RefPtr collection : copyToVectorSpecialization<Vector<HTMLCollection*, 8>>(m_collectionsInvalidatedAtDocument))
-        invalidate(*collection);
+    m_listsInvalidatedAtDocument.forEach([&](auto& list) { invalidate(list); });
+    m_collectionsInvalidatedAtDocument.forEach([&](auto& collection) { invalidate(collection); });
 }
 
 void Node::invalidateNodeListAndCollectionCachesInAncestors()

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -59,7 +59,7 @@ private:
 };
 
 // HTMLCollection subclasses NodeList to maintain legacy ObjC API compatibility.
-class HTMLCollection : public NodeList {
+class HTMLCollection : public NodeList, public CanMakeWeakPtr<HTMLCollection> {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(HTMLCollection, WEBCORE_EXPORT);
 public:
     WEBCORE_EXPORT virtual ~HTMLCollection();


### PR DESCRIPTION
#### 2f397e156a3d346eb90514704b01661cf026428f
<pre>
CrashTracer: com.apple.WebKit.WebContent at WebCore: WebCore::Document::~Document
<a href="https://rdar.apple.com/24502093">rdar://24502093</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309920">https://bugs.webkit.org/show_bug.cgi?id=309920</a>

Reviewed by NOBODY (OOPS!).

Document::~Document() crashes at a RELEASE_ASSERT that
m_listsInvalidatedAtDocument is empty. The ownership chain
(LiveNodeList holds Ref&lt;ContainerNode&gt; which keeps
m_referencingNodeCount &gt; 0) should prevent Document deletion
while registered lists exist, but 1000 production crash logs
confirm the issue is real.

Convert the raw-pointer HashSets to WeakHashSet. The
computeSize() call in ~Document() prunes dangling WeakPtr
entries before the assertion check, eliminating the crash if the
registered entries were pointers to already-destroyed objects.
The RELEASE_ASSERT is retained to catch any case where live
entries survive to ~Document().

No test because the crash could not be reproduced locally due to
the ownership model described above.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::~Document):
(WebCore::Document::registerNodeListForInvalidation):
(WebCore::Document::unregisterNodeListForInvalidation):
(WebCore::Document::registerCollection):
(WebCore::Document::unregisterCollection):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/LiveNodeList.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::Document::invalidateNodeListAndCollectionCaches):
* Source/WebCore/html/HTMLCollection.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f397e156a3d346eb90514704b01661cf026428f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103539 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb95bb1e-fd7d-4de7-886e-14fdf97c3bb1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151978 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115793 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82256 "3 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a40760e-da08-4d00-bfb0-f3253635542d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153065 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96522 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7dd981a7-b5b7-4e1c-9aa8-dfc7ca1171e0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17006 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14955 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6662 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126621 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161290 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4381 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123797 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22665 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19002 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123998 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22652 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134385 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78881 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19120 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11142 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22264 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86065 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21979 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22131 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22033 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->