### PR TITLE
[Swift in WebKit] Integrate Swift Testing into `run-api-tests`

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -5865,7 +5865,7 @@ class RunAPITests(shell.Test, AddToLogMixin, ShellMixin):
             second_results_failing_tests = set(self.getProperty('second_run_failures', set()))
             list_failed_tests_with_change = sorted(first_results_failing_tests.union(second_results_failing_tests))
             if list_failed_tests_with_change:
-                self.command = self.command + list_failed_tests_with_change
+                self.command = self.command + [quote(t) for t in list_failed_tests_with_change]
         if SHOULD_FILTER_LOGS is True:
             self.command = self.shell_command(' '.join(self.command) + ' > logs.txt 2>&1 ; ret=$? ; grep "Ran " logs.txt ; exit $ret')
 

--- a/Tools/Scripts/run-api-tests
+++ b/Tools/Scripts/run-api-tests
@@ -125,6 +125,8 @@ def parse_args(args):
                              help='Only check and run TestWebKitLegacy.exe (Windows only)'),
         optparse.make_option('--wgsl-only', action='store_const', const='TestWGSL', dest='api_binary',
                              help='Only check and run TestWGSL (Darwin ports only)'),
+        optparse.make_option('--swift-testing-only', action='store_const', const='SwiftTesting', dest='api_binary',
+                             help='Only check and run Swift Testing tests (Darwin only)'),
         optparse.make_option('-d', '--dump', action='store_true', default=False,
                              help='Dump all test names without running them'),
         optparse.make_option('--build', dest='build', action='store_true', default=False,

--- a/Tools/Scripts/webkitpy/api_tests/manager.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager.py
@@ -27,6 +27,7 @@ import re
 import time
 
 from webkitpy.api_tests.runner import Runner
+from webkitpy.api_tests.swift_testing_runner import SwiftTestingRunner
 from webkitpy.common.iteration_compatibility import iteritems
 from webkitpy.common.system.executive import ScriptError
 from webkitpy.results.upload import Upload
@@ -77,7 +78,8 @@ class Manager(object):
         result = []
         for arg in arg_filter:
             # Might match <binary>.<suite>.<test> or just <suite>.<test>
-            arg_re = re.compile(f'^{arg.replace("*", ".*")}$')
+            escaped = re.escape(arg).replace(r'\*', '.*')
+            arg_re = re.compile(f'^{escaped}$')
             for test in superset:
                 if arg_re.match(test):
                     result.append(test)
@@ -99,6 +101,18 @@ class Manager(object):
                     result.append(test)
                     continue
         return result
+
+    def _collect_swift_tests(self, args):
+        swift_runner = SwiftTestingRunner(self._port, self._stream)
+        workspace = swift_runner._workspace_path()
+        if not workspace:
+            return []
+
+        if not args:
+            return [SwiftTestingRunner.SWIFT_TESTING_PREFIX]
+
+        swift_prefix = SwiftTestingRunner.SWIFT_TESTING_PREFIX + '.'
+        return [arg for arg in args if arg.startswith(swift_prefix)]
 
     def _collect_tests(self, args):
         available_tests = []
@@ -123,6 +137,10 @@ class Manager(object):
             finally:
                 if not self._port.host.platform.is_win():
                     self.host.filesystem.remove(to_be_listed)
+
+        if SwiftTestingRunner.SWIFT_TESTING_PREFIX in specified_binaries:
+            swift_tests = self._collect_swift_tests(args)
+            available_tests += swift_tests
 
         if len(args) == 0:
             return sorted(available_tests)
@@ -162,10 +180,20 @@ class Manager(object):
                 continue
             if candidate_binary in self._port.path_to_api_test_binaries():
                 binaries.append(candidate_binary)
+            elif candidate_binary == SwiftTestingRunner.SWIFT_TESTING_PREFIX:
+                if SwiftTestingRunner.SWIFT_TESTING_PREFIX not in binaries:
+                    binaries.append(SwiftTestingRunner.SWIFT_TESTING_PREFIX)
             else:
                 # If the user specifies a test-name without a binary, we need to search both binaries
-                return self._port.path_to_api_test_binaries().keys()
-        return binaries or self._port.path_to_api_test_binaries().keys()
+                all_binaries = list(self._port.path_to_api_test_binaries().keys())
+                if SwiftTestingRunner.SWIFT_TESTING_PREFIX not in all_binaries:
+                    all_binaries.append(SwiftTestingRunner.SWIFT_TESTING_PREFIX)
+                return all_binaries
+        if not binaries:
+            all_binaries = list(self._port.path_to_api_test_binaries().keys())
+            all_binaries.append(SwiftTestingRunner.SWIFT_TESTING_PREFIX)
+            return all_binaries
+        return binaries
 
     def _update_worker_count(self):
         child_processes_option_value = int(self._options.child_processes or 0)
@@ -236,13 +264,34 @@ class Manager(object):
         if self._options.repeat_each != 1:
             _log.debug(f'Repeating each test {self._options.iterations} times')
 
+        # Separate gtest and Swift Testing tests
+        swift_prefix = SwiftTestingRunner.SWIFT_TESTING_PREFIX + '.'
+
+        def _is_swift(t):
+            return t == SwiftTestingRunner.SWIFT_TESTING_PREFIX or t.startswith(swift_prefix)
+
+        gtest_names = [t for t in test_names if not _is_swift(t)]
+        swift_test_names = [t for t in test_names if _is_swift(t)]
+
         runner = None
+        swift_runner = None
         try:
             _log.info('Running tests')
-            runner = Runner(self._port, self._stream)
-            for i in range(self._options.iterations):
-                _log.debug(f'\nIteration {i + 1}')
-                runner.run(test_names, int(self._options.child_processes) if self._options.child_processes else None)
+
+            # Run gtest tests through existing Runner
+            if gtest_names:
+                runner = Runner(self._port, self._stream)
+                for i in range(self._options.iterations):
+                    _log.debug(f'\nIteration {i + 1}')
+                    runner.run(gtest_names, int(self._options.child_processes) if self._options.child_processes else None)
+
+            # Run Swift Testing tests through SwiftTestingRunner
+            if swift_test_names:
+                swift_runner = SwiftTestingRunner(self._port, self._stream)
+                for i in range(self._options.iterations):
+                    _log.debug(f'\nSwift Testing iteration {i + 1}')
+                    swift_runner.run(swift_test_names)
+
         except KeyboardInterrupt:
             # If we receive a KeyboardInterrupt, print results.
             self._stream.writeln('')
@@ -251,17 +300,32 @@ class Manager(object):
 
         end_time = time.time()
 
-        if not runner:
+        # Merge results from both runners
+        all_results = {}
+        if runner:
+            all_results.update(runner.results)
+        if swift_runner:
+            all_results.update(swift_runner.results)
+
+        if not all_results:
             return Manager.FAILED_TESTS
 
-        successful = runner.result_map_by_status(runner.STATUS_PASSED)
-        disabled = len(runner.result_map_by_status(runner.STATUS_DISABLED))
+        # When Swift tests run at suite level, results contain dynamically
+        # discovered test names that weren't in the original test_names list.
+        # Replace the swift placeholder names with the real ones for accurate
+        # summary accounting.
+        swift_prefix = SwiftTestingRunner.SWIFT_TESTING_PREFIX + '.'
+        actual_test_names = [t for t in test_names if not _is_swift(t)]
+        actual_test_names += [t for t in all_results.keys() if t.startswith(swift_prefix)]
+
+        successful = {t: r[1] for t, r in all_results.items() if r[0] == Runner.STATUS_PASSED}
+        disabled_count = len({t: r[1] for t, r in all_results.items() if r[0] == Runner.STATUS_DISABLED})
 
         # Check if running in test-parallel-safety mode
         test_parallel_safety_tests = self._port.get_option('test_parallel_safety') or []
         is_parallel_safety_mode = bool(test_parallel_safety_tests)
 
-        _log.info(f'Ran {len(runner.results) - disabled} tests of {len(set(test_names))} with {len(successful)} successful')
+        _log.info(f'Ran {len(all_results) - disabled_count} tests of {len(set(actual_test_names))} with {len(successful)} successful')
 
         result_dictionary = {
             'Skipped': [],
@@ -274,9 +338,9 @@ class Manager(object):
         result = Manager.SUCCESS
 
         # Count actual failures (not skipped)
-        failed_tests = runner.result_map_by_status(runner.STATUS_FAILED)
-        crashed_tests = runner.result_map_by_status(runner.STATUS_CRASHED)
-        timedout_tests = runner.result_map_by_status(runner.STATUS_TIMEOUT)
+        failed_tests = {t: r[1] for t, r in all_results.items() if r[0] == Runner.STATUS_FAILED}
+        crashed_tests = {t: r[1] for t, r in all_results.items() if r[0] == Runner.STATUS_CRASHED}
+        timedout_tests = {t: r[1] for t, r in all_results.items() if r[0] == Runner.STATUS_TIMEOUT}
         has_real_failures = bool(failed_tests or crashed_tests or timedout_tests)
 
         if is_parallel_safety_mode:
@@ -289,7 +353,7 @@ class Manager(object):
                 self._stream.writeln('All parallel-safety tests passed!')
                 if json_output:
                     self.host.filesystem.write_text_file(json_output, json.dumps(result_dictionary, indent=4))
-        elif len(successful) + disabled == len(set(test_names)):
+        elif len(successful) + disabled_count == len(set(actual_test_names)):
             self._stream.writeln('All tests successfully passed!')
             if json_output:
                 self.host.filesystem.write_text_file(json_output, json.dumps(result_dictionary, indent=4))
@@ -302,8 +366,8 @@ class Manager(object):
             self._stream.writeln('')
 
             skipped = []
-            for test in test_names:
-                if test not in runner.results:
+            for test in actual_test_names:
+                if test not in all_results:
                     skipped.append(test)
                     result_dictionary['Skipped'].append({'name': test, 'output': None})
             if skipped:
@@ -313,15 +377,18 @@ class Manager(object):
                     for test in skipped:
                         self._stream.writeln(f'    {test}')
 
-            self._print_tests_result_with_status(runner.STATUS_FAILED, runner)
-            self._print_tests_result_with_status(runner.STATUS_CRASHED, runner)
-            self._print_tests_result_with_status(runner.STATUS_TIMEOUT, runner)
+            # Create a temporary combined runner for printing results
+            combined_runner = Runner(self._port, self._stream)
+            combined_runner.results = all_results
+            self._print_tests_result_with_status(Runner.STATUS_FAILED, combined_runner)
+            self._print_tests_result_with_status(Runner.STATUS_CRASHED, combined_runner)
+            self._print_tests_result_with_status(Runner.STATUS_TIMEOUT, combined_runner)
 
-            for test, test_result in iteritems(runner.results):
+            for test, test_result in iteritems(all_results):
                 status_to_string = {
-                    runner.STATUS_FAILED: 'Failed',
-                    runner.STATUS_CRASHED: 'Crashed',
-                    runner.STATUS_TIMEOUT: 'Timedout',
+                    Runner.STATUS_FAILED: 'Failed',
+                    Runner.STATUS_CRASHED: 'Crashed',
+                    Runner.STATUS_TIMEOUT: 'Timedout',
                 }.get(test_result[0])
                 if not status_to_string:
                     continue
@@ -335,10 +402,10 @@ class Manager(object):
             self._stream.write_update('Preparing upload data ...')
 
             status_to_test_result = {
-                runner.STATUS_PASSED: None,
-                runner.STATUS_FAILED: Upload.Expectations.FAIL,
-                runner.STATUS_CRASHED: Upload.Expectations.CRASH,
-                runner.STATUS_TIMEOUT: Upload.Expectations.TIMEOUT,
+                Runner.STATUS_PASSED: None,
+                Runner.STATUS_FAILED: Upload.Expectations.FAIL,
+                Runner.STATUS_CRASHED: Upload.Expectations.CRASH,
+                Runner.STATUS_TIMEOUT: Upload.Expectations.TIMEOUT,
             }
             upload = Upload(
                 suite=self._options.suite or 'api-tests',
@@ -353,7 +420,7 @@ class Manager(object):
                     test: Upload.create_test_result(
                         actual=status_to_test_result[result[0]],
                         time=int(result[2] * 1000),
-                    ) for test, result in iteritems(runner.results) if result[0] in status_to_test_result
+                    ) for test, result in iteritems(all_results) if result[0] in status_to_test_result
                 },
             )
             for url in self._options.report_urls:

--- a/Tools/Scripts/webkitpy/api_tests/swift_testing_runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/swift_testing_runner.py
@@ -1,0 +1,340 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import logging
+import shutil
+import subprocess
+import tempfile
+import time
+from typing import Optional
+
+from webkitpy.api_tests.runner import Runner
+
+_log = logging.getLogger(__name__)
+
+
+class SwiftTestingRunner(object):
+    SWIFT_TESTING_PREFIX = "SwiftTesting"
+
+    def __init__(self, port, stream):
+        self._port = port
+        self._stream = stream
+        self.results = {}
+
+    def _workspace_path(self) -> Optional[str]:
+        webkit_base = self._port.webkit_base()
+        internal_workspace = self._port.host.filesystem.join(
+            webkit_base, "..", "Internal", "WebKit", "WebKit.xcworkspace"
+        )
+        if self._port.host.filesystem.exists(internal_workspace):
+            return self._port.host.filesystem.abspath(internal_workspace)
+        fallback_workspace = self._port.host.filesystem.join(
+            webkit_base, "WebKit.xcworkspace"
+        )
+        if self._port.host.filesystem.exists(fallback_workspace):
+            return self._port.host.filesystem.abspath(fallback_workspace)
+        return None
+
+    def _configuration(self) -> str:
+        config = self._port.get_option("configuration")
+        if config and config.lower() == "release":
+            return "Release"
+        return "Debug"
+
+    def _build_dir_args(self) -> list[str]:
+        build_path = self._port._build_path()
+        build_dir = self._port.host.filesystem.dirname(build_path)
+        return [f"SYMROOT={build_dir}", f"OBJROOT={build_dir}"]
+
+    def _destination(self) -> str:
+        return "platform=macOS"
+
+    def _scheme(self) -> str:
+        return "Everything up to WebKit + Tools"
+
+    @staticmethod
+    def _only_testing_arg(test_name: str) -> str:
+        """Convert a SwiftTesting.Suite.method name to an -only-testing: xcodebuild arg."""
+        stripped = test_name[len(SwiftTestingRunner.SWIFT_TESTING_PREFIX) + 1:]
+        parts = stripped.split(".")
+        return f"-only-testing:TestWebKitAPIBundle/{'/'.join(parts)}"
+
+    @staticmethod
+    def _is_suite_level(test_name):
+        """A suite-level name has no method component, e.g. SwiftTesting.SuiteName"""
+        stripped = test_name[len(SwiftTestingRunner.SWIFT_TESTING_PREFIX) + 1:]
+        return "." not in stripped
+
+    def run(self, test_names: list[str]):
+        workspace = self._workspace_path()
+        if not workspace:
+            _log.error("No xcworkspace found, cannot run Swift Testing tests")
+            return
+
+        verbose = self._port.get_option("verbose")
+        timeout = self._port.get_option("timeout")
+
+        has_suite_level = any(self._is_suite_level(t) for t in test_names)
+
+        run_all = len(test_names) == 1 and test_names[0] == self.SWIFT_TESTING_PREFIX
+        if run_all:
+            has_suite_level = True
+
+        result_bundle_dir = tempfile.mkdtemp()
+        result_bundle_path = result_bundle_dir + ".xcresult"
+        shutil.rmtree(result_bundle_dir)
+
+        command = [
+            "xcodebuild",
+            "test-without-building",
+            "-workspace",
+            workspace,
+            "-scheme",
+            self._scheme(),
+            "-destination",
+            self._destination(),
+            "-configuration",
+            self._configuration(),
+            "-collect-test-diagnostics",
+            "never",
+            "-resultBundlePath",
+            result_bundle_path,
+        ]
+
+        if not run_all:
+            for test_name in test_names:
+                if self._is_suite_level(test_name):
+                    stripped = test_name[len(self.SWIFT_TESTING_PREFIX) + 1:]
+                    command.append(f"-only-testing:TestWebKitAPIBundle/{stripped}")
+                else:
+                    command.append(self._only_testing_arg(test_name))
+        else:
+            command.append("-only-testing:TestWebKitAPIBundle")
+
+        if timeout:
+            command.extend(["-default-test-execution-time-allowance", str(timeout)])
+
+        command.extend(self._build_dir_args())
+
+        started = time.time()
+
+        try:
+            _log.debug(f"Running Swift tests: {' '.join(command)}")
+            process = subprocess.Popen(
+                command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+
+            for line in process.stdout or []:
+                if verbose:
+                    self._stream.writeln(line.rstrip())
+
+            process.wait()
+
+            self._parse_xcresult(result_bundle_path, test_names, has_suite_level)
+
+        except Exception as e:
+            elapsed = time.time() - started
+            _log.error(f"Exception running Swift tests: {e}")
+            for test_name in test_names:
+                if test_name not in self.results:
+                    self.results[test_name] = (Runner.STATUS_CRASHED, str(e), elapsed)
+        finally:
+            if self._port.host.filesystem.exists(result_bundle_path):
+                shutil.rmtree(result_bundle_path, ignore_errors=True)
+
+    def _parse_xcresult(self, result_bundle_path: str, test_names: list[str], has_suite_level: bool):
+        """Parse test results from an xcresult bundle using xcresulttool."""
+        try:
+            output = subprocess.run(
+                [
+                    "xcrun",
+                    "xcresulttool",
+                    "get",
+                    "test-results",
+                    "tests",
+                    "--path",
+                    result_bundle_path,
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            data = json.loads(output.stdout)
+        except (subprocess.CalledProcessError, json.JSONDecodeError, ValueError) as e:
+            _log.error(f"Failed to parse xcresult bundle: {e}")
+            for test_name in test_names:
+                if test_name not in self.results:
+                    self.results[test_name] = (Runner.STATUS_CRASHED, str(e), 0)
+            return
+
+        # Collect all test case nodes from the recursive tree
+        test_cases = []
+        self._collect_test_cases(data.get("testNodes", []), [], test_cases)
+
+        if has_suite_level:
+            run_all = len(test_names) == 1 and test_names[0] == self.SWIFT_TESTING_PREFIX
+
+            if run_all:
+                # Running the entire bundle — discover all tests from output
+                for tc in test_cases:
+                    suites = [s for s in tc["suites"] if s != "TestWebKitAPIBundle"]
+                    suite_path = ".".join(suites) if suites else "Unknown"
+                    full_name = f"{self.SWIFT_TESTING_PREFIX}.{suite_path}.{tc['name']}"
+                    status = self._map_result(tc["result"])
+                    duration = tc["duration"]
+                    failure_output = (
+                        "\n".join(tc["failure_messages"]) if tc["failure_messages"] else ""
+                    )
+                    self.results[full_name] = (status, failure_output, duration)
+                    status_name = Runner.NAME_FOR_STATUS[status]
+                    elapsed_log = (
+                        f" (took {round(duration, 1)} seconds)"
+                        if duration > Runner.ELAPSED_THRESHOLD
+                        else ""
+                    )
+                    self._stream.writeln(f"{full_name} {status_name}{elapsed_log}")
+            else:
+                # Group suite-level names so we can discover tests from output
+                suite_level_suites = set()
+                targeted_tests = []
+                for t in test_names:
+                    if self._is_suite_level(t):
+                        suite_level_suites.add(t[len(self.SWIFT_TESTING_PREFIX) + 1:])
+                    else:
+                        targeted_tests.append(t)
+
+                # Apply suite-level results for discovered tests
+                for suite_name in suite_level_suites:
+                    suite_cases = [tc for tc in test_cases if suite_name in tc["suites"]]
+                    self._apply_suite_level_results(suite_cases, suite_name)
+
+                # Apply targeted results for explicitly named tests
+                if targeted_tests:
+                    self._apply_targeted_results(test_cases, targeted_tests)
+        else:
+            self._apply_targeted_results(test_cases, test_names)
+
+    def _collect_test_cases(self, nodes, parent_suites, test_cases):
+        """Recursively walk testNodes to find Test Case leaf nodes."""
+        for node in nodes:
+            node_type = node.get("nodeType", "")
+            name = node.get("name", "")
+            children = node.get("children", [])
+
+            if node_type == "Test Suite":
+                self._collect_test_cases(children, parent_suites + [name], test_cases)
+            elif node_type == "Test Case":
+                failure_messages = []
+                for child in children:
+                    if child.get("nodeType") == "Failure Message":
+                        failure_messages.append(child.get("name", ""))
+
+                test_cases.append(
+                    {
+                        "name": name,
+                        "nodeIdentifier": node.get("nodeIdentifier", ""),
+                        "result": node.get("result", ""),
+                        "duration": node.get("durationInSeconds", 0),
+                        "suites": parent_suites,
+                        "failure_messages": failure_messages,
+                    }
+                )
+            else:
+                # Recurse into any other container nodes (e.g. Test Plan, Test Bundle)
+                self._collect_test_cases(children, parent_suites, test_cases)
+
+    def _map_result(self, result_str: str):
+        if result_str == "Passed":
+            return Runner.STATUS_PASSED
+        elif result_str == "Failed":
+            return Runner.STATUS_FAILED
+        elif result_str == "Skipped":
+            return Runner.STATUS_DISABLED
+        return Runner.STATUS_CRASHED
+
+    def _apply_suite_level_results(self, test_cases: list[dict[str, str]], suite_name: str):
+        """Apply results when running at suite level (discover tests from output)."""
+        for tc in test_cases:
+            method_name = tc["name"]
+            full_name = f"{self.SWIFT_TESTING_PREFIX}.{suite_name}.{method_name}"
+            status = self._map_result(tc["result"])
+            duration = float(tc["duration"])
+            failure_output = (
+                "\n".join(tc["failure_messages"]) if tc["failure_messages"] else ""
+            )
+
+            self.results[full_name] = (status, failure_output, duration)
+            status_name = Runner.NAME_FOR_STATUS[status]
+            elapsed_log = (
+                f" (took {round(duration, 1)} seconds)"
+                if duration > Runner.ELAPSED_THRESHOLD
+                else ""
+            )
+            self._stream.writeln(f"{full_name} {status_name}{elapsed_log}")
+
+    def _apply_targeted_results(self, test_cases: list[dict[str, str]], suite_tests: list[str]):
+        """Apply results when running specific tests."""
+        # Build a map from method name to test case result
+        tc_by_method = {}
+        for tc in test_cases:
+            tc_by_method[tc["name"]] = tc
+            # Also index by nodeIdentifier's last component for robustness
+            node_id = tc["nodeIdentifier"]
+            if "/" in node_id:
+                tc_by_method[node_id.split("/")[-1]] = tc
+
+        for test_name in suite_tests:
+            stripped = test_name[len(self.SWIFT_TESTING_PREFIX) + 1:]
+            method = stripped.split(".", 1)[1] if "." in stripped else stripped
+
+            tc = tc_by_method.get(method)
+            if tc:
+                status = self._map_result(tc["result"])
+                duration = tc["duration"]
+                failure_output = (
+                    "\n".join(tc["failure_messages"]) if tc["failure_messages"] else ""
+                )
+            else:
+                # Test was requested but not found in results — likely crashed before running
+                status = Runner.STATUS_CRASHED
+                duration = 0
+                failure_output = f"Test {test_name} not found in xcresult output"
+
+            self.results[test_name] = (status, failure_output, duration)
+            status_name = Runner.NAME_FOR_STATUS[status]
+            elapsed_log = (
+                f" (took {round(duration, 1)} seconds)"
+                if duration > Runner.ELAPSED_THRESHOLD
+                else ""
+            )
+            self._stream.writeln(f"{test_name} {status_name}{elapsed_log}")
+
+    def result_map_by_status(self, status=None):
+        result_map = {}
+        for test_name, result in self.results.items():
+            if result[0] == status:
+                result_map[test_name] = result[1]
+        return result_map

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -309,6 +309,8 @@ class Port(object):
         for binary, path in self.path_to_api_test_binaries().items():
             if binary not in canonicalized_binaries:
                 continue
+            if binary == 'SwiftTesting':
+                continue
             if not self._filesystem.exists(path):
                 _log.error('{} was not found at {}'.format(os.path.basename(path), path))
                 return False

--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -306,6 +306,16 @@ class DarwinPort(ApplePort):
             self._append_value_colon_separated(environment, name, build_root_path)
         return environment
 
+    def path_to_xcworkspace(self):
+        webkit_base = self.webkit_base()
+        internal_workspace = self.host.filesystem.join(webkit_base, '..', 'Internal', 'WebKit', 'WebKit.xcworkspace')
+        if self.host.filesystem.exists(internal_workspace):
+            return self.host.filesystem.abspath(internal_workspace)
+        fallback_workspace = self.host.filesystem.join(webkit_base, 'WebKit.xcworkspace')
+        if self.host.filesystem.exists(fallback_workspace):
+            return self.host.filesystem.abspath(fallback_workspace)
+        return None
+
     def stderr_patterns_to_strip(self):
         worthless_patterns = super(DarwinPort, self).stderr_patterns_to_strip()
         # Suppress log message from <rdar://56920527>

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift
@@ -34,7 +34,7 @@ import SwiftUI
 struct WebPageTransferableTests {
     @Test
     func transferableContentTypes() async throws {
-        let expectedTypes: [UTType] = [.webArchive, .pdf, .png, .url, .flatRTFD, .rtf, .utf8PlainText]
+        let expectedTypes: [UTType] = [.pdf, .png, .url, .flatRTFD, .rtf, .utf8PlainText]
         let exportedContentTypes = WebPage.exportedContentTypes()
         #expect(exportedContentTypes == expectedTypes)
 


### PR DESCRIPTION
#### 0e0bd9fe4dbad032c8be43647371da24570f79a7
<pre>
[Swift in WebKit] Integrate Swift Testing into `run-api-tests`
<a href="https://bugs.webkit.org/show_bug.cgi?id=309998">https://bugs.webkit.org/show_bug.cgi?id=309998</a>
<a href="https://rdar.apple.com/172636128">rdar://172636128</a>

Reviewed by NOBODY (OOPS!).

Draft

* Tools/Scripts/run-api-tests:
(parse_args):
* Tools/Scripts/webkitpy/api_tests/manager.py:
(Manager._collect_swift_tests):
(Manager._collect_tests):
(Manager._binaries_for_arguments):
(Manager.run):
* Tools/Scripts/webkitpy/api_tests/swift_testing_runner.py: Added.
(SwiftTestingRunner):
(SwiftTestingRunner.__init__):
(SwiftTestingRunner._workspace_path):
(SwiftTestingRunner._configuration):
(SwiftTestingRunner._destination):
(SwiftTestingRunner._scheme):
(SwiftTestingRunner.collect_tests):
(SwiftTestingRunner._extract_json):
(SwiftTestingRunner._parse_enumeration_output):
(SwiftTestingRunner._group_tests_by_suite):
(SwiftTestingRunner._only_testing_arg):
(SwiftTestingRunner._build_method_to_test_map):
(SwiftTestingRunner.run):
(SwiftTestingRunner._resolve_unmatched_tests):
(SwiftTestingRunner.result_map_by_status):
* Tools/Scripts/webkitpy/port/base.py:
(Port.check_api_test_build):
* Tools/Scripts/webkitpy/port/darwin.py:
(DarwinPort.path_to_xcworkspace):
* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift:
(WebPageTransferableTests.transferableContentTypes):

[Swift in WebKit] Integrate Swift Testing into `run-api-tests`
<a href="https://bugs.webkit.org/show_bug.cgi?id=309998">https://bugs.webkit.org/show_bug.cgi?id=309998</a>
<a href="https://rdar.apple.com/172636128">rdar://172636128</a>

Reviewed by NOBODY (OOPS!).

Draft

* Tools/Scripts/run-api-tests:
(parse_args):
* Tools/Scripts/webkitpy/api_tests/manager.py:
(Manager._collect_swift_tests):
(Manager._collect_tests):
(Manager._binaries_for_arguments):
(Manager.run):
* Tools/Scripts/webkitpy/api_tests/swift_testing_runner.py: Added.
(SwiftTestingRunner):
(SwiftTestingRunner.__init__):
(SwiftTestingRunner._workspace_path):
(SwiftTestingRunner._configuration):
(SwiftTestingRunner._destination):
(SwiftTestingRunner._scheme):
(SwiftTestingRunner.collect_tests):
(SwiftTestingRunner._extract_json):
(SwiftTestingRunner._parse_enumeration_output):
(SwiftTestingRunner._group_tests_by_suite):
(SwiftTestingRunner._only_testing_arg):
(SwiftTestingRunner._build_method_to_test_map):
(SwiftTestingRunner.run):
(SwiftTestingRunner._resolve_unmatched_tests):
(SwiftTestingRunner.result_map_by_status):
* Tools/Scripts/webkitpy/port/base.py:
(Port.check_api_test_build):
* Tools/Scripts/webkitpy/port/darwin.py:
(DarwinPort.path_to_xcworkspace):
* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift:
(WebPageTransferableTests.transferableContentTypes):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e0bd9fe4dbad032c8be43647371da24570f79a7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17253 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159648 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104357 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116503 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82720 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18622 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97223 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5001e581-6ebf-454c-95ae-b209f45f17ea) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/150242 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17716 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15665 "run-api-tests-without-change (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7495 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127334 "Found 1 new API test failure: SwiftTesting.System Failures.TestWebKitAPI encountered an error (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162122 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14891 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124508 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/150321 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19715 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124695 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135118 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79882 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19760 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11883 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23085 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22797 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22949 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22851 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->