### PR TITLE
swiftc-wrapper.sh: strip arguments that swiftc doesn't support

### DIFF
--- a/Tools/Scripts/swift/swiftc-wrapper.sh
+++ b/Tools/Scripts/swift/swiftc-wrapper.sh
@@ -1,20 +1,29 @@
 #!/bin/bash
 # cmake accumulates CFLAGS from pkg-config, and then passes them to swiftc.
-# One such argument is -pthread which swiftc cannot accommodate. Filter it out.
+# This script filters out the arguments that swiftc cannot accommodate.
 
 set -e
 
-REAL_SWIFTC=
+REAL_SWIFTC=swiftc
 args=()
 
 for arg in "$@"; do
-    if [ "$arg" != "-pthread" ]; then
-        if [[ "$arg" == --original-swift-compiler=* ]]; then
+    case "$arg" in
+        "-mfpmath=sse") ;;
+        "-msse") ;;
+        "-msse2") ;;
+        "-pthread") ;;
+        "-Wl,"*)
+            ldarg="${arg#-Wl,}"
+            args+=("-Xlinker" "${ldarg//,/=}")
+            ;;
+        "--original-swift-compiler="*)
             REAL_SWIFTC="${arg#--original-swift-compiler=}"
-        else
+            ;;
+        *)
             args+=("$arg")
-        fi
-    fi
+            ;;
+    esac
 done
 
 exec "$REAL_SWIFTC" "${args[@]}"


### PR DESCRIPTION
#### 76fd1a8278515ad6d02964a04faa96b33e884ddd
<pre>
swiftc-wrapper.sh: strip arguments that swiftc doesn&apos;t support
<a href="https://bugs.webkit.org/show_bug.cgi?id=305785">https://bugs.webkit.org/show_bug.cgi?id=305785</a>

Reviewed by Adrian Perez de Castro.

Some of the compilation flags used in the Linux build of WebKit are
not supported by swiftc, causing the compilation to fail. Strip the
ones that are unsupported, and convert the linker flags to the format
expected by swiftc.

REAL_SWIFTC is also set to swiftc by default, and can be overridden
with the --original-swift-compiler option.

* Tools/Scripts/swift/swiftc-wrapper.sh:

Canonical link: <a href="https://commits.webkit.org/309313@main">https://commits.webkit.org/309313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3275cf52721d5a9a98b0c5455b748285b1d86062

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158838 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103560 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151999 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23314 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115811 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82267 "4 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134687 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96541 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17026 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14975 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6683 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126641 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161311 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14163 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123815 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22686 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19022 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124016 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33706 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22673 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134406 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78912 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19144 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11163 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22286 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22000 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22152 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22054 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->