### PR TITLE
Consolidate insertions of multiple nodes from a DocumentFragment into a single notification

### DIFF
--- a/LayoutTests/fast/dom/MutationObserver/removed-out-of-order-expected.txt
+++ b/LayoutTests/fast/dom/MutationObserver/removed-out-of-order-expected.txt
@@ -4,13 +4,13 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS mutations.length is 2
-PASS mutations[0].addedNodes.length is 1
+PASS mutations[0].addedNodes.length is 2
 PASS mutations[0].removedNodes.length is 0
 PASS mutations[0].addedNodes[0].tagName is 'B'
-PASS mutations[1].addedNodes.length is 1
+PASS mutations[0].addedNodes[1].tagName is 'I'
+PASS mutations[1].addedNodes.length is 0
 PASS mutations[1].removedNodes.length is 1
 PASS mutations[1].removedNodes[0].tagName is 'B'
-PASS mutations[1].addedNodes[0].tagName is 'I'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/MutationObserver/removed-out-of-order.html
+++ b/LayoutTests/fast/dom/MutationObserver/removed-out-of-order.html
@@ -17,13 +17,14 @@ sandbox.innerHTML = '<b></b><i></i>';
 
 var mutations = observer.takeRecords();
 shouldBe("mutations.length", "2");
-shouldBe("mutations[0].addedNodes.length", "1");
+shouldBe("mutations[0].addedNodes.length", "2");
 shouldBe("mutations[0].removedNodes.length", "0");
 shouldBe("mutations[0].addedNodes[0].tagName", "'B'");
-shouldBe("mutations[1].addedNodes.length", "1");
+shouldBe("mutations[0].addedNodes[1].tagName", "'I'");
+shouldBe("mutations[1].addedNodes.length", "0");
 shouldBe("mutations[1].removedNodes.length", "1");
 shouldBe("mutations[1].removedNodes[0].tagName", "'B'");
-shouldBe("mutations[1].addedNodes[0].tagName", "'I'");
+
 </script>
 </script>
 <script src="../../../resources/js-test-post.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/details-name-exclusivity-fragment-insertion-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/details-name-exclusivity-fragment-insertion-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test that inserting two open details elements with the same name via DocumentFragment results in exactly one being open.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/details-name-exclusivity-fragment-insertion.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/details-name-exclusivity-fragment-insertion.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+test(() => {
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    const fragment = document.createDocumentFragment();
+
+    const details1 = document.createElement("details");
+    details1.setAttribute("name", "group");
+    details1.setAttribute("open", "");
+    details1.textContent = "Details 1";
+    fragment.appendChild(details1);
+
+    const details2 = document.createElement("details");
+    details2.setAttribute("name", "group");
+    details2.setAttribute("open", "");
+    details2.textContent = "Details 2";
+    fragment.appendChild(details2);
+
+    container.appendChild(fragment);
+
+    // Exactly one should remain open. The first in tree order keeps its open
+    // attribute; later ones see the conflict during post-insertion steps and
+    // close themselves.
+    let openCount = 0;
+    if (details1.hasAttribute("open"))
+        openCount++;
+    if (details2.hasAttribute("open"))
+        openCount++;
+
+    assert_equals(openCount, 1);
+    assert_true(details1.hasAttribute('open'));
+    assert_false(details2.hasAttribute('open'));
+
+    // Also test with three open details in a fragment.
+    const container2 = document.createElement("div");
+    document.body.appendChild(container2);
+
+    const fragment2 = document.createDocumentFragment();
+
+    const detailsA = document.createElement("details");
+    detailsA.setAttribute("name", "group2");
+    detailsA.setAttribute("open", "");
+    fragment2.appendChild(detailsA);
+
+    const detailsB = document.createElement("details");
+    detailsB.setAttribute("name", "group2");
+    detailsB.setAttribute("open", "");
+    fragment2.appendChild(detailsB);
+
+    const detailsC = document.createElement("details");
+    detailsC.setAttribute("name", "group2");
+    detailsC.setAttribute("open", "");
+    fragment2.appendChild(detailsC);
+
+    container2.appendChild(fragment2);
+
+    openCount = 0;
+    if (detailsA.hasAttribute("open"))
+        openCount++;
+    if (detailsB.hasAttribute("open"))
+        openCount++;
+    if (detailsC.hasAttribute("open"))
+        openCount++;
+
+    assert_equals(openCount, 1);
+    assert_true(detailsA.hasAttribute('open'));
+
+    // Test inserting into a container that already has an open details with the same name.
+    const container3 = document.createElement("div");
+    document.body.appendChild(container3);
+
+    const existing = document.createElement("details");
+    existing.setAttribute("name", "group3");
+    existing.setAttribute("open", "");
+    container3.appendChild(existing);
+
+    const fragment3 = document.createDocumentFragment();
+
+    const detailsD = document.createElement("details");
+    detailsD.setAttribute("name", "group3");
+    detailsD.setAttribute("open", "");
+    fragment3.appendChild(detailsD);
+
+    container3.appendChild(fragment3);
+
+    assert_false(detailsD.hasAttribute('open'));
+    assert_true(existing.hasAttribute('open'));
+
+    container.remove();
+    container2.remove();
+    container3.remove();
+}, "Test that inserting two open details elements with the same name via DocumentFragment results in exactly one being open.");
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/127-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/127-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (FAIL), message = SyntaxError: Unexpected end of script
-
-FAIL scheduler: appending non-text children to script  assert_array_equals: lengths differ, expected array ["inline script #1", "inline script #2", "end inline script #2", "end inline script #1"] length 4, got ["inline script #1", "end inline script #1"] length 2
+PASS scheduler: appending non-text children to script
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/128-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/128-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (FAIL), message = SyntaxError: Unexpected end of script
-
-FAIL scheduler: appending script element to script  assert_array_equals: lengths differ, expected array ["inline script #1", "inline script #3", "inline script #2", "end inline script #2", "end inline script #1"] length 5, got ["inline script #1", "inline script #3", "end inline script #1"] length 3
+FAIL scheduler: appending script element to script  assert_array_equals: expected property 1 to be "inline script #3" but got "inline script #2" (expected array ["inline script #1", "inline script #3", "inline script #2", "end inline script #2", "end inline script #1"] got ["inline script #1", "inline script #2", "end inline script #2", "inline script #3", "end inline script #1"])
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/130-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/130-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (FAIL), message = SyntaxError: Unexpected end of script
-
-FAIL scheduler: appending external script element to script  assert_array_equals: lengths differ, expected array ["inline script #1", "inline script #2", "end inline script #2", "end inline script #1", "external script #1"] length 5, got ["inline script #1", "end inline script #1", "external script #1"] length 3
+PASS scheduler: appending external script element to script
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/147-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/147-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL scheduler: insert multiple inline scripts; first script moves subsequent scripts  null is not an object (evaluating 's.parentNode')
+PASS scheduler: insert multiple inline scripts; first script moves subsequent scripts
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/148-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/148-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL scheduler: insert multiple inline scripts; first script deletes subsequent script  null is not an object (evaluating 's.parentNode')
+FAIL scheduler: insert multiple inline scripts; first script deletes subsequent script  assert_array_equals: lengths differ, expected array ["inline script #1", "inline script #2", "inline script #3", "inline script #4"] length 4, got ["inline script #1", "inline script #2", "inline script #4"] length 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/inserting-fragment-under-shadow-host-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/inserting-fragment-under-shadow-host-expected.txt
@@ -1,0 +1,3 @@
+
+PASS This tests inserting a document fragment with a mixture of elements and text nodes, which should dispatch a `slotchange` event.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/inserting-fragment-under-shadow-host.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/shadow-dom/inserting-fragment-under-shadow-host.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+
+promise_test(() => {
+    const host = document.createElement('span');
+    document.body.appendChild(host);
+    const shadowRoot = host.attachShadow({mode: 'closed'});
+    shadowRoot.innerHTML = '<slot></slot>';
+
+    let slotchangeDidFire = false;
+    shadowRoot.querySelector('slot').addEventListener('slotchange', () => slotchangeDidFire = true);
+    host.innerHTML = '<span slot="unused"></span>b<span slot="unused"></span>';
+
+    return new Promise((resolve) => {
+        queueMicrotask(() => {
+            assert_true(slotchangeDidFire);
+            host.remove();
+            resolve();
+        });
+    })
+}, 'This tests inserting a document fragment with a mixture of elements and text nodes, which should dispatch a `slotchange` event.');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -17,7 +17,6 @@ html/HTMLFormElement.cpp
 [ iOS ] html/HTMLImageLoader.cpp
 html/HTMLOptionElement.cpp
 [ iOS ] html/HTMLPictureElement.cpp
-html/HTMLSelectElement.cpp
 html/OffscreenCanvas.cpp
 html/canvas/CanvasRenderingContext2DBase.cpp
 inspector/InspectorNodeFinder.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -64,7 +64,6 @@ html/HTMLFormElement.cpp
 html/HTMLMediaElement.cpp
 html/HTMLOptionElement.cpp
 [ iOS ] html/HTMLPictureElement.cpp
-html/HTMLSelectElement.cpp
 html/OffscreenCanvas.cpp
 html/canvas/CanvasRenderingContext2DBase.cpp
 inspector/InspectorAuditAccessibilityObject.cpp

--- a/Source/WebCore/dom/CharacterData.cpp
+++ b/Source/WebCore/dom/CharacterData.cpp
@@ -86,6 +86,7 @@ static ContainerNode::ChildChange NODELETE makeChildChange(CharacterData& charac
     return {
         ContainerNode::ChildChange::Type::TextChanged,
         nullptr,
+        nullptr,
         ElementTraversal::previousSibling(characterData),
         ElementTraversal::nextSibling(characterData),
         source,

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -153,7 +153,7 @@ ALWAYS_INLINE auto ContainerNode::removeAllChildrenWithScriptAssertion(ChildChan
         collectChildNodes(*this, children);
     }
 
-    ContainerNode::ChildChange childChange { ChildChange::Type::AllChildrenRemoved, nullptr, nullptr, nullptr, source, ContainerNode::ChildChange::AffectsElements::Unknown };
+    ContainerNode::ChildChange childChange { ChildChange::Type::AllChildrenRemoved, nullptr, nullptr, nullptr, nullptr, source, ContainerNode::ChildChange::AffectsElements::Unknown };
 
     bool hadElementChild = false;
 
@@ -210,6 +210,7 @@ static ContainerNode::ChildChange makeChildChangeForRemoval(Node& childToRemove,
 
     return {
         changeType,
+        nullptr,
         dynamicDowncast<Element>(childToRemove),
         ElementTraversal::previousSibling(childToRemove),
         ElementTraversal::nextSibling(childToRemove),
@@ -286,7 +287,7 @@ enum class ReplacedAllChildren { No, YesIncludingElements, YesNotIncludingElemen
 static ContainerNode::ChildChange makeChildChangeForInsertion(ContainerNode& containerNode, Node& child, Node* beforeChild, ContainerNode::ChildChange::Source source, ReplacedAllChildren replacedAllChildren)
 {
     if (replacedAllChildren != ReplacedAllChildren::No)
-        return { ContainerNode::ChildChange::Type::AllChildrenReplaced, nullptr, nullptr, nullptr, source, replacedAllChildren == ReplacedAllChildren::YesIncludingElements ? ContainerNode::ChildChange::AffectsElements::Yes : ContainerNode::ChildChange::AffectsElements::No };
+        return { ContainerNode::ChildChange::Type::AllChildrenReplaced, nullptr, nullptr, nullptr, nullptr, source, replacedAllChildren == ReplacedAllChildren::YesIncludingElements ? ContainerNode::ChildChange::AffectsElements::Yes : ContainerNode::ChildChange::AffectsElements::No };
 
     auto changeType = [&] {
         if (is<Element>(child))
@@ -299,6 +300,7 @@ static ContainerNode::ChildChange makeChildChangeForInsertion(ContainerNode& con
     auto* beforeChildElement = dynamicDowncast<Element>(beforeChild);
     return {
         changeType,
+        nullptr,
         dynamicDowncast<Element>(child),
         beforeChild ? ElementTraversal::previousSibling(*beforeChild) : ElementTraversal::lastChild(containerNode),
         !beforeChild || beforeChildElement ? beforeChildElement : ElementTraversal::nextSibling(*beforeChild),
@@ -307,10 +309,49 @@ static ContainerNode::ChildChange makeChildChangeForInsertion(ContainerNode& con
     };
 }
 
+static ContainerNode::ChildChange makeChildChangeForInsertion(ContainerNode& containerNode, NodeVector& children, Node* beforeChild, ContainerNode::ChildChange::Source source, ReplacedAllChildren replacedAllChildren)
+{
+    using Type = ContainerNode::ChildChange::Type;
+    using AffectsElements = ContainerNode::ChildChange::AffectsElements;
+
+    if (replacedAllChildren != ReplacedAllChildren::No)
+        return { Type::AllChildrenReplaced, &children, nullptr, nullptr, nullptr, source, replacedAllChildren == ReplacedAllChildren::YesIncludingElements ? AffectsElements::Yes : AffectsElements::No };
+
+    ASSERT(children.size());
+    auto changeType = Type::NonContentsChildInserted;
+    for (auto& child : children) {
+        if (is<Element>(child)) {
+            if (changeType == Type::TextInserted)
+                changeType = Type::ElementAndTextInserted;
+            else if (changeType != Type::ElementAndTextInserted)
+                changeType = Type::ElementInserted;
+            continue;
+        }
+        if (is<Text>(child)) {
+            if (changeType == Type::ElementInserted)
+                changeType = Type::ElementAndTextInserted;
+            else if (changeType != Type::ElementAndTextInserted)
+                changeType = Type::TextInserted;
+            continue;
+        }
+    }
+
+    auto* beforeChildElement = dynamicDowncast<Element>(beforeChild);
+    return {
+        changeType,
+        &children,
+        nullptr,
+        beforeChild ? ElementTraversal::previousSibling(*beforeChild) : ElementTraversal::lastChild(containerNode),
+        !beforeChild || beforeChildElement ? beforeChildElement : ElementTraversal::nextSibling(*beforeChild),
+        source,
+        changeType == Type::ElementInserted || changeType == Type::ElementAndTextInserted ? AffectsElements::Yes : AffectsElements::No
+    };
+}
+
 enum class ClonedChildIncludesElements { No, Yes };
 static ContainerNode::ChildChange NODELETE makeChildChangeForCloneInsertion(ClonedChildIncludesElements clonedChildIncludesElements)
 {
-    return { ContainerNode::ChildChange::Type::AllChildrenReplaced, nullptr, nullptr, nullptr, ContainerNode::ChildChange::Source::Clone,
+    return { ContainerNode::ChildChange::Type::AllChildrenReplaced, nullptr, nullptr, nullptr, nullptr, ContainerNode::ChildChange::Source::Clone,
         clonedChildIncludesElements == ClonedChildIncludesElements::Yes ? ContainerNode::ChildChange::AffectsElements::Yes : ContainerNode::ChildChange::AffectsElements::No };
 }
 
@@ -343,6 +384,45 @@ static ALWAYS_INLINE void executeNodeInsertionWithScriptAssertion(ContainerNode&
 
     if (source == ContainerNode::ChildChange::Source::API)
         dispatchChildInsertionEvents(child);
+}
+
+template<typename DOMInsertionWork>
+static ALWAYS_INLINE void executeNodeInsertionWithScriptAssertion(ContainerNode& containerNode, NodeVector& children, Node* beforeChild,
+    ContainerNode::ChildChange::Source source, ReplacedAllChildren replacedAllChildren, NOESCAPE const DOMInsertionWork& doNodeInsertion)
+{
+    if (children.isEmpty())
+        return;
+
+    // FIXME: Make it work with multiple children. Add TextAndElementInserted.
+    auto childChange = makeChildChangeForInsertion(containerNode, children, beforeChild, source, replacedAllChildren);
+
+    NodeVector postInsertionNotificationTargets;
+    {
+        WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
+        ScriptDisallowedScope::InMainThread scriptDisallowedScope;
+        Style::ChildChangeInvalidation styleInvalidation(containerNode, childChange);
+
+        if (containerNode.isShadowRoot() || containerNode.isInShadowTree()) [[unlikely]]
+            containerNode.containingShadowRoot()->resolveSlotsBeforeNodeInsertionOrRemoval();
+
+        for (auto& child : children) {
+            doNodeInsertion(child);
+            ChildListMutationScope(containerNode).childAdded(child);
+            notifyChildNodeInserted(containerNode, child, postInsertionNotificationTargets);
+        }
+    }
+
+    // FIXME: Move childrenChanged into ScriptDisallowedScope block.
+    containerNode.childrenChanged(childChange);
+
+    ASSERT(ScriptDisallowedScope::InMainThread::isEventDispatchAllowedInSubtree(containerNode));
+    for (auto& target : postInsertionNotificationTargets)
+        target->didFinishInsertingNode();
+
+    if (source == ContainerNode::ChildChange::Source::API) {
+        for (auto& child : children)
+            dispatchChildInsertionEvents(child);
+    }
 }
 
 template<typename DOMInsertionWork>
@@ -578,26 +658,21 @@ ExceptionOr<void> ContainerNode::insertBefore(Node& newChild, RefPtr<Node>&& ref
             if (checkAcceptResult.hasException())
                 return checkAcceptResult.releaseException();
         }
+        if (next->parentNode() != this)
+            return { };
+        for (auto& child : targets) {
+            if (child->parentNode())
+                return { };
+        }
     }
 
     InspectorInstrumentation::willInsertDOMNode(protect(document()), *this);
 
     ChildListMutationScope mutation(*this);
-    for (auto& child : targets) {
-        // Due to arbitrary code running in response to a DOM mutation event it's
-        // possible that "next" is no longer a child of "this".
-        // It's also possible that "child" has been inserted elsewhere.
-        // In either of those cases, we'll just stop.
-        if (next->parentNode() != this)
-            break;
-        if (child->parentNode())
-            break;
-
-        executeNodeInsertionWithScriptAssertion(*this, child.get(), next.ptr(), ChildChange::Source::API, ReplacedAllChildren::No, [&] {
-            child->setTreeScopeRecursively(treeScope());
-            insertBeforeCommon(next, child);
-        });
-    }
+    executeNodeInsertionWithScriptAssertion(*this, targets, next.ptr(), ChildChange::Source::API, ReplacedAllChildren::No, [&](Node& child) {
+        child.setTreeScopeRecursively(treeScope());
+        insertBeforeCommon(next, child);
+    });
 
     dispatchSubtreeModifiedEvent();
     return { };
@@ -607,6 +682,8 @@ void ContainerNode::insertBeforeCommon(Node& nextChild, Node& newChild)
 {
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
+    ASSERT(nextChild.parentNode() == this);
+    ASSERT(&nextChild != &newChild);
     ASSERT(!newChild.parentNode()); // Use insertBefore if you need to handle reparenting (and want DOM mutation events).
     ASSERT(!newChild.nextSibling());
     ASSERT(!newChild.previousSibling());
@@ -632,6 +709,7 @@ void ContainerNode::appendChildCommon(Node& child)
 {
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;
 
+    ASSERT(!child.parentNode());
     child.setParentNode(this);
 
     if (auto* lastChild = this->lastChild()) {
@@ -696,6 +774,12 @@ ExceptionOr<void> ContainerNode::replaceChild(Node& newChild, Node& oldChild)
             if (validityResult.hasException())
                 return validityResult.releaseException();
         }
+        if (refChild && refChild->parentNode() != this)
+            return { };
+        for (auto& child : targets) {
+            if (child->parentNode())
+                return { };
+        }
         beforeScriptExecutionCount = ScriptController::scriptExecutionCount();
     }
 
@@ -717,30 +801,24 @@ ExceptionOr<void> ContainerNode::replaceChild(Node& newChild, Node& oldChild)
                 if (validityResult.hasException())
                     return validityResult.releaseException();
             }
+            if (refChild && refChild->parentNode() != this)
+                return { };
+            for (auto& child : targets) {
+                if (child->parentNode())
+                    return { };
+            }
         }
     }
 
     InspectorInstrumentation::willInsertDOMNode(protect(document()), *this);
 
-    // Add the new child(ren).
-    for (auto& child : targets) {
-        // Due to arbitrary code running in response to a DOM mutation event it's
-        // possible that "refChild" is no longer a child of "this".
-        // It's also possible that "child" has been inserted elsewhere.
-        // In either of those cases, we'll just stop.
-        if (refChild && refChild->parentNode() != this)
-            break;
-        if (child->parentNode())
-            break;
-
-        executeNodeInsertionWithScriptAssertion(*this, child.get(), refChild.get(), ChildChange::Source::API, ReplacedAllChildren::No, [&] {
-            child->setTreeScopeRecursively(treeScope());
-            if (refChild)
-                insertBeforeCommon(*refChild, child.get());
-            else
-                appendChildCommon(child);
-        });
-    }
+    executeNodeInsertionWithScriptAssertion(*this, targets, refChild.get(), ChildChange::Source::API, ReplacedAllChildren::No, [&](Node& child) {
+        child.setTreeScopeRecursively(treeScope());
+        if (refChild)
+            insertBeforeCommon(*refChild, child);
+        else
+            appendChildCommon(child);
+    });
 
     dispatchSubtreeModifiedEvent();
     return { };
@@ -836,6 +914,8 @@ void ContainerNode::replaceAll(Node* node)
         return;
     }
 
+    InspectorInstrumentation::willInsertDOMNode(protect(document()), *this);
+
     Ref protectedThis { *this };
     ChildListMutationScope mutation(*this);
     NodeVector removedChildren;
@@ -843,7 +923,6 @@ void ContainerNode::replaceAll(Node* node)
         ? ReplacedAllChildren::YesIncludingElements : ReplacedAllChildren::YesNotIncludingElements;
 
     executeNodeInsertionWithScriptAssertion(*this, *node, nullptr, ChildChange::Source::API, replacedAllChildren, [&] {
-        InspectorInstrumentation::willInsertDOMNode(protect(document()), *this);
         node->setTreeScopeRecursively(treeScope());
         appendChildCommon(*node);
     });
@@ -915,25 +994,19 @@ ExceptionOr<void> ContainerNode::appendChildWithoutPreInsertionValidityCheck(Nod
             if (nodeTypeResult.hasException())
                 return nodeTypeResult.releaseException();
         }
+        for (auto& child : targets) {
+            if (child->parentNode())
+                return { };
+        }
     }
 
     InspectorInstrumentation::willInsertDOMNode(protect(document()), *this);
 
-    // Now actually add the child(ren)
     ChildListMutationScope mutation(*this);
-    for (auto& child : targets) {
-        // If the child has a parent again, just stop what we're doing, because
-        // that means someone is doing something with DOM mutation -- can't re-parent
-        // a child that already has a parent.
-        if (child->parentNode())
-            break;
-
-        // Append child to the end of the list
-        executeNodeInsertionWithScriptAssertion(*this, child.get(), nullptr, ChildChange::Source::API, ReplacedAllChildren::No, [&] {
-            child->setTreeScopeRecursively(treeScope());
-            appendChildCommon(child);
-        });
-    }
+    executeNodeInsertionWithScriptAssertion(*this, targets, nullptr, ChildChange::Source::API, ReplacedAllChildren::No, [&](Node& child) {
+        child.setTreeScopeRecursively(treeScope());
+        appendChildCommon(child);
+    });
 
     dispatchSubtreeModifiedEvent();
     return { };
@@ -953,7 +1026,6 @@ ExceptionOr<void> ContainerNode::insertChildrenBeforeWithoutPreInsertionValidity
         }
     }
 
-
     if (ScriptController::scriptExecutionCount() != beforeScriptExecutionCount) {
         // Check conditions when events in removeChild executed js.
         for (auto& child : newChildren) {
@@ -961,24 +1033,24 @@ ExceptionOr<void> ContainerNode::insertChildrenBeforeWithoutPreInsertionValidity
             if (nodeTypeResult.hasException())
                 return nodeTypeResult.releaseException();
         }
+        if (refChild && refChild->parentNode() != this)
+            return { };
+        for (auto& child : newChildren) {
+            if (child->parentNode())
+                return { };
+        }
     }
 
     InspectorInstrumentation::willInsertDOMNode(protect(document()), *this);
 
     ChildListMutationScope mutation(*this);
-    for (auto& child : newChildren) {
-        if (refChild && refChild->parentNode() != this) // Event listeners moved nextChild elsewhere.
-            break;
-        if (child->parentNode()) // Event listeners inserted this child elsewhere.
-            break;
-        executeNodeInsertionWithScriptAssertion(*this, child.get(), refChild.get(), ChildChange::Source::API, ReplacedAllChildren::No, [&] {
-            child->setTreeScopeRecursively(treeScope());
-            if (refChild)
-                insertBeforeCommon(*refChild, child.get());
-            else
-                appendChildCommon(child);
-        });
-    }
+    executeNodeInsertionWithScriptAssertion(*this, newChildren, refChild.get(), ChildChange::Source::API, ReplacedAllChildren::No, [&](auto& child) {
+        child->setTreeScopeRecursively(treeScope());
+        if (refChild)
+            insertBeforeCommon(*refChild, child);
+        else
+            appendChildCommon(child);
+    });
 
     dispatchSubtreeModifiedEvent();
     return { };
@@ -1025,7 +1097,7 @@ void ContainerNode::parserNotifyChildrenChanged()
     ASSERT(is<Element>(*this));
     ASSERT(hasHeldBackChildrenChanged());
     clearHasHeldBackChildrenChanged();
-    childrenChanged(ChildChange { ContainerNode::ChildChange::Type::AllChildrenReplaced, nullptr, nullptr, nullptr, ChildChange::Source::Parser,
+    childrenChanged(ChildChange { ContainerNode::ChildChange::Type::AllChildrenReplaced, nullptr, nullptr, nullptr, nullptr, ChildChange::Source::Parser,
         firstElementChild() ? ChildChange::AffectsElements::Yes : ChildChange::AffectsElements::No, IsMutationBySetInnerHTML::Yes });
 }
 

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -82,11 +82,12 @@ public:
 
     enum class CanDelayNodeDeletion : uint8_t { No, Yes, Unknown };
     struct ChildChange {
-        enum class Type : uint8_t { ElementInserted, ElementRemoved, TextInserted, TextRemoved, TextChanged, AllChildrenRemoved, NonContentsChildRemoved, NonContentsChildInserted, AllChildrenReplaced };
+        enum class Type : uint8_t { ElementInserted, ElementRemoved, ElementAndTextInserted, TextInserted, TextRemoved, TextChanged, AllChildrenRemoved, NonContentsChildRemoved, NonContentsChildInserted, AllChildrenReplaced };
         enum class Source : uint8_t { Parser, API, Clone };
         enum class AffectsElements : uint8_t { Unknown, No, Yes };
 
         ChildChange::Type type;
+        const NodeVector* const insertedChildren;
         // Making these raw pointers RefPtr leads to a Speedometer 3 regression.
         SUPPRESS_UNCOUNTED_MEMBER Element* siblingChanged;
         SUPPRESS_UNCOUNTED_MEMBER Element* previousSiblingElement;
@@ -99,6 +100,7 @@ public:
         {
             switch (type) {
             case ChildChange::Type::ElementInserted:
+            case ChildChange::Type::ElementAndTextInserted:
             case ChildChange::Type::TextInserted:
             case ChildChange::Type::NonContentsChildInserted:
             case ChildChange::Type::AllChildrenReplaced:

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3641,6 +3641,7 @@ bool Element::childTypeAllowed(NodeType type) const
     }
     return false;
 }
+
 void Element::childrenChanged(const ChildChange& change)
 {
     ContainerNode::childrenChanged(change);
@@ -3655,6 +3656,7 @@ void Element::childrenChanged(const ChildChange& change)
         case ChildChange::Type::AllChildrenReplaced:
             shadowRoot->didRemoveAllChildrenOfShadowHost();
             break;
+        case ChildChange::Type::ElementAndTextInserted:
         case ChildChange::Type::TextInserted:
         case ChildChange::Type::TextRemoved:
         case ChildChange::Type::TextChanged:
@@ -3667,9 +3669,20 @@ void Element::childrenChanged(const ChildChange& change)
     }
 
     if (document().isDirAttributeDirty()) [[unlikely]] {
-        // Inserting a replaced Element (image, canvas, input, etc) should be treated as a neutral character.
-        if (selfOrPrecedingNodesAffectDirAuto() && !(change.type == ChildChange::Type::ElementInserted && change.siblingChanged->isReplaced()))
-            updateEffectiveTextDirection();
+        if (selfOrPrecedingNodesAffectDirAuto()) {
+            bool allInsertedElementsAreTreatedAsNeutralCharacter = false;
+            if (change.siblingChanged && change.siblingChanged->isReplaced())
+                allInsertedElementsAreTreatedAsNeutralCharacter = true;
+            else if (change.insertedChildren) {
+                allInsertedElementsAreTreatedAsNeutralCharacter = true;
+                for (auto& child : *change.insertedChildren) {
+                    if (RefPtr element = dynamicDowncast<Element>(child); !element || !element->isReplaced())
+                        allInsertedElementsAreTreatedAsNeutralCharacter = false;
+                }
+            }
+            if (!allInsertedElementsAreTreatedAsNeutralCharacter)
+                updateEffectiveTextDirection();
+        }
     }
 }
 

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -218,7 +218,7 @@ public:
 
     // Call this to get the value of an attribute that is known not to be the style
     // attribute or one of the SVG animatable attributes.
-    inline bool hasAttributeWithoutSynchronization(const QualifiedName&) const;
+    inline bool NODELETE hasAttributeWithoutSynchronization(const QualifiedName&) const;
     inline const AtomString& attributeWithoutSynchronization(const QualifiedName&) const;
     inline const AtomString& attributeWithDefaultARIA(const QualifiedName&) const;
     inline String attributeTrimmedWithDefaultARIA(const QualifiedName&) const;

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -166,6 +166,7 @@ void ShadowRoot::childrenChanged(const ChildChange& childChange)
     // FIXME: Avoid always invalidating style just for first-child, etc... as done in Element::childrenChanged.
     switch (childChange.type) {
     case ChildChange::Type::ElementInserted:
+    case ChildChange::Type::ElementAndTextInserted:
     case ChildChange::Type::ElementRemoved:
         m_host->invalidateStyleForSubtreeInternal();
         break;

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -187,13 +187,16 @@ void HTMLDetailsElement::attributeChanged(const QualifiedName& name, const AtomS
                 queueDetailsToggleEventTask(ToggleState::Open, ToggleState::Closed);
             }
         }
-    } else
+    } else if (name == nameAttr)
         ensureDetailsExclusivityAfterMutation();
 }
 
 Node::InsertedIntoAncestorResult HTMLDetailsElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
     HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+
+    m_shouldCloseElementAfterInsertion = shouldClose();
+
     if (!insertionType.connectedToDocument)
         return InsertedIntoAncestorResult::Done;
     return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
@@ -201,10 +204,16 @@ Node::InsertedIntoAncestorResult HTMLDetailsElement::insertedIntoAncestor(Insert
 
 void HTMLDetailsElement::didFinishInsertingNode()
 {
-    ensureDetailsExclusivityAfterMutation();
+    // FIXME: Spec makes this DOM mutation synchronously in "insertion steps"
+    // but our current model of insertedIntoAncestor is not compatible with that.
+    if (hasAttributeWithoutSynchronization(openAttr) && m_shouldCloseElementAfterInsertion) {
+        ShouldNotFireMutationEventsScope scope(document());
+        toggleOpen();
+    }
+    m_shouldCloseElementAfterInsertion = false;
 }
 
-Vector<Ref<HTMLDetailsElement>> HTMLDetailsElement::otherElementsInNameGroup()
+Vector<Ref<HTMLDetailsElement>> HTMLDetailsElement::otherElementsInNameGroup() const
 {
     Vector<Ref<HTMLDetailsElement>> otherElementsInNameGroup;
     const auto& detailElementName = attributeWithoutSynchronization(nameAttr);
@@ -217,15 +226,22 @@ Vector<Ref<HTMLDetailsElement>> HTMLDetailsElement::otherElementsInNameGroup()
 
 void HTMLDetailsElement::ensureDetailsExclusivityAfterMutation()
 {
-    if (hasAttributeWithoutSynchronization(openAttr) && !attributeWithoutSynchronization(nameAttr).isEmpty()) {
-        ShouldNotFireMutationEventsScope scope(document());
-        for (auto& otherDetailsElement : otherElementsInNameGroup()) {
-            if (otherDetailsElement->hasAttributeWithoutSynchronization(openAttr)) {
-                toggleOpen();
-                break;
-            }
+    if (!shouldClose())
+        return;
+    ShouldNotFireMutationEventsScope scope(document());
+    toggleOpen();
+}
+
+bool HTMLDetailsElement::shouldClose() const
+{
+    const auto& detailElementName = attributeWithoutSynchronization(nameAttr);
+    if (hasAttributeWithoutSynchronization(openAttr) && !detailElementName.isEmpty()) {
+        for (auto& otherElement : otherElementsInNameGroup()) {
+            if (otherElement->hasAttributeWithoutSynchronization(openAttr))
+                return true;
         }
     }
+    return false;
 }
 
 void HTMLDetailsElement::toggleOpen()

--- a/Source/WebCore/html/HTMLDetailsElement.h
+++ b/Source/WebCore/html/HTMLDetailsElement.h
@@ -49,8 +49,9 @@ private:
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void didFinishInsertingNode() final;
 
-    Vector<Ref<HTMLDetailsElement>> otherElementsInNameGroup();
+    Vector<Ref<HTMLDetailsElement>> otherElementsInNameGroup() const;
     void ensureDetailsExclusivityAfterMutation();
+    bool shouldClose() const;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 
     void didAddUserAgentShadowRoot(ShadowRoot&) final;
@@ -60,6 +61,7 @@ private:
     WeakPtr<HTMLSummaryElement, WeakPtrImplWithEventTargetData> m_defaultSummary;
     RefPtr<HTMLSlotElement> m_defaultSlot;
     bool m_isOpen { false };
+    bool m_shouldCloseElementAfterInsertion { false };
 
     RefPtr<ToggleEventTask> m_toggleEventTask;
 };

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -242,6 +242,7 @@ void HTMLMeterElement::appendShadowTreeForBaseAppearance(ShadowRoot& root)
     trackElement->setUserAgentPart(UserAgentParts::sliderTrack());
     trackElement->setInlineStyleProperty(CSSPropertyAppearance, "inherit"_s);
     trackElement->setInlineStyleProperty(CSSPropertyDisplay, "-internal-auto-base(none, inline-block) !important"_s);
+    ScriptDisallowedScope::EventAllowedScope rootScope { root };
     root.appendChild(trackElement);
 
     Ref fillElement = HTMLDivElement::create(document);

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -158,6 +158,7 @@ void HTMLProgressElement::appendShadowTreeForAutoAppearance(ShadowRoot& root)
     innerElement->setUserAgentPart(UserAgentParts::webkitProgressInnerElement());
     innerElement->setInlineStyleProperty(CSSPropertyAppearance, "inherit"_s);
     innerElement->setInlineStyleProperty(CSSPropertyDisplay, "-internal-auto-base(inline-block, none) !important"_s);
+    ScriptDisallowedScope::EventAllowedScope rootScope { root };
     root.appendChild(innerElement);
 
     Ref barElement = HTMLDivElement::create(document);
@@ -183,6 +184,7 @@ void HTMLProgressElement::appendShadowTreeForBaseAppearance(ShadowRoot& root)
     trackElement->setUserAgentPart(UserAgentParts::sliderTrack());
     trackElement->setInlineStyleProperty(CSSPropertyAppearance, "inherit"_s);
     trackElement->setInlineStyleProperty(CSSPropertyDisplay, "-internal-auto-base(none, inline-block) !important"_s);
+    ScriptDisallowedScope::EventAllowedScope rootScope { root };
     root.appendChild(trackElement);
 
     Ref fillElement = HTMLDivElement::create(document);

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -607,12 +607,23 @@ CompletionHandlerCallingScope HTMLSelectElement::optionToSelectFromChildChangeSc
     };
 
     RefPtr<HTMLOptionElement> optionToSelect;
-    if (change.type == ChildChange::Type::ElementInserted) {
-        if (auto* option = dynamicDowncast<HTMLOptionElement>(*change.siblingChanged)) {
-            if (option->selectedWithoutUpdate())
-                optionToSelect = option;
-        } else if (auto* optGroup = dynamicDowncast<HTMLOptGroupElement>(change.siblingChanged); !parentOptGroup && optGroup)
-            optionToSelect = getLastSelectedOption(*optGroup);
+    if (change.type == ChildChange::Type::ElementInserted || change.type == ChildChange::Type::ElementAndTextInserted) {
+        auto handleInsertedElement = [&](Element& insertedElement) {
+            if (auto* option = dynamicDowncast<HTMLOptionElement>(insertedElement)) {
+                if (option->selectedWithoutUpdate())
+                    optionToSelect = option;
+            } else if (auto* optGroup = dynamicDowncast<HTMLOptGroupElement>(insertedElement); !parentOptGroup && optGroup)
+                optionToSelect = getLastSelectedOption(*optGroup);
+        };
+        if (RefPtr element = change.siblingChanged)
+            handleInsertedElement(*element);
+        else if (change.insertedChildren) {
+            for (auto& child : *change.insertedChildren) {
+                if (RefPtr element = dynamicDowncast<Element>(child))
+                    handleInsertedElement(*element);
+            }
+        }
+
     } else if (parentOptGroup && change.type == ContainerNode::ChildChange::Type::AllChildrenReplaced)
         optionToSelect = getLastSelectedOption(*parentOptGroup);
 

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -266,25 +266,25 @@ void ChildChangeInvalidation::traverseAddedElements(Function&& function)
     if (!m_childChange.isInsertion())
         return;
 
-    RefPtr newElement = [&] {
-        auto* previous = m_childChange.previousSiblingElement;
-        auto* candidate = previous ? ElementTraversal::nextSibling(*previous) : ElementTraversal::firstChild(parentElement());
-        if (candidate == m_childChange.nextSiblingElement)
-            candidate = nullptr;
-        return candidate;
-    }();
+    auto callFunctionOnInclusiveDescendants = [&](Element& element) {
+        function(element);
 
-    if (!newElement)
-        return;
+        auto& features = parentElement().styleResolver().ruleSets().features();
+        if (!needsDescendantTraversal(features))
+            return;
 
-    function(*newElement);
+        for (Ref descendant : descendantsOfType<Element>(element))
+            function(descendant);
+    };
 
-    auto& features = parentElement().styleResolver().ruleSets().features();
-    if (!needsDescendantTraversal(features))
-        return;
-
-    for (Ref descendant : descendantsOfType<Element>(*newElement))
-        function(descendant);
+    if (RefPtr newElement = m_childChange.siblingChanged)
+        callFunctionOnInclusiveDescendants(*newElement);
+    else if (auto* children = m_childChange.insertedChildren) {
+        for (Ref node : *children) {
+            if (auto* element = dynamicDowncast<Element>(node.get()))
+                callFunctionOnInclusiveDescendants(*element);
+        }
+    }
 }
 
 template<typename Function>

--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -312,6 +312,7 @@ void SVGAnimateMotionElement::childrenChanged(const ChildChange& change)
         updateAnimationPath();
         break;
     case ChildChange::Type::ElementInserted:
+    case ChildChange::Type::ElementAndTextInserted:
     case ChildChange::Type::TextInserted:
     case ChildChange::Type::TextRemoved:
     case ChildChange::Type::TextChanged:


### PR DESCRIPTION
#### 0bc30dba55bbd67eb6ea893f5644a9974ed2d05b
<pre>
Consolidate insertions of multiple nodes from a DocumentFragment into a single notification
<a href="https://bugs.webkit.org/show_bug.cgi?id=309975">https://bugs.webkit.org/show_bug.cgi?id=309975</a>

Reviewed by Chris Dumez and Darin Adler.

This PR changes a various DOM APIs and primitives so that inserting multiple nodes from
a DocumentFragment happens in a single atomic step without any script execution (including
mutation events).

To do this, this PR introduces a variant of executeNodeInsertionWithScriptAssertion which
takes a Vector of nodes to insert instead of a single node. All the nodes in the Vector
will be inserted within a scope with ScriptDisallowedScope as a single atomic DOM mutation
without event dispatching or script execution. The function then calls childrenChanged,
didFinishInsertingNode, and dispatch mutation events for all the nodes that got inserted.

The new behavior matches that of the latest DOM / HTML5 specification and Gecko and Blink.

Tests: fast/dom/MutationObserver/removed-out-of-order.html
       imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/details-name-exclusivity-fragment-insertion.html
       imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/127.html
       imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/130.html
       imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/147.html
       imported/w3c/web-platform-tests/shadow-dom/inserting-fragment-under-shadow-host.html

* LayoutTests/fast/dom/MutationObserver/removed-out-of-order-expected.txt:
* LayoutTests/fast/dom/MutationObserver/removed-out-of-order.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/details-name-exclusivity-fragment-insertion-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-details-element/details-name-exclusivity-fragment-insertion.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/127-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/128-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/130-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/147-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/execution-timing/148-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/inserting-fragment-under-shadow-host-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/shadow-dom/inserting-fragment-under-shadow-host.html: Added.
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/dom/CharacterData.cpp:
(WebCore::makeChildChange):
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::removeAllChildrenWithScriptAssertion):
(WebCore::makeChildChangeForRemoval):
(WebCore::makeChildChangeForInsertion):
(WebCore::makeChildChangeForCloneInsertion):
(WebCore::executeNodeInsertionWithScriptAssertion):
(WebCore::ContainerNode::insertBefore):
(WebCore::ContainerNode::insertBeforeCommon):
(WebCore::ContainerNode::appendChildCommon):
(WebCore::ContainerNode::replaceChild):
(WebCore::ContainerNode::replaceAll):
(WebCore::ContainerNode::appendChildWithoutPreInsertionValidityCheck):
(WebCore::ContainerNode::insertChildrenBeforeWithoutPreInsertionValidityCheck):
(WebCore::ContainerNode::parserNotifyChildrenChanged):
* Source/WebCore/dom/ContainerNode.h:
(WebCore::ContainerNode::ChildChange::isInsertion const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::childrenChanged):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::ShadowRoot::childrenChanged):
* Source/WebCore/html/HTMLDetailsElement.cpp:
(WebCore::HTMLDetailsElement::attributeChanged):
(WebCore::HTMLDetailsElement::insertedIntoAncestor):
(WebCore::HTMLDetailsElement::didFinishInsertingNode):
(WebCore::HTMLDetailsElement::otherElementsInNameGroup const):
(WebCore::HTMLDetailsElement::ensureDetailsExclusivityAfterMutation):
(WebCore::HTMLDetailsElement::shouldClose const):
(WebCore::HTMLDetailsElement::otherElementsInNameGroup): Deleted.
* Source/WebCore/html/HTMLDetailsElement.h:
* Source/WebCore/html/HTMLMeterElement.cpp:
(WebCore::HTMLMeterElement::appendShadowTreeForBaseAppearance):
* Source/WebCore/html/HTMLProgressElement.cpp:
(WebCore::HTMLProgressElement::appendShadowTreeForAutoAppearance):
(WebCore::HTMLProgressElement::appendShadowTreeForBaseAppearance):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::optionToSelectFromChildChangeScope):
* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::traverseAddedElements):
* Source/WebCore/svg/SVGAnimateMotionElement.cpp:
(WebCore::SVGAnimateMotionElement::childrenChanged):

Canonical link: <a href="https://commits.webkit.org/309388@main">https://commits.webkit.org/309388@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/524598597d387d99d99d40811850b1e5a8589f44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150470 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159192 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103904 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44931e94-6031-4fcb-aace-de3e5be5ae1d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23366 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116104 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82493 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7243bdc0-42b6-4d55-a6ac-9059f76503fb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153430 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134979 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96832 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/43068fc0-a8df-4ecd-9481-1805c512f51f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17312 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15261 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7040 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12903 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161666 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4786 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14456 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124103 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19308 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124301 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134698 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79397 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23129 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19413 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11455 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22631 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86430 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22344 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22496 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22398 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->