### PR TITLE
[JSC] Set methods should throw TypeError when iterator next() returns non-object

### DIFF
--- a/JSTests/stress/set-methods-iterator-next-non-object-result.js
+++ b/JSTests/stress/set-methods-iterator-next-non-object-result.js
@@ -1,0 +1,65 @@
+function shouldThrowTypeError(func, callCountGetter, description) {
+    let threw = false;
+    try {
+        func();
+    } catch (e) {
+        threw = true;
+        if (!(e instanceof TypeError))
+            throw new Error(description + ": expected TypeError but got " + e);
+    }
+    if (!threw)
+        throw new Error(description + ": expected TypeError but no exception was thrown");
+    if (callCountGetter() !== 1)
+        throw new Error(description + ": next() should be called exactly once but was called " + callCountGetter() + " times");
+}
+
+function makeSetLike(nextReturnValue) {
+    let callCount = 0;
+    let setLike = {
+        size: 2,
+        has() { throw new Error("Unexpected call to |has|"); },
+        keys() {
+            return {
+                next() {
+                    if (++callCount > 100)
+                        throw new Error("infinite loop detected");
+                    return nextReturnValue;
+                },
+                return() { throw new Error("Unexpected call to |return|"); },
+            };
+        },
+    };
+    return [setLike, () => callCount];
+}
+
+let primitives = [42, "string", true, null, undefined, Symbol(), 3.14, 0n];
+
+for (let prim of primitives) {
+    let desc = "(next() => " + (typeof prim === "symbol" ? "Symbol()" : String(prim)) + ")";
+
+    {
+        let [setLike, count] = makeSetLike(prim);
+        shouldThrowTypeError(() => new Set([1, 2, 3]).difference(setLike), count, "difference " + desc);
+    }
+    {
+        let [setLike, count] = makeSetLike(prim);
+        shouldThrowTypeError(() => new Set([1, 2, 3]).symmetricDifference(setLike), count, "symmetricDifference " + desc);
+    }
+    {
+        let [setLike, count] = makeSetLike(prim);
+        shouldThrowTypeError(() => new Set([1, 2, 3]).isSupersetOf(setLike), count, "isSupersetOf " + desc);
+    }
+    {
+        let [setLike, count] = makeSetLike(prim);
+        shouldThrowTypeError(() => new Set([1, 2, 3]).isDisjointFrom(setLike), count, "isDisjointFrom " + desc);
+    }
+}
+
+{
+    let [setLike, count] = makeSetLike(42);
+    shouldThrowTypeError(() => new Set([1, 2, 3]).union(setLike), count, "union (sanity check)");
+}
+{
+    let [setLike, count] = makeSetLike(42);
+    shouldThrowTypeError(() => new Set([1, 2, 3]).intersection(setLike), count, "intersection (sanity check)");
+}

--- a/Source/JavaScriptCore/runtime/SetPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SetPrototype.cpp
@@ -629,6 +629,9 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncDifference, (JSGlobalObject* globalObject, 
                 RETURN_IF_EXCEPTION(scope, { });
             }
 
+            if (!nextResult.isObject()) [[unlikely]]
+                return throwVMTypeError(globalObject, scope, "Iterator result interface is not an object."_s);
+
             JSValue doneValue = nextResult.get(globalObject, vm.propertyNames->done);
             RETURN_IF_EXCEPTION(scope, { });
 
@@ -760,6 +763,9 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncSymmetricDifference, (JSGlobalObject* globa
             nextResult = call(globalObject, nextMethod, nextCallData, keysResult, nextArgs);
             RETURN_IF_EXCEPTION(scope, { });
         }
+
+        if (!nextResult.isObject()) [[unlikely]]
+            return throwVMTypeError(globalObject, scope, "Iterator result interface is not an object."_s);
 
         JSValue doneValue = nextResult.get(globalObject, vm.propertyNames->done);
         RETURN_IF_EXCEPTION(scope, { });
@@ -975,6 +981,9 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsSupersetOf, (JSGlobalObject* globalObject
             RETURN_IF_EXCEPTION(scope, { });
         }
 
+        if (!nextResult.isObject()) [[unlikely]]
+            return throwVMTypeError(globalObject, scope, "Iterator result interface is not an object."_s);
+
         JSValue doneValue = nextResult.get(globalObject, vm.propertyNames->done);
         RETURN_IF_EXCEPTION(scope, { });
 
@@ -1146,6 +1155,9 @@ JSC_DEFINE_HOST_FUNCTION(setProtoFuncIsDisjointFrom, (JSGlobalObject* globalObje
                 nextResult = call(globalObject, nextMethod, nextCallData, keysResult, nextArgs);
                 RETURN_IF_EXCEPTION(scope, { });
             }
+
+            if (!nextResult.isObject()) [[unlikely]]
+                return throwVMTypeError(globalObject, scope, "Iterator result interface is not an object."_s);
 
             JSValue doneValue = nextResult.get(globalObject, vm.propertyNames->done);
             RETURN_IF_EXCEPTION(scope, { });


### PR DESCRIPTION
#### 4d96716c8dc8eb15bea579d6097eba53ec4d3ed4
<pre>
[JSC] Set methods should throw TypeError when iterator next() returns non-object
<a href="https://bugs.webkit.org/show_bug.cgi?id=309961">https://bugs.webkit.org/show_bug.cgi?id=309961</a>

Reviewed by Yusuke Suzuki.

Set.prototype.difference, symmetricDifference, isSupersetOf, and
isDisjointFrom have hand-written iterator loops that call
nextResult.get(vm.propertyNames-&gt;done) without checking whether nextResult
is an Object. When next() returns a primitive (e.g. 42), (42).done yields
undefined, which coerces to false, causing an infinite loop.

IteratorNext step 5 [1] requires throwing a TypeError when the result is
not an Object. Set.prototype.union and Set.prototype.intersection are
unaffected because they go through forEachInIteratorProtocol/iteratorStep,
which already perform this check in IteratorOperations.cpp.

This patch adds the missing isObject() check before reading .done in all
four methods, using the same error message as IteratorOperations.cpp for
consistency. The check is placed before .get(done), so that prototype
getters on primitives are not observably called. IteratorClose is not
invoked, since an abrupt completion from IteratorNext itself does not
trigger iterator close.

[1]: <a href="https://tc39.es/ecma262/#sec-iteratornext">https://tc39.es/ecma262/#sec-iteratornext</a>

Test: JSTests/stress/set-methods-iterator-next-non-object-result.js

* JSTests/stress/set-methods-iterator-next-non-object-result.js: Added.
(shouldThrowTypeError):
(makeSetLike):
(let.prim.of.primitives.3.difference):
(let.prim.of.primitives.3.isSupersetOf):
(3.union):
* Source/JavaScriptCore/runtime/SetPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/309286@main">https://commits.webkit.org/309286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0a2ded9569417bb78734dbcb5dedac74351568f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150143 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22901 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158855 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103577 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23331 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115827 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82281 "4 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134704 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96558 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17044 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14990 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6700 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142126 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126659 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161328 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10941 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4419 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123831 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124032 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33686 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22690 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134423 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78952 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19160 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11180 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181574 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22303 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86103 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46473 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22017 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22169 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22071 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->