### PR TITLE
[Cocoa] Remote Layer Hosting should bypass the WebContent process

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7221,6 +7221,22 @@ RegExpBufferBoundariesEnabled:
     WebKit:
       default: false
 
+RemoteLayerHostingBypassesWebContentProcess:
+  type: bool
+  status: unstable
+  category: media
+  humanReadableName: "GPU Process: Remote Layer Hosting Bypasses WebContent Process"
+  humanReadableDescription: "Host the GPU process video layer directly in the UI process, bypassing the WebContent process"
+  condition: ENABLE(GPU_PROCESS) && PLATFORM(COCOA)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  sharedPreferenceForWebProcess: true
+
 RemoteMediaSessionManagerEnabled:
   type: bool
   status: unstable

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2712,6 +2712,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/TypedArrayPixelBuffer.h
     platform/graphics/VP9Utilities.h
     platform/graphics/VelocityData.h
+    platform/graphics/VideoLayerContext.h
     platform/graphics/VideoLayerManager.h
     platform/graphics/VideoPlaybackQualityMetrics.h
     platform/graphics/VideoTarget.h

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -6895,6 +6895,7 @@
 		E3B2F0F01D7F4CB500B0C9D1 /* LoadableClassicScript.h in Headers */ = {isa = PBXBuildFile; fileRef = E3B2F0E41D7F35EC00B0C9D1 /* LoadableClassicScript.h */; };
 		E3BBC24723835526006EC39F /* CSSValueKey.h in Headers */ = {isa = PBXBuildFile; fileRef = E3BBC2452383551A006EC39F /* CSSValueKey.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3BFBA6C2E036BE600A38E4F /* HostingContext.h in Headers */ = {isa = PBXBuildFile; fileRef = E3BFBA6B2E036BE600A38E4F /* HostingContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		CD9A10022F70000200AA0002 /* VideoLayerContext.h in Headers */ = {isa = PBXBuildFile; fileRef = CD9A10012F70000100AA0001 /* VideoLayerContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3C0412F254CA29B0021D0E6 /* SystemSoundManager.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C0412D254CA29B0021D0E6 /* SystemSoundManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3C04138254CB30D0021D0E6 /* SystemSoundDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C04131254CA6660021D0E6 /* SystemSoundDelegate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E3C788EE2D035C9500D6C13D /* LogClient.h in Headers */ = {isa = PBXBuildFile; fileRef = E3C788ED2D035C9500D6C13D /* LogClient.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -22798,6 +22799,7 @@
 		E3BF19E622AF302A009C9926 /* HashChangeEvent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = HashChangeEvent.cpp; sourceTree = "<group>"; };
 		E3BF19E722AF309F009C9926 /* SecurityPolicyViolationEvent.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SecurityPolicyViolationEvent.cpp; sourceTree = "<group>"; };
 		E3BFBA6B2E036BE600A38E4F /* HostingContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HostingContext.h; sourceTree = "<group>"; };
+		CD9A10012F70000100AA0001 /* VideoLayerContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VideoLayerContext.h; sourceTree = "<group>"; };
 		E3C0412D254CA29B0021D0E6 /* SystemSoundManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemSoundManager.h; sourceTree = "<group>"; };
 		E3C04131254CA6660021D0E6 /* SystemSoundDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SystemSoundDelegate.h; sourceTree = "<group>"; };
 		E3C04132254CA7110021D0E6 /* SystemSoundManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SystemSoundManager.cpp; sourceTree = "<group>"; };
@@ -37163,6 +37165,7 @@
 				E4AFCFA40DAF29A300F5F55C /* UnitBezier.h */,
 				0F5A57CA229B18AE0025EDA9 /* VelocityData.cpp */,
 				0F1A0C36229A481800D37ADB /* VelocityData.h */,
+				CD9A10012F70000100AA0001 /* VideoLayerContext.h */,
 				1DAB3113251D725C00FC9485 /* VideoLayerManager.h */,
 				075033A6252BD36800F70CE3 /* VideoPlaybackQualityMetrics.h */,
 				CDAD8DF42BED37E600107D24 /* VideoTarget.h */,
@@ -49925,6 +49928,7 @@
 				41DEEFB02719B29000CB8D74 /* VideoFrameRequestCallback.h in Headers */,
 				416049332743B0E800A86FA0 /* VideoFrameTimeMetadata.h in Headers */,
 				E300511729DB9A1300E1C3A4 /* VideoFullscreenCaptions.h in Headers */,
+				CD9A10022F70000200AA0002 /* VideoLayerContext.h in Headers */,
 				1DAB3114251D725C00FC9485 /* VideoLayerManager.h in Headers */,
 				1DAB3115251D74DB00FC9485 /* VideoLayerManagerObjC.h in Headers */,
 				41DD3C2D2902C47700369BEF /* VideoMatrixCoefficients.h in Headers */,

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -75,6 +75,10 @@
 #include "PictureInPictureObserver.h"
 #endif
 
+#if USE(COORDINATED_GRAPHICS)
+#include "CoordinatedPlatformLayerBufferProxy.h"
+#endif
+
 #if RELEASE_LOG_DISABLED
 #define HTMLVIDEOELEMENT_RELEASE_LOG(formatString, ...)
 #else
@@ -313,6 +317,22 @@ unsigned HTMLVideoElement::videoHeight() const
     if (!player())
         return 0;
     return clampToUnsigned(protect(player())->naturalSize().height());
+}
+
+VideoLayerContext HTMLVideoElement::videoLayerContext()
+{
+    bool hostedByUIProcess = false;
+#if ENABLE(GPU_PROCESS) && PLATFORM(COCOA)
+    hostedByUIProcess = document().settings().remoteLayerHostingBypassesWebContentProcess();
+#endif
+
+    return VideoLayerContext {
+        .hostingContext = layerHostingContext(),
+        .mediaElementIdentifier = identifier(),
+        .videoLayerSize = videoLayerSize(),
+        .naturalSize = HTMLMediaElement::naturalSize(),
+        .hostedByUIProcess = hostedByUIProcess,
+    };
 }
 
 void HTMLVideoElement::scheduleResizeEvent(const FloatSize& naturalSize)

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -31,6 +31,7 @@
 #include <WebCore/HTMLMediaElement.h>
 #include <WebCore/Supplementable.h>
 #include <WebCore/VideoFrameRequestCallback.h>
+#include <WebCore/VideoLayerContext.h>
 #include <memory>
 #include <wtf/Forward.h>
 
@@ -57,6 +58,8 @@ public:
 
     WEBCORE_EXPORT unsigned videoWidth() const;
     WEBCORE_EXPORT unsigned videoHeight() const;
+
+    WEBCORE_EXPORT VideoLayerContext videoLayerContext();
 
     WEBCORE_EXPORT ExceptionOr<void> webkitEnterFullscreen();
     WEBCORE_EXPORT void webkitExitFullscreen();

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.h
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.h
@@ -51,6 +51,7 @@ WEBCORE_EXPORT @interface WebAVPlayerLayer : CALayer
 @property (nonatomic, copy, nullable) NSDictionary *pixelBufferAttributes;
 @property CGSize videoDimensions;
 @property (nonatomic) NSEdgeInsets legibleContentInsets;
+@property (nonatomic) BOOL previewsResizeWithTransform;
 @property (nonatomic, readonly) BOOL showingCaptionPreview;
 - (WebCore::FloatRect)calculateTargetVideoFrame;
 

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -83,6 +83,7 @@ private:
     std::unique_ptr<WebCore::WebAVPlayerLayerPresentationModelClient> _presentationModelClient;
     NSEdgeInsets _legibleContentInsets;
     BOOL _showingCaptionPreview;
+    BOOL _previewsResizeWithTransform;
 #if !RELEASE_LOG_DISABLED
     uint64_t _logIdentifier;
 #endif
@@ -99,6 +100,7 @@ private:
         self.name = @"WebAVPlayerLayer";
         _presentationModelClient = WTF::makeUnique<WebCore::WebAVPlayerLayerPresentationModelClient>(self);
         _showingCaptionPreview = NO;
+        _previewsResizeWithTransform = YES;
     }
     return self;
 }
@@ -249,6 +251,11 @@ static bool NODELETE areFramesEssentiallyEqualWithTolerance(const WebCore::Float
         [_captionsLayer setFrame:captionsFrame];
         if (auto model = _presentationModel.get())
             model->setTextTrackRepresentationBounds(enclosingIntRect(captionsFrame));
+    }
+
+    if (!_previewsResizeWithTransform) {
+        [self resolveBounds];
+        return;
     }
 
     float videoAspectRatio = self.videoDimensions.width / self.videoDimensions.height;

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -77,6 +77,7 @@ class GraphicsLayerContentsDisplayDelegate;
 class GraphicsLayerFactory;
 class GraphicsLayerKeyframeValueList;
 class HTMLVideoElement;
+struct VideoLayerContext;
 class Image;
 class ImageBuffer;
 class Model;
@@ -406,7 +407,7 @@ public:
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE) || ENABLE(SPATIAL_PORTAL)
     virtual void removeModelContents() { }
 #endif
-    virtual void setContentsToVideoElement(HTMLVideoElement&, ContentsLayerPurpose) { }
+    virtual void setContentsToVideoLayer(const VideoLayerContext&, HTMLVideoElement&, ContentsLayerPurpose) { }
     virtual void setContentsDisplayDelegate(RefPtr<GraphicsLayerContentsDisplayDelegate>&&, ContentsLayerPurpose);
     WEBCORE_EXPORT virtual RefPtr<GraphicsLayerAsyncContentsDisplayDelegate> createAsyncContentsDisplayDelegate(GraphicsLayerAsyncContentsDisplayDelegate* existing);
 #if ENABLE(MODEL_ELEMENT)

--- a/Source/WebCore/platform/graphics/VideoLayerContext.h
+++ b/Source/WebCore/platform/graphics/VideoLayerContext.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/FloatSize.h>
+#include <WebCore/HostingContext.h>
+#include <WebCore/MediaPlayerClientIdentifier.h>
+
+namespace WebCore {
+
+// Note that this deliberately does not carry the video element's platform layer.
+// HTMLMediaElement::platformLayer() is not a cheap getter: for a remote renderer it takes a
+// lock and lazily creates the layer. It must stay lazily evaluated at the point of use, so
+// that building one of these for a layer that is going to be hosted by context ID does not
+// create a video layer in this process as a side effect.
+struct VideoLayerContext {
+    HostingContext hostingContext;
+    MediaPlayerClientIdentifier mediaElementIdentifier;
+    FloatSize videoLayerSize;
+    FloatSize naturalSize;
+
+    bool hostedByUIProcess { false };
+
+    bool hasHostingContext() const { return hostingContext.contextID || hostedByUIProcess; }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -61,6 +61,7 @@
 #include "TransformOperationsSharedPrimitivesPrefix.h"
 #include "TransformState.h"
 #include "TranslateTransformOperation.h"
+#include "VideoLayerContext.h"
 #include <QuartzCore/CATransform3D.h>
 #include <limits.h>
 #include <pal/spi/cf/CFUtilitiesSPI.h>
@@ -380,7 +381,7 @@ Ref<PlatformCALayer> GraphicsLayerCA::createPlatformCALayerHost(LayerHostingCont
     return GraphicsLayerCA::createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, owner);
 }
 
-Ref<PlatformCALayer> GraphicsLayerCA::createPlatformVideoLayer(HTMLVideoElement&, PlatformCALayerClient* owner)
+Ref<PlatformCALayer> GraphicsLayerCA::createPlatformVideoLayer(const VideoLayerContext&, HTMLVideoElement&, PlatformCALayerClient* owner)
 {
     // By default, just make a plain layer; subclasses can override to provide a custom PlatformCALayer for hosting context id.
     return GraphicsLayerCA::createPlatformCALayer(PlatformCALayer::LayerType::LayerTypeLayer, owner);
@@ -1497,17 +1498,18 @@ void GraphicsLayerCA::removeModelContents()
 }
 #endif
 
-void GraphicsLayerCA::setContentsToVideoElement(HTMLVideoElement& videoElement, ContentsLayerPurpose purpose)
+void GraphicsLayerCA::setContentsToVideoLayer(const VideoLayerContext& videoLayerContext, HTMLVideoElement& videoElement, ContentsLayerPurpose purpose)
 {
 #if HAVE(AVKIT)
-    if (auto hostingContextID = videoElement.layerHostingContext().contextID) {
+    auto hostingContextID = videoLayerContext.hostingContext.contextID;
+    if (videoLayerContext.hasHostingContext()) {
         if (m_contentsLayer && !m_contentsDisplayDelegate
             && m_layerHostingContextID == hostingContextID
             && m_contentsLayerPurpose == purpose) {
                 return;
         }
 
-        m_contentsLayer = createPlatformVideoLayer(videoElement, this);
+        m_contentsLayer = createPlatformVideoLayer(videoLayerContext, videoElement, this);
         m_layerHostingContextID = hostingContextID;
         m_contentsLayerPurpose = purpose;
         m_contentsDisplayDelegate = nullptr;
@@ -1516,7 +1518,13 @@ void GraphicsLayerCA::setContentsToVideoElement(HTMLVideoElement& videoElement, 
         noteLayerPropertyChanged(ContentsPlatformLayerChanged);
         return;
     }
+#else
+    UNUSED_PARAM(videoLayerContext);
 #endif
+    // Reached when the layer is not hosted from another process, so the element's own platform
+    // layer is the contents. This is fetched here rather than carried in the VideoLayerContext
+    // because it lazily creates the layer for a remote renderer, which must not happen on the
+    // hosted path above.
     SUPPRESS_FORWARD_DECL_ARG setContentsToPlatformLayer(videoElement.platformLayer(), purpose);
 }
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -55,6 +55,7 @@ class HTMLVideoElement;
 class Image;
 class NativeImage;
 class TransformState;
+struct VideoLayerContext;
 
 #if ENABLE(MODEL_CONTEXT)
 class ModelContext;
@@ -182,7 +183,7 @@ public:
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE) || ENABLE(SPATIAL_PORTAL)
     WEBCORE_EXPORT void removeModelContents() override;
 #endif
-    WEBCORE_EXPORT void setContentsToVideoElement(HTMLVideoElement&, ContentsLayerPurpose) override;
+    WEBCORE_EXPORT void setContentsToVideoLayer(const VideoLayerContext&, HTMLVideoElement&, ContentsLayerPurpose) override;
     WEBCORE_EXPORT void setContentsDisplayDelegate(RefPtr<GraphicsLayerContentsDisplayDelegate>&&, ContentsLayerPurpose) override;
     WEBCORE_EXPORT PlatformLayerIdentifier setContentsToAsyncDisplayDelegate(RefPtr<GraphicsLayerContentsDisplayDelegate>, ContentsLayerPurpose);
 
@@ -328,7 +329,7 @@ private:
     virtual Ref<PlatformCALayer> createPlatformCALayer(Ref<WebCore::Model>, PlatformCALayerClient* owner);
 #endif
     virtual Ref<PlatformCALayer> createPlatformCALayerHost(LayerHostingContextIdentifier, PlatformCALayerClient*);
-    WEBCORE_EXPORT virtual Ref<PlatformCALayer> createPlatformVideoLayer(HTMLVideoElement&, PlatformCALayerClient* owner);
+    WEBCORE_EXPORT virtual Ref<PlatformCALayer> createPlatformVideoLayer(const VideoLayerContext&, HTMLVideoElement&, PlatformCALayerClient* owner);
     virtual Ref<PlatformCAAnimation> createPlatformCAAnimation(PlatformCAAnimation::AnimationType, const String& keyPath);
 
     virtual void setLayerContentsToImageBuffer(PlatformCALayer&, ImageBuffer*) { }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1355,7 +1355,7 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
             && videoElement->document().page()->chrome().client().isUsingUISideCompositing()
 #endif
             )
-            m_graphicsLayer->setContentsToVideoElement(videoElement, GraphicsLayer::ContentsLayerPurpose::Media);
+            m_graphicsLayer->setContentsToVideoLayer(videoElement->videoLayerContext(), videoElement, GraphicsLayer::ContentsLayerPurpose::Media);
         else
             m_graphicsLayer->setContentsToPlatformLayer(videoElement->platformLayer(), GraphicsLayer::ContentsLayerPurpose::Media);
         updateContentsRects();

--- a/Source/WebKit/DerivedSources-input.xcfilelist
+++ b/Source/WebKit/DerivedSources-input.xcfilelist
@@ -54,6 +54,7 @@ $(PROJECT_DIR)/GPUProcess/RemoteSharedResourceCache.messages.in
 $(PROJECT_DIR)/GPUProcess/ShapeDetection/RemoteBarcodeDetector.messages.in
 $(PROJECT_DIR)/GPUProcess/ShapeDetection/RemoteFaceDetector.messages.in
 $(PROJECT_DIR)/GPUProcess/ShapeDetection/RemoteTextDetector.messages.in
+$(PROJECT_DIR)/GPUProcess/cocoa/RemoteLayerHostingManager.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/Model/RemoteMesh.messages.in
 $(PROJECT_DIR)/GPUProcess/graphics/PathSegment.serialization.in
 $(PROJECT_DIR)/GPUProcess/graphics/RemoteGraphicsContext.messages.in
@@ -564,6 +565,7 @@ $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiScript.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiSession.json
 $(PROJECT_DIR)/UIProcess/Automation/protocol/BidiStorage.json
 $(PROJECT_DIR)/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
+$(PROJECT_DIR)/UIProcess/Cocoa/RemoteLayerHostingManagerProxy.messages.in
 $(PROJECT_DIR)/UIProcess/Cocoa/VideoPresentationManagerProxy.messages.in
 $(PROJECT_DIR)/UIProcess/Downloads/DownloadProxy.messages.in
 $(PROJECT_DIR)/UIProcess/DrawingAreaProxy.messages.in

--- a/Source/WebKit/DerivedSources-output.xcfilelist
+++ b/Source/WebKit/DerivedSources-output.xcfilelist
@@ -233,6 +233,10 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPC/RemoteImageDecoderAVFMessageRece
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPC/RemoteImageDecoderAVFMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPC/RemoteImageDecoderAVFProxyMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPC/RemoteImageDecoderAVFProxyMessages.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPC/RemoteLayerHostingManagerMessageReceiver.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPC/RemoteLayerHostingManagerMessages.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPC/RemoteLayerHostingManagerProxyMessageReceiver.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPC/RemoteLayerHostingManagerProxyMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPC/RemoteLayerTreeDrawingAreaProxyMessageReceiver.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPC/RemoteLayerTreeDrawingAreaProxyMessages.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebKit/IPC/RemoteLegacyCDMFactoryProxyMessageReceiver.cpp

--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -183,6 +183,7 @@ MESSAGE_RECEIVERS = \
 	UIProcess/WebLockRegistryProxy \
 	UIProcess/WebPermissionControllerProxy \
 	UIProcess/Cocoa/PlaybackSessionManagerProxy \
+	UIProcess/Cocoa/RemoteLayerHostingManagerProxy \
 	UIProcess/Cocoa/VideoPresentationManagerProxy \
 	UIProcess/ViewGestureController \
 	UIProcess/WebProcessProxy \
@@ -282,6 +283,7 @@ MESSAGE_RECEIVERS = \
 	GPUProcess/ShapeDetection/RemoteBarcodeDetector \
 	GPUProcess/ShapeDetection/RemoteFaceDetector \
 	GPUProcess/ShapeDetection/RemoteTextDetector \
+	GPUProcess/cocoa/RemoteLayerHostingManager \
 	GPUProcess/graphics/Model/RemoteMesh \
 	GPUProcess/graphics/RemoteGraphicsContext \
 	GPUProcess/graphics/RemoteGraphicsContextGL \

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -132,6 +132,10 @@
 #include "RemoteImageDecoderAVFProxyMessages.h"
 #endif
 
+#if PLATFORM(COCOA)
+#include "RemoteLayerHostingManager.h"
+#endif
+
 #if ENABLE(GPU_PROCESS)
 #include "RemoteMediaEngineConfigurationFactoryProxy.h"
 #include "RemoteMediaEngineConfigurationFactoryProxyMessages.h"
@@ -395,6 +399,10 @@ GPUConnectionToWebProcess::~GPUConnectionToWebProcess()
     RELEASE_ASSERT(RunLoop::isMain());
 
     m_connection->invalidate();
+
+#if PLATFORM(COCOA)
+    protect(m_gpuProcess)->remoteLayerHostingManager().removeAllRemoteLayersForProcess(m_webProcessIdentifier);
+#endif
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     m_sampleBufferDisplayLayerManager->close();

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -68,6 +68,10 @@
 #include "RemoteAudioSessionProxyManager.h"
 #endif
 
+#if PLATFORM(COCOA)
+#include "RemoteLayerHostingManager.h"
+#endif
+
 #if ENABLE(MEDIA_STREAM)
 #include <WebCore/MockRealtimeMediaSourceCenter.h>
 #endif
@@ -95,6 +99,9 @@ constexpr Seconds minimumLifetimeBeforeIdleExit { 5_s };
 
 GPUProcess::GPUProcess()
     : m_idleExitTimer(*this, &GPUProcess::tryExitIfUnused)
+#if PLATFORM(COCOA)
+    , m_remoteLayerHostingManager { RemoteLayerHostingManager::create(*this) }
+#endif
 {
     RELEASE_LOG(Process, "%p - GPUProcess::GPUProcess:", this);
 #if ASSERT_ENABLED && PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
@@ -605,6 +612,13 @@ RemoteAudioSessionProxyManager& GPUProcess::audioSessionManager() const
     if (!m_audioSessionManager)
         m_audioSessionManager = RemoteAudioSessionProxyManager::create(const_cast<GPUProcess&>(*this));
     return *m_audioSessionManager;
+}
+#endif
+
+#if PLATFORM(COCOA)
+RemoteLayerHostingManager& GPUProcess::remoteLayerHostingManager()
+{
+    return m_remoteLayerHostingManager;
 }
 #endif
 

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -85,6 +85,7 @@ namespace WebKit {
 
 class GPUConnectionToWebProcess;
 class RemoteAudioSessionProxyManager;
+class RemoteLayerHostingManager;
 class RemoteSnapshot;
 struct CoreIPCAuditToken;
 struct GPUProcessConnectionParameters;
@@ -122,6 +123,10 @@ public:
 
 #if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
     RemoteAudioSessionProxyManager& audioSessionManager() const;
+#endif
+
+#if PLATFORM(COCOA)
+    RemoteLayerHostingManager& remoteLayerHostingManager() LIFETIME_BOUND;
 #endif
 
     WebCore::NowPlayingManager& nowPlayingManager() LIFETIME_BOUND;
@@ -308,6 +313,9 @@ private:
 #endif
 #if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
     mutable RefPtr<RemoteAudioSessionProxyManager> m_audioSessionManager;
+#endif
+#if PLATFORM(COCOA)
+    const Ref<RemoteLayerHostingManager> m_remoteLayerHostingManager;
 #endif
 #if ENABLE(WEBXR)
     std::optional<WebCore::ProcessIdentity> m_processIdentity;

--- a/Source/WebKit/GPUProcess/cocoa/RemoteLayerHostingManager.h
+++ b/Source/WebKit/GPUProcess/cocoa/RemoteLayerHostingManager.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GPU_PROCESS)
+
+#include "MessageReceiver.h"
+#include "PlaybackSessionContextIdentifier.h"
+#include <WebCore/FloatSize.h>
+#include <wtf/CompletionHandler.h>
+#include <wtf/HashMap.h>
+#include <wtf/RefCounted.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
+
+OBJC_CLASS CALayer;
+
+namespace IPC {
+class Connection;
+}
+
+namespace WTF {
+struct MachSendRightAnnotated;
+}
+
+namespace WebKit {
+
+class GPUProcess;
+class LayerHostingContext;
+
+class RemoteLayerHostingManager
+    : public RefCounted<RemoteLayerHostingManager>
+    , private IPC::MessageReceiver {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLayerHostingManager);
+public:
+    static Ref<RemoteLayerHostingManager> create(GPUProcess&);
+    virtual ~RemoteLayerHostingManager();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+    void invalidate();
+    void createRemoteLayerForPlayer(PlaybackSessionContextIdentifier, RetainPtr<CALayer>&&, bool canShowWhileLocked);
+    void removeRemoteLayerForPlayer(PlaybackSessionContextIdentifier);
+    void removeAllRemoteLayersForProcess(WebCore::ProcessIdentifier);
+    void setContentLayerForRemoteLayer(PlaybackSessionContextIdentifier, RetainPtr<CALayer>&&);
+    uint64_t remoteLayerCountForTesting() const { return m_remoteLayers.size(); }
+
+private:
+    friend class GPUProcess;
+
+    explicit RemoteLayerHostingManager(GPUProcess&);
+
+    // IPC::MessageReceiver
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
+
+    // Messages from RemoteLayerHostingManagerProxy
+    void setRemoteLayerSizeFenced(PlaybackSessionContextIdentifier, const WebCore::FloatSize&, WTF::MachSendRightAnnotated&&);
+    void setRemoteLayerVideoGravityFenced(PlaybackSessionContextIdentifier, const String&, WTF::MachSendRightAnnotated&&);
+    void countRemoteLayersForTesting(CompletionHandler<void(uint64_t)>&&);
+    void remoteLayerTreeAsTextForTesting(CompletionHandler<void(String&&)>&&);
+
+    void takeAndInvalidateRemoteLayer(PlaybackSessionContextIdentifier);
+
+    struct RemoteLayerInfo {
+        std::unique_ptr<LayerHostingContext> hostingContext;
+        RetainPtr<CALayer> contentLayer;
+        WebCore::FloatSize size;
+        String videoGravity;
+    };
+
+    WeakPtr<GPUProcess> m_gpuProcess;
+    HashMap<PlaybackSessionContextIdentifier, RemoteLayerInfo> m_remoteLayers;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/cocoa/RemoteLayerHostingManager.messages.in
+++ b/Source/WebKit/GPUProcess/cocoa/RemoteLayerHostingManager.messages.in
@@ -1,0 +1,40 @@
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(GPU_PROCESS)
+
+[
+    DispatchedFrom=UI,
+    DispatchedTo=GPU,
+    ExceptionForEnabledBy
+]
+messages -> RemoteLayerHostingManager {
+    SetRemoteLayerSizeFenced(WebKit::PlaybackSessionContextIdentifier identifier, WebCore::FloatSize size, struct MachSendRightAnnotated sendRightAnnotated)
+
+    SetRemoteLayerVideoGravityFenced(WebKit::PlaybackSessionContextIdentifier identifier, String videoGravity, struct MachSendRightAnnotated sendRightAnnotated)
+
+    CountRemoteLayersForTesting() -> (uint64_t count)
+    RemoteLayerTreeAsTextForTesting() -> (String description) Synchronous
+}
+
+#endif

--- a/Source/WebKit/GPUProcess/cocoa/RemoteLayerHostingManager.mm
+++ b/Source/WebKit/GPUProcess/cocoa/RemoteLayerHostingManager.mm
@@ -1,0 +1,309 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "RemoteLayerHostingManager.h"
+
+#if ENABLE(GPU_PROCESS)
+
+#import "GPUProcess.h"
+#import "LayerHostingContext.h"
+#import "RemoteLayerHostingManagerMessages.h"
+#import "RemoteLayerHostingManagerProxyMessages.h"
+#import <WebCore/FloatRect.h>
+#import <objc/runtime.h>
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <ranges>
+#import <wtf/MachSendRightAnnotated.h>
+#import <wtf/RunLoop.h>
+#import <wtf/TZoneMallocInlines.h>
+#import <wtf/text/MakeString.h>
+#import <wtf/text/StringBuilder.h>
+
+#if USE(EXTENSIONKIT)
+#import <BrowserEngineKit/BELayerHierarchyHostingTransactionCoordinator.h>
+#endif
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerHostingManager);
+
+Ref<RemoteLayerHostingManager> RemoteLayerHostingManager::create(GPUProcess& gpuProcess)
+{
+    return adoptRef(*new RemoteLayerHostingManager(gpuProcess));
+}
+
+RemoteLayerHostingManager::RemoteLayerHostingManager(GPUProcess& gpuProcess)
+    : m_gpuProcess(&gpuProcess)
+{
+    gpuProcess.addMessageReceiver(Messages::RemoteLayerHostingManager::messageReceiverName(), *this);
+}
+
+RemoteLayerHostingManager::~RemoteLayerHostingManager()
+{
+    invalidate();
+}
+
+void RemoteLayerHostingManager::invalidate()
+{
+    if (RefPtr process = m_gpuProcess.get())
+        process->removeMessageReceiver(Messages::RemoteLayerHostingManager::messageReceiverName());
+    m_remoteLayers.clear();
+}
+
+void RemoteLayerHostingManager::createRemoteLayerForPlayer(PlaybackSessionContextIdentifier identifier, RetainPtr<CALayer>&& platformLayer, bool canShowWhileLocked)
+{
+    auto it = m_remoteLayers.find(identifier);
+    if (it != m_remoteLayers.end()) {
+        // Already exists — just update the content layer.
+        setContentLayerForRemoteLayer(identifier, WTF::move(platformLayer));
+        return;
+    }
+
+    RemoteLayerInfo info;
+
+    LayerHostingContextOptions contextOptions;
+#if USE(EXTENSIONKIT)
+    // Without this the context has no BELayerHierarchy, so it cannot be hosted by, or
+    // fenced against, a BELayerHierarchyHostingView in the UI process.
+    contextOptions.useHostable = true;
+#endif
+#if PLATFORM(IOS_FAMILY)
+    contextOptions.canShowWhileLocked = canShowWhileLocked;
+#else
+    UNUSED_PARAM(canShowWhileLocked);
+#endif
+    info.hostingContext = LayerHostingContext::create(contextOptions);
+
+    info.hostingContext->setRootLayer(platformLayer.get());
+
+    info.size = WebCore::FloatSize([platformLayer bounds].size);
+    info.contentLayer = WTF::move(platformLayer);
+
+    auto hostingContext = info.hostingContext->hostingContext();
+
+    m_remoteLayers.add(identifier, WTF::move(info));
+
+    if (RefPtr process = m_gpuProcess.get()) {
+        if (auto* connection = process->parentProcessConnection())
+            connection->send(Messages::RemoteLayerHostingManagerProxy::DidCreateRemoteLayer(identifier, WTF::move(hostingContext)), 0);
+    }
+}
+
+void RemoteLayerHostingManager::setContentLayerForRemoteLayer(PlaybackSessionContextIdentifier identifier, RetainPtr<CALayer>&& contentLayer)
+{
+    auto it = m_remoteLayers.find(identifier);
+    if (it == m_remoteLayers.end())
+        return;
+
+    auto& info = it->value;
+
+    if (info.contentLayer)
+        [info.contentLayer removeFromSuperlayer];
+
+    info.contentLayer = WTF::move(contentLayer);
+    info.hostingContext->setRootLayer(info.contentLayer.get());
+    [info.contentLayer setFrame:CGRectMake(0, 0, info.size.width(), info.size.height())];
+}
+
+void RemoteLayerHostingManager::setRemoteLayerSizeFenced(PlaybackSessionContextIdentifier identifier, const WebCore::FloatSize& size, WTF::MachSendRightAnnotated&& fence)
+{
+    auto it = m_remoteLayers.find(identifier);
+    if (it == m_remoteLayers.end())
+        return;
+
+    auto& info = it->value;
+    if (info.size == size)
+        return;
+
+    if (!info.hostingContext)
+        return;
+
+#if USE(EXTENSIONKIT)
+    RetainPtr<BELayerHierarchyHostingTransactionCoordinator> hostingUpdateCoordinator;
+#if ENABLE(MACH_PORT_LAYER_HOSTING)
+    auto fenceCopy = fence;
+    hostingUpdateCoordinator = LayerHostingContext::createHostingUpdateCoordinator(WTF::move(fenceCopy));
+#else
+    hostingUpdateCoordinator = LayerHostingContext::createHostingUpdateCoordinator(fence.sendRight.sendRight());
+#endif // ENABLE(MACH_PORT_LAYER_HOSTING)
+    [hostingUpdateCoordinator addLayerHierarchy:info.hostingContext->hostable().get()];
+#else
+    info.hostingContext->setFencePort(fence.sendRight.sendRight());
+#endif // USE(EXTENSIONKIT)
+
+    info.size = size;
+
+    if (info.contentLayer) {
+        [CATransaction begin];
+        [CATransaction setDisableActions:YES];
+        [info.contentLayer setFrame:CGRectMake(0, 0, size.width(), size.height())];
+        [CATransaction commit];
+    }
+
+#if USE(EXTENSIONKIT)
+    [hostingUpdateCoordinator commit];
+#endif
+}
+
+void RemoteLayerHostingManager::setRemoteLayerVideoGravityFenced(PlaybackSessionContextIdentifier identifier, const String& videoGravity, WTF::MachSendRightAnnotated&& fence)
+{
+    auto it = m_remoteLayers.find(identifier);
+    if (it == m_remoteLayers.end())
+        return;
+
+    auto& info = it->value;
+    if (info.videoGravity == videoGravity)
+        return;
+
+    if (!info.hostingContext)
+        return;
+
+#if USE(EXTENSIONKIT)
+    RetainPtr<BELayerHierarchyHostingTransactionCoordinator> hostingUpdateCoordinator;
+#if ENABLE(MACH_PORT_LAYER_HOSTING)
+    auto fenceCopy = fence;
+    hostingUpdateCoordinator = LayerHostingContext::createHostingUpdateCoordinator(WTF::move(fenceCopy));
+#else
+    hostingUpdateCoordinator = LayerHostingContext::createHostingUpdateCoordinator(fence.sendRight.sendRight());
+#endif // ENABLE(MACH_PORT_LAYER_HOSTING)
+    [hostingUpdateCoordinator addLayerHierarchy:info.hostingContext->hostable().get()];
+#else
+    info.hostingContext->setFencePort(fence.sendRight.sendRight());
+#endif // USE(EXTENSIONKIT)
+
+    info.videoGravity = videoGravity;
+
+    if (info.contentLayer) {
+        [CATransaction begin];
+        [CATransaction setDisableActions:YES];
+        if ([info.contentLayer respondsToSelector:@selector(setVideoGravity:)])
+            [info.contentLayer performSelector:@selector(setVideoGravity:) withObject:videoGravity.createNSString().get()];
+        [CATransaction commit];
+    }
+
+#if USE(EXTENSIONKIT)
+    [hostingUpdateCoordinator commit];
+#endif
+}
+
+void RemoteLayerHostingManager::takeAndInvalidateRemoteLayer(PlaybackSessionContextIdentifier identifier)
+{
+    auto info = m_remoteLayers.take(identifier);
+
+    if (info.hostingContext)
+        info.hostingContext->invalidate();
+
+    if (info.contentLayer)
+        [info.contentLayer removeFromSuperlayer];
+}
+
+// Initiated here, because the player or renderer that owned the video layer has gone away or
+// stopped rendering: the UIProcess must be told to drop its layer host.
+void RemoteLayerHostingManager::removeRemoteLayerForPlayer(PlaybackSessionContextIdentifier identifier)
+{
+    if (!m_remoteLayers.contains(identifier))
+        return;
+
+    takeAndInvalidateRemoteLayer(identifier);
+
+    if (RefPtr process = m_gpuProcess.get()) {
+        if (auto* connection = process->parentProcessConnection())
+            connection->send(Messages::RemoteLayerHostingManagerProxy::DidRemoveRemoteLayer(identifier), 0);
+    }
+}
+
+void RemoteLayerHostingManager::countRemoteLayersForTesting(CompletionHandler<void(uint64_t)>&& completionHandler)
+{
+    completionHandler(m_remoteLayers.size());
+}
+
+static void appendLayerTreeAsText(StringBuilder& builder, CALayer *layer, unsigned depth)
+{
+    for (unsigned i = 0; i < depth; ++i)
+        builder.append("  "_s);
+    builder.append(String::fromUTF8(class_getName([layer class])));
+    if (NSString *name = [layer name]; name.length)
+        builder.append(makeString(" name=\""_s, String { name }, '"'));
+    auto bounds = [layer bounds];
+    auto position = [layer position];
+    builder.append(makeString(" bounds=("_s, bounds.size.width, ", "_s, bounds.size.height, ')'));
+    builder.append(makeString(" position=("_s, position.x, ", "_s, position.y, ')'));
+    builder.append('\n');
+
+    for (CALayer *sublayer in [layer sublayers])
+        appendLayerTreeAsText(builder, sublayer, depth + 1);
+}
+
+void RemoteLayerHostingManager::remoteLayerTreeAsTextForTesting(CompletionHandler<void(String&&)>&& completionHandler)
+{
+    StringBuilder builder;
+
+    // Sorted so that the output is stable across runs; HashMap iteration order is not.
+    auto identifiers = copyToVector(m_remoteLayers.keys());
+    std::ranges::sort(identifiers, [](auto& a, auto& b) {
+        if (a.processIdentifier() != b.processIdentifier())
+            return a.processIdentifier().toUInt64() < b.processIdentifier().toUInt64();
+        return a.object().toUInt64() < b.object().toUInt64();
+    });
+
+    for (auto& identifier : identifiers) {
+        auto it = m_remoteLayers.find(identifier);
+        if (it == m_remoteLayers.end())
+            continue;
+
+        auto& info = it->value;
+        builder.append(makeString("remote layer "_s, identifier.toString(),
+            " contextID="_s, info.hostingContext ? info.hostingContext->cachedContextID() : 0,
+            " size=("_s, info.size.width(), ", "_s, info.size.height(), ")\n"_s));
+        if (info.contentLayer)
+            appendLayerTreeAsText(builder, info.contentLayer.get(), 1);
+        else
+            builder.append("  <no content layer>\n"_s);
+    }
+
+    String description = builder.toString();
+    completionHandler(WTF::move(description));
+}
+
+void RemoteLayerHostingManager::removeAllRemoteLayersForProcess(WebCore::ProcessIdentifier processIdentifier)
+{
+    // Identifiers are process-qualified, so a disconnecting or crashing WebContent process
+    // can be swept without depending on each player or renderer being torn down
+    // individually. RemoteAudioVideoRendererProxyManager in particular is destroyed without
+    // calling shutdown() on its renderers.
+    Vector<PlaybackSessionContextIdentifier> identifiersToRemove;
+    for (auto& identifier : m_remoteLayers.keys()) {
+        if (identifier.processIdentifier() == processIdentifier)
+            identifiersToRemove.append(identifier);
+    }
+
+    for (auto& identifier : identifiersToRemove)
+        removeRemoteLayerForPlayer(identifier);
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -54,6 +54,8 @@
 
 #include <wtf/LoggerHelper.h>
 #if PLATFORM(COCOA)
+#include "PlaybackSessionContextIdentifier.h"
+#include "RemoteLayerHostingManager.h"
 #include <wtf/MachSendRightAnnotated.h>
 #endif
 #include <wtf/Markable.h>
@@ -198,6 +200,10 @@ void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdenti
 void RemoteAudioVideoRendererProxyManager::shutdown(RemoteAudioVideoRendererIdentifier identifier)
 {
     MESSAGE_CHECK(m_renderers.contains(identifier));
+
+#if PLATFORM(COCOA)
+    removeContentLayerForRemoteLayerHosting(identifier);
+#endif
 
     if (auto iterator = m_renderers.find(identifier); iterator != m_renderers.end())
         m_renderers.remove(iterator);
@@ -698,6 +704,64 @@ RemoteAudioVideoRendererState RemoteAudioVideoRendererProxyManager::stateFor(Rem
     };
 }
 
+#if PLATFORM(COCOA)
+bool RemoteAudioVideoRendererProxyManager::remoteLayerHostingBypassesWebContentProcess() const
+{
+    RefPtr connection = m_gpuConnectionToWebProcess.get();
+    if (!connection)
+        return false;
+
+    if (auto sharedPreferences = connection->sharedPreferencesForWebProcess())
+        return sharedPreferences->remoteLayerHostingBypassesWebContentProcess;
+
+    return false;
+}
+
+void RemoteAudioVideoRendererProxyManager::updateContentLayerForRemoteLayerHosting(RemoteAudioVideoRendererIdentifier identifier)
+{
+    auto& context = contextFor(identifier);
+
+    RefPtr connection = m_gpuConnectionToWebProcess.get();
+    if (!connection)
+        return;
+
+    if (!context.mediaElementIdentifier)
+        return;
+
+    auto contextId = PlaybackSessionContextIdentifier { *context.mediaElementIdentifier, connection->webProcessIdentifier() };
+
+    RetainPtr platformLayer = context.renderer->platformVideoLayer();
+
+    if (!platformLayer) {
+        protect(connection->gpuProcess().remoteLayerHostingManager())->removeRemoteLayerForPlayer(contextId);
+        return;
+    }
+
+    bool canShowWhileLocked = false;
+#if PLATFORM(IOS_FAMILY)
+    canShowWhileLocked = context.preferences.contains(VideoRendererPreference::CanShowWhileLocked);
+#endif
+    protect(connection->gpuProcess().remoteLayerHostingManager())->createRemoteLayerForPlayer(contextId, WTF::move(platformLayer), canShowWhileLocked);
+}
+
+void RemoteAudioVideoRendererProxyManager::removeContentLayerForRemoteLayerHosting(RemoteAudioVideoRendererIdentifier identifier)
+{
+    auto iterator = m_renderers.find(identifier);
+    if (iterator == m_renderers.end())
+        return;
+
+    RefPtr connection = m_gpuConnectionToWebProcess.get();
+    if (!connection)
+        return;
+
+    if (!iterator->value.mediaElementIdentifier)
+        return;
+
+    auto contextId = PlaybackSessionContextIdentifier { *iterator->value.mediaElementIdentifier, connection->webProcessIdentifier() };
+    protect(connection->gpuProcess().remoteLayerHostingManager())->removeRemoteLayerForPlayer(contextId);
+}
+#endif // PLATFORM(COCOA)
+
 void RemoteAudioVideoRendererProxyManager::rendereringModeChanged(RemoteAudioVideoRendererIdentifier identifier)
 {
     ALWAYS_LOG(LOGIDENTIFIER, identifier.loggingString());
@@ -709,14 +773,18 @@ void RemoteAudioVideoRendererProxyManager::rendereringModeChanged(RemoteAudioVid
 #if PLATFORM(COCOA)
     auto& context = contextFor(identifier);
 
-    bool canShowWhileLocked = false;
+    if (remoteLayerHostingBypassesWebContentProcess())
+        updateContentLayerForRemoteLayerHosting(identifier);
+    else {
+        bool canShowWhileLocked = false;
 #if PLATFORM(IOS_FAMILY)
-    canShowWhileLocked = context.preferences.contains(VideoRendererPreference::CanShowWhileLocked);
+        canShowWhileLocked = context.preferences.contains(VideoRendererPreference::CanShowWhileLocked);
 #endif
 
-    // See webkit.org/b/299655
-    SUPPRESS_FORWARD_DECL_ARG if (auto maybeHostingContext = context.layerHostingContextManager.createHostingContextIfNeeded(context.renderer->platformVideoLayer(), canShowWhileLocked))
-        publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::LayerHostingContextChanged(state, *maybeHostingContext, context.layerHostingContextManager.videoLayerSize()));
+        // See webkit.org/b/299655
+        SUPPRESS_FORWARD_DECL_ARG if (auto maybeHostingContext = context.layerHostingContextManager.createHostingContextIfNeeded(context.renderer->platformVideoLayer(), canShowWhileLocked))
+            publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::LayerHostingContextChanged(state, *maybeHostingContext, context.layerHostingContextManager.videoLayerSize()));
+    }
 #endif
     publishAndSend(identifier, Messages::AudioVideoRendererRemoteMessageReceiver::RenderingModeChanged(state));
 }

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -166,6 +166,10 @@ private:
     void attemptToDecrypt(RemoteAudioVideoRendererIdentifier);
 #endif
 
+    void updateContentLayerForRemoteLayerHosting(RemoteAudioVideoRendererIdentifier);
+    void removeContentLayerForRemoteLayerHosting(RemoteAudioVideoRendererIdentifier);
+    bool remoteLayerHostingBypassesWebContentProcess() const;
+
     struct RendererContext {
         RefPtr<WebCore::AudioVideoRenderer> renderer;
         Markable<WebCore::HTMLMediaElementIdentifier> mediaElementIdentifier;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -141,6 +141,9 @@ RemoteMediaPlayerProxy::~RemoteMediaPlayerProxy()
 void RemoteMediaPlayerProxy::invalidate()
 {
     m_updateCachedStateMessageTimer.stop();
+#if PLATFORM(COCOA)
+    removeContentLayerForRemoteLayerHosting();
+#endif
     protect(m_player)->invalidate();
     if (RefPtr sandboxExtension = m_sandboxExtension) {
         sandboxExtension->revoke();

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -371,7 +371,11 @@ private:
     void bitmapImageForCurrentTime(CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
 
     void setShouldDisableHDR(bool);
-    void requestHostingContext(CompletionHandler<void(WebCore::HostingContext)>&&);
+    using LayerHostingContextCallback = CompletionHandler<void(WebCore::HostingContext)>;
+    void requestHostingContext(LayerHostingContextCallback&&);
+    void updateContentLayerForRemoteLayerHosting();
+    void removeContentLayerForRemoteLayerHosting();
+    bool remoteLayerHostingBypassesWebContentProcess() const;
     void setShouldCheckHardwareSupport(bool);
 #if HAVE(SPATIAL_TRACKING_LABEL)
     void setDefaultSpatialTrackingLabel(const String&);

--- a/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
+++ b/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
@@ -28,10 +28,15 @@
 
 #if ENABLE(GPU_PROCESS) && PLATFORM(COCOA)
 
+#import "GPUConnectionToWebProcess.h"
+#import "GPUProcess.h"
 #import "LayerHostingContext.h"
 #import "LayerHostingContextManager.h"
 #import "Logging.h"
 #import "MediaPlayerPrivateRemoteMessages.h"
+#import "PlaybackSessionContextIdentifier.h"
+#import "RemoteLayerHostingManager.h"
+#import "RemoteMediaPlayerManagerProxy.h"
 #import "RemoteVideoFrameObjectHeap.h"
 #import <QuartzCore/QuartzCore.h>
 #import <WebCore/DestinationColorSpace.h>
@@ -62,17 +67,80 @@ void RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
+    if (remoteLayerHostingBypassesWebContentProcess())
+        updateContentLayerForRemoteLayerHosting();
+    else {
+        bool canShowWhileLocked =
+#if PLATFORM(IOS_FAMILY)
+            m_configuration.canShowWhileLocked;
+#else
+            false;
+#endif
+
+        if (auto hostingContext = m_layerHostingContextManager->createHostingContextIfNeeded(protect(m_player)->platformLayer(), canShowWhileLocked))
+            protect(m_webProcessConnection)->send(Messages::MediaPlayerPrivateRemote::LayerHostingContextChanged(*hostingContext, m_layerHostingContextManager->videoLayerSize()), m_id);
+    }
+
+    protect(m_webProcessConnection)->send(Messages::MediaPlayerPrivateRemote::RenderingModeChanged(), m_id);
+}
+
+bool RemoteMediaPlayerProxy::remoteLayerHostingBypassesWebContentProcess() const
+{
+    RefPtr manager = m_manager.get();
+    if (!manager)
+        return false;
+
+    RefPtr connection = manager->gpuConnectionToWebProcess();
+    if (!connection)
+        return false;
+
+    if (auto sharedPreferences = connection->sharedPreferencesForWebProcess())
+        return sharedPreferences->remoteLayerHostingBypassesWebContentProcess;
+
+    return false;
+}
+
+void RemoteMediaPlayerProxy::updateContentLayerForRemoteLayerHosting()
+{
+    RefPtr manager = m_manager.get();
+    if (!manager)
+        return;
+
+    RefPtr connection = manager->gpuConnectionToWebProcess();
+    if (!connection)
+        return;
+
+    auto contextId = PlaybackSessionContextIdentifier { m_clientIdentifier, connection->webProcessIdentifier() };
+
+    RefPtr player = m_player;
+    RetainPtr platformLayer = player ? player->platformLayer() : nullptr;
+
+    if (!platformLayer) {
+        protect(connection->gpuProcess().remoteLayerHostingManager())->removeRemoteLayerForPlayer(contextId);
+        return;
+    }
+
     bool canShowWhileLocked =
 #if PLATFORM(IOS_FAMILY)
         m_configuration.canShowWhileLocked;
 #else
         false;
 #endif
+    protect(connection->gpuProcess().remoteLayerHostingManager())->createRemoteLayerForPlayer(contextId, WTF::move(platformLayer), canShowWhileLocked);
+}
 
-    if (auto hostingContext = m_layerHostingContextManager->createHostingContextIfNeeded(protect(m_player)->platformLayer(), canShowWhileLocked))
-        protect(m_webProcessConnection)->send(Messages::MediaPlayerPrivateRemote::LayerHostingContextChanged(*hostingContext, m_layerHostingContextManager->videoLayerSize()), m_id);
+void RemoteMediaPlayerProxy::removeContentLayerForRemoteLayerHosting()
+{
+    RefPtr manager = m_manager.get();
+    if (!manager)
+        return;
 
-    protect(m_webProcessConnection)->send(Messages::MediaPlayerPrivateRemote::RenderingModeChanged(), m_id);
+    RefPtr connection = manager->gpuConnectionToWebProcess();
+    if (!connection)
+        return;
+
+    auto contextId = PlaybackSessionContextIdentifier { m_clientIdentifier, connection->webProcessIdentifier() };
+    protect(connection->gpuProcess().remoteLayerHostingManager())->removeRemoteLayerForPlayer(contextId);
 }
 
 void RemoteMediaPlayerProxy::requestHostingContext(CompletionHandler<void(WebCore::HostingContext)>&& completionHandler)

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm
@@ -30,6 +30,7 @@
 
 #import "GPUConnectionToWebProcess.h"
 #import "IPCUtilities.h"
+#import "Logging.h"
 #import "MessageSenderInlines.h"
 #import "RemoteVideoFrameObjectHeap.h"
 #import "SampleBufferDisplayLayerMessages.h"

--- a/Source/WebKit/Headers.cmake
+++ b/Source/WebKit/Headers.cmake
@@ -540,6 +540,7 @@ endif ()
 # FIXME: Eventually add all non-installed headers to this list, so that the
 # per-directory -I paths can be removed.
 set(WebKit_PROJECT_HEADERS
+    GPUProcess/cocoa/RemoteLayerHostingManager.h
     GPUProcess/graphics/Model/Float3.h
     GPUProcess/graphics/Model/Float4x4.h
     GPUProcess/graphics/Model/ModelTypes.h

--- a/Source/WebKit/PlatformCocoa.cmake
+++ b/Source/WebKit/PlatformCocoa.cmake
@@ -286,6 +286,8 @@ set(WebKit_FORWARDING_HEADERS_FILES
 )
 
 list(APPEND WebKit_MESSAGES_IN_FILES
+    GPUProcess/cocoa/RemoteLayerHostingManager
+
     GPUProcess/media/RemoteImageDecoderAVFProxy
 
     GPUProcess/media/ios/RemoteMediaSessionHelperProxy
@@ -303,6 +305,7 @@ list(APPEND WebKit_MESSAGES_IN_FILES
     UIProcess/ViewGestureController
 
     UIProcess/Cocoa/PlaybackSessionManagerProxy
+    UIProcess/Cocoa/RemoteLayerHostingManagerProxy
     UIProcess/Cocoa/VideoPresentationManagerProxy
 
     UIProcess/Inspector/WebInspectorUIExtensionControllerProxy

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -360,6 +360,8 @@
     [Legacy] StructureParam WebCore::HostingContext.sendRightAnnotated
 
     [NotSentFromWebContent] MessageParam VideoPresentationManager.SetVideoLayerFrameFenced sendRightAnnotated
+    [NotSentFromWebContent] MessageParam RemoteLayerHostingManager.SetRemoteLayerSizeFenced sendRightAnnotated
+    [NotSentFromWebContent] MessageParam RemoteLayerHostingManager.SetRemoteLayerVideoGravityFenced sendRightAnnotated
 }
 
 [UnsafeWrapper] RetainPtr<CFDataRef> {

--- a/Source/WebKit/Shared/ProcessQualified.serialization.in
+++ b/Source/WebKit/Shared/ProcessQualified.serialization.in
@@ -100,6 +100,11 @@ header: <WebCore/ProcessQualified.h>
     WebCore::ProcessIdentifier processIdentifier();
 };
 
+[Alias=class WebCore::ProcessQualified<ObjectIdentifier<WebCore::MediaPlayerClientIdentifierType>>, CustomHeader] alias WebKit::PlaybackSessionContextIdentifier {
+    WebCore::MediaPlayerClientIdentifier object();
+    WebCore::ProcessIdentifier processIdentifier();
+};
+
 header: <WebCore/WebKitJSHandle.h>
 [Alias=class ProcessQualified<ObjectIdentifier<WebCore::JSHandleIdentifierType>>, CustomHeader] alias WebCore::JSHandleIdentifier {
     WebCore::WebProcessJSHandleIdentifier object();

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -71,6 +71,7 @@ NetworkProcess/webrtc/NetworkRTCUDPSocketCocoa.mm @nonARC
 GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm @nonARC
 GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm @nonARC
 GPUProcess/cocoa/GPUProcessCocoa.mm @nonARC
+GPUProcess/cocoa/RemoteLayerHostingManager.mm @nonARC
 GPUProcess/graphics/Model/MeshImpl.cpp
 GPUProcess/graphics/Model/WebKitMesh.mm
 GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
@@ -464,6 +465,7 @@ UIProcess/Cocoa/PlatformWritingToolsUtilities.mm @nonARC
 UIProcess/Cocoa/PlatformXRCoordinator.mm @nonARC
 UIProcess/Cocoa/PlaybackSessionManagerProxy.mm @nonARC
 UIProcess/Cocoa/ProcessAssertionCocoa.mm @nonARC
+UIProcess/Cocoa/RemoteLayerHostingManagerProxy.mm @nonARC
 UIProcess/Cocoa/ResourceLoadDelegate.mm @nonARC
 UIProcess/Cocoa/SafeBrowsingUtilities.mm @nonARC
 UIProcess/Cocoa/SessionStateCoding.mm @nonARC
@@ -497,6 +499,8 @@ UIProcess/Cocoa/WKTextEffectManager.mm @nonARC
 UIProcess/Cocoa/WKTextPlaceholder.mm @nonARC
 UIProcess/Cocoa/WKTextSelectionRect.mm @nonARC
 UIProcess/Cocoa/WKWebViewContentProviderRegistry.mm @nonARC
+UIProcess/Cocoa/WKVideoLayerHost.mm @nonARC
+UIProcess/Cocoa/WKVideoLayerHostView.mm @nonARC
 
 UIProcess/DigitalCredentials/WKDigitalCredentialsPicker.mm @nonARC
 
@@ -974,6 +978,8 @@ RemoteImageBufferSetMessageReceiver.cpp @cost:5
 RemoteImageDecoderAVFManagerMessageReceiver.cpp
 RemoteImageDecoderAVFProxyMessageReceiver.cpp
 RemoteLayerTreeDrawingAreaProxyMessageReceiver.cpp
+RemoteLayerHostingManagerMessageReceiver.cpp
+RemoteLayerHostingManagerProxyMessageReceiver.cpp
 RemoteLegacyCDMFactoryProxyMessageReceiver.cpp
 RemoteLegacyCDMProxyMessageReceiver.cpp
 RemoteLegacyCDMSessionMessageReceiver.cpp

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -43,6 +43,7 @@
 #import "EditingRange.h"
 #import "FindClient.h"
 #import "FullscreenClient.h"
+#import "GPUProcessProxy.h"
 #import "GlobalFindInPageState.h"
 #import "IconLoadingDelegate.h"
 #import "ImageAnalysisUtilities.h"
@@ -59,6 +60,7 @@
 #import "PlatformWritingToolsUtilities.h"
 #import "ProcessTerminationReason.h"
 #import "ProvisionalPageProxy.h"
+#import "RemoteLayerHostingManagerProxy.h"
 #import "RemoteLayerTreeScrollingPerformanceData.h"
 #import "RemoteObjectRegistry.h"
 #import "RemoteObjectRegistryMessages.h"
@@ -6165,6 +6167,37 @@ static inline OptionSet<WebCore::LayoutMilestone> NODELETE layoutMilestones(_WKR
     _page->getContentsAsString(WebKit::ContentAsStringIncludesChildFrames::No, [handler = makeBlockPtr(completionHandler), connection = protect(_page->legacyMainFrameProcess().connection())](String string) {
         handler(string.createNSString().get(), nil);
     });
+}
+
+- (NSUInteger)_hostedVideoLayerCountForTesting
+{
+#if ENABLE(GPU_PROCESS) && PLATFORM(COCOA)
+    if (RefPtr gpuProcess = _page->configuration().processPool().gpuProcess())
+        return protect(gpuProcess->remoteLayerHostingManagerProxy())->hostedLayerCountForTesting();
+#endif
+    return 0;
+}
+
+- (void)_gpuProcessHostedVideoLayerCountForTesting:(void (^)(NSUInteger))completionHandler
+{
+#if ENABLE(GPU_PROCESS) && PLATFORM(COCOA)
+    if (RefPtr gpuProcess = _page->configuration().processPool().gpuProcess()) {
+        protect(gpuProcess->remoteLayerHostingManagerProxy())->countGPUProcessRemoteLayersForTesting([handler = makeBlockPtr(completionHandler)](uint64_t count) {
+            handler(count);
+        });
+        return;
+    }
+#endif
+    completionHandler(0);
+}
+
+- (NSString *)_gpuProcessRemoteLayerTreeAsTextForTesting
+{
+#if ENABLE(GPU_PROCESS) && PLATFORM(COCOA)
+    if (RefPtr gpuProcess = _page->configuration().processPool().gpuProcess())
+        return protect(gpuProcess->remoteLayerHostingManagerProxy())->gpuProcessRemoteLayerTreeAsTextForTesting().createNSString().autorelease();
+#endif
+    return @"";
 }
 
 - (void)_getContentsOfAllFramesAsStringWithCompletionHandler:(void (^)(NSString *))completionHandler

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -379,6 +379,18 @@ for this property.
 - (void)_createWebArchiveForFrames:(NSArray<WKFrameInfo *> *)frames rootFrame:(WKFrameInfo *)rootFrame completionHandler:(void (^)(NSData *, NSError *))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 - (void)_getContentsAsStringWithCompletionHandler:(void (^)(NSString *, NSError *))completionHandler WK_API_AVAILABLE(macos(10.13), ios(11.0));
 - (void)_getContentsAsStringWithCompletionHandlerKeepIPCConnectionAliveForTesting:(void (^)(NSString *, NSError *))completionHandler;
+
+// Counts the video layer hosts tracked for the GPU process this view is using, in the UI
+// process and in the GPU process respectively. These count every media player the GPU
+// process has reported a video layer for, across all pages using that GPU process, so they
+// are only meaningful in a test with a single web view.
+- (NSUInteger)_hostedVideoLayerCountForTesting;
+- (void)_gpuProcessHostedVideoLayerCountForTesting:(void (^)(NSUInteger))completionHandler;
+
+// A dump of the CALayer hierarchy on the GPU process side of the video layer hosting
+// boundary, which cannot be reached by walking this process's layers. Synchronous; testing
+// and debugging only.
+- (NSString *)_gpuProcessRemoteLayerTreeAsTextForTesting;
 - (void)_getContentsOfAllFramesAsStringWithCompletionHandler:(void (^)(NSString *))completionHandler WK_API_AVAILABLE(macos(11.0), ios(14.0));
 - (void)_getContentsAsAttributedStringWithCompletionHandler:(void (^)(NSAttributedString *, NSDictionary<NSAttributedStringDocumentAttributeKey, id> *, NSError *))completionHandler WK_API_AVAILABLE(macos(10.15), ios(13.0));
 

--- a/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
@@ -32,6 +32,7 @@
 #include "GPUProcessCreationParameters.h"
 #include "GPUProcessMessages.h"
 #include "MediaPermissionUtilities.h"
+#include "RemoteLayerHostingManagerProxy.h"
 #include "WebProcessProxy.h"
 #include <wtf/cf/TypeCastsCF.h>
 #include <wtf/cocoa/SpanCocoa.h>
@@ -131,6 +132,11 @@ void GPUProcessProxy::postWillTakeSnapshotNotification(CompletionHandler<void()>
 void GPUProcessProxy::sinkCompletedSnapshotToPDF(RemoteSnapshotIdentifier identifier, const WebCore::FloatSize& size, WebCore::FrameIdentifier rootFrameIdentifier, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&& completionHandler)
 {
     sendWithAsyncReply(Messages::GPUProcess::SinkCompletedSnapshotToPDF { identifier, size, rootFrameIdentifier }, WTF::move(completionHandler));
+}
+
+RemoteLayerHostingManagerProxy& GPUProcessProxy::remoteLayerHostingManagerProxy()
+{
+    return m_remoteLayerHostingManagerProxy;
 }
 
 }

--- a/Source/WebKit/UIProcess/Cocoa/RemoteLayerHostingManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/RemoteLayerHostingManagerProxy.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GPU_PROCESS)
+
+#include "MessageReceiver.h"
+#include "PlaybackSessionContextIdentifier.h"
+#include <WebCore/CocoaView.h>
+#include <WebCore/FloatRect.h>
+#include <WebCore/HostingContext.h>
+#include <wtf/HashMap.h>
+#include <wtf/RefCounted.h>
+#include <wtf/RetainPtr.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
+
+OBJC_CLASS CALayer;
+OBJC_CLASS WKVideoLayerHostView;
+
+namespace WTF {
+struct MachSendRightAnnotated;
+}
+
+namespace WebKit {
+
+class GPUProcessProxy;
+class WebPageProxy;
+
+using LayerHostingContextID = uint32_t;
+
+class RemoteLayerHostingManagerProxy
+    : public RefCounted<RemoteLayerHostingManagerProxy>
+    , public IPC::MessageReceiver {
+    WTF_MAKE_TZONE_ALLOCATED(RemoteLayerHostingManagerProxy);
+public:
+    static Ref<RemoteLayerHostingManagerProxy> create(GPUProcessProxy&);
+    virtual ~RemoteLayerHostingManagerProxy();
+
+    void ref() const final { RefCounted::ref(); }
+    void deref() const final { RefCounted::deref(); }
+
+    void invalidate();
+
+    RetainPtr<WKVideoLayerHostView> ensureLayerHostViewForIdentifier(PlaybackSessionContextIdentifier);
+
+    void setPageForIdentifier(PlaybackSessionContextIdentifier, WebPageProxy&);
+
+    void releaseLayerHostForIdentifier(PlaybackSessionContextIdentifier);
+
+    void setRemoteLayerHostSize(PlaybackSessionContextIdentifier, const WebCore::FloatSize&);
+
+    void setRemoteLayerVideoGravity(PlaybackSessionContextIdentifier, const String&);
+
+#if USE(EXTENSIONKIT)
+    void addVisibilityPropogationView(PlaybackSessionContextIdentifier);
+    void removeVisibilityPropogationView(PlaybackSessionContextIdentifier);
+#endif
+
+    uint64_t hostedLayerCountForTesting() const { return m_hostedLayers.size(); }
+    void countGPUProcessRemoteLayersForTesting(CompletionHandler<void(uint64_t)>&&);
+
+    String gpuProcessRemoteLayerTreeAsTextForTesting();
+
+private:
+    friend class GPUProcessProxy;
+
+    explicit RemoteLayerHostingManagerProxy(GPUProcessProxy&);
+
+    void runWithFenceForIdentifier(PlaybackSessionContextIdentifier, Function<void(WTF::MachSendRightAnnotated&&)>&&);
+
+    // IPC::MessageReceiver
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+
+    // Messages from RemoteLayerHostingManager (GPUProcess → UIProcess)
+    void didCreateRemoteLayer(PlaybackSessionContextIdentifier, WebCore::HostingContext&&);
+    void didRemoveRemoteLayer(PlaybackSessionContextIdentifier);
+
+    struct RemoteLayerHostInfo {
+        RetainPtr<WKVideoLayerHostView> hostView;
+        WebCore::HostingContext hostingContext;
+        WebCore::FloatSize size;
+        WeakPtr<WebPageProxy> page;
+        String videoGravity;
+
+        bool hasGPUProcessVideoLayer { false };
+        bool hasUIProcessConsumer { false };
+    };
+
+    RemoteLayerHostInfo& ensureRemoteLayerHostInfo(PlaybackSessionContextIdentifier);
+    void applyHostingContextToLayerHost(RemoteLayerHostInfo&);
+    void removeRemoteLayerHostIfUnused(PlaybackSessionContextIdentifier);
+
+    WeakPtr<GPUProcessProxy> m_gpuProcess;
+    HashMap<PlaybackSessionContextIdentifier, RemoteLayerHostInfo> m_hostedLayers;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/Cocoa/RemoteLayerHostingManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/RemoteLayerHostingManagerProxy.messages.in
@@ -1,0 +1,36 @@
+# Copyright (C) 2025 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+# THE POSSIBILITY OF SUCH DAMAGE.
+
+#if ENABLE(GPU_PROCESS)
+
+[
+    DispatchedFrom=GPU,
+    DispatchedTo=UI,
+    ExceptionForEnabledBy
+]
+messages -> RemoteLayerHostingManagerProxy {
+    DidCreateRemoteLayer(WebKit::PlaybackSessionContextIdentifier identifier, struct WebCore::HostingContext hostingContext)
+    DidRemoveRemoteLayer(WebKit::PlaybackSessionContextIdentifier identifier)
+}
+
+#endif

--- a/Source/WebKit/UIProcess/Cocoa/RemoteLayerHostingManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/RemoteLayerHostingManagerProxy.mm
@@ -1,0 +1,346 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RemoteLayerHostingManagerProxy.h"
+
+#if ENABLE(GPU_PROCESS) && PLATFORM(COCOA)
+
+#import "DrawingAreaProxy.h"
+#import "GPUProcessProxy.h"
+#import "LayerHostingContext.h"
+#import "RemoteLayerHostingManagerMessages.h"
+#import "RemoteLayerHostingManagerProxyMessages.h"
+#import "WKVideoLayerHost.h"
+#import "WKVideoLayerHostView.h"
+#import "WebPageProxy.h"
+#import <QuartzCore/QuartzCore.h>
+#import <WebCore/FloatRect.h>
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <wtf/MachSendRightAnnotated.h>
+#import <wtf/RunLoop.h>
+#import <wtf/TZoneMallocInlines.h>
+
+#if USE(EXTENSIONKIT)
+#import <BrowserEngineKit/BELayerHierarchyHandle.h>
+#import <BrowserEngineKit/BELayerHierarchyHostingTransactionCoordinator.h>
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+#import <UIKit/UIWindow.h>
+#endif
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerHostingManagerProxy);
+
+Ref<RemoteLayerHostingManagerProxy> RemoteLayerHostingManagerProxy::create(GPUProcessProxy& gpuProcess)
+{
+    return adoptRef(*new RemoteLayerHostingManagerProxy(gpuProcess));
+}
+
+RemoteLayerHostingManagerProxy::RemoteLayerHostingManagerProxy(GPUProcessProxy& gpuProcess)
+    : m_gpuProcess(gpuProcess)
+{
+    gpuProcess.addMessageReceiver(Messages::RemoteLayerHostingManagerProxy::messageReceiverName(), *this);
+}
+
+RemoteLayerHostingManagerProxy::~RemoteLayerHostingManagerProxy()
+{
+    invalidate();
+}
+
+void RemoteLayerHostingManagerProxy::invalidate()
+{
+    if (RefPtr process = m_gpuProcess.get())
+        process->removeMessageReceiver(Messages::RemoteLayerHostingManagerProxy::messageReceiverName());
+
+    m_hostedLayers.clear();
+}
+
+RetainPtr<WKVideoLayerHostView> RemoteLayerHostingManagerProxy::ensureLayerHostViewForIdentifier(PlaybackSessionContextIdentifier identifier)
+{
+    return ensureRemoteLayerHostInfo(identifier).hostView;
+}
+
+void RemoteLayerHostingManagerProxy::applyHostingContextToLayerHost(RemoteLayerHostInfo& info)
+{
+    if (!info.hostView)
+        return;
+
+#if USE(EXTENSIONKIT)
+    RetainPtr<BELayerHierarchyHandle> layerHandle;
+    if (info.hasGPUProcessVideoLayer) {
+#if ENABLE(MACH_PORT_LAYER_HOSTING)
+        layerHandle = LayerHostingContext::createHostingHandle(WTF::MachSendRightAnnotated { info.hostingContext.sendRightAnnotated });
+#else
+        if (RefPtr process = m_gpuProcess.get())
+            layerHandle = LayerHostingContext::createHostingHandle(process->processID(), info.hostingContext.contextID);
+#endif
+        if (!layerHandle)
+            RELEASE_LOG_ERROR(Media, "RemoteLayerHostingManagerProxy: could not create a layer hierarchy handle for the GPU process video layer");
+    }
+    [[info.hostView layerHierarchyHostingView] setHandle:layerHandle.get()];
+#else
+    [[info.hostView layerHost] setContextId:info.hostingContext.contextID];
+#endif
+}
+
+auto RemoteLayerHostingManagerProxy::ensureRemoteLayerHostInfo(PlaybackSessionContextIdentifier identifier) -> RemoteLayerHostInfo&
+{
+    auto& info = m_hostedLayers.ensure(identifier, [] {
+        return RemoteLayerHostInfo { };
+    }).iterator->value;
+
+    if (info.hostView)
+        return info;
+
+    RetainPtr view = adoptNS([[WKVideoLayerHostView alloc] initWithFrame:CGRectZero]);
+#if PLATFORM(MAC)
+    [view setWantsLayer:YES];
+#endif
+#if PLATFORM(IOS_FAMILY)
+    [view setUserInteractionEnabled:NO];
+#endif
+
+    RetainPtr layerHost = [view layerHost];
+
+    info.hostView = WTF::move(view);
+
+    [layerHost setIdentifier:identifier];
+    [layerHost setParent:this];
+
+    applyHostingContextToLayerHost(info);
+
+    return info;
+}
+
+void RemoteLayerHostingManagerProxy::setPageForIdentifier(PlaybackSessionContextIdentifier identifier, WebPageProxy& page)
+{
+    auto& info = ensureRemoteLayerHostInfo(identifier);
+    info.page = page;
+    info.hasUIProcessConsumer = true;
+}
+
+void RemoteLayerHostingManagerProxy::releaseLayerHostForIdentifier(PlaybackSessionContextIdentifier identifier)
+{
+    auto it = m_hostedLayers.find(identifier);
+    if (it == m_hostedLayers.end())
+        return;
+
+    it->value.hasUIProcessConsumer = false;
+    removeRemoteLayerHostIfUnused(identifier);
+}
+
+void RemoteLayerHostingManagerProxy::removeRemoteLayerHostIfUnused(PlaybackSessionContextIdentifier identifier)
+{
+    auto it = m_hostedLayers.find(identifier);
+    if (it == m_hostedLayers.end())
+        return;
+
+    if (it->value.hasGPUProcessVideoLayer || it->value.hasUIProcessConsumer)
+        return;
+
+    RetainPtr hostView = it->value.hostView;
+    m_hostedLayers.remove(it);
+    [hostView removeFromSuperview];
+}
+
+void RemoteLayerHostingManagerProxy::setRemoteLayerHostSize(PlaybackSessionContextIdentifier identifier, const WebCore::FloatSize& size)
+{
+    auto it = m_hostedLayers.find(identifier);
+    if (it == m_hostedLayers.end())
+        return;
+
+    auto& info = it->value;
+    if (info.size == size)
+        return;
+
+    info.size = size;
+
+    RefPtr process = m_gpuProcess.get();
+    if (!process)
+        return;
+
+    runWithFenceForIdentifier(identifier, [&](auto&& fence) {
+        process->send(Messages::RemoteLayerHostingManager::SetRemoteLayerSizeFenced(identifier, size, WTF::move(fence)), 0);
+    });
+}
+
+void RemoteLayerHostingManagerProxy::setRemoteLayerVideoGravity(PlaybackSessionContextIdentifier identifier, const String& videoGravity)
+{
+    auto it = m_hostedLayers.find(identifier);
+    if (it == m_hostedLayers.end())
+        return;
+
+    auto& info = it->value;
+    if (info.videoGravity == videoGravity)
+        return;
+
+    info.videoGravity = videoGravity;
+
+    RefPtr process = m_gpuProcess.get();
+    if (!process)
+        return;
+
+    runWithFenceForIdentifier(identifier, [&](auto&& fence) {
+        process->send(Messages::RemoteLayerHostingManager::SetRemoteLayerVideoGravityFenced(identifier, videoGravity, WTF::move(fence)), 0);
+    });
+}
+
+void RemoteLayerHostingManagerProxy::countGPUProcessRemoteLayersForTesting(CompletionHandler<void(uint64_t)>&& completionHandler)
+{
+    RefPtr process = m_gpuProcess.get();
+    if (!process) {
+        completionHandler(0);
+        return;
+    }
+
+    process->sendWithAsyncReply(Messages::RemoteLayerHostingManager::CountRemoteLayersForTesting(), WTF::move(completionHandler), 0);
+}
+
+String RemoteLayerHostingManagerProxy::gpuProcessRemoteLayerTreeAsTextForTesting()
+{
+    RefPtr process = m_gpuProcess.get();
+    if (!process)
+        return { };
+
+    auto sendResult = process->sendSync(Messages::RemoteLayerHostingManager::RemoteLayerTreeAsTextForTesting(), 0);
+    if (!sendResult.succeeded())
+        return "<no reply from GPU process>"_s;
+
+    auto [description] = sendResult.takeReply();
+    return description;
+}
+
+void RemoteLayerHostingManagerProxy::didCreateRemoteLayer(PlaybackSessionContextIdentifier identifier, WebCore::HostingContext&& hostingContext)
+{
+    auto& info = ensureRemoteLayerHostInfo(identifier);
+    info.hostingContext = WTF::move(hostingContext);
+    info.hasGPUProcessVideoLayer = true;
+    applyHostingContextToLayerHost(info);
+}
+
+void RemoteLayerHostingManagerProxy::didRemoveRemoteLayer(PlaybackSessionContextIdentifier identifier)
+{
+    auto it = m_hostedLayers.find(identifier);
+    if (it == m_hostedLayers.end())
+        return;
+
+    auto& info = it->value;
+    info.hasGPUProcessVideoLayer = false;
+    info.hostingContext = { };
+
+    applyHostingContextToLayerHost(info);
+
+    removeRemoteLayerHostIfUnused(identifier);
+}
+
+void RemoteLayerHostingManagerProxy::runWithFenceForIdentifier(PlaybackSessionContextIdentifier identifier, Function<void(WTF::MachSendRightAnnotated&&)>&& task)
+{
+    WTF::MachSendRightAnnotated fence;
+
+    auto it = m_hostedLayers.find(identifier);
+    if (it == m_hostedLayers.end()) {
+        task(WTF::move(fence));
+        return;
+    }
+
+#if PLATFORM(IOS_FAMILY)
+#if USE(EXTENSIONKIT)
+    RetainPtr hostingView = [it->value.hostView layerHierarchyHostingView];
+    if (hostingView) {
+        RetainPtr hostingUpdateCoordinator = [BELayerHierarchyHostingTransactionCoordinator coordinatorWithError:nil];
+        [hostingUpdateCoordinator addLayerHierarchyHostingView:hostingView.get()];
+#if ENABLE(MACH_PORT_LAYER_HOSTING)
+        fence = LayerHostingContext::fence(hostingUpdateCoordinator.get());
+#else
+        OSObjectPtr<xpc_object_t> xpcRepresentationHostingCoordinator = [hostingUpdateCoordinator createXPCRepresentation];
+        fence.sendRight = MachSendRight::adopt(xpc_dictionary_copy_mach_send(xpcRepresentationHostingCoordinator.get(), machPortKey));
+#endif
+        task(WTF::move(fence));
+        [hostingUpdateCoordinator commit];
+        return;
+    }
+#else
+    fence.sendRight = MachSendRight::adopt([UIWindow _synchronizeDrawingAcrossProcesses]);
+#endif // USE(EXTENSIONKIT)
+#else
+    if (RefPtr page = it->value.page) {
+        if (RefPtr drawingArea = page->drawingArea())
+            fence.sendRight = drawingArea->createFence();
+    }
+#endif
+    task(WTF::move(fence));
+}
+
+#if USE(EXTENSIONKIT)
+void RemoteLayerHostingManagerProxy::addVisibilityPropogationView(PlaybackSessionContextIdentifier identifier)
+{
+    auto it = m_hostedLayers.find(identifier);
+    if (it == m_hostedLayers.end())
+        return;
+    RetainPtr hostView = it->value.hostView;
+    RefPtr page = it->value.page;
+
+    if (!hostView || !page)
+        return;
+
+    RefPtr pageClient = page->pageClient();
+    if (!pageClient)
+        return;
+
+    if (RetainPtr oldVisibilityPropagationView = [hostView visibilityPropagationView])
+        pageClient->removeVisibilityPropagationView(oldVisibilityPropagationView.get());
+
+    if (RetainPtr newVisibilityPropagationView = pageClient->createVisibilityPropagationView())
+        [hostView setVisibilityPropagationView:newVisibilityPropagationView];
+}
+
+void RemoteLayerHostingManagerProxy::removeVisibilityPropogationView(PlaybackSessionContextIdentifier identifier)
+{
+    auto it = m_hostedLayers.find(identifier);
+    if (it == m_hostedLayers.end())
+        return;
+    RetainPtr hostView = it->value.hostView;
+    RefPtr page = it->value.page;
+
+    if (!hostView || !page)
+        return;
+
+    RefPtr pageClient = page->pageClient();
+    if (!pageClient)
+        return;
+
+    if (RetainPtr oldVisibilityPropagationView = [hostView visibilityPropagationView])
+        pageClient->removeVisibilityPropagationView(oldVisibilityPropagationView.get());
+    [hostView setVisibilityPropagationView:nil];
+}
+#endif
+
+
+} // namespace WebKit
+
+#endif // ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -62,6 +62,7 @@ constexpr size_t DefaultMockPictureInPictureWindowHeight = 100;
 class WebPageProxy;
 class PlaybackSessionManagerProxy;
 class PlaybackSessionModelContext;
+class RemoteLayerHostingManagerProxy;
 class VideoPresentationManagerProxy;
 #if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
 class LayerHostingVisibilityPropagator;
@@ -248,7 +249,11 @@ private:
 
     void hasVideoInPictureInPictureDidChange(bool);
 
-    RetainPtr<WKLayerHostView> createLayerHostViewWithID(PlaybackSessionContextIdentifier, const WebCore::HostingContext&, const WebCore::FloatSize& initialSize, float hostingScaleFactor);
+    RetainPtr<CocoaView> createLayerHostViewWithID(PlaybackSessionContextIdentifier, const WebCore::HostingContext&, const WebCore::FloatSize& initialSize, float hostingScaleFactor);
+    RetainPtr<CocoaView> createRemoteLayerHostViewWithID(PlaybackSessionContextIdentifier, const WebCore::FloatSize& initialSize);
+    // FIXME: Remove along with WKLayerHostView once RemoteLayerHostingBypassesWebContentProcess
+    // is enabled unconditionally. See https://bugs.webkit.org/show_bug.cgi?id=309973.
+    RetainPtr<WKLayerHostView> createLegacyLayerHostViewWithID(PlaybackSessionContextIdentifier, const WebCore::HostingContext&, const WebCore::FloatSize& initialSize, float hostingScaleFactor);
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     void setVisibilityPropagationViewForLayerHostView(UIView *, WKLayerHostView *);
@@ -316,6 +321,8 @@ private:
     void callCloseCompletionHandlers();
 
     void videosInElementFullscreenChanged();
+    RefPtr<RemoteLayerHostingManagerProxy> remoteLayerHostingManager();
+    bool remoteLayerHostingBypassesWebContentProcess() const;
 
 #if !RELEASE_LOG_DISABLED
     const Logger& NODELETE logger() const;

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -40,10 +40,12 @@
 #import "PlaybackSessionInterfaceAVKit.h"
 #import "PlaybackSessionInterfaceLMK.h"
 #import "PlaybackSessionManagerProxy.h"
+#import "RemoteLayerHostingManagerProxy.h"
 #import "VideoPresentationInterfaceAVKit.h"
 #import "VideoPresentationInterfaceLMK.h"
 #import "VideoPresentationManagerMessages.h"
 #import "VideoPresentationManagerProxyMessages.h"
+#import "WKVideoLayerHostView.h"
 #import "WKVideoView.h"
 #import "WebFrameProxy.h"
 #import "WebFullScreenManagerProxy.h"
@@ -83,6 +85,9 @@
 
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, connection)
 
+// FIXME: Remove WKLayerHostView, and everything guarded by
+// !remoteLayerHostingBypassesWebContentProcess(), once that setting is enabled
+// unconditionally. See https://bugs.webkit.org/show_bug.cgi?id=309973.
 @interface WKLayerHostView : CocoaView
 @property (nonatomic, assign) uint32_t contextID;
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
@@ -838,6 +843,9 @@ void VideoPresentationManagerProxy::removeClientForContext(PlaybackSessionContex
     ALWAYS_LOG(LOGIDENTIFIER, clientCount);
 
     if (clientCount <= 0) {
+        if (RefPtr remoteLayerHostingManager = this->remoteLayerHostingManager())
+            remoteLayerHostingManager->releaseLayerHostForIdentifier(contextId);
+
         invalidateInterface(ensureInterface(contextId));
         m_playbackSessionManagerProxy->removeClientForContext(contextId);
         m_clientCounts.remove(contextId);
@@ -879,6 +887,12 @@ void VideoPresentationManagerProxy::hasVideoInPictureInPictureDidChange(bool val
     m_pipChangeObservers.forEach([value] (auto& observer) { observer(value); });
 }
 
+static void configureResizeBehaviorForHostedVideoLayer(WebAVPlayerLayer *playerLayer, bool remoteLayerHostingBypassesWebContentProcess)
+{
+    if (remoteLayerHostingBypassesWebContentProcess)
+        [playerLayer setPreviewsResizeWithTransform:NO];
+}
+
 PlatformLayerContainer VideoPresentationManagerProxy::createLayerWithID(PlaybackSessionContextIdentifier contextId, const WebCore::HostingContext& hostingContext, const WebCore::FloatSize& initialSize, const WebCore::FloatSize& nativeSize, float hostingDeviceScaleFactor)
 {
     auto [model, interface] = ensureModelAndInterface(contextId);
@@ -887,15 +901,18 @@ PlatformLayerContainer VideoPresentationManagerProxy::createLayerWithID(Playback
     if (model->videoDimensions().isEmpty() && !nativeSize.isEmpty())
         model->setVideoDimensions(nativeSize);
 
-    RetainPtr<WKLayerHostView> view = createLayerHostViewWithID(contextId, hostingContext, initialSize, hostingDeviceScaleFactor);
+    RetainPtr<CocoaView> view = createLayerHostViewWithID(contextId, hostingContext, initialSize, hostingDeviceScaleFactor);
+    if (!view)
+        return nullptr;
 
     if (!interface->playerLayer()) {
         ALWAYS_LOG(LOGIDENTIFIER, model->logIdentifier(), ", Creating AVPlayerLayer, initialSize: ", initialSize, ", nativeSize: ", nativeSize);
-        auto playerLayer = adoptNS([[WebAVPlayerLayer alloc] init]);
+        RetainPtr playerLayer = adoptNS([[WebAVPlayerLayer alloc] init]);
         RetainPtr viewLayer = [view layer];
 
         [playerLayer setPresentationModel:model.ptr()];
         [playerLayer setVideoSublayer:viewLayer.get()];
+        configureResizeBehaviorForHostedVideoLayer(playerLayer.get(), remoteLayerHostingBypassesWebContentProcess());
 
         // The videoView may already be reparented in fullscreen, so only parent the view
         // if it has no existing parent:
@@ -914,7 +931,48 @@ PlatformLayerContainer VideoPresentationManagerProxy::createLayerWithID(Playback
     return interface->playerLayer();
 }
 
-RetainPtr<WKLayerHostView> VideoPresentationManagerProxy::createLayerHostViewWithID(PlaybackSessionContextIdentifier contextId, const WebCore::HostingContext& hostingContext, const WebCore::FloatSize& initialSize, float hostingDeviceScaleFactor)
+RetainPtr<CocoaView> VideoPresentationManagerProxy::createLayerHostViewWithID(PlaybackSessionContextIdentifier contextId, const WebCore::HostingContext& hostingContext, const WebCore::FloatSize& initialSize, float hostingDeviceScaleFactor)
+{
+    if (remoteLayerHostingBypassesWebContentProcess())
+        return createRemoteLayerHostViewWithID(contextId, initialSize);
+    return createLegacyLayerHostViewWithID(contextId, hostingContext, initialSize, hostingDeviceScaleFactor);
+}
+
+RetainPtr<CocoaView> VideoPresentationManagerProxy::createRemoteLayerHostViewWithID(PlaybackSessionContextIdentifier contextId, const WebCore::FloatSize& initialSize)
+{
+    auto [model, interface] = ensureModelAndInterface(contextId);
+
+    RetainPtr view = interface->layerHostView();
+    if (!view) {
+        RefPtr remoteLayerHostingManager = this->remoteLayerHostingManager();
+        if (!remoteLayerHostingManager)
+            return nil;
+        RefPtr page = m_page.get();
+        if (!page)
+            return nil;
+        remoteLayerHostingManager->setPageForIdentifier(contextId, *page);
+        view = (CocoaView *)remoteLayerHostingManager->ensureLayerHostViewForIdentifier(contextId).get();
+        if (!view)
+            return nil;
+
+#if USE(EXTENSIONKIT)
+        remoteLayerHostingManager->addVisibilityPropogationView(contextId);
+#endif
+
+        interface->setLayerHostView(view.get());
+
+        RetainPtr layer = [view layer];
+        layer.get().masksToBounds = NO;
+        layer.get().name = @"WKVideoLayerHostView layer";
+        layer.get().frame = CGRectMake(0, 0, initialSize.width(), initialSize.height());
+    }
+
+    interface->setupCaptionsLayer(retainPtr([view layer]).get(), initialSize);
+
+    return view;
+}
+
+RetainPtr<WKLayerHostView> VideoPresentationManagerProxy::createLegacyLayerHostViewWithID(PlaybackSessionContextIdentifier contextId, const WebCore::HostingContext& hostingContext, const WebCore::FloatSize& initialSize, float hostingDeviceScaleFactor)
 {
     auto [model, interface] = ensureModelAndInterface(contextId);
 
@@ -954,7 +1012,7 @@ RetainPtr<WKLayerHostView> VideoPresentationManagerProxy::createLayerHostViewWit
     if (layerHandle)
         [view->_hostingView setHandle:layerHandle.get()];
     else
-        RELEASE_LOG_ERROR(Media, "VideoPresentationManagerProxy::createLayerHostViewWithID: could not create layer handle");
+        RELEASE_LOG_ERROR(Media, "VideoPresentationManagerProxy::createLegacyLayerHostViewWithID: could not create layer handle");
 #else
     [view setContextID:hostingContext.contextID];
 #endif
@@ -1000,7 +1058,7 @@ RetainPtr<WKVideoView> VideoPresentationManagerProxy::createViewWithID(PlaybackS
     auto [model, interface] = ensureModelAndInterface(contextId);
     addClientForContext(contextId);
 
-    RetainPtr<WKLayerHostView> view = createLayerHostViewWithID(contextId, hostingContext, initialSize, hostingDeviceScaleFactor);
+    RetainPtr view = createLayerHostViewWithID(contextId, hostingContext, initialSize, hostingDeviceScaleFactor);
 
     if (!interface->videoView()) {
         ALWAYS_LOG(LOGIDENTIFIER, model->logIdentifier(), ", Creating AVPlayerLayerView");
@@ -1013,6 +1071,7 @@ RetainPtr<WKVideoView> VideoPresentationManagerProxy::createViewWithID(PlaybackS
         [playerLayer setVideoDimensions:nativeSize];
         [playerLayer setPresentationModel:model.ptr()];
         [playerLayer setVideoSublayer:[view layer]];
+        configureResizeBehaviorForHostedVideoLayer(playerLayer.get(), remoteLayerHostingBypassesWebContentProcess());
 
         [playerView addSubview:view.get()];
         [playerView setUserInteractionEnabled:NO];
@@ -1144,18 +1203,22 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(IPC::Connection& conne
     ASSERT(interface->videoView());
 #endif
 
-    RetainPtr view = interface->layerHostView() ? RetainPtr { static_cast<WKLayerHostView*>(interface->layerHostView()) } : createLayerHostViewWithID(contextId, hostingContext, initialSize, hostingDeviceScaleFactor);
+    if (!remoteLayerHostingBypassesWebContentProcess()) {
+        RetainPtr<CocoaView> view = interface->layerHostView() ? RetainPtr<CocoaView> { interface->layerHostView() } : createLayerHostViewWithID(contextId, hostingContext, initialSize, hostingDeviceScaleFactor);
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
-    RefPtr pageClient = page->pageClient();
-    if (RetainPtr visibilityPropagationView = pageClient ? pageClient->createVisibilityPropagationView() : nil)
-        setVisibilityPropagationViewForLayerHostView(visibilityPropagationView.get(), view.get());
+        RefPtr pageClient = page->pageClient();
+        if (RetainPtr layerHostView = dynamic_objc_cast<WKLayerHostView>(view.get())) {
+            if (RetainPtr visibilityPropagationView = pageClient ? pageClient->createVisibilityPropagationView() : nil)
+                setVisibilityPropagationViewForLayerHostView(visibilityPropagationView.get(), layerHostView.get());
+        }
 #if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
-    if (RefPtr layerHostingVisibilityPropagator = pageClient ? pageClient->createLayerHostingVisibilityPropagator() : nil)
-        model->setLayerHostingVisibilityPropagator(WTF::move(layerHostingVisibilityPropagator));
+        if (RefPtr layerHostingVisibilityPropagator = pageClient ? pageClient->createLayerHostingVisibilityPropagator() : nil)
+            model->setLayerHostingVisibilityPropagator(WTF::move(layerHostingVisibilityPropagator));
 #endif
 #else
-    UNUSED_VARIABLE(view);
+        UNUSED_VARIABLE(view);
 #endif
+    }
 
 #if PLATFORM(IOS_FAMILY)
     UNUSED_PARAM(hasObjectViewBox);
@@ -1174,7 +1237,9 @@ void VideoPresentationManagerProxy::setupFullscreenWithID(IPC::Connection& conne
     IntRect initialWindowRect;
     page->rootViewToWindow(enclosingIntRect(screenRect), initialWindowRect);
     interface->setupFullscreen(initialWindowRect, protect(page->platformWindow()).get(), videoFullscreenMode, allowsPictureInPicture, hasObjectViewBox);
-    interface->setupCaptionsLayer(retainPtr([view layer]).get(), initialSize);
+    if (RetainPtr view = interface->layerHostView())
+        interface->setupCaptionsLayer(retainPtr([view layer]).get(), initialSize);
+    createLayerHostViewWithID(contextId, hostingContext, initialSize, hostingDeviceScaleFactor);
 #endif
 }
 
@@ -1540,15 +1605,18 @@ void VideoPresentationManagerProxy::returnVideoView(PlaybackSessionContextIdenti
 
 void VideoPresentationManagerProxy::didSetupFullscreen(PlaybackSessionContextIdentifier contextId)
 {
-#if PLATFORM(IOS_FAMILY)
+#if !PLATFORM(IOS_FAMILY)
+    if (!remoteLayerHostingBypassesWebContentProcess()) {
+        sendToWebProcess(contextId, Messages::VideoPresentationManager::DidSetupFullscreen(contextId.object()));
+        return;
+    }
+#endif
+
     RefPtr page = m_page.get();
     if (page)
         page->willEnterFullscreen(contextId);
 
     enterFullscreenForContext(contextId);
-#else
-    sendToWebProcess(contextId, Messages::VideoPresentationManager::DidSetupFullscreen(contextId.object()));
-#endif
 }
 
 void VideoPresentationManagerProxy::willExitFullscreen(PlaybackSessionContextIdentifier contextId)
@@ -1611,13 +1679,20 @@ void VideoPresentationManagerProxy::didCleanupFullscreen(PlaybackSessionContextI
 
     auto [model, interface] = ensureModelAndInterface(contextId);
 
+    if (remoteLayerHostingBypassesWebContentProcess()) {
+#if USE(EXTENSIONKIT)
+        if (RefPtr remoteLayerHostingManager = this->remoteLayerHostingManager())
+            remoteLayerHostingManager->removeVisibilityPropogationView(contextId);
+#endif
+    } else {
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
-    if (RetainPtr layerHostView = dynamic_objc_cast<WKLayerHostView>(interface->layerHostView()))
-        setVisibilityPropagationViewForLayerHostView(nil, layerHostView.get());
+        if (RetainPtr layerHostView = dynamic_objc_cast<WKLayerHostView>(interface->layerHostView()))
+            setVisibilityPropagationViewForLayerHostView(nil, layerHostView.get());
 #if ENABLE(ENDOWMENT_BASED_APPLICATION_STATE_TRACKING)
-    model->setLayerHostingVisibilityPropagator(nullptr);
+        model->setLayerHostingVisibilityPropagator(nullptr);
 #endif
 #endif
+    }
 
     [protect(interface->layerHostView()) removeFromSuperview];
     interface->removeCaptionsLayer();
@@ -1650,6 +1725,14 @@ void VideoPresentationManagerProxy::setVideoLayerFrame(PlaybackSessionContextIde
 
     auto [model, interface] = ensureModelAndInterface(contextId);
     interface->setCaptionsFrame(CGRectMake(0, 0, frame.width(), frame.height()));
+
+    // The captions layer above lives in this process and must be updated on both paths.
+    // The video layer geometry, however, is forwarded to the GPU process directly by
+    // -[WKVideoLayerHost setFrame:] when remote layer hosting bypasses the WebContent
+    // process, so there is nothing further to send from here.
+    if (remoteLayerHostingBypassesWebContentProcess())
+        return;
+
     WTF::MachSendRightAnnotated sendRightAnnotated;
 #if PLATFORM(IOS_FAMILY)
 #if USE(EXTENSIONKIT)
@@ -1817,6 +1900,28 @@ RefPtr<PlatformVideoPresentationInterface> VideoPresentationManagerProxy::bestVi
 #else
     return nullptr;
 #endif
+}
+
+RefPtr<RemoteLayerHostingManagerProxy> VideoPresentationManagerProxy::remoteLayerHostingManager()
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return nullptr;
+
+    RefPtr gpuProcess = page->configuration().processPool().gpuProcess();
+    if (!gpuProcess)
+        return nullptr;
+
+    return gpuProcess->remoteLayerHostingManagerProxy();
+}
+
+bool VideoPresentationManagerProxy::remoteLayerHostingBypassesWebContentProcess() const
+{
+#if ENABLE(GPU_PROCESS) && PLATFORM(COCOA)
+    if (RefPtr page = m_page.get())
+        return protect(page->preferences())->remoteLayerHostingBypassesWebContentProcess();
+#endif
+    return false;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/WKVideoLayerHost.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKVideoLayerHost.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import "PlaybackSessionContextIdentifier.h"
+#import <AVFoundation/AVAnimation.h>
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
+
+namespace WebKit {
+class RemoteLayerHostingManagerProxy;
+}
+
+@interface WKVideoLayerHost : CALayerHost
+@property (nonatomic, assign) WebKit::RemoteLayerHostingManagerProxy* parent;
+@property (nonatomic, retain) AVLayerVideoGravity videoGravity;
+-(void)setIdentifier:(WebKit::PlaybackSessionContextIdentifier)identifier;
+@end
+

--- a/Source/WebKit/UIProcess/Cocoa/WKVideoLayerHost.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKVideoLayerHost.mm
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WKVideoLayerHost.h"
+
+#include "RemoteLayerHostingManagerProxy.h"
+
+@implementation WKVideoLayerHost {
+    WeakPtr<WebKit::RemoteLayerHostingManagerProxy> _parent;
+    std::optional<WebKit::PlaybackSessionContextIdentifier> _identifier;
+    RetainPtr<AVLayerVideoGravity> _videoGravity;
+}
+
+- (void)setParent:(WebKit::RemoteLayerHostingManagerProxy*)parent
+{
+    _parent = parent;
+}
+
+- (WebKit::RemoteLayerHostingManagerProxy*)parent
+{
+    return _parent.get();
+}
+
+- (void)setIdentifier:(WebKit::PlaybackSessionContextIdentifier)identifier
+{
+    _identifier = identifier;
+}
+
+- (void)setFrame:(CGRect)frame {
+    [super setFrame:frame];
+    if (RefPtr parent = _parent; parent && _identifier)
+        parent->setRemoteLayerHostSize(*_identifier, WebCore::FloatSize(frame.size));
+}
+
+- (AVLayerVideoGravity)videoGravity {
+    return _videoGravity.get();
+}
+
+- (void)setVideoGravity:(AVLayerVideoGravity)videoGravity {
+    if ([videoGravity isEqual:_videoGravity.get()])
+        return;
+    _videoGravity = videoGravity;
+
+    if (RefPtr parent = _parent; parent && _identifier)
+        parent->setRemoteLayerVideoGravity(*_identifier, _videoGravity.get());
+}
+
+- (NSString *)name {
+    return @"WKVideoLayerHost";
+}
+@end

--- a/Source/WebKit/UIProcess/Cocoa/WKVideoLayerHostView.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKVideoLayerHostView.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <WebCore/CocoaView.h>
+
+#if USE(EXTENSIONKIT)
+#import <BrowserEngineKit/BELayerHierarchyHostingView.h>
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+#import <UIKit/UIView.h>
+#else
+#import <AppKit/NSView.h>
+#endif
+
+@class WKVideoLayerHost;
+
+#if PLATFORM(IOS_FAMILY)
+@interface WKVideoLayerHostView : UIView
+#else
+@interface WKVideoLayerHostView : NSView
+#endif
+#if USE(EXTENSIONKIT)
+@property (nonatomic, strong) CocoaView *visibilityPropagationView;
+
+// Where a BELayerHierarchy is hosted, in place of CALayerHost's contextId. Sized to track
+// this view, so that the hosted hierarchy follows the video layer's geometry.
+@property (nonatomic, readonly) BELayerHierarchyHostingView *layerHierarchyHostingView;
+#endif
+@property (readonly) WKVideoLayerHost *layerHost;
+
+@end

--- a/Source/WebKit/UIProcess/Cocoa/WKVideoLayerHostView.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKVideoLayerHostView.mm
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WKVideoLayerHostView.h"
+
+#include "WKVideoLayerHost.h"
+#include <wtf/WeakObjCPtr.h>
+#include <wtf/cocoa/TypeCastsCocoa.h>
+
+#if PLATFORM(IOS_FAMILY)
+using CocoaRect = CGRect;
+#else
+using CocoaRect = NSRect;
+#endif
+
+@implementation WKVideoLayerHostView {
+#if PLATFORM(IOS_FAMILY)
+    WeakObjCPtr<UIWindow> _window;
+#endif
+#if USE(EXTENSIONKIT)
+    RetainPtr<CocoaView> _visibilityPropagationView;
+    RetainPtr<BELayerHierarchyHostingView> _hostingView;
+#endif
+}
+
+- (instancetype)initWithFrame:(CocoaRect)frame {
+    self = [super initWithFrame:frame];
+    if (!self)
+        return nil;
+
+#if USE(EXTENSIONKIT)
+    _hostingView = adoptNS([[BELayerHierarchyHostingView alloc] init]);
+    [_hostingView setFrame:[self bounds]];
+    [self addSubview:_hostingView.get()];
+#endif
+
+    return self;
+}
+
+#if USE(EXTENSIONKIT)
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+    [_hostingView setFrame:[self bounds]];
+}
+
+- (BELayerHierarchyHostingView *)layerHierarchyHostingView
+{
+    return _hostingView.get();
+}
+#endif
+
+#if PLATFORM(IOS_FAMILY)
++ (Class)layerClass {
+    return [WKVideoLayerHost class];
+}
+#else
+- (CALayer *)makeBackingLayer {
+    return adoptNS([[WKVideoLayerHost alloc] init]).autorelease();
+}
+#endif
+
+- (WKVideoLayerHost *)layerHost {
+    return checked_objc_cast<WKVideoLayerHost>([self layer]);
+}
+
+- (BOOL)clipsToBounds {
+    return NO;
+}
+
+#if PLATFORM(IOS_FAMILY)
+- (void)willMoveToWindow:(UIWindow *)newWindow {
+    _window = newWindow;
+    [super willMoveToWindow:newWindow];
+}
+
+- (UIWindow *)window {
+    if (!_window)
+        return nil;
+    return [super window];
+}
+#endif
+
+#if USE(EXTENSIONKIT)
+- (CocoaView *)visibilityPropagationView
+{
+    return _visibilityPropagationView.get();
+}
+
+- (void)setVisibilityPropagationView:(CocoaView *)visibilityPropagationView
+{
+    [_visibilityPropagationView removeFromSuperview];
+    _visibilityPropagationView = visibilityPropagationView;
+    [self addSubview:_visibilityPropagationView.get()];
+}
+#endif // USE(EXTENSIONKIT)
+
+@end
+

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -65,6 +65,10 @@
 #include <wtf/spi/darwin/XPCSPI.h>
 #endif
 
+#if PLATFORM(COCOA)
+#include "RemoteLayerHostingManagerProxy.h"
+#endif
+
 #if USE(SANDBOX_EXTENSIONS_FOR_CACHE_AND_TEMP_DIRECTORY_ACCESS)
 #include "SandboxUtilities.h"
 #include <wtf/FileSystem.h>
@@ -168,6 +172,9 @@ GPUProcessProxy::GPUProcessProxy()
     : AuxiliaryProcessProxy("GPUProcess"_s, WebProcessPool::anyProcessPoolNeedsUIBackgroundAssertion() ? ShouldTakeUIBackgroundAssertion::Yes : ShouldTakeUIBackgroundAssertion::No)
 #if ENABLE(MEDIA_STREAM)
     , m_useMockCaptureDevices(MockRealtimeMediaSourceCenter::mockRealtimeMediaSourceCenterEnabled())
+#endif
+#if PLATFORM(COCOA)
+    , m_remoteLayerHostingManagerProxy { RemoteLayerHostingManagerProxy::create(*this) }
 #endif
 {
     connect();

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -75,6 +75,7 @@ class SandboxExtensionHandle;
 class WebPageProxy;
 class WebProcessProxy;
 class WebsiteDataStore;
+class RemoteLayerHostingManagerProxy;
 
 struct CoreIPCAuditToken;
 struct GPUProcessConnectionParameters;
@@ -179,6 +180,8 @@ public:
     void postWillTakeSnapshotNotification(CompletionHandler<void()>&&);
 
     void sinkCompletedSnapshotToPDF(RemoteSnapshotIdentifier, const WebCore::FloatSize&, WebCore::FrameIdentifier root, CompletionHandler<void(RefPtr<WebCore::SharedBuffer>&&)>&&);
+
+    RemoteLayerHostingManagerProxy& remoteLayerHostingManagerProxy() LIFETIME_BOUND;
 #endif
     void sinkCompletedSnapshotToBitmap(RemoteSnapshotIdentifier, const WebCore::FloatSize&, WebCore::FrameIdentifier root, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&);
     void releaseSnapshot(RemoteSnapshotIdentifier);
@@ -208,6 +211,7 @@ private:
 
     // IPC::Connection::Client
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) override;
     void didClose(IPC::Connection&) override;
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName, const Vector<uint32_t>& indicesOfObjectsFailingDecoding) override;
 
@@ -261,6 +265,7 @@ private:
 #if PLATFORM(COCOA)
     static bool s_enableMetalDebugDeviceInNewGPUProcessesForTesting;
     static bool s_enableMetalShaderValidationInNewGPUProcessesForTesting;
+    const Ref<RemoteLayerHostingManagerProxy> m_remoteLayerHostingManagerProxy;
 #endif
 
     HashSet<PAL::SessionID> m_sessionIDs;

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in
@@ -27,7 +27,7 @@
     DispatchedTo=UI,
     ExceptionForEnabledBy
 ]
-messages -> GPUProcessProxy {
+messages -> GPUProcessProxy WantsDispatchMessage {
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     DidCreateContextForVisibilityPropagation(WebKit::WebPageProxyIdentifier pageProxyID, WebCore::PageIdentifier pageID, WebKit::LayerHostingContextID contextID)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2359,6 +2359,8 @@
 		CA05397923EE324400A553DC /* ContentAsStringIncludesChildFrames.h in Headers */ = {isa = PBXBuildFile; fileRef = CA05397823EE324400A553DC /* ContentAsStringIncludesChildFrames.h */; };
 		CD003A5319D49B5D005ABCE0 /* WebMediaKeyStorageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = CD003A5119D49B5D005ABCE0 /* WebMediaKeyStorageManager.h */; };
 		CD0C6831201FD10100A59409 /* WKFullScreenViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = CD0C682F201FD10100A59409 /* WKFullScreenViewController.h */; };
+		CD150CA72F64E68C00E66163 /* RemoteLayerHostingManager.h in Headers */ = {isa = PBXBuildFile; fileRef = CD150CA32F64E68400E66163 /* RemoteLayerHostingManager.h */; };
+		CD150CAB2F64E6B000E66163 /* RemoteLayerHostingManagerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = CD150CA82F64E6A900E66163 /* RemoteLayerHostingManagerProxy.h */; };
 		CD19A26E1A13E834008D650E /* WebDiagnosticLoggingClient.h in Headers */ = {isa = PBXBuildFile; fileRef = CD19A26A1A13E821008D650E /* WebDiagnosticLoggingClient.h */; };
 		CD19D2EA2046406F0017074A /* FullscreenTouchSecheuristic.h in Headers */ = {isa = PBXBuildFile; fileRef = CD19D2E82046406F0017074A /* FullscreenTouchSecheuristic.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CD4570D424411D0F00A3DCEB /* AudioSessionRoutingArbitrator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD4570CB2440FB2A00A3DCEB /* AudioSessionRoutingArbitrator.cpp */; };
@@ -8401,6 +8403,18 @@
 		CD09FD0A26152E2300E4ACF1 /* WebKitSwift.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = WebKitSwift.xcconfig; sourceTree = "<group>"; };
 		CD0C682F201FD10100A59409 /* WKFullScreenViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKFullScreenViewController.h; sourceTree = "<group>"; };
 		CD0C6830201FD10100A59409 /* WKFullScreenViewController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKFullScreenViewController.mm; sourceTree = "<group>"; };
+		CD150CA12F64E68400E66163 /* GPUConnectionToWebProcessCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GPUConnectionToWebProcessCocoa.mm; sourceTree = "<group>"; };
+		CD150CA22F64E68400E66163 /* GPUProcessCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = GPUProcessCocoa.mm; sourceTree = "<group>"; };
+		CD150CA32F64E68400E66163 /* RemoteLayerHostingManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteLayerHostingManager.h; sourceTree = "<group>"; };
+		CD150CA42F64E68400E66163 /* RemoteLayerHostingManager.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteLayerHostingManager.mm; sourceTree = "<group>"; };
+		CD150CA52F64E68400E66163 /* RemoteLayerHostingManager.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteLayerHostingManager.messages.in; sourceTree = "<group>"; };
+		CD150CA82F64E6A900E66163 /* RemoteLayerHostingManagerProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteLayerHostingManagerProxy.h; sourceTree = "<group>"; };
+		CD150CA92F64E6A900E66163 /* RemoteLayerHostingManagerProxy.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteLayerHostingManagerProxy.mm; sourceTree = "<group>"; };
+		CD150CAA2F64E6A900E66163 /* RemoteLayerHostingManagerProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteLayerHostingManagerProxy.messages.in; sourceTree = "<group>"; };
+		CD150CAC2F650EF700E66163 /* RemoteLayerHostingManagerMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteLayerHostingManagerMessageReceiver.cpp; sourceTree = "<group>"; };
+		CD150CAD2F650EF700E66163 /* RemoteLayerHostingManagerMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteLayerHostingManagerMessages.h; sourceTree = "<group>"; };
+		CD150CAE2F650EF700E66163 /* RemoteLayerHostingManagerProxyMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteLayerHostingManagerProxyMessageReceiver.cpp; sourceTree = "<group>"; };
+		CD150CAF2F650EF700E66163 /* RemoteLayerHostingManagerProxyMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteLayerHostingManagerProxyMessages.h; sourceTree = "<group>"; };
 		CD19A2691A13E820008D650E /* WebDiagnosticLoggingClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebDiagnosticLoggingClient.cpp; sourceTree = "<group>"; };
 		CD19A26A1A13E821008D650E /* WebDiagnosticLoggingClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebDiagnosticLoggingClient.h; sourceTree = "<group>"; };
 		CD19D2E82046406F0017074A /* FullscreenTouchSecheuristic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FullscreenTouchSecheuristic.h; sourceTree = "<group>"; };
@@ -8478,6 +8492,10 @@
 		CD8FD70D2EF3272300291438 /* RemoteMediaResourceLoader.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteMediaResourceLoader.messages.in; sourceTree = "<group>"; };
 		CD8FD70E2EF3283600291438 /* RemoteMediaResourceLoaderMessageReceiver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = RemoteMediaResourceLoaderMessageReceiver.cpp; path = /Volumes/Users/jer/Projects/WebKit.git/OpenSource/WebKitBuild/Debug/DerivedSources/WebKit/RemoteMediaResourceLoaderMessageReceiver.cpp; sourceTree = "<absolute>"; };
 		CD8FD70F2EF3283600291438 /* RemoteMediaResourceLoaderMessages.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = RemoteMediaResourceLoaderMessages.h; path = /Volumes/Users/jer/Projects/WebKit.git/OpenSource/WebKitBuild/Debug/DerivedSources/WebKit/RemoteMediaResourceLoaderMessages.h; sourceTree = "<absolute>"; };
+		CD913E322F68EDAC00D8EA53 /* WKVideoLayerHostView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKVideoLayerHostView.h; sourceTree = "<group>"; };
+		CD913E332F68EDAC00D8EA53 /* WKVideoLayerHostView.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKVideoLayerHostView.mm; sourceTree = "<group>"; };
+		CD913E342F68EDC200D8EA53 /* WKVideoLayerHost.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKVideoLayerHost.h; sourceTree = "<group>"; };
+		CD913E352F68EDC200D8EA53 /* WKVideoLayerHost.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKVideoLayerHost.mm; sourceTree = "<group>"; };
 		CD95493526159004008372D9 /* libWebKitSwift.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libWebKitSwift.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		CD9A649F27C8972C003827C0 /* UIProcessLogInitialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIProcessLogInitialization.h; sourceTree = "<group>"; };
 		CD9A64A027C8972C003827C0 /* UIProcessLogInitialization.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UIProcessLogInitialization.cpp; sourceTree = "<group>"; };
@@ -10921,6 +10939,9 @@
 				C145CC0E23DCA427003A5EEB /* PreferenceObserver.h */,
 				C15CBB3323F34C3800300CC7 /* PreferenceObserver.mm */,
 				3AA50E2C28D37F8700D024E4 /* ProcessAssertionCocoa.mm */,
+				CD150CA82F64E6A900E66163 /* RemoteLayerHostingManagerProxy.h */,
+				CD150CAA2F64E6A900E66163 /* RemoteLayerHostingManagerProxy.messages.in */,
+				CD150CA92F64E6A900E66163 /* RemoteLayerHostingManagerProxy.mm */,
 				5CB7AFDD23C5273D00E49CF3 /* ResourceLoadDelegate.h */,
 				5CB7AFDE23C5273D00E49CF3 /* ResourceLoadDelegate.mm */,
 				F46CCD8E2EDD1B9C00D4BA3E /* SafeBrowsingUtilities.h */,
@@ -10990,6 +11011,10 @@
 				CE45945B240F85B90078019F /* WKTextSelectionRect.mm */,
 				076897EF2D07B330006F9FA7 /* WKUIDelegateAdapter.swift */,
 				079A4DAF2D73EA4A00CA387F /* WKURLSchemeHandlerAdapter.swift */,
+				CD913E342F68EDC200D8EA53 /* WKVideoLayerHost.h */,
+				CD913E352F68EDC200D8EA53 /* WKVideoLayerHost.mm */,
+				CD913E322F68EDAC00D8EA53 /* WKVideoLayerHostView.h */,
+				CD913E332F68EDAC00D8EA53 /* WKVideoLayerHostView.mm */,
 				2D7AAFD218C8640600A7ACD4 /* WKWebViewContentProvider.h */,
 				2DC6D9C118C44A610043BAD4 /* WKWebViewContentProviderRegistry.h */,
 				2DC6D9C218C44A610043BAD4 /* WKWebViewContentProviderRegistry.mm */,
@@ -12465,7 +12490,7 @@
 		2D9FB1FF2375209D0049F936 /* GPUProcess */ = {
 			isa = PBXGroup;
 			children = (
-				079D1D9C2698DBD000883577 /* cocoa */,
+				CD150CA62F64E68400E66163 /* cocoa */,
 				2D9FB20D2375209D0049F936 /* EntryPoint */,
 				550640A124071A2900AAE045 /* graphics */,
 				2D9FB2042375209D0049F936 /* ios */,
@@ -13738,6 +13763,10 @@
 				1D47659925CE74AC007AF312 /* RemoteImageDecoderAVFManagerMessages.h */,
 				1D47658F25CCCE92007AF312 /* RemoteImageDecoderAVFProxyMessageReceiver.cpp */,
 				1D47659025CCCE93007AF312 /* RemoteImageDecoderAVFProxyMessages.h */,
+				CD150CAC2F650EF700E66163 /* RemoteLayerHostingManagerMessageReceiver.cpp */,
+				CD150CAD2F650EF700E66163 /* RemoteLayerHostingManagerMessages.h */,
+				CD150CAE2F650EF700E66163 /* RemoteLayerHostingManagerProxyMessageReceiver.cpp */,
+				CD150CAF2F650EF700E66163 /* RemoteLayerHostingManagerProxyMessages.h */,
 				0FF24A2B1879E4BC003ABF0C /* RemoteLayerTreeDrawingAreaProxyMessageReceiver.cpp */,
 				0FF24A2C1879E4BC003ABF0C /* RemoteLayerTreeDrawingAreaProxyMessages.h */,
 				CDE555292406B896008A3DDB /* RemoteLegacyCDMFactoryProxyMessageReceiver.cpp */,
@@ -17499,6 +17528,18 @@
 			path = forms;
 			sourceTree = "<group>";
 		};
+		CD150CA62F64E68400E66163 /* cocoa */ = {
+			isa = PBXGroup;
+			children = (
+				CD150CA12F64E68400E66163 /* GPUConnectionToWebProcessCocoa.mm */,
+				CD150CA22F64E68400E66163 /* GPUProcessCocoa.mm */,
+				CD150CA32F64E68400E66163 /* RemoteLayerHostingManager.h */,
+				CD150CA52F64E68400E66163 /* RemoteLayerHostingManager.messages.in */,
+				CD150CA42F64E68400E66163 /* RemoteLayerHostingManager.mm */,
+			);
+			path = cocoa;
+			sourceTree = "<group>";
+		};
 		CD4570D82444CA1700A3DCEB /* Media */ = {
 			isa = PBXGroup;
 			children = (
@@ -18793,6 +18834,8 @@
 				F451C0FE2703B263002BA03B /* RemoteGraphicsContextProxy.h in Headers */,
 				2D47B56D1810714E003A3AEE /* RemoteLayerBackingStore.h in Headers */,
 				2DDF731518E95060004F5A66 /* RemoteLayerBackingStoreCollection.h in Headers */,
+				CD150CA72F64E68C00E66163 /* RemoteLayerHostingManager.h in Headers */,
+				CD150CAB2F64E6B000E66163 /* RemoteLayerHostingManagerProxy.h in Headers */,
 				5F4D67D682584880B7E5A569 /* RemoteLayerTreeCommitBundle.h in Headers */,
 				1AB16AEA164B3A8800290D62 /* RemoteLayerTreeContext.h in Headers */,
 				1AB16ADE1648598400290D62 /* RemoteLayerTreeDrawingArea.h in Headers */,

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -409,7 +409,9 @@ PlatformLayer* AudioVideoRendererRemote::platformVideoLayer() const
 #if PLATFORM(COCOA)
     Locker locker { m_lock };
     if (!m_videoLayer && m_layerHostingContext.contextID) {
-        auto expandedVideoLayerSize = expandedIntSize(videoLayerSize());
+        // m_lock is already held, so read m_videoLayerSize directly rather than through
+        // videoLayerSize(), which would take it a second time. WTF::Lock is not recursive.
+        auto expandedVideoLayerSize = expandedIntSize(m_videoLayerSize);
         m_videoLayer = createVideoLayerRemote(const_cast<AudioVideoRendererRemote&>(*this), m_layerHostingContext.contextID, WebCore::MediaPlayer::VideoGravity::ResizeAspect, expandedVideoLayerSize);
         m_videoLayerManager->setVideoLayer(m_videoLayer.get(), expandedVideoLayerSize);
     }

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -29,6 +29,7 @@
 
 #include "GPUProcessConnection.h"
 #include "LayerHostingContext.h"
+#include "PlaybackSessionContextIdentifier.h"
 #include "RemoteAudioVideoRendererIdentifier.h"
 #include "RemoteAudioVideoRendererState.h"
 #include "VideoLayerRemote.h"

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h
@@ -63,7 +63,7 @@ private:
     Ref<WebCore::PlatformCALayer> createPlatformCALayer(Ref<WebCore::Model>, WebCore::PlatformCALayerClient* owner) override;
 #endif
 #if HAVE(AVKIT)
-    Ref<WebCore::PlatformCALayer> createPlatformVideoLayer(WebCore::HTMLVideoElement&, WebCore::PlatformCALayerClient* owner) override;
+    Ref<WebCore::PlatformCALayer> createPlatformVideoLayer(const WebCore::VideoLayerContext&, WebCore::HTMLVideoElement&, WebCore::PlatformCALayerClient* owner) override;
 #endif
     Ref<WebCore::PlatformCAAnimation> createPlatformCAAnimation(WebCore::PlatformCAAnimation::AnimationType, const String& keyPath) override;
     Ref<WebCore::PlatformCALayer> createPlatformCALayerHost(WebCore::LayerHostingContextIdentifier, WebCore::PlatformCALayerClient*) override;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm
@@ -35,12 +35,12 @@
 #include "WebPage.h"
 #include "WebProcess.h"
 #include <WebCore/GraphicsLayerContentsDisplayDelegate.h>
-#include <WebCore/HTMLVideoElement.h>
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/Model.h>
 #include <WebCore/PlatformCALayerDelegatedContents.h>
 #include <WebCore/PlatformScreen.h>
 #include <WebCore/RemoteFrame.h>
+#include <WebCore/VideoLayerContext.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(MODEL_PROCESS)
@@ -111,10 +111,10 @@ Ref<PlatformCALayer> GraphicsLayerCARemote::createPlatformCALayerHost(WebCore::L
 }
 
 #if HAVE(AVKIT)
-Ref<PlatformCALayer> GraphicsLayerCARemote::createPlatformVideoLayer(WebCore::HTMLVideoElement& videoElement, PlatformCALayerClient* owner)
+Ref<PlatformCALayer> GraphicsLayerCARemote::createPlatformVideoLayer(const WebCore::VideoLayerContext& videoLayerContext, WebCore::HTMLVideoElement& videoElement, PlatformCALayerClient* owner)
 {
     Ref context = *m_context;
-    return PlatformCALayerRemote::create(videoElement, owner, context.get());
+    return PlatformCALayerRemote::create(videoLayerContext, videoElement, owner, context.get());
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h
@@ -36,6 +36,7 @@
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
+class HTMLVideoElement;
 class LayerPool;
 #if ENABLE(THREADED_ANIMATIONS)
 class AcceleratedEffect;
@@ -68,7 +69,7 @@ public:
     static Ref<PlatformCALayerRemote> create(Ref<WebCore::Model>, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
 #endif
 #if HAVE(AVKIT)
-    static Ref<PlatformCALayerRemote> create(WebCore::HTMLVideoElement&, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
+    static Ref<PlatformCALayerRemote> create(const WebCore::VideoLayerContext&, WebCore::HTMLVideoElement&, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
 #endif
     static Ref<PlatformCALayerRemote> create(const PlatformCALayerRemote&, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm
@@ -90,9 +90,9 @@ Ref<PlatformCALayerRemote> PlatformCALayerRemote::create(Ref<WebCore::Model> mod
 #endif
 
 #if HAVE(AVKIT)
-Ref<PlatformCALayerRemote> PlatformCALayerRemote::create(WebCore::HTMLVideoElement& videoElement, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
+Ref<PlatformCALayerRemote> PlatformCALayerRemote::create(const WebCore::VideoLayerContext& videoLayerContext, WebCore::HTMLVideoElement& videoElement, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
 {
-    return PlatformCALayerRemoteCustom::create(videoElement, owner, context);
+    return PlatformCALayerRemoteCustom::create(videoLayerContext, videoElement, owner, context);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h
@@ -28,6 +28,7 @@
 #include "PlatformCALayerRemote.h"
 
 namespace WebCore {
+class HTMLVideoElement;
 class PlatformCALayerClient;
 
 #if ENABLE(MODEL_PROCESS)
@@ -48,7 +49,7 @@ public:
     static Ref<PlatformCALayerRemote> create(Ref<WebCore::ModelContext>, WebCore::PlatformCALayerClient*, RemoteLayerTreeContext&);
 #endif
 #if HAVE(AVKIT)
-    static Ref<PlatformCALayerRemote> create(WebCore::HTMLVideoElement&, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
+    static Ref<PlatformCALayerRemote> create(const WebCore::VideoLayerContext&, WebCore::HTMLVideoElement&, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
 #endif
 
     virtual ~PlatformCALayerRemoteCustom();
@@ -65,7 +66,7 @@ public:
 private:
     PlatformCALayerRemoteCustom(WebCore::PlatformCALayer::LayerType, PlatformLayer *, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
     PlatformCALayerRemoteCustom(WebCore::PlatformCALayer::LayerType, LayerHostingContextID, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
-    PlatformCALayerRemoteCustom(WebCore::HTMLVideoElement&, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
+    PlatformCALayerRemoteCustom(const WebCore::VideoLayerContext&, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
 #if ENABLE(MODEL_PROCESS)
     PlatformCALayerRemoteCustom(WebCore::PlatformCALayer::LayerType, Ref<WebCore::ModelContext>, WebCore::PlatformCALayerClient* owner, RemoteLayerTreeContext&);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm
@@ -32,8 +32,8 @@
 #import "WebProcess.h"
 #import <AVFoundation/AVFoundation.h>
 #import <WebCore/GraphicsLayerCA.h>
-#import <WebCore/HTMLVideoElement.h>
 #import <WebCore/PlatformCALayerCocoa.h>
+#import <WebCore/VideoLayerContext.h>
 #import <WebCore/WebCoreCALayerExtras.h>
 #import <WebCore/WebLayer.h>
 #import <wtf/RetainPtr.h>
@@ -66,10 +66,10 @@ Ref<PlatformCALayerRemote> PlatformCALayerRemoteCustom::create(Ref<WebCore::Mode
 #endif
 
 #if HAVE(AVKIT)
-Ref<PlatformCALayerRemote> PlatformCALayerRemoteCustom::create(WebCore::HTMLVideoElement& videoElement, PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
+Ref<PlatformCALayerRemote> PlatformCALayerRemoteCustom::create(const WebCore::VideoLayerContext& videoLayerContext, WebCore::HTMLVideoElement& videoElement, PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
 {
-    auto layer = adoptRef(*new PlatformCALayerRemoteCustom(videoElement, owner, context));
-    context.layerDidEnterContext(layer.get(), layer->layerType(), videoElement);
+    Ref layer = adoptRef(*new PlatformCALayerRemoteCustom(videoLayerContext, owner, context));
+    context.layerDidEnterContext(layer.get(), layer->layerType(), videoLayerContext, videoElement);
     return WTF::move(layer);
 }
 #endif
@@ -80,8 +80,8 @@ PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom(WebCore::PlatformCALaye
     m_layerHostingContext = LayerHostingContext::createTransportLayerForRemoteHosting(hostedContextIdentifier);
 }
 
-PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom(HTMLVideoElement& videoElement, PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
-    : PlatformCALayerRemoteCustom(PlatformCALayer::LayerType::LayerTypeAVPlayerLayer, videoElement.layerHostingContext().contextID, owner, context)
+PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom(const WebCore::VideoLayerContext& videoLayerContext, PlatformCALayerClient* owner, RemoteLayerTreeContext& context)
+    : PlatformCALayerRemoteCustom(PlatformCALayer::LayerType::LayerTypeAVPlayerLayer, videoLayerContext.hostingContext.contextID, owner, context)
 {
     m_hasVideo = true;
 }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h
@@ -41,6 +41,7 @@
 
 namespace WebCore {
 class HTMLVideoElement;
+struct VideoLayerContext;
 enum class GraphicsLayerType : uint8_t;
 enum class UseLosslessCompression : bool;
 }
@@ -66,7 +67,7 @@ public:
 
     void layerDidEnterContext(PlatformCALayerRemote&, WebCore::PlatformCALayer::LayerType);
 #if HAVE(AVKIT)
-    void layerDidEnterContext(PlatformCALayerRemote&, WebCore::PlatformCALayer::LayerType, WebCore::HTMLVideoElement&);
+    void layerDidEnterContext(PlatformCALayerRemote&, WebCore::PlatformCALayer::LayerType, const WebCore::VideoLayerContext&, WebCore::HTMLVideoElement&);
 #endif
     void layerWillLeaveContext(PlatformCALayerRemote&);
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm
@@ -44,6 +44,7 @@
 #import <WebCore/LocalFrameView.h>
 #import <WebCore/Page.h>
 #import <WebCore/PixelFormat.h>
+#import <WebCore/VideoLayerContext.h>
 #import <wtf/SetForScope.h>
 #import <wtf/SystemTracing.h>
 #import <wtf/TZoneMallocInlines.h>
@@ -123,25 +124,25 @@ void RemoteLayerTreeContext::layerDidEnterContext(PlatformCALayerRemote& layer, 
 }
 
 #if HAVE(AVKIT)
-void RemoteLayerTreeContext::layerDidEnterContext(PlatformCALayerRemote& layer, PlatformCALayer::LayerType type, WebCore::HTMLVideoElement& videoElement)
+void RemoteLayerTreeContext::layerDidEnterContext(PlatformCALayerRemote& layer, PlatformCALayer::LayerType type, const WebCore::VideoLayerContext& videoLayerContext, WebCore::HTMLVideoElement& videoElement)
 {
     PlatformLayerIdentifier layerID = layer.layerID();
 
 #if ENABLE(MACH_PORT_LAYER_HOSTING)
-    layer.setSendRightAnnotated(videoElement.layerHostingContext().sendRightAnnotated);
+    layer.setSendRightAnnotated(videoLayerContext.hostingContext.sendRightAnnotated);
 #endif
 
     RemoteLayerTreeTransaction::LayerCreationProperties creationProperties;
     layer.populateCreationProperties(creationProperties, *this, type);
     ASSERT(!creationProperties.videoElementData);
     creationProperties.videoElementData = RemoteLayerTreeTransaction::LayerCreationProperties::VideoElementData {
-        videoElement.identifier(),
-        videoElement.videoLayerSize(),
-        videoElement.naturalSize()
+        videoLayerContext.mediaElementIdentifier,
+        videoLayerContext.videoLayerSize,
+        videoLayerContext.naturalSize
     };
 
     protect(protect(webPage())->videoPresentationManager())->setupRemoteLayerHosting(videoElement);
-    m_videoLayers.add(layerID, videoElement.identifier());
+    m_videoLayers.add(layerID, videoLayerContext.mediaElementIdentifier);
 
     m_createdLayers.add(layerID, WTF::move(creationProperties));
     m_livePlatformLayers.add(layerID, &layer);

--- a/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
+++ b/Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm
@@ -497,6 +497,13 @@ void VideoPresentationManager::enterVideoFullscreenForVideoElement(HTMLVideoElem
     };
 
     HostingContext hostingContext;
+#if ENABLE(GPU_PROCESS) && PLATFORM(COCOA)
+    if (videoElement.document().settings().remoteLayerHostingBypassesWebContentProcess()) {
+        setupFullscreen({ }, FloatSize(videoElement.videoWidth(), videoElement.videoHeight()));
+        return;
+    }
+#endif
+
     bool blockMediaLayerRehosting = videoElement.document().settings().blockMediaLayerRehostingInWebContentProcess() && videoElement.document().page() &&  videoElement.document().page()->chrome().client().isUsingUISideCompositing();
     if (blockMediaLayerRehosting) {
         hostingContext = videoElement.layerHostingContext();

--- a/Tools/TestWebKitAPI/SourcesCocoa.txt
+++ b/Tools/TestWebKitAPI/SourcesCocoa.txt
@@ -258,6 +258,7 @@ Tests/WebKit/WKWebView/Proxy.mm @nonARC
 Tests/WebKit/WKWebView/PushAPI.mm @nonARC
 Tests/WebKit/WKWebView/QuickLook.mm @nonARC
 Tests/WebKit/WKWebView/ReloadWithDifferingInitialScale.mm @nonARC
+Tests/WebKit/WKWebView/RemoteLayerHosting.mm @nonARC
 Tests/WebKit/WKWebView/RemoteObjectRegistry.mm @nonARC
 Tests/WebKit/WKWebView/RemoveFullscreenElementFromDOM.mm @nonARC
 Tests/WebKit/WKWebView/RenderedImageWithOptions.mm @nonARC

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RemoteLayerHosting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RemoteLayerHosting.mm
@@ -1,0 +1,513 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(COCOA) && ENABLE(GPU_PROCESS)
+
+#import "Helpers/PlatformUtilities.h"
+#import "Helpers/Test.h"
+#import "Helpers/Utilities.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import "Helpers/cocoa/UISideCompositingScope.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKPreferencesRefPrivate.h>
+#import <WebKit/WKRetainPtr.h>
+#import <WebKit/WKString.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
+#import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <wtf/RetainPtr.h>
+#import <wtf/cocoa/TypeCastsCocoa.h>
+
+#if USE(EXTENSIONKIT)
+#import <BrowserEngineKit/BELayerHierarchyHostingView.h>
+#endif
+
+namespace TestWebKitAPI {
+
+// WKVideoLayerHost is internal to WebKit, so it is identified by name here rather than by
+// importing its header. It derives from CALayerHost, so a search for CALayerHost finds the
+// video host layer on both the new and the legacy hosting path.
+static NSString * const videoLayerHostClassName = @"WKVideoLayerHost";
+
+template<typename Functor> static void forEachLayer(CALayer *layer, const Functor& functor)
+{
+    functor(layer);
+    for (CALayer *sublayer in layer.sublayers)
+        forEachLayer(sublayer, functor);
+}
+
+static void appendLayerDescription(NSMutableString *description, CALayer *layer, unsigned depth)
+{
+    [description appendString:[@"" stringByPaddingToLength:depth * 2 withString:@" " startingAtIndex:0]];
+    [description appendString:NSStringFromClass([layer class])];
+    if (layer.name.length)
+        [description appendFormat:@" name=\"%@\"", layer.name];
+    [description appendFormat:@" bounds=(%g, %g)", layer.bounds.size.width, layer.bounds.size.height];
+    // -frame accounts for -bounds, -position and -affineTransform, so it can differ from
+    // -bounds when WebAVPlayerLayer has scaled a layer rather than resizing it.
+    [description appendFormat:@" frame=(%g, %g)", layer.frame.size.width, layer.frame.size.height];
+    if (!CGAffineTransformIsIdentity(layer.affineTransform))
+        [description appendFormat:@" scale=(%g, %g)", layer.affineTransform.a, layer.affineTransform.d];
+    if ([layer isKindOfClass:[CALayerHost class]])
+        [description appendFormat:@" contextId=%u", static_cast<CALayerHost *>(layer).contextId];
+    [description appendString:@"\n"];
+
+    for (CALayer *sublayer in layer.sublayers)
+        appendLayerDescription(description, sublayer, depth + 1);
+}
+
+static NSString *layerTreeDescription(CALayer *layer)
+{
+    RetainPtr description = adoptNS([[NSMutableString alloc] init]);
+    appendLayerDescription(description.get(), layer, 0);
+    return description.autorelease();
+}
+
+static RetainPtr<CALayer> findLayerOfClassNamed(CALayer *root, NSString *className)
+{
+    Class layerClass = NSClassFromString(className);
+    if (!layerClass)
+        return nil;
+
+    RetainPtr<CALayer> result;
+    forEachLayer(root, [&](CALayer *layer) {
+        if (!result && [layer isKindOfClass:layerClass])
+            result = layer;
+    });
+    return result;
+}
+
+// The layer hosting the GPU process video layer, whichever hosting path created it: it is
+// the CALayerHost parented into the WebAVPlayerLayer that represents the video element.
+static RetainPtr<CALayerHost> findVideoHostLayer(CALayer *root)
+{
+    RetainPtr playerLayer = findLayerOfClassNamed(root, @"WebAVPlayerLayer");
+    if (!playerLayer)
+        return nil;
+
+    for (CALayer *sublayer in [playerLayer sublayers]) {
+        if ([sublayer isKindOfClass:[CALayerHost class]])
+            return static_cast<CALayerHost *>(sublayer);
+    }
+    return nil;
+}
+
+#if USE(EXTENSIONKIT)
+// Under BrowserEngineKit the remote hierarchy is adopted by a BELayerHierarchyHostingView
+// rather than by setting a context ID, so that is where hosting has to be observed. The layer
+// host view is never added to a view hierarchy — only its layer is parented — so it is
+// reached through its backing layer's delegate.
+static RetainPtr<BELayerHierarchyHostingView> findLayerHierarchyHostingView(CALayer *videoHostLayer)
+{
+    RetainPtr view = dynamic_objc_cast<UIView>([videoHostLayer delegate]);
+    for (UIView *subview in [view subviews]) {
+        if ([subview isKindOfClass:[BELayerHierarchyHostingView class]])
+            return static_cast<BELayerHierarchyHostingView *>(subview);
+    }
+    return nil;
+}
+#endif
+
+#if PLATFORM(MAC)
+static RetainPtr<CALayer> findCaptionsLayer(CALayer *root)
+{
+    RetainPtr<CALayer> result;
+    forEachLayer(root, [&](CALayer *layer) {
+        if (!result && [layer.name isEqualToString:@"Captions layer"])
+            result = layer;
+    });
+    return result;
+}
+#endif
+
+static RetainPtr<TestWKWebView> createWebViewAndStartPlayback(bool remoteLayerHostingBypassesWebContentProcess)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get().mediaTypesRequiringUserActionForPlayback = WKAudiovisualMediaTypeNone;
+#if PLATFORM(IOS_FAMILY)
+    configuration.get().allowsInlineMediaPlayback = YES;
+    configuration.get()._inlineMediaPlaybackRequiresPlaysInlineAttribute = NO;
+#endif
+
+    // Navigating away must actually destroy the media elements, rather than parking the page
+    // in the back/forward cache with its players still alive.
+    [[configuration preferences] _setUsesPageCache:NO];
+
+    WKPreferencesRef preferences = (__bridge WKPreferencesRef)[configuration preferences];
+    WKPreferencesSetBoolValueForKeyForTesting(preferences, true, adoptWK(WKStringCreateWithUTF8CString("UseGPUProcessForMediaEnabled")).get());
+    WKPreferencesSetBoolValueForKeyForTesting(preferences, remoteLayerHostingBypassesWebContentProcess, adoptWK(WKStringCreateWithUTF8CString("RemoteLayerHostingBypassesWebContentProcess")).get());
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 400) configuration:configuration.get() addToWindow:YES]);
+
+    __block bool isPlaying = false;
+    [webView performAfterReceivingMessage:@"playing" action:^{ isPlaying = true; }];
+    [webView synchronouslyLoadTestPageNamed:@"video-with-audio"];
+    Util::run(&isPlaying);
+
+    // The video layer is created in response to the media player reporting that it has
+    // begun rendering, which happens after playback starts. Wait for the layer tree
+    // containing it to be committed to this process.
+    [webView waitForNextPresentationUpdate];
+
+    return webView;
+}
+
+// WebAVPlayerLayer resolves the video sublayer's geometry asynchronously: -layoutSublayers
+// applies a transform and schedules -resolveBounds, which does the final -setFrame:. Poll
+// until the host layer's frame stops changing so that geometry comparisons are not made
+// against an intermediate state.
+//
+// The frame, rather than the bounds, is the comparable quantity across the two hosting
+// paths: the legacy path leaves a scale transform on the layer, so its bounds remain the
+// element's default size while its frame reflects the size the video is presented at.
+static CGSize waitForStableVideoHostLayerFrameSize(TestWKWebView *webView)
+{
+    constexpr unsigned requiredStableSamples = 3;
+    constexpr unsigned maximumSamples = 100;
+
+    CGSize previousSize = CGSizeMake(-1, -1);
+    unsigned stableSamples = 0;
+
+    for (unsigned sample = 0; sample < maximumSamples; ++sample) {
+        [webView waitForNextPresentationUpdate];
+
+        RetainPtr hostLayer = findVideoHostLayer([webView layer]);
+        CGSize currentSize = hostLayer ? [hostLayer frame].size : CGSizeZero;
+
+        if (!CGSizeEqualToSize(currentSize, CGSizeZero) && CGSizeEqualToSize(currentSize, previousSize)) {
+            if (++stableSamples >= requiredStableSamples)
+                return currentSize;
+        } else
+            stableSamples = 0;
+
+        previousSize = currentSize;
+        Util::runFor(0.05_s);
+    }
+
+    return previousSize;
+}
+
+#pragma mark - Layer hosting path
+
+// Verifies that starting video playback with RemoteLayerHostingBypassesWebContentProcess
+// enabled produces a WKVideoLayerHost in the UI process layer tree, hosting a context
+// supplied by the GPU process.
+TEST(RemoteLayerHosting, VideoLayerIsHostedDirectlyFromGPUProcess)
+{
+    UISideCompositingScope scope { UISideCompositingState::Enabled };
+
+    ASSERT_TRUE(!!NSClassFromString(videoLayerHostClassName));
+
+    RetainPtr webView = createWebViewAndStartPlayback(true);
+    RetainPtr rootLayer = [webView layer];
+
+    NSLog(@"Layer tree with remote layer hosting enabled:\n%@", layerTreeDescription(rootLayer.get()));
+
+    RetainPtr videoLayerHost = findLayerOfClassNamed(rootLayer.get(), videoLayerHostClassName);
+    EXPECT_NOT_NULL(videoLayerHost.get());
+    if (!videoLayerHost)
+        return;
+
+    // Hosting must actually have been established, rather than the view merely having been
+    // created: DidCreateRemoteLayer has to have arrived and been applied. How that shows up
+    // differs by platform, because BrowserEngineKit adopts a layer hierarchy from a handle
+    // instead of exposing a usable CA context ID.
+#if USE(EXTENSIONKIT)
+    RetainPtr hostingView = findLayerHierarchyHostingView(videoLayerHost.get());
+    EXPECT_NOT_NULL(hostingView.get());
+    EXPECT_NOT_NULL([hostingView handle]);
+#else
+    EXPECT_NE(0u, static_cast<CALayerHost *>(videoLayerHost.get()).contextId);
+#endif
+}
+
+// The counterpart of the test above: with the setting disabled, the video layer must still
+// be hosted the old way, through a plain CALayerHost created by VideoPresentationManagerProxy.
+// Without this, the test above could pass for the wrong reason.
+TEST(RemoteLayerHosting, VideoLayerIsHostedViaWebContentProcessWhenDisabled)
+{
+    UISideCompositingScope scope { UISideCompositingState::Enabled };
+
+    RetainPtr webView = createWebViewAndStartPlayback(false);
+    RetainPtr rootLayer = [webView layer];
+
+    NSLog(@"Layer tree with remote layer hosting disabled:\n%@", layerTreeDescription(rootLayer.get()));
+
+    EXPECT_NULL(findLayerOfClassNamed(rootLayer.get(), videoLayerHostClassName).get());
+
+    RetainPtr layerHost = findLayerOfClassNamed(rootLayer.get(), @"CALayerHost");
+    EXPECT_NOT_NULL(layerHost.get());
+}
+
+#pragma mark - Geometry
+
+// The video element in video-with-audio.html has no CSS size, so it is laid out at the
+// video's intrinsic size and the aspect ratios match: the video should exactly fill its
+// WebAVPlayerLayer.
+//
+// Note that there is deliberately no comparison against the legacy path here. The host layer
+// does not mean the same thing on both: on the legacy path it is a viewport onto the
+// WebContent process's transport context, which letterboxes the video inside itself, so its
+// geometry legitimately differs from the video's presented size.
+TEST(RemoteLayerHosting, VideoLayerFillsPlayerLayer)
+{
+    UISideCompositingScope scope { UISideCompositingState::Enabled };
+
+    RetainPtr webView = createWebViewAndStartPlayback(true);
+    CGSize hostSize = waitForStableVideoHostLayerFrameSize(webView.get());
+
+    RetainPtr playerLayer = findLayerOfClassNamed([webView layer], @"WebAVPlayerLayer");
+    EXPECT_NOT_NULL(playerLayer.get());
+    if (!playerLayer)
+        return;
+
+    CGSize playerSize = [playerLayer bounds].size;
+    NSLog(@"Player layer = (%g, %g), video host layer = (%g, %g)", playerSize.width, playerSize.height, hostSize.width, hostSize.height);
+
+    // WebAVPlayerLayer may reach the target size by scaling rather than resizing, so the
+    // frame is the product of a floating point transform.
+    constexpr CGFloat tolerance = 0.01;
+    EXPECT_NEAR(playerSize.width, hostSize.width, tolerance);
+    EXPECT_NEAR(playerSize.height, hostSize.height, tolerance);
+
+#if USE(EXTENSIONKIT)
+    // The hosted hierarchy is adopted by a subview of the layer host view rather than by its
+    // backing layer, so that view has to be sized along with the video layer as well.
+    RetainPtr hostLayer = findVideoHostLayer([webView layer]);
+    RetainPtr hostingView = hostLayer ? findLayerHierarchyHostingView(hostLayer.get()) : nil;
+    EXPECT_NOT_NULL(hostingView.get());
+    if (!hostingView)
+        return;
+
+    CGSize hostingViewSize = [hostingView bounds].size;
+    NSLog(@"Layer hierarchy hosting view = (%g, %g)", hostingViewSize.width, hostingViewSize.height);
+
+    EXPECT_NEAR(hostSize.width, hostingViewSize.width, tolerance);
+    EXPECT_NEAR(hostSize.height, hostingViewSize.height, tolerance);
+#endif
+}
+
+// A resize is normally previewed by scaling the video layer and resolved to the real size once
+// the process owning that layer catches up. On this path the owning process is the GPU process,
+// which is close enough at hand to resize synchronously, so WebAVPlayerLayer is told not to
+// preview at all. That matters beyond tidiness: -[WKVideoLayerHost setFrame:] is what tells the
+// GPU process how large to make its layer, and the preview path does not go through -setFrame:.
+// While a preview transform is in effect the host layer's bounds, the size the GPU process was
+// given, and the size on screen all disagree.
+TEST(RemoteLayerHosting, VideoLayerResizeIsNotPreviewedWithTransform)
+{
+    UISideCompositingScope scope { UISideCompositingState::Enabled };
+
+    RetainPtr webView = createWebViewAndStartPlayback(true);
+    waitForStableVideoHostLayerFrameSize(webView.get());
+
+    RetainPtr hostLayer = findVideoHostLayer([webView layer]);
+    EXPECT_NOT_NULL(hostLayer.get());
+    if (!hostLayer)
+        return;
+
+    CGSize bounds = [hostLayer bounds].size;
+    CGSize frame = [hostLayer frame].size;
+    CGAffineTransform transform = [hostLayer affineTransform];
+    NSLog(@"Video host layer bounds = (%g, %g), frame = (%g, %g), transform scale = (%g, %g)", bounds.width, bounds.height, frame.width, frame.height, transform.a, transform.d);
+
+    EXPECT_TRUE(CGAffineTransformIsIdentity(transform));
+    EXPECT_EQ(bounds.width, frame.width);
+    EXPECT_EQ(bounds.height, frame.height);
+}
+
+#pragma mark - Captions
+
+// Captions are only overlaid on the hosted video layer where the interface parents a captions
+// layer into it. VideoPresentationInterfaceAVKitLegacy, the interface used for inline video on
+// iOS, overrides setupCaptionsLayer() to ignore the parent it is handed and attach the captions
+// layer to the fullscreen player layer instead, which does not exist inline — so there is no
+// captions layer in the inline layer tree there to make an assertion about. That is true of
+// both hosting paths.
+#if PLATFORM(MAC)
+
+// The captions layer is parented into the video host layer and sized to cover it, so that
+// text tracks are laid out over the video. On the new path
+// VideoPresentationManagerProxy::setVideoLayerFrame no longer messages the WebContent
+// process, so this verifies it still drives setCaptionsFrame().
+static void testCaptionsLayerCoversVideoLayer(bool remoteLayerHostingBypassesWebContentProcess)
+{
+    UISideCompositingScope scope { UISideCompositingState::Enabled };
+
+    RetainPtr webView = createWebViewAndStartPlayback(remoteLayerHostingBypassesWebContentProcess);
+    waitForStableVideoHostLayerFrameSize(webView.get());
+
+    RetainPtr rootLayer = [webView layer];
+    NSLog(@"Layer tree when checking captions (bypass = %d):\n%@", remoteLayerHostingBypassesWebContentProcess, layerTreeDescription(rootLayer.get()));
+
+    RetainPtr hostLayer = findVideoHostLayer(rootLayer.get());
+    RetainPtr captionsLayer = findCaptionsLayer(rootLayer.get());
+    EXPECT_NOT_NULL(hostLayer.get());
+    EXPECT_NOT_NULL(captionsLayer.get());
+    if (!hostLayer || !captionsLayer)
+        return;
+
+    // The captions layer is a child of the host layer, so it is sized in the host layer's
+    // own coordinate space: it should cover the host layer's bounds.
+    CGSize hostBounds = [hostLayer bounds].size;
+    CGSize captionsFrame = [captionsLayer frame].size;
+    NSLog(@"Host bounds = (%g, %g), captions frame = (%g, %g)", hostBounds.width, hostBounds.height, captionsFrame.width, captionsFrame.height);
+
+    EXPECT_FALSE(CGSizeEqualToSize(captionsFrame, CGSizeZero));
+    EXPECT_EQ(hostBounds.width, captionsFrame.width);
+    EXPECT_EQ(hostBounds.height, captionsFrame.height);
+}
+
+TEST(RemoteLayerHosting, CaptionsLayerCoversVideoLayer)
+{
+    testCaptionsLayerCoversVideoLayer(true);
+}
+
+TEST(RemoteLayerHosting, CaptionsLayerCoversVideoLayerWhenDisabled)
+{
+    testCaptionsLayerCoversVideoLayer(false);
+}
+
+#endif // PLATFORM(MAC)
+
+#pragma mark - GPU process side of the hosting boundary
+
+// A UI process layer tree walk stops at the CALayerHost. This exercises the synchronous
+// debugging message that dumps the hierarchy on the other side of the boundary.
+TEST(RemoteLayerHosting, GPUProcessLayerTreeIsReachableForTesting)
+{
+    UISideCompositingScope scope { UISideCompositingState::Enabled };
+
+    RetainPtr webView = createWebViewAndStartPlayback(true);
+    CGSize hostSize = waitForStableVideoHostLayerFrameSize(webView.get());
+
+    NSString *gpuLayerTree = [webView _gpuProcessRemoteLayerTreeAsTextForTesting];
+    NSLog(@"GPU process layer tree:\n%@", gpuLayerTree);
+
+    EXPECT_GT(gpuLayerTree.length, 0u);
+    EXPECT_TRUE([gpuLayerTree containsString:@"remote layer "]);
+    EXPECT_FALSE([gpuLayerTree containsString:@"<no content layer>"]);
+
+    // The hosted content layer must sit at the origin of its hosting context, since its
+    // position within the UI process layer tree is a property of the layer host there. The
+    // UI process cannot see this, so it is only checkable through this dump.
+    EXPECT_TRUE([gpuLayerTree containsString:@"position=(0, 0)"]);
+
+    // The size the GPU process was told to use must equal the size the layer host presents
+    // at, or the video is rendered at one size and scaled to another. This holds because
+    // WebAVPlayerLayer resizes the sublayer directly on this path instead of previewing the
+    // resize with a transform, which -[WKVideoLayerHost setFrame:] cannot observe.
+    NSString *expectedSize = [NSString stringWithFormat:@"size=(%g, %g)", hostSize.width, hostSize.height];
+    NSLog(@"UI process host layer presents at (%g, %g), looking for \"%@\"", hostSize.width, hostSize.height, expectedSize);
+    EXPECT_TRUE([gpuLayerTree containsString:expectedSize]);
+}
+
+// With the setting disabled nothing is hosted through this mechanism, so the dump is empty.
+TEST(RemoteLayerHosting, GPUProcessLayerTreeIsEmptyWhenDisabled)
+{
+    UISideCompositingScope scope { UISideCompositingState::Enabled };
+
+    RetainPtr webView = createWebViewAndStartPlayback(false);
+    waitForStableVideoHostLayerFrameSize(webView.get());
+
+    EXPECT_EQ(0u, [webView _gpuProcessRemoteLayerTreeAsTextForTesting].length);
+}
+
+#pragma mark - Lifetime
+
+static uint64_t gpuProcessHostedVideoLayerCount(TestWKWebView *webView)
+{
+    __block bool done = false;
+    __block NSUInteger result = 0;
+    [webView _gpuProcessHostedVideoLayerCountForTesting:^(NSUInteger count) {
+        result = count;
+        done = true;
+    }];
+    Util::run(&done);
+    return result;
+}
+
+// Navigating away destroys the media players, which must discard their hosting contexts in
+// the GPU process and the corresponding layer hosts in this process. A layer tree walk
+// cannot see this: the layer host is unparented by remote layer tree teardown regardless,
+// while the bookkeeping on both sides is what leaks.
+TEST(RemoteLayerHosting, HostedLayersAreReleasedAfterNavigation)
+{
+    UISideCompositingScope scope { UISideCompositingState::Enabled };
+
+    RetainPtr webView = createWebViewAndStartPlayback(true);
+    waitForStableVideoHostLayerFrameSize(webView.get());
+
+    EXPECT_GT([webView _hostedVideoLayerCountForTesting], 0u);
+    EXPECT_GT(gpuProcessHostedVideoLayerCount(webView.get()), 0u);
+
+    [webView synchronouslyLoadHTMLString:@"<body>no video here</body>"];
+    [webView waitForNextPresentationUpdate];
+
+    // Teardown is driven by the GPU process reporting that each player's remote layer is
+    // gone, so allow for the round trip.
+    unsigned timeout = 0;
+    while (([webView _hostedVideoLayerCountForTesting] || gpuProcessHostedVideoLayerCount(webView.get())) && timeout++ < 100)
+        Util::runFor(0.05_s);
+
+    EXPECT_EQ(0u, [webView _hostedVideoLayerCountForTesting]);
+    EXPECT_EQ(0u, gpuProcessHostedVideoLayerCount(webView.get()));
+    EXPECT_NULL(findLayerOfClassNamed([webView layer], videoLayerHostClassName).get());
+}
+
+// The two processes must agree on how many layers are hosted; a mismatch means one side
+// created or dropped an entry the other did not.
+TEST(RemoteLayerHosting, HostedLayerCountsAgreeAcrossProcesses)
+{
+    UISideCompositingScope scope { UISideCompositingState::Enabled };
+
+    RetainPtr webView = createWebViewAndStartPlayback(true);
+    waitForStableVideoHostLayerFrameSize(webView.get());
+
+    NSUInteger uiProcessCount = [webView _hostedVideoLayerCountForTesting];
+    uint64_t gpuProcessCount = gpuProcessHostedVideoLayerCount(webView.get());
+    NSLog(@"Hosted video layers: UI process = %lu, GPU process = %llu", static_cast<unsigned long>(uiProcessCount), gpuProcessCount);
+
+    EXPECT_GT(uiProcessCount, 0u);
+    EXPECT_EQ(static_cast<uint64_t>(uiProcessCount), gpuProcessCount);
+}
+
+// With the setting disabled nothing should be hosted through this mechanism at all.
+TEST(RemoteLayerHosting, NoLayersAreHostedWhenDisabled)
+{
+    UISideCompositingScope scope { UISideCompositingState::Enabled };
+
+    RetainPtr webView = createWebViewAndStartPlayback(false);
+    waitForStableVideoHostLayerFrameSize(webView.get());
+
+    EXPECT_EQ(0u, [webView _hostedVideoLayerCountForTesting]);
+    EXPECT_EQ(0u, gpuProcessHostedVideoLayerCount(webView.get()));
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(MAC) && ENABLE(GPU_PROCESS)


### PR DESCRIPTION
#### eaa8e65cd1d6e9d59dda5a54326fa9862b5620e6
<pre>
[Cocoa] Remote Layer Hosting should bypass the WebContent process
<a href="https://rdar.apple.com/172589049">rdar://172589049</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=309973">https://bugs.webkit.org/show_bug.cgi?id=309973</a>

Reviewed by NOBODY (OOPS!).

Video layers live in the GPU process but are composited by the UI process, and today they
get there by way of the WebContent process: the GPU process hands its layer hosting context
to the WebContent process, which re-hosts it into a transport context of its own, which the
UI process then hosts. The WebContent process contributes nothing to the pixels; it is purely
a relay. But because the geometry of the video layer travels through it, a hang in the
WebContent process stalls the UI process during a synchronous resize.

Rather than relaying, have the GPU process create the hosting context and tell the UI process
about it directly. The UI process creates the layer host and drives geometry back. The
WebContent process is out of the loop for hosting, and keeps only its existing role of
describing where the video element sits in the layer tree.

This is a large behavioral change to a path every video depends on, so it is behind the
`RemoteLayerHostingBypassesWebContentProcess` experimental feature, defaulting off. The old
path is untouched; the parts that exist only to serve it are marked with FIXMEs naming this
bug so they can be removed in one pass once the setting is enabled.

Notable choices:

1. `RemoteLayerHostingManager` (GPU process) owns a hosting context per media element and
   parents the media player&apos;s platform layer into it. `RemoteLayerHostingManagerProxy` (UI
   process) owns the `WKVideoLayerHostView` that adopts it. The manager hangs off GPUProcess
   rather than off each connection, because the UI process reaches it over the single GPU
   connection and must address layers belonging to any WebContent process.
2. Layers are keyed by `PlaybackSessionContextIdentifier`. Process qualification can&apos;t be
   recovered from the connection the way <a href="https://commits.webkit.org/318820@main">318820@main</a> arranged for other media identifiers,
   since that one GPU connection is shared by every WebContent process. That commit removed
   this type&apos;s serialization alias as dead code, correctly, as nothing sent it anymore; this
   is the first sender, so the alias comes back. The GPU process still builds the identifier
   the way that commit established, by pairing a bare identifier with the sending
   connection&apos;s process identity.
3. Geometry is sent as a size, not a frame. The hosted layer is always at the origin of its
   own context, and where it appears on screen is a property of the hosting layer in the UI
   process; sending an origin the GPU process can&apos;t act on invites the two sides to disagree.
4. `WebAVPlayerLayer` no longer previews resizes with a local transform on this path
   (`previewsResizeWithTransform=NO`). Previewing exists because the WebContent process
   owning the layer may be busy running script, however the GPU process runs none. By
   disabling previewing, all processes involved in compositing will synchronously agree on
   the video layer&apos;s dimensions.
5. Teardown is driven by the UI process, not by MediaPlayer lifetime. A hosted layer outlives
   its MediaPlayer routinely: HTMLMediaElement recreates the player when the source changes,
   and the layer can be alive in fullscreen or PiP while absent from the compositor. So
   `RemoteLayerHostInfo` tracks `hasGPUProcessVideoLayer` and `hasUIProcessConsumer`
   separately, and releases the host only when both are gone. Hooking teardown to
   `MediaPlayer::invalidate()` instead destroys the context in the window
   `HTMLMediaElement::createMediaPlayer()` opens between releasing the old player and
   creating the new one.
6. `setContentsToVideoElement()` becomes `setContentsToVideoLayer()`, taking a
   `WebCore::VideoLayerContext` of the hosting details the compositing machinery needs, in
   the manner of `ModelContext`. It deliberately does not carry the element&apos;s platform layer:
   `HTMLMediaElement::platformLayer()` is not a cheap getter, and for a remote renderer takes
   a lock and lazily creates the layer, so fetching it eagerly would create a video layer in
   the WebContent process for every element about to be hosted by context ID instead.
7. Gravity is plumbed through so that a resize and a gravity change can share a fence, but
   nothing drives it yet: the compositor applies gravity to the `WebAVPlayerLayer`, which
   resolves it into geometry itself rather than forwarding it to its video sublayer. Gravity
   is a layout attribute and should flow up through the compositor rather than down through
   the video element to the MediaPlayer; that is left to a follow-up, and the plumbing is
   kept rather than deleted.

A UI process layer tree walk stops at the `CALayerHost`, which has made this area hard to
test. `RemoteLayerTreeAsTextForTesting` dumps the GPU process side of the boundary so a test
can interleave it with a UI process walk, and `CountRemoteLayersForTesting` lets a test
assert the two processes agree on how many layers exist. Both are exposed through WKWebView
SPI and used by the new API tests, which cover hosting on both paths, geometry, captions,
and teardown.

Also fix a latent deadlock this change would otherwise expose:
`AudioVideoRendererRemote::platformVideoLayer()` takes `m_lock` and then calls
`videoLayerSize()`, which takes it again. `WTF::Lock` is not recursive, so the WebContent
main thread wedges the first time that branch is taken, and it is reachable today whenever
something calls `platformLayer()` on an MSE or WebM player before the video layer exists.
Read `m_videoLayerSize` directly inside the lock instead.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RemoteLayerHosting.mm

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::videoLayerContext):
* Source/WebCore/html/HTMLVideoElement.h:
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.h:
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer init]):
(-[WebAVPlayerLayer layoutSublayers]):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::setContentsToVideoLayer):
(WebCore::GraphicsLayer::setContentsToVideoElement): Deleted.
* Source/WebCore/platform/graphics/VideoLayerContext.h: Added.
(WebCore::VideoLayerContext::hasHostingContext const):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::createPlatformVideoLayer):
(WebCore::GraphicsLayerCA::setContentsToVideoLayer):
(WebCore::GraphicsLayerCA::setContentsToVideoElement): Deleted.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):
* Source/WebKit/DerivedSources-input.xcfilelist:
* Source/WebKit/DerivedSources-output.xcfilelist:
* Source/WebKit/DerivedSources.make:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::~GPUConnectionToWebProcess):
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::GPUProcess):
(WebKit::GPUProcess::remoteLayerHostingManager):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/cocoa/RemoteLayerHostingManager.h: Added.
(WebKit::RemoteLayerHostingManager::remoteLayerCountForTesting const):
* Source/WebKit/GPUProcess/cocoa/RemoteLayerHostingManager.messages.in: Added.
* Source/WebKit/GPUProcess/cocoa/RemoteLayerHostingManager.mm: Added.
(WebKit::RemoteLayerHostingManager::create):
(WebKit::RemoteLayerHostingManager::RemoteLayerHostingManager):
(WebKit::RemoteLayerHostingManager::~RemoteLayerHostingManager):
(WebKit::RemoteLayerHostingManager::invalidate):
(WebKit::RemoteLayerHostingManager::createRemoteLayerForPlayer):
(WebKit::RemoteLayerHostingManager::setContentLayerForRemoteLayer):
(WebKit::RemoteLayerHostingManager::setRemoteLayerSizeFenced):
(WebKit::RemoteLayerHostingManager::setRemoteLayerVideoGravityFenced):
(WebKit::RemoteLayerHostingManager::takeAndInvalidateRemoteLayer):
(WebKit::RemoteLayerHostingManager::removeRemoteLayerForPlayer):
(WebKit::RemoteLayerHostingManager::countRemoteLayersForTesting):
(WebKit::appendLayerTreeAsText):
(WebKit::RemoteLayerHostingManager::remoteLayerTreeAsTextForTesting):
(WebKit::RemoteLayerHostingManager::removeAllRemoteLayersForProcess):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::shutdown):
(WebKit::RemoteAudioVideoRendererProxyManager::remoteLayerHostingBypassesWebContentProcess const):
(WebKit::RemoteAudioVideoRendererProxyManager::updateContentLayerForRemoteLayerHosting):
(WebKit::RemoteAudioVideoRendererProxyManager::removeContentLayerForRemoteLayerHosting):
(WebKit::RemoteAudioVideoRendererProxyManager::rendereringModeChanged):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::invalidate):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged):
(WebKit::RemoteMediaPlayerProxy::remoteLayerHostingBypassesWebContentProcess const):
(WebKit::RemoteMediaPlayerProxy::updateContentLayerForRemoteLayerHosting):
(WebKit::RemoteMediaPlayerProxy::removeContentLayerForRemoteLayerHosting):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm:
* Source/WebKit/Headers.cmake:
* Source/WebKit/PlatformCocoa.cmake:
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/Shared/ProcessQualified.serialization.in:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _hostedVideoLayerCountForTesting]):
(-[WKWebView _gpuProcessHostedVideoLayerCountForTesting:]):
(-[WKWebView _gpuProcessRemoteLayerTreeAsTextForTesting]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm:
(WebKit::GPUProcessProxy::remoteLayerHostingManagerProxy):
* Source/WebKit/UIProcess/Cocoa/RemoteLayerHostingManagerProxy.h: Added.
(WebKit::RemoteLayerHostingManagerProxy::hostedLayerCountForTesting const):
* Source/WebKit/UIProcess/Cocoa/RemoteLayerHostingManagerProxy.messages.in: Added.
* Source/WebKit/UIProcess/Cocoa/RemoteLayerHostingManagerProxy.mm: Added.
(WebKit::RemoteLayerHostingManagerProxy::create):
(WebKit::RemoteLayerHostingManagerProxy::RemoteLayerHostingManagerProxy):
(WebKit::RemoteLayerHostingManagerProxy::~RemoteLayerHostingManagerProxy):
(WebKit::RemoteLayerHostingManagerProxy::invalidate):
(WebKit::RemoteLayerHostingManagerProxy::ensureLayerHostViewForIdentifier):
(WebKit::RemoteLayerHostingManagerProxy::applyHostingContextToLayerHost):
(WebKit::RemoteLayerHostingManagerProxy::ensureRemoteLayerHostInfo):
(WebKit::RemoteLayerHostingManagerProxy::setPageForIdentifier):
(WebKit::RemoteLayerHostingManagerProxy::releaseLayerHostForIdentifier):
(WebKit::RemoteLayerHostingManagerProxy::removeRemoteLayerHostIfUnused):
(WebKit::RemoteLayerHostingManagerProxy::setRemoteLayerHostSize):
(WebKit::RemoteLayerHostingManagerProxy::setRemoteLayerVideoGravity):
(WebKit::RemoteLayerHostingManagerProxy::countGPUProcessRemoteLayersForTesting):
(WebKit::RemoteLayerHostingManagerProxy::gpuProcessRemoteLayerTreeAsTextForTesting):
(WebKit::RemoteLayerHostingManagerProxy::didCreateRemoteLayer):
(WebKit::RemoteLayerHostingManagerProxy::didRemoveRemoteLayer):
(WebKit::RemoteLayerHostingManagerProxy::runWithFenceForIdentifier):
(WebKit::RemoteLayerHostingManagerProxy::addVisibilityPropogationView):
(WebKit::RemoteLayerHostingManagerProxy::removeVisibilityPropogationView):
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::removeClientForContext):
(WebKit::configureResizeBehaviorForHostedVideoLayer):
(WebKit::VideoPresentationManagerProxy::createLayerWithID):
(WebKit::VideoPresentationManagerProxy::createLayerHostViewWithID):
(WebKit::VideoPresentationManagerProxy::createRemoteLayerHostViewWithID):
(WebKit::VideoPresentationManagerProxy::createLegacyLayerHostViewWithID):
(WebKit::VideoPresentationManagerProxy::createViewWithID):
(WebKit::VideoPresentationManagerProxy::setupFullscreenWithID):
(WebKit::VideoPresentationManagerProxy::didSetupFullscreen):
(WebKit::VideoPresentationManagerProxy::didCleanupFullscreen):
(WebKit::VideoPresentationManagerProxy::setVideoLayerFrame):
(WebKit::VideoPresentationManagerProxy::remoteLayerHostingManager):
(WebKit::VideoPresentationManagerProxy::remoteLayerHostingBypassesWebContentProcess const):
* Source/WebKit/UIProcess/Cocoa/WKVideoLayerHost.h: Added.
* Source/WebKit/UIProcess/Cocoa/WKVideoLayerHost.mm: Added.
(-[WKVideoLayerHost setParent:]):
(-[WKVideoLayerHost parent]):
(-[WKVideoLayerHost setIdentifier:]):
(-[WKVideoLayerHost setFrame:]):
(-[WKVideoLayerHost videoGravity]):
(-[WKVideoLayerHost setVideoGravity:]):
(-[WKVideoLayerHost name]):
* Source/WebKit/UIProcess/Cocoa/WKVideoLayerHostView.h: Added.
* Source/WebKit/UIProcess/Cocoa/WKVideoLayerHostView.mm: Added.
(-[WKVideoLayerHostView initWithFrame:]):
(-[WKVideoLayerHostView layoutSubviews]):
(-[WKVideoLayerHostView layerHierarchyHostingView]):
(+[WKVideoLayerHostView layerClass]):
(-[WKVideoLayerHostView makeBackingLayer]):
(-[WKVideoLayerHostView layerHost]):
(-[WKVideoLayerHostView clipsToBounds]):
(-[WKVideoLayerHostView willMoveToWindow:]):
(-[WKVideoLayerHostView window]):
(-[WKVideoLayerHostView visibilityPropagationView]):
(-[WKVideoLayerHostView setVisibilityPropagationView:]):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::GPUProcessProxy):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.messages.in:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::platformVideoLayer const):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/GraphicsLayerCARemote.mm:
(WebKit::GraphicsLayerCARemote::createPlatformVideoLayer):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemote.mm:
(WebKit::PlatformCALayerRemote::create):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/PlatformCALayerRemoteCustom.mm:
(WebKit::PlatformCALayerRemoteCustom::create):
(WebKit::PlatformCALayerRemoteCustom::PlatformCALayerRemoteCustom):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeContext.mm:
(WebKit::RemoteLayerTreeContext::layerDidEnterContext):
* Source/WebKit/WebProcess/cocoa/VideoPresentationManager.mm:
(WebKit::VideoPresentationManager::enterVideoFullscreenForVideoElement):
* Tools/TestWebKitAPI/SourcesCocoa.txt:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RemoteLayerHosting.mm: Added.
(TestWebKitAPI::forEachLayer):
(TestWebKitAPI::appendLayerDescription):
(TestWebKitAPI::layerTreeDescription):
(TestWebKitAPI::findLayerOfClassNamed):
(TestWebKitAPI::findVideoHostLayer):
(TestWebKitAPI::findLayerHierarchyHostingView):
(TestWebKitAPI::findCaptionsLayer):
(TestWebKitAPI::createWebViewAndStartPlayback):
(TestWebKitAPI::waitForStableVideoHostLayerFrameSize):
(TestWebKitAPI::TEST(RemoteLayerHosting, VideoLayerIsHostedDirectlyFromGPUProcess)):
(TestWebKitAPI::TEST(RemoteLayerHosting, VideoLayerIsHostedViaWebContentProcessWhenDisabled)):
(TestWebKitAPI::TEST(RemoteLayerHosting, VideoLayerFillsPlayerLayer)):
(TestWebKitAPI::TEST(RemoteLayerHosting, VideoLayerResizeIsNotPreviewedWithTransform)):
(TestWebKitAPI::testCaptionsLayerCoversVideoLayer):
(TestWebKitAPI::TEST(RemoteLayerHosting, CaptionsLayerCoversVideoLayer)):
(TestWebKitAPI::TEST(RemoteLayerHosting, CaptionsLayerCoversVideoLayerWhenDisabled)):
(TestWebKitAPI::TEST(RemoteLayerHosting, GPUProcessLayerTreeIsReachableForTesting)):
(TestWebKitAPI::TEST(RemoteLayerHosting, GPUProcessLayerTreeIsEmptyWhenDisabled)):
(TestWebKitAPI::gpuProcessHostedVideoLayerCount):
(TestWebKitAPI::TEST(RemoteLayerHosting, HostedLayersAreReleasedAfterNavigation)):
(TestWebKitAPI::TEST(RemoteLayerHosting, HostedLayerCountsAgreeAcrossProcesses)):
(TestWebKitAPI::TEST(RemoteLayerHosting, NoLayersAreHostedWhenDisabled)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eaa8e65cd1d6e9d59dda5a54326fa9862b5620e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/181116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/55061 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/48859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/191333 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/145439 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9ebb3dcd-789b-4743-93a2-59ecb0bf6220) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/182978 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/56359 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/54777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/141337 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/98164 "4 flakes 11 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/039471ca-2231-4911-980a-2b15581de43c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/184071 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/44997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/162085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/121788 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/376ae7b0-6400-47bf-82eb-fdf9283ed052) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/180440 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/43670 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/41952 "Passed tests") | [✅ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/251/builds/3753 "Passed tests") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/10568 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/154074 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/41613 "Passed tests") | [✅ 🛠 gtk3-gcc](https://ews-build.webkit.org/#/builders/284/builds/2490 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/42390 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/47673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/46207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/193265 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/54727 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/150722 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/55415 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/38234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/150438 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/45030 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/127681 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/123229 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/53932 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/16609 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/53314 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/53551 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/53379 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->