### PR TITLE
[JSC] RegExpMatchFastGlobal should have NodeMustGenerate to prevent FTL DCE

### DIFF
--- a/JSTests/stress/regexp-match-fast-global-dce-lastmatch.js
+++ b/JSTests/stress/regexp-match-fast-global-dce-lastmatch.js
@@ -1,0 +1,52 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: " + JSON.stringify(actual) + " expected: " + JSON.stringify(expected));
+}
+
+function test(s) {
+    s.match(/l/g);
+}
+noInline(test);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    /seed/.test("seeded");
+    test("hello");
+    shouldBe(RegExp.lastMatch, "l");
+    shouldBe(RegExp.input, "hello");
+}
+
+function testMulti(s) {
+    s.match(/l+/g);
+}
+noInline(testMulti);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    /seed/.test("seeded");
+    testMulti("hello world");
+    shouldBe(RegExp.lastMatch, "l");
+    shouldBe(RegExp.leftContext, "hello wor");
+    shouldBe(RegExp.rightContext, "d");
+}
+
+function testCapture(s) {
+    s.match(/(l)(o)/g);
+}
+noInline(testCapture);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    /(s)(e)/.test("seed");
+    testCapture("hello foo");
+    shouldBe(RegExp.$1, "l");
+    shouldBe(RegExp.$2, "o");
+}
+
+function testNoMatch(s) {
+    s.match(/xyz/g);
+}
+noInline(testNoMatch);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    /seed/.test("seeded");
+    testNoMatch("hello");
+    shouldBe(RegExp.lastMatch, "seed");
+}

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -353,7 +353,7 @@ namespace JSC { namespace DFG {
     macro(RegExpTest, NodeResultJS | NodeMustGenerate) \
     macro(RegExpTestInline, NodeResultJS | NodeMustGenerate) \
     macro(RegExpMatchFast, NodeResultJS | NodeMustGenerate) \
-    macro(RegExpMatchFastGlobal, NodeResultJS) \
+    macro(RegExpMatchFastGlobal, NodeResultJS | NodeMustGenerate) \
     macro(RegExpSearch, NodeResultInt32 | NodeMustGenerate) \
     macro(GetRegExpFlag, NodeResultBoolean) \
     macro(StringReplace, NodeResultJS | NodeMustGenerate) \


### PR DESCRIPTION
#### e8f0cb20dfb0f7180bf9182cb665b1c9daa3b1d0
<pre>
[JSC] RegExpMatchFastGlobal should have NodeMustGenerate to prevent FTL DCE
<a href="https://bugs.webkit.org/show_bug.cgi?id=309953">https://bugs.webkit.org/show_bug.cgi?id=309953</a>

Reviewed by Yusuke Suzuki.

DFGStrengthReductionPhase converts RegExpMatchFast to RegExpMatchFastGlobal
when the regexp is a constant with the global flag. This conversion calls
setOpAndDefaultFlags(RegExpMatchFastGlobal) which resets flags to the
default, and RegExpMatchFastGlobal was missing NodeMustGenerate.

DFGClobberize.h correctly declares write(RegExpState) for this node, so DFG
DCE preserves it. However FTL DCE only checks NodeMustGenerate, so when the
match result is unused it eliminates the node and RegExp.lastMatch/$1/etc.
are left stale from a prior match:

    function test(s) { s.match(/l/g); }  // result unused
    /seed/.test(&quot;seeded&quot;);
    test(&quot;hello&quot;);
    RegExp.lastMatch;  // FTL: &quot;seed&quot; (stale), expected: &quot;l&quot;

RegExpMatchFast (the source op) already has NodeMustGenerate. Adding it to
RegExpMatchFastGlobal makes FTL behavior match DFG and lower tiers.

Test: JSTests/stress/regexp-match-fast-global-dce-lastmatch.js

* JSTests/stress/regexp-match-fast-global-dce-lastmatch.js: Added.
(shouldBe):
(test):
(testMulti):
(testCapture):
(testNoMatch):
* Source/JavaScriptCore/dfg/DFGNodeType.h:

Canonical link: <a href="https://commits.webkit.org/309271@main">https://commits.webkit.org/309271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e40ec485e7ae3cd6b4f42ba72ec8daf5a98e330

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158839 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23315 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22987 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115813 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134688 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96543 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17027 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14976 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6684 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142110 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126642 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161312 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10925 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4403 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123817 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19023 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124018 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33672 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22674 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134407 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78913 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19146 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11164 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181558 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22287 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86087 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46469 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22001 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22153 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22055 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->