### PR TITLE
[AppKit Gestures] Refactor pointer event dispatch to support NSPressGestureRecognizer

### DIFF
--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1018,6 +1018,11 @@ bool EventHandler::handleMouseDraggedEvent(const MouseEventWithHitTestResults& e
     if (!m_mousePressed)
         return false;
 
+    // FIXME: Drag-and-drop is not supported for this input source yet,
+    // and text selections are driven by WKTextSelectionController.
+    if (event.event().inputSource() == MouseEventInputSource::Automation)
+        return false;
+
     Ref frame = m_frame.get();
 
     if (handleDrag(event, checkDragHysteresis))

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -567,7 +567,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 
 - (void)mouseDragged:(NSEvent *)event
 {
-    _impl->mouseDragged(event);
+    _impl->mouseDragged(event, WebKit::WebMouseEventInputSource::UserDriven);
 }
 
 - (void)otherMouseDown:(NSEvent *)event

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -158,6 +158,7 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     WeakPtr<WebKit::WebViewImpl> _viewImpl;
 
     RetainPtr<NSPanGestureRecognizer> _panGestureRecognizer;
+    RetainPtr<NSPressGestureRecognizer> _mouseTrackingGestureRecognizer;
     RetainPtr<NSPressGestureRecognizer> _singleClickGestureRecognizer;
     RetainPtr<NSClickGestureRecognizer> _doubleClickGestureRecognizer;
     RetainPtr<NSPressGestureRecognizer> _secondaryClickGestureRecognizer;
@@ -172,7 +173,10 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     std::optional<WebKit::TransactionID> _layerTreeTransactionIdAtLastInteractionStart;
     Markable<WebKit::ClickIdentifier> _latestClickID;
     WebCore::PointerID _commitPotentialClickPointerId;
-    WebCore::FloatPoint _lastInteractionLocation;
+    WebCore::FloatPoint _lastInteractionLocationInWebView;
+
+    bool _mouseTrackingHasSentMouseDown;
+    WebCore::FloatPoint _mouseTrackingStartLocationInWindow;
 }
 
 #if __has_include(<WebKitAdditions/WKAppKitGestureControllerAdditionsImpl.mm>)
@@ -189,14 +193,20 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     _page = page.get();
     _viewImpl = viewImpl.get();
 
-    [self setUpPanGestureRecognizer];
-    [self setUpSingleClickGestureRecognizer];
-    [self setUpDoubleClickGestureRecognizer];
-    [self setUpSecondaryClickGestureRecognizer];
+    [self setUpGestureRecognizers];
     [self addGesturesToWebView];
     [self enableGesturesIfNeeded];
 
     return self;
+}
+
+- (void)setUpGestureRecognizers
+{
+    [self setUpPanGestureRecognizer];
+    [self setUpMouseTrackingGestureRecognizer];
+    [self setUpSingleClickGestureRecognizer];
+    [self setUpDoubleClickGestureRecognizer];
+    [self setUpSecondaryClickGestureRecognizer];
 }
 
 - (void)setUpPanGestureRecognizer
@@ -209,6 +219,14 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     [self configureForScrolling:_panGestureRecognizer.get()];
     [_panGestureRecognizer setDelegate:self];
     [_panGestureRecognizer setName:@"WKPanGesture"];
+}
+
+- (void)setUpMouseTrackingGestureRecognizer
+{
+    _mouseTrackingGestureRecognizer = adoptNS([[NSPressGestureRecognizer alloc] initWithTarget:self action:@selector(mouseTrackingGestureRecognized:)]);
+    [self configureForMouseTracking:_mouseTrackingGestureRecognizer.get()];
+    [_mouseTrackingGestureRecognizer setDelegate:self];
+    [_mouseTrackingGestureRecognizer setName:@"WKMouseTrackingGesture"];
 }
 
 - (void)setUpSingleClickGestureRecognizer
@@ -246,6 +264,7 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
         return;
 
     [webView addGestureRecognizer:_panGestureRecognizer.get()];
+    [webView addGestureRecognizer:_mouseTrackingGestureRecognizer.get()];
     [webView addGestureRecognizer:_singleClickGestureRecognizer.get()];
     [webView addGestureRecognizer:_doubleClickGestureRecognizer.get()];
     [webView addGestureRecognizer:_secondaryClickGestureRecognizer.get()];
@@ -254,6 +273,7 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
 - (void)enableGesturesIfNeeded
 {
     [self enableGestureIfNeeded:_panGestureRecognizer.get()];
+    [self enableGestureIfNeeded:_mouseTrackingGestureRecognizer.get()];
     [self enableGestureIfNeeded:_singleClickGestureRecognizer.get()];
     [self enableGestureIfNeeded:_doubleClickGestureRecognizer.get()];
     [self enableGestureIfNeeded:_secondaryClickGestureRecognizer.get()];
@@ -396,6 +416,93 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     viewImpl->mouseUp(mouseUp.get(), WebKit::WebMouseEventInputSource::Automation);
 }
 
+- (void)mouseTrackingGestureRecognized:(NSGestureRecognizer *)gesture
+{
+    CheckedPtr viewImpl = _viewImpl.get();
+    if (!viewImpl)
+        return;
+
+    RetainPtr webView = viewImpl->view();
+    if (!webView)
+        return;
+
+    RefPtr page = _page.get();
+    if (!page)
+        return;
+
+    if (_mouseTrackingGestureRecognizer != gesture)
+        return;
+
+    if (viewImpl->ignoresAllEvents())
+        return;
+
+ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
+    auto modifierFlags = [gesture modifierFlags];
+ALLOW_NEW_API_WITHOUT_GUARDS_END
+    WebCore::FloatPoint locationInWindow { [gesture locationInView:nil] };
+    auto windowNumber = viewImpl->windowNumber();
+    auto timestamp = GetCurrentEventTime();
+
+    switch (gesture.state) {
+    case NSGestureRecognizerStateBegan:
+        _mouseTrackingHasSentMouseDown = false;
+        _mouseTrackingStartLocationInWindow = locationInWindow;
+        break;
+
+    case NSGestureRecognizerStateChanged: {
+        if (!_mouseTrackingHasSentMouseDown) {
+            RetainPtr mouseDown = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown
+                location:_mouseTrackingStartLocationInWindow
+                modifierFlags:modifierFlags
+                timestamp:timestamp
+                windowNumber:windowNumber
+                context:nil
+                eventNumber:0
+                clickCount:1
+                pressure:1.0];
+            viewImpl->mouseDown(mouseDown.get(), WebKit::WebMouseEventInputSource::Automation);
+            _mouseTrackingHasSentMouseDown = true;
+        }
+
+        RetainPtr mouseDragged = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDragged
+            location:locationInWindow
+            modifierFlags:modifierFlags
+            timestamp:timestamp
+            windowNumber:windowNumber
+            context:nil
+            eventNumber:0
+            clickCount:1
+            pressure:1.0];
+        viewImpl->mouseDragged(mouseDragged.get(), WebKit::WebMouseEventInputSource::Automation);
+        break;
+    }
+
+    case NSGestureRecognizerStateEnded: {
+        if (_mouseTrackingHasSentMouseDown) {
+            RetainPtr mouseUp = [NSEvent mouseEventWithType:NSEventTypeLeftMouseUp
+                location:locationInWindow
+                modifierFlags:modifierFlags
+                timestamp:timestamp
+                windowNumber:windowNumber
+                context:nil
+                eventNumber:0
+                clickCount:1
+                pressure:0.0];
+            viewImpl->mouseUp(mouseUp.get(), WebKit::WebMouseEventInputSource::Automation);
+        }
+        [[fallthrough]];
+    }
+
+    case NSGestureRecognizerStateCancelled:
+    case NSGestureRecognizerStateFailed:
+        _mouseTrackingHasSentMouseDown = false;
+        break;
+
+    default:
+        break;
+    }
+}
+
 #pragma mark - Click Handling
 
 - (void)_handleClickBegan:(NSGestureRecognizer *)gesture
@@ -413,7 +520,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         return;
 
     WebCore::FloatPoint position = [gesture locationInView:webView.get()];
-    _lastInteractionLocation = position;
+    _lastInteractionLocationInWebView = position;
 
     if (RefPtr drawingArea = page->drawingArea()) {
         if (RefPtr remoteDrawingArea = dynamicDowncast<WebKit::RemoteLayerTreeDrawingAreaProxy>(*drawingArea))
@@ -730,6 +837,12 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
     if (isSamePair(gestureRecognizer, otherGestureRecognizer, _singleClickGestureRecognizer.get(), _panGestureRecognizer.get()))
         return YES;
 
+    if (isSamePair(gestureRecognizer, otherGestureRecognizer, _mouseTrackingGestureRecognizer.get(), _singleClickGestureRecognizer.get()))
+        return YES;
+
+    if (isSamePair(gestureRecognizer, otherGestureRecognizer, _mouseTrackingGestureRecognizer.get(), _panGestureRecognizer.get()))
+        return YES;
+
     if (gestureRecognizer == _singleClickGestureRecognizer
         && isBuiltInScrollViewPanGestureRecognizer(otherGestureRecognizer)
         && [otherGestureRecognizer.view isKindOfClass:NSScrollView.class])
@@ -743,11 +856,12 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
     if (!webView)
         return NO;
 
-    // Allow the single click GR to be simultaneously recognized with any of those from the text selection manager.
-
+    // Allow the single click or mouse tracking GRs to be simultaneously
+    // recognized with any of those from the text selection manager.
     for (NSGestureRecognizer *gestureForFailureRequirements in [[webView textSelectionManager] gesturesForFailureRequirements]) {
-        if ((gestureRecognizer == _singleClickGestureRecognizer && otherGestureRecognizer == gestureForFailureRequirements)
-            || (otherGestureRecognizer == _singleClickGestureRecognizer && gestureRecognizer == gestureForFailureRequirements))
+        if (isSamePair(gestureRecognizer, otherGestureRecognizer, _singleClickGestureRecognizer.get(), gestureForFailureRequirements))
+            return YES;
+        if (isSamePair(gestureRecognizer, otherGestureRecognizer, _mouseTrackingGestureRecognizer.get(), gestureForFailureRequirements))
             return YES;
     }
 
@@ -812,7 +926,7 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
 
 - (BOOL)_gestureRecognizer:(NSGestureRecognizer *)preventingGestureRecognizer canPreventGestureRecognizer:(NSGestureRecognizer *)preventedGestureRecognizer
 {
-    bool isOurClickGesture = preventingGestureRecognizer == _singleClickGestureRecognizer || preventingGestureRecognizer == _secondaryClickGestureRecognizer;
+    bool isOurClickGesture = preventingGestureRecognizer == _singleClickGestureRecognizer || preventingGestureRecognizer == _secondaryClickGestureRecognizer || preventingGestureRecognizer == _mouseTrackingGestureRecognizer;
     return !isOurClickGesture || ![self _isScrollOrZoomGestureRecognizer:preventedGestureRecognizer];
 }
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -703,7 +703,7 @@ public:
     void mouseMoved(NSEvent *);
     void mouseDown(NSEvent *, WebMouseEventInputSource);
     void mouseUp(NSEvent *, WebMouseEventInputSource);
-    void mouseDragged(NSEvent *);
+    void mouseDragged(NSEvent *, WebMouseEventInputSource);
     void mouseEntered(NSEvent *);
     void mouseExited(NSEvent *);
     void otherMouseDown(NSEvent *);
@@ -940,7 +940,7 @@ private:
     void mouseMovedInternal(NSEvent *);
     void mouseDownInternal(NSEvent *, WebMouseEventInputSource);
     void mouseUpInternal(NSEvent *, WebMouseEventInputSource);
-    void mouseDraggedInternal(NSEvent *);
+    void mouseDraggedInternal(NSEvent *, WebMouseEventInputSource);
 
     void handleProcessSwapOrExit();
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -6263,9 +6263,9 @@ void WebViewImpl::mouseUpInternal(NSEvent *event, WebMouseEventInputSource input
     nativeMouseEventHandlerInternal(event, inputSource);
 }
 
-void WebViewImpl::mouseDraggedInternal(NSEvent *event)
+void WebViewImpl::mouseDraggedInternal(NSEvent *event, WebMouseEventInputSource inputSource)
 {
-    nativeMouseEventHandlerInternal(event, WebMouseEventInputSource::UserDriven);
+    nativeMouseEventHandlerInternal(event, inputSource);
 }
 
 void WebViewImpl::mouseMoved(NSEvent *event)
@@ -6383,14 +6383,14 @@ void WebViewImpl::mouseUp(NSEvent *event, WebMouseEventInputSource inputSource)
     mouseUpInternal(event, inputSource);
 }
 
-void WebViewImpl::mouseDragged(NSEvent *event)
+void WebViewImpl::mouseDragged(NSEvent *event, WebMouseEventInputSource inputSource)
 {
     if (m_ignoresNonWheelEvents)
         return;
     if (ignoresMouseDraggedEvents())
         return;
 
-    mouseDraggedInternal(event);
+    mouseDraggedInternal(event, inputSource);
 }
 
 bool WebViewImpl::windowIsFrontWindowUnderMouse(NSEvent *event)


### PR DESCRIPTION
#### f79cd48ee2b323d60af56ba9d04329859ef1d885
<pre>
[AppKit Gestures] Refactor pointer event dispatch to support NSPressGestureRecognizer
<a href="https://bugs.webkit.org/show_bug.cgi?id=309939">https://bugs.webkit.org/show_bug.cgi?id=309939</a>
<a href="https://rdar.apple.com/170691859">rdar://170691859</a>

Reviewed by Richard Robinson.

In an earlier series of commits (terminating in 307810@main), we simply
taught the gesture controller about click events. This left a gap in our
pointer tracking/event dispatch support since we were unable to dispatch
general pointerDown/Move/Up event sequences to the web.

This patch addresses this disparity by simulating a mouse tracking loop
with a press gesture recognizer. We synthesize representative NSEvent
instances based on the tracking recognizer&apos;s state changes, and pass
them through our native mouse event handling codepath in WebViewImpl.

Note that we make a special concession for mouseDown so as to not fight
against deferred click support. The intention is that either of the two
paths fires a mouseDown, and not both. Further note that we opt out of
much of the EventHandler::handleMouseDraggedEvent() path for pointer
events originating from this recognizer. Among other things, a refactor
of drag-and-drop flows to also support gesture reconizers is forthcoming.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMouseDraggedEvent):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView mouseDragged:]):
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController initWithPage:viewImpl:]):
(-[WKAppKitGestureController setUpGestureRecognizers]):
(-[WKAppKitGestureController setUpMouseTrackingGestureRecognizer]):
(-[WKAppKitGestureController addGesturesToWebView]):
(-[WKAppKitGestureController enableGesturesIfNeeded]):
(-[WKAppKitGestureController mouseTrackingGestureRecognized:]):
(-[WKAppKitGestureController _handleClickBegan:]):
(-[WKAppKitGestureController gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]):
(-[WKAppKitGestureController _gestureRecognizer:canPreventGestureRecognizer:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::mouseDraggedInternal):
(WebKit::WebViewImpl::mouseDragged):

Canonical link: <a href="https://commits.webkit.org/309295@main">https://commits.webkit.org/309295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d488dc4a7122793cb455841d7a955c66e77421aa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16524 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158918 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103639 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115876 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82322 "2 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17988 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134746 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96609 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17088 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15036 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6764 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126703 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161391 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11003 "Build is in progress. Recent messages:") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4517 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14222 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123879 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124084 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22752 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134465 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79071 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23093 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19206 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11222 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181636 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22365 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86165 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/181636 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22079 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22231 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22133 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->