### PR TITLE
[JSC] Use page-based zero-fill for large zero-clear for ArrayBuffer

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.cpp
@@ -32,6 +32,9 @@
 #include "WaiterListManager.h"
 #include "WeakInlines.h"
 #include <wtf/Gigacage.h>
+#include <wtf/MathExtras.h>
+#include <wtf/OSAllocator.h>
+#include <wtf/PageBlock.h>
 #include <wtf/SafeStrerror.h>
 
 #if ENABLE(WEBASSEMBLY)
@@ -43,6 +46,27 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 namespace JSC {
 namespace ArrayBufferInternal {
 static constexpr bool verbose = false;
+}
+
+static void zeroFill(void* base, size_t size)
+{
+    constexpr size_t largeZeroFillThreshold = 1 * MB;
+    if (size >= largeZeroFillThreshold) {
+        size_t pageSizeValue = WTF::pageSize();
+        uintptr_t begin = reinterpret_cast<uintptr_t>(base);
+        uintptr_t end = begin + size;
+        uintptr_t pageAlignedBegin = roundUpToMultipleOf(pageSizeValue, begin);
+        uintptr_t pageAlignedEnd = roundDownToMultipleOf(pageSizeValue, end);
+        if (pageAlignedEnd > pageAlignedBegin) {
+            if (begin != pageAlignedBegin)
+                memset(base, 0, pageAlignedBegin - begin);
+            OSAllocator::zeroFill(reinterpret_cast<void*>(pageAlignedBegin), pageAlignedEnd - pageAlignedBegin);
+            if (end != pageAlignedEnd)
+                memset(reinterpret_cast<void*>(pageAlignedEnd), 0, end - pageAlignedEnd);
+        } else
+            memset(base, 0, size);
+    } else
+        memset(base, 0, size);
 }
 
 Ref<SharedTask<void(void*)>> ArrayBuffer::primitiveGigacageDestructor()
@@ -562,7 +586,7 @@ Expected<int64_t, GrowFailReason> ArrayBuffer::resize(VM& vm, size_t newByteLeng
         }
 
         if (m_contents.m_sizeInBytes < newByteLength)
-            memset(std::bit_cast<uint8_t*>(data()) + m_contents.m_sizeInBytes, 0, newByteLength - m_contents.m_sizeInBytes);
+            zeroFill(std::bit_cast<uint8_t*>(data()) + m_contents.m_sizeInBytes, newByteLength - m_contents.m_sizeInBytes);
 
         m_contents.m_sizeInBytes = newByteLength;
     }
@@ -653,7 +677,7 @@ Expected<int64_t, GrowFailReason> SharedArrayBufferContents::grow(const Abstract
         memoryHandle->updateSize(desiredSize);
     }
 
-    memset(std::bit_cast<uint8_t*>(data()) + sizeInBytes, 0, newByteLength - sizeInBytes);
+    zeroFill(std::bit_cast<uint8_t*>(data()) + sizeInBytes, newByteLength - sizeInBytes);
 
     updateSize(newByteLength);
 

--- a/Source/WTF/wtf/OSAllocator.h
+++ b/Source/WTF/wtf/OSAllocator.h
@@ -88,6 +88,8 @@ public:
 
     WTF_EXPORT_PRIVATE static void protect(void*, size_t, bool readable, bool writable);
     WTF_EXPORT_PRIVATE static bool tryProtect(void*, size_t, bool readable, bool writable);
+
+    WTF_EXPORT_PRIVATE static void zeroFill(void* base, size_t);
 };
 
 inline void* OSAllocator::reserveAndCommit(size_t reserveSize, size_t commitSize, Usage usage, void* address, bool writable, bool executable, bool jitCageEnabled)

--- a/Source/WTF/wtf/playstation/OSAllocatorPlayStation.cpp
+++ b/Source/WTF/wtf/playstation/OSAllocatorPlayStation.cpp
@@ -144,4 +144,9 @@ void OSAllocator::protect(void* address, size_t bytes, bool readable, bool writa
     }
 }
 
+void OSAllocator::zeroFill(void* base, size_t size)
+{
+    memset(base, 0, size);
+}
+
 } // namespace WTF

--- a/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
+++ b/Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp
@@ -27,6 +27,7 @@
 #include <wtf/OSAllocator.h>
 
 #include <errno.h>
+#include <mutex>
 #include <sys/mman.h>
 #include <wtf/Assertions.h>
 #include <wtf/DataLog.h>
@@ -301,6 +302,39 @@ void OSAllocator::protect(void* address, size_t bytes, bool readable, bool writa
         dataLogLn("mprotect failed: ", safeStrerror(errno).data());
         RELEASE_ASSERT_NOT_REACHED();
     }
+}
+
+void OSAllocator::zeroFill(void* base, size_t size)
+{
+    ASSERT(isPageAligned(base));
+    ASSERT(isPageAligned(size));
+
+#if defined(MADV_ZERO) && OS(DARWIN)
+    static std::once_flag onceKey;
+    static bool madvZeroSupported = false;
+    std::call_once(onceKey,
+        [&] {
+            size_t size = pageSize();
+            void* base = mmap(nullptr, size, PROT_NONE, MAP_PRIVATE | MAP_ANON, -1, 0);
+            RELEASE_ASSERT(base && base != MAP_FAILED);
+
+            int rc = madvise(base, size, MADV_ZERO);
+            if (rc)
+                madvZeroSupported = (errno != ENOTSUP);
+            else
+                madvZeroSupported = true;
+
+            munmap(base, size);
+        });
+    if (madvZeroSupported) {
+        int rc = madvise(base, size, MADV_ZERO);
+        if (rc != -1)
+            return;
+    }
+#endif
+
+    void* result = mmap(base, size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANON | MAP_FIXED, -1, 0);
+    RELEASE_ASSERT(result != MAP_FAILED);
 }
 
 } // namespace WTF

--- a/Source/WTF/wtf/win/OSAllocatorWin.cpp
+++ b/Source/WTF/wtf/win/OSAllocatorWin.cpp
@@ -159,4 +159,9 @@ void OSAllocator::protect(void* address, size_t bytes, bool readable, bool writa
     }
 }
 
+void OSAllocator::zeroFill(void* base, size_t size)
+{
+    memset(base, 0, size);
+}
+
 } // namespace WTF


### PR DESCRIPTION
#### bee72f6e27503571b08689a7c5dd4ca29d0e1352
<pre>
[JSC] Use page-based zero-fill for large zero-clear for ArrayBuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=309938">https://bugs.webkit.org/show_bug.cgi?id=309938</a>
<a href="https://rdar.apple.com/172531380">rdar://172531380</a>

Reviewed by Yijia Huang.

Add page-based zero-clearing function to WTF and use it in ArrayBuffer&apos;s
growing, which is mainly used wasm memory growth.

* Source/JavaScriptCore/runtime/ArrayBuffer.cpp:
(JSC::zeroFill):
(JSC::ArrayBuffer::resize):
(JSC::SharedArrayBufferContents::grow):
* Source/WTF/wtf/OSAllocator.h:
* Source/WTF/wtf/playstation/OSAllocatorPlayStation.cpp:
(WTF::OSAllocator::zeroFill):
* Source/WTF/wtf/posix/OSAllocatorPOSIX.cpp:
(WTF::OSAllocator::zeroFill):
* Source/WTF/wtf/win/OSAllocatorWin.cpp:
(WTF::OSAllocator::zeroFill):

Canonical link: <a href="https://commits.webkit.org/309467@main">https://commits.webkit.org/309467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fb6f8d0e54c8e2ce218e0bf577357ac58f3d659

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150801 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23559 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/17130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/159524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23765 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/159524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153761 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/18507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/159524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/7371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/142784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/161998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11599 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/5118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/14769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/161998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23363 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/19601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/161998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23352 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/135007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23164 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/19664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/11769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/182326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22963 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/86763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/182326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22675 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22827 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22729 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->