### PR TITLE
WKWebView loadHTMLString:baseURL: is a no-op on second call when baseURL contains a fragment

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/srcdoc/consecutive-srcdoc-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/srcdoc/consecutive-srcdoc-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS changing srcdoc does a replace navigation since the URL is still about:srcdoc
-TIMEOUT changing srcdoc to about:srcdoc#yo then another srcdoc does two push navigations and we can navigate back Test timed out
+FAIL changing srcdoc to about:srcdoc#yo then another srcdoc does two push navigations and we can navigate back assert_equals: srcdoc content must be restored from history expected "srcdoc1" but got "srcdoc2"
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1929,7 +1929,7 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
 
     const String& httpMethod = loader->request().httpMethod();
 
-    if (shouldPerformFragmentNavigation(isFormSubmission, httpMethod, policyChecker().loadType(), newURL)) {
+    if (shouldPerformFragmentNavigation(isFormSubmission, httpMethod, policyChecker().loadType(), newURL) && !loader->substituteData().isValid()) {
 
         RefPtr oldDocumentLoader = m_documentLoader;
         NavigationAction action { protect(frame->document()).releaseNonNull(), loader->request(), InitiatedByMainFrame::Unknown, loader->isRequestFromClientOrUserInput(), policyChecker().loadType(), isFormSubmission };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadDataWithNilMIMEType.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadDataWithNilMIMEType.mm
@@ -36,3 +36,14 @@ TEST(WebKit, LoadDataWithNilMIMEType)
     [webView loadData:[@"test" dataUsingEncoding:NSUTF8StringEncoding] MIMEType:mimeType characterEncodingName:@"UTF-8" baseURL:[NSURL URLWithString:@"about:blank"]];
     [webView _test_waitForDidFinishNavigation];
 }
+
+TEST(WebKit, LoadHTMLStringWithFragmentInBaseURL)
+{
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSZeroRect]);
+
+    [webView loadHTMLString:@"<body>first</body>" baseURL:[NSURL URLWithString:@"http://example.test/#test"]];
+    [webView _test_waitForDidFinishNavigation];
+
+    [webView loadHTMLString:@"<body>second</body>" baseURL:[NSURL URLWithString:@"http://example.test/#test"]];
+    [webView _test_waitForDidFinishNavigation];
+}


### PR DESCRIPTION
#### 27ade177851927fba50877e7ec47b8a996dfdb5d
<pre>
WKWebView loadHTMLString:baseURL: is a no-op on second call when baseURL contains a fragment
<a href="https://bugs.webkit.org/show_bug.cgi?id=309923">https://bugs.webkit.org/show_bug.cgi?id=309923</a>
<a href="https://rdar.apple.com/168589818">rdar://168589818</a>

Reviewed by Brady Eidson.

Calling `[WKWebView loadHTMLString:baseURL:]` (or `loadData:MIMEType:characterEncodingName:baseURL:`)
with a baseURL containing a fragment identifier (e.g., `<a href="http://example.test/#test`)">http://example.test/#test`)</a>
works on the first call but silently fails on subsequent calls with the same
baseURL. No `WKNavigationDelegate` methods are called and the new HTML content
is never loaded.

The root cause is in `FrameLoader::loadWithDocumentLoader()`. After the first
load, the document URL becomes the baseURL (including fragment). On the second
call, `shouldPerformFragmentNavigation()` compares the current document URL
with the new URL, and since they match when ignoring fragments, it treats the
load as a same-document fragment navigation. This causes an early return that
skips loading the substitute data containing the new HTML.

The fix adds a check to skip the fragment navigation optimization when the
`DocumentLoader` carries substitute data, since substitute data always represents
an explicit new document load regardless of URL similarity.

Updated the expected result for consecutive-srcdoc.html because this change
exposed a pre-existing issue where srcdoc content is not properly restored
during history navigation. That issue is outside the scope of this fix.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadDataWithNilMIMEType.mm
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/srcdoc/consecutive-srcdoc-expected.txt:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadWithDocumentLoader):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LoadDataWithNilMIMEType.mm:
(TEST(WebKit, LoadHTMLStringWithFragmentInBaseURL)):

Canonical link: <a href="https://commits.webkit.org/309290@main">https://commits.webkit.org/309290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c13f2a6dda846672cefa45e6ef46a7473671691a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16452 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158845 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103567 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e2044bb0-07b2-44ff-a841-fddf2e8b9769) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115819 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82272 "4 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c18bdc4-0475-4030-8646-ca329bfc8d2b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134695 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96549 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17034 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14983 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6690 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126649 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161318 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4409 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123823 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22693 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124024 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33689 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134414 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78925 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19151 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11171 "Too many flaky failures: http/tests/media/clearkey/collect-webkit-media-session.html, http/tests/misc/object-image-error-with-onload.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, http/tests/security/cannot-read-cssrules.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/register-bypassing-scheme.html, http/tests/security/mixedContent/redirect-http-to-https-script-in-iframe-UpgradeMixedContent.html, http/tests/site-isolation/frame-index.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22293 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86093 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22007 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22159 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22061 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->