### PR TITLE
[SaferCPP] Replace raw pointers and leaking references with smart pointers in style/ElementRuleCollector.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -106,7 +106,6 @@ rendering/RenderTreeAsText.cpp
 rendering/cocoa/RenderThemeCocoa.mm
 [ iOS ] rendering/ios/RenderThemeIOS.mm
 rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
-style/ElementRuleCollector.cpp
 style/MatchResultCache.cpp
 style/PageRuleCollector.cpp
 style/RuleSetBuilder.cpp

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -58,33 +58,29 @@
 #include "StyledElement.h"
 #include "UserAgentStyle.h"
 #include <ranges>
-#include <wtf/SetForScope.h>
+#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 namespace Style {
 
 static const StyleProperties& leftToRightDeclaration()
 {
-IGNORE_GCC_WARNINGS_BEGIN("dangling-reference")
-    static auto& declaration = [] () -> const StyleProperties& {
-        auto properties = MutableStyleProperties::create();
-        properties->setProperty(CSSPropertyDirection, CSSValueLtr);
-        return properties.leakRef();
+    static NeverDestroyed<Ref<MutableStyleProperties>> properties = [] {
+        auto p = MutableStyleProperties::create();
+        p->setProperty(CSSPropertyDirection, CSSValueLtr);
+        return p;
     }();
-IGNORE_GCC_WARNINGS_END
-    return declaration;
+    return properties.get().get();
 }
 
 static const StyleProperties& rightToLeftDeclaration()
 {
-IGNORE_GCC_WARNINGS_BEGIN("dangling-reference")
-    static auto& declaration = [] () -> const StyleProperties& {
-        auto properties = MutableStyleProperties::create();
-        properties->setProperty(CSSPropertyDirection, CSSValueRtl);
-        return properties.leakRef();
+    static NeverDestroyed<Ref<MutableStyleProperties>> properties = [] {
+        auto p = MutableStyleProperties::create();
+        p->setProperty(CSSPropertyDirection, CSSValueRtl);
+        return p;
     }();
-IGNORE_GCC_WARNINGS_END
-    return declaration;
+    return properties.get().get();
 }
 
 struct MatchRequest {
@@ -192,7 +188,7 @@ void ElementRuleCollector::collectMatchingRules(DeclarationOrigin origin)
         return;
     }
 
-    auto* parent = element().parentElement();
+    RefPtr parent = element().parentElement();
     if (parent && parent->shadowRoot()) {
         matchSlottedPseudoElementRules(origin);
         if (isFirstMatchModeAndHasMatchedAnyRules())
@@ -221,27 +217,27 @@ void ElementRuleCollector::collectMatchingRules(const MatchRequest& matchRequest
     ASSERT_WITH_MESSAGE(!(m_mode == SelectorChecker::Mode::StyleInvalidation && m_pseudoElementRequest), "When in StyleInvalidation or SharingRules, SelectorChecker does not try to match the pseudo ID. While ElementRuleCollector supports matching a particular pseudoId in this case, this would indicate a error at the call site since matching a particular element should be unnecessary.");
 
     auto& element = this->element();
-    auto* shadowRoot = element.containingShadowRoot();
+    RefPtr shadowRoot = element.containingShadowRoot();
     if (shadowRoot && shadowRoot->mode() == ShadowRootMode::UserAgent)
         collectMatchingUserAgentPartRules(matchRequest);
 
     bool isHTMLElement = element.isHTMLElement();
     bool isCaseInsensitiveForHTML = isHTMLElement && element.document().isHTMLDocument();
-    auto& ruleSet = matchRequest.ruleSet;
+    Ref ruleSet = matchRequest.ruleSet;
 
     // We need to collect the rules for id, class, tag, and everything else into a buffer and
     // then sort the buffer.
     auto& id = element.idForStyleResolution();
     if (!id.isNull())
-        collectMatchingRulesForList(ruleSet.idRules(id), matchRequest);
+        collectMatchingRulesForList(ruleSet->idRules(id), matchRequest);
     if (element.hasClass()) {
         for (auto& className : element.classNames())
-            collectMatchingRulesForList(ruleSet.classRules(className), matchRequest);
+            collectMatchingRulesForList(ruleSet->classRules(className), matchRequest);
     }
-    if (element.hasAttributesWithoutUpdate() && ruleSet.hasAttributeRules()) {
+    if (element.hasAttributesWithoutUpdate() && ruleSet->hasAttributeRules()) {
         Vector<const RuleSet::RuleDataVector*, 4> ruleVectors;
         for (auto& attribute : element.attributes()) {
-            if (auto* rules = ruleSet.attributeRules(attribute.localName(), isCaseInsensitiveForHTML))
+            if (auto* rules = ruleSet->attributeRules(attribute.localName(), isCaseInsensitiveForHTML))
                 ruleVectors.append(rules);
         }
         for (auto* rules : ruleVectors)
@@ -250,31 +246,31 @@ void ElementRuleCollector::collectMatchingRules(const MatchRequest& matchRequest
 
     if (m_pseudoElementRequest) {
         if (m_pseudoElementRequest->type() == PseudoElementType::UserAgentPartFallback)
-            collectMatchingRulesForList(ruleSet.userAgentPartRules(m_pseudoElementRequest->nameOrPart()), matchRequest);
+            collectMatchingRulesForList(ruleSet->userAgentPartRules(m_pseudoElementRequest->nameOrPart()), matchRequest);
         else if (!m_pseudoElementRequest->nameOrPart().isNull())
-            collectMatchingRulesForList(ruleSet.namedPseudoElementRules(m_pseudoElementRequest->nameOrPart()), matchRequest);
+            collectMatchingRulesForList(ruleSet->namedPseudoElementRules(m_pseudoElementRequest->nameOrPart()), matchRequest);
     }
 
     if (element.isLink())
-        collectMatchingRulesForList(ruleSet.linkPseudoClassRules(), matchRequest);
+        collectMatchingRulesForList(ruleSet->linkPseudoClassRules(), matchRequest);
     if (matchesFocusPseudoClass(element))
-        collectMatchingRulesForList(ruleSet.focusPseudoClassRules(), matchRequest);
+        collectMatchingRulesForList(ruleSet->focusPseudoClassRules(), matchRequest);
     if (matchesFocusVisiblePseudoClass(element))
-        collectMatchingRulesForList(ruleSet.focusVisiblePseudoClassRules(), matchRequest);
+        collectMatchingRulesForList(ruleSet->focusVisiblePseudoClassRules(), matchRequest);
 #if ENABLE(FULLSCREEN_API)
     if (auto* fullscreen = element.document().fullscreenIfExists(); fullscreen && fullscreen->isFullscreen())
-        collectMatchingRulesForList(ruleSet.fullscreenPseudoClassRules(), matchRequest);
+        collectMatchingRulesForList(ruleSet->fullscreenPseudoClassRules(), matchRequest);
 #endif
     if (&element == element.document().documentElement())
-        collectMatchingRulesForList(ruleSet.rootElementRules(), matchRequest);
-    collectMatchingRulesForList(ruleSet.tagRules(element.localName(), isCaseInsensitiveForHTML), matchRequest);
-    collectMatchingRulesForList(ruleSet.universalRules(), matchRequest);
+        collectMatchingRulesForList(ruleSet->rootElementRules(), matchRequest);
+    collectMatchingRulesForList(ruleSet->tagRules(element.localName(), isCaseInsensitiveForHTML), matchRequest);
+    collectMatchingRulesForList(ruleSet->universalRules(), matchRequest);
 
     // Shortcut selectors like "::marker" for HTML elements.
-    auto pseudoElementTypes = isHTMLElement ? ruleSet.universalHTMLPseudoElementTypes() : ruleSet.universalPseudoElementTypes();
+    auto pseudoElementTypes = isHTMLElement ? ruleSet->universalHTMLPseudoElementTypes() : ruleSet->universalPseudoElementTypes();
     if (m_pseudoElementRequest) {
         if (pseudoElementTypes.contains(m_pseudoElementRequest->type()))
-            collectMatchingRulesForList(ruleSet.universalPseudoElementRules(), matchRequest);
+            collectMatchingRulesForList(ruleSet->universalPseudoElementRules(), matchRequest);
     } else {
         // If pseudo-element is not requested then just mark the bits that tell that this element has these.
         m_matchedPseudoElements.add(pseudoElementTypes & allPublicPseudoElementTypes);
@@ -354,12 +350,12 @@ bool ElementRuleCollector::matchesAnyAuthorRules()
 void ElementRuleCollector::matchUserAgentPartRules(DeclarationOrigin origin)
 {
     ASSERT(element().isInShadowTree());
-    auto* shadowRoot = element().containingShadowRoot();
+    RefPtr shadowRoot = element().containingShadowRoot();
     if (!shadowRoot || shadowRoot->mode() != ShadowRootMode::UserAgent)
         return;
 
     // Look up user agent parts also from the host scope style as they are web-exposed.
-    auto* hostRules = Scope::forNode(*shadowRoot->host()).resolver().ruleSets().styleForDeclarationOrigin(origin);
+    RefPtr hostRules = Scope::forNode(*shadowRoot->host()).resolver().ruleSets().styleForDeclarationOrigin(origin);
     if (!hostRules)
         return;
 
@@ -371,7 +367,7 @@ void ElementRuleCollector::matchHostPseudoClassRules(DeclarationOrigin origin)
 {
     ASSERT(element().shadowRoot());
 
-    auto* shadowRules = element().shadowRoot()->styleScope().resolver().ruleSets().styleForDeclarationOrigin(origin);
+    RefPtr shadowRules = element().shadowRoot()->styleScope().resolver().ruleSets().styleForDeclarationOrigin(origin);
     if (!shadowRules)
         return;
 
@@ -391,7 +387,7 @@ void ElementRuleCollector::matchHostPseudoClassRules(DeclarationOrigin origin)
 
 void ElementRuleCollector::matchSlottedPseudoElementRules(DeclarationOrigin origin)
 {
-    auto* slot = element().assignedSlot();
+    RefPtr slot = element().assignedSlot();
     auto styleScopeOrdinal = ScopeOrdinal::FirstSlot;
 
     for (; slot; slot = slot->assignedSlot(), ++styleScopeOrdinal) {
@@ -399,7 +395,7 @@ void ElementRuleCollector::matchSlottedPseudoElementRules(DeclarationOrigin orig
         if (!styleScope.resolver().ruleSets().isAuthorStyleDefined())
             continue;
 
-        auto* scopeRules = styleScope.resolver().ruleSets().styleForDeclarationOrigin(origin);
+        RefPtr scopeRules = styleScope.resolver().ruleSets().styleForDeclarationOrigin(origin);
         if (!scopeRules)
             continue;
 
@@ -419,8 +415,8 @@ void ElementRuleCollector::matchPartPseudoElementRules(DeclarationOrigin origin)
 
     bool isUserAgentPart = element().containingShadowRoot()->mode() == ShadowRootMode::UserAgent && !element().userAgentPart().isNull();
 
-    auto& partMatchingElement = isUserAgentPart ? *element().shadowHost() : element();
-    if (partMatchingElement.partNames().isEmpty() || !partMatchingElement.isInShadowTree())
+    Ref<const Element> partMatchingElement = isUserAgentPart ? *element().shadowHost() : element();
+    if (partMatchingElement->partNames().isEmpty() || !partMatchingElement->isInShadowTree())
         return;
 
     matchPartPseudoElementRulesForScope(partMatchingElement, origin);
@@ -428,7 +424,7 @@ void ElementRuleCollector::matchPartPseudoElementRules(DeclarationOrigin origin)
 
 void ElementRuleCollector::matchPartPseudoElementRulesForScope(const Element& partMatchingElement, DeclarationOrigin origin)
 {
-    auto* element = &partMatchingElement;
+    RefPtr<const Element> element = &partMatchingElement;
     auto styleScopeOrdinal = ScopeOrdinal::Element;
 
     for (; element; element = element->shadowHost(), --styleScopeOrdinal) {
@@ -436,7 +432,7 @@ void ElementRuleCollector::matchPartPseudoElementRulesForScope(const Element& pa
         if (!styleScope.resolver().ruleSets().isAuthorStyleDefined())
             continue;
 
-        auto* hostRules = styleScope.resolver().ruleSets().styleForDeclarationOrigin(origin);
+        RefPtr hostRules = styleScope.resolver().ruleSets().styleForDeclarationOrigin(origin);
         if (!hostRules)
             continue;
 
@@ -457,15 +453,15 @@ void ElementRuleCollector::matchPartPseudoElementRulesForScope(const Element& pa
 void ElementRuleCollector::matchSlottedPseudoElementRulesInUserAgentShadowTree(DeclarationOrigin origin)
 {
     ASSERT(element().isInShadowTree());
-    auto* shadowRoot = element().containingShadowRoot();
+    RefPtr shadowRoot = element().containingShadowRoot();
     if (!shadowRoot || shadowRoot->mode() != ShadowRootMode::UserAgent)
         return;
 
-    auto* host = shadowRoot->host();
+    RefPtr host = shadowRoot->host();
     if (!host)
         return;
 
-    auto* slot = host->assignedSlot();
+    RefPtr slot = host->assignedSlot();
     auto styleScopeOrdinal = ScopeOrdinal::FirstSlot;
 
     for (; slot; slot = slot->assignedSlot(), ++styleScopeOrdinal) {
@@ -473,7 +469,7 @@ void ElementRuleCollector::matchSlottedPseudoElementRulesInUserAgentShadowTree(D
         if (!styleScope.resolver().ruleSets().isAuthorStyleDefined())
             continue;
 
-        auto* scopeRules = styleScope.resolver().ruleSets().styleForDeclarationOrigin(origin);
+        RefPtr scopeRules = styleScope.resolver().ruleSets().styleForDeclarationOrigin(origin);
         if (!scopeRules)
             continue;
 
@@ -489,13 +485,13 @@ void ElementRuleCollector::collectMatchingUserAgentPartRules(const MatchRequest&
 {
     ASSERT(element().isInUserAgentShadowTree());
 
-    auto& rules = matchRequest.ruleSet;
+    Ref rules = matchRequest.ruleSet;
 #if ENABLE(VIDEO)
     if (element().isWebVTTElement())
-        collectMatchingRulesForList(&rules.cuePseudoRules(), matchRequest);
+        collectMatchingRulesForList(&rules->cuePseudoRules(), matchRequest);
 #endif
     if (auto& part = element().userAgentPart(); !part.isEmpty())
-        collectMatchingRulesForList(rules.userAgentPartRules(part), matchRequest);
+        collectMatchingRulesForList(rules->userAgentPartRules(part), matchRequest);
 }
 
 void ElementRuleCollector::matchUserRules()
@@ -510,7 +506,7 @@ void ElementRuleCollector::matchUserRules()
 void ElementRuleCollector::matchUARules()
 {
     // First we match rules from the user agent sheet.
-    auto* userAgentStyleSheet = m_isPrintStyle
+    RefPtr userAgentStyleSheet = m_isPrintStyle
         ? UserAgentStyle::defaultPrintStyle : UserAgentStyle::defaultStyle;
     matchUARules(*userAgentStyleSheet);
 
@@ -536,7 +532,7 @@ void ElementRuleCollector::matchUARules(const RuleSet& rules)
 
 static Vector<AtomString> classListForNamedViewTransitionPseudoElement(const Document& document, const AtomString& name)
 {
-    auto* activeViewTransition = document.activeViewTransition();
+    RefPtr activeViewTransition = document.activeViewTransition();
     if (!activeViewTransition)
         return { };
 
@@ -659,10 +655,10 @@ void ElementRuleCollector::collectMatchingRulesForListSlow(const RuleSet::RuleDa
             scopingRoots = WTF::move(roots);
         }
 
-        auto& rule = ruleData.styleRule();
+        Ref rule = ruleData.styleRule();
 
         // If the rule has no properties to apply, then ignore it in the non-debug mode.
-        if (rule.properties().isEmpty() && !m_shouldIncludeEmptyRules)
+        if (rule->properties().isEmpty() && !m_shouldIncludeEmptyRules)
             continue;
 
         auto addRuleIfMatches = [&] (const ScopingRootWithDistance& scopingRootWithDistance = { }) {
@@ -769,7 +765,7 @@ std::pair<bool, std::optional<Vector<ElementRuleCollector::ScopingRootWithDistan
             auto match = [&] (const auto* scopingRoot, const auto& selector) {
                 auto subContext = context;
                 subContext.scope = scopingRoot;
-                const auto* ancestor = &element();
+                RefPtr<const Element> ancestor = &element();
                 while (ancestor) {
                     auto match = checker.match(selector, *ancestor, subContext);
                     if (match)
@@ -817,7 +813,7 @@ std::pair<bool, std::optional<Vector<ElementRuleCollector::ScopingRootWithDistan
             auto appendImplicitScopingRoot = [&](const auto* client) {
 
                 auto addScopingRootWithDistance = [&](auto* scopingRoot) {
-                    const auto* ancestor = &element();
+                    RefPtr<const Element> ancestor = &element();
                     unsigned distance = 0;
                     while (ancestor) {
                         if (ancestor == scopingRoot)
@@ -906,8 +902,8 @@ void ElementRuleCollector::matchAllRules(bool matchAuthorAndUserStyles, bool inc
     if (matchAuthorAndUserStyles)
         matchUserRules();
 
-    if (auto* styledElement = dynamicDowncast<StyledElement>(element())) {
-        if (auto* presentationalHintStyle = styledElement->presentationalHintStyle()) {
+    if (RefPtr styledElement = dynamicDowncast<StyledElement>(element())) {
+        if (RefPtr presentationalHintStyle = styledElement->presentationalHintStyle()) {
             // https://html.spec.whatwg.org/#presentational-hints
 
             // Presentation attributes in SVG elements tend to be unique and not restyled often. Avoid bloating the cache.
@@ -916,17 +912,16 @@ void ElementRuleCollector::matchAllRules(bool matchAuthorAndUserStyles, bool inc
             bool allowFullCaching = !styledElement->isSVGElement() || presentationalHintStyle->refCount() > matchedDeclarationsCacheSharingThreshold;
 
             auto isCacheable = allowFullCaching ? IsCacheable::Yes : IsCacheable::Partially;
-            addElementStyleProperties(presentationalHintStyle, RuleSet::cascadeLayerPriorityForPresentationalHints, isCacheable);
+            addElementStyleProperties(presentationalHintStyle.get(), RuleSet::cascadeLayerPriorityForPresentationalHints, isCacheable);
         }
 
         // Tables and table cells share an additional presentation style that must be applied
         // after all attributes, since their style depends on the values of multiple attributes.
         addElementStyleProperties(styledElement->additionalPresentationalHintStyle(), RuleSet::cascadeLayerPriorityForPresentationalHints);
 
-        if (auto* htmlElement = dynamicDowncast<HTMLElement>(*styledElement)) {
+        if (RefPtr htmlElement = dynamicDowncast<HTMLElement>(*styledElement)) {
             if (auto textDirection = computeTextDirectionIfDirIsAuto(*htmlElement)) {
-                auto& properties = *textDirection == TextDirection::LTR ? leftToRightDeclaration() : rightToLeftDeclaration();
-                addMatchedProperties({ properties }, DeclarationOrigin::Author);
+                addMatchedProperties({ *textDirection == TextDirection::LTR ? leftToRightDeclaration() : rightToLeftDeclaration() }, DeclarationOrigin::Author);
             }
         }
     }
@@ -949,13 +944,13 @@ void ElementRuleCollector::matchAllRules(bool matchAuthorAndUserStyles, bool inc
 
 void ElementRuleCollector::addElementInlineStyleProperties(bool includeSMILProperties)
 {
-    auto* styledElement = dynamicDowncast<StyledElement>(element());
+    RefPtr styledElement = dynamicDowncast<StyledElement>(element());
     if (!styledElement)
         return;
 
-    if (auto* inlineStyle = styledElement->inlineStyle()) {
+    if (RefPtr inlineStyle = styledElement->inlineStyle()) {
         auto isInlineStyleCacheable = inlineStyle->isMutable() ? IsCacheable::No : IsCacheable::Yes;
-        addElementStyleProperties(inlineStyle, RuleSet::cascadeLayerPriorityForUnlayered, isInlineStyleCacheable, FromStyleAttribute::Yes);
+        addElementStyleProperties(inlineStyle.get(), RuleSet::cascadeLayerPriorityForUnlayered, isInlineStyleCacheable, FromStyleAttribute::Yes);
     }
 
     if (includeSMILProperties) {


### PR DESCRIPTION
#### e017b07ddf72c20929164b17e067e37ba610338d
<pre>
[SaferCPP] Replace raw pointers and leaking references with smart pointers in style/ElementRuleCollector.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=309932">https://bugs.webkit.org/show_bug.cgi?id=309932</a>

Reviewed by Ryosuke Niwa.

Replace uncounted local variables with RefPtr/Ref smart pointers throughout
ElementRuleCollector.cpp to satisfy the SaferCPP UncountedLocalVarsChecker.
Also replace the leakRef() pattern in leftToRightDeclaration() and
rightToLeftDeclaration() with NeverDestroyed&lt;Ref&lt;MutableStyleProperties&gt;&gt;,
eliminating the need for GCC dangling-reference warning suppression.

* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::leftToRightDeclaration):
(WebCore::Style::rightToLeftDeclaration):
(WebCore::Style::ElementRuleCollector::collectMatchingRules):
(WebCore::Style::ElementRuleCollector::matchUserAgentPartRules):
(WebCore::Style::ElementRuleCollector::matchHostPseudoClassRules):
(WebCore::Style::ElementRuleCollector::matchSlottedPseudoElementRules):
(WebCore::Style::ElementRuleCollector::matchPartPseudoElementRules):
(WebCore::Style::ElementRuleCollector::matchPartPseudoElementRulesForScope):
(WebCore::Style::ElementRuleCollector::matchSlottedPseudoElementRulesInUserAgentShadowTree):
(WebCore::Style::ElementRuleCollector::collectMatchingUserAgentPartRules):
(WebCore::Style::ElementRuleCollector::matchUARules):
(WebCore::Style::classListForNamedViewTransitionPseudoElement):
(WebCore::Style::ElementRuleCollector::collectMatchingRulesForListSlow):
(WebCore::Style::ElementRuleCollector::scopeRulesMatch):
(WebCore::Style::ElementRuleCollector::matchAllRules):
(WebCore::Style::ElementRuleCollector::addElementInlineStyleProperties):

Canonical link: <a href="https://commits.webkit.org/309460@main">https://commits.webkit.org/309460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dae0acc30db27d983c6c90f1d876fcb212546ac0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23334 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159298 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104010 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152449 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23486 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116203 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82545 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96931 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17408 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15358 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7146 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127022 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161772 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4892 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14580 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124202 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23136 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19405 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124400 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134793 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79513 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23162 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19488 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11553 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22738 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86536 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22450 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22602 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->