### PR TITLE
TaskQueueGcd::Delete can deadlock

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/task_queue_gcd.cc
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/rtc_base/task_queue_gcd.cc
@@ -96,7 +96,9 @@ TaskQueueGcd::TaskQueueGcd(absl::string_view queue_name, int gcd_priority)
 TaskQueueGcd::~TaskQueueGcd() = default;
 
 void TaskQueueGcd::Delete() {
+#if !WEBRTC_WEBKIT_BUILD
   RTC_DCHECK(!IsCurrent());
+#endif
   // Implementation/behavioral note:
   // Dispatch queues are reference counted via calls to dispatch_retain and
   // dispatch_release. Pending blocks submitted to a queue also hold a
@@ -106,7 +108,15 @@ void TaskQueueGcd::Delete() {
 
   // Use dispatch_sync to set the is_active_ to guarantee that there's not a
   // race with checking it from a task.
+#if WEBRTC_WEBKIT_BUILD
+  if (IsCurrent()) {
+    is_active_ = false;
+  } else {
+    dispatch_sync_f(queue_, this, &SetNotActive);
+  }
+#else
   dispatch_sync_f(queue_, this, &SetNotActive);
+#endif
   dispatch_release(queue_);
 }
 


### PR DESCRIPTION
#### 0d44f8167e57e3020da3f8b53961a59bae00b3f3
<pre>
TaskQueueGcd::Delete can deadlock
<a href="https://rdar.apple.com/170066167">rdar://170066167</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310008">https://bugs.webkit.org/show_bug.cgi?id=310008</a>

Reviewed by Eric Carlson.

RTPSenderVideoFrameTransformerDelegate::OnTransformedFrame is hopping to its transformer queue with a ref to RTPSenderVideoFrameTransformerDelegate.
When executing the task, the task might have the last reference to RTPSenderVideoFrameTransformerDelegate, leading to the destruction of the transformer queue within itself.
In that case, the transformer queue will try to dispatch_sync to itself to ensure that its active boolean flag is set appropriately. This will deadlock.
To prevent this, if TaskQueueGcd::Delete os called from the queue itself, we directly set the active boolean flag.

Canonical link: <a href="https://commits.webkit.org/310507@main">https://commits.webkit.org/310507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/769a43a868808d4a8db7324946c0e2d49ad3f659

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159021 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103741 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f654b58-9d95-4796-97d5-96b3ef37c6f6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115965 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82402 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/69d9b6f0-c1fa-4106-8422-54811314f392) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18079 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134836 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96697 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a1d2d58-39f0-4e06-84ce-70ae9e466a22) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17178 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15120 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6866 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126793 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12760 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161495 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14313 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123967 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22867 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124171 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/34556 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134555 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79221 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19294 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11312 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22467 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22181 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22333 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22235 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->