### PR TITLE
[non-Cocoa] Simplify WTR::TestController::doAfterProcessingAllPendingKeyEvents()

### DIFF
--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -5706,32 +5706,22 @@ WKRetainPtr<WKTypeRef> TestController::handleAXSearchPredicate(WKDictionaryRef m
 #if !PLATFORM(COCOA)
 void TestController::doAfterProcessingAllPendingMouseEvents(CompletionHandler<void()>&& handler)
 {
-    m_pendingMouseEventsCompletionHanders.append(WTF::move(handler));
-    WKPageDoAfterProcessingAllPendingMouseEvents(mainWebView()->page(), this, [](void* userData) {
-        static_cast<TestController*>(userData)->flushPendingMouseEventsCompletionHanders();
+    auto* completionHandler = new CompletionHandler<void()>(WTF::move(handler));
+    WKPageDoAfterProcessingAllPendingMouseEvents(mainWebView()->page(), completionHandler, [](void* userData) {
+        auto* completionHandler = static_cast<CompletionHandler<void()>*>(userData);
+        (*completionHandler)();
+        delete completionHandler;
     });
-}
-
-void TestController::flushPendingMouseEventsCompletionHanders()
-{
-    auto handlers = std::exchange(m_pendingMouseEventsCompletionHanders, { });
-    for (auto& handler : handlers)
-        handler();
 }
 
 void TestController::doAfterProcessingAllPendingKeyEvents(CompletionHandler<void()>&& handler)
 {
-    m_pendingKeyEventsCompletionHanders.append(WTF::move(handler));
-    WKPageDoAfterProcessingAllPendingKeyEvents(mainWebView()->page(), this, [](void* userData) {
-        static_cast<TestController*>(userData)->flushPendingKeyEventsCompletionHanders();
+    auto* completionHandler = new CompletionHandler<void()>(WTF::move(handler));
+    WKPageDoAfterProcessingAllPendingKeyEvents(mainWebView()->page(), completionHandler, [](void* userData) {
+        auto* completionHandler = static_cast<CompletionHandler<void()>*>(userData);
+        (*completionHandler)();
+        delete completionHandler;
     });
-}
-
-void TestController::flushPendingKeyEventsCompletionHanders()
-{
-    auto handlers = std::exchange(m_pendingKeyEventsCompletionHanders, { });
-    for (auto& handler : handlers)
-        handler();
 }
 #endif
 

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -485,9 +485,7 @@ public:
 
 #if !PLATFORM(COCOA)
     void doAfterProcessingAllPendingMouseEvents(CompletionHandler<void()>&&);
-    void flushPendingMouseEventsCompletionHanders();
     void doAfterProcessingAllPendingKeyEvents(CompletionHandler<void()>&&);
-    void flushPendingKeyEventsCompletionHanders();
 #endif
 
 private:
@@ -896,11 +894,6 @@ private:
 
 #if ENABLE(WPE_PLATFORM)
     bool m_useWPELegacyAPI { false };
-#endif
-
-#if !PLATFORM(COCOA)
-    Vector<CompletionHandler<void()>> m_pendingMouseEventsCompletionHanders;
-    Vector<CompletionHandler<void()>> m_pendingKeyEventsCompletionHanders;
 #endif
 };
 


### PR DESCRIPTION
#### 2001d0220c765e51d26b36c327421e31a290bbef
<pre>
[non-Cocoa] Simplify WTR::TestController::doAfterProcessingAllPendingKeyEvents()
<a href="https://bugs.webkit.org/show_bug.cgi?id=309648">https://bugs.webkit.org/show_bug.cgi?id=309648</a>

Reviewed by Anne van Kesteren.

m_pendingKeyEventsCompletionHanders of Vector&lt;CompletionHandler&lt;void()&gt;&gt; was
added to TestController. But, this wasn&apos;t needed.

Changed doAfterProcessingAllPendingKeyEvents() to allocate a memory for the
completion handler.

Changed doAfterProcessingAllPendingMouseEvents() too.

* Tools/WebKitTestRunner/TestController.cpp:
* Tools/WebKitTestRunner/TestController.h:

Canonical link: <a href="https://commits.webkit.org/309262@main">https://commits.webkit.org/309262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c0f28934daa4f3f46a0d505f65a1da74314946e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158804 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23280 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115781 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134661 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96510 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6650 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126605 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161278 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14137 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123784 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123986 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/22640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134380 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23085 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11136 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22252 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/21967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22119 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/22021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->