### PR TITLE
Suppress deprecation warnings in UserAgentIOS.mm (Follow-up)

### DIFF
--- a/Source/WebCore/platform/ios/PlatformScreenIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformScreenIOS.mm
@@ -216,8 +216,11 @@ float screenPPIFactor()
 
 FloatSize screenSize()
 {
+// FIXME: rdar://172495534 Stop using deprecated `_isClassic` and `UIApplicationSceneClassicModeOriginalPad`.
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (PAL::deviceHasIPadCapability() && [[PAL::getUIApplicationClassSingleton() sharedApplication] _isClassic])
         return { 320, 480 };
+ALLOW_DEPRECATED_DECLARATIONS_END
 
     if (auto data = screenData(primaryScreenDisplayID()))
         return data->screenRect.size();
@@ -227,8 +230,11 @@ FloatSize screenSize()
 
 FloatSize availableScreenSize()
 {
+// FIXME: rdar://172495534 Stop using deprecated `_isClassic` and `UIApplicationSceneClassicModeOriginalPad`.
+ALLOW_DEPRECATED_DECLARATIONS_END
     if (PAL::deviceHasIPadCapability() && [[PAL::getUIApplicationClassSingleton() sharedApplication] _isClassic])
         return { 320, 480 };
+ALLOW_DEPRECATED_DECLARATIONS_END
 
     if (auto data = screenData(primaryScreenDisplayID()))
         return data->screenAvailableRect.size();


### PR DESCRIPTION
#### 882facb4f2375c21dd05dba840ec1541ecf257f1
<pre>
Suppress deprecation warnings in UserAgentIOS.mm (Follow-up)
webkit.org/b/309908
<a href="https://rdar.apple.com/172494241">rdar://172494241</a>

Unreviewed build fix.

* Source/WebCore/platform/ios/PlatformScreenIOS.mm:
(WebCore::screenSize):
(WebCore::availableScreenSize):

Canonical link: <a href="https://commits.webkit.org/309258@main">https://commits.webkit.org/309258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0111587f53c665bba4159cad243ef5de5c8b793b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150086 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/22828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/16405 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/158797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/151959 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/23260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/22942 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/158797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/153046 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/23260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/16405 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/158797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/23260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/16405 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/6643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/23260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/16405 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/161271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/16405 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/161271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/22646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/22942 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/161271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/22633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/16405 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23082 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/16405 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/22245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/86046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/21960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/22112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/22014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->