### PR TITLE
[JSC] Optimize B3 SIMD shuffle more

### DIFF
--- a/Source/JavaScriptCore/b3/B3ReduceSIMDShuffle.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceSIMDShuffle.cpp
@@ -95,7 +95,6 @@ private:
     // expose another composition opportunity.
     void composeShuffles()
     {
-        UseCountsWithoutUsingInstructions useCounts(m_proc);
         bool changed = true;
         unsigned iterations = 0;
         constexpr unsigned maxIterations = 4;
@@ -109,89 +108,111 @@ private:
                     Value* value = block->at(index);
                     if (value->opcode() != VectorSwizzle)
                         continue;
-                    if (value->numChildren() != 3)
-                        continue;
 
-                    Value* patternValue = value->child(2);
-                    if (!patternValue->isConstant())
-                        continue;
-
-                    v128_t outerPattern = patternValue->as<Const128Value>()->value();
-
-                    for (unsigned childIdx = 0; childIdx < 2; ++childIdx) {
-                        Value* inner = value->child(childIdx);
-                        // The inner must be a single-use unary VectorSwizzle with a constant pattern.
-                        if (inner->opcode() != VectorSwizzle)
-                            continue;
-                        if (inner->numChildren() != 2)
-                            continue;
-                        if (useCounts.numUses(inner) != 1)
-                            continue;
-                        if (!inner->child(1)->isConstant())
+                    if (value->numChildren() == 3) {
+                        Value* patternValue = value->child(2);
+                        if (!patternValue->hasV128())
                             continue;
 
-                        v128_t innerPattern = inner->child(1)->as<Const128Value>()->value();
-                        // Compose: for each output byte, chase through outer → inner patterns
-                        // to find the original source byte index.
-                        v128_t newPattern = SIMDShuffle::composeShuffle(outerPattern, innerPattern, childIdx == 0);
+                        v128_t outerPattern = patternValue->asV128();
 
-                        // After composition, the new shuffle reads from innerSrc (the inner's
-                        // original input) and other (the outer's other child).
-                        Value* innerSrc = inner->child(0);
-                        Value* other = value->child(1 - childIdx);
+                        for (unsigned childIdx = 0; childIdx < 2; ++childIdx) {
+                            Value* inner = value->child(childIdx);
+                            // The inner must be a unary VectorSwizzle with a constant pattern.
+                            if (inner->opcode() != VectorSwizzle)
+                                continue;
+                            if (inner->numChildren() != 2)
+                                continue;
+                            if (!inner->child(1)->hasV128())
+                                continue;
 
-                        // Maintain the convention: child(0) = newChild0, child(1) = newChild1.
-                        // If inner was child(0), innerSrc becomes newChild0 and other stays newChild1.
-                        // If inner was child(1), other stays newChild0 and innerSrc becomes newChild1.
-                        Value* newChild0;
-                        Value* newChild1;
-                        if (childIdx == 0) {
-                            newChild0 = innerSrc;
-                            newChild1 = other;
-                        } else {
-                            newChild0 = other;
-                            newChild1 = innerSrc;
-                        }
+                            v128_t innerPattern = inner->child(1)->asV128();
+                            // Compose: for each output byte, chase through outer → inner patterns
+                            // to find the original source byte index.
+                            v128_t newPattern = SIMDShuffle::composeShuffle(outerPattern, innerPattern, childIdx == 0);
 
-                        // If all composed indices reference only one side (0..15 or 16..31),
-                        // emit a 2-child unary shuffle instead of a 3-child binary shuffle.
-                        // This enables further optimizations like DUP detection in ReduceStrength.
-                        if (auto side = SIMDShuffle::isOnlyOneSideMask(newPattern)) {
-                            Value* src;
-                            v128_t unaryPattern = newPattern;
-                            if (*side == 0)
-                                src = newChild0;
-                            else {
-                                src = newChild1;
-                                for (unsigned i = 0; i < 16; ++i)
-                                    unaryPattern.u8x16[i] -= 16;
+                            // After composition, the new shuffle reads from innerSrc (the inner's
+                            // original input) and other (the outer's other child).
+                            Value* innerSrc = inner->child(0);
+                            Value* other = value->child(1 - childIdx);
+
+                            // Maintain the convention: child(0) = newChild0, child(1) = newChild1.
+                            // If inner was child(0), innerSrc becomes newChild0 and other stays newChild1.
+                            // If inner was child(1), other stays newChild0 and innerSrc becomes newChild1.
+                            Value* newChild0;
+                            Value* newChild1;
+                            if (childIdx == 0) {
+                                newChild0 = innerSrc;
+                                newChild1 = other;
+                            } else {
+                                newChild0 = other;
+                                newChild1 = innerSrc;
                             }
-                            Value* newPat = m_proc.addConstant(value->origin(), B3::V128, unaryPattern);
-                            m_insertionSet.insertValue(index, newPat);
-                            Value* newShuffle = m_insertionSet.insert<SIMDValue>(
-                                index, value->origin(), VectorSwizzle, B3::V128,
-                                SIMDLane::i8x16, SIMDSignMode::None, src, newPat);
-                            value->replaceWithIdentity(newShuffle);
-                        } else {
-                            Value* newPat = m_proc.addConstant(value->origin(), B3::V128, newPattern);
-                            m_insertionSet.insertValue(index, newPat);
-                            Value* newShuffle = m_insertionSet.insert<SIMDValue>(
-                                index, value->origin(), VectorSwizzle, B3::V128,
-                                SIMDLane::i8x16, SIMDSignMode::None, newChild0, newChild1, newPat);
-                            value->replaceWithIdentity(newShuffle);
+
+                            // If all composed indices reference only one side (0..15 or 16..31),
+                            // emit a 2-child unary shuffle instead of a 3-child binary shuffle.
+                            // This enables further optimizations like DUP detection in ReduceStrength.
+                            if (auto side = SIMDShuffle::isOnlyOneSideMask(newPattern)) {
+                                Value* src;
+                                v128_t unaryPattern = newPattern;
+                                if (*side == 0)
+                                    src = newChild0;
+                                else {
+                                    src = newChild1;
+                                    for (unsigned i = 0; i < 16; ++i)
+                                        unaryPattern.u8x16[i] -= 16;
+                                }
+                                Value* newPat = m_proc.addConstant(value->origin(), B3::V128, unaryPattern);
+                                m_insertionSet.insertValue(index, newPat);
+                                Value* newShuffle = m_insertionSet.insert<SIMDValue>(
+                                    index, value->origin(), VectorSwizzle, B3::V128,
+                                    SIMDLane::i8x16, SIMDSignMode::None, src, newPat);
+                                value->replaceWithIdentity(newShuffle);
+                            } else {
+                                Value* newPat = m_proc.addConstant(value->origin(), B3::V128, newPattern);
+                                m_insertionSet.insertValue(index, newPat);
+                                Value* newShuffle = m_insertionSet.insert<SIMDValue>(
+                                    index, value->origin(), VectorSwizzle, B3::V128,
+                                    SIMDLane::i8x16, SIMDSignMode::None, newChild0, newChild1, newPat);
+                                value->replaceWithIdentity(newShuffle);
+                            }
+
+                            changed = true;
+                            dataLogLnIf(B3ReduceSIMDShuffleInternal::verbose, "Composed shuffle: ", *value);
+                            break;
                         }
 
+                        continue;
+                    }
+
+                    if (value->numChildren() == 2) {
+                        if (!value->child(1)->hasV128())
+                            continue;
+
+                        Value* inner = value->child(0);
+                        if (inner->opcode() != VectorSwizzle || inner->numChildren() != 2)
+                            continue;
+                        if (!inner->child(1)->hasV128())
+                            continue;
+
+                        v128_t outerPat = value->child(1)->asV128();
+                        v128_t innerPat = inner->child(1)->asV128();
+                        v128_t composed = SIMDShuffle::composeUnaryShuffle(outerPat, innerPat);
+
+                        Value* newPat = m_proc.addConstant(value->origin(), B3::V128, composed);
+                        m_insertionSet.insertValue(index, newPat);
+                        Value* newShuffle = m_insertionSet.insert<SIMDValue>(
+                            index, value->origin(), VectorSwizzle, B3::V128,
+                            SIMDLane::i8x16, SIMDSignMode::None, inner->child(0), newPat);
+                        value->replaceWithIdentity(newShuffle);
                         changed = true;
-                        dataLogLnIf(B3ReduceSIMDShuffleInternal::verbose, "Composed shuffle: ", *value);
-                        break;
+                        dataLogLnIf(B3ReduceSIMDShuffleInternal::verbose, "Composed unary shuffle: ", *value);
+                        continue;
                     }
                 }
 
                 m_insertionSet.execute(block);
             }
-
-            if (changed)
-                useCounts = UseCountsWithoutUsingInstructions(m_proc);
         }
     }
 

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -3493,13 +3493,16 @@ private:
                             }
                         }
 
-                        // Also try unary-specific patterns (REV, EXT).
+                        // General unary EXT (byte rotation): {k, k+1, ..., 15, 0, 1, ..., k-1}
+                        // Subsumes S64x2Reverse (which is EXT #8).
+                        if (auto offset = SIMDShuffle::isUnaryEXT(pattern)) {
+                            replaceWithNew<SIMDValue>(m_value->origin(), VectorExtractPair, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, static_cast<uint8_t>(*offset), m_value->child(0), m_value->child(0));
+                            break;
+                        }
+
+                        // Also try unary-specific patterns (REV).
                         {
                             auto canonical = SIMDShuffle::tryMatchCanonicalUnary(pattern);
-                            if (canonical == CanonicalShuffle::S64x2Reverse) {
-                                replaceWithNew<SIMDValue>(m_value->origin(), VectorExtractPair, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, static_cast<uint8_t>(8), m_value->child(0), m_value->child(0));
-                                break;
-                            }
                             if (auto info = canonicalShuffleInfo(canonical)) {
                                 if (info->opcode == VectorReverse) {
                                     replaceWithNew<SIMDValue>(m_value->origin(), info->opcode, B3::V128, info->lane, SIMDSignMode::None, info->groupSize, m_value->child(0));

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1533,5 +1533,7 @@ void testVectorSwizzleUnaryToEXT();
 void testVectorCanonicalSameInputFolding();
 void testVectorSwizzleToDupElement();
 void testVectorSwizzleComposition();
+void testVectorSwizzleUnaryComposition();
+void testVectorSwizzleCompositionMultiUse();
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1165,6 +1165,8 @@ void run(const TestConfig* config)
             RUN(testVectorCanonicalSameInputFolding());
             RUN(testVectorSwizzleToDupElement());
             RUN(testVectorSwizzleComposition());
+            RUN(testVectorSwizzleUnaryComposition());
+            RUN(testVectorSwizzleCompositionMultiUse());
         }
         RUN(testMulHigh32());
         RUN(testMulHigh64());

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -3939,16 +3939,18 @@ void testVectorSwizzleUnaryToEXT()
     if constexpr (!isARM64())
         return;
 
-    // S64x2 reverse = swap 64-bit halves = EXT #8 with same register
-    // Pattern: {8,9,10,11,12,13,14,15, 0,1,2,3,4,5,6,7}
     v128_t v;
     for (unsigned i = 0; i < 16; ++i) v.u8x16[i] = i;
-    {
-        const uint8_t pat[] = { 8,9,10,11,12,13,14,15, 0,1,2,3,4,5,6,7 };
+
+    // Test all 15 rotation offsets (EXT #1 through #15).
+    for (unsigned offset = 1; offset <= 15; ++offset) {
+        uint8_t pat[16];
         v128_t exp;
-        for (unsigned i = 0; i < 8; ++i) exp.u8x16[i] = 8 + i;
-        for (unsigned i = 0; i < 8; ++i) exp.u8x16[8 + i] = i;
-        testUnarySwizzlePattern("S64x2Reverse → EXT #8", pat, v, exp);
+        for (unsigned i = 0; i < 16; ++i) {
+            pat[i] = (offset + i) % 16;
+            exp.u8x16[i] = (offset + i) % 16;
+        }
+        testUnarySwizzlePattern("Unary EXT", pat, v, exp);
     }
 }
 
@@ -4460,6 +4462,125 @@ void testVectorSwizzleComposition()
     CHECK(vectors[2].u8x16[13] == 6);
     CHECK(vectors[2].u8x16[14] == 5);
     CHECK(vectors[2].u8x16[15] == 4);
+}
+
+void testVectorSwizzleUnaryComposition()
+{
+    if constexpr (!isARM64())
+        return;
+
+    // Compose two chained unary rotations: EXT4(EXT4(x)) = EXT8(x).
+    // inner = VectorSwizzle(input, rotate4Pattern)
+    // outer = VectorSwizzle(inner, rotate4Pattern)
+    // After composition, this should be a single rotation by 8.
+
+    alignas(16) v128_t vectors[2];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+
+    // Rotate by 4: {4,5,...,15,0,1,2,3}
+    v128_t rotate4;
+    for (unsigned i = 0; i < 16; ++i)
+        rotate4.u8x16[i] = (4 + i) % 16;
+    Value* rotate4Const = root->appendNew<Const128Value>(proc, Origin(), rotate4);
+
+    Value* inner = root->appendNew<SIMDValue>(proc, Origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, input, rotate4Const);
+    Value* rotate4Const2 = root->appendNew<Const128Value>(proc, Origin(), rotate4);
+    Value* outer = root->appendNew<SIMDValue>(proc, Origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, inner, rotate4Const2);
+
+    root->appendNew<MemoryValue>(proc, Store, Origin(), outer, address, static_cast<int32_t>(sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+    for (unsigned i = 0; i < 16; ++i) vectors[0].u8x16[i] = i;
+    invoke<void>(*code, vectors);
+
+    // Expected: rotation by 8 → {8,9,10,11,12,13,14,15,0,1,2,3,4,5,6,7}
+    for (unsigned i = 0; i < 16; ++i)
+        CHECK(vectors[1].u8x16[i] == ((8 + i) % 16));
+}
+
+void testVectorSwizzleCompositionMultiUse()
+{
+    if constexpr (!isARM64())
+        return;
+
+    // Test that composition works when inner has multiple consumers.
+    // inner = VectorSwizzle(src, rev32Pattern)  (used by both outer shuffles)
+    // outer1 = VectorSwizzle(other, inner, concatPattern)
+    // outer2 = VectorSwizzle(inner, other, concatPattern2)
+
+    alignas(16) v128_t vectors[4];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* src = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* other = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address, static_cast<int32_t>(sizeof(v128_t)));
+
+    // Inner: reverse bytes within 32-bit groups
+    v128_t innerPat;
+    for (unsigned i = 0; i < 16; i += 4) {
+        innerPat.u8x16[i] = i + 3;
+        innerPat.u8x16[i + 1] = i + 2;
+        innerPat.u8x16[i + 2] = i + 1;
+        innerPat.u8x16[i + 3] = i;
+    }
+    Value* innerPatConst = root->appendNew<Const128Value>(proc, Origin(), innerPat);
+    Value* inner = root->appendNew<SIMDValue>(proc, Origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, src, innerPatConst);
+
+    // outer1 = binary shuffle(other, inner): take lo64 from other, hi64 from inner
+    // Pattern: {0..7 from child0, 24..31 from child1}
+    v128_t outerPat1;
+    for (unsigned i = 0; i < 8; ++i) outerPat1.u8x16[i] = i;         // child0[0..7]
+    for (unsigned i = 0; i < 8; ++i) outerPat1.u8x16[8 + i] = 24 + i; // child1[8..15]
+    Value* outerPatConst1 = root->appendNew<Const128Value>(proc, Origin(), outerPat1);
+    Value* outer1 = root->appendNew<SIMDValue>(proc, Origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, other, inner, outerPatConst1);
+
+    // outer2 = binary shuffle(inner, other): take lo64 from inner, hi64 from other
+    v128_t outerPat2;
+    for (unsigned i = 0; i < 8; ++i) outerPat2.u8x16[i] = i;           // child0[0..7] = inner[0..7]
+    for (unsigned i = 0; i < 8; ++i) outerPat2.u8x16[8 + i] = 24 + i;  // child1[8..15] = other[8..15]
+    Value* outerPatConst2 = root->appendNew<Const128Value>(proc, Origin(), outerPat2);
+    Value* outer2 = root->appendNew<SIMDValue>(proc, Origin(), VectorSwizzle, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, inner, other, outerPatConst2);
+
+    root->appendNew<MemoryValue>(proc, Store, Origin(), outer1, address, static_cast<int32_t>(2 * sizeof(v128_t)));
+    root->appendNew<MemoryValue>(proc, Store, Origin(), outer2, address, static_cast<int32_t>(3 * sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+    for (unsigned i = 0; i < 16; ++i) vectors[0].u8x16[i] = i;        // src
+    for (unsigned i = 0; i < 16; ++i) vectors[1].u8x16[i] = 0x80 + i;  // other
+    invoke<void>(*code, vectors);
+
+    // outer1: {other[0..7], rev32(src)[8..15]}
+    for (unsigned i = 0; i < 8; ++i)
+        CHECK(vectors[2].u8x16[i] == 0x80 + i);
+    // rev32(src)[8..15] = {11,10,9,8, 15,14,13,12}
+    CHECK(vectors[2].u8x16[8] == 11);
+    CHECK(vectors[2].u8x16[9] == 10);
+    CHECK(vectors[2].u8x16[10] == 9);
+    CHECK(vectors[2].u8x16[11] == 8);
+    CHECK(vectors[2].u8x16[12] == 15);
+    CHECK(vectors[2].u8x16[13] == 14);
+    CHECK(vectors[2].u8x16[14] == 13);
+    CHECK(vectors[2].u8x16[15] == 12);
+
+    // outer2: {rev32(src)[0..7], other[8..15]}
+    // rev32(src)[0..7] = {3,2,1,0, 7,6,5,4}
+    CHECK(vectors[3].u8x16[0] == 3);
+    CHECK(vectors[3].u8x16[1] == 2);
+    CHECK(vectors[3].u8x16[2] == 1);
+    CHECK(vectors[3].u8x16[3] == 0);
+    CHECK(vectors[3].u8x16[4] == 7);
+    CHECK(vectors[3].u8x16[5] == 6);
+    CHECK(vectors[3].u8x16[6] == 5);
+    CHECK(vectors[3].u8x16[7] == 4);
+    for (unsigned i = 8; i < 16; ++i)
+        CHECK(vectors[3].u8x16[i] == 0x80 + i);
 }
 
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/jit/SIMDShuffle.h
+++ b/Source/JavaScriptCore/jit/SIMDShuffle.h
@@ -204,6 +204,21 @@ public:
         return true;
     }
 
+    // Detect unary EXT (byte rotation) pattern.
+    // Returns offset if pattern[i] == (offset + i) % 16 for all i,
+    // with offset in [1, 15]. Offset 0 is identity (handled separately).
+    static std::optional<uint8_t> isUnaryEXT(v128_t pattern)
+    {
+        uint8_t first = pattern.u8x16[0];
+        if (first == 0 || first >= 16)
+            return std::nullopt;
+        for (unsigned i = 1; i < 16; ++i) {
+            if (pattern.u8x16[i] != ((first + i) % 16))
+                return std::nullopt;
+        }
+        return first;
+    }
+
     // Detect EXT (byte extraction / concatenation) pattern for binary shuffle.
     // Returns the byte offset if the pattern is {offset, offset+1, ..., 31, 0, 1, ...}
     // i.e., pattern[i] == (offset + i) % 32 for some offset in [0, 15].
@@ -276,6 +291,22 @@ public:
             return CanonicalShuffle::S64x2Reverse;
 
         return CanonicalShuffle::Unknown;
+    }
+
+    // Compose two unary shuffles: outer(inner(x)) → combined(x).
+    // Both patterns have indices in 0..15 (or OOB >= 16).
+    static v128_t composeUnaryShuffle(v128_t outerPattern, v128_t innerPattern)
+    {
+        v128_t result;
+        for (unsigned i = 0; i < 16; ++i) {
+            uint8_t outerIdx = outerPattern.u8x16[i];
+            if (outerIdx >= 16) {
+                result.u8x16[i] = 0xFF; // OOB
+                continue;
+            }
+            result.u8x16[i] = innerPattern.u8x16[outerIdx];
+        }
+        return result;
     }
 
     // Compose an outer shuffle with an inner shuffle.


### PR DESCRIPTION
#### 99bafdf6e24aa667caf8a518455bff9d2e72ab64
<pre>
[JSC] Optimize B3 SIMD shuffle more
<a href="https://bugs.webkit.org/show_bug.cgi?id=309942">https://bugs.webkit.org/show_bug.cgi?id=309942</a>
<a href="https://rdar.apple.com/172533561">rdar://172533561</a>

Reviewed by Justin Michaud.

1. Add unary EXT detection. Byte rotation patterns {k, k+1, ..., 15, 0, ..., k-1}
   are now recognized for all offsets 1-15 and lowered to VectorExtractPair (ext)
   instead of tbl.

2. Extend shuffle composition in B3ReduceSIMDShuffle.
   - Added unary-of-unary composition. VectorSwizzle(VectorSwizzle(x, pat1), pat2)
     is composed into a single VectorSwizzle(x, composed_pat). This enables chained
     rotations like EXT4(EXT4(x)) to fold into EXT8(x), then get lowered to a
     single ext instruction.
   - Relaxed the single-use restriction on inner shuffles for binary(unary())
     composition. Composition replaces only the outer node, the inner survives for
     other consumers and DCE removes it if all uses are composed away.

Tests: Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_7.cpp

* Source/JavaScriptCore/b3/B3ReduceSIMDShuffle.cpp:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testVectorSwizzleUnaryToEXT):
(testVectorSwizzleUnaryComposition):
(testVectorSwizzleCompositionMultiUse):
* Source/JavaScriptCore/jit/SIMDShuffle.h:
(JSC::SIMDShuffle::isUnaryEXT):
(JSC::SIMDShuffle::composeUnaryShuffle):

Canonical link: <a href="https://commits.webkit.org/309299@main">https://commits.webkit.org/309299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/341f55c565e66c7ce78b4eee3180951727ab17c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150150 "33 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103584 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ff18ef2-a4a9-48fa-a280-2c72a881d8bd) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23015 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115834 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82286 "8 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cebd086f-07cf-46bc-86bd-6df0da51a50b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134709 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96565 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3a278cf-146c-40ba-b8f7-ac4a6e0f3c56) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17047 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14997 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6707 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142133 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126662 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161335 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10948 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4426 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123838 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22710 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19044 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124039 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22697 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134428 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78971 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23095 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19166 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11185 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181581 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22310 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86110 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46477 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22024 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22176 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22078 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->