### PR TITLE
ZStream::~ZStream() should call inflateEnd() for decompression mode

### DIFF
--- a/Source/WebCore/Modules/compression/ZStream.cpp
+++ b/Source/WebCore/Modules/compression/ZStream.cpp
@@ -38,6 +38,7 @@ bool ZStream::initializeIfNecessary(Algorithm algorithm, Operation operation)
 
     switch (operation) {
     case Operation::Compression:
+        m_isCompression = true;
         switch (algorithm) {
         // Values chosen here are based off
         // https://developer.apple.com/documentation/compression/compression_algorithm/compression_zlib?language=objc
@@ -79,8 +80,12 @@ ZStream::ZStream()
 
 ZStream::~ZStream()
 {
-    if (m_isInitialized)
-        deflateEnd(&m_stream);
+    if (m_isInitialized) {
+        if (m_isCompression)
+            deflateEnd(&m_stream);
+        else
+            inflateEnd(&m_stream);
+    }
 }
 
 }

--- a/Source/WebCore/Modules/compression/ZStream.h
+++ b/Source/WebCore/Modules/compression/ZStream.h
@@ -44,6 +44,7 @@ public:
 private:
     z_stream m_stream;
     bool m_isInitialized { false };
+    bool m_isCompression { false };
 };
 
 }


### PR DESCRIPTION
#### a02650dc50821e673b0fff38ada84017ab822314
<pre>
ZStream::~ZStream() should call inflateEnd() for decompression mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=309760">https://bugs.webkit.org/show_bug.cgi?id=309760</a>

Reviewed by NOBODY (OOPS!).

deflateEnd() was used even if it&apos;s initialized by inflateInit2().

* Source/WebCore/Modules/compression/ZStream.cpp:
(WebCore::ZStream::initializeIfNecessary):
(WebCore::ZStream::~ZStream):
* Source/WebCore/Modules/compression/ZStream.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a02650dc50821e673b0fff38ada84017ab822314

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158812 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103535 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22958 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115788 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82252 "9 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153061 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96517 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16998 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14950 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6658 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126613 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161286 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4377 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14135 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123792 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22661 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123993 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22648 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134378 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78877 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19117 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11134 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22260 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86061 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21975 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22127 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22029 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->