### PR TITLE
Web Inspector: improve UX of color picker value component inputs

### DIFF
--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -189,6 +189,8 @@ localizedStrings["Allow media capture on insecure sites"] = "Allow media capture
 localizedStrings["Allow page to clear Console"] = "Allow page to clear Console";
 /* Label for checkbox that controls whether network throttling functionality is enabled. */
 localizedStrings["Allow throttling"] = "Allow throttling";
+/* Label for alpha color component of CSS color. */
+localizedStrings["Alpha @ Color Picker"] = "Alpha";
 localizedStrings["Also defer evaluating breakpoint conditions, ignore counts, and actions until execution has continued outside of the related script instead of at the breakpoint\u2019s location."] = "Also defer evaluating breakpoint conditions, ignore counts, and actions until execution has continued outside of the related script instead of at the breakpoint\u2019s location.";
 /* Property title for `font-variant-alternates`. */
 localizedStrings["Alternate Glyphs @ Font Details Sidebar Property"] = "Alternate Glyphs";
@@ -282,6 +284,8 @@ localizedStrings["Block @ Local Override Type"] = "Block";
 localizedStrings["Block Request URL"] = "Block Request URL";
 localizedStrings["Block URL with %s error"] = "Block URL with %s error";
 localizedStrings["Block Variables"] = "Block Variables";
+/* Label for blue color component of CSS color. */
+localizedStrings["Blue @ Color Picker"] = "Blue";
 /* Input label for the blur radius of a CSS box shadow */
 localizedStrings["Blur @ Box Shadow Editor"] = "Blur";
 localizedStrings["Body:"] = "Body:";
@@ -444,8 +448,6 @@ localizedStrings["Connection Close Frame"] = "Connection Close Frame";
 localizedStrings["Connection Closed"] = "Connection Closed";
 localizedStrings["Connection ID"] = "Connection ID";
 localizedStrings["Connection:"] = "Connection:";
-/* Label for contrast ratio section in Color Picker */
-localizedStrings["Contrast @ Color Picker"] = "Contrast";
 localizedStrings["Console"] = "Console";
 localizedStrings["Console Evaluation"] = "Console Evaluation";
 localizedStrings["Console Evaluation %d"] = "Console Evaluation %d";
@@ -467,6 +469,8 @@ localizedStrings["Continuation Frame"] = "Continuation Frame";
 localizedStrings["Continue script execution (%s or %s)"] = "Continue script execution (%s or %s)";
 localizedStrings["Continue to Here"] = "Continue to Here";
 localizedStrings["Continue without automatically stopping"] = "Continue without automatically stopping";
+/* Label for contrast ratio section in Color Picker */
+localizedStrings["Contrast @ Color Picker"] = "Contrast";
 localizedStrings["Controls"] = "Controls";
 localizedStrings["Convert to Display-P3"] = "Convert to Display-P3";
 localizedStrings["Convert to sRGB"] = "Convert to sRGB";
@@ -867,6 +871,8 @@ localizedStrings["Go to variable"] = "Go to variable";
 localizedStrings["Grammar"] = "Grammar";
 /* Name of Graphics Tab */
 localizedStrings["Graphics Tab Name"] = "Graphics";
+/* Label for green color component of CSS color. */
+localizedStrings["Green @ Color Picker"] = "Green";
 /* CSS Grid layout section name */
 localizedStrings["Grid @ Elements details sidebar"] = "Grid";
 localizedStrings["Group"] = "Group";
@@ -915,6 +921,8 @@ localizedStrings["Historical @ Font Details Sidebar Property Value"] = "Historic
 /* Property value for `font-variant-alternates: historical-forms`. */
 localizedStrings["Historical Forms @ Font Details Sidebar Property Value"] = "Historical Forms";
 localizedStrings["Host"] = "Host";
+/* Label for hue color component of CSS color. */
+localizedStrings["Hue @ Color Picker"] = "Hue";
 localizedStrings["ICO"] = "ICO";
 localizedStrings["IP"] = "IP";
 localizedStrings["IP Address"] = "IP Address";
@@ -1014,6 +1022,8 @@ localizedStrings["Ligatures @ Font Details Sidebar Property"] = "Ligatures";
 localizedStrings["Light @ Settings General Appearance"] = "Light";
 /* Label for the light color scheme preference. */
 localizedStrings["Light @ User Preferences Overrides"] = "Light";
+/* Label for lightness color component of CSS color. */
+localizedStrings["Lightness @ Color Picker"] = "Lightness";
 localizedStrings["Limit syntax highlighting on long lines of code"] = "Limit syntax highlighting on long lines of code";
 localizedStrings["Line %d"] = "Line %d";
 localizedStrings["Line %d:%d"] = "Line %d:%d";
@@ -1389,6 +1399,8 @@ localizedStrings["Recording Type Offscreen Canvas WebGL"] = "WebGL (Offscreen)";
 localizedStrings["Recording Type Offscreen Canvas WebGL2"] = "WebGL2 (Offscreen)";
 localizedStrings["Recording Warning: %s"] = "Recording Warning: %s";
 localizedStrings["Recordings"] = "Recordings";
+/* Label for red color component of CSS color. */
+localizedStrings["Red @ Color Picker"] = "Red";
 localizedStrings["Redirect"] = "Redirect";
 localizedStrings["Redirect Response"] = "Redirect Response";
 localizedStrings["Redirects"] = "Redirects";
@@ -1497,6 +1509,8 @@ localizedStrings["SVG"] = "SVG";
 /* Title for Sample Rate row in Media Sidebar */
 localizedStrings["Sample Rate @ Media Sidebar"] = "Sample Rate";
 localizedStrings["Samples"] = "Samples";
+/* Label for saturation color component of CSS color. */
+localizedStrings["Saturation @ Color Picker"] = "Saturation";
 localizedStrings["Save %d"] = "Save %d";
 localizedStrings["Save File"] = "Save File";
 localizedStrings["Save Image"] = "Save Image";

--- a/Source/WebInspectorUI/UserInterface/Views/ColorPicker.css
+++ b/Source/WebInspectorUI/UserInterface/Views/ColorPicker.css
@@ -86,15 +86,26 @@
     flex: 1;
 }
 
-.color-picker > .color-inputs-wrapper > .color-inputs > div {
+.color-picker > .color-inputs-wrapper > .color-inputs > label {
     display: flex;
     align-items: center;
     width: 100%;
 }
 
-.color-picker > .color-inputs-wrapper > .color-inputs input {
+.color-picker > .color-inputs-wrapper > .color-inputs > label + label {
+    margin-inline-start: 0.5em;
+}
+
+.color-picker > .color-inputs-wrapper > .color-inputs > label > input {
     width: 100%;
-    margin: 0 0.25em;
+    margin: 0;
+    margin-inline-start: 0.25em;
+    padding: 0 2px;
+    font-variant-numeric: tabular-nums;
+}
+
+.color-picker > .color-inputs-wrapper > .color-inputs > label > input::-webkit-inner-spin-button {
+    appearance: none
 }
 
 .color-picker > .color-inputs-wrapper > :is(.pick-color-from-screen, .format-options) {

--- a/Source/WebInspectorUI/UserInterface/Views/ColorPicker.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ColorPicker.js
@@ -350,6 +350,18 @@ WI.ColorPicker = class ColorPicker extends WI.Object
         this._element.classList.toggle("gamut-p3", this._color.gamut === WI.Color.Gamut.DisplayP3);
     }
 
+    _needsAlphaColorInput()
+    {
+        switch (this._color.format) {
+        case WI.Color.Format.RGBA:
+        case WI.Color.Format.HSLA:
+        case WI.Color.Format.HEXAlpha:
+        case WI.Color.Format.ShortHEXAlpha:
+            return true;
+        }
+        return false;
+    }
+
     _createColorInputsIfNeeded()
     {
         let hasAlpha = this._color.alpha !== 1;
@@ -362,19 +374,17 @@ WI.ColorPicker = class ColorPicker extends WI.Object
         this._colorInputs = [];
         this._colorInputsContainerElement.removeChildren();
 
-        let createColorInput = (label, {max, step, units} = {}) => {
-            let containerElement = this._colorInputsContainerElement.createChild("div");
-            containerElement.append(label);
+        let createColorInput = (label, title, {max, step} = {}) => {
+            let labelElement = this._colorInputsContainerElement.createChild("label");
+            labelElement.title = title;
+            labelElement.textContent = label;
 
-            let numberInputElement = containerElement.createChild("input");
+            let numberInputElement = labelElement.createChild("input");
             numberInputElement.type = "number";
             numberInputElement.min = 0;
             numberInputElement.max = max;
             numberInputElement.step = step || 1;
             this._colorInputs.push(numberInputElement);
-
-            if (units && units.length)
-                containerElement.append(units);
         };
 
         switch (this._color.format) {
@@ -385,22 +395,22 @@ WI.ColorPicker = class ColorPicker extends WI.Object
         case WI.Color.Format.HEXAlpha:
         case WI.Color.Format.ShortHEXAlpha:
         case WI.Color.Format.Keyword:
-            createColorInput("R", {max: 255});
-            createColorInput("G", {max: 255});
-            createColorInput("B", {max: 255});
+            createColorInput("R", WI.UIString("Red", "Red @ Color Picker", "Label for red color component of CSS color."), {max: 255});
+            createColorInput("G", WI.UIString("Green", "Green @ Color Picker", "Label for green color component of CSS color."), {max: 255});
+            createColorInput("B", WI.UIString("Blue", "Blue @ Color Picker", "Label for blue color component of CSS color."), {max: 255});
             break;
 
         case WI.Color.Format.HSL:
         case WI.Color.Format.HSLA:
-            createColorInput("H", {max: 360});
-            createColorInput("S", {max: 100, units: "%"});
-            createColorInput("L", {max: 100, units: "%"});
+            createColorInput("H", WI.UIString("Hue", "Hue @ Color Picker", "Label for hue color component of CSS color."), {max: 360});
+            createColorInput("S", WI.UIString("Saturation", "Saturation @ Color Picker", "Label for saturation color component of CSS color."), {max: 100});
+            createColorInput("L", WI.UIString("Lightness", "Lightness @ Color Picker", "Label for lightness color component of CSS color."), {max: 100});
             break;
 
         case WI.Color.Format.ColorFunction:
-            createColorInput("R", {max: 1, step: 0.01});
-            createColorInput("G", {max: 1, step: 0.01});
-            createColorInput("B", {max: 1, step: 0.01});
+            createColorInput("R", WI.UIString("Red", "Red @ Color Picker", "Label for red color component of CSS color."), {max: 1, step: 0.01});
+            createColorInput("G", WI.UIString("Green", "Green @ Color Picker", "Label for green color component of CSS color."), {max: 1, step: 0.01});
+            createColorInput("B", WI.UIString("Blue", "Blue @ Color Picker", "Label for blue color component of CSS color."), {max: 1, step: 0.01});
             break;
 
         default:
@@ -408,13 +418,8 @@ WI.ColorPicker = class ColorPicker extends WI.Object
             return;
         }
 
-        if (this._color.alpha !== 1
-            || this._color.format === WI.Color.Format.RGBA
-            || this._color.format === WI.Color.Format.HSLA
-            || this._color.format === WI.Color.Format.HEXAlpha
-            || this._color.format === WI.Color.Format.ShortHEXAlpha) {
-            createColorInput("A", {max: 1, step: 0.01});
-        }
+        if (this._color.alpha !== 1 || this._needsAlphaColorInput())
+            createColorInput("A", WI.UIString("Alpha", "Alpha @ Color Picker", "Label for alpha color component of CSS color."), {max: 1, step: 0.01});
     }
 
     _showColorComponentInputs()
@@ -446,7 +451,7 @@ WI.ColorPicker = class ColorPicker extends WI.Object
             console.error(`Unknown color format: ${this._color.format}`);
         }
 
-        if (this._color.alpha !== 1)
+        if (this._color.alpha !== 1 || this._needsAlphaColorInput())
             components.push(this._color.alpha);
 
         console.assert(this._colorInputs.length === components.length);


### PR DESCRIPTION
#### 27d35b7ad29b94423461b00135cd606693711c41
<pre>
Web Inspector: improve UX of color picker value component inputs
<a href="https://bugs.webkit.org/show_bug.cgi?id=309963">https://bugs.webkit.org/show_bug.cgi?id=309963</a>

Reviewed by BJ Burg.

- drop the `%` labels after the `&lt;input&gt;` for `S` and `L` as that consumes a lot of space and is often smushed into the subsequent text (i.e. not clear what it refers to)
- hide the up/down arrows inside each `&lt;input&gt;` since they take up space and are such small targets to click (and there&apos;s already keyboard shortcuts for the same thing)
- decrease the padding inside and around each `&lt;input&gt;` so that there&apos;s more space for the number value
- ensure that when switching from a non-alpha format to an alpha format (e.g. HSL to HSLA, RGB to RGBA, etc.) that the alpha `&lt;input&gt;` at least shows `1`

* Source/WebInspectorUI/UserInterface/Views/ColorPicker.js:
(WI.ColorPicker.prototype._needsAlphaColorInput): Added.
(WI.ColorPicker.prototype._createColorInputsIfNeeded):
(WI.ColorPicker.prototype._showColorComponentInputs):
* Source/WebInspectorUI/UserInterface/Views/ColorPicker.css:
(.color-picker &gt; .color-inputs-wrapper &gt; .color-inputs &gt; label): Renamed from `.color-picker &gt; .color-inputs-wrapper &gt; .color-inputs &gt; div`.
(.color-picker &gt; .color-inputs-wrapper &gt; .color-inputs &gt; label + label): Added.
(.color-picker &gt; .color-inputs-wrapper &gt; .color-inputs &gt; label &gt; input): Renamed from `.color-picker &gt; .color-inputs-wrapper &gt; .color-inputs input`.
(.color-picker &gt; .color-inputs-wrapper &gt; .color-inputs &gt; label &gt; input::-webkit-inner-spin-button): Added.

* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:

Canonical link: <a href="https://commits.webkit.org/309367@main">https://commits.webkit.org/309367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e530e93d02bf4ae12c9f417a9d3198163aa8372

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159194 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116105 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18217 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/134981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96833 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15262 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7042 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12905 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161668 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14458 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/124104 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124302 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33740 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/23019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134700 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79399 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/11457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22633 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/86432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/22346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/22498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/22400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->