### PR TITLE
Use `const Ref` for IntersectionObserver::m_callback

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -33,7 +33,6 @@ bindings/js/JSHTMLElementCustom.cpp
 bindings/js/JSHistoryCustom.cpp
 bindings/js/JSIDBCursorCustom.cpp
 bindings/js/JSIDBRequestCustom.cpp
-bindings/js/JSIntersectionObserverCustom.cpp
 bindings/js/JSLazyEventListener.cpp
 bindings/js/JSLocationCustom.cpp
 bindings/js/JSMessagePortCustom.cpp

--- a/Source/WebCore/bindings/js/JSIntersectionObserverCustom.cpp
+++ b/Source/WebCore/bindings/js/JSIntersectionObserverCustom.cpp
@@ -36,8 +36,7 @@ namespace WebCore {
 template<typename Visitor>
 void JSIntersectionObserver::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    if (auto* callback = wrapped().callbackConcurrently())
-        callback->visitJSFunctionInGCThread(visitor);
+    wrapped().callbackConcurrently().visitJSFunctionInGCThread(visitor);
     addWebCoreOpaqueRoot(visitor, wrapped().root());
 }
 

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -248,7 +248,7 @@ bool IntersectionObserver::isObserving(const Element& element) const
 
 void IntersectionObserver::observe(Element& target)
 {
-    if (!trackingDocument() || !m_callback || isObserving(target))
+    if (!trackingDocument() || isObserving(target))
         return;
 
     target.ensureIntersectionObserverData().registrations.append({ *this, std::nullopt });
@@ -695,9 +695,6 @@ auto IntersectionObserver::updateObservations(const Frame& hostFrame) -> NeedNot
 
 std::optional<ReducedResolutionSeconds> IntersectionObserver::nowTimestamp() const
 {
-    if (!m_callback)
-        return std::nullopt;
-
     RefPtr<LocalDOMWindow> window;
     {
         auto* context = m_callback->scriptExecutionContext();

--- a/Source/WebCore/page/IntersectionObserver.h
+++ b/Source/WebCore/page/IntersectionObserver.h
@@ -122,7 +122,7 @@ public:
     void appendQueuedEntry(Ref<IntersectionObserverEntry>&&);
     void notify();
 
-    IntersectionObserverCallback* callbackConcurrently() { return m_callback.get(); }
+    IntersectionObserverCallback& callbackConcurrently() { return m_callback; }
     bool isReachableFromOpaqueRoots(JSC::AbstractSlotVisitor&) const;
 
 private:
@@ -153,7 +153,7 @@ private:
     IntersectionObserverMarginBox m_rootMargin;
     IntersectionObserverMarginBox m_scrollMargin;
     Vector<double> m_thresholds;
-    RefPtr<IntersectionObserverCallback> m_callback;
+    const Ref<IntersectionObserverCallback> m_callback;
     Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> m_observationTargets;
     Vector<GCReachableRef<Element>> m_pendingTargets;
     Vector<Ref<IntersectionObserverEntry>> m_queuedEntries;


### PR DESCRIPTION
#### 4ccdbebd68c709165088f1300fc13a58432da4ff
<pre>
Use `const Ref` for IntersectionObserver::m_callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=309955">https://bugs.webkit.org/show_bug.cgi?id=309955</a>

Reviewed by Geoffrey Garen and Anne van Kesteren.

Mark the data member as const as the code in JSIntersectionObserver::visitAdditionalChildrenInGCThread()
would not be safe if this member was ever modified. Also use Ref instead
of RefPtr since it can never be null.

* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/bindings/js/JSIntersectionObserverCustom.cpp:
(WebCore::JSIntersectionObserver::visitAdditionalChildrenInGCThread):
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::observe):
(WebCore::IntersectionObserver::nowTimestamp const):
* Source/WebCore/page/IntersectionObserver.h:
(WebCore::IntersectionObserver::callbackConcurrently):

Canonical link: <a href="https://commits.webkit.org/309278@main">https://commits.webkit.org/309278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38ca73c50760c84fa3e3b4ea5d84d1ab4689c2cb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16456 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158849 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103571 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1bc6235a-f4de-4df9-8896-62c7a21a9aa1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22999 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115822 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82280 "2 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17936 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96553 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/207b69eb-1ffd-47d5-b513-112d60b552b1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17036 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14985 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6694 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12621 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161322 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4413 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14173 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123826 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124027 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33683 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22684 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134416 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78935 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19153 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11173 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22297 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86097 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22011 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22163 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22065 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->