### PR TITLE
[webkitscmpy] GitHub doesn't support updating PR head

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
@@ -182,7 +182,9 @@ class GitHub(Scm):
         def update(self, pull_request, head=None, title=None, body=None, commits=None, base=None, opened=None, draft=None):
             if not isinstance(pull_request, PullRequest):
                 raise ValueError("Expected 'pull_request' to be of type '{}' not '{}'".format(PullRequest, type(pull_request)))
-            if not any((head, title, body, commits, base)) and opened is None:
+            if head is not None and head != pull_request.head:
+                raise ValueError(f"GitHub does not support updating the head branch of a pull request (requested: {pull_request.head} to {head})")
+            if not any((title, body, commits, base)) and opened is None:
                 raise ValueError('No arguments to update pull-request provided')
             if draft is not None:
                 sys.stderr.write('GitHub does not allow editing draft state via API\n')
@@ -192,8 +194,6 @@ class GitHub(Scm):
                 title=title or pull_request.title,
                 base=base or pull_request.base,
             )
-            if head:
-                updates['head'] = '{}:{}'.format(user, head)
             if body or commits:
                 updates['body'] = PullRequest.create_body(body, commits)
             if opened is not None:

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -2380,6 +2380,21 @@ Reviewed by NOBODY (OOPS!).
             pr = remote.GitHub(self.remote).pull_requests.get(1)
             self.assertEqual(pr.title, 'New Title')
 
+    def test_update_head_mismatch(self):
+        with self.webserver():
+            pr = remote.GitHub(self.remote).pull_requests.get(1)
+            self.assertEqual(pr.head, 'eng/pull-request')
+            with self.assertRaises(ValueError):
+                pr.generator.update(pr, head='eng/different-branch', title='New Title')
+
+    def test_update_same_head(self):
+        with self.webserver():
+            pr = remote.GitHub(self.remote).pull_requests.get(1)
+            self.assertEqual(pr.head, 'eng/pull-request')
+            pr.generator.update(pr, head='eng/pull-request', title='New Title')
+            pr = remote.GitHub(self.remote).pull_requests.get(1)
+            self.assertEqual(pr.title, 'New Title')
+
     def test_reviewers(self):
         with self.webserver():
             pr = remote.GitHub(self.remote).pull_requests.get(1)


### PR DESCRIPTION
#### dfc03caa0d839bfcaab0bcb85f17e58ccf9f9286
<pre>
[webkitscmpy] GitHub doesn&apos;t support updating PR head
<a href="https://bugs.webkit.org/show_bug.cgi?id=309809">https://bugs.webkit.org/show_bug.cgi?id=309809</a>
<a href="https://rdar.apple.com/172395889">rdar://172395889</a>

Reviewed by Jonathan Bedard.

The GitHub REST API does not accept `head` in the body of `PATCH
/repos/{owner}/{repo}/pulls/{pull_number}` per
&lt;<a href="https://docs.github.com/en/rest/pulls/pulls?apiVersion=2026-03-10#update-a-pull-request">https://docs.github.com/en/rest/pulls/pulls?apiVersion=2026-03-10#update-a-pull-request</a>&gt;.

Raise an error if someone tries to change it, allowing head=None
(default) and head=pull_request.head (no-op for compatibility).

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:

Canonical link: <a href="https://commits.webkit.org/312561@main">https://commits.webkit.org/312561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/478fdc239ec2ec32ce4768f497961d5a860b07d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16382 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158774 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103497 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14d28878-60bc-4edc-ae71-9488e528a0d6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151936 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115754 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82229 "3 flakes 1 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de76c348-50a9-4d96-b583-cd253620f411) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17872 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134630 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96483 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81b4b596-b474-434b-9e23-c381cb38cf67) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/149384 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16972 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14918 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6620 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126587 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161248 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14106 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123757 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/149463 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22624 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123959 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134349 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78839 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24395 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19096 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11105 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22195 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21937 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22089 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21991 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->