### PR TITLE
[Site Isolation] Web Inspector: Need to report preserved WebFrameProxies as new frame targets after cross-origin page navigation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation-expected.txt
@@ -1,0 +1,22 @@
+CONSOLE MESSAGE: Hello from leaf-iframe http://localhost:8000/site-isolation/inspector/target/resources/leaf-iframe.html
+CONSOLE MESSAGE: Hello from leaf-iframe http://127.0.0.1:8000/site-isolation/inspector/target/resources/leaf-iframe.html
+Test that frame targets are properly destroyed and created during a cross-origin page navigation.
+
+
+
+== Running test suite: SiteIsolation.Target.CrossOriginPageNavigation
+-- Running test case: SiteIsolation.Target.CrossOriginPageNavigation.FrameTargetLifetime
+PASS: Should have main, middle, and leaf frame targets before navigation.
+Frame URLs before navigation:
+http://127.0.0.1:8000/site-isolation/inspector/target/resources/middle-iframe.html
+http://127.0.0.1:8000/site-isolation/inspector/target/target-cross-origin-page-navigation.html
+http://localhost:8000/site-isolation/inspector/target/resources/leaf-iframe.html
+Navigating cross-origin...
+ERROR: Received a command response without a corresponding callback or promise. [object Object]
+PASS: Should have main, middle, and leaf frame targets after navigation.
+Frame URLs after navigation:
+http://127.0.0.1:8000/site-isolation/inspector/target/resources/leaf-iframe.html
+http://localhost:8000/site-isolation/inspector/target/resources/middle-iframe.html
+http://localhost:8000/site-isolation/inspector/target/target-cross-origin-page-navigation.html
+PASS: Frame targets should be new despite the same page structure.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html
@@ -1,0 +1,55 @@
+<script src="../../../inspector/resources/inspector-test.js"></script>
+
+<script>
+    function test() {
+        let suite = InspectorTest.createAsyncSuite("SiteIsolation.Target.CrossOriginPageNavigation");
+
+        suite.addTestCase({
+            name: "SiteIsolation.Target.CrossOriginPageNavigation.FrameTargetLifetime",
+            description: "On cross-origin page navigation, frame targets are destroyed and created as appropriate.",
+            async test() {
+                async function logDocumentURLs(targets) {
+                    let urls = await Promise.all(targets.map(async function (target) {
+                        let { result } = await target.RuntimeAgent.evaluate.invoke({
+                            expression: "document.location.href",
+                            objectGroup: "test",
+                            returnByValue: true,
+                        });
+                        return result.value;
+                    }));
+                    InspectorTest.log(urls.sort().join("\n"));
+                }
+
+                let oldFrameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+                InspectorTest.expectEqual(oldFrameTargets.length, 3, "Should have main, middle, and leaf frame targets before navigation.");
+                InspectorTest.log("Frame URLs before navigation:");
+                await logDocumentURLs(oldFrameTargets);
+
+                InspectorTest.log("Navigating cross-origin...");
+                InspectorTest.deferOutputUntilTestPageIsReloaded();
+                // FIXME <https://webkit.org/b/309922>: Address the unrelated console error that shows up
+                // during this navigation.
+                InspectorTest.evaluateInPage(`location.hostname = "localhost";`);
+
+                // Wait for the log from leaf-iframe to ensure all loading has completed.
+                await WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded);
+
+                let newFrameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+                InspectorTest.expectEqual(newFrameTargets.length, 3, "Should have main, middle, and leaf frame targets after navigation.");
+                InspectorTest.log("Frame URLs after navigation:");
+                await logDocumentURLs(newFrameTargets);
+
+                let oldIds = oldFrameTargets.map((t) => t.identifier);
+                let targetsHaveNewIds = newFrameTargets.every((t) => !oldIds.includes(t.identifier));
+                InspectorTest.expectThat(targetsHaveNewIds, "Frame targets should be new despite the same page structure.");
+            },
+        });
+
+        suite.runTestCasesAndFinish();
+    }
+</script>
+
+<body onload="runTest()">
+    <p>Test that frame targets are properly destroyed and created during a cross-origin page navigation.</p>
+    <iframe src="resources/middle-iframe.html"></iframe>
+</body>

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -228,13 +228,21 @@ void WebPageInspectorController::didCommitProvisionalPage(WebCore::PageIdentifie
     newTarget->didCommitProvisionalTarget();
     targetAgent->didCommitProvisionalTarget(oldID, newID);
 
-    // We've disconnected from the old page and will not receive any message from it, so
-    // we destroy everything but the new target here.
-    // FIXME: <https://webkit.org/b/202937> do not destroy targets that belong to the committed page.
+    // Update target list to only include targets from the committed page.
     for (auto& target : m_targets.values())
         targetAgent->targetDestroyed(*target);
     m_targets.clear();
     m_targets.set(newTarget->identifier(), WTF::move(newTarget));
+
+    if (shouldManageFrameTargets()) {
+        // WebFrameProxies are structurally preserved across page navigation rather than destroyed and recreated,
+        // so no didCreateFrame/willDestroyFrame callbacks fire for them. Recreate the frame targets here.
+        //
+        // (Frame target ids include the process id, which changes across a cross-origin navigation,
+        // so surviving frames need to surface as new targets to the frontend.)
+        for (RefPtr frame = m_inspectedPage->mainFrame(); frame; frame = frame->traverseNext().frame)
+            didCreateFrame(*frame);
+    }
 }
 
 void WebPageInspectorController::didCreateFrame(WebFrameProxy& frame)


### PR DESCRIPTION
#### 2878ab233c05bacd05b78e87d60ebf54de756987
<pre>
[Site Isolation] Web Inspector: Need to report preserved WebFrameProxies as new frame targets after cross-origin page navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=310043">https://bugs.webkit.org/show_bug.cgi?id=310043</a>
<a href="https://rdar.apple.com/172326572">rdar://172326572</a>

Reviewed by BJ Burg.

During a cross-origin page navigation, rather than destroying and
creating new WebFrameProxies, we actually preserve them as much as the
page&apos;s structure permits and merely assign them new web processes.
(Source: <a href="https://github.com/WebKit/WebKit/blob/57438b0e69831fedd7851825b33b09a0917c9b74/Source/WebKit/UIProcess/WebPageProxy.cpp#L5378)">https://github.com/WebKit/WebKit/blob/57438b0e69831fedd7851825b33b09a0917c9b74/Source/WebKit/UIProcess/WebPageProxy.cpp#L5378)</a>

Since we are currently tying a frame target&apos;s lifetime purely onto its
WebFrameProxy, when we clean out the target list when committing a
loaded provisional page, we lose the frame targets but never created
new ones, as WebFrameProxies may be reused from the old page and
not created by the new page.

Given that when the provisional page commits, the destination web
processes for the WebFrameProxies have already been updated, we surface
new frame targets with the updated ids. This is necessary over trying
to keep the preserved frame targets because frame ids include the
process id which have changed.

Test: http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html

It should be sufficient to let this test only verify the resulting
frame targets rather than all destroying/creating events in between.
The scenario involves a nested cross-origin iframe and provisional frame
targets can occur, so the stream of events is complex. We let the
target.html sister test to cover the behavior around provisional
frames&apos; lifetime.

There is a console error showing up in the frontend signaling additional
work is required to better support navigation with inspector open.
The error shows up in the test results as noise. Filed Bug 309922 as
a follow-up.

* LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html: Added.
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::didCommitProvisionalPage):
(WebKit::WebPageInspectorController::didCreateFrame):

Canonical link: <a href="https://commits.webkit.org/309357@main">https://commits.webkit.org/309357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cf59091c68b6c812d5e61ec36cf1bae539907df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159150 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23617 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116068 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134943 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96796 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd981359-40aa-496a-8d38-e1778f6f254f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6998 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126888 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/12867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161624 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14420 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124064 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22988 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124262 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/22975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134662 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23120 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11419 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22589 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/86388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22302 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22454 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22356 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->