### PR TITLE
[GTK] Detect `*-dark-*` themes as dark too

### DIFF
--- a/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp
@@ -61,14 +61,14 @@ bool SystemSettingsManagerProxy::darkMode() const
     // Or maybe just use the settings portal, because we don't want to depend on libhandy, and maybe don't want to depend on libadwaita?
     if (const char* themeNameEnv = g_getenv("GTK_THEME")) {
         String themeNameEnvString = String::fromUTF8(themeNameEnv);
-        return themeNameEnvString.endsWith("-dark"_s) || themeNameEnvString.endsWith("-Dark"_s) || themeNameEnvString.endsWith(":dark"_s);
+        return themeNameEnvString.containsIgnoringASCIICase("-dark-"_s) || themeNameEnvString.endsWithIgnoringASCIICase("-dark"_s) || themeNameEnvString.endsWith(":dark"_s);
     }
 
     GUniqueOutPtr<char> themeName;
     g_object_get(m_settings, "gtk-theme-name", &themeName.outPtr(), nullptr);
     if (themeName) {
         String themeNameString = String::fromUTF8(themeName.get());
-        if (themeNameString.endsWith("-dark"_s) || themeNameString.endsWith("-Dark"_s))
+        if (themeNameString.containsIgnoringASCIICase("-dark-"_s) || themeNameString.endsWithIgnoringASCIICase("-dark"_s))
             return true;
     }
 


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=308876

Reviewed by NOBODY (OOPS!).

Previous heuristics didn't match themes containing "-dark-" in their name.

* Source/WebKit/UIProcess/gtk/SystemSettingsManagerProxyGtk.cpp:
(WebKit::SystemSettingsManagerProxy::darkMode const):<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c5b9fa9c2b386a81ab4f03798d23307d923b5e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158857 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103579 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23333 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23009 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115829 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82283 "4 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17943 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96560 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17043 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14991 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6702 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126658 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161330 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4421 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14181 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123833 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22705 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19038 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124034 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22692 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134424 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78954 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19159 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11181 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22305 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86105 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22019 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22171 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22073 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->