### PR TITLE
[css-tables] Fix collapsed-border-background-inset WPT mismatch test to use transparent borders

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset-expected-mismatch.html
@@ -2,13 +2,13 @@
 <title>CSS Test Reference (mismatch): collapsed border cell background fills full width</title>
 <style>
 th {
-    border: 0px solid red;
+    border: 0px solid transparent;
 }
 tr.green {
     background: green;
 }
 td {
-    border: 50px solid red;
+    border: 50px solid transparent;
     padding: 6px 12px;
     text-align: left;
     vertical-align: top;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset-notref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset-notref.html
@@ -2,13 +2,13 @@
 <title>CSS Test Reference (mismatch): collapsed border cell background fills full width</title>
 <style>
 th {
-    border: 0px solid red;
+    border: 0px solid transparent;
 }
 tr.green {
     background: green;
 }
 td {
-    border: 50px solid red;
+    border: 50px solid transparent;
     padding: 6px 12px;
     text-align: left;
     vertical-align: top;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset.html
@@ -4,11 +4,11 @@
 <link rel="mismatch" href="collapsed-border-background-inset-notref.html">
 <style>
 th {
-    border: 0px solid red;
+    border: 0px solid transparent;
     background: green;
 }
 td {
-    border: 50px solid red;
+    border: 50px solid transparent;
     padding: 6px 12px;
     text-align: left;
     vertical-align: top;


### PR DESCRIPTION
#### 79a563d0954dcc62c93728031a2d277ec84a5b96
<pre>
[css-tables] Fix collapsed-border-background-inset WPT mismatch test to use transparent borders
<a href="https://bugs.webkit.org/show_bug.cgi?id=309977">https://bugs.webkit.org/show_bug.cgi?id=309977</a>
<a href="https://rdar.apple.com/172594589">rdar://172594589</a>

Reviewed by Tim Nguyen.

The mismatch test was untestable because it used opaque red borders that
painted on top of the cell background, hiding the very difference it was
trying to detect. Change to transparent borders so the cell background
inset behavior is actually visible.

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset-expected-mismatch.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset-notref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-border-background-inset.html:

Canonical link: <a href="https://commits.webkit.org/309431@main">https://commits.webkit.org/309431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df0934b41217464447430d41d43f83ace046c1d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103632 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/263e8418-4021-4924-902d-f032ed24cf84) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115870 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82316 "3 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4774d9d4-f0da-478d-9ed3-2ce7e9c6bd01) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17984 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134740 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96602 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a0b2cf41-4a11-4a44-8eb4-8c6b7201439a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17084 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15031 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6757 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126699 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161384 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123872 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22758 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19078 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124076 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33782 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22745 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134459 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79058 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19201 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11216 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22358 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22072 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22224 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22126 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->