### PR TITLE
[MacOS IOS] imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html is a flaky image diff

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested-expected.html
@@ -1,9 +1,12 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
+<head>
 <title>ref for nested iframes with css zoom</title>
 <link rel="author" title="Yotam Hacohen" href="mailto:yotha@chromium.org">
 <link rel="author" title="Stefan Zager" href="mailto:szager@chromium.org">
 <link rel="author" title="Google" href="http://www.google.com/">
 <link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<script src="/common/reftest-wait.js"></script>
 
 <style>
 body {
@@ -21,8 +24,23 @@ iframe {
   --scale: 1.5;
 }
 </style>
+</head>
 
+<body>
+<script>
+let loadedCount = 0;
+
+addEventListener("message", ({ data }) => {
+  if (data != "leaf_loaded") return;
+  loadedCount += 1;
+  if (loadedCount == document.querySelectorAll('iframe').length) {
+    takeScreenshot();
+  }
+});
+</script>
 <iframe id="baseline-ref" src="resources/nested-iframe.html" scrolling="no"></iframe>
 <iframe id="zoom-child-ref" src="resources/nested-iframe.html?subscale=2" scrolling="no"></iframe>
 <iframe id="zoom-top-ref" class="scale" src="resources/nested-iframe.html?topscale=1.5" scrolling="no"></iframe>
 <iframe id="zoom-top-child-ref" class="scale" src="resources/nested-iframe.html?topscale=1.5&subscale=2" scrolling="no"></iframe>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html
@@ -28,19 +28,18 @@ iframe {
 
 <body>
 <script>
-const totalLeafIframes = 4;
+let loadedCount = 0;
 
-addEventListener("load", () => {
-  let loadedCount = 0;
-  addEventListener("message", ({ data }) => {
-    // We need to wait for the nested iframe (leaf.html) to load, in addition
-    // to the top-level iframe (nested-iframe.html).
-    if (data != "leaf_loaded") return;
-      loadedCount += 1;
-      if (loadedCount == totalLeafIframes) {
-        takeScreenshot();
-      }
-  });
+// Register message listener immediately (not inside load handler) to avoid
+// missing leaf_loaded messages that arrive before the window load event.
+addEventListener("message", ({ data }) => {
+  // We need to wait for the nested iframe (leaf.html) to load, in addition
+  // to the top-level iframe (nested-iframe.html).
+  if (data != "leaf_loaded") return;
+  loadedCount += 1;
+  if (loadedCount == document.querySelectorAll('iframe').length) {
+    takeScreenshot();
+  }
 });
 </script>
 <iframe id="baseline" src="resources/nested-iframe.html" scrolling="no"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/iframe-zoom-nested-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/iframe-zoom-nested-ref.html
@@ -1,9 +1,12 @@
 <!DOCTYPE html>
+<html class="reftest-wait">
+<head>
 <title>ref for nested iframes with css zoom</title>
 <link rel="author" title="Yotam Hacohen" href="mailto:yotha@chromium.org">
 <link rel="author" title="Stefan Zager" href="mailto:szager@chromium.org">
 <link rel="author" title="Google" href="http://www.google.com/">
 <link rel="help" href="https://drafts.csswg.org/css-viewport/">
+<script src="/common/reftest-wait.js"></script>
 
 <style>
 body {
@@ -21,8 +24,23 @@ iframe {
   --scale: 1.5;
 }
 </style>
+</head>
 
+<body>
+<script>
+let loadedCount = 0;
+
+addEventListener("message", ({ data }) => {
+  if (data != "leaf_loaded") return;
+  loadedCount += 1;
+  if (loadedCount == document.querySelectorAll('iframe').length) {
+    takeScreenshot();
+  }
+});
+</script>
 <iframe id="baseline-ref" src="../resources/nested-iframe.html" scrolling="no"></iframe>
 <iframe id="zoom-child-ref" src="../resources/nested-iframe.html?subscale=2" scrolling="no"></iframe>
 <iframe id="zoom-top-ref" class="scale" src="../resources/nested-iframe.html?topscale=1.5" scrolling="no"></iframe>
 <iframe id="zoom-top-child-ref" class="scale" src="../resources/nested-iframe.html?topscale=1.5&subscale=2" scrolling="no"></iframe>
+</body>
+</html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8482,8 +8482,6 @@ webkit.org/b/313562 imported/w3c/web-platform-tests/navigation-api/navigate-even
 
 webkit.org/b/304851 imported/w3c/web-platform-tests/workers/worker-performance.worker.html [ Pass Failure ]
 
-webkit.org/b/309917 imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html [ ImageOnlyFailure Pass ]
-
 webkit.org/b/304995 [ Release ] imported/w3c/web-platform-tests/largest-contentful-paint/video-poster.html [ Pass Failure ]
 
 webkit.org/b/305404 imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-auto-001.html [ Pass ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2335,8 +2335,6 @@ webkit.org/b/306278 [ arm64 ] media/media-source/media-managedmse-resume-after-r
 
 webkit.org/b/306294 http/wpt/offscreen-canvas/transferToImageBitmap-webgl.html [ ImageOnlyFailure Pass ]
 
-webkit.org/b/309917 imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html [ ImageOnlyFailure Pass ]
-
 webkit.org/b/306570 [ Tahoe arm64 ] http/tests/webcodecs/video-decoder-callbacks-do-not-leak.html [ Pass Failure ]
 
 webkit.org/b/306629 [ Release arm64 ] imported/w3c/web-platform-tests/media-source/mediasource-config-change-webm-av-video-bitrate.html [ Pass Failure ]


### PR DESCRIPTION
#### 527346d57f8cc02763692c6b91a8a59dfbe62413
<pre>
[MacOS IOS] imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html is a flaky image diff
<a href="https://rdar.apple.com/172508874">rdar://172508874</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309917">https://bugs.webkit.org/show_bug.cgi?id=309917</a>

Reviewed by Sammy Gill.

 This test is failing due to two timing issues:

  1. The test file registers its message listener inside the load handler. Each nested leaf.html calls top.postMessage(&quot;leaf_loaded&quot;) on its own
   load event, and these messages can arrive before the main window&apos;s load fires. When that happens, they&apos;re silently dropped and
  takeScreenshot() is never called, causing a timeout.
  2. The reference files have no waiting mechanism, so the test harness can capture the screenshot before the nested iframes have finished
  loading, causing flaky image failures.

  Modified iframe-zoom-nested.html:
  Moved the message listener registration to the top level so it&apos;s ready immediately.

  Modified iframe-zoom-nested-expected.html and iframe-zoom-nested-ref.html:
  Added reftest-wait and the same message-based waiting mechanism used by the test file.

* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/reference/iframe-zoom-nested-ref.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/312232@main">https://commits.webkit.org/312232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/112f2aaf7982d2a266226679529723995b2421bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103479 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115741 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82219 "4 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96470 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16953 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14899 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6602 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126568 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161230 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14093 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123748 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22572 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123950 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35628 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134336 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78821 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19083 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11092 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22177 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21919 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22071 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21973 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->