### PR TITLE
Simplify visitAdditionalChildrenInGCThread() for TrustedTypePolicy

### DIFF
--- a/Source/WebCore/bindings/js/JSTrustedTypePolicyCustom.cpp
+++ b/Source/WebCore/bindings/js/JSTrustedTypePolicyCustom.cpp
@@ -33,21 +33,7 @@ namespace WebCore {
 template<typename Visitor>
 void JSTrustedTypePolicy::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    SUPPRESS_UNCOUNTED_LOCAL CreateHTMLCallback* createHTML = nullptr;
-    SUPPRESS_UNCOUNTED_LOCAL CreateScriptCallback* createScript = nullptr;
-    SUPPRESS_UNCOUNTED_LOCAL CreateScriptURLCallback* createScriptURL = nullptr;
-    {
-        Locker locker { wrapped().lock() };
-        createHTML = wrapped().options().createHTML.get();
-        createScript = wrapped().options().createScript.get();
-        createScriptURL = wrapped().options().createScriptURL.get();
-    }
-    if (createHTML)
-        SUPPRESS_UNCOUNTED_ARG createHTML->visitJSFunctionInGCThread(visitor);
-    if (createScript)
-        SUPPRESS_UNCOUNTED_ARG createScript->visitJSFunctionInGCThread(visitor);
-    if (createScriptURL)
-        SUPPRESS_UNCOUNTED_ARG createScriptURL->visitJSFunctionInGCThread(visitor);
+    wrapped().visitAdditionalChildrenInGCThread(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSTrustedTypePolicy);

--- a/Source/WebCore/dom/TrustedTypePolicy.cpp
+++ b/Source/WebCore/dom/TrustedTypePolicy.cpp
@@ -99,29 +99,14 @@ ExceptionOr<String> TrustedTypePolicy::getPolicyValue(TrustedType trustedTypeNam
 {
     CallbackResult<String> policyValue(CallbackResultType::UnableToExecute);
     if (trustedTypeName == TrustedType::TrustedHTML) {
-        RefPtr<CreateHTMLCallback> protectedCreateHTML;
-        {
-            Locker locker { lock() };
-            protectedCreateHTML = m_options.createHTML;
-        }
-        if (protectedCreateHTML && protectedCreateHTML->hasCallback())
-            policyValue = protectedCreateHTML->invokeRethrowingException(input, WTF::move(arguments));
+        if (m_options.createHTML && m_options.createHTML->hasCallback())
+            policyValue = m_options.createHTML->invokeRethrowingException(input, WTF::move(arguments));
     } else if (trustedTypeName == TrustedType::TrustedScript) {
-        RefPtr<CreateScriptCallback> protectedCreateScript;
-        {
-            Locker locker { lock() };
-            protectedCreateScript = m_options.createScript;
-        }
-        if (protectedCreateScript && protectedCreateScript->hasCallback())
-            policyValue = protectedCreateScript->invokeRethrowingException(input, WTF::move(arguments));
+        if (m_options.createScript && m_options.createScript->hasCallback())
+            policyValue = m_options.createScript->invokeRethrowingException(input, WTF::move(arguments));
     } else if (trustedTypeName == TrustedType::TrustedScriptURL) {
-        RefPtr<CreateScriptURLCallback> protectedCreateScriptURL;
-        {
-            Locker locker { lock() };
-            protectedCreateScriptURL = m_options.createScriptURL;
-        }
-        if (protectedCreateScriptURL && protectedCreateScriptURL->hasCallback())
-            policyValue = protectedCreateScriptURL->invokeRethrowingException(input, WTF::move(arguments));
+        if (m_options.createScriptURL && m_options.createScriptURL->hasCallback())
+            policyValue = m_options.createScriptURL->invokeRethrowingException(input, WTF::move(arguments));
     } else {
         ASSERT_NOT_REACHED();
         return Exception { ExceptionCode::TypeError };
@@ -149,5 +134,21 @@ WebCoreOpaqueRoot root(TrustedTypePolicy* policy)
 }
 
 TrustedTypePolicy::~TrustedTypePolicy() = default;
+
+template<typename Visitor>
+void TrustedTypePolicy::visitAdditionalChildrenInGCThread(Visitor& visitor)
+{
+    // No need to lock since m_options is const. m_options's RefPtrs cannot
+    // be modified by the main thread while the GC thread is reading them
+    // here.
+    SUPPRESS_UNCOUNTED_LOCAL if (auto* createHTML = m_options.createHTML.get())
+        SUPPRESS_UNCOUNTED_ARG createHTML->visitJSFunctionInGCThread(visitor);
+    SUPPRESS_UNCOUNTED_LOCAL if (auto* createScript = m_options.createScript.get())
+        SUPPRESS_UNCOUNTED_ARG createScript->visitJSFunctionInGCThread(visitor);
+    SUPPRESS_UNCOUNTED_LOCAL if (auto* createScriptURL = m_options.createScriptURL.get())
+        SUPPRESS_UNCOUNTED_ARG createScriptURL->visitJSFunctionInGCThread(visitor);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(TrustedTypePolicy);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/TrustedTypePolicy.h
+++ b/Source/WebCore/dom/TrustedTypePolicy.h
@@ -52,26 +52,20 @@ class TrustedTypePolicy : public ScriptWrappable, public RefCounted<TrustedTypeP
 public:
     static Ref<TrustedTypePolicy> create(const String&, const TrustedTypePolicyOptions&);
     ~TrustedTypePolicy();
+
     ExceptionOr<Ref<TrustedHTML>> createHTML(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&&);
     ExceptionOr<Ref<TrustedScript>> createScript(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&&);
     ExceptionOr<Ref<TrustedScriptURL>> createScriptURL(const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&&);
     ExceptionOr<String> getPolicyValue(TrustedType trustedTypeName, const String& input, FixedVector<JSC::Strong<JSC::Unknown>>&&, IfMissing = IfMissing::Throw);
-    const String name() const { return m_name; }
+    const String& name() const { return m_name; }
 
-    const TrustedTypePolicyOptions& options() const
-    {
-        IGNORE_CLANG_WARNINGS_BEGIN("thread-safety-reference-return")
-        return m_options;
-        IGNORE_CLANG_WARNINGS_END
-    }
-    Lock& lock() LIFETIME_BOUND WTF_RETURNS_LOCK(m_lock) { return m_lock; }
+    template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);
 
 private:
     TrustedTypePolicy(const String&, const TrustedTypePolicyOptions&);
 
-    String m_name;
-    TrustedTypePolicyOptions m_options WTF_GUARDED_BY_LOCK(m_lock);
-    mutable Lock m_lock;
+    const String m_name;
+    const TrustedTypePolicyOptions m_options;
 };
 
 WebCoreOpaqueRoot NODELETE root(TrustedTypePolicy*);

--- a/Source/WebCore/dom/TrustedTypePolicyOptions.h
+++ b/Source/WebCore/dom/TrustedTypePolicyOptions.h
@@ -32,9 +32,9 @@
 namespace WebCore {
 
 struct TrustedTypePolicyOptions {
-    RefPtr<CreateHTMLCallback> createHTML;
-    RefPtr<CreateScriptCallback> createScript;
-    RefPtr<CreateScriptURLCallback> createScriptURL;
+    const RefPtr<CreateHTMLCallback> createHTML;
+    const RefPtr<CreateScriptCallback> createScript;
+    const RefPtr<CreateScriptURLCallback> createScriptURL;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 6f7684791a5e8e298781278066ce1361b686375e
<pre>
Simplify visitAdditionalChildrenInGCThread() for TrustedTypePolicy
<a href="https://bugs.webkit.org/show_bug.cgi?id=309948">https://bugs.webkit.org/show_bug.cgi?id=309948</a>

Reviewed by Geoffrey Garen and Ryosuke Niwa.

Remove Lock used when accessing m_options and mark m_options as const
instead. Since m_options is const, its smart pointers cannot be modified
on the main thread while the GC thread is accessing them.

Note that even though there was a lock, it was not doing much since the
GC thread was holding raw pointers to those main thread objects outside
the lock&apos;s scope.

* Source/WebCore/bindings/js/JSTrustedTypePolicyCustom.cpp:
(WebCore::JSTrustedTypePolicy::visitAdditionalChildrenInGCThread):
* Source/WebCore/dom/TrustedTypePolicy.cpp:
(WebCore::TrustedTypePolicy::getPolicyValue):
(WebCore::TrustedTypePolicy::visitAdditionalChildrenInGCThread):
* Source/WebCore/dom/TrustedTypePolicy.h:
(WebCore::TrustedTypePolicy::name const):
(WebCore::TrustedTypePolicy::options const): Deleted.
(WebCore::TrustedTypePolicy::WTF_RETURNS_LOCK): Deleted.
* Source/WebCore/dom/TrustedTypePolicyOptions.h:

Canonical link: <a href="https://commits.webkit.org/309281@main">https://commits.webkit.org/309281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/076fd15a3a164fd2c9c29953fa5b533bcae52911

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16488 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158882 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a85d1b97-f3fb-4e12-a13b-3613cf0da3eb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23036 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115850 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9256faea-1162-45b7-a897-6c32763d550e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96582 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17063 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15013 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6727 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126678 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12648 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161355 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4445 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/14200 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/123853 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22729 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124057 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33681 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22716 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134443 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79012 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19182 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11200 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22329 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86129 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22043 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22195 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22097 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->