### PR TITLE
[iOS] Captions do not render when using AVExperienceController

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -86,6 +86,7 @@ AVExperienceControllerFullscreenEnabled:
   category: media
   getter: isAVExperienceControllerFullscreenEnabled
   webcoreGetter: isAVExperienceControllerFullscreenEnabled
+  defaultsOverridable: true
   humanReadableName: "AVExperienceController Fullscreen"
   humanReadableDescription: "Enable fullscreen video via AVExperienceController"
   condition: HAVE(AVEXPERIENCECONTROLLER)

--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceAVKit.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceAVKit.mm
@@ -153,14 +153,14 @@ void PlaybackSessionInterfaceAVKit::volumeChanged(double volume)
 
 void PlaybackSessionInterfaceAVKit::startObservingNowPlayingMetadata()
 {
-    if (m_playbackSessionModel)
-        m_playbackSessionModel->addNowPlayingMetadataObserver(m_nowPlayingMetadataObserver);
+    if (CheckedPtr model = m_playbackSessionModel.get())
+        model->addNowPlayingMetadataObserver(m_nowPlayingMetadataObserver);
 }
 
 void PlaybackSessionInterfaceAVKit::stopObservingNowPlayingMetadata()
 {
-    if (m_playbackSessionModel)
-        m_playbackSessionModel->removeNowPlayingMetadataObserver(m_nowPlayingMetadataObserver);
+    if (CheckedPtr model = m_playbackSessionModel.get())
+        model->removeNowPlayingMetadataObserver(m_nowPlayingMetadataObserver);
 }
 
 void PlaybackSessionInterfaceAVKit::nowPlayingMetadataChanged(const WebCore::NowPlayingMetadata& metadata)

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.h
@@ -42,6 +42,8 @@ public:
     static Ref<VideoPresentationInterfaceAVKit> create(WebCore::PlaybackSessionInterfaceIOS&);
     ~VideoPresentationInterfaceAVKit();
 
+    void didToggleCaptionStylePreviewID(const String&);
+
 #if !RELEASE_LOG_DISABLED
     ASCIILiteral logClassName() const { return "VideoPresentationInterfaceAVKit"_s; };
 #endif
@@ -73,8 +75,7 @@ private:
     bool isExternalPlaybackActive() const final { return false; }
     bool willRenderToLayer() const final { return false; }
     AVPlayerViewController *avPlayerViewController() const final { return nullptr; }
-    CALayer *captionsLayer() final { return nullptr; }
-    void setupCaptionsLayer(CALayer *, const WebCore::FloatSize&) final { }
+    void setupCaptionsLayer(CALayer *, const WebCore::FloatSize&) final;
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     WKSPlayableViewControllerHost *playableViewController() final { return nullptr; }
 #endif

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.mm
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.mm
@@ -48,27 +48,51 @@ NS_ASSUME_NONNULL_BEGIN
 @interface WKExperienceControllerDelegate: NSObject <WKSExperienceControllerDelegate>
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithModel:(WebCore::PlaybackSessionModel&)model NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithParent:(WebKit::VideoPresentationInterfaceAVKit&)parent NS_DESIGNATED_INITIALIZER;
 @end
 
 @implementation WKExperienceControllerDelegate {
-    WeakPtr<WebCore::PlaybackSessionModel> _model;
+    WeakPtr<WebKit::VideoPresentationInterfaceAVKit> _parent;
 }
 
-- (instancetype)initWithModel:(WebCore::PlaybackSessionModel&)model
+- (instancetype)initWithParent:(WebKit::VideoPresentationInterfaceAVKit&)parent
 {
     self = [super init];
     if (!self)
         return nil;
 
-    _model = model;
+    _parent = parent;
     return self;
 }
 
 - (void)experienceControllerDidExitFullscreen:(nonnull WKSExperienceController *)experienceController
 {
-    if (CheckedPtr model = _model.get())
-        model->exitFullscreen();
+    if (RefPtr parent = _parent.get()) {
+        if (CheckedPtr playbackSessionModel = parent->playbackSessionModel())
+            playbackSessionModel->exitFullscreen();
+    }
+}
+
+- (void)experienceControllerDidBeginScrubbing:(nonnull WKSExperienceController *)experienceController
+{
+    if (RefPtr parent = _parent.get()) {
+        if (CheckedPtr playbackSessionModel = parent->playbackSessionModel())
+            playbackSessionModel->beginScrubbing();
+    }
+}
+
+- (void)experienceControllerDidEndScrubbing:(nonnull WKSExperienceController *)experienceController
+{
+    if (RefPtr parent = _parent.get()) {
+        if (CheckedPtr playbackSessionModel = parent->playbackSessionModel())
+            playbackSessionModel->endScrubbing();
+    }
+}
+
+- (void)experienceController:(nonnull WKSExperienceController *)experienceController didToggleCaptionStylePreviewID:(NSString * _Nullable)captionStylePreviewID
+{
+    if (RefPtr parent = _parent.get())
+        parent->didToggleCaptionStylePreviewID(captionStylePreviewID);
 }
 
 @end
@@ -86,11 +110,23 @@ Ref<VideoPresentationInterfaceAVKit> VideoPresentationInterfaceAVKit::create(Web
 
 VideoPresentationInterfaceAVKit::VideoPresentationInterfaceAVKit(WebCore::PlaybackSessionInterfaceIOS& playbackSessionInterface)
     : VideoPresentationInterfaceIOS { playbackSessionInterface }
-    , m_experienceControllerDelegate { adoptNS([[WKExperienceControllerDelegate alloc] initWithModel:*playbackSessionInterface.playbackSessionModel()]) }
+    , m_experienceControllerDelegate { adoptNS([[WKExperienceControllerDelegate alloc] initWithParent:*this]) }
 {
 }
 
 VideoPresentationInterfaceAVKit::~VideoPresentationInterfaceAVKit() = default;
+
+void VideoPresentationInterfaceAVKit::didToggleCaptionStylePreviewID(const String& captionStylePreviewID)
+{
+    RefPtr model = videoPresentationModel();
+    if (!model)
+        return;
+
+    if (captionStylePreviewID.isEmpty())
+        model->requestHideCaptionDisplaySettingsPreview();
+    else
+        model->requestShowCaptionDisplaySettingsPreview(captionStylePreviewID);
+}
 
 WebAVPlayerLayer *VideoPresentationInterfaceAVKit::fullscreenPlayerLayer()
 {
@@ -118,10 +154,12 @@ void VideoPresentationInterfaceAVKit::setupPlayerViewController()
 
     m_fullscreenPlayerLayerView = adoptNS([WebCore::allocWebAVPlayerLayerViewInstance() init]);
     [fullscreenPlayerLayer() setPresentationModel:videoPresentationModel()];
+    [fullscreenPlayerLayer() setCaptionsLayer:captionsLayer()];
     [playerLayerView() transferVideoViewTo:m_fullscreenPlayerLayerView.get()];
 
     RetainPtr contentSource = playbackSessionInterface().contentSource();
     [contentSource setVideoLayer:fullscreenPlayerLayer()];
+    [contentSource setCaptionLayer:captionsLayer()];
 
     RetainPtr platformContentSource = [allocAVPlayerViewControllerContentSourceInstance() initWithVideoPlaybackControllable:contentSource.get()];
     m_experienceController = [allocWKSExperienceControllerInstance() initWithContentSource:platformContentSource.get()];
@@ -135,6 +173,16 @@ void VideoPresentationInterfaceAVKit::invalidatePlayerViewController()
     m_fullscreenPlayerLayerView = nil;
     [m_experienceController setDelegate:nil];
     m_experienceController = nil;
+}
+
+void VideoPresentationInterfaceAVKit::setupCaptionsLayer(CALayer *, const WebCore::FloatSize&)
+{
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    [captionsLayer() removeFromSuperlayer];
+    [fullscreenPlayerLayer() setCaptionsLayer:captionsLayer()];
+    [fullscreenPlayerLayer() layoutSublayers];
+    [CATransaction commit];
 }
 
 void VideoPresentationInterfaceAVKit::presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&& completionHandler)

--- a/Source/WebKit/Platform/ios/WKAVContentSource.h
+++ b/Source/WebKit/Platform/ios/WKAVContentSource.h
@@ -60,6 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong) AVInterfaceMetadata *metadata;
 @property (nonatomic, strong, nullable) CALayer *videoLayer;
 @property (nonatomic) CGSize videoSize;
+@property (nonatomic, strong, nullable) CALayer *captionLayer;
 @end
 
 RetainPtr<AVInterfaceMetadata> createPlatformMetadata(NSString * _Nullable title, NSString * _Nullable subtitle);

--- a/Source/WebKit/Platform/ios/WKAVContentSource.mm
+++ b/Source/WebKit/Platform/ios/WKAVContentSource.mm
@@ -67,6 +67,7 @@ NS_ASSUME_NONNULL_BEGIN
     RetainPtr<AVInterfaceMetadata> _metadata;
     RetainPtr<CALayer> _videoLayer;
     CGSize _videoSize;
+    RetainPtr<CALayer> _captionLayer;
 }
 
 static RetainPtr<AVInterfaceTimelineSegment> emptyTimelineSegment()
@@ -166,6 +167,11 @@ static RetainPtr<AVInterfaceTimelineSegment> emptyTimelineSegment()
 - (void)setVideoSize:(CGSize)videoSize
 {
     _videoSize = videoSize;
+}
+
+- (void)setCaptionLayer:(CALayer * _Nullable)captionLayer
+{
+    _captionLayer = captionLayer;
 }
 
 - (void)setCurrentPlaybackPositionInternal:(CMTime)currentPlaybackPosition
@@ -441,6 +447,11 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (CGSize)videoSize
 {
     return _videoSize;
+}
+
+- (CALayer * _Nullable)captionLayer
+{
+    return _captionLayer;
 }
 
 @end

--- a/Source/WebKit/WebKitSwift/AVKit/WKSExperienceController.h
+++ b/Source/WebKit/WebKitSwift/AVKit/WKSExperienceController.h
@@ -34,6 +34,9 @@ NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @protocol WKSExperienceControllerDelegate <NSObject>
 - (void)experienceControllerDidExitFullscreen:(WKSExperienceController *)experienceController;
+- (void)experienceControllerDidBeginScrubbing:(WKSExperienceController *)experienceController;
+- (void)experienceControllerDidEndScrubbing:(WKSExperienceController *)experienceController;
+- (void)experienceController:(WKSExperienceController *)experienceController didToggleCaptionStylePreviewID:(NSString * _Nullable)captionStylePreviewID;
 @end
 
 NS_SWIFT_MAIN_ACTOR


### PR DESCRIPTION
#### e1896d3e35f0cd9023fbaa216f5d08577e7c9319
<pre>
[iOS] Captions do not render when using AVExperienceController
<a href="https://bugs.webkit.org/show_bug.cgi?id=309990">https://bugs.webkit.org/show_bug.cgi?id=309990</a>
<a href="https://rdar.apple.com/172617203">rdar://172617203</a>

Reviewed by Eric Carlson.

Added a captionLayer to WKAVContentSource and populated it with VideoPresentationInterface&apos;s
captionsLayer. Two additional drive-by fixes:
- Made AVExperienceControllerFullscreenEnabled overridable by user defaults.
- Implemented did(Begin|End)Scrubbing callbacks in WKSExperienceController.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/Platform/ios/PlaybackSessionInterfaceAVKit.mm:
(WebKit::PlaybackSessionInterfaceAVKit::startObservingNowPlayingMetadata):
(WebKit::PlaybackSessionInterfaceAVKit::stopObservingNowPlayingMetadata):
* Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.mm:
(-[WKExperienceControllerDelegate initWithParent:]):
(-[WKExperienceControllerDelegate experienceControllerDidExitFullscreen:]):
(-[WKExperienceControllerDelegate experienceControllerDidBeginScrubbing:]):
(-[WKExperienceControllerDelegate experienceControllerDidEndScrubbing:]):
(-[WKExperienceControllerDelegate experienceController:didToggleCaptionStylePreviewID:]):
(WebKit::VideoPresentationInterfaceAVKit::didToggleCaptionStylePreviewID):
(WebKit::VideoPresentationInterfaceAVKit::setupPlayerViewController):
(WebKit::VideoPresentationInterfaceAVKit::setupCaptionsLayer):
(-[WKExperienceControllerDelegate initWithModel:]): Deleted.
* Source/WebKit/Platform/ios/WKAVContentSource.h:
* Source/WebKit/Platform/ios/WKAVContentSource.mm:
(-[WKAVContentSource setCaptionLayer:]):
(-[WKAVContentSource captionLayer]):
* Source/WebKit/WebKitSwift/AVKit/WKSExperienceController.h:

Canonical link: <a href="https://commits.webkit.org/309302@main">https://commits.webkit.org/309302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5adc45588a09e51bba4dfdaafbeeb54de1f3947b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23007 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158963 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103683 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23437 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115915 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82361 "9 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96648 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17128 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15073 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6808 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142232 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126743 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12709 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161437 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11047 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4565 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123916 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124121 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33696 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22796 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134504 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79148 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19245 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11261 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181680 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22409 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86209 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46493 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22123 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22275 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22177 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->