### PR TITLE
[JSC] Fix SIGSEGV in `Temporal.PlainDate.from` with out-of-range month and `overflow: "reject"`

### DIFF
--- a/JSTests/stress/temporal-plaindate-from-reject-month-out-of-range.js
+++ b/JSTests/stress/temporal-plaindate-from-reject-month-out-of-range.js
@@ -1,0 +1,51 @@
+//@ requireOptions("--useTemporal=1")
+
+function shouldThrow(func, errorType) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!(error instanceof errorType))
+        throw new Error(`Expected ${errorType.name} but got ${error}`);
+}
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected} but got ${actual}`);
+}
+
+const rejectOpt = { overflow: "reject" };
+const hugeMonths = [13, 255, 256, 1e300, Number.MAX_SAFE_INTEGER, Number.MAX_VALUE, 2 ** 31, 2 ** 32, 2 ** 53];
+
+for (const m of hugeMonths) {
+    shouldThrow(() => Temporal.PlainDate.from({ year: 2000, month: m, day: 1 }, rejectOpt), RangeError);
+    shouldThrow(() => Temporal.PlainDateTime.from({ year: 2000, month: m, day: 1 }, rejectOpt), RangeError);
+    shouldThrow(() => Temporal.PlainYearMonth.from({ year: 2000, month: m }, rejectOpt), RangeError);
+    shouldThrow(() => Temporal.PlainMonthDay.from({ month: m, day: 1 }, rejectOpt), RangeError);
+}
+
+{
+    const d = Temporal.PlainDate.from({ year: 2000, month: 1e300, day: 1 }, { overflow: "constrain" });
+    shouldBe(d.month, 12);
+    shouldBe(d.day, 1);
+}
+{
+    const d = Temporal.PlainDate.from({ year: 2000, month: 12, day: 1e300 }, { overflow: "constrain" });
+    shouldBe(d.month, 12);
+    shouldBe(d.day, 31);
+}
+{
+    const d = Temporal.PlainDateTime.from({ year: 2000, month: 1e300, day: 1e300 }, { overflow: "constrain" });
+    shouldBe(d.month, 12);
+    shouldBe(d.day, 31);
+}
+{
+    const d = Temporal.PlainYearMonth.from({ year: 2000, month: 1e300 }, { overflow: "constrain" });
+    shouldBe(d.month, 12);
+}
+{
+    const d = Temporal.PlainMonthDay.from({ month: 1e300, day: 1 }, { overflow: "constrain" });
+    shouldBe(d.monthCode, "M12");
+}

--- a/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalCalendar.cpp
@@ -295,16 +295,16 @@ ISO8601::PlainDate TemporalCalendar::isoDateFromFields(JSGlobalObject* globalObj
     }
 
     if (overflow == TemporalOverflow::Constrain)
-        month = std::min<unsigned>(month, 12);
-
-    uint8_t daysInMonth = ISO8601::daysInMonth(year, month);
-    if (overflow == TemporalOverflow::Constrain)
-        day = std::min<unsigned>(day, daysInMonth);
+        month = std::min<double>(month, 12);
 
     if (!(month >= 1 && month <= 12)) [[unlikely]] {
         throwRangeError(globalObject, scope, "month is out of range"_s);
         return { };
     }
+
+    uint8_t daysInMonth = ISO8601::daysInMonth(year, month);
+    if (overflow == TemporalOverflow::Constrain)
+        day = std::min<double>(day, daysInMonth);
 
     if (!(day >= 1 && day <= daysInMonth)) [[unlikely]] {
         throwRangeError(globalObject, scope, "day is out of range"_s);


### PR DESCRIPTION
#### ce0c3918570d3601eb584ebe6d07ceeb75419bbf
<pre>
[JSC] Fix SIGSEGV in `Temporal.PlainDate.from` with out-of-range month and `overflow: &quot;reject&quot;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=309957">https://bugs.webkit.org/show_bug.cgi?id=309957</a>

Reviewed by Yusuke Suzuki.

Temporal.PlainDate.from({year: 2000, month: 1e300, day: 1}, {overflow: &quot;reject&quot;})
crashes with SIGSEGV. The same applies to PlainDateTime, PlainYearMonth, and
PlainMonthDay since they share isoDateFromFields().

The cause is that ISO8601::daysInMonth(year, month) is called before the month
range check. With &quot;reject&quot;, the constrain clamp is skipped, so a double like
1e300 is implicitly converted to the uint8_t parameter (undefined behavior per
[conv.fpint]), and daysInMonths[...][month - 1] reads out of bounds.

Fix by moving the month range check before the daysInMonth() call. Also change
std::min&lt;unsigned&gt; to std::min&lt;double&gt; for the constrain clamps: the old code
relied on double-to-unsigned conversion of out-of-range values, which is also
undefined behavior and only happened to work on ARM64 due to saturation.

Test: JSTests/stress/temporal-plaindate-from-reject-month-out-of-range.js

* JSTests/stress/temporal-plaindate-from-reject-month-out-of-range.js: Added.
(shouldThrow):
(shouldBe):
(shouldThrow.Temporal.PlainMonthDay.from):
* Source/JavaScriptCore/runtime/TemporalCalendar.cpp:
(JSC::TemporalCalendar::isoDateFromFields):

Canonical link: <a href="https://commits.webkit.org/309519@main">https://commits.webkit.org/309519@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/856d6daea9eb9c61a6b8f0135f926c76d28da7d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158848 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103570 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/22998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115821 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82275 "4 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153096 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96552 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17035 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14984 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6693 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142119 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12620 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161321 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10934 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4412 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123825 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124026 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33839 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134415 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78934 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19154 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11172 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181567 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22296 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86096 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46471 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22010 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22162 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->