### PR TITLE
[claude] Add plugins to WebKit repository

### DIFF
--- a/.claude/plugins/.claude-plugin/marketplace.json
+++ b/.claude/plugins/.claude-plugin/marketplace.json
@@ -1,0 +1,13 @@
+{
+  "name": "webkit-plugins",
+  "owner": {
+    "name": "WebKit"
+  },
+  "plugins": [
+    {
+      "name": "git-webkit",
+      "source": "./git-webkit",
+      "description": "Teaches Claude to use git-webkit tools for working with the WebKit repository"
+    }
+  ]
+}

--- a/.claude/plugins/git-webkit/.claude-plugin/plugin.json
+++ b/.claude/plugins/git-webkit/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "git-webkit",
+  "description": "Teaches Claude to use git-webkit tools for working with the WebKit repository",
+  "version": "1.0.0"
+}

--- a/.claude/plugins/git-webkit/skills/checkout/SKILL.md
+++ b/.claude/plugins/git-webkit/skills/checkout/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: checkout-webkit-commit
+description: Use when the user wants to checkout a branch, checkout a PR, checkout a commit or move HEAD to a specific commit in the WebKit repository. The user can specify a pull requests by number or URL.
+user-invocable: true
+allowed-tools: Bash(git-webkit checkout:*), Bash(Tools/Scripts/git-webkit checkout:*), Bash(git-webkit find:*), Bash(Tools/Scripts/git-webkit find:*), Bash(git checkout:*),
+---
+
+Use `git-webkit checkout` instead of `git checkout` to check out branches, commits, or pull requests when the string provided does not match a hash, branch or tag in the repository.
+
+## How to use
+
+### Check out a branch or commit
+```
+git-webkit checkout <branch-or-ref>
+```
+
+### Check out a pull request
+```
+git-webkit checkout pr-<number>
+```
+
+### Check out a PR from an alternate remote
+When the user provides a PR URL (e.g., `https://github.com/<org>/<repo>/pull/<number>`), extract the remote and PR number, then use `--remote`:
+```
+git-webkit checkout pr-<number> --remote <remote>
+```
+
+## Locating git-webkit
+
+If `git-webkit` is not in PATH, use `Tools/Scripts/git-webkit` instead (relative to the repository root).
+
+## Rules
+
+1. Use `git-webkit checkout` instead of `git checkout` or `git switch` in the WebKit repository.
+2. When the user provides a PR URL, parse the remote from the URL and pass it with `--remote`.
+3. Convert any commit hashes in the output to WebKit identifiers using `git-webkit find` before presenting them to the user. Always display identifiers in backticks (e.g., `285301@main`).
+4. Never prefix `git-webkit` or `Tools/Scripts/git-webkit` with `python3`. The script is directly executable.

--- a/.claude/plugins/git-webkit/skills/classify/SKILL.md
+++ b/.claude/plugins/git-webkit/skills/classify/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: classify-webkit-commit
+description: Use when the user wants to classify a commit or understand what kind of change a commit represents in the WebKit repository.
+user-invocable: true
+allowed-tools: Bash(git-webkit classify:*), Bash(Tools/Scripts/git-webkit classify:*), Bash(git-webkit find:*), Bash(Tools/Scripts/git-webkit find:*)
+---
+
+Use `git-webkit classify` to compute the classification of a given commit.
+
+## How to use
+
+```
+git-webkit classify <commit-ref>
+```
+
+The commit ref can be a hash, identifier, branch name, or any valid git ref.
+
+## Locating git-webkit
+
+If `git-webkit` is not in PATH, use `Tools/Scripts/git-webkit` instead (relative to the repository root).
+
+## Rules
+
+1. Convert any commit hashes in the output to WebKit identifiers using `git-webkit find` before presenting them to the user. Always display identifiers in backticks (e.g., `285301@main`).
+2. Never prefix `git-webkit` or `Tools/Scripts/git-webkit` with `python3`. The script is directly executable.

--- a/.claude/plugins/git-webkit/skills/find/SKILL.md
+++ b/.claude/plugins/git-webkit/skills/find/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: find-webkit-commit
+description: Convert between commit hashes and WebKit identifiers using git-webkit. Use when working with git commits, commit hashes, or commit references in the WebKit repository.
+user-invocable: false
+allowed-tools: Bash(git-webkit find:*), Bash(Tools/Scripts/git-webkit find:*), Bash(git-webkit log:*), Bash(Tools/Scripts/git-webkit log:*), Bash(git-webkit blame:*), Bash(Tools/Scripts/git-webkit blame:*), Bash(git-webkit show:*), Bash(Tools/Scripts/git-webkit show:*)
+---
+
+When working in the WebKit repository, ALWAYS reference commits by their WebKit "identifier" rather than by hash.
+
+## What is a commit identifier?
+
+A commit identifier is a human-readable reference of the form:
+
+- `<number>@main` for commits on the main branch (e.g., `285301@main`)
+- `<branch-point>.<number>@<branch>` for commits on other branches (e.g., `278024.26@safari-7621-branch`)
+
+These are more stable and readable than raw commit hashes.
+
+## How to convert between hashes and identifiers
+
+Use `git-webkit find` to convert in either direction:
+
+### Hash to identifier
+```
+git-webkit find <hash>
+```
+
+### Identifier to hash
+```
+git-webkit find <identifier>
+```
+
+For example:
+```
+git-webkit find c8a159ededf1
+git-webkit find 285301@main
+```
+
+## Prefer git-webkit over git for log, blame, and show
+
+`git-webkit` provides wrappers that automatically display identifiers instead of hashes:
+
+- Use `git-webkit log` instead of `git log`
+- Use `git-webkit blame` instead of `git blame`
+- Use `git-webkit show` instead of `git show`
+
+These commands accept the same arguments as their git counterparts but output identifiers directly, avoiding the need to manually convert hashes.
+
+## Locating git-webkit
+
+If `git-webkit` is not in PATH, use `Tools/Scripts/git-webkit` instead (relative to the repository root).
+
+## Rules
+
+1. Use `git-webkit log`, `git-webkit blame`, and `git-webkit show` instead of `git log`, `git blame`, and `git show`.
+2. When you encounter a commit hash from other git commands (e.g., `git bisect`), convert it to an identifier using `git-webkit find` before presenting it to the user.
+3. When the user provides a commit hash, convert it to an identifier for display.
+4. When the user provides an identifier, you can use it directly with `git-webkit find` to get the hash if needed for git operations.
+5. Always display identifiers in backticks (e.g., `285301@main`).
+6. Never prefix `git-webkit` or `Tools/Scripts/git-webkit` with `python3`. The script is directly executable.

--- a/.claude/plugins/git-webkit/skills/pull/SKILL.md
+++ b/.claude/plugins/git-webkit/skills/pull/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: update-webkit
+description: Use when the user wants to update, pull, or sync their WebKit repository or branch.
+user-invocable: true
+allowed-tools: Bash(git-webkit pull:*), Bash(Tools/Scripts/git-webkit pull:*), Bash(git-webkit find:*), Bash(Tools/Scripts/git-webkit find:*)
+---
+
+Use `git-webkit pull` to update the current repository.
+
+## What it does
+
+- Updates the current production branch (e.g., `main`) with the latest upstream changes
+- If on a development branch, rebases it on the updated production branch
+- Works safely even when there are local uncommitted edits
+
+## How to use
+
+```
+git-webkit pull
+```
+
+No additional arguments are needed.
+
+## Locating git-webkit
+
+If `git-webkit` is not in PATH, use `Tools/Scripts/git-webkit` instead (relative to the repository root).
+
+## Rules
+
+1. Use `git-webkit pull` instead of `git pull` or `git fetch` + `git rebase` in the WebKit repository.
+2. Do not pass `--force` or other flags unless the user explicitly requests them.
+3. After pulling, convert any commit hashes in the output to WebKit identifiers using `git-webkit find` before presenting them to the user. Always display identifiers in backticks (e.g., `285301@main`).
+4. Never prefix `git-webkit` or `Tools/Scripts/git-webkit` with `python3`. The script is directly executable.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "extraKnownMarketplaces": {
+    "webkit-plugins": {
+      "source": {
+        "source": "directory",
+        "path": ".claude/plugins"
+      }
+    }
+  }
+}


### PR DESCRIPTION
#### 35db8e728c9fca03a0e2969cccfc187ba56aff4a
<pre>
[claude] Add plugins to WebKit repository
<a href="https://bugs.webkit.org/show_bug.cgi?id=309924">https://bugs.webkit.org/show_bug.cgi?id=309924</a>
<a href="https://rdar.apple.com/172516481">rdar://172516481</a>

Reviewed by David Kilzer and BJ Burg.

* .claude/plugins/.claude-plugin/marketplace.json: Added.
* .claude/plugins/git-webkit/.claude-plugin/plugin.json: Added.
* .claude/plugins/git-webkit/skills/checkout/SKILL.md: Added.
* .claude/plugins/git-webkit/skills/classify/SKILL.md: Added.
* .claude/plugins/git-webkit/skills/find/SKILL.md: Added.
* .claude/plugins/git-webkit/skills/pull/SKILL.md: Added.
* .claude/settings.json: Added.

Canonical link: <a href="https://commits.webkit.org/309479@main">https://commits.webkit.org/309479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/587457191a745c4f1223bc732904b5ee2291a698

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159420 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104132 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23658 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/116307 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104132 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153658 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/18417 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135194 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97035 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17514 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15463 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/7268 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127128 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161894 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/14672 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/124305 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/23258 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/19510 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/124504 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/23246 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/134913 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79635 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23171 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/23246 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/11675 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22860 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/22572 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/22724 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/22626 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->