### PR TITLE
Add onend EventHandler to SVGAnimationElement and fix event name mapping for onbegin/onend/onrepeat

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/custom-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/custom-events-expected.txt
@@ -1,4 +1,4 @@
 
 PASS custom events with the name 'end' should only call the event listener for the event 'end' and no attribute handlers or IDL listeners
-FAIL custom events with the name 'endEvent' should call 'onend' attribute handlers and IDL property listeners, and 'endEvent' listeners assert_equals: expected 1 but got 0
+PASS custom events with the name 'endEvent' should call 'onend' attribute handlers and IDL property listeners, and 'endEvent' listeners
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/event-listeners-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/event-listeners-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL When the animation ends, only the 'onend' attribute + IDL listeners and the 'endEvent' listener should be called assert_equals: expected 1 but got 0
+PASS When the animation ends, only the 'onend' attribute + IDL listeners and the 'endEvent' listener should be called
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
@@ -1640,7 +1640,7 @@ PASS SVGAnimationElement interface: existence and properties of interface protot
 PASS SVGAnimationElement interface: existence and properties of interface prototype object's @@unscopables property
 PASS SVGAnimationElement interface: attribute targetElement
 PASS SVGAnimationElement interface: attribute onbegin
-FAIL SVGAnimationElement interface: attribute onend assert_true: The prototype object must have a property "onend" expected true got false
+PASS SVGAnimationElement interface: attribute onend
 PASS SVGAnimationElement interface: attribute onrepeat
 PASS SVGAnimationElement interface: operation getStartTime()
 PASS SVGAnimationElement interface: operation getCurrentTime()
@@ -1661,7 +1661,7 @@ PASS SVGAnimateElement must be primary interface of objects.animate
 PASS Stringification of objects.animate
 PASS SVGAnimationElement interface: objects.animate must inherit property "targetElement" with the proper type
 PASS SVGAnimationElement interface: objects.animate must inherit property "onbegin" with the proper type
-FAIL SVGAnimationElement interface: objects.animate must inherit property "onend" with the proper type assert_inherits: property "onend" not found in prototype chain
+PASS SVGAnimationElement interface: objects.animate must inherit property "onend" with the proper type
 PASS SVGAnimationElement interface: objects.animate must inherit property "onrepeat" with the proper type
 PASS SVGAnimationElement interface: objects.animate must inherit property "getStartTime()" with the proper type
 PASS SVGAnimationElement interface: objects.animate must inherit property "getCurrentTime()" with the proper type
@@ -1689,7 +1689,7 @@ PASS SVGSetElement must be primary interface of objects.set
 PASS Stringification of objects.set
 PASS SVGAnimationElement interface: objects.set must inherit property "targetElement" with the proper type
 PASS SVGAnimationElement interface: objects.set must inherit property "onbegin" with the proper type
-FAIL SVGAnimationElement interface: objects.set must inherit property "onend" with the proper type assert_inherits: property "onend" not found in prototype chain
+PASS SVGAnimationElement interface: objects.set must inherit property "onend" with the proper type
 PASS SVGAnimationElement interface: objects.set must inherit property "onrepeat" with the proper type
 PASS SVGAnimationElement interface: objects.set must inherit property "getStartTime()" with the proper type
 PASS SVGAnimationElement interface: objects.set must inherit property "getCurrentTime()" with the proper type
@@ -1717,7 +1717,7 @@ PASS SVGAnimateMotionElement must be primary interface of objects.animateMotion
 PASS Stringification of objects.animateMotion
 PASS SVGAnimationElement interface: objects.animateMotion must inherit property "targetElement" with the proper type
 PASS SVGAnimationElement interface: objects.animateMotion must inherit property "onbegin" with the proper type
-FAIL SVGAnimationElement interface: objects.animateMotion must inherit property "onend" with the proper type assert_inherits: property "onend" not found in prototype chain
+PASS SVGAnimationElement interface: objects.animateMotion must inherit property "onend" with the proper type
 PASS SVGAnimationElement interface: objects.animateMotion must inherit property "onrepeat" with the proper type
 PASS SVGAnimationElement interface: objects.animateMotion must inherit property "getStartTime()" with the proper type
 PASS SVGAnimationElement interface: objects.animateMotion must inherit property "getCurrentTime()" with the proper type
@@ -1760,7 +1760,7 @@ PASS SVGAnimateTransformElement must be primary interface of objects.animateTran
 PASS Stringification of objects.animateTransform
 PASS SVGAnimationElement interface: objects.animateTransform must inherit property "targetElement" with the proper type
 PASS SVGAnimationElement interface: objects.animateTransform must inherit property "onbegin" with the proper type
-FAIL SVGAnimationElement interface: objects.animateTransform must inherit property "onend" with the proper type assert_inherits: property "onend" not found in prototype chain
+PASS SVGAnimationElement interface: objects.animateTransform must inherit property "onend" with the proper type
 PASS SVGAnimationElement interface: objects.animateTransform must inherit property "onrepeat" with the proper type
 PASS SVGAnimationElement interface: objects.animateTransform must inherit property "getStartTime()" with the proper type
 PASS SVGAnimationElement interface: objects.animateTransform must inherit property "getCurrentTime()" with the proper type

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt
@@ -90,5 +90,6 @@ PASS getAttributeType("dummy", "onunload", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onencrypted", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onwaitingforkey", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onbegin", "dummyNs", attrNs)
+PASS getAttributeType("dummy", "onend", "dummyNs", attrNs)
 PASS getAttributeType("dummy", "onrepeat", "dummyNs", attrNs)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative-expected.txt
@@ -501,6 +501,8 @@ PASS VIDEO.setAttribute(onwaitingforkey, "unsafe_handler()") calls default polic
 PASS VIDEO.setAttributeNS(onwaitingforkey, "unsafe_handler()") calls default policy
 PASS animation.setAttribute(onbegin, "unsafe_handler()") calls default policy
 PASS animation.setAttributeNS(onbegin, "unsafe_handler()") calls default policy
+PASS animation.setAttribute(onend, "unsafe_handler()") calls default policy
+PASS animation.setAttributeNS(onend, "unsafe_handler()") calls default policy
 PASS animation.setAttribute(onrepeat, "unsafe_handler()") calls default policy
 PASS animation.setAttributeNS(onrepeat, "unsafe_handler()") calls default policy
 PASS DIV.setAttribute("onafterprint", "unsafe_handler()") calls default policy

--- a/Source/WebCore/svg/SVGAnimationElement.idl
+++ b/Source/WebCore/svg/SVGAnimationElement.idl
@@ -40,8 +40,9 @@
     undefined endElement();
     undefined endElementAt(float offset);
 
-    attribute EventHandler onbegin;
-    attribute EventHandler onrepeat;
+    [ImplementedAs=onbeginEvent] attribute EventHandler onbegin;
+    [ImplementedAs=onendEvent] attribute EventHandler onend;
+    [ImplementedAs=onrepeatEvent] attribute EventHandler onrepeat;
 };
 
 SVGAnimationElement includes SVGTests;


### PR DESCRIPTION
#### 98168e157ebfe6df7d9ce8289064e57566c42709
<pre>
Add onend EventHandler to SVGAnimationElement and fix event name mapping for onbegin/onend/onrepeat
<a href="https://bugs.webkit.org/show_bug.cgi?id=309941">https://bugs.webkit.org/show_bug.cgi?id=309941</a>
<a href="https://rdar.apple.com/172533070">rdar://172533070</a>

Reviewed by NOBODY (OOPS!).

The SVG spec [1] defines onbegin, onend, and onrepeat IDL attributes on
SVGAnimationElement that should map to beginEvent, endEvent, and
repeatEvent respectively. onend was missing entirely, and onbegin/onrepeat
were silently mapping to the wrong event names due to a naming collision
in the codegen.

The IDL code generator strips &quot;on&quot; and appends &quot;Event&quot; to produce the
C++ accessor (e.g. onend -&gt; endEvent). But make-event-names.py also
appends &quot;Event&quot; to every EventNames.json entry to create accessors, so
eventNames().endEvent refers to the &quot;end&quot; event, not &quot;endEvent&quot;. The
correct accessor for the &quot;endEvent&quot; event is eventNames().endEventEvent.

Using [ImplementedAs=onendEvent] makes the codegen strip &quot;on&quot; to get
&quot;endEvent&quot;, then append &quot;Event&quot; to get &quot;endEventEvent&quot;, producing the
correct eventNames().endEventEvent accessor.

[1] <a href="https://svgwg.org/specs/animations/#InterfaceSVGAnimationElement">https://svgwg.org/specs/animations/#InterfaceSVGAnimationElement</a>

* Source/WebCore/svg/SVGAnimationElement.idl:

&gt; Progressions:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/custom-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/event-listeners-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt:

&gt; Additional Coverage:
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/event-listeners.html: `onbegin` and `onrepeat` special case testing

&gt; Rebaselines:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/TrustedTypePolicyFactory-getAttributeType-event-handler-content-attributes.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/set-event-handlers-content-attributes.tentative-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01172240bd2501025e6fe359e40d55c3c06aa403

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150098 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16417 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158809 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3418676-4450-4233-8473-b1a714638f6c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151971 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115786 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f29bb353-a189-4752-b180-65a1a8aa8167) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134664 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96515 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c2916a1-9b42-4649-9969-5d576e2cdf2c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16997 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6655 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12588 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161283 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14140 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123790 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123991 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22645 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134383 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78874 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19115 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11140 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22257 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86058 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/21972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22124 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22026 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->