### PR TITLE
[JSC] for-using statement should dispose resources when condition is false on first check

### DIFF
--- a/JSTests/stress/for-using-initializer-dispose-on-false-condition.js
+++ b/JSTests/stress/for-using-initializer-dispose-on-false-condition.js
@@ -1,0 +1,88 @@
+//@ requireOptions("--useExplicitResourceManagement=true")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+{
+    let disposed = false;
+    for (using x = { [Symbol.dispose]() { disposed = true; } }; false; ) {
+        throw new Error("unreachable");
+    }
+    shouldBe(disposed, true);
+}
+
+{
+    let order = [];
+    for (using x = { [Symbol.dispose]() { order.push("a"); } }, y = { [Symbol.dispose]() { order.push("b"); } }; false; ) {
+        throw new Error("unreachable");
+    }
+    shouldBe(order.join(","), "b,a");
+}
+
+{
+    let disposed = false;
+    let i = 5;
+    for (using x = { [Symbol.dispose]() { disposed = true; } }; i < 3; i++) {
+        throw new Error("unreachable");
+    }
+    shouldBe(disposed, true);
+}
+
+{
+    let disposed = false;
+    let a = false, b = false;
+    for (using x = { [Symbol.dispose]() { disposed = true; } }; a || b; ) {
+        throw new Error("unreachable");
+    }
+    shouldBe(disposed, true);
+}
+
+{
+    let disposed = false;
+    let a = true, b = false;
+    for (using x = { [Symbol.dispose]() { disposed = true; } }; a && b; ) {
+        throw new Error("unreachable");
+    }
+    shouldBe(disposed, true);
+}
+
+{
+    let order = [];
+    let i = 0;
+    for (using x = { [Symbol.dispose]() { order.push("dispose"); } }; i < 3; i++) {
+        order.push("body" + i);
+    }
+    shouldBe(order.join(","), "body0,body1,body2,dispose");
+}
+
+{
+    let disposed = false;
+    label: for (using x = { [Symbol.dispose]() { disposed = true; } }; false; ) {
+        throw new Error("unreachable");
+    }
+    shouldBe(disposed, true);
+}
+
+{
+    let disposed = false;
+    function f() {
+        for (using x = { [Symbol.dispose]() { disposed = true; } }; false; ) {
+            throw new Error("unreachable");
+        }
+        return 42;
+    }
+    shouldBe(f(), 42);
+    shouldBe(disposed, true);
+}
+
+function loopTest() {
+    let disposed = 0;
+    for (using x = { [Symbol.dispose]() { disposed++; } }; false; ) {
+    }
+    return disposed;
+}
+noInline(loopTest);
+for (let i = 0; i < testLoopCount; i++)
+    shouldBe(loopTest(), 1);

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -4644,6 +4644,9 @@ void ForNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
     RegisterID* forLoopSymbolTable = nullptr;
     generator.pushLexicalScope(this, BytecodeGenerator::ScopeType::LetConstScope, BytecodeGenerator::TDZCheckOptimization::Optimize, BytecodeGenerator::NestedScopeType::IsNested, &forLoopSymbolTable);
 
+    Ref<Label> loopEnd = generator.newLabel();
+    Label& conditionFalseTarget = usingDeclarationCount() ? loopEnd.get() : scope->breakTarget();
+
     auto emitLoopBody = [&](BytecodeGenerator& generator) {
         if (m_expr1) {
             generator.emitNodeInIgnoreResultPosition(m_expr1);
@@ -4653,7 +4656,7 @@ void ForNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
 
         Ref<Label> topOfLoop = generator.newLabel();
         if (m_expr2)
-            generator.emitNodeInConditionContext(m_expr2, topOfLoop.get(), scope->breakTarget(), FallThroughMeansTrue);
+            generator.emitNodeInConditionContext(m_expr2, topOfLoop.get(), conditionFalseTarget, FallThroughMeansTrue);
 
         generator.emitLabel(topOfLoop.get());
         generator.emitLoopHint();
@@ -4667,9 +4670,11 @@ void ForNode::emitBytecode(BytecodeGenerator& generator, RegisterID* dst)
             generator.emitNodeInIgnoreResultPosition(m_expr3);
 
         if (m_expr2)
-            generator.emitNodeInConditionContext(m_expr2, topOfLoop.get(), scope->breakTarget(), FallThroughMeansFalse);
+            generator.emitNodeInConditionContext(m_expr2, topOfLoop.get(), conditionFalseTarget, FallThroughMeansFalse);
         else
             generator.emitJump(topOfLoop.get());
+
+        generator.emitLabel(loopEnd.get());
     };
 
     generator.emitBodyWithUsingIfNeeded(usingDeclarationCount(),


### PR DESCRIPTION
#### 138963318c8793eb4db5973edc1eebf1eb78d170
<pre>
[JSC] for-using statement should dispose resources when condition is false on first check
<a href="https://bugs.webkit.org/show_bug.cgi?id=309960">https://bugs.webkit.org/show_bug.cgi?id=309960</a>

Reviewed by Yusuke Suzuki.

When a for statement has a using declaration in its initializer, the loop
body is wrapped in a synthesized try-finally by emitBodyWithUsingIfNeeded
so that resources are disposed on all exit paths. However, the condition
checks generated a direct conditional branch to the loop&apos;s breakTarget,
which is emitted after the finally block. This caused disposal to be
skipped when the condition was false on the first iteration:

    for (using x = { [Symbol.dispose]() { disposed = true } }; false; ) {}
    disposed;  // JSC: false, expected: true

test262 did not catch this because initializer-disposed-at-end-of-forstatement.js
starts with i=0 and tests i&lt;1, always executing at least one iteration before
the bottom check (FallThroughMeansFalse) correctly falls through to the finally.

This patch adds a loopEnd label at the end of the loop body (inside the try)
and routes both condition checks to it when using declarations are present.
When there are no using declarations, the condition false target remains
breakTarget as before, and the unused loopEnd label produces no bytecode.

Test: JSTests/stress/for-using-initializer-dispose-on-false-condition.js

* JSTests/stress/for-using-initializer-dispose-on-false-condition.js: Added.
(shouldBe):
(throw.new.Error):
(shouldBe.f):
(loopTest):
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::ForNode::emitBytecode):

Canonical link: <a href="https://commits.webkit.org/309304@main">https://commits.webkit.org/309304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c36662c4554ab12610260b6a479a850b5b621e3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22899 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158853 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103575 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23329 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23005 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115825 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82278 "3 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17940 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134701 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96556 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17040 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14989 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6698 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142124 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126655 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12625 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161326 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10939 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4417 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14177 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123829 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22701 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124030 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33698 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22688 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134420 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78944 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19158 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11177 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181572 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22301 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86101 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46472 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22015 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22167 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->