### PR TITLE
[JSC] Add more SIMD lowering

### DIFF
--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -2210,6 +2210,12 @@ public:
         insn(0b11001110100'00000'000000'00000'00000 | (static_cast<uint32_t>(vm) << 16) | (static_cast<uint32_t>(imm6) << 10) | (static_cast<uint32_t>(vn) << 5) | static_cast<uint32_t>(vd));
     }
 
+    ALWAYS_INLINE void eor3(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm, FPRegisterID va)
+    {
+        // Three-way exclusive OR. Requires SHA3 (FEAT_SHA3) extension.
+        insn(0b110011100'00'00000'0'00000'00000'00000 | (static_cast<uint32_t>(vm) << 16) | (static_cast<uint32_t>(va) << 10) | (static_cast<uint32_t>(vn) << 5) | static_cast<uint32_t>(vd));
+    }
+
     ALWAYS_INLINE void tbl(FPRegisterID vd, FPRegisterID vn, FPRegisterID vm)
     {
         const unsigned len = 0;

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -6720,6 +6720,12 @@ public:
         m_assembler.xar(dest, a, b, static_cast<uint8_t>(rotate.m_value));
     }
 
+    void vectorXor3(FPRegisterID a, FPRegisterID b, FPRegisterID c, FPRegisterID dest)
+    {
+        ASSERT(supportsSHA3());
+        m_assembler.eor3(dest, a, b, c);
+    }
+
     void moveZeroToVector(FPRegisterID dest)
     {
         m_assembler.movi<128, 8>(dest, 0);

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -5145,9 +5145,25 @@ private:
             emitSIMDBinaryOp(Air::VectorOr);
             return;
         }
-        case B3::VectorXor:
+        case B3::VectorXor: {
+#if CPU(ARM64)
+            // VectorXor(VectorXor(a, b), c) → EOR3(a, b, c)
+            // VectorXor(a, VectorXor(b, c)) → EOR3(b, c, a)
+            if (isARM64_SHA3()) {
+                for (unsigned childIdx = 0; childIdx < 2; ++childIdx) {
+                    Value* inner = m_value->child(childIdx);
+                    Value* other = m_value->child(1 - childIdx);
+                    if (inner->opcode() == B3::VectorXor && canBeInternal(inner)) {
+                        commitInternal(inner);
+                        append(Air::VectorXor3, tmp(inner->child(0)), tmp(inner->child(1)), tmp(other), tmp(m_value));
+                        return;
+                    }
+                }
+            }
+#endif
             emitSIMDBinaryOp(Air::VectorXor);
             return;
+        }
         case B3::VectorUnzipEven:
             emitSIMDBinaryOp(Air::VectorUnzipEven);
             return;

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -3431,9 +3431,23 @@ private:
             break;
         }
 
+        case VectorDotProduct: {
+            handleCommutativity();
+
+            // Turn this: VectorDotProduct(v, splatOne16)
+            // Into this: VectorExtaddPairwise(v)
+            constexpr v128_t splatOne16 = v128_t::fromU16x8(1, 1, 1, 1, 1, 1, 1, 1);
+            if (m_value->child(1)->hasV128() && bitEquals(m_value->child(1)->asV128(), splatOne16)) {
+                // VectorExtaddPairwise uses the input lane type (i16x8), not the output (i32x4).
+                replaceWithNew<SIMDValue>(m_value->origin(), VectorExtaddPairwise, B3::V128, SIMDLane::i16x8, SIMDSignMode::Signed, m_value->child(0));
+                break;
+            }
+            break;
+        }
+
         case VectorSwizzle: {
-            if (m_value->numChildren() == 2 && m_value->child(1)->isConstant()) {
-                v128_t pattern = m_value->child(1)->as<Const128Value>()->value();
+            if (m_value->numChildren() == 2 && m_value->child(1)->hasV128()) {
+                v128_t pattern = m_value->child(1)->asV128();
                 if (SIMDShuffle::isIdentity(pattern)) {
                     replaceWithIdentity(m_value->child(0));
                     break;
@@ -3499,8 +3513,8 @@ private:
             }
 
             if constexpr (isARM64()) {
-                if (m_value->numChildren() == 3 && m_value->child(2)->isConstant()) {
-                    v128_t pattern = m_value->child(2)->as<Const128Value>()->value();
+                if (m_value->numChildren() == 3 && m_value->child(2)->hasV128()) {
+                    v128_t pattern = m_value->child(2)->asV128();
                     if (m_pass == ReduceStrengthPass::Final) {
                         // Try to match binary canonical patterns (UZP, ZIP, TRN).
                         {

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -2037,6 +2037,9 @@ arm64: VectorExtractPair U:G:Ptr, U:G:8, U:F:128, U:F:128, D:F:128
 arm64_sha3: VectorXorRotateRight64 U:F:128, U:F:128, U:G:8, D:F:128
     Tmp, Tmp, Imm, Tmp
 
+arm64_sha3: VectorXor3 U:F:128, U:F:128, U:F:128, D:F:128
+    Tmp, Tmp, Tmp, Tmp
+
 64: VectorAbs U:G:Ptr, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp
 

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1503,6 +1503,8 @@ void testFCCmpNegatedAndDouble(double, double, double, double);
 
 // SIMD XOR+rotate pattern matching
 void testVectorXorRotateRight64();
+void testVectorXor3();
+void testVectorDotProductSplatOne();
 
 // SIMD VectorUnzip/Zip/Transpose/Reverse B3 opcodes
 void testVectorUnzipEven();

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1133,6 +1133,7 @@ void run(const TestConfig* config)
         RUN(testVectorExtractLane0Double());
         RUN(testVectorMulHigh());
         RUN(testVectorMulLow());
+        RUN(testVectorDotProductSplatOne());
         RUN_UNARY(testVectorXorOrAllOnesConstantToVectorAndXor, v128Operands());
         RUN_UNARY(testVectorXorAndAllOnesConstantToVectorOrXor, v128Operands());
         RUN_BINARY(testVectorOrConstants, v128Operands(), v128Operands());
@@ -1143,6 +1144,7 @@ void run(const TestConfig* config)
             RUN(testVectorFmulByElementFloat());
             RUN(testVectorFmulByElementDouble());
             RUN(testVectorXorRotateRight64());
+            RUN(testVectorXor3());
             RUN(testVectorUnzipEven());
             RUN(testVectorUnzipOdd());
             RUN(testVectorZipLower());

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -3224,6 +3224,122 @@ void testVectorXorRotateRight64()
     }
 }
 
+// Test dot(v, splat(1)) → extadd_pairwise strength reduction.
+// i32x4.dot_i16x8_s(v, {1,1,...}) = i32x4.extadd_pairwise_i16x8_s(v)
+void testVectorDotProductSplatOne()
+{
+    alignas(16) v128_t vectors[3];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+
+    // Create splat(1) as i16x8
+    v128_t splatOne;
+    splatOne.u64x2[0] = 0x0001000100010001ULL;
+    splatOne.u64x2[1] = 0x0001000100010001ULL;
+    Value* ones = root->appendNew<Const128Value>(proc, Origin(), splatOne);
+
+    // dot_i16x8_s(input, splat(1)) should become extadd_pairwise
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorDotProduct, B3::V128, SIMDLane::i32x4, SIMDSignMode::Signed, input, ones);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    // Test: input = {3, -2, 5, -7, 100, -100, 0, 1} as i16x8
+    vectors[0].u16x8[0] = 3; vectors[0].u16x8[1] = static_cast<uint16_t>(-2);
+    vectors[0].u16x8[2] = 5; vectors[0].u16x8[3] = static_cast<uint16_t>(-7);
+    vectors[0].u16x8[4] = 100; vectors[0].u16x8[5] = static_cast<uint16_t>(-100);
+    vectors[0].u16x8[6] = 0; vectors[0].u16x8[7] = 1;
+    invoke<void>(*code, vectors);
+
+    // Expected: pairwise sum of adjacent i16 pairs → i32
+    // {3 + (-2), 5 + (-7), 100 + (-100), 0 + 1} = {1, -2, 0, 1}
+    CHECK(vectors[1].u32x4[0] == static_cast<uint32_t>(1));
+    CHECK(vectors[1].u32x4[1] == static_cast<uint32_t>(-2));
+    CHECK(vectors[1].u32x4[2] == static_cast<uint32_t>(0));
+    CHECK(vectors[1].u32x4[3] == static_cast<uint32_t>(1));
+
+    // Also test commuted form: dot(splat(1), v)
+    {
+        Procedure proc2;
+        BasicBlock* root2 = proc2.addBlock();
+        auto args2 = cCallArgumentValues<void*>(proc2, root2);
+        Value* addr = args2[0];
+        Value* inp = root2->appendNew<MemoryValue>(proc2, Load, V128, Origin(), addr);
+        Value* onesVal = root2->appendNew<Const128Value>(proc2, Origin(), splatOne);
+        Value* res = root2->appendNew<SIMDValue>(proc2, Origin(), VectorDotProduct, B3::V128, SIMDLane::i32x4, SIMDSignMode::Signed, onesVal, inp);
+        root2->appendNew<MemoryValue>(proc2, Store, Origin(), res, addr, static_cast<int32_t>(sizeof(v128_t)));
+        root2->appendNewControlValue(proc2, Return, Origin());
+
+        auto code2 = compileProc(proc2);
+        invoke<void>(*code2, vectors);
+        CHECK(vectors[1].u32x4[0] == static_cast<uint32_t>(1));
+        CHECK(vectors[1].u32x4[1] == static_cast<uint32_t>(-2));
+        CHECK(vectors[1].u32x4[2] == static_cast<uint32_t>(0));
+        CHECK(vectors[1].u32x4[3] == static_cast<uint32_t>(1));
+    }
+}
+
+// Test EOR3 (3-way XOR) pattern matching: VectorXor(VectorXor(a, b), c) → EOR3(a, b, c)
+void testVectorXor3()
+{
+    if constexpr (!isARM64())
+        return;
+    if (!isARM64_SHA3())
+        return;
+
+    alignas(16) v128_t vectors[4];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* a = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* b = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
+    Value* c = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(2 * sizeof(v128_t)));
+
+    // a ^ b ^ c
+    Value* xorAB = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, a, b);
+    Value* xorABC = root->appendNew<SIMDValue>(proc, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, xorAB, c);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), xorABC, address, static_cast<int32_t>(3 * sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    vectors[0].u64x2[0] = 0x0123456789ABCDEFULL;
+    vectors[0].u64x2[1] = 0xFEDCBA9876543210ULL;
+    vectors[1].u64x2[0] = 0xFF00FF00FF00FF00ULL;
+    vectors[1].u64x2[1] = 0x00FF00FF00FF00FFULL;
+    vectors[2].u64x2[0] = 0xAAAAAAAAAAAAAAAAULL;
+    vectors[2].u64x2[1] = 0x5555555555555555ULL;
+    invoke<void>(*code, vectors);
+
+    CHECK(vectors[3].u64x2[0] == (vectors[0].u64x2[0] ^ vectors[1].u64x2[0] ^ vectors[2].u64x2[0]));
+    CHECK(vectors[3].u64x2[1] == (vectors[0].u64x2[1] ^ vectors[1].u64x2[1] ^ vectors[2].u64x2[1]));
+
+    // Also test commuted form: VectorXor(c, VectorXor(a, b))
+    {
+        Procedure proc2;
+        BasicBlock* root2 = proc2.addBlock();
+        auto args2 = cCallArgumentValues<void*>(proc2, root2);
+        Value* addr = args2[0];
+        Value* va = root2->appendNew<MemoryValue>(proc2, Load, V128, Origin(), addr);
+        Value* vb = root2->appendNew<MemoryValue>(proc2, Load, V128, Origin(), addr, static_cast<int32_t>(sizeof(v128_t)));
+        Value* vc = root2->appendNew<MemoryValue>(proc2, Load, V128, Origin(), addr, static_cast<int32_t>(2 * sizeof(v128_t)));
+        Value* xorAB2 = root2->appendNew<SIMDValue>(proc2, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, va, vb);
+        Value* result = root2->appendNew<SIMDValue>(proc2, Origin(), VectorXor, B3::V128, SIMDLane::v128, SIMDSignMode::None, vc, xorAB2);
+        root2->appendNew<MemoryValue>(proc2, Store, Origin(), result, addr, static_cast<int32_t>(3 * sizeof(v128_t)));
+        root2->appendNewControlValue(proc2, Return, Origin());
+
+        auto code2 = compileProc(proc2);
+        invoke<void>(*code2, vectors);
+        CHECK(vectors[3].u64x2[0] == (vectors[0].u64x2[0] ^ vectors[1].u64x2[0] ^ vectors[2].u64x2[0]));
+        CHECK(vectors[3].u64x2[1] == (vectors[0].u64x2[1] ^ vectors[1].u64x2[1] ^ vectors[2].u64x2[1]));
+    }
+}
+
 // Test VectorUnzipEven/Odd B3 opcodes (reduced from VectorSwizzle in ReduceStrength).
 void testVectorUnzipEven()
 {


### PR DESCRIPTION
#### dbf8cb7e3eccb57417d8846bc3d659d9a8530838
<pre>
[JSC] Add more SIMD lowering
<a href="https://bugs.webkit.org/show_bug.cgi?id=309933">https://bugs.webkit.org/show_bug.cgi?id=309933</a>
<a href="https://rdar.apple.com/172525410">rdar://172525410</a>

Reviewed by Justin Michaud.

This patch adds a bit more SIMD lowering which can be found in the
benchmarks.

1. eor3

ARM64 SHA3 has eor3, which is three-way xor. We use it if we find the
pattern.

2. VectorDotProduct -&gt; VectorExtaddPairwise

When the input is constant unit vector (all-one), it can be converted to VectorExtaddPairwise.

Tests: Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_7.cpp

* Source/JavaScriptCore/assembler/ARM64Assembler.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::vectorXor3):
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testVectorDotProductSplatOne):
(testVectorXor3):

Canonical link: <a href="https://commits.webkit.org/309298@main">https://commits.webkit.org/309298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8e8a33a9921294513e0f2ba33fdce387ca6e1d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150246 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23004 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158960 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103680 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23128 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115912 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82359 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134783 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96644 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17126 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15070 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6805 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142229 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161434 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11044 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4562 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/14259 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123913 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124118 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134502 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79145 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23094 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19242 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11259 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181677 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22406 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86206 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46492 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22120 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22272 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22174 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->