### PR TITLE
<general-enclosed> in media queries should reject content with unmatched close brackets per <any-value> grammar

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-none-expected.txt
@@ -68,7 +68,7 @@ PASS <img srcset="/images/green-1x1.png?e59 50w, /images/green-16x16.png?e59 51w
 PASS <img srcset="/images/green-1x1.png?e60 50w, /images/green-16x16.png?e60 51w" sizes="(min-width:0) or (min-width:-1px) 1px"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e61 50w, /images/green-16x16.png?e61 51w" sizes="(min-width:0) or (unknown &quot;general-enclosed&quot;) 1px"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e62 50w, /images/green-16x16.png?e62 51w" sizes="(min-width:0) or unknown-general-enclosed(foo) 1px"> ref sizes="1px" (display:none)
-FAIL <img srcset="/images/green-1x1.png?e63 50w, /images/green-16x16.png?e63 51w" sizes="(min-width:0) or (]) 100vw, 1px"> ref sizes="1px" (display:none) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e63 50w, /images/green-16x16.png?e63 51w" sizes="(min-width:0) or (]) 100vw, 1px"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e64 50w, /images/green-16x16.png?e64 51w" sizes="(min-width:0) or unknown-media-type 100vw, 1px"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e65 50w, /images/green-16x16.png?e65 51w" sizes="(123) 100vw, 1px"> ref sizes="1px" (display:none)
 PASS <img srcset="/images/green-1x1.png?e66 50w, /images/green-16x16.png?e66 51w" sizes="not (123) 100vw, 1px"> ref sizes="1px" (display:none)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode-expected.txt
@@ -68,7 +68,7 @@ PASS <img srcset="/images/green-1x1.png?e59 50w, /images/green-16x16.png?e59 51w
 PASS <img srcset="/images/green-1x1.png?e60 50w, /images/green-16x16.png?e60 51w" sizes="(min-width:0) or (min-width:-1px) 1px"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e61 50w, /images/green-16x16.png?e61 51w" sizes="(min-width:0) or (unknown &quot;general-enclosed&quot;) 1px"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e62 50w, /images/green-16x16.png?e62 51w" sizes="(min-width:0) or unknown-general-enclosed(foo) 1px"> ref sizes="1px" (quirks mode)
-FAIL <img srcset="/images/green-1x1.png?e63 50w, /images/green-16x16.png?e63 51w" sizes="(min-width:0) or (]) 100vw, 1px"> ref sizes="1px" (quirks mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e63 50w, /images/green-16x16.png?e63 51w" sizes="(min-width:0) or (]) 100vw, 1px"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e64 50w, /images/green-16x16.png?e64 51w" sizes="(min-width:0) or unknown-media-type 100vw, 1px"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e65 50w, /images/green-16x16.png?e65 51w" sizes="(123) 100vw, 1px"> ref sizes="1px" (quirks mode)
 PASS <img srcset="/images/green-1x1.png?e66 50w, /images/green-16x16.png?e66 51w" sizes="not (123) 100vw, 1px"> ref sizes="1px" (quirks mode)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode-expected.txt
@@ -68,7 +68,7 @@ PASS <img srcset="/images/green-1x1.png?e59 50w, /images/green-16x16.png?e59 51w
 PASS <img srcset="/images/green-1x1.png?e60 50w, /images/green-16x16.png?e60 51w" sizes="(min-width:0) or (min-width:-1px) 1px"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e61 50w, /images/green-16x16.png?e61 51w" sizes="(min-width:0) or (unknown &quot;general-enclosed&quot;) 1px"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e62 50w, /images/green-16x16.png?e62 51w" sizes="(min-width:0) or unknown-general-enclosed(foo) 1px"> ref sizes="1px" (standards mode)
-FAIL <img srcset="/images/green-1x1.png?e63 50w, /images/green-16x16.png?e63 51w" sizes="(min-width:0) or (]) 100vw, 1px"> ref sizes="1px" (standards mode) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e63 50w, /images/green-16x16.png?e63 51w" sizes="(min-width:0) or (]) 100vw, 1px"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e64 50w, /images/green-16x16.png?e64 51w" sizes="(min-width:0) or unknown-media-type 100vw, 1px"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e65 50w, /images/green-16x16.png?e65 51w" sizes="(123) 100vw, 1px"> ref sizes="1px" (standards mode)
 PASS <img srcset="/images/green-1x1.png?e66 50w, /images/green-16x16.png?e66 51w" sizes="not (123) 100vw, 1px"> ref sizes="1px" (standards mode)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000px-expected.txt
@@ -68,7 +68,7 @@ PASS <img srcset="/images/green-1x1.png?e59 50w, /images/green-16x16.png?e59 51w
 PASS <img srcset="/images/green-1x1.png?e60 50w, /images/green-16x16.png?e60 51w" sizes="(min-width:0) or (min-width:-1px) 1px"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e61 50w, /images/green-16x16.png?e61 51w" sizes="(min-width:0) or (unknown &quot;general-enclosed&quot;) 1px"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e62 50w, /images/green-16x16.png?e62 51w" sizes="(min-width:0) or unknown-general-enclosed(foo) 1px"> ref sizes="1px" (width:1000px)
-FAIL <img srcset="/images/green-1x1.png?e63 50w, /images/green-16x16.png?e63 51w" sizes="(min-width:0) or (]) 100vw, 1px"> ref sizes="1px" (width:1000px) assert_equals: expected "http://web-platform.test:8800/images/green-1x1.png" but got "http://web-platform.test:8800/images/green-16x16.png"
+PASS <img srcset="/images/green-1x1.png?e63 50w, /images/green-16x16.png?e63 51w" sizes="(min-width:0) or (]) 100vw, 1px"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e64 50w, /images/green-16x16.png?e64 51w" sizes="(min-width:0) or unknown-media-type 100vw, 1px"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e65 50w, /images/green-16x16.png?e65 51w" sizes="(123) 100vw, 1px"> ref sizes="1px" (width:1000px)
 PASS <img srcset="/images/green-1x1.png?e66 50w, /images/green-16x16.png?e66 51w" sizes="not (123) 100vw, 1px"> ref sizes="1px" (width:1000px)

--- a/Source/WebCore/css/parser/CSSParserTokenRange.cpp
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.cpp
@@ -109,6 +109,29 @@ const CSSParserToken& CSSParserTokenRange::consumeLast() LIFETIME_BOUND
     return WTF::consumeLast(m_tokens);
 }
 
+bool CSSParserTokenRange::consumeAnyValue()
+{
+    // https://drafts.csswg.org/css-syntax-3/#typedef-any-value
+    // <any-value> must not contain bad tokens or unmatched close brackets.
+    while (!atEnd()) {
+        auto& token = consume();
+        switch (token.type()) {
+        case BadStringToken:
+        case BadUrlToken:
+            return false;
+        case RightParenthesisToken:
+        case RightBracketToken:
+        case RightBraceToken:
+            if (token.getBlockType() != CSSParserToken::BlockEnd)
+                return false;
+            break;
+        default:
+            break;
+        }
+    }
+    return true;
+}
+
 String CSSParserTokenRange::serialize(CSSParserToken::SerializationMode mode) const
 {
     StringBuilder builder;

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -90,6 +90,9 @@ public:
 
     void NODELETE consumeComponentValue();
 
+    // https://drafts.csswg.org/css-syntax-3/#typedef-any-value
+    bool consumeAnyValue();
+
     void consumeWhitespace()
     {
         size_t i = 0;

--- a/Source/WebCore/css/query/GenericMediaQueryParser.h
+++ b/Source/WebCore/css/query/GenericMediaQueryParser.h
@@ -127,6 +127,11 @@ std::optional<QueryInParens> GenericMediaQueryParser<ConcreteParser>::consumeQue
             auto name = range.peek().value();
             auto functionRange = range.consumeBlock();
             range.consumeWhitespace();
+
+            auto validationRange = functionRange;
+            if (!validationRange.consumeAnyValue())
+                return { };
+
             return GeneralEnclosed { name.toString(), functionRange.serialize() };
         }
     }
@@ -153,6 +158,10 @@ std::optional<QueryInParens> GenericMediaQueryParser<ConcreteParser>::consumeQue
         feature->functionId = functionId;
         return { *feature };
     }
+
+    auto validationRange = originalBlockRange;
+    if (!validationRange.consumeAnyValue())
+        return { };
 
     return GeneralEnclosed { functionId ? nameString(*functionId) : nullAtom(), originalBlockRange.serialize() };
 }


### PR DESCRIPTION
#### 21df09b4a6b86cdd61f7b1e2269b874b3bf918b1
<pre>
&lt;general-enclosed&gt; in media queries should reject content with unmatched close brackets per &lt;any-value&gt; grammar
<a href="https://bugs.webkit.org/show_bug.cgi?id=309966">https://bugs.webkit.org/show_bug.cgi?id=309966</a>
<a href="https://rdar.apple.com/172575115">rdar://172575115</a>

Reviewed by Antti Koivisto.

The CSS spec defines [1] &lt;general-enclosed&gt; as ( &lt;any-value&gt;? ), where &lt;any-value&gt;
explicitly forbids [2] bad tokens and unmatched close brackets (], ), }).
WebKit&apos;s media query parser was accepting any parenthesized content as
&lt;general-enclosed&gt; without validating this constraint.

This caused `(min-width:0) or (])` to incorrectly match: (]) was accepted as
GeneralEnclosed (evaluating to Unknown), and Kleene logic gives True or Unknown = True.
Per spec, (]) should fail to parse as &lt;general-enclosed&gt;, causing the entire or-condition
to fail.

[1] <a href="https://drafts.csswg.org/mediaqueries-4/#typedef-general-enclosed">https://drafts.csswg.org/mediaqueries-4/#typedef-general-enclosed</a>
[2] <a href="https://drafts.csswg.org/css-syntax-3/#typedef-any-value">https://drafts.csswg.org/css-syntax-3/#typedef-any-value</a>

* Source/WebCore/css/parser/CSSParserTokenRange.h:
* Source/WebCore/css/parser/CSSParserTokenRange.cpp:
(WebCore::CSSParserTokenRange::consumeAnyValue):
Added consumeAnyValue() which validates the &lt;any-value&gt; grammar by rejecting
bad tokens (BadStringToken, BadUrlToken) and unmatched close brackets
(RightParenthesisToken, RightBracketToken, RightBraceToken with non-BlockEnd type).

* Source/WebCore/css/query/GenericMediaQueryParser.h:
(WebCore::MQ::GenericMediaQueryParser&lt;ConcreteParser&gt;::consumeQueryInParens):
Use consumeAnyValue() to validate block content before creating GeneralEnclosed,
for both the function-token and parenthesized-block paths.

&gt; Progressions:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-display-non
e-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-quirks-mode
-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-m
ode-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-width-1000p
x-expected.txt:

Canonical link: <a href="https://commits.webkit.org/309497@main">https://commits.webkit.org/309497@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d150edb86d41179a69479c2d04c8a6c228e08e7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159070 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103782 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1846a84c-6192-48e3-9860-645480a0aef9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23240 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116017 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82435 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce181a29-2d49-4d27-a485-d5cea4585e4a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153308 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96740 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84e5b320-5375-4ae0-8939-d3e4c004b32f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17218 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15157 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6917 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12798 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161537 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4664 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124008 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19204 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124207 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33824 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134593 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79275 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19331 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11462 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22509 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86308 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22222 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22374 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22276 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->