### PR TITLE
Adopt WTF::AlignedStorage in more places

### DIFF
--- a/Source/WTF/wtf/SegmentedVector.h
+++ b/Source/WTF/wtf/SegmentedVector.h
@@ -248,25 +248,19 @@ namespace WTF {
         using SegmentPtr = std::unique_ptr<Segment, NonDestructingDeleter<Segment, Malloc>>;
 
         struct EmptyInlineStorage { };
-        struct alignas(T) InlineStorageData { std::byte m_data[sizeof(T) * InlineCapacity]; };
-
-// armv7 compiler doesn't recognize that m_data is aligned to sizeof(T) by InlineStorageData
-// and complains that the two reinterpret_cast()s below increase the alignment.
-IGNORE_WARNINGS_BEGIN("cast-align")
+        struct InlineStorageData { AlignedStorage<T> m_data[InlineCapacity]; };
 
         ALWAYS_INLINE T* inlineStorage() LIFETIME_BOUND
         {
             static_assert(hasInlineStorage);
-            return reinterpret_cast<T*>(m_inlineStorageMember.m_data);
+            return m_inlineStorageMember.m_data[0].get();
         }
 
         ALWAYS_INLINE const T* inlineStorage() const LIFETIME_BOUND
         {
             static_assert(hasInlineStorage);
-            return reinterpret_cast<const T*>(m_inlineStorageMember.m_data);
+            return m_inlineStorageMember.m_data[0].get();
         }
-
-IGNORE_WARNINGS_END
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 

--- a/Source/WTF/wtf/SizeLimits.cpp
+++ b/Source/WTF/wtf/SizeLimits.cpp
@@ -81,7 +81,7 @@ template<typename T, unsigned inlineCapacity>
 struct SameSizeAsVectorWithInlineCapacity : SameSizeAsVectorWithInlineCapacityBase<T> {
     WTF_MAKE_NONCOPYABLE(SameSizeAsVectorWithInlineCapacity);
 public:
-    alignas(T) std::byte inlineBuffer[sizeof(T) * inlineCapacity];
+    AlignedStorage<T> inlineBuffer[inlineCapacity];
 };
 
 static_assert(sizeof(Vector<int>) == sizeof(SameSizeAsVectorWithInlineCapacity<int>), "Vector should stay small!");

--- a/Source/WTF/wtf/ThreadSpecific.h
+++ b/Source/WTF/wtf/ThreadSpecific.h
@@ -41,9 +41,9 @@
 
 #pragma once
 
+#include <wtf/AlignedStorage.h>
 #include <wtf/MainThread.h>
 #include <wtf/Noncopyable.h>
-#include <wtf/StdLibExtras.h>
 #include <wtf/Threading.h>
 
 // X11 headers define a bunch of macros with common terms, interfering with WebCore and WTF enum values.
@@ -100,14 +100,9 @@ private:
             owner->setInTLS(nullptr);
         }
 
-        PointerType storagePointer() const
-        {
-            SUPPRESS_MEMORY_UNSAFE_CAST return const_cast<PointerType>(reinterpret_cast<const T*>(&m_storage));
-        }
+        PointerType storagePointer() const { return const_cast<PointerType>(m_storage.get()); }
 
-        union alignas(T) {
-            std::byte bytes[sizeof(T)];
-        } m_storage;
+        AlignedStorage<T> m_storage;
         ThreadSpecific<T, canBeGCThread>* owner;
     };
 


### PR DESCRIPTION
#### 2b20fec90afc2ea95344ce041fe1a78d9bb30cde
<pre>
Adopt WTF::AlignedStorage in more places
<a href="https://bugs.webkit.org/show_bug.cgi?id=310004">https://bugs.webkit.org/show_bug.cgi?id=310004</a>

Reviewed by Darin Adler.

Adopt WTF::AlignedStorage in more places to simplify the code a bit.

* Source/WTF/wtf/SegmentedVector.h:
* Source/WTF/wtf/SizeLimits.cpp:
* Source/WTF/wtf/ThreadSpecific.h:
(WTF::ThreadSpecific::Data::storagePointer const):
(WTF::ThreadSpecific::Data::alignas): Deleted.

Canonical link: <a href="https://commits.webkit.org/309363@main">https://commits.webkit.org/309363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e71d828edbf83e36c47d2d4808def99c34e4a13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150297 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159011 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103731 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8cff789e-37dd-435c-a014-33e536dbc59a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115958 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82397 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/347280b2-0d43-4129-a182-b67c2ad3bc82) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96690 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ac9e183-65e2-49d6-8f2a-58d15c2e7782) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17175 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15115 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6856 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142280 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12756 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161485 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11095 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4613 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123961 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22857 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124165 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33738 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134551 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79211 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19290 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11308 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181728 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22469 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86257 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46500 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22171 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22323 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22225 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->