### PR TITLE
[RenderReplaced] Apply transferred fixed min/max block-size constraints for intrinsic keyword widths when height is auto

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4506,7 +4506,6 @@ imported/w3c/web-platform-tests/css/css-sizing/image-min-max-content-intrinsic-s
 imported/w3c/web-platform-tests/css/css-sizing/image-min-max-content-intrinsic-size-change-008.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-sizing/inline-intrinsic-size-calc.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-sizing/max-content-input-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-sizing/replaced-aspect-ratio-intrinsic-size-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-sizing/replaced-aspect-ratio-stretch-fit-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-sizing/vert-block-size-small-or-larger-than-container-with-min-or-max-content-1.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/intrinsic-size-017.html [ ImageOnlyFailure ]

--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4513,7 +4513,6 @@ imported/w3c/web-platform-tests/css/css-sizing/fit-content-length-percentage-015
 imported/w3c/web-platform-tests/css/css-sizing/fit-content-length-percentage-016.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-sizing/hori-block-size-small-or-larger-than-container-with-min-or-max-content-1.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-sizing/max-content-input-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-sizing/replaced-aspect-ratio-intrinsic-size-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-sizing/vert-block-size-small-or-larger-than-container-with-min-or-max-content-1.html [ ImageOnlyFailure ]
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/flex-aspect-ratio-038.html [ ImageOnlyFailure ]
 webkit.org/b/214463 imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/floats-aspect-ratio-001.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -864,7 +864,7 @@ void RenderReplaced::computePreferredLogicalWidths()
 
     // We cannot resolve any percent logical width here as the available logical
     // width may not be set on our containing block.
-    if (style().logicalWidth().isPercentOrCalculated())
+    if (style().logicalWidth().isPercentOrCalculated() || style().logicalWidth().isIntrinsicOrStretch())
         computeAspectRatioAdjustedIntrinsicLogicalWidths(m_minPreferredLogicalWidth, m_maxPreferredLogicalWidth);
     else
         m_minPreferredLogicalWidth = m_maxPreferredLogicalWidth = computeReplacedLogicalWidth(ShouldComputePreferred::ComputePreferred);

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -867,6 +867,24 @@ void RenderReplaced::computeIntrinsicKeywordLogicalWidths(LayoutUnit& minLogical
         }
     }
     RenderBox::computeIntrinsicKeywordLogicalWidths(minLogicalWidth, maxLogicalWidth);
+
+    // When block-size is auto, the RenderBox paths above don't transfer fixed
+    // min/max block-size through the intrinsic aspect ratio. Clamp here so
+    // intrinsic keyword widths still honor min-height/max-height.
+    if (!hasIntrinsicAspectRatio() || !style().logicalHeight().isAuto())
+        return;
+
+    auto aspectRatio = computeIntrinsicAspectRatio();
+    auto& style = this->style();
+    auto clamp = [&](LayoutUnit value) {
+        if (auto fixedMaxHeight = style.logicalMaxHeight().tryFixed())
+            value = std::min(value, LayoutUnit { fixedMaxHeight->resolveZoom(style.usedZoomForLength()) * aspectRatio });
+        if (auto fixedMinHeight = style.logicalMinHeight().tryFixed())
+            value = std::max(value, LayoutUnit { fixedMinHeight->resolveZoom(style.usedZoomForLength()) * aspectRatio });
+        return value;
+    };
+    minLogicalWidth = clamp(minLogicalWidth);
+    maxLogicalWidth = clamp(maxLogicalWidth);
 }
 
 void RenderReplaced::computePreferredLogicalWidths()


### PR DESCRIPTION
#### ab59a67dd7ab165d2cc59b0bbf5fddff87ebdb72
<pre>
[RenderReplaced] Apply transferred fixed min/max block-size constraints for intrinsic keyword widths when height is auto
<a href="https://bugs.webkit.org/show_bug.cgi?id=309997">https://bugs.webkit.org/show_bug.cgi?id=309997</a>

Reviewed by NOBODY (OOPS!).

Replaced elements with an intrinsic aspect ratio already transfer
fixed/percent/stretch block sizes into the inline axis through
`RenderBox::computeIntrinsicKeywordLogicalWidths` (via
`computeLogicalWidthFromAspectRatioInternal`, which clamps by min/max
height), and through the `logicalHeight().isSpecified()` branch. The
gap was the narrow case where block-size computes to `auto` but
min-height/max-height is a fixed length — in that case the intrinsic
inline size (max-content/min-content/fit-content) was returned raw,
ignoring the transferred constraint.

Handle this in `RenderReplaced::computeIntrinsicKeywordLogicalWidths`:
after the existing paths (fixed block-size -&gt; derived width, otherwise
`RenderBox::computeIntrinsicKeywordLogicalWidths`), clamp the returned
intrinsic inline size by fixed min/max block-size converted through
the intrinsic aspect ratio. This only triggers when block-size is
auto, so the established paths for fixed/percent/stretch heights and
the `shouldComputeLogicalWidthFromAspectRatio` path are untouched.

* LayoutTests/TestExpectations: Progression.
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::computeIntrinsicKeywordLogicalWidths):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab59a67dd7ab165d2cc59b0bbf5fddff87ebdb72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35037 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170466 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/117934 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/722fcbbe-4ed6-4708-8664-825ea8d01500) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163432 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35038 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125346 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88277 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6714c4d2-e677-4b1f-9d01-dabfd07ff2e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/105942 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8110d9a9-5a19-401b-af2a-8763ab8297cb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26694 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25204 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18187 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/172954 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/19995 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24526 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133635 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29299 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133641 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144680 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96611 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28167 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21499 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34205 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101650 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33705 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/33948 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33854 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->