### PR TITLE
[threaded-animations] remote timeline is not preserved in update for animation targeting primary and backdrop layers

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/accelerated-timeline-preservation-during-update-for-primary-and-backdrop-layer-effects-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/accelerated-timeline-preservation-during-update-for-primary-and-backdrop-layer-effects-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Updating an animation targeting both the primary and backdrop layer for an element preserves the shared timeline.
+

--- a/LayoutTests/webanimations/threaded-animations/accelerated-timeline-preservation-during-update-for-primary-and-backdrop-layer-effects.html
+++ b/LayoutTests/webanimations/threaded-animations/accelerated-timeline-preservation-during-update-for-primary-and-backdrop-layer-effects.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<body>
+<style>
+
+@keyframes anim { 
+    from {
+        translate: 100px;
+        backdrop-filter: saturate(100%);
+    }
+
+    to {
+        translate: 200px;
+        backdrop-filter: saturate(140%);
+    }
+}
+
+#target {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+    background-color: black;
+    animation: anim 1000s;
+}
+
+</style>
+
+<div id="target"></div>
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script src="threaded-animations-utils.js"></script>
+
+<script>
+
+promise_test(async t => {
+    const animation = document.getAnimations()[0];
+    await animationAcceleration(animation);
+
+    // Create an update where the existing animation is modified, which will yield a
+    // new accelerated animation but will re-use the existing accelerated timeline.
+    animation.effect.updateTiming({ duration: 500 * 1000 });
+    await threadedAnimationsCommit();
+}, "Updating an animation targeting both the primary and backdrop layer for an element preserves the shared timeline.");
+
+</script>
+</body>

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -306,6 +306,7 @@ AcceleratedEffect::AcceleratedEffect(const AcceleratedEffect& source, OptionSet<
     : m_timelineIdentifier(source.m_timelineIdentifier)
 {
     m_timing = source.m_timing;
+    m_timeline = source.m_timeline;
     m_animationType = source.m_animationType;
     m_compositeOperation = source.m_compositeOperation;
     m_paused = source.m_paused;


### PR DESCRIPTION
#### 9ca97ba47fc50780afddee75944b6e9fa7fee43e
<pre>
[threaded-animations] remote timeline is not preserved in update for animation targeting primary and backdrop layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=309962">https://bugs.webkit.org/show_bug.cgi?id=309962</a>
<a href="https://rdar.apple.com/171248927">rdar://171248927</a>

Reviewed by Cameron McCormack.

If we create an accelerated animation that animates properties affecting both the primary and backdrop
layers, such as an animation animating both `opacity` (primary) and `backdrop-filter` (backdrop), we end
up slicing the list of animation effects in two in `AcceleratedEffectStack::setEffects()`. To do this, we
use the `AccelerateEffect::copyWithProperties()` method which makes a copy of the effect and filters only
the properties relevant to the layer type.

But a bad error was made in 301942@main when we added support for different timeline types and only copied
`m_timelineIdentifier` in the `AcceleratedEffect(const AcceleratedEffect&amp;, OptionSet&lt;AcceleratedEffectProperty&gt;&amp;)`
constructor variant, and forgot to also copy `m_timeline`. This meant that the `AcceleratedTimeline` created
for the effect was immediately destroyed following the initial animation commit to the remote layer tree.

As such, if that animation needs an update, a new version of it will be created in a remote layer tree commit
but the timeline update in that same commit will list that timeline for deletion since it will no longer exist.
For additional details, see 308011@main.

We fix this by simply ensuring we preserve `m_timeline` when `AccelerateEffect::copyWithProperties()` is called.

Test: webanimations/threaded-animations/accelerated-timeline-preservation-during-update-for-primary-and-backdrop-layer-effects.html

* LayoutTests/webanimations/threaded-animations/accelerated-timeline-preservation-during-update-for-primary-and-backdrop-layer-effects-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/accelerated-timeline-preservation-during-update-for-primary-and-backdrop-layer-effects.html: Added.
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::AcceleratedEffect):

Canonical link: <a href="https://commits.webkit.org/309277@main">https://commits.webkit.org/309277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6eafff04acbe1f3a07e5c536d9f5683822106bfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150147 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22905 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158859 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103581 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/957f73ac-ba1d-417c-94ef-14bbbe6a1ad9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115831 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05d94f65-bc78-46dd-af4a-be6eeaef240a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153107 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17945 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134707 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96562 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1a83edc-d8f6-4374-b49a-a365bad96f44) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17045 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14994 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6704 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161332 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4423 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Found 41601 issues") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14183 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123835 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124036 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33679 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22694 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134426 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78964 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19163 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11183 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22307 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86107 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22021 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22173 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22075 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->