### PR TITLE
[SaferCPP] Use Ref/RefPtr for inlineStyle in style/MatchResultCache.cpp

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -106,7 +106,6 @@ rendering/RenderTreeAsText.cpp
 rendering/cocoa/RenderThemeCocoa.mm
 [ iOS ] rendering/ios/RenderThemeIOS.mm
 rendering/svg/legacy/LegacyRenderSVGTransformableContainer.cpp
-style/MatchResultCache.cpp
 style/PageRuleCollector.cpp
 style/RuleSetBuilder.cpp
 style/StyleBuilder.cpp

--- a/Source/WebCore/style/MatchResultCache.cpp
+++ b/Source/WebCore/style/MatchResultCache.cpp
@@ -108,13 +108,13 @@ bool MatchResultCache::isUsableAfterInlineStyleChange(const MatchResultCache::En
 PropertyCascade::IncludedProperties MatchResultCache::computeAndUpdateChangedProperties(MatchResultCache::Entry& entry)
 {
     auto& originalProperties = entry.originalInlineProperties;
-    auto& inlineStyle = entry.inlineStyle.get();
+    Ref inlineStyle = entry.inlineStyle;
 
     PropertyCascade::IncludedProperties result;
 
     auto size = originalProperties.size();
     for (size_t index = 0; index < size; ++index) {
-        auto currentProperty = inlineStyle.propertyAt(index);
+        auto currentProperty = inlineStyle->propertyAt(index);
         auto propertyID = currentProperty.id();
 
         ASSERT(originalProperties[index].propertyID == propertyID);
@@ -184,7 +184,7 @@ void MatchResultCache::set(const Element& element, const UnadjustedStyle& unadju
     // For now we cache match results if there is mutable inline style. This way we can avoid
     // selector matching when it gets mutated again.
     auto* styledElement = dynamicDowncast<StyledElement>(element);
-    auto* inlineStyle = styledElement ? dynamicDowncast<MutableStyleProperties>(styledElement->inlineStyle()) : nullptr;
+    RefPtr inlineStyle = styledElement ? dynamicDowncast<MutableStyleProperties>(styledElement->inlineStyle()) : nullptr;
 
     if (inlineStyle)
         m_entries.set(element, makeUniqueRef<Entry>(copy(unadjustedStyle), *inlineStyle));


### PR DESCRIPTION
#### 3ac7b98a7de0749b78511f84ee938dc7256bfa0a
<pre>
[SaferCPP] Use Ref/RefPtr for inlineStyle in style/MatchResultCache.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=309950">https://bugs.webkit.org/show_bug.cgi?id=309950</a>

Reviewed by NOBODY (OOPS!).

Replace a raw reference and a raw pointer to MutableStyleProperties with
Ref and RefPtr respectively, resolving the uncounted-local-vars checker
warnings. Remove style/MatchResultCache.cpp from
UncountedLocalVarsCheckerExpectations as it is now clean.

* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/style/MatchResultCache.cpp:
(WebCore::Style::MatchResultCache::computeAndUpdateChangedProperties):
(WebCore::Style::MatchResultCache::set):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ac7b98a7de0749b78511f84ee938dc7256bfa0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17114 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159507 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104219 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152658 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23749 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116380 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82638 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18490 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135268 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97108 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17587 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15537 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7355 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13192 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161981 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5102 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14749 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124381 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23347 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19584 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124579 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34822 "Failed to checkout and rebase branch from PR 60623") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23336 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134987 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79722 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19645 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11749 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22947 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86747 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22659 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22811 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22713 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->