### PR TITLE
[SVG] Invalid attribute type in one animation group prevents all subsequent animation groups from running

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-begin-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-begin-event-expected.txt
@@ -1,0 +1,3 @@
+
+PASS beginEvent must fire for a delayed animation when an invalid attribute type group exists
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-begin-event.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-begin-event.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<title>beginEvent must fire for a delayed animation when an invalid attribute type group exists</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<svg>
+  <!-- Invalid animation: attributeType="CSS" on a non-CSS attribute. -->
+  <rect>
+    <animate attributeName="href" attributeType="CSS" values="foo"/>
+  </rect>
+
+  <!-- Valid animation with a delayed begin. -->
+  <rect width="100" height="100" fill="red">
+    <animate id="valid" attributeName="fill" values="green" begin="0.05s"/>
+  </rect>
+</svg>
+<script>
+async_test(t => {
+  document.getElementById("valid").addEventListener("beginEvent", t.step_func_done(() => {
+    assert_true(true, "beginEvent fired for delayed animation");
+  }));
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-other-animations-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-other-animations-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-other-animations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-other-animations.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>An invalid attribute type in one animation group must not block other animation groups</title>
+<link rel="match" href="../struct/reftests/reference/green-100x100.html">
+<svg>
+  <!-- Invalid animation: attributeType="CSS" on a non-CSS attribute. -->
+  <rect>
+    <animate attributeName="href" attributeType="CSS" values="foo" dur="1s"/>
+  </rect>
+
+  <!-- Valid animation: should still run despite the earlier invalid group. -->
+  <rect width="100" height="100" fill="red">
+    <set attributeName="fill" to="green" fill="freeze"/>
+  </rect>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-same-group-animation-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-same-group-animation-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-same-group-animation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-same-group-animation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>An invalid attributeType on one animate must not block a subsequent animate in the same group</title>
+<link rel="match" href="../struct/reftests/reference/green-100x100.html">
+<svg>
+  <rect width="100" height="100" fill="red">
+    <animate attributeType="CSS" attributeName="fill" fill="freeze" begin="0" dur="0.05s" to="blue"/>
+    <set attributeName="fill" to="green" fill="freeze"/>
+  </rect>
+</svg>

--- a/Source/WebCore/svg/animation/SMILTimeContainer.cpp
+++ b/Source/WebCore/svg/animation/SMILTimeContainer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2013 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -292,7 +292,7 @@ void SMILTimeContainer::updateAnimations(SMILTime elapsed, bool seekToTime)
             // Results are accumulated to the first animation that animates and contributes to a particular element/attribute pair.
             if (!firstAnimation) {
                 if (!animation->hasValidAttributeType())
-                    return;
+                    continue;
                 firstAnimation = animation.copyRef();
             }
 


### PR DESCRIPTION
#### 297f976adf7c77f3736be308a888cabb50abc03e
<pre>
[SVG] Invalid attribute type in one animation group prevents all subsequent animation groups from running
<a href="https://bugs.webkit.org/show_bug.cgi?id=309976">https://bugs.webkit.org/show_bug.cgi?id=309976</a>
<a href="https://rdar.apple.com/172593109">rdar://172593109</a>

Reviewed by Said Abou-Hallawa.

SMILTimeContainer::updateAnimations() used return instead of continue when
encountering an animation group whose first animation had an invalid
attribute type. This caused the entire function to exit, preventing all
subsequent animation groups from being processed, their events from
being dispatched, and the animation timer from being restarted.

Without this fix, we timeout on one of below tests while fail another.
Added another test based on Said&apos;s input for subsequent animation.

* Source/WebCore/svg/animation/SMILTimeContainer.cpp:
(WebCore::SMILTimeContainer::updateAnimations):
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-begin-event-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-begin-event.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-other-animations-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-other-animations.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-same-group-animation-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/invalid-attribute-type-does-not-block-same-group-animation.html: Added.

Canonical link: <a href="https://commits.webkit.org/309436@main">https://commits.webkit.org/309436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c7fe6f3fe0316c1bc2a1872ef01c68fee68c896

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150508 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159230 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103942 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0393723b-c94b-429c-b26c-329ada30bb37) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23697 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23408 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116137 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82510 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eb38c58e-5b70-42df-a3ec-14a84f71a562) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153468 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135014 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96865 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac845d6f-70e1-45fd-8a62-3590d53acddb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17346 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15296 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7078 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161704 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4824 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124135 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23068 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19343 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124333 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33786 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23056 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134733 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79435 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19436 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11493 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22670 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86468 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22382 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22534 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22436 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->