### PR TITLE
ResizeObserver::observeInternal can be slow when there are lot of observed nodes

### DIFF
--- a/Source/WebCore/page/ResizeObserver.cpp
+++ b/Source/WebCore/page/ResizeObserver.cpp
@@ -67,20 +67,36 @@ ResizeObserver::~ResizeObserver()
         m_document->removeResizeObserver(*this);
 }
 
-void ResizeObserver::observeInternal(Element& target, const ResizeObserverBoxOptions boxOptions)
+ResizeObservation* ResizeObserver::observationForElement(Element& target)
 {
-    ASSERT(!m_JSOrNativeCallback.valueless_by_exception());
+    auto* data = target.resizeObserverDataIfExists();
+    if (!data)
+        return nullptr;
+
+    // There tend to be more elements to be observed than there are observers.
+    // Check if this observer appears in node's observer data first to avoid a linear search over m_observations.
+    if (data->observers.size() * 2 < m_observations.size() && data->observers.contains(this))
+        return nullptr;
 
     auto position = m_observations.findIf([&](auto& observation) {
         return observation->target() == &target;
     });
 
-    if (position != notFound) {
+    if (position == notFound)
+        return nullptr;
+
+    return m_observations[position].ptr();
+}
+
+void ResizeObserver::observeInternal(Element& target, const ResizeObserverBoxOptions boxOptions)
+{
+    ASSERT(!m_JSOrNativeCallback.valueless_by_exception());
+
+    if (RefPtr existingObservation = observationForElement(target)) {
         // The spec suggests unconditionally unobserving here, but that causes a test failure:
         // https://github.com/web-platform-tests/wpt/issues/30708
-        if (m_observations[position]->observedBox() == boxOptions)
+        if (existingObservation->observedBox() == boxOptions)
             return;
-
         unobserve(target);
     }
 
@@ -299,12 +315,8 @@ ResizeObserverCallback* ResizeObserver::callbackConcurrently()
 
 void ResizeObserver::resetObservationSize(Element& target)
 {
-    auto position = m_observations.findIf([&](auto& observation) {
-        return observation->target() == &target;
-    });
-
-    if (position != notFound)
-        m_observations[position]->resetObservationSize();
+    if (RefPtr observation = observationForElement(target))
+        observation->resetObservationSize();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/ResizeObserver.h
+++ b/Source/WebCore/page/ResizeObserver.h
@@ -86,6 +86,7 @@ public:
 private:
     ResizeObserver(Document&, JSOrNativeResizeObserverCallback&&);
 
+    ResizeObservation* observationForElement(Element&);
     bool removeTarget(Element&);
     void removeAllTargets();
     bool removeObservation(const Element&);


### PR DESCRIPTION
#### 56629df9968367e0bfb2f2fec31c58c0d57d6a2c
<pre>
ResizeObserver::observeInternal can be slow when there are lot of observed nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=309984">https://bugs.webkit.org/show_bug.cgi?id=309984</a>

Reviewed by Chris Dumez.

ResizeObserver::observeInternal can be slow when m_observations is large since
it does a linear search of the target in m_observations.

Since we tend to have a lot more elements than ResizeObservers, do the reverse
search in ResizeObserverData of the target first.

No new tests since there should be no observable behavior changes besides perf.

* Source/WebCore/page/ResizeObserver.cpp:
(WebCore::ResizeObserver::observationForElement): Added.
(WebCore::ResizeObserver::observeInternal):
(WebCore::ResizeObserver::resetObservationSize):
* Source/WebCore/page/ResizeObserver.h:

Canonical link: <a href="https://commits.webkit.org/309334@main">https://commits.webkit.org/309334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1fa65bca67c8b9148fa76a4b77208c7d506d3ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159049 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103768 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23226 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115989 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82425 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c2ebefe-e42c-458b-9da8-ede8b0fb42c0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134864 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96721 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fea2f321-0e74-43a0-9727-efd1753e943f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17201 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15144 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6895 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161523 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4650 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14341 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123990 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22894 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19191 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124194 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134583 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79261 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23109 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19318 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11340 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22495 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86294 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22208 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22360 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22262 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->