### PR TITLE
Blocked website bypasses restriction by redirecting to a different domain

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -3531,6 +3531,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     testing/MockContentFilterSettingsClient.h
     testing/MockGamepad.h
     testing/MockGamepadProvider.h
+    testing/MockParentalControlsURLFilter.h
     testing/MockWebAuthenticationConfiguration.h
 
     testing/js/WebCoreTestSupport.h

--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -1091,6 +1091,9 @@ list(APPEND WebCoreTestSupport_PRIVATE_HEADERS testing/cocoa/WebArchiveDumpSuppo
 list(APPEND WebCoreTestSupport_SOURCES
     testing/Internals.mm
     testing/MockApplePaySetupFeature.cpp
+    testing/MockContentFilter.cpp
+    testing/MockContentFilterSettings.cpp
+    testing/MockParentalControlsURLFilter.mm
     testing/MockMediaSessionCoordinator.cpp
     testing/MockPaymentCoordinator.cpp
     testing/MockPreviewLoaderClient.cpp

--- a/Source/WebCore/WebCore_Private.modulemap
+++ b/Source/WebCore/WebCore_Private.modulemap
@@ -12,6 +12,8 @@ framework module WebCore_Private [system] {
 
         requires cplusplus
 
+        exclude header "MockParentalControlsURLFilter.h"
+
         module * {
             export *
         }

--- a/Source/WebCore/loader/ContentFilter.cpp
+++ b/Source/WebCore/loader/ContentFilter.cpp
@@ -192,7 +192,10 @@ void ContentFilter::continueAfterWillSendRequest(ResourceRequest&& request, cons
             contentFilterCallbackAggregator->didReceivePlatformContentFilterDecision(platformContentFilter, WTF::move(urlString));
         };
 
-        ASSERT(platformContentFilter->needsMoreData());
+        if (!platformContentFilter->needsMoreData()) {
+            completion({ });
+            continue;
+        }
         platformContentFilter->willSendRequest(ResourceRequest { request }, redirectResponse, WTF::move(completion));
     }
 }

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/PlatformContentFilter.h>
 #include <wtf/Compiler.h>
+#include <wtf/CompletionHandler.h>
 #include <wtf/Condition.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/TZoneMalloc.h>

--- a/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm
@@ -93,14 +93,31 @@ ParentalControlsContentFilter::ParentalControlsContentFilter(const PlatformConte
     UNUSED_PARAM(params);
 }
 
-void ParentalControlsContentFilter::willSendRequest(ResourceRequest&&, const ResourceResponse&, CompletionHandler<void(String&&)>&& completionHandler)
-{
-    completionHandler({ });
-}
-
 static inline bool canHandleResponse(const ResourceResponse& response)
 {
     return response.url().protocolIsInHTTPFamily();
+}
+
+void ParentalControlsContentFilter::willSendRequest(ResourceRequest&&, const ResourceResponse& redirectResponse, CompletionHandler<void(String&&)>&& completionHandler)
+{
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    if (redirectResponse.isNull() || !canHandleResponse(redirectResponse) || !enabled()) {
+        completionHandler({ });
+        return;
+    }
+
+    urlFilter()->isURLAllowed(m_mainDocumentURL, redirectResponse.url(), [this, protectedThis = Ref { *this }, evaluatedURL = redirectResponse.url(), completionHandler = WTF::move(completionHandler)](bool isAllowed, NSData *replacementData) mutable {
+        if (!isAllowed) {
+            m_state = State::Blocked;
+            m_evaluatedURL = evaluatedURL;
+            m_replacementData = replacementData;
+        }
+        completionHandler({ });
+    });
+#else
+    UNUSED_PARAM(redirectResponse);
+    completionHandler({ });
+#endif
 }
 
 void ParentalControlsContentFilter::responseReceived(const ResourceResponse& response)

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
@@ -52,7 +52,9 @@ public:
 #else
     WEBCORE_EXPORT static ParentalControlsURLFilter& singleton();
     WEBCORE_EXPORT static void setGlobalFilter(Ref<ParentalControlsURLFilter>&&);
+    WEBCORE_EXPORT static bool hasGlobalFilter();
 #endif
+    WEBCORE_EXPORT static void setFilterForTesting(Ref<ParentalControlsURLFilter>&&);
     WEBCORE_EXPORT static void allowURL(const ParentalControlsURLFilterParameters&, CompletionHandler<void(bool)>&&);
     WEBCORE_EXPORT static WorkQueue& workQueueSingleton();
     WEBCORE_EXPORT bool isEnabled() const;

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
@@ -110,7 +110,21 @@ void ParentalControlsURLFilter::setGlobalFilter(Ref<ParentalControlsURLFilter>&&
     globalFilter() = WTF::move(filter);
 }
 
+bool ParentalControlsURLFilter::hasGlobalFilter()
+{
+    return !!globalFilter();
+}
+
 #endif
+
+void ParentalControlsURLFilter::setFilterForTesting(Ref<ParentalControlsURLFilter>&& filter)
+{
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    allFiltersWithConfigurationPath().set(emptyString(), WTF::move(filter));
+#else
+    setGlobalFilter(WTF::move(filter));
+#endif
+}
 
 ParentalControlsURLFilter::ParentalControlsURLFilter() = default;
 

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilterParameters.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilterParameters.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
+#include <wtf/URL.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/testing/MockParentalControlsURLFilter.h
+++ b/Source/WebCore/testing/MockParentalControlsURLFilter.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+
+#include <WebCore/ParentalControlsURLFilter.h>
+#include <wtf/HashSet.h>
+#include <wtf/URL.h>
+#include <wtf/URLHash.h>
+
+namespace WebCore {
+
+class MockParentalControlsURLFilter final : public ParentalControlsURLFilter {
+public:
+    WEBCORE_TESTSUPPORT_EXPORT static Ref<MockParentalControlsURLFilter> create(Vector<URL>&& blockedURLs);
+    WEBCORE_TESTSUPPORT_EXPORT ~MockParentalControlsURLFilter();
+
+private:
+    explicit MockParentalControlsURLFilter(Vector<URL>&& blockedURLs);
+
+    bool isEnabledImpl() const final;
+    void isURLAllowedImpl(const URL& mainDocumentURL, const URL&, CompletionHandler<void(bool, NSData *)>&&) final;
+    void allowURL(const URL&, CompletionHandler<void(bool)>&&) final;
+
+    HashSet<URL> m_blockedURLs;
+};
+
+} // namespace WebCore
+
+#endif // HAVE(WEBCONTENTRESTRICTIONS)
+

--- a/Source/WebCore/testing/MockParentalControlsURLFilter.mm
+++ b/Source/WebCore/testing/MockParentalControlsURLFilter.mm
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "MockParentalControlsURLFilter.h"
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+
+#import <wtf/CompletionHandler.h>
+#import <wtf/MainThread.h>
+#import <wtf/URL.h>
+#import <wtf/WorkQueue.h>
+
+namespace WebCore {
+
+Ref<MockParentalControlsURLFilter> MockParentalControlsURLFilter::create(Vector<URL>&& blockedURLs)
+{
+    return adoptRef(*new MockParentalControlsURLFilter(WTF::move(blockedURLs)));
+}
+
+MockParentalControlsURLFilter::MockParentalControlsURLFilter(Vector<URL>&& blockedURLs)
+{
+    for (auto& url : blockedURLs)
+        m_blockedURLs.add(WTF::move(url));
+}
+
+MockParentalControlsURLFilter::~MockParentalControlsURLFilter() = default;
+
+bool MockParentalControlsURLFilter::isEnabledImpl() const
+{
+    return true;
+}
+
+void MockParentalControlsURLFilter::isURLAllowedImpl(const URL& mainDocumentURL, const URL& url, CompletionHandler<void(bool, NSData *)>&& completionHandler)
+{
+    ASSERT(isMainThread());
+
+    bool isBlocked = m_blockedURLs.contains(url) || (!mainDocumentURL.isEmpty() && m_blockedURLs.contains(mainDocumentURL));
+
+    workQueueSingleton().dispatch([completionHandler = WTF::move(completionHandler), isAllowed = !isBlocked]() mutable {
+        completionHandler(isAllowed, nullptr);
+    });
+}
+
+void MockParentalControlsURLFilter::allowURL(const URL&, CompletionHandler<void(bool)>&& completionHandler)
+{
+    completionHandler(true);
+}
+
+} // namespace WebCore
+
+#endif // HAVE(WEBCONTENTRESTRICTIONS)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -135,6 +135,7 @@
 #endif
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
+#include <WebCore/MockParentalControlsURLFilter.h>
 #include <WebCore/ParentalControlsURLFilter.h>
 #endif
 
@@ -3448,6 +3449,13 @@ void NetworkProcess::allowEvaluatedURL(const WebCore::ParentalControlsURLFilterP
 #else
     filter->allowURL(parameters.urlToAllow, WTF::move(completionHandler));
 #endif
+}
+
+void NetworkProcess::installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, CompletionHandler<void()>&& completionHandler)
+{
+    Ref mock = WebCore::MockParentalControlsURLFilter::create(WTF::move(blockedURLs));
+    WebCore::ParentalControlsURLFilter::setFilterForTesting(WTF::move(mock));
+    completionHandler();
 }
 #endif
 

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -488,6 +488,7 @@ public:
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
     void allowEvaluatedURL(const WebCore::ParentalControlsURLFilterParameters&, CompletionHandler<void(bool)>&&);
+    void installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, CompletionHandler<void()>&&);
 #endif
 
 #if HAVE(ENHANCED_SECURITY_LINKS)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -295,6 +295,7 @@ messages -> NetworkProcess : AuxiliaryProcess WantsAsyncDispatchMessage {
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
     AllowEvaluatedURL(struct WebCore::ParentalControlsURLFilterParameters parameters) -> (bool allowed)
+    InstallMockParentalControlsURLFilterForTesting(Vector<URL> blockedURLs) -> ()
 #endif
 
 #if HAVE(ENHANCED_SECURITY_LINKS)

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1271,13 +1271,24 @@ void NetworkResourceLoader::willSendRedirectedRequestInternal(ResourceRequest&& 
         m_firstResponseURL = redirectResponse.url();
 
 #if ENABLE(CONTENT_FILTERING)
-    if (m_contentFilter && !protect(m_contentFilter)->continueAfterWillSendRequest(redirectRequest, redirectResponse)) {
-        if (RefPtr networkLoad = std::exchange(m_networkLoad, nullptr))
-            networkLoad->clearClient();
-        return completionHandler({ });
+    if (m_contentFilter) {
+        auto redirectResponseForContentFilter = redirectResponse;
+        protect(m_contentFilter)->continueAfterWillSendRequest(WTF::move(redirectRequest), redirectResponseForContentFilter, [this, protectedThis = Ref { *this }, request = WTF::move(request), redirectResponse = WTF::move(redirectResponse), isFromServiceWorker, completionHandler = WTF::move(completionHandler)](ResourceRequest&& filteredRequest) mutable {
+            if (filteredRequest.isNull()) {
+                if (RefPtr networkLoad = std::exchange(m_networkLoad, nullptr))
+                    networkLoad->clearClient();
+                return completionHandler({ });
+            }
+            continueWillSendRedirectedRequestAfterContentFiltering(WTF::move(request), WTF::move(filteredRequest), WTF::move(redirectResponse), isFromServiceWorker, WTF::move(completionHandler));
+        });
+        return;
     }
 #endif
+    continueWillSendRedirectedRequestAfterContentFiltering(WTF::move(request), WTF::move(redirectRequest), WTF::move(redirectResponse), isFromServiceWorker, WTF::move(completionHandler));
+}
 
+void NetworkResourceLoader::continueWillSendRedirectedRequestAfterContentFiltering(ResourceRequest&& request, ResourceRequest&& redirectRequest, ResourceResponse&& redirectResponse, IsFromServiceWorker isFromServiceWorker, CompletionHandler<void(WebCore::ResourceRequest&&)>&& completionHandler)
+{
     std::optional<WebCore::PCM::AttributionTriggerData> privateClickMeasurementAttributionTriggerData;
     if (auto result = WebCore::PrivateClickMeasurement::parseAttributionRequest(redirectRequest.url())) {
         privateClickMeasurementAttributionTriggerData = result.value();

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -284,6 +284,7 @@ private:
 
     enum class IsFromServiceWorker : bool { No, Yes };
     void willSendRedirectedRequestInternal(WebCore::ResourceRequest&&, WebCore::ResourceRequest&& redirectRequest, WebCore::ResourceResponse&&, IsFromServiceWorker, CompletionHandler<void(WebCore::ResourceRequest&&)>&&);
+    void continueWillSendRedirectedRequestAfterContentFiltering(WebCore::ResourceRequest&&, WebCore::ResourceRequest&& redirectRequest, WebCore::ResourceResponse&&, IsFromServiceWorker, CompletionHandler<void(WebCore::ResourceRequest&&)>&&);
     std::optional<WebCore::NetworkLoadMetrics> computeResponseMetrics(const WebCore::ResourceResponse&) const;
 
     void startRequest(const WebCore::ResourceRequest&);

--- a/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
+++ b/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
@@ -117,10 +117,8 @@ void WebParentalControlsURLFilter::setSharedParentalControlsURLFilterIfNecessary
 {
 #if !HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
     ASSERT(isMainRunLoop());
-    static bool initialized = false;
-    if (!initialized) {
+    if (!WebCore::ParentalControlsURLFilter::hasGlobalFilter()) {
         WebCore::ParentalControlsURLFilter::setGlobalFilter(WebParentalControlsURLFilter::create());
-        initialized = true;
     }
 #endif
 }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -1615,6 +1615,19 @@ struct WKWebsiteData {
     });
 }
 
+- (void)_installMockParentalControlsURLFilterForTestingWithBlockedURLs:(NSArray<NSURL *> *)blockedURLs completionHandler:(void(^)(void))completionHandler
+{
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    auto urls = makeVector<URL>(blockedURLs);
+
+    protect(*_websiteDataStore)->installMockParentalControlsURLFilterForTesting(WTF::move(urls), [completionHandler = makeBlockPtr(completionHandler)] {
+        completionHandler();
+    });
+#else
+    completionHandler();
+#endif
+}
+
 - (NSString *)_thirdPartyCookieBlockingModeForTesting
 {
     switch (protect(*_websiteDataStore)->thirdPartyCookieBlockingMode()) {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h
@@ -163,6 +163,8 @@ typedef NS_ENUM(uint8_t, _WKRestrictedOpenerType) {
 
 - (void)_isStorageSuspendedForTesting:(WK_SWIFT_UI_ACTOR void(^)(BOOL))completionHandler WK_API_AVAILABLE(macos(26.4), ios(26.4), visionos(26.4));
 
+- (void)_installMockParentalControlsURLFilterForTestingWithBlockedURLs:(NSArray<NSURL *> *)blockedURLs completionHandler:(void(^)(void))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -2085,6 +2085,11 @@ void NetworkProcessProxy::allowEvaluatedURL(const WebCore::ParentalControlsURLFi
 {
     sendWithAsyncReply(Messages::NetworkProcess::AllowEvaluatedURL(parameters), WTF::move(completionHandler));
 }
+
+void NetworkProcessProxy::installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, CompletionHandler<void()>&& completionHandler)
+{
+    sendWithAsyncReply(Messages::NetworkProcess::InstallMockParentalControlsURLFilterForTesting(WTF::move(blockedURLs)), WTF::move(completionHandler));
+}
 #endif
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -363,6 +363,7 @@ public:
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
     void allowEvaluatedURL(const WebCore::ParentalControlsURLFilterParameters&, CompletionHandler<void(bool)>&&);
+    void installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, CompletionHandler<void()>&&);
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2946,6 +2946,13 @@ void WebsiteDataStore::isStorageSuspendedForTesting(CompletionHandler<void(bool)
     protect(networkProcess())->isStorageSuspendedForTesting(m_sessionID, WTF::move(completionHandler));
 }
 
+#if HAVE(WEBCONTENTRESTRICTIONS)
+void WebsiteDataStore::installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, CompletionHandler<void()>&& completionHandler)
+{
+    protect(networkProcess())->installMockParentalControlsURLFilterForTesting(WTF::move(blockedURLs), WTF::move(completionHandler));
+}
+#endif
+
 #if !PLATFORM(COCOA)
 
 void WebsiteDataStore::removeEnhancedSecuritySites(const Vector<WebCore::SecurityOriginData>&, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -524,6 +524,10 @@ public:
     void clearStorageAccessForTesting(CompletionHandler<void()>&&);
     void isStorageSuspendedForTesting(CompletionHandler<void(bool)>&&) const;
 
+#if HAVE(WEBCONTENTRESTRICTIONS)
+    void installMockParentalControlsURLFilterForTesting(Vector<URL>&& blockedURLs, CompletionHandler<void()>&&);
+#endif
+
     void trackEnhancedSecurityForDomain(WebCore::RegistrableDomain&&, EnhancedSecurity);
     void fetchEnhancedSecurityOnlyDomains(CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&);
 

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1078,6 +1078,7 @@
 				WebKit/WKWebView/NowPlayingMetadataObserver.mm,
 				WebKit/WKWebView/NowPlayingSession.mm,
 				WebKit/WKWebView/OrthogonalFlowAvailableSize.mm,
+				WebKit/WKWebView/ParentalControlsContentFilteringTests.mm,
 				WebKit/WKWebView/SmartLists.mm,
 				WebKit/WKWebView/SpatialAudioExperience.mm,
 				WebKit/WKWebView/WebRTC.mm,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParentalControlsContentFilteringTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParentalControlsContentFilteringTests.mm
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if HAVE(WEBCONTENTRESTRICTIONS)
+
+#import "HTTPServer.h"
+#import "PlatformUtilities.h"
+#import "Test.h"
+#import "TestNavigationDelegate.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKErrorRef.h>
+#import <WebKit/WKWebsiteDataStorePrivate.h>
+
+using namespace TestWebKitAPI;
+
+TEST(ParentalControlsContentFilteringTests, BlockedURLAfterRedirect)
+{
+    HTTPServer server({
+        { "/start"_s, { 302, {{ "Location"_s, "/final"_s }}, "redirecting..."_s } },
+        { "/final"_s, { "Done."_s } }
+    });
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    auto blockedURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/start", server.port()]];
+    __block bool mockInstalled = false;
+    [[webView configuration].websiteDataStore _installMockParentalControlsURLFilterForTestingWithBlockedURLs:@[blockedURL] completionHandler:^{
+        mockInstalled = true;
+    }];
+    Util::run(&mockInstalled);
+
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    __block bool didFail = false;
+    [navigationDelegate setDidFailProvisionalNavigation:^(WKWebView *, WKNavigation *, NSError *error) {
+        EXPECT_WK_STREQ(WebKitErrorDomain, error.domain);
+        EXPECT_EQ(kWKErrorCodeFrameLoadBlockedByContentFilter, error.code);
+        didFail = true;
+    }];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:server.request("/start"_s)];
+
+    Util::run(&didFail);
+}
+
+TEST(ParentalControlsContentFilteringTests, BlockedURLAfterMultipleRedirections_BlockStart)
+{
+    HTTPServer server({
+        { "/start"_s, { 302, {{ "Location"_s, "/middle"_s }}, "redirecting..."_s } },
+        { "/middle"_s, { 302, {{ "Location"_s, "/final"_s }}, "redirecting..."_s } },
+        { "/final"_s, { "Done."_s } }
+    });
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    auto blockedURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/start", server.port()]];
+    __block bool mockInstalled = false;
+    [[webView configuration].websiteDataStore _installMockParentalControlsURLFilterForTestingWithBlockedURLs:@[blockedURL] completionHandler:^{
+        mockInstalled = true;
+    }];
+    Util::run(&mockInstalled);
+
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    __block bool didFail = false;
+    [navigationDelegate setDidFailProvisionalNavigation:^(WKWebView *, WKNavigation *, NSError *error) {
+        EXPECT_WK_STREQ(WebKitErrorDomain, error.domain);
+        EXPECT_EQ(kWKErrorCodeFrameLoadBlockedByContentFilter, error.code);
+        didFail = true;
+    }];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:server.request("/start"_s)];
+
+    Util::run(&didFail);
+}
+
+TEST(ParentalControlsContentFilteringTests, BlockedURLAfterMultipleRedirections_BlockMiddle)
+{
+    HTTPServer server({
+        { "/start"_s, { 302, {{ "Location"_s, "/middle"_s }}, "redirecting..."_s } },
+        { "/middle"_s, { 302, {{ "Location"_s, "/final"_s }}, "redirecting..."_s } },
+        { "/final"_s, { "Done."_s } }
+    });
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    auto blockedURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/middle", server.port()]];
+    __block bool mockInstalled = false;
+    [[webView configuration].websiteDataStore _installMockParentalControlsURLFilterForTestingWithBlockedURLs:@[blockedURL] completionHandler:^{
+        mockInstalled = true;
+    }];
+    Util::run(&mockInstalled);
+
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    __block bool didFail = false;
+    [navigationDelegate setDidFailProvisionalNavigation:^(WKWebView *, WKNavigation *, NSError *error) {
+        EXPECT_WK_STREQ(WebKitErrorDomain, error.domain);
+        EXPECT_EQ(kWKErrorCodeFrameLoadBlockedByContentFilter, error.code);
+        didFail = true;
+    }];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:server.request("/start"_s)];
+
+    Util::run(&didFail);
+}
+
+TEST(ParentalControlsContentFilteringTests, BlockedURLAfterMultipleRedirections_BlockFinal)
+{
+    HTTPServer server({
+        { "/start"_s, { 302, {{ "Location"_s, "/middle"_s }}, "redirecting..."_s } },
+        { "/middle"_s, { 302, {{ "Location"_s, "/final"_s }}, "redirecting..."_s } },
+        { "/final"_s, { "Done."_s } }
+    });
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
+    auto blockedURL = [NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%d/final", server.port()]];
+    __block bool mockInstalled = false;
+    [[webView configuration].websiteDataStore _installMockParentalControlsURLFilterForTestingWithBlockedURLs:@[blockedURL] completionHandler:^{
+        mockInstalled = true;
+    }];
+    Util::run(&mockInstalled);
+
+    RetainPtr navigationDelegate = adoptNS([[TestNavigationDelegate alloc] init]);
+    __block bool didFail = false;
+    [navigationDelegate setDidFailProvisionalNavigation:^(WKWebView *, WKNavigation *, NSError *error) {
+        EXPECT_WK_STREQ(WebKitErrorDomain, error.domain);
+        EXPECT_EQ(kWKErrorCodeFrameLoadBlockedByContentFilter, error.code);
+        didFail = true;
+    }];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:server.request("/start"_s)];
+
+    Util::run(&didFail);
+}
+
+#endif // HAVE(WEBCONTENTRESTRICTIONS)


### PR DESCRIPTION
#### db6b2e64a5e963539242ba5de7f96c4a8dc2dc7d
<pre>
Blocked website bypasses restriction by redirecting to a different domain
<a href="https://bugs.webkit.org/show_bug.cgi?id=309979">https://bugs.webkit.org/show_bug.cgi?id=309979</a>
<a href="https://rdar.apple.com/147259482">rdar://147259482</a>

Reviewed by Sihui Liu.

Domains that redirect may not properly be blocked. We should correct this so that
redirected sites still apply web content restrictions. We also refactor the
NetworkResourceLoader to asynchronously process filtering.

Tests: Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParentalControlsContentFilteringTests.mm

* Source/WebCore/Headers.cmake:
* Source/WebCore/PlatformMac.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/WebCore_Private.modulemap:
* Source/WebCore/loader/ContentFilter.cpp:
(WebCore::ContentFilter::continueAfterWillSendRequest):
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsContentFilter.mm:
(WebCore::canHandleResponse):
(WebCore::ParentalControlsContentFilter::willSendRequest):
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm:
(WebCore::ParentalControlsURLFilter::hasGlobalFilter):
(WebCore::ParentalControlsURLFilter::setFilterForTesting):
* Source/WebCore/platform/cocoa/ParentalControlsURLFilterParameters.h:
* Source/WebCore/testing/MockParentalControlsURLFilter.h: Copied from Source/WebCore/platform/cocoa/ParentalControlsURLFilterParameters.h.
* Source/WebCore/testing/MockParentalControlsURLFilter.mm: Added.
(WebCore::MockParentalControlsURLFilter::create):
(WebCore::MockParentalControlsURLFilter::MockParentalControlsURLFilter):
(WebCore::MockParentalControlsURLFilter::isEnabledImpl const):
(WebCore::MockParentalControlsURLFilter::isURLAllowedImpl):
(WebCore::MockParentalControlsURLFilter::allowURL):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::installMockParentalControlsURLFilterForTesting):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::willSendRedirectedRequestInternal):
(WebKit::NetworkResourceLoader::continueWillSendRedirectedRequestAfterContentFiltering):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm:
(WebKit::WebParentalControlsURLFilter::setSharedParentalControlsURLFilterIfNecessary):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore _installMockParentalControlsURLFilterForTestingWithBlockedURLs:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStorePrivate.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::installMockParentalControlsURLFilterForTesting):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::installMockParentalControlsURLFilterForTesting):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ParentalControlsContentFilteringTests.mm: Added.
(TEST(ParentalControlsContentFilteringTests, BlockedURLAfterRedirect)):
(TEST(ParentalControlsContentFilteringTests, BlockedURLAfterMultipleRedirections_BlockStart)):
(TEST(ParentalControlsContentFilteringTests, BlockedURLAfterMultipleRedirections_BlockMiddle)):
(TEST(ParentalControlsContentFilteringTests, BlockedURLAfterMultipleRedirections_BlockFinal)):

Canonical link: <a href="https://commits.webkit.org/311880@main">https://commits.webkit.org/311880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43b0a64351421711952732d4ca0eea1ee3947190

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158150 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31487 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166979 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112233 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160021 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122476 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85974 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161108 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103145 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23800 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22154 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14751 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133484 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169468 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/14822 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21455 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130657 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26219 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130772 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31171 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141626 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89067 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24062 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25484 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18432 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30723 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/96256 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30244 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30474 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30371 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->