### PR TITLE
[Swift in WebKit] Add a few more safety annotations across WebKit to be able to remove some `unsafe` uses

### DIFF
--- a/Source/WTF/wtf/CheckedRef.h
+++ b/Source/WTF/wtf/CheckedRef.h
@@ -31,6 +31,7 @@
 #include <wtf/HashTraits.h>
 #include <wtf/RawPtrTraits.h>
 #include <wtf/SingleThreadIntegralWrapper.h>
+#include <wtf/SwiftBridging.h>
 #include <wtf/TypeTraits.h>
 #include <wtf/UniqueRef.h>
 
@@ -393,7 +394,7 @@ private:
 #if ASSERT_ENABLED || ENABLE(SECURITY_ASSERTIONS)
     DeletionFlagType m_didBeginDeletion { false };
 #endif
-};
+} SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
 
 template<typename T, DefaultedOperatorEqual defaultedOperatorEqual = DefaultedOperatorEqual::No, CheckedPtrDeleteCheckException deleteException = CheckedPtrDeleteCheckException::No>
 class CanMakeCheckedPtr : public CanMakeCheckedPtrBase<SingleThreadIntegralWrapper<uint32_t>, uint32_t, bool, deleteException> {

--- a/Source/WebCore/platform/SelectionGeometry.h
+++ b/Source/WebCore/platform/SelectionGeometry.h
@@ -29,6 +29,7 @@
 #include <WebCore/IntRect.h>
 #include <WebCore/WritingMode.h>
 #include <optional>
+#include <wtf/SwiftBridging.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -114,7 +115,7 @@ private:
     int m_pageNumber { 0 };
 
     mutable std::optional<IntRect> m_cachedEnclosingRect;
-};
+} SWIFT_ESCAPABLE;
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const SelectionGeometry&);
 

--- a/Source/WebCore/platform/graphics/IntRect.h
+++ b/Source/WebCore/platform/graphics/IntRect.h
@@ -28,6 +28,7 @@
 #include <WebCore/IntPoint.h>
 #include <WebCore/LayoutUnit.h>
 #include <wtf/Platform.h>
+#include <wtf/SwiftBridging.h>
 #include <wtf/TZoneMalloc.h>
 
 #if USE(CG)
@@ -227,7 +228,7 @@ public:
 private:
     IntPoint m_location;
     IntSize m_size;
-};
+} SWIFT_ESCAPABLE;
 
 inline IntRect intersection(const IntRect& a, const IntRect& b)
 {

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -32,11 +32,12 @@
 #include <WebCore/IntRect.h>
 #include <WebCore/PlatformLayerIdentifier.h>
 #include <WebCore/ScrollTypes.h>
+#include <WebCore/SelectionGeometry.h>
 #include <WebCore/SelectionType.h>
 #include <WebCore/WritingDirection.h>
+#include <optional>
+#include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
-
-#include <WebCore/SelectionGeometry.h>
 
 #if USE(DICTATION_ALTERNATIVES)
 #include <WebCore/DictationContext.h>

--- a/Source/WebKit/UIProcess/WebPageProxy.swift
+++ b/Source/WebKit/UIProcess/WebPageProxy.swift
@@ -97,7 +97,7 @@ extension WebKit.WebPageProxy {
     }
 
     var editorState: WebKit.EditorState {
-        unsafe editorStateCopy()
+        editorStateCopy()
     }
 }
 

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
@@ -67,9 +67,9 @@ extension WKTextSelectionController {
             return
         }
 
-        let editorState = unsafe page.editorState
+        let editorState = page.editorState
         view.textSelectionManager?.textSelectionMode =
-            unsafe editorState.isContentEditable || editorState.isContentRichlyEditable ? .editable : .selectable
+            editorState.isContentEditable || editorState.isContentRichlyEditable ? .editable : .selectable
     }
 }
 
@@ -81,11 +81,11 @@ extension WKTextSelectionController {
             return .zero
         }
 
-        guard let visualData = unsafe Optional(fromCxx: page.editorState.visualData) else {
+        guard let visualData = Optional(fromCxx: page.editorState.visualData) else {
             return .zero
         }
 
-        return unsafe CGRect(visualData.caretRectAtStart)
+        return CGRect(visualData.caretRectAtStart)
     }
 
     var selectionIsInsertionPoint: Bool {
@@ -93,8 +93,8 @@ extension WKTextSelectionController {
             return false
         }
 
-        let editorState = unsafe page.editorState
-        return unsafe editorState.selectionType == .Caret
+        let editorState = page.editorState
+        return editorState.selectionType == .Caret
     }
 
     @objc(isTextSelectedAtPoint:)
@@ -107,18 +107,18 @@ extension WKTextSelectionController {
 
         Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) point: \(String(reflecting: point))")
 
-        let editorState = unsafe page.editorState
-        let hasSelection = unsafe editorState.selectionType != .None
+        let editorState = page.editorState
+        let hasSelection = editorState.selectionType != .None
 
-        if unsafe !hasSelection || !editorState.hasPostLayoutAndVisualData() {
+        if !hasSelection || !editorState.hasPostLayoutAndVisualData() {
             Logger.viewGestures.log(
                 "[pageProxyID=\(page.logIdentifier())] Editor state has no selection, post layout data, or visual data"
             )
             return false
         }
 
-        let isRange = unsafe editorState.selectionType == .Range
-        let isContentEditable = unsafe editorState.isContentEditable
+        let isRange = editorState.selectionType == .Range
+        let isContentEditable = editorState.isContentEditable
 
         if !isContentEditable && !isRange {
             Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] Selection is neither contenteditable nor a range")
@@ -129,10 +129,10 @@ extension WKTextSelectionController {
         // If so, then the rest of the logic in this function can be elided in that case.
 
         var selectionRects: [WKTextSelectionRect] = []
-        let selectionGeometries = unsafe editorState.visualData.pointee.selectionGeometries
+        let selectionGeometries = editorState.visualData.pointee.selectionGeometries
 
         // FIXME: `WTF::Vector` should be able to be used as a Swift `Sequence`.
-        for i in unsafe 0..<selectionGeometries.size() {
+        for i in 0..<selectionGeometries.size() {
             let selectionGeometry = unsafe selectionGeometries.__atUnsafe(i).pointee
             selectionRects.append(.init(selectionGeometry: selectionGeometry, delegate: nil))
         }
@@ -153,8 +153,8 @@ extension WKTextSelectionController {
 
         Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) point: \(String(reflecting: point))")
 
-        let previousState = unsafe page.editorState
-        let previousVisualData = unsafe Optional(fromCxx: previousState.visualData)
+        let previousState = page.editorState
+        let previousVisualData = Optional(fromCxx: previousState.visualData)
 
         // FIXME: Properly handle the case where this isn't actually true.
         let isInteractingWithFocusedElement = true
@@ -173,29 +173,29 @@ extension WKTextSelectionController {
             )
         }
 
-        let newState = unsafe page.editorState
-        let newVisualData = unsafe Optional(fromCxx: newState.visualData)
+        let newState = page.editorState
+        let newVisualData = Optional(fromCxx: newState.visualData)
 
-        guard let previousVisualData = unsafe previousVisualData, let newVisualData = unsafe newVisualData else {
+        guard let previousVisualData, let newVisualData else {
             return false
         }
 
         // FIXME: (rdar://170847912) Use the `!=` operator instead when possible.
-        return unsafe !(previousVisualData.caretRectAtStart == newVisualData.caretRectAtStart)
+        return !(previousVisualData.caretRectAtStart == newVisualData.caretRectAtStart)
     }
 
     @objc(showContextMenuAtPoint:)
     func showContextMenu(at point: NSPoint) {
         // The `point` location is relative to the window.
 
-        guard let page = view._protectedPage().get(), let impl = unsafe view._impl() else {
+        guard let page = view._protectedPage().get(), let impl = view._impl() else {
             return
         }
 
         Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) point: \(String(reflecting: point))")
 
         let timestamp = GetCurrentEventTime()
-        let windowNumber = unsafe impl.windowNumber()
+        let windowNumber = impl.windowNumber()
 
         let mouseDown = NSEvent.mouseEvent(
             with: .rightMouseDown,
@@ -220,8 +220,8 @@ extension WKTextSelectionController {
             pressure: 0
         )
 
-        unsafe impl.mouseDown(mouseDown, .Automation)
-        unsafe impl.mouseUp(mouseUp, .Automation)
+        impl.mouseDown(mouseDown, .Automation)
+        impl.mouseUp(mouseUp, .Automation)
     }
 
     @objc(dragSelectionWithGesture:completionHandler:)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -1181,7 +1181,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RetainPtr<WKAppKitGestureController> m_appKitGestureController;
     RetainPtr<WKTextSelectionController> m_textSelectionController;
 #endif
-} SWIFT_UNSAFE_REFERENCE;
+} SWIFT_SHARED_REFERENCE(.incrementCheckedPtrCount, .decrementCheckedPtrCount);
 
 } // namespace WebKit
 


### PR DESCRIPTION
#### aa2ee992eb3e8b7cbfaff4b817375c93b2a0dfa1
<pre>
[Swift in WebKit] Add a few more safety annotations across WebKit to be able to remove some `unsafe` uses
<a href="https://bugs.webkit.org/show_bug.cgi?id=309991">https://bugs.webkit.org/show_bug.cgi?id=309991</a>
<a href="https://rdar.apple.com/172619877">rdar://172619877</a>

Reviewed by Abrar Rahman Protyasha.

Add safety annotations acros various files in WebKit to be able to remove `unsafe` from uses of `WebViewImpl`
and `EditorState`.

* Source/WTF/wtf/CheckedRef.h:

Like other smart pointer types, add `SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT` to `CanMakeCheckedPtrBase` to
indicate that functions which return this type or derived types return them as unretained.

* Source/WebCore/platform/SelectionGeometry.h:
* Source/WebCore/platform/graphics/IntRect.h:

Mark these types as `SWIFT_ESCAPABLE`. This type is indeed escapable because it is a POD type with
only trivial value types as members, who themselves are all safe.

This is needed because these types are part of `EditorState`. With these annotations, `EditorState` is now safe.

* Source/WebKit/Shared/EditorState.h:

Add some missing imports.

* Source/WebKit/UIProcess/WebPageProxy.swift:
(WebKit.editorState):
* Source/WebKit/UIProcess/mac/WKTextSelectionController.swift:
(WKTextSelectionController.selectionDidChange):
(WKTextSelectionController.insertionCursorRect):
(WKTextSelectionController.selectionIsInsertionPoint):
(WKTextSelectionController.isTextSelected(at:)):
(WKTextSelectionController.moveInsertionCursor(to:placeAtWordBoundary:)):
(WKTextSelectionController.showContextMenu(at:)):

Remove `unsafe`.

* Source/WebKit/UIProcess/mac/WebViewImpl.h:

Use `SWIFT_SHARED_REFERENCE` with the CanMakeCheckedPtrBase reference counting functions instead of `SWIFT_UNSAFE_REFERENCE`.
This makes `WebViewImpl` considered safe to use from Swift.

Canonical link: <a href="https://commits.webkit.org/309346@main">https://commits.webkit.org/309346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5b0d110664f8959c0f5d69fc106baa267dc87f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158954 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103675 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23123 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115909 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82355 "4 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96641 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17122 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15066 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6800 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142224 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161430 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11039 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4557 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123911 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22801 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124116 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33727 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134497 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79137 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19239 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11254 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181672 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22401 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86201 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46489 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22115 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22267 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22169 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->