### PR TITLE
[JSC] Support fast C++ -> JS calls in x64

### DIFF
--- a/Source/JavaScriptCore/interpreter/CachedCallInlines.h
+++ b/Source/JavaScriptCore/interpreter/CachedCallInlines.h
@@ -54,7 +54,7 @@ ALWAYS_INLINE JSValue CachedCall::callWithArguments(JSGlobalObject* globalObject
     }
 #endif
 
-#if CPU(ARM64) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
+#if (CPU(ARM64) || CPU(X86_64)) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
     ASSERT(sizeof...(args) == static_cast<size_t>(m_protoCallFrame.argumentCount()));
     constexpr unsigned argumentCountIncludingThis = 1 + sizeof...(args);
     if constexpr (argumentCountIncludingThis <= 7) {

--- a/Source/JavaScriptCore/interpreter/Interpreter.h
+++ b/Source/JavaScriptCore/interpreter/Interpreter.h
@@ -170,7 +170,7 @@ using JSOrWasmInstruction = Variant<const JSInstruction*, uintptr_t /* IPIntOffs
         JSValue executeCallImpl(VM&, JSObject*, const CallData&, JSValue, JSCell*, const ArgList&);
 
     public:
-#if CPU(ARM64) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
+#if (CPU(ARM64) || CPU(X86_64)) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
         template<typename... Args> requires (std::is_convertible_v<Args, JSValue> && ...)
         JSValue tryCallWithArguments(CachedCall&, JSValue, Args...);
 #endif

--- a/Source/JavaScriptCore/interpreter/InterpreterInlines.h
+++ b/Source/JavaScriptCore/interpreter/InterpreterInlines.h
@@ -127,7 +127,7 @@ ALWAYS_INLINE JSValue Interpreter::executeCachedCall(CachedCall& cachedCall)
     return JSValue::decode(vmEntryToJavaScript(entry, &vm, &cachedCall.m_protoCallFrame));
 }
 
-#if CPU(ARM64) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
+#if (CPU(ARM64) || CPU(X86_64)) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
 template<typename... Args> requires (std::is_convertible_v<Args, JSValue> && ...)
 ALWAYS_INLINE JSValue Interpreter::tryCallWithArguments(CachedCall& cachedCall, JSValue thisValue, Args... args)
 {

--- a/Source/JavaScriptCore/interpreter/MicrotaskCallInlines.h
+++ b/Source/JavaScriptCore/interpreter/MicrotaskCallInlines.h
@@ -59,7 +59,7 @@ ALWAYS_INLINE JSValue MicrotaskCall::tryCallWithArguments(VM& vm, JSFunction* fu
     ASSERT(vm.currentThreadIsHoldingAPILock());
 
     constexpr unsigned argumentCountIncludingThis = 1 + sizeof...(args);
-#if CPU(ARM64) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
+#if (CPU(ARM64) || CPU(X86_64)) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
     static_assert(argumentCountIncludingThis <= 7);
     if (m_numParameters <= argumentCountIncludingThis) [[likely]] {
         auto* entry = m_addressForCall;

--- a/Source/JavaScriptCore/llint/LLIntThunks.h
+++ b/Source/JavaScriptCore/llint/LLIntThunks.h
@@ -42,7 +42,7 @@ extern "C" {
     void SYSV_ABI NOT_TAIL_CALLED vmEntryCustomSetter(JSGlobalObject*, EncodedJSValue, EncodedJSValue, PropertyName, void*);
     EncodedJSValue SYSV_ABI NOT_TAIL_CALLED vmEntryHostFunction(JSGlobalObject*, CallFrame*, void*);
 
-#if CPU(ARM64) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
+#if (CPU(ARM64) || CPU(X86_64)) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
     EncodedJSValue SYSV_ABI NOT_TAIL_CALLED vmEntryToJavaScriptWith0Arguments(void*, VM*, CodeBlock*, JSObject*, JSValue, JSCell*);
     EncodedJSValue SYSV_ABI NOT_TAIL_CALLED vmEntryToJavaScriptWith1Arguments(void*, VM*, CodeBlock*, JSObject*, JSValue, JSCell*, JSValue);
     EncodedJSValue SYSV_ABI NOT_TAIL_CALLED vmEntryToJavaScriptWith2Arguments(void*, VM*, CodeBlock*, JSObject*, JSValue, JSCell*, JSValue, JSValue);

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -1861,14 +1861,46 @@ else
 end
     doVMEntry(makeJavaScriptCall)
 
-if (ARM64E or ARM64) and ADDRESS64
+if ((ARM64E or ARM64) or X86_64) and ADDRESS64 and not C_LOOP
     macro vmEntryToJavaScriptSetup()
         functionPrologue()
         pushCalleeSaves()
         vmEntryRecord(cfr, sp)
-        storepairq a1, a5, VMEntryRecord::m_vm[sp]
-        loadpairq VM::topCallFrame[a1], t8, t9 # topCallFrame and topEntryFrame
-        storepairq t8, t9, VMEntryRecord::m_prevTopCallFrame[sp]
+        if ARM64 or ARM64E
+            storepairq a1, a5, VMEntryRecord::m_vm[sp]
+            loadpairq VM::topCallFrame[a1], t8, t9 # topCallFrame and topEntryFrame
+            storepairq t8, t9, VMEntryRecord::m_prevTopCallFrame[sp]
+        else
+            storeq a1, VMEntryRecord::m_vm[sp]
+            storeq a5, VMEntryRecord::m_context[sp]
+            loadq VM::topCallFrame[a1], t0
+            storeq t0, VMEntryRecord::m_prevTopCallFrame[sp]
+            loadq VM::topEntryFrame[a1], t0
+            storeq t0, VMEntryRecord::m_prevTopEntryFrame[sp]
+        end
+    end
+
+    macro vmEntryToJavaScriptStoreHeader(scratch, argCount)
+        move argCount, scratch
+        if ARM64 or ARM64E
+            storepairq a2, a3, CodeBlock + (SlotSize * 0)[sp]
+            storepairq scratch, a4, CodeBlock + (SlotSize * 2)[sp]
+        else
+            storeq a2, CodeBlock + (SlotSize * 0)[sp]
+            storeq a3, CodeBlock + (SlotSize * 1)[sp]
+            storeq scratch, CodeBlock + (SlotSize * 2)[sp]
+            storeq a4, CodeBlock + (SlotSize * 3)[sp]
+        end
+    end
+
+    macro vmEntryToJavaScriptSetTopCallFrame()
+        if ARM64 or ARM64E
+            move sp, t8
+            storepairq t8, cfr, VM::topCallFrame[a1] # topCallFrame and topEntryFrame
+        else
+            storeq sp, VM::topCallFrame[a1]
+            storeq cfr, VM::topEntryFrame[a1]
+        end
     end
 
     #  versions - these include a context parameter (JSCell*)
@@ -1878,12 +1910,13 @@ if (ARM64E or ARM64) and ADDRESS64
     _vmEntryToJavaScriptWith0Arguments:
         # entry must be a0
         vmEntryToJavaScriptSetup()
-        move 1, t8 # argumentCountIncludingThis
         subp ((CallFrameHeaderSize + 1 * SlotSize + StackAlignment - 1) & ~StackAlignmentMask), sp
-        storepairq a2, a3, CodeBlock + (SlotSize * 0)[sp]
-        storepairq t8, a4, CodeBlock + (SlotSize * 2)[sp]
-        move sp, t8
-        storepairq t8, cfr, VM::topCallFrame[a1] # topCallFrame and topEntryFrame
+        if ARM64 or ARM64E
+            vmEntryToJavaScriptStoreHeader(t8, 1)
+        else
+            vmEntryToJavaScriptStoreHeader(t0, 1)
+        end
+        vmEntryToJavaScriptSetTopCallFrame()
         jmp _llint_call_javascript
 
     # EncodedJSValue vmEntryToJavaScriptWith1Arguments(void*, VM*, CodeBlock*, JSObject*, JSValue, JSCell*, JSValue)
@@ -1892,15 +1925,17 @@ if (ARM64E or ARM64) and ADDRESS64
     _vmEntryToJavaScriptWith1Arguments:
         # entry must be a0
         vmEntryToJavaScriptSetup()
-        move 2, t8 # argumentCountIncludingThis
         subp ((CallFrameHeaderSize + 2 * SlotSize + StackAlignment - 1) & ~StackAlignmentMask), sp
-        storepairq a2, a3, CodeBlock + (SlotSize * 0)[sp]
-        storepairq t8, a4, CodeBlock + (SlotSize * 2)[sp]
-        storepairq a6, a6, CodeBlock + (SlotSize * 4)[sp]
-        move sp, t8
-        storepairq t8, cfr, VM::topCallFrame[a1] # topCallFrame and topEntryFrame
+        if ARM64 or ARM64E
+            vmEntryToJavaScriptStoreHeader(t8, 2)
+            storepairq a6, a6, CodeBlock + (SlotSize * 4)[sp]
+        else
+            vmEntryToJavaScriptStoreHeader(t0, 2)
+            loadq 16[cfr], t0
+            storeq t0, CodeBlock + (SlotSize * 4)[sp]
+        end
+        vmEntryToJavaScriptSetTopCallFrame()
         jmp _llint_call_javascript
-
 
     # EncodedJSValue vmEntryToJavaScriptWith2Arguments(void*, VM*, CodeBlock*, JSObject*, JSValue, JSCell*, JSValue, JSValue)
     # entry, vm, codeBlock, callee, thisValue, context, arg0, arg1
@@ -1908,13 +1943,18 @@ if (ARM64E or ARM64) and ADDRESS64
     _vmEntryToJavaScriptWith2Arguments:
         # entry must be a0
         vmEntryToJavaScriptSetup()
-        move 3, t8 # argumentCountIncludingThis
         subp ((CallFrameHeaderSize + 3 * SlotSize + StackAlignment - 1) & ~StackAlignmentMask), sp
-        storepairq a2, a3, CodeBlock + (SlotSize * 0)[sp]
-        storepairq t8, a4, CodeBlock + (SlotSize * 2)[sp]
-        storepairq a6, a7, CodeBlock + (SlotSize * 4)[sp]
-        move sp, t8
-        storepairq t8, cfr, VM::topCallFrame[a1] # topCallFrame and topEntryFrame
+        if ARM64 or ARM64E
+            vmEntryToJavaScriptStoreHeader(t8, 3)
+            storepairq a6, a7, CodeBlock + (SlotSize * 4)[sp]
+        else
+            vmEntryToJavaScriptStoreHeader(t0, 3)
+            loadq 16[cfr], t0
+            loadq 24[cfr], t5
+            storeq t0, CodeBlock + (SlotSize * 4)[sp]
+            storeq t5, CodeBlock + (SlotSize * 5)[sp]
+        end
+        vmEntryToJavaScriptSetTopCallFrame()
         jmp _llint_call_javascript
 
     # EncodedJSValue vmEntryToJavaScriptWith3Arguments(void*, VM*, CodeBlock*, JSObject*, JSValue, JSCell*, JSValue, JSValue, JSValue)
@@ -1923,15 +1963,22 @@ if (ARM64E or ARM64) and ADDRESS64
     _vmEntryToJavaScriptWith3Arguments:
         # entry must be a0
         vmEntryToJavaScriptSetup()
-        move 4, t8 # argumentCountIncludingThis
         subp ((CallFrameHeaderSize + 4 * SlotSize + StackAlignment - 1) & ~StackAlignmentMask), sp
-        loadq 16[cfr], t9 # Load arg2 from stack
-        storepairq a2, a3, CodeBlock + (SlotSize * 0)[sp]
-        storepairq t8, a4, CodeBlock + (SlotSize * 2)[sp]
-        storepairq a6, a7, CodeBlock + (SlotSize * 4)[sp]
-        storepairq t9, t9, CodeBlock + (SlotSize * 6)[sp]
-        move sp, t8
-        storepairq t8, cfr, VM::topCallFrame[a1] # topCallFrame and topEntryFrame
+        if ARM64 or ARM64E
+            loadq 16[cfr], t9 # Load arg2 from stack
+            vmEntryToJavaScriptStoreHeader(t8, 4)
+            storepairq a6, a7, CodeBlock + (SlotSize * 4)[sp]
+            storepairq t9, t9, CodeBlock + (SlotSize * 6)[sp]
+        else
+            vmEntryToJavaScriptStoreHeader(t0, 4)
+            loadq 16[cfr], t0
+            loadq 24[cfr], t5
+            storeq t0, CodeBlock + (SlotSize * 4)[sp]
+            storeq t5, CodeBlock + (SlotSize * 5)[sp]
+            loadq 32[cfr], t0
+            storeq t0, CodeBlock + (SlotSize * 6)[sp]
+        end
+        vmEntryToJavaScriptSetTopCallFrame()
         jmp _llint_call_javascript
 
     # EncodedJSValue vmEntryToJavaScriptWith4Arguments(void*, VM*, CodeBlock*, JSObject*, JSValue, JSCell*, JSValue, JSValue, JSValue, JSValue)
@@ -1940,15 +1987,24 @@ if (ARM64E or ARM64) and ADDRESS64
     _vmEntryToJavaScriptWith4Arguments:
         # entry must be a0
         vmEntryToJavaScriptSetup()
-        move 5, t8 # argumentCountIncludingThis
         subp ((CallFrameHeaderSize + 5 * SlotSize + StackAlignment - 1) & ~StackAlignmentMask), sp
-        loadpairq 16[cfr], t9, t10
-        storepairq a2, a3, CodeBlock + (SlotSize * 0)[sp]
-        storepairq t8, a4, CodeBlock + (SlotSize * 2)[sp]
-        storepairq a6, a7, CodeBlock + (SlotSize * 4)[sp]
-        storepairq t9, t10, CodeBlock + (SlotSize * 6)[sp]
-        move sp, t8
-        storepairq t8, cfr, VM::topCallFrame[a1] # topCallFrame and topEntryFrame
+        if ARM64 or ARM64E
+            loadpairq 16[cfr], t9, t10
+            vmEntryToJavaScriptStoreHeader(t8, 5)
+            storepairq a6, a7, CodeBlock + (SlotSize * 4)[sp]
+            storepairq t9, t10, CodeBlock + (SlotSize * 6)[sp]
+        else
+            vmEntryToJavaScriptStoreHeader(t0, 5)
+            loadq 16[cfr], t0
+            loadq 24[cfr], t5
+            storeq t0, CodeBlock + (SlotSize * 4)[sp]
+            storeq t5, CodeBlock + (SlotSize * 5)[sp]
+            loadq 32[cfr], t0
+            loadq 40[cfr], t5
+            storeq t0, CodeBlock + (SlotSize * 6)[sp]
+            storeq t5, CodeBlock + (SlotSize * 7)[sp]
+        end
+        vmEntryToJavaScriptSetTopCallFrame()
         jmp _llint_call_javascript
 
     # EncodedJSValue vmEntryToJavaScriptWith5Arguments(void*, VM*, CodeBlock*, JSObject*, JSValue, JSCell*, JSValue, JSValue, JSValue, JSValue, JSValue)
@@ -1957,17 +2013,28 @@ if (ARM64E or ARM64) and ADDRESS64
     _vmEntryToJavaScriptWith5Arguments:
         # entry must be a0
         vmEntryToJavaScriptSetup()
-        move 6, t8 # argumentCountIncludingThis
         subp ((CallFrameHeaderSize + 6 * SlotSize + StackAlignment - 1) & ~StackAlignmentMask), sp
-        loadpairq 16[cfr], t9, t10
-        loadq 32[cfr], t11
-        storepairq a2, a3, CodeBlock + (SlotSize * 0)[sp]
-        storepairq t8, a4, CodeBlock + (SlotSize * 2)[sp]
-        storepairq a6, a7, CodeBlock + (SlotSize * 4)[sp]
-        storepairq t9, t10, CodeBlock + (SlotSize * 6)[sp]
-        storepairq t11, t11, CodeBlock + (SlotSize * 8)[sp]
-        move sp, t8
-        storepairq t8, cfr, VM::topCallFrame[a1] # topCallFrame and topEntryFrame
+        if ARM64 or ARM64E
+            loadpairq 16[cfr], t9, t10
+            loadq 32[cfr], t11
+            vmEntryToJavaScriptStoreHeader(t8, 6)
+            storepairq a6, a7, CodeBlock + (SlotSize * 4)[sp]
+            storepairq t9, t10, CodeBlock + (SlotSize * 6)[sp]
+            storepairq t11, t11, CodeBlock + (SlotSize * 8)[sp]
+        else
+            vmEntryToJavaScriptStoreHeader(t0, 6)
+            loadq 16[cfr], t0
+            loadq 24[cfr], t5
+            storeq t0, CodeBlock + (SlotSize * 4)[sp]
+            storeq t5, CodeBlock + (SlotSize * 5)[sp]
+            loadq 32[cfr], t0
+            loadq 40[cfr], t5
+            storeq t0, CodeBlock + (SlotSize * 6)[sp]
+            storeq t5, CodeBlock + (SlotSize * 7)[sp]
+            loadq 48[cfr], t0
+            storeq t0, CodeBlock + (SlotSize * 8)[sp]
+        end
+        vmEntryToJavaScriptSetTopCallFrame()
         jmp _llint_call_javascript
 
     # EncodedJSValue vmEntryToJavaScriptWith6Arguments(void*, VM*, CodeBlock*, JSObject*, JSValue, JSCell*, JSValue, JSValue, JSValue, JSValue, JSValue, JSValue)
@@ -1976,17 +2043,30 @@ if (ARM64E or ARM64) and ADDRESS64
     _vmEntryToJavaScriptWith6Arguments:
         # entry must be a0
         vmEntryToJavaScriptSetup()
-        move 7, t8 # argumentCountIncludingThis
         subp ((CallFrameHeaderSize + 7 * SlotSize + StackAlignment - 1) & ~StackAlignmentMask), sp
-        loadpairq 16[cfr], t9, t10
-        loadpairq 32[cfr], t11, t12 # Load arg4 and arg5 from stack
-        storepairq a2, a3, CodeBlock + (SlotSize * 0)[sp]
-        storepairq t8, a4, CodeBlock + (SlotSize * 2)[sp]
-        storepairq a6, a7, CodeBlock + (SlotSize * 4)[sp]
-        storepairq t9, t10, CodeBlock + (SlotSize * 6)[sp]
-        storepairq t11, t12, CodeBlock + (SlotSize * 8)[sp]
-        move sp, t8
-        storepairq t8, cfr, VM::topCallFrame[a1] # topCallFrame and topEntryFrame
+        if ARM64 or ARM64E
+            loadpairq 16[cfr], t9, t10
+            loadpairq 32[cfr], t11, t12 # Load arg4 and arg5 from stack
+            vmEntryToJavaScriptStoreHeader(t8, 7)
+            storepairq a6, a7, CodeBlock + (SlotSize * 4)[sp]
+            storepairq t9, t10, CodeBlock + (SlotSize * 6)[sp]
+            storepairq t11, t12, CodeBlock + (SlotSize * 8)[sp]
+        else
+            vmEntryToJavaScriptStoreHeader(t0, 7)
+            loadq 16[cfr], t0
+            loadq 24[cfr], t5
+            storeq t0, CodeBlock + (SlotSize * 4)[sp]
+            storeq t5, CodeBlock + (SlotSize * 5)[sp]
+            loadq 32[cfr], t0
+            loadq 40[cfr], t5
+            storeq t0, CodeBlock + (SlotSize * 6)[sp]
+            storeq t5, CodeBlock + (SlotSize * 7)[sp]
+            loadq 48[cfr], t0
+            loadq 56[cfr], t5
+            storeq t0, CodeBlock + (SlotSize * 8)[sp]
+            storeq t5, CodeBlock + (SlotSize * 9)[sp]
+        end
+        vmEntryToJavaScriptSetTopCallFrame()
         jmp _llint_call_javascript
 end
 

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -124,7 +124,7 @@ static JSValue callMicrotask(JSGlobalObject* globalObject, JSValue functionObjec
             ASSERT(newCodeBlock);
             newCodeBlock->m_shouldAlwaysBeInlined = false;
         }
-#if CPU(ARM64) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
+#if (CPU(ARM64) || CPU(X86_64)) && CPU(ADDRESS64) && !ENABLE(C_LOOP)
         if ((sizeof...(args) + 1) >= newCodeBlock->numParameters()) [[likely]] {
             auto* entry = functionExecutable->generatedJITCodeAddressForCall();
             auto* callee = asObject(functionObject.asCell());


### PR DESCRIPTION
#### 32de67469bf09b776688dc566766da058f221286
<pre>
[JSC] Support fast C++ -&gt; JS calls in x64
<a href="https://bugs.webkit.org/show_bug.cgi?id=309926">https://bugs.webkit.org/show_bug.cgi?id=309926</a>
<a href="https://rdar.apple.com/172519516">rdar://172519516</a>

Reviewed by Sosuke Suzuki.

Implement vmEntryToJavaScriptWith0Arguments - vmEntryToJavaScriptWith6Arguments
variants in x64 too. It is not super hard: t0 (rax) is not used for
argument registers, so we can easily use it for scratch register.

* Source/JavaScriptCore/interpreter/CachedCallInlines.h:
(JSC::CachedCall::callWithArguments):
* Source/JavaScriptCore/interpreter/Interpreter.h:
* Source/JavaScriptCore/interpreter/InterpreterInlines.h:
* Source/JavaScriptCore/interpreter/MicrotaskCallInlines.h:
(JSC::MicrotaskCall::tryCallWithArguments):
* Source/JavaScriptCore/llint/LLIntThunks.h:
* Source/JavaScriptCore/llint/LowLevelInterpreter.asm:
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::callMicrotask):

Canonical link: <a href="https://commits.webkit.org/309269@main">https://commits.webkit.org/309269@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbaa93fcb0655045a2959d31e3dbe89292ad0202

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103513 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d7aacf71-58ad-4285-b107-d186a2b18d45) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115771 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fcbc03c6-3bba-4a8f-a16a-d07ed0471cec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96500 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1068fc80-bfa0-4d93-a251-05542a6d72b2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16983 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14932 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6636 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142062 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161264 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10877 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4355 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123773 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22639 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18979 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 5 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123975 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22626 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134362 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78855 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23087 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19123 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11118 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181510 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22238 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86039 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46463 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21953 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22105 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22007 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->