### PR TITLE
[JSC] Use simple ARM64 shl, ushr, sshr

### DIFF
--- a/JSTests/wasm/stress/simd-shift-immediate.js
+++ b/JSTests/wasm/stress/simd-shift-immediate.js
@@ -1,0 +1,249 @@
+//@ requireOptions("--useWasmSIMD=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test vector shift-by-immediate for all lane types, sign modes, and edge cases.
+// Constant shifts use NEON SHL/SSHR/USHR immediate instructions on ARM64.
+// Dynamic shifts use the mask+splat+SSHL/USHL path.
+// Both paths must produce identical results.
+
+// Module 1: i8x16 shifts
+async function testI8x16() {
+    let wat = `(module
+      (memory (export "mem") 1)
+      (func (export "shl_3") (param i32 i32)
+        (v128.store (local.get 1) (i8x16.shl (v128.load (local.get 0)) (i32.const 3))))
+      (func (export "shl_dyn") (param i32 i32 i32)
+        (v128.store (local.get 1) (i8x16.shl (v128.load (local.get 0)) (local.get 2))))
+      (func (export "shr_u_4") (param i32 i32)
+        (v128.store (local.get 1) (i8x16.shr_u (v128.load (local.get 0)) (i32.const 4))))
+      (func (export "shr_u_dyn") (param i32 i32 i32)
+        (v128.store (local.get 1) (i8x16.shr_u (v128.load (local.get 0)) (local.get 2))))
+      (func (export "shr_s_2") (param i32 i32)
+        (v128.store (local.get 1) (i8x16.shr_s (v128.load (local.get 0)) (i32.const 2))))
+      (func (export "shr_s_dyn") (param i32 i32 i32)
+        (v128.store (local.get 1) (i8x16.shr_s (v128.load (local.get 0)) (local.get 2))))
+      (func (export "shl_0") (param i32 i32)
+        (v128.store (local.get 1) (i8x16.shl (v128.load (local.get 0)) (i32.const 0))))
+      (func (export "shl_7") (param i32 i32)
+        (v128.store (local.get 1) (i8x16.shl (v128.load (local.get 0)) (i32.const 7))))
+      (func (export "shl_8") (param i32 i32)
+        (v128.store (local.get 1) (i8x16.shl (v128.load (local.get 0)) (i32.const 8))))
+      (func (export "shl_11") (param i32 i32)
+        (v128.store (local.get 1) (i8x16.shl (v128.load (local.get 0)) (i32.const 11))))
+    )`
+    const instance = await instantiate(wat, {}, { simd: true })
+    const u8 = new Uint8Array(instance.exports.mem.buffer)
+    const e = instance.exports
+    const pattern = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0xFF, 0x7F, 0x3F, 0x1F, 0x0F, 0x07, 0x03, 0x01]
+    for (let i = 0; i < 16; i++) u8[i] = pattern[i]
+
+    for (let iter = 0; iter < wasmTestLoopCount; ++iter) {
+        // shl const=3 vs dyn=3
+        e.shl_3(0, 16)
+        e.shl_dyn(0, 32, 3)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], u8[32 + i])
+
+        // shr_u const=4 vs dyn=4
+        e.shr_u_4(0, 16)
+        e.shr_u_dyn(0, 32, 4)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], u8[32 + i])
+
+        // shr_s const=2 vs dyn=2
+        e.shr_s_2(0, 16)
+        e.shr_s_dyn(0, 32, 2)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], u8[32 + i])
+
+        // shift 0: identity
+        e.shl_0(0, 16)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], pattern[i])
+
+        // shift 8: wraps to 0 (identity)
+        e.shl_8(0, 16)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], pattern[i])
+
+        // shift 11 == shift 3
+        e.shl_11(0, 16)
+        e.shl_3(0, 32)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], u8[32 + i])
+    }
+}
+
+// Module 2: i16x8 shifts
+async function testI16x8() {
+    let wat = `(module
+      (memory (export "mem") 1)
+      (func (export "shl_5") (param i32 i32)
+        (v128.store (local.get 1) (i16x8.shl (v128.load (local.get 0)) (i32.const 5))))
+      (func (export "shl_dyn") (param i32 i32 i32)
+        (v128.store (local.get 1) (i16x8.shl (v128.load (local.get 0)) (local.get 2))))
+      (func (export "shr_u_8") (param i32 i32)
+        (v128.store (local.get 1) (i16x8.shr_u (v128.load (local.get 0)) (i32.const 8))))
+      (func (export "shr_u_dyn") (param i32 i32 i32)
+        (v128.store (local.get 1) (i16x8.shr_u (v128.load (local.get 0)) (local.get 2))))
+      (func (export "shr_s_10") (param i32 i32)
+        (v128.store (local.get 1) (i16x8.shr_s (v128.load (local.get 0)) (i32.const 10))))
+      (func (export "shr_s_dyn") (param i32 i32 i32)
+        (v128.store (local.get 1) (i16x8.shr_s (v128.load (local.get 0)) (local.get 2))))
+      (func (export "shr_u_0") (param i32 i32)
+        (v128.store (local.get 1) (i16x8.shr_u (v128.load (local.get 0)) (i32.const 0))))
+      (func (export "shr_u_16") (param i32 i32)
+        (v128.store (local.get 1) (i16x8.shr_u (v128.load (local.get 0)) (i32.const 16))))
+      (func (export "shr_u_19") (param i32 i32)
+        (v128.store (local.get 1) (i16x8.shr_u (v128.load (local.get 0)) (i32.const 19))))
+    )`
+    const instance = await instantiate(wat, {}, { simd: true })
+    const u8 = new Uint8Array(instance.exports.mem.buffer)
+    const e = instance.exports
+    const pattern = [0xDE, 0xAD, 0xBE, 0xEF, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x11, 0x22, 0x33, 0x44]
+    for (let i = 0; i < 16; i++) u8[i] = pattern[i]
+
+    for (let iter = 0; iter < wasmTestLoopCount; ++iter) {
+        e.shl_5(0, 16)
+        e.shl_dyn(0, 32, 5)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], u8[32 + i])
+
+        e.shr_u_8(0, 16)
+        e.shr_u_dyn(0, 32, 8)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], u8[32 + i])
+
+        e.shr_s_10(0, 16)
+        e.shr_s_dyn(0, 32, 10)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], u8[32 + i])
+
+        // shift 0: identity
+        e.shr_u_0(0, 16)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], pattern[i])
+
+        // shift 16: wraps to 0
+        e.shr_u_16(0, 16)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], pattern[i])
+
+        // shift 19 == shift 3
+        e.shr_u_19(0, 16)
+        e.shr_u_dyn(0, 32, 3)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], u8[32 + i])
+    }
+}
+
+// Module 3: i32x4 shifts
+async function testI32x4() {
+    let wat = `(module
+      (memory (export "mem") 1)
+      (func (export "shl_16") (param i32 i32)
+        (v128.store (local.get 1) (i32x4.shl (v128.load (local.get 0)) (i32.const 16))))
+      (func (export "shl_dyn") (param i32 i32 i32)
+        (v128.store (local.get 1) (i32x4.shl (v128.load (local.get 0)) (local.get 2))))
+      (func (export "shr_u_12") (param i32 i32)
+        (v128.store (local.get 1) (i32x4.shr_u (v128.load (local.get 0)) (i32.const 12))))
+      (func (export "shr_u_dyn") (param i32 i32 i32)
+        (v128.store (local.get 1) (i32x4.shr_u (v128.load (local.get 0)) (local.get 2))))
+      (func (export "shr_s_20") (param i32 i32)
+        (v128.store (local.get 1) (i32x4.shr_s (v128.load (local.get 0)) (i32.const 20))))
+      (func (export "shr_s_dyn") (param i32 i32 i32)
+        (v128.store (local.get 1) (i32x4.shr_s (v128.load (local.get 0)) (local.get 2))))
+      (func (export "shl_0") (param i32 i32)
+        (v128.store (local.get 1) (i32x4.shl (v128.load (local.get 0)) (i32.const 0))))
+      (func (export "shl_32") (param i32 i32)
+        (v128.store (local.get 1) (i32x4.shl (v128.load (local.get 0)) (i32.const 32))))
+    )`
+    const instance = await instantiate(wat, {}, { simd: true })
+    const u8 = new Uint8Array(instance.exports.mem.buffer)
+    const mem = new DataView(instance.exports.mem.buffer)
+    const e = instance.exports
+    const pattern = [0xDE, 0xAD, 0xBE, 0xEF, 0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0, 0x11, 0x22, 0x33, 0x44]
+    for (let i = 0; i < 16; i++) u8[i] = pattern[i]
+
+    for (let iter = 0; iter < wasmTestLoopCount; ++iter) {
+        e.shl_16(0, 16)
+        e.shl_dyn(0, 32, 16)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], u8[32 + i])
+
+        e.shr_u_12(0, 16)
+        e.shr_u_dyn(0, 32, 12)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], u8[32 + i])
+
+        e.shr_s_20(0, 16)
+        e.shr_s_dyn(0, 32, 20)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], u8[32 + i])
+
+        // shift 0: identity
+        e.shl_0(0, 16)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], pattern[i])
+
+        // shift 32: wraps to 0
+        e.shl_32(0, 16)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], pattern[i])
+    }
+}
+
+// Module 4: i64x2 shifts
+async function testI64x2() {
+    let wat = `(module
+      (memory (export "mem") 1)
+      (func (export "shl_32") (param i32 i32)
+        (v128.store (local.get 1) (i64x2.shl (v128.load (local.get 0)) (i32.const 32))))
+      (func (export "shl_dyn") (param i32 i32 i32)
+        (v128.store (local.get 1) (i64x2.shl (v128.load (local.get 0)) (local.get 2))))
+      (func (export "shr_u_48") (param i32 i32)
+        (v128.store (local.get 1) (i64x2.shr_u (v128.load (local.get 0)) (i32.const 48))))
+      (func (export "shr_u_dyn") (param i32 i32 i32)
+        (v128.store (local.get 1) (i64x2.shr_u (v128.load (local.get 0)) (local.get 2))))
+      (func (export "shr_s_16") (param i32 i32)
+        (v128.store (local.get 1) (i64x2.shr_s (v128.load (local.get 0)) (i32.const 16))))
+      (func (export "shr_s_dyn") (param i32 i32 i32)
+        (v128.store (local.get 1) (i64x2.shr_s (v128.load (local.get 0)) (local.get 2))))
+      (func (export "shr_s_0") (param i32 i32)
+        (v128.store (local.get 1) (i64x2.shr_s (v128.load (local.get 0)) (i32.const 0))))
+      (func (export "shr_s_63") (param i32 i32)
+        (v128.store (local.get 1) (i64x2.shr_s (v128.load (local.get 0)) (i32.const 63))))
+      (func (export "shr_s_64") (param i32 i32)
+        (v128.store (local.get 1) (i64x2.shr_s (v128.load (local.get 0)) (i32.const 64))))
+    )`
+    const instance = await instantiate(wat, {}, { simd: true })
+    const u8 = new Uint8Array(instance.exports.mem.buffer)
+    const mem = new DataView(instance.exports.mem.buffer)
+    const e = instance.exports
+
+    mem.setBigUint64(0, 0x8000000000000001n, true)
+    mem.setBigUint64(8, 0xFFFFFFFFFFFFFFFFn, true)
+
+    for (let iter = 0; iter < wasmTestLoopCount; ++iter) {
+        e.shl_32(0, 16)
+        e.shl_dyn(0, 32, 32)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], u8[32 + i])
+
+        e.shr_u_48(0, 16)
+        e.shr_u_dyn(0, 32, 48)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], u8[32 + i])
+
+        e.shr_s_16(0, 16)
+        e.shr_s_dyn(0, 32, 16)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], u8[32 + i])
+
+        // shift 0: identity
+        e.shr_s_0(0, 16)
+        assert.eq(mem.getBigUint64(16, true), 0x8000000000000001n)
+        assert.eq(mem.getBigUint64(24, true), 0xFFFFFFFFFFFFFFFFn)
+
+        // shift 64: wraps to 0
+        e.shr_s_64(0, 16)
+        assert.eq(mem.getBigUint64(16, true), 0x8000000000000001n)
+        assert.eq(mem.getBigUint64(24, true), 0xFFFFFFFFFFFFFFFFn)
+
+        // shift 63: max signed right shift
+        e.shr_s_63(0, 16)
+        e.shr_s_dyn(0, 32, 63)
+        for (let i = 0; i < 16; i++) assert.eq(u8[16 + i], u8[32 + i])
+    }
+}
+
+async function test() {
+    await testI8x16()
+    await testI16x8()
+    await testI32x4()
+    await testI64x2()
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/assembler/ARM64Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64Assembler.h
@@ -2104,6 +2104,17 @@ public:
         insn(0b011'011110'0000'000'000001'00000'00000 | (immh << 19) | (immb << 16) | (vn << 5) | vd);
     }
 
+    ALWAYS_INLINE void shl_vi(FPRegisterID vd, FPRegisterID vn, uint8_t shift, SIMDLane lane)
+    {
+        uint8_t maxShift = elementByteSize(lane) * 8;
+        ASSERT_UNUSED(maxShift, shift < maxShift);
+        unsigned immh = elementByteSize(lane) | ((shift & 0b0111000) >> 3);
+        unsigned immb = shift & 0b0111;
+        ASSERT(immh);
+        ASSERT(!(immh & (~0b1111)));
+        insn(0b010'011110'0000'000'010101'00000'00000 | (immh << 19) | (immb << 16) | (vn << 5) | vd);
+    }
+
     template<SIMDLane narrowedLane>
     ALWAYS_INLINE void shrn(FPRegisterID vd, FPRegisterID vn, uint8_t shift)
     {

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -6881,6 +6881,18 @@ public:
         m_assembler.sshr_vi(dest, input, shift.m_value, simdInfo.lane);
     }
 
+    void vectorUshr8(SIMDInfo simdInfo, FPRegisterID input, TrustedImm32 shift, FPRegisterID dest)
+    {
+        ASSERT(scalarTypeIsIntegral(simdInfo.lane));
+        m_assembler.ushr_vi(dest, input, shift.m_value, simdInfo.lane);
+    }
+
+    void vectorShl8(SIMDInfo simdInfo, FPRegisterID input, TrustedImm32 shift, FPRegisterID dest)
+    {
+        ASSERT(scalarTypeIsIntegral(simdInfo.lane));
+        m_assembler.shl_vi(dest, input, shift.m_value, simdInfo.lane);
+    }
+
     void vectorHorizontalAdd(SIMDInfo simdInfo, FPRegisterID input, FPRegisterID dest)
     {
         RELEASE_ASSERT(scalarTypeIsIntegral(simdInfo.lane));

--- a/Source/JavaScriptCore/b3/B3LowerMacros.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerMacros.cpp
@@ -661,26 +661,6 @@ private:
                 if (isX86() && m_value->as<SIMDValue>()->simdLane() == SIMDLane::i64x2)
                     invertedComparisonByXor(VectorGreaterThan, m_value->child(0), m_value->child(1));
                 break;
-            case VectorShr:
-            case VectorShl: {
-                if constexpr (!isARM64())
-                    break;
-                SIMDValue* value = m_value->as<SIMDValue>();
-                SIMDLane lane = value->simdLane();
-
-                int32_t mask = (elementByteSize(lane) * CHAR_BIT) - 1;
-                Value* shiftAmount = m_insertionSet.insert<Value>(m_index, BitAnd, m_origin, value->child(1), m_insertionSet.insertIntConstant(m_index, m_origin, Int32, mask));
-                if (value->opcode() == VectorShr) {
-                    // ARM64 doesn't have a version of this instruction for right shift. Instead, if the input to
-                    // left shift is negative, it's a right shift by the absolute value of that amount.
-                    shiftAmount = m_insertionSet.insert<Value>(m_index, Neg, m_origin, shiftAmount);
-                }
-                Value* shiftVector = m_insertionSet.insert<SIMDValue>(m_index, m_origin, VectorSplat, B3::V128, SIMDLane::i8x16, SIMDSignMode::None, shiftAmount);
-                Value* result = m_insertionSet.insert<SIMDValue>(m_index, m_origin, VectorShiftByVector, B3::V128, value->simdInfo(), value->child(0), shiftVector);
-                m_value->replaceWithIdentity(result);
-                m_changed = true;
-                break;
-            }
 
             case WasmStructGet: {
                 WasmStructGetValue* structGet = m_value->as<WasmStructGetValue>();

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -4824,13 +4824,6 @@ private:
             return;
         }
 
-        case B3::VectorShiftByVector: {
-            ASSERT(isARM64());
-            SIMDValue* value = m_value->as<SIMDValue>();
-            append(value->signMode() == SIMDSignMode::Signed ? VectorSshl : VectorUshl, Arg::simdInfo(value->simdInfo()), tmp(value->child(0)), tmp(value->child(1)), tmp(value));
-            return;
-        }
-
         case B3::VectorSplat: {
             SIMDValue* value = m_value->as<SIMDValue>();
             SIMDLane lane = value->simdLane();
@@ -4894,19 +4887,46 @@ private:
 
         case B3::VectorShr:
         case B3::VectorShl: {
-            ASSERT(!isARM64()); // In ARM64, they are macro.
             SIMDValue* value = m_value->as<SIMDValue>();
             SIMDLane lane = value->simdLane();
 
             int32_t mask = (elementByteSize(lane) * CHAR_BIT) - 1;
 
-            auto v = tmp(value->child(0));
-            auto shift = tmp(value->child(1));
+            if constexpr (isARM64()) {
+                auto v = tmp(value->child(0));
 
-            Tmp shiftAmount = m_code.newTmp(B3::GP);
-            Tmp shiftVector = m_code.newTmp(B3::FP);
+                if (value->child(1)->hasInt32()) {
+                    int32_t shiftImm = value->child(1)->asInt32() & mask;
+                    if (!shiftImm) {
+                        append(Air::MoveVector, v, tmp(value));
+                        return;
+                    }
+                    if (value->opcode() == VectorShl)
+                        append(VectorShl8, Arg::simdInfo(value->simdInfo()), v, Arg::imm(shiftImm), tmp(value));
+                    else
+                        append(value->signMode() == SIMDSignMode::Signed ? VectorSshr8 : VectorUshr8, Arg::simdInfo(value->simdInfo()), v, Arg::imm(shiftImm), tmp(value));
+                    return;
+                }
+
+                auto shift = tmp(value->child(1));
+                Tmp shiftAmount = m_code.newTmp(B3::GP);
+                Tmp shiftVector = m_code.newTmp(B3::FP);
+
+                append(And32, Arg::bitImm(mask), shift, shiftAmount);
+                if (value->opcode() == VectorShr)
+                    append(Neg32, shiftAmount);
+                append(VectorSplatInt8, shiftAmount, shiftVector);
+                append(value->signMode() == SIMDSignMode::Signed ? VectorSshl : VectorUshl, Arg::simdInfo(value->simdInfo()), v, shiftVector, tmp(value));
+                return;
+            }
 
             if constexpr (isX86()) {
+                auto v = tmp(value->child(0));
+                auto shift = tmp(value->child(1));
+
+                Tmp shiftAmount = m_code.newTmp(B3::GP);
+                Tmp shiftVector = m_code.newTmp(B3::FP);
+
                 append(Move, shift, shiftAmount);
                 append(And32, Arg::imm(mask), shiftAmount);
                 if (value->opcode() == VectorShr && value->signMode() == SIMDSignMode::Signed && value->simdLane() == SIMDLane::i64x2) {
@@ -5030,30 +5050,17 @@ private:
         case B3::VectorOr: {
 #if CPU(ARM64)
             // Try to match XAR (XOR-and-rotate-right) pattern for i64x2.
-            // Pattern: VectorOr(VectorShiftByVector(x, shiftVecL), VectorShiftByVector(x, shiftVecR))
-            // After optimization, the shift vectors are Const128 (splatted byte values).
-            // One is a positive byte (left shift amount), the other is a negative byte (right shift).
+            // Pattern: VectorOr(VectorShl(x, constK), VectorShr(x, constK))
+            // or VectorOr(VectorAdd(x, x), VectorShr(x, constK)) after strength reduction.
             // When x = VectorXor(a, b), emit XAR(a, b, rotateRight).
             if (isARM64_SHA3()) {
                 Value* left = m_value->child(0);
                 Value* right = m_value->child(1);
 
-                // Extract the shift amount from a shift vector (Const128 with splatted bytes
-                // or VectorSplat of a Const32).
-                auto extractShiftAmount = [](Value* shiftVec) -> std::optional<int8_t> {
-                    if (shiftVec->opcode() != Const128)
-                        return std::nullopt;
-
-                    auto result = SIMDShuffle::isI8x16SameElement(shiftVec->as<Const128Value>()->value());
-                    if (!result)
-                        return std::nullopt;
-
-                    return static_cast<int8_t>(result.value());
-                };
-
                 auto tryMatchXAR = [&]() -> bool {
                     // Each child of VectorOr should be either:
-                    // - VectorShiftByVector:i64x2(x, shiftConst) — a general shift
+                    // - VectorShl:i64x2(x, constK) — a left shift by constant
+                    // - VectorShr:i64x2(x, constK) — a right shift by constant
                     // - VectorAdd:i64x2(x, x) — equivalent to shl-by-1 (from strength reduction)
                     // We need one left-shift and one right-shift on the same value x,
                     // with shift amounts summing to 64.
@@ -5064,15 +5071,11 @@ private:
                     };
 
                     auto extractShift = [&](Value* v) -> std::optional<ShiftInfo> {
-                        if (v->opcode() == B3::VectorShiftByVector) {
-                            SIMDValue* sv = v->as<SIMDValue>();
-                            if (sv->simdLane() != SIMDLane::i64x2)
-                                return std::nullopt;
-                            auto amt = extractShiftAmount(sv->child(1));
-                            if (!amt)
-                                return std::nullopt;
-                            return ShiftInfo { sv->child(0), *amt };
-                        }
+                        if (v->opcode() == B3::VectorShl && v->as<SIMDValue>()->simdLane() == SIMDLane::i64x2 && v->child(1)->hasInt32())
+                            return ShiftInfo { v->child(0), static_cast<int8_t>(v->child(1)->asInt32()) };
+
+                        if (v->opcode() == B3::VectorShr && v->as<SIMDValue>()->simdLane() == SIMDLane::i64x2 && v->child(1)->hasInt32())
+                            return ShiftInfo { v->child(0), static_cast<int8_t>(-v->child(1)->asInt32()) };
 
                         // We lowered left-shift by 1 to VectorAdd(x, x)
                         if (v->opcode() == B3::VectorAdd && v->as<SIMDValue>()->simdLane() == SIMDLane::i64x2
@@ -5116,7 +5119,7 @@ private:
 
                     // Check if the shifted value is VectorXor(a, b) that we can fold.
                     // The XOR's use count depends on how the shifts reference it:
-                    // - VectorShiftByVector(xor, ...) adds 1 use
+                    // - VectorShl/VectorShr(xor, const) adds 1 use
                     // - VectorAdd(xor, xor) adds 2 uses (both children reference xor)
                     unsigned expectedXorUses = 0;
                     expectedXorUses += (left->opcode() == B3::VectorAdd) ? 2 : 1;

--- a/Source/JavaScriptCore/b3/B3Opcode.h
+++ b/Source/JavaScriptCore/b3/B3Opcode.h
@@ -462,7 +462,6 @@ enum Opcode : uint8_t {
     // Currently only some architectures support this.
     // FIXME: Expand this to identical instructions for the other architectures as a macro.
     VectorMulByElement,
-    VectorShiftByVector,
 
     // SSA support, in the style of DFG SSA.
     Upsilon, // This uses the UpsilonValue class.

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -3422,21 +3422,11 @@ private:
             break;
         }
 
-        case VectorShiftByVector: {
-            // VectorShiftByVector(x, splat(1)) for unsigned left shift → VectorAdd(x, x)
-            // Since x + x = x << 1, this avoids the shift instruction.
-            if constexpr (isARM64()) {
-                SIMDValue* value = m_value->as<SIMDValue>();
-                if (value->signMode() == SIMDSignMode::Unsigned || value->signMode() == SIMDSignMode::None) {
-                    Value* shiftVec = m_value->child(1);
-                    if (shiftVec->opcode() == Const128) {
-                        auto result = SIMDShuffle::isI8x16SameElement(shiftVec->as<Const128Value>()->value());
-                        if (result && result.value() == 1) {
-                            replaceWithNew<SIMDValue>(m_value->origin(), VectorAdd, B3::V128, value->simdLane(), SIMDSignMode::None, m_value->child(0), m_value->child(0));
-                            break;
-                        }
-                    }
-                }
+        case VectorShl: {
+            SIMDValue* value = m_value->as<SIMDValue>();
+            if (value->child(1)->hasInt32() && value->child(1)->asInt32() == 1) {
+                replaceWithNew<SIMDValue>(m_value->origin(), VectorAdd, B3::V128, value->simdLane(), SIMDSignMode::None, m_value->child(0), m_value->child(0));
+                break;
             }
             break;
         }

--- a/Source/JavaScriptCore/b3/B3SIMDValue.h
+++ b/Source/JavaScriptCore/b3/B3SIMDValue.h
@@ -106,7 +106,6 @@ public:
         case VectorReverse:
         case VectorExtractPair:
         case VectorMulByElement:
-        case VectorShiftByVector:
         case VectorDotProduct:
         case VectorRelaxedSwizzle:
         case VectorRelaxedMAdd:

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -594,15 +594,6 @@ public:
                 VALIDATE(value->asSIMDValue()->immediate() < (16 / elementByteSize(value->asSIMDValue()->simdLane())), ("At ", *value));
                 break;
 
-            case VectorShiftByVector:
-                VALIDATE(isARM64(), ("At ", *value));
-                VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
-                VALIDATE(value->numChildren() == 2, ("At ", *value));
-                VALIDATE(value->type() == V128, ("At ", *value));
-                VALIDATE(value->child(0)->type() == V128, ("At ", *value));
-                VALIDATE(value->child(1)->type() == V128, ("At ", *value));
-                break;
-
             case VectorBitmask:
             case VectorAllTrue:
             case VectorAnyTrue:

--- a/Source/JavaScriptCore/b3/B3Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Value.cpp
@@ -787,7 +787,6 @@ Effects Value::effects() const
     case VectorReverse:
     case VectorExtractPair:
     case VectorMulByElement:
-    case VectorShiftByVector:
     case VectorRelaxedSwizzle:
     case VectorRelaxedMAdd:
     case VectorRelaxedNMAdd:
@@ -1094,7 +1093,6 @@ ValueKey Value::key() const
     case VectorShr:
     case VectorMulSat:
     case VectorAvgRound:
-    case VectorShiftByVector:
     case VectorRelaxedSwizzle:
     case VectorUnzipEven:
     case VectorUnzipOdd:

--- a/Source/JavaScriptCore/b3/B3Value.h
+++ b/Source/JavaScriptCore/b3/B3Value.h
@@ -557,7 +557,6 @@ protected:
         case VectorMulSat:
         case VectorAvgRound:
         case VectorMulByElement:
-        case VectorShiftByVector:
         case VectorRelaxedSwizzle:
         case VectorUnzipEven:
         case VectorUnzipOdd:
@@ -805,7 +804,6 @@ private:
         case VectorMulSat:
         case VectorAvgRound:
         case VectorMulByElement:
-        case VectorShiftByVector:
         case VectorRelaxedSwizzle:
         case VectorUnzipEven:
         case VectorUnzipOdd:

--- a/Source/JavaScriptCore/b3/B3ValueInlines.h
+++ b/Source/JavaScriptCore/b3/B3ValueInlines.h
@@ -266,7 +266,6 @@ namespace JSC { namespace B3 {
     case VectorExtractPair: \
     case VectorRelaxedSwizzle: \
     case VectorMulByElement: \
-    case VectorShiftByVector: \
     case VectorRelaxedMAdd: \
     case VectorRelaxedNMAdd: \
     case VectorRelaxedLaneSelect: \

--- a/Source/JavaScriptCore/b3/B3ValueKey.cpp
+++ b/Source/JavaScriptCore/b3/B3ValueKey.cpp
@@ -198,7 +198,6 @@ Value* ValueKey::materialize(Procedure& proc, Origin origin) const
     case VectorShr:
     case VectorMulSat:
     case VectorAvgRound:
-    case VectorShiftByVector:
     case VectorUnzipEven:
     case VectorUnzipOdd:
     case VectorZipLower:

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -1998,10 +1998,13 @@ x86_64: VectorUshr8 U:F:128, U:F:128, D:F:128, S:F:128, S:F:128
 x86_64: VectorSshr8 U:F:128, U:F:128, D:F:128, S:F:128, S:F:128
     Tmp, Tmp, Tmp, Tmp, Tmp
 
-x86_64: VectorUshr8 U:G:Ptr, U:F:128, U:G:8, D:F:128
+64: VectorUshr8 U:G:Ptr, U:F:128, U:G:8, D:F:128
     SIMDInfo, Tmp, Imm, Tmp
 
 64: VectorSshr8 U:G:Ptr, U:F:128, U:G:8, D:F:128
+    SIMDInfo, Tmp, Imm, Tmp
+
+arm64: VectorShl8 U:G:Ptr, U:F:128, U:G:8, D:F:128
     SIMDInfo, Tmp, Imm, Tmp
 
 arm64: VectorHorizontalAdd U:G:Ptr, U:F:128, D:F:128

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1514,7 +1514,11 @@ void testVectorTransposeOdd();
 void testVectorReverse();
 
 // SIMD strength reduction: shift-by-1 → add
-void testVectorShiftByVectorShlByOne();
+void testVectorShlByOne();
+
+// SIMD vector shift by immediate
+void testVectorShlImmediate();
+void testVectorShrImmediate();
 
 // SIMD shuffle → canonical instruction strength reduction
 void testVectorSwizzleToUnzipEven();

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1150,7 +1150,9 @@ void run(const TestConfig* config)
             RUN(testVectorTransposeEven());
             RUN(testVectorTransposeOdd());
             RUN(testVectorReverse());
-            RUN(testVectorShiftByVectorShlByOne());
+            RUN(testVectorShlByOne());
+            RUN(testVectorShlImmediate());
+            RUN(testVectorShrImmediate());
             RUN(testVectorSwizzleToUnzipEven());
             RUN(testVectorSwizzleBinaryToUnzipOdd());
             RUN(testVectorSwizzleBinaryCanonical());

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -3162,7 +3162,7 @@ void testTruncSShrAddUnalignedConstant()
 }
 
 // Test XOR-and-rotate-right pattern matching for XAR instruction (SHA3).
-// Pattern: VectorOr(VectorShiftByVector(VectorXor(a, b), shlAmount), VectorShiftByVector(VectorXor(a, b), shrAmount))
+// Pattern: VectorOr(VectorShl(VectorXor(a, b), shlConst), VectorShr(VectorXor(a, b), shrConst))
 // Should be folded into a single XAR instruction on ARM64 with SHA3 support.
 void testVectorXorRotateRight64()
 {
@@ -3399,8 +3399,8 @@ void testVectorReverse()
     CHECK(vectors[1].u32x4[3] == 0xCC);
 }
 
-// Test that VectorShiftByVector(x, splat(1)) is strength-reduced to VectorAdd(x, x).
-void testVectorShiftByVectorShlByOne()
+// Test that VectorShl(x, 1) is strength-reduced to VectorAdd(x, x).
+void testVectorShlByOne()
 {
     alignas(16) v128_t vectors[2];
     Procedure proc;
@@ -3409,8 +3409,7 @@ void testVectorShiftByVectorShlByOne()
     Value* address = arguments[0];
     Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
 
-    // Build VectorShl(input, 1) — will become VectorShiftByVector after LowerMacros,
-    // then VectorAdd(input, input) after ReduceStrength.
+    // Build VectorShl(input, 1) — will become VectorAdd(input, input) after ReduceStrength.
     Value* shiftAmount = root->appendNew<Const32Value>(proc, Origin(), 1);
     Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorShl, B3::V128, SIMDLane::i64x2, SIMDSignMode::Unsigned, input, shiftAmount);
 
@@ -3433,6 +3432,143 @@ void testVectorShiftByVectorShlByOne()
     CHECK(vectors[1].u64x2[1] == 2);
 }
 
+template<typename T>
+static void testVectorShlImmediateForLane(SIMDLane lane, unsigned shift, T inputVal)
+{
+    if constexpr (!isARM64())
+        return;
+
+    alignas(16) v128_t vectors[2];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* shiftAmount = root->appendNew<Const32Value>(proc, Origin(), shift);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorShl, B3::V128, lane, SIMDSignMode::Unsigned, input, shiftAmount);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    constexpr unsigned numLanes = sizeof(v128_t) / sizeof(T);
+    for (unsigned i = 0; i < numLanes; ++i)
+        reinterpret_cast<T*>(&vectors[0])[i] = inputVal;
+    invoke<void>(*code, vectors);
+
+    unsigned bitWidth = sizeof(T) * 8;
+    unsigned maskedShift = shift & (bitWidth - 1);
+    for (unsigned i = 0; i < numLanes; ++i) {
+        T expected = static_cast<T>(inputVal << maskedShift);
+        CHECK(reinterpret_cast<T*>(&vectors[1])[i] == expected);
+    }
+}
+
+void testVectorShlImmediate()
+{
+    if constexpr (!isARM64())
+        return;
+
+    // i8x16
+    testVectorShlImmediateForLane<uint8_t>(SIMDLane::i8x16, 1, static_cast<uint8_t>(0xAB));
+    testVectorShlImmediateForLane<uint8_t>(SIMDLane::i8x16, 4, static_cast<uint8_t>(0x0F));
+    testVectorShlImmediateForLane<uint8_t>(SIMDLane::i8x16, 7, static_cast<uint8_t>(0x01));
+
+    // i16x8
+    testVectorShlImmediateForLane<uint16_t>(SIMDLane::i16x8, 1, static_cast<uint16_t>(0xABCD));
+    testVectorShlImmediateForLane<uint16_t>(SIMDLane::i16x8, 8, static_cast<uint16_t>(0x00FF));
+    testVectorShlImmediateForLane<uint16_t>(SIMDLane::i16x8, 15, static_cast<uint16_t>(0x0001));
+
+    // i32x4
+    testVectorShlImmediateForLane<uint32_t>(SIMDLane::i32x4, 1, 0xDEADBEEFu);
+    testVectorShlImmediateForLane<uint32_t>(SIMDLane::i32x4, 16, 0x0000FFFFu);
+    testVectorShlImmediateForLane<uint32_t>(SIMDLane::i32x4, 31, 0x00000001u);
+
+    // i64x2
+    testVectorShlImmediateForLane<uint64_t>(SIMDLane::i64x2, 1, 0x0123456789ABCDEFull);
+    testVectorShlImmediateForLane<uint64_t>(SIMDLane::i64x2, 32, 0x00000000FFFFFFFFull);
+    testVectorShlImmediateForLane<uint64_t>(SIMDLane::i64x2, 63, 0x0000000000000001ull);
+}
+
+template<typename T, typename SignedT>
+static void testVectorShrImmediateForLane(SIMDLane lane, SIMDSignMode signMode, unsigned shift, T inputVal)
+{
+    if constexpr (!isARM64())
+        return;
+
+    alignas(16) v128_t vectors[2];
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    auto arguments = cCallArgumentValues<void*>(proc, root);
+    Value* address = arguments[0];
+    Value* input = root->appendNew<MemoryValue>(proc, Load, V128, Origin(), address);
+    Value* shiftAmount = root->appendNew<Const32Value>(proc, Origin(), shift);
+    Value* result = root->appendNew<SIMDValue>(proc, Origin(), VectorShr, B3::V128, lane, signMode, input, shiftAmount);
+    root->appendNew<MemoryValue>(proc, Store, Origin(), result, address, static_cast<int32_t>(sizeof(v128_t)));
+    root->appendNewControlValue(proc, Return, Origin());
+
+    auto code = compileProc(proc);
+
+    constexpr unsigned numLanes = sizeof(v128_t) / sizeof(T);
+    for (unsigned i = 0; i < numLanes; ++i)
+        reinterpret_cast<T*>(&vectors[0])[i] = inputVal;
+    invoke<void>(*code, vectors);
+
+    unsigned bitWidth = sizeof(T) * 8;
+    unsigned maskedShift = shift & (bitWidth - 1);
+    for (unsigned i = 0; i < numLanes; ++i) {
+        T expected;
+        if (signMode == SIMDSignMode::Signed)
+            expected = static_cast<T>(static_cast<SignedT>(inputVal) >> maskedShift);
+        else
+            expected = static_cast<T>(inputVal >> maskedShift);
+        CHECK(reinterpret_cast<T*>(&vectors[1])[i] == expected);
+    }
+}
+
+void testVectorShrImmediate()
+{
+    if constexpr (!isARM64())
+        return;
+
+    // i8x16 unsigned
+    testVectorShrImmediateForLane<uint8_t, int8_t>(SIMDLane::i8x16, SIMDSignMode::Unsigned, 1, static_cast<uint8_t>(0xAB));
+    testVectorShrImmediateForLane<uint8_t, int8_t>(SIMDLane::i8x16, SIMDSignMode::Unsigned, 4, static_cast<uint8_t>(0xFF));
+    testVectorShrImmediateForLane<uint8_t, int8_t>(SIMDLane::i8x16, SIMDSignMode::Unsigned, 7, static_cast<uint8_t>(0x80));
+
+    // i8x16 signed
+    testVectorShrImmediateForLane<uint8_t, int8_t>(SIMDLane::i8x16, SIMDSignMode::Signed, 1, static_cast<uint8_t>(0xAB));
+    testVectorShrImmediateForLane<uint8_t, int8_t>(SIMDLane::i8x16, SIMDSignMode::Signed, 4, static_cast<uint8_t>(0xFF));
+    testVectorShrImmediateForLane<uint8_t, int8_t>(SIMDLane::i8x16, SIMDSignMode::Signed, 7, static_cast<uint8_t>(0x80));
+
+    // i16x8 unsigned
+    testVectorShrImmediateForLane<uint16_t, int16_t>(SIMDLane::i16x8, SIMDSignMode::Unsigned, 1, static_cast<uint16_t>(0xABCD));
+    testVectorShrImmediateForLane<uint16_t, int16_t>(SIMDLane::i16x8, SIMDSignMode::Unsigned, 8, static_cast<uint16_t>(0xFF00));
+    testVectorShrImmediateForLane<uint16_t, int16_t>(SIMDLane::i16x8, SIMDSignMode::Unsigned, 15, static_cast<uint16_t>(0x8000));
+
+    // i16x8 signed
+    testVectorShrImmediateForLane<uint16_t, int16_t>(SIMDLane::i16x8, SIMDSignMode::Signed, 1, static_cast<uint16_t>(0xABCD));
+    testVectorShrImmediateForLane<uint16_t, int16_t>(SIMDLane::i16x8, SIMDSignMode::Signed, 8, static_cast<uint16_t>(0xFF00));
+
+    // i32x4 unsigned
+    testVectorShrImmediateForLane<uint32_t, int32_t>(SIMDLane::i32x4, SIMDSignMode::Unsigned, 1, 0xDEADBEEFu);
+    testVectorShrImmediateForLane<uint32_t, int32_t>(SIMDLane::i32x4, SIMDSignMode::Unsigned, 16, 0xFFFF0000u);
+    testVectorShrImmediateForLane<uint32_t, int32_t>(SIMDLane::i32x4, SIMDSignMode::Unsigned, 31, 0x80000000u);
+
+    // i32x4 signed
+    testVectorShrImmediateForLane<uint32_t, int32_t>(SIMDLane::i32x4, SIMDSignMode::Signed, 1, 0xDEADBEEFu);
+    testVectorShrImmediateForLane<uint32_t, int32_t>(SIMDLane::i32x4, SIMDSignMode::Signed, 16, 0xFFFF0000u);
+
+    // i64x2 unsigned
+    testVectorShrImmediateForLane<uint64_t, int64_t>(SIMDLane::i64x2, SIMDSignMode::Unsigned, 1, 0x0123456789ABCDEFull);
+    testVectorShrImmediateForLane<uint64_t, int64_t>(SIMDLane::i64x2, SIMDSignMode::Unsigned, 32, 0xFFFFFFFF00000000ull);
+    testVectorShrImmediateForLane<uint64_t, int64_t>(SIMDLane::i64x2, SIMDSignMode::Unsigned, 63, 0x8000000000000000ull);
+
+    // i64x2 signed
+    testVectorShrImmediateForLane<uint64_t, int64_t>(SIMDLane::i64x2, SIMDSignMode::Signed, 1, 0x8000000000000000ull);
+    testVectorShrImmediateForLane<uint64_t, int64_t>(SIMDLane::i64x2, SIMDSignMode::Signed, 32, 0xFFFFFFFF00000000ull);
+    testVectorShrImmediateForLane<uint64_t, int64_t>(SIMDLane::i64x2, SIMDSignMode::Signed, 63, 0x8000000000000000ull);
+}
 // Helper: build a 3-child (binary) VectorSwizzle with the given byte pattern, verify result.
 static void testBinarySwizzlePattern(const char*, const uint8_t pattern[16], v128_t inputA, v128_t inputB, v128_t expected)
 {

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -3526,17 +3526,29 @@ void NODELETE BBQJIT::notifyFunctionUsesSIMD()
     LOG_INSTRUCTION("Vector", op, src, srcLocation, shift, shiftLocation, RESULT(result));
 
 #if CPU(ARM64)
-    m_jit.and32(Imm32(mask), shiftLocation.asGPR(), wasmScratchGPR);
-    if (op == SIMDLaneOperation::Shr) {
-        // ARM64 doesn't have a version of this instruction for right shift. Instead, if the input to
-        // left shift is negative, it's a right shift by the absolute value of that amount.
-        m_jit.neg32(wasmScratchGPR);
+    if (shift.isConst()) {
+        int32_t shiftImm = shift.asI32() & mask;
+        if (!shiftImm)
+            m_jit.moveVector(srcLocation.asFPR(), resultLocation.asFPR());
+        else if (op == SIMDLaneOperation::Shl)
+            m_jit.vectorShl8(info, srcLocation.asFPR(), TrustedImm32(shiftImm), resultLocation.asFPR());
+        else if (info.signMode == SIMDSignMode::Signed)
+            m_jit.vectorSshr8(info, srcLocation.asFPR(), TrustedImm32(shiftImm), resultLocation.asFPR());
+        else
+            m_jit.vectorUshr8(info, srcLocation.asFPR(), TrustedImm32(shiftImm), resultLocation.asFPR());
+    } else {
+        m_jit.and32(Imm32(mask), shiftLocation.asGPR(), wasmScratchGPR);
+        if (op == SIMDLaneOperation::Shr) {
+            // ARM64 doesn't have a version of this instruction for right shift. Instead, if the input to
+            // left shift is negative, it's a right shift by the absolute value of that amount.
+            m_jit.neg32(wasmScratchGPR);
+        }
+        m_jit.vectorSplatInt8(wasmScratchGPR, wasmScratchFPR);
+        if (info.signMode == SIMDSignMode::Signed)
+            m_jit.vectorSshl(info, srcLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
+        else
+            m_jit.vectorUshl(info, srcLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
     }
-    m_jit.vectorSplatInt8(wasmScratchGPR, wasmScratchFPR);
-    if (info.signMode == SIMDSignMode::Signed)
-        m_jit.vectorSshl(info, srcLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
-    else
-        m_jit.vectorUshl(info, srcLocation.asFPR(), wasmScratchFPR, resultLocation.asFPR());
 #else
     ASSERT(isX86());
     m_jit.move(shiftLocation.asGPR(), wasmScratchGPR);


### PR DESCRIPTION
#### b349f3567217decce737ccd416e9845a6963cc92
<pre>
[JSC] Use simple ARM64 shl, ushr, sshr
<a href="https://bugs.webkit.org/show_bug.cgi?id=309964">https://bugs.webkit.org/show_bug.cgi?id=309964</a>
<a href="https://rdar.apple.com/172571493">rdar://172571493</a>

Reviewed by Keith Miller.

ARM64 has shl, ushr, sshr with immediate for SIMD. So we do not need to
support Vector shift operation in a complicated way. We add these
instructions support as vectorUshr8, vectorSshr8, vectorShl8, aligned to
x64. And use them in B3 and BBQJIT.

Thus we no longer need VectorShiftByVector, so drop it.

Tests: JSTests/wasm/stress/simd-shift-immediate.js
       Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_7.cpp

* JSTests/wasm/stress/simd-shift-immediate.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.async testI8x16):
(async testI16x8):
(async testI32x4):
(async testI64x2):
(async test):
* Source/JavaScriptCore/assembler/ARM64Assembler.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::vectorUshr8):
(JSC::MacroAssemblerARM64::vectorShl8):
* Source/JavaScriptCore/b3/B3LowerMacros.cpp:
* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3Opcode.h:
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:
* Source/JavaScriptCore/b3/B3SIMDValue.h:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/b3/B3Value.cpp:
(JSC::B3::Value::effects const):
(JSC::B3::Value::key const):
* Source/JavaScriptCore/b3/B3Value.h:
* Source/JavaScriptCore/b3/B3ValueInlines.h:
* Source/JavaScriptCore/b3/B3ValueKey.cpp:
(JSC::B3::ValueKey::materialize const):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(testVectorShlByOne):
(testVectorShlImmediateForLane):
(testVectorShlImmediate):
(testVectorShrImmediateForLane):
(testVectorShrImmediate):
(testVectorShiftByVectorShlByOne): Deleted.
* Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addSIMDShift):

Canonical link: <a href="https://commits.webkit.org/309289@main">https://commits.webkit.org/309289@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5afc4c5f6d63ca34e972af42f08a284987fb9cee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150149 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158861 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103583 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2374f616-0984-4add-99e2-64a5280653cc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23014 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115833 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82287 "4 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e9a8314-a144-4e24-a01d-559fe591319a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134708 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96564 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aac9a6d8-193e-46a1-8766-5a600889d6ca) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17048 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14996 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6706 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142132 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161334 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/10947 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4425 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123837 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124038 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22696 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134427 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/78966 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23090 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19165 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11184 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181580 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22309 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86109 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46476 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22023 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22175 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22077 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->