### PR TITLE
[Site Isolation] Fix EnhancedSecurity.PSONToEnhancedSecurity

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm
@@ -27,6 +27,7 @@
 
 #import "HTTPServer.h"
 #import "PlatformUtilities.h"
+#import "SiteIsolationUtilities.h"
 #import "TestCocoa.h"
 #import "TestNavigationDelegate.h"
 #import "TestUIDelegate.h"
@@ -167,9 +168,17 @@ TEST(EnhancedSecurity, PSONToEnhancedSecurity)
     [webView loadRequest:[NSURLRequest requestWithURL:url2]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
-    EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
-    EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-    EXPECT_NE(pid1, [webView _webProcessIdentifier]);
+    // Under Site Isolation, navigation has to reuse existing site process in BCG,
+    // so navigation inherits enhanced security state of that process.
+    if (isSiteIsolationEnabled(webView.get())) {
+        EXPECT_FALSE(isEnhancedSecurityEnabled(webView.get()));
+        EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:nil].UTF8String);
+        EXPECT_EQ(pid1, [webView _webProcessIdentifier]);
+    } else {
+        EXPECT_TRUE(isEnhancedSecurityEnabled(webView.get()));
+        EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:nil].UTF8String);
+        EXPECT_NE(pid1, [webView _webProcessIdentifier]);
+    }
 }
 
 TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)
@@ -205,9 +214,17 @@ TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)
     [webView loadRequest:[NSURLRequest requestWithURL:url2]];
     TestWebKitAPI::Util::run(&finishedNavigation);
 
-    EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
-    EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-    EXPECT_NE(pid1, [webView _webProcessIdentifier]);
+    // Under Site Isolation, navigation has to reuse existing site process in BCG,
+    // so navigation inherits enhanced security state of that process.
+    if (isSiteIsolationEnabled(webView.get())) {
+        EXPECT_FALSE(isEnhancedSecurityEnabled(webView.get()));
+        EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:nil].UTF8String);
+        EXPECT_EQ(pid1, [webView _webProcessIdentifier]);
+    } else {
+        EXPECT_TRUE(isEnhancedSecurityEnabled(webView.get()));
+        EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:nil].UTF8String);
+        EXPECT_NE(pid1, [webView _webProcessIdentifier]);
+    }
 }
 
 static RetainPtr<_WKProcessPoolConfiguration> psonProcessPoolConfiguration()
@@ -492,7 +509,11 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNaviga
 
     EXPECT_EQ(true, isEnhancedSecurityEnabled(webView.get()));
     EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-    EXPECT_STREQ("security", [webView _webContentProcessVariantForFrame:[webView firstChildFrame]._handle].UTF8String);
+    // Without Site Isolation, cross-site frame must be loaded in the same process as main frame,
+    // so process variant cannot change; with Site Isolation, cross-site frame is put in a
+    // different process, and that process can have different variant.
+    auto frameProcessVariant = isSiteIsolationEnabled(webView.get()) ? "standard" : "security";
+    EXPECT_STREQ(frameProcessVariant, [webView _webContentProcessVariantForFrame:[webView firstChildFrame]._handle].UTF8String);
 
 }
 
@@ -544,7 +565,6 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavig
 
 TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabledCrossOrigin)
 {
-
     HTTPServer server({
         { "/example"_s, { "<iframe id='webkit_frame' src='https://example.com/webkit'></iframe>"_s } },
         { "/example_subframe"_s, { "<script>alert('done')</script>"_s } },
@@ -584,7 +604,11 @@ TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavig
 
     EXPECT_EQ(false, isEnhancedSecurityEnabled(webView.get()));
     EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:nil].UTF8String);
-    EXPECT_STREQ("standard", [webView _webContentProcessVariantForFrame:[webView firstChildFrame]._handle].UTF8String);
+    // Without Site Isolation, cross-site frame must be loaded in the same process as main frame,
+    // so process variant cannot change; with Site Isolation, cross-site frame is put in a
+    // different process, and that process can have different variant.
+    auto frameProcessVariant = isSiteIsolationEnabled(webView.get()) ? "security" : "standard";
+    EXPECT_STREQ(frameProcessVariant, [webView _webContentProcessVariantForFrame:[webView firstChildFrame]._handle].UTF8String);
 }
 
 TEST(EnhancedSecurity, WindowOpenWithNoopenerFromEnhancedSecurityPage)


### PR DESCRIPTION
#### c9a5ef901a472d491aca0ae140c21250e3f3cc11
<pre>
[Site Isolation] Fix EnhancedSecurity.PSONToEnhancedSecurity
<a href="https://bugs.webkit.org/show_bug.cgi?id=309999">https://bugs.webkit.org/show_bug.cgi?id=309999</a>
<a href="https://rdar.apple.com/172638545">rdar://172638545</a>

Reviewed by Rupin Mittal.

EnhancedSecurity has different behavior under Site Isolation, specifically:
1. Without Site Isolation, all frames in a page are loaded in the same process, so process (process variant) will not
change after subframe navigation. With Site Isolation, frames can be loaded in different processes, so it can change.
2. Without Site Isolation, if enhanced security state of a navigation does not match that of current process, we can
swap process to use a process with matching variant. With Site Isolation, the process is selected based on site -- if
a process for the site already exists in the browsing context group, we have to use that process since the navigating
frame will need sync access to same-origin frames in the same group. See 306717@main.

Therefore, we should update the existing tests with different expectations under Site Isolation (so they won&apos;t end up
failing when Site Isolation is on).

* Tools/TestWebKitAPI/Tests/WebKitCocoa/EnhancedSecurity.mm:
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecurity)):
(TestWebKitAPI::TEST(EnhancedSecurity, PSONToEnhancedSecuritySamePage)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysEnabledAfterSubFrameNavigationRequestDisablesCrossOrigin)):
(TestWebKitAPI::TEST(EnhancedSecurity, EnhancedSecurityNavigationStaysDisabledAfterSubFrameNavigationRequestEnabledCrossOrigin)):

Canonical link: <a href="https://commits.webkit.org/309341@main">https://commits.webkit.org/309341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad1fe6f5723d2a548f37dc9e8781391d685139bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/158995 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103715 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83bf5d31-b0ee-43af-b409-6f81b3d175c8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152154 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115944 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82381 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/966da050-86fd-4e7b-a784-468f6f2bbe15) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18058 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134814 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96676 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7f26407-312d-4c06-9f41-8024b04f47b7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17157 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15099 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6840 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126772 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12738 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161469 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14291 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123944 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124148 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33723 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134533 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79189 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19273 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11290 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22441 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22155 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22307 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22209 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->