### PR TITLE
[GStreamer] clang-22 unsafe-buffer-usage-in-unique-ptr-array-access warnings

### DIFF
--- a/Source/WebCore/platform/audio/FFTFrame.h
+++ b/Source/WebCore/platform/audio/FFTFrame.h
@@ -42,7 +42,7 @@
 #include <memory>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
-#include <wtf/UniqueArray.h>
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
@@ -108,7 +108,7 @@ private:
 #if USE(GSTREAMER)
     GUniquePtr<GstFFTF32> m_fft;
     GUniquePtr<GstFFTF32> m_inverseFft;
-    UniqueArray<GstFFTF32Complex> m_complexData;
+    Vector<GstFFTF32Complex> m_complexData;
 #endif // USE(GSTREAMER)
 
     AudioFloatArray m_realData;

--- a/Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp
+++ b/Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp
@@ -45,7 +45,7 @@ namespace WebCore {
 FFTFrame::FFTFrame(unsigned fftSize)
     : m_FFTSize(fftSize)
     , m_log2FFTSize(static_cast<unsigned>(log2(fftSize)))
-    , m_complexData(makeUniqueArray<GstFFTF32Complex>(unpackedFFTDataSize(m_FFTSize)))
+    , m_complexData(unpackedFFTDataSize(m_FFTSize))
     , m_realData(unpackedFFTDataSize(m_FFTSize))
     , m_imagData(unpackedFFTDataSize(m_FFTSize))
 {
@@ -68,7 +68,7 @@ FFTFrame::FFTFrame()
 FFTFrame::FFTFrame(const FFTFrame& frame)
     : m_FFTSize(frame.m_FFTSize)
     , m_log2FFTSize(frame.m_log2FFTSize)
-    , m_complexData(makeUniqueArray<GstFFTF32Complex>(unpackedFFTDataSize(m_FFTSize)))
+    , m_complexData(unpackedFFTDataSize(m_FFTSize))
     , m_realData(unpackedFFTDataSize(frame.m_FFTSize))
     , m_imagData(unpackedFFTDataSize(frame.m_FFTSize))
 {
@@ -89,7 +89,7 @@ FFTFrame::~FFTFrame() = default;
 
 void FFTFrame::doFFT(std::span<const float> data)
 {
-    gst_fft_f32_fft(m_fft.get(), data.data(), m_complexData.get());
+    gst_fft_f32_fft(m_fft.get(), data.data(), m_complexData.mutableSpan().data());
 
     auto imagData = m_imagData.span();
     auto realData = m_realData.span();
@@ -109,7 +109,7 @@ void FFTFrame::doInverseFFT(std::span<float> data)
         m_complexData[i].r = realData[i];
     }
 
-    gst_fft_f32_inverse_fft(m_inverseFft.get(), m_complexData.get(), data.data());
+    gst_fft_f32_inverse_fft(m_inverseFft.get(), m_complexData.mutableSpan().data(), data.data());
 
     // Scale so that a forward then inverse FFT yields exactly the original data.
     VectorMath::multiplyByScalar(data.first(m_FFTSize), 1.0 / m_FFTSize, data);


### PR DESCRIPTION
#### 0816379351c30372d8d8001336dc65e93e76ef93
<pre>
[GStreamer] clang-22 unsafe-buffer-usage-in-unique-ptr-array-access warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=309980">https://bugs.webkit.org/show_bug.cgi?id=309980</a>

Reviewed by Xabier Rodriguez-Calvar.

Store the FFT complex numbers in a Vector instead of a std::unique_ptr.

* Source/WebCore/platform/audio/FFTFrame.h:
* Source/WebCore/platform/audio/gstreamer/FFTFrameGStreamer.cpp:
(WebCore::FFTFrame::FFTFrame):
(WebCore::FFTFrame::doFFT):
(WebCore::FFTFrame::doInverseFFT):

Canonical link: <a href="https://commits.webkit.org/309309@main">https://commits.webkit.org/309309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b149d30db7c4fcd958779958d1a78035cb008026

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158919 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103640 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115877 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82323 "9 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134745 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96610 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17089 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15035 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6765 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126704 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12669 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161392 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4518 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14221 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123878 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/149606 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19082 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124083 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33701 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22753 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134464 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79070 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19204 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11221 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22366 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86166 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22080 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22232 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22134 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->