### PR TITLE
[webkitpy] [webkitcorepy] Expected failures / unexpected successes not properly handled

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/testing/test_runner.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/testing/test_runner.py
@@ -110,12 +110,22 @@ class TestRunner(object):
                         for member in value:
                             sys.stderr.write(member[1] + '\n')
                     result = True
+                if incremental.unexpectedSuccesses:
+                    sys.stdout.write('unexpectedly passed\n')
+                    if args.log_level <= logging.ERROR:
+                        sys.stderr.write('\n')
+                        for test in incremental.unexpectedSuccesses:
+                            sys.stderr.write(f'UNEXPECTED SUCCESS: {test.id()}\n')
+                    result = True
                 if result:
                     continue
 
                 if incremental.skipped or not incremental.testsRun:
                     chars += 8
                     sys.stdout.write('skipped\n')
+                elif incremental.expectedFailures:
+                    chars += 16
+                    sys.stdout.write('expected failure\n')
                 else:
                     chars += 7
                     sys.stdout.write('passed\n')
@@ -129,7 +139,7 @@ class TestRunner(object):
 
         print('\nRan {} of {} tests in {:0.3f} seconds\n'.format(results.testsRun, len(tests_to_run), tm() - start_time))
 
-        if results.failures or results.errors:
+        if results.failures or results.errors or results.unexpectedSuccesses:
             print('FAILED')
             for attribute in ('failure', 'error'):
                 value = getattr(results, attribute + 's')
@@ -145,11 +155,18 @@ class TestRunner(object):
                         for line in part[1].splitlines():
                             print('{}{}'.format(' ' * self.INDENT * 3, line))
                         print()
+            if results.unexpectedSuccesses:
+                print(f'    {len(results.unexpectedSuccesses)} unexpected success(es)')
+                if args.log_level < logging.WARNING:
+                    for test in results.unexpectedSuccesses:
+                        print(f'        {self.id(test)}')
             return 1
         elif not results.testsRun:
             print('No tests run')
             return -1
         print('SUCCESS')
+        if results.expectedFailures:
+            print(f'    {len(results.expectedFailures)} expected failure(s)')
         return 0
 
     def main(self, *args, **kwargs):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/testing/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/testing/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/testing/test_runner_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/testing/test_runner_unittest.py
@@ -1,0 +1,162 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import argparse
+import logging
+import re
+import unittest
+
+from webkitcorepy import OutputCapture
+from webkitcorepy.testing.test_runner import TestRunner
+
+
+class _Test_TestRunner(unittest.TestCase):
+    def _test_pass(self):
+        pass
+
+    def _test_fail(self):
+        self.fail('assertion failed')
+
+    def _test_error(self):
+        raise Exception('exception')
+
+    def _test_skip(self):
+        self.skipTest('skipped')
+
+    @unittest.expectedFailure
+    def _test_expected_failure(self):
+        self.fail('expected failure')
+
+    @unittest.expectedFailure
+    def _test_unexpected_success(self):
+        pass
+
+    def id(self):
+        return self._testMethodName
+
+
+class StubTestRunner(TestRunner):
+    def __init__(self, test_names):
+        super().__init__('stub')
+        self._test_names = test_names
+
+    def tests(self, args=None):
+        return self._test_names
+
+    def run_test(self, test):
+        result = unittest.TestResult()
+        _Test_TestRunner(test).run(result)
+        return result
+
+
+class TestRunnerTest(unittest.TestCase):
+    maxDiff = None
+
+    @staticmethod
+    def _normalize(stdout):
+        return re.sub(r'[0-9]+\.[0-9]+ seconds', '1.111 seconds', stdout)
+
+    def _run(self, test_name):
+        runner = StubTestRunner([test_name])
+        with OutputCapture() as captured:
+            ret = runner.run(argparse.Namespace(log_level=logging.WARNING))
+        return ret, self._normalize(captured.stdout.getvalue()), captured.stderr.getvalue()
+
+    def test_passed(self):
+        ret, stdout, stderr = self._run('_test_pass')
+        self.assertEqual(ret, 0)
+        self.assertEqual(stdout, """\
+[1/1] _test_pass passed
+
+Ran 1 of 1 tests in 1.111 seconds
+
+SUCCESS
+""")
+        self.assertEqual(stderr, '')
+
+    def test_failed(self):
+        ret, stdout, stderr = self._run('_test_fail')
+        self.assertEqual(ret, 1)
+        self.assertEqual(stdout, """\
+[1/1] _test_fail failed
+
+Ran 1 of 1 tests in 1.111 seconds
+
+FAILED
+    1 failure
+""")
+        self.assertIn('AssertionError: assertion failed', stderr)
+        self.assertEqual(stderr.count('AssertionError: assertion failed'), 1)
+
+    def test_errored(self):
+        ret, stdout, stderr = self._run('_test_error')
+        self.assertEqual(ret, 1)
+        self.assertEqual(stdout, """\
+[1/1] _test_error erred
+
+Ran 1 of 1 tests in 1.111 seconds
+
+FAILED
+    1 error
+""")
+        self.assertIn('Exception: exception', stderr)
+        self.assertEqual(stderr.count('Exception: exception'), 1)
+
+    def test_skipped(self):
+        ret, stdout, stderr = self._run('_test_skip')
+        self.assertEqual(ret, 0)
+        self.assertEqual(stdout, """\
+[1/1] _test_skip skipped
+
+Ran 1 of 1 tests in 1.111 seconds
+
+SUCCESS
+""")
+        self.assertEqual(stderr, '')
+
+    def test_unexpected_success_causes_failure(self):
+        ret, stdout, stderr = self._run('_test_unexpected_success')
+        self.assertEqual(ret, 1)
+        self.assertEqual(stdout, """\
+[1/1] _test_unexpected_success unexpectedly passed
+
+Ran 1 of 1 tests in 1.111 seconds
+
+FAILED
+    1 unexpected success(es)
+""")
+        self.assertEqual(stderr, """
+UNEXPECTED SUCCESS: _test_unexpected_success
+""")
+
+    def test_expected_failure_returns_success(self):
+        ret, stdout, stderr = self._run('_test_expected_failure')
+        self.assertEqual(ret, 0)
+        self.assertEqual(stdout, """\
+[1/1] _test_expected_failure expected failure
+
+Ran 1 of 1 tests in 1.111 seconds
+
+SUCCESS
+    1 expected failure(s)
+""")
+        self.assertEqual(stderr, '')

--- a/Tools/Scripts/webkitpy/test/main.py
+++ b/Tools/Scripts/webkitpy/test/main.py
@@ -265,6 +265,12 @@ class Tester(object):
                 results[test] = Upload.create_test_result(actual=Upload.Expectations.ERROR, log='/n'.join(errors))
             for test, failures in test_runner.failures:
                 results[test] = Upload.create_test_result(actual=Upload.Expectations.FAIL, log='/n'.join(failures))
+            for test in test_runner.expected_failures:
+                results[test] = Upload.create_test_result(
+                    expected=Upload.Expectations.FAIL, actual=Upload.Expectations.FAIL)
+            for test in test_runner.unexpected_successes:
+                results[test] = Upload.create_test_result(
+                    expected=Upload.Expectations.FAIL, actual=Upload.Expectations.PASS)
 
             _host.initialize_scm()
             upload = Upload(

--- a/Tools/Scripts/webkitpy/test/printer.py
+++ b/Tools/Scripts/webkitpy/test/printer.py
@@ -120,16 +120,20 @@ class Printer(object):
 
         write(self._test_line(self.running_tests[0], suffix))
 
-    def print_finished_test(self, source, test_name, test_time, failures, errors):
+    def print_finished_test(self, source, test_name, test_time, failures, errors,
+                            expected_failures=None, unexpected_successes=None):
         write = self.meter.writeln
-        if failures:
-            lines = failures[0].splitlines() + ['']
+        if failures or unexpected_successes:
+            lines = (failures or []) + ['UNEXPECTED SUCCESS' for _ in (unexpected_successes or [])]
             suffix = ' failed:'
             self.num_failures += 1
         elif errors:
             lines = errors[0].splitlines() + ['']
             suffix = ' erred:'
             self.num_errors += 1
+        elif expected_failures:
+            suffix = ' expected failure'
+            lines = []
         else:
             suffix = ' passed'
             lines = []

--- a/Tools/Scripts/webkitpy/test/printer_unittest.py
+++ b/Tools/Scripts/webkitpy/test/printer_unittest.py
@@ -1,0 +1,109 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+import unittest
+
+from webkitcorepy import StringIO
+
+from webkitpy.test.printer import Printer
+from webkitpy.tool.mocktool import MockOptions
+
+
+class PrinterTest(unittest.TestCase):
+    def setUp(self):
+        # Printer.configure() emits an INFO log message to the root logger.
+        # Remove existing handlers so it doesn't appear in test-webkitpy's output.
+        root_logger = logging.getLogger()
+        handlers = root_logger.handlers[:]
+        for handler in handlers:
+            root_logger.removeHandler(handler)
+        self.addCleanup(lambda: [root_logger.addHandler(h) for h in handlers])
+
+    def _make_printer(self, num_tests=1):
+        options = MockOptions(verbose=0, timing=False, quiet=False, pass_through=False)
+        stream = StringIO()
+        printer = Printer(stream, options)
+        printer.num_tests = num_tests
+        stream.truncate(0)
+        stream.seek(0)
+        return printer, stream
+
+    def _drive(self, printer, stream, failures=None, errors=None, expected_failures=None, unexpected_successes=None):
+        printer.print_started_test(None, 'test1')
+        stream.truncate(0)
+        stream.seek(0)
+        printer.print_finished_test(None, 'test1', 0.0, failures or [], errors or [], expected_failures, unexpected_successes)
+        finished_output = stream.getvalue()
+        stream.truncate(0)
+        stream.seek(0)
+        printer.print_result(0.0)
+        result_output = stream.getvalue()
+        return finished_output, result_output
+
+    def test_passed(self):
+        printer, stream = self._make_printer()
+        finished_output, result_output = self._drive(printer, stream)
+        self.assertEqual(finished_output, '')
+        self.assertEqual(printer.num_started, 1)
+        self.assertEqual(printer.num_failures, 0)
+        self.assertEqual(printer.num_errors, 0)
+        self.assertEqual(result_output, 'Ran 1 test in 0.000s\n\nOK\n')
+
+    def test_failed(self):
+        printer, stream = self._make_printer()
+        finished_output, result_output = self._drive(printer, stream, failures=['boom'])
+        self.assertEqual(finished_output, '[1/1] test1 failed:\n  boom\n')
+        self.assertEqual(printer.num_failures, 1)
+        self.assertEqual(printer.num_errors, 0)
+        self.assertEqual(result_output, 'Ran 1 test in 0.000s\nFAILED (failures=1, errors=0)\n')
+
+    def test_errored(self):
+        printer, stream = self._make_printer()
+        finished_output, result_output = self._drive(printer, stream, errors=['boom'])
+        self.assertEqual(finished_output, '[1/1] test1 erred:\n  boom\n  \n')
+        self.assertEqual(printer.num_failures, 0)
+        self.assertEqual(printer.num_errors, 1)
+        self.assertEqual(result_output, 'Ran 1 test in 0.000s\nFAILED (failures=0, errors=1)\n')
+
+    def test_unexpected_success(self):
+        printer, stream = self._make_printer()
+        finished_output, result_output = self._drive(printer, stream, unexpected_successes=['test1'])
+        self.assertEqual(finished_output, '[1/1] test1 failed:\n  UNEXPECTED SUCCESS\n')
+        self.assertEqual(printer.num_failures, 1)
+        self.assertEqual(printer.num_errors, 0)
+        self.assertEqual(result_output, 'Ran 1 test in 0.000s\nFAILED (failures=1, errors=0)\n')
+
+    def test_expected_failure(self):
+        printer, stream = self._make_printer()
+        finished_output, result_output = self._drive(printer, stream, expected_failures=['test1'])
+        self.assertEqual(finished_output, '[1/1] test1 expected failure\n')
+        self.assertEqual(printer.num_failures, 0)
+        self.assertEqual(printer.num_errors, 0)
+        self.assertEqual(result_output, 'Ran 1 test in 0.000s\n\nOK\n')
+
+    def test_failed_with_expected_failures_list(self):
+        printer, stream = self._make_printer()
+        finished_output, result_output = self._drive(printer, stream, failures=['boom'], expected_failures=['test1'])
+        self.assertEqual(finished_output, '[1/1] test1 failed:\n  boom\n')
+        self.assertEqual(printer.num_failures, 1)
+        self.assertEqual(result_output, 'Ran 1 test in 0.000s\nFAILED (failures=1, errors=0)\n')

--- a/Tools/Scripts/webkitpy/test/runner.py
+++ b/Tools/Scripts/webkitpy/test/runner.py
@@ -22,7 +22,6 @@
 
 """code to actually run a list of python tests."""
 
-import re
 import time
 import unittest
 
@@ -35,6 +34,8 @@ class Runner(object):
         self.tests_run = []
         self.errors = []
         self.failures = []
+        self.expected_failures = []
+        self.unexpected_successes = []
         self.worker_factory = lambda caller: _Worker(caller, self.loader)
 
     def run(self, test_names, num_workers):
@@ -44,7 +45,8 @@ class Runner(object):
         with message_pool.get(self, self.worker_factory, num_workers) as pool:
             pool.run(('test', test_name) for test_name in test_names)
 
-    def handle(self, message_name, source, test_name=None, delay=None, failures=None, errors=None):
+    def handle(self, message_name, source, test_name=None, delay=None, failures=None, errors=None,
+               expected_failures=None, unexpected_successes=None):
         if message_name == 'did_spawn_worker':
             return
 
@@ -60,7 +62,12 @@ class Runner(object):
             self.failures.append((test_name, failures))
         if errors:
             self.errors.append((test_name, errors))
-        self.printer.print_finished_test(source, test_name, delay, failures, errors)
+        if expected_failures:
+            self.expected_failures.extend(expected_failures)
+        if unexpected_successes:
+            self.unexpected_successes.extend(unexpected_successes)
+        self.printer.print_finished_test(source, test_name, delay, failures, errors,
+                                         expected_failures, unexpected_successes)
 
 
 class _Worker(object):
@@ -81,11 +88,13 @@ class _Worker(object):
                len(result.skipped) + len(result.expectedFailures) +
                len(result.unexpectedSuccesses) + result.successes) == result.testsRun
 
-        failures = ([failure[1] for failure in result.failures]
-                    + ["UNEXPECTED SUCCESS" for _ in result.unexpectedSuccesses])
+        failures = [failure[1] for failure in result.failures]
+        expected_failures = [failure[0].id() for failure in result.expectedFailures]
+        unexpected_successes = [test.id() for test in result.unexpectedSuccesses]
 
         self._caller.post('finished_test', test_name, time.time() - start,
-                          failures, [error[1] for error in result.errors])
+                          failures, [error[1] for error in result.errors],
+                          expected_failures, unexpected_successes)
 
 
 class TestResult(unittest.TestResult):

--- a/Tools/Scripts/webkitpy/test/runner_unittest.py
+++ b/Tools/Scripts/webkitpy/test/runner_unittest.py
@@ -113,3 +113,16 @@ class RunnerTest(unittest.TestCase):
         self.assertEqual(len(runner.tests_run), 3)
         self.assertEqual(len(runner.failures), 1)
         self.assertEqual(len(runner.errors), 1)
+
+    def test_run_expected_failures(self):
+        options = MockOptions(verbose=0, timing=False, child_processes=1, quiet=False, pass_through=False)
+        stream = StringIO()
+        loader = FakeLoader(('test1 (Foo)', 'x', ''),
+                            ('test2 (Foo)', 'u', ''))
+        runner = Runner(Printer(stream, options), loader)
+        runner.run(['Foo.test1', 'Foo.test2'], 1)
+        self.assertEqual(len(runner.tests_run), 2)
+        self.assertEqual(len(runner.failures), 0)
+        self.assertEqual(len(runner.errors), 0)
+        self.assertEqual(len(runner.expected_failures), 1)
+        self.assertEqual(len(runner.unexpected_successes), 1)


### PR DESCRIPTION
#### b3f6dc92c6a45dbd5f4fcec996c551e319ffe678
<pre>
[webkitpy] [webkitcorepy] Expected failures / unexpected successes not properly handled
<a href="https://bugs.webkit.org/show_bug.cgi?id=309834">https://bugs.webkit.org/show_bug.cgi?id=309834</a>
<a href="https://rdar.apple.com/172412849">rdar://172412849</a>

Reviewed by Elliott Williams.

The test runners did not correctly handle Python&apos;s @unittest.expectedFailure
decorator. Expected failures were reported as &quot;passed&quot;, and unexpected
successes (where a test marked as expected-to-fail actually passes) were
conflated with regular failures without being clearly identified.

Track expected failures and unexpected successes as distinct outcomes
throughout the pipeline, instead of conflating them with passes and
failures.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/testing/test_runner.py:
(TestRunner.run): Report expected failures as &quot;expected failure&quot; instead of
&quot;passed&quot;, and treat unexpected successes as failures.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/testing/__init__.py: Added.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/testing/test_runner_unittest.py: Added.
(_Test_TestRunner):
(_Test_TestRunner._test_pass):
(_Test_TestRunner._test_fail):
(_Test_TestRunner._test_error):
(_Test_TestRunner._test_skip):
(_Test_TestRunner._test_expected_failure):
(_Test_TestRunner._test_unexpected_success):
(_Test_TestRunner.id):
(StubTestRunner):
(StubTestRunner.__init__):
(StubTestRunner.tests):
(StubTestRunner.run_test):
(TestRunnerTest):
(TestRunnerTest._normalize):
(TestRunnerTest._run):
(TestRunnerTest.test_passed):
(TestRunnerTest.test_failed):
(TestRunnerTest.test_errored):
(TestRunnerTest.test_skipped):
(TestRunnerTest.test_unexpected_success_causes_failure):
(TestRunnerTest.test_expected_failure_returns_success):
* Tools/Scripts/webkitpy/test/main.py:
(Tester._run_tests): Include expected/actual values for expected failures
and unexpected successes in uploaded test results.
* Tools/Scripts/webkitpy/test/printer.py:
(Printer.print_finished_test): Accept expected_failures and
unexpected_successes, so unexpected successes are shown as failures and
expected failures get their own summary suffix.
* Tools/Scripts/webkitpy/test/printer_unittest.py: Added.
(PrinterTest):
(PrinterTest.setUp):
(PrinterTest._make_printer):
(PrinterTest._drive):
(PrinterTest.test_passed):
(PrinterTest.test_failed):
(PrinterTest.test_errored):
(PrinterTest.test_unexpected_success):
(PrinterTest.test_expected_failure):
(PrinterTest.test_failed_with_expected_failures_list):
* Tools/Scripts/webkitpy/test/runner.py:
(Runner.__init__): Track expected failures and unexpected successes.
(Runner.handle): Ditto.
(_Worker.handle): Compute expected_failures and unexpected_successes
separately instead of folding unexpected successes into failures.
* Tools/Scripts/webkitpy/test/runner_unittest.py:
(FakeModuleSuite.run): Support &apos;x&apos; (expected failure) and &apos;u&apos; (unexpected
success) fake results.
(RunnerTest.test_run_expected_failures):

Canonical link: <a href="https://commits.webkit.org/319652@main">https://commits.webkit.org/319652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58704e5265ec52495a62db0131dd09fcd16749a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191317 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145423 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/a27e34ac-5945-4aa3-be1b-74036946b8a6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54761 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141316 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98014 "") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44981 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162067 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121767 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/b03d5838-41c9-4031-8aec-6a4ab7f99ef7) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180424 "Found 1 webkitpy test failure: webkitpy.test.runner_unittest.RunnerTest.test_run_expected_failures") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43654 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41933 "Passed tests") | | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41595 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2474 "Built successfully") | | 
| | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193249 "Built successfully") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/180501 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54711 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150703 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55399 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150418 "Passed tests") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/27669 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45011 "Passed tests") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123212 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53916 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16591 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53298 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53535 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53363 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->