### PR TITLE
[Tools][WPE] generate-bundle: add some fixes for running it inside the SDK (follow-up)

### DIFF
--- a/Tools/Scripts/generate-bundle
+++ b/Tools/Scripts/generate-bundle
@@ -669,7 +669,11 @@ class BundleCreator(object):
 
     def _generate_tls_cafile(self, data_directory):
         cafile_path = os.path.join(data_directory, 'bundle-ca-certificates.pem')
-        retcode, stdout, stderr = self._run_cmd_and_get_output(['trust', 'extract', '--format=pem-bundle', cafile_path])
+        if shutil.which('trust'):
+            retcode, stdout, stderr = self._run_cmd_and_get_output(['trust', 'extract', '--format=pem-bundle', cafile_path])
+        else:
+            _log.warning('trust: command not found, please install p11-kit.')
+            retcode = 127
         # trust fails inside flatpak due to https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/904
         # fall-back to trying to manually copy the bundle
         if (retcode != 0) or (not os.path.isfile(cafile_path)) or (os.path.getsize(cafile_path) < 100):

--- a/Tools/glib/dependencies/apt
+++ b/Tools/glib/dependencies/apt
@@ -75,7 +75,6 @@ PACKAGES=(
     mesa-common-dev
     ninja-build
     patch
-    patchelf
     ruby
     $(aptIfExists gi-docgen)
     $(aptIfExists libaom-dev)
@@ -87,6 +86,7 @@ PACKAGES=(
 
     # These are dependencies necessary for running tests.
     apache2
+    binutils
     curl
     fonts-liberation
     hyphen-de
@@ -112,6 +112,7 @@ PACKAGES=(
     libgirepository1.0-dev
     libgles2-mesa-dev
     liborc-0.4-dev
+    libp11-kit-dev
     libproxy-dev
     libpsl-dev
     libssl-dev
@@ -139,4 +140,8 @@ PACKAGES=(
     gstreamer1.0-plugins-good
     gstreamer1.0-plugins-ugly
     gstreamer1.0-pulseaudio
+
+    # These are for generate-bundle script
+    patchelf
+    p11-kit
 )

--- a/Tools/glib/dependencies/dnf
+++ b/Tools/glib/dependencies/dnf
@@ -66,6 +66,7 @@ PACKAGES=(
     wpebackend-fdo-devel
 
     # These are dependencies necessary for running tests.
+    binutils
     curl
     gdb
     httpd
@@ -90,6 +91,7 @@ PACKAGES=(
     libpsl-devel
     libtheora-devel
     libuuid-devel
+    libp11-devel
     libxcb-devel
     mesa-libEGL-devel
     orc-devel
@@ -111,4 +113,8 @@ PACKAGES=(
     gstreamer1-plugins-good
     gstreamer1-plugins-good-extras
     gstreamer1-plugins-ugly-free
+
+    # These are for generate-bundle script
+    patchelf
+    p11-kit
 )

--- a/Tools/glib/dependencies/pacman
+++ b/Tools/glib/dependencies/pacman
@@ -50,6 +50,7 @@ PACKAGES=(
     # These are dependencies necessary for running tests.
     # Note: ruby-json and ruby-highline are available in the AUR.
     apache
+    binutils
     curl
     gdb
     psmisc
@@ -79,4 +80,8 @@ PACKAGES=(
     gst-plugins-base
     gst-plugins-good
     gst-plugins-ugly
+
+    # These are for generate-bundle script
+    patchelf
+    p11-kit
 )

--- a/Tools/gtk/dependencies/apt
+++ b/Tools/gtk/dependencies/apt
@@ -58,7 +58,6 @@ PACKAGES+=(
     libgpg-error-dev
     libjson-glib-dev
     libmtdev-dev
-    libp11-kit-dev
     libpciaccess-dev
     libtiff5-dev
     libudev-dev

--- a/Tools/gtk/dependencies/dnf
+++ b/Tools/gtk/dependencies/dnf
@@ -53,7 +53,6 @@ PACKAGES+=(
     libevdev-devel
     libgpg-error-devel
     libinput-devel
-    libp11-devel
     libpciaccess-devel
     libtiff-devel
     libunistring-devel

--- a/Tools/gtk/dependencies/pacman
+++ b/Tools/gtk/dependencies/pacman
@@ -80,7 +80,6 @@ PACKAGES+=(
     libxkbcommon-x11
     libxkbfile
     mtdev
-    p11-kit
     perl-xml-libxm
     python2
     python2-lxml


### PR DESCRIPTION
#### cf875c1e2585c20682f29c085bf4652283ed733d
<pre>
[Tools][WPE] generate-bundle: add some fixes for running it inside the SDK (follow-up)
<a href="https://bugs.webkit.org/show_bug.cgi?id=305768">https://bugs.webkit.org/show_bug.cgi?id=305768</a>

Unreviewed follow-up for 306045@main

If trust command from p11-kit is not installed, then the script will fail because
it can&apos;t find the binary to execute. Avoid this by checking if trust is there
before trying to execute it. Also add p11-kit to the list of default packages
to be installed.

Meanwhile at it add also a few other packages that are missing on the install
list like patchelf or binutils (which provides strip, readelf, c++filt, etc.)
strip and readelf are needed by generate-bundle and c++filt is needed by the
webkitpy automated crash log generation code for Linux. That is why this one
is added on the general list for running tests.

* Tools/Scripts/generate-bundle:
(BundleCreator._generate_tls_cafile):
* Tools/glib/dependencies/apt:
* Tools/glib/dependencies/dnf:
* Tools/glib/dependencies/pacman:
* Tools/gtk/dependencies/apt:
* Tools/gtk/dependencies/dnf:
* Tools/gtk/dependencies/pacman:

Canonical link: <a href="https://commits.webkit.org/309257@main">https://commits.webkit.org/309257@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/283225325573cdb6e6f2126f02154310bbffd4de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150082 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/22814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/16401 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158793 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151955 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22938 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/115770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153042 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/17887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/134645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/96499 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/6639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/12569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161267 "Built successfully") | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/14121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/123774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/22642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/18980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/123976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/22629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/134364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23081 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/11120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/22241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/21956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/22108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/22010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->