### PR TITLE
[WPE][GTK] Setting WEBKIT_DEBUG=Media triggers WebProcess crash

### DIFF
--- a/Source/WebCore/Scripts/generate-log-declarations.py
+++ b/Source/WebCore/Scripts/generate-log-declarations.py
@@ -39,7 +39,7 @@ def generate_log_client_declarations_file(log_messages, log_client_declarations_
             message_name = log_message[0]
             message_format = log_message[1]
             file.write("#define MESSAGE_" + message_name + " " + message_format + "\n")
-            message_format_without_public_string_modifier = message_format.replace("%{public}s", "%s")
+            message_format_without_public_string_modifier = message_format.replace("%\" PUBLIC_LOG_STRING \"", "%s")
             file.write("#define MESSAGE_WITHOUT_PUBLIC_STRING_MODIFIER_" + message_name + " " + message_format_without_public_string_modifier + "\n")
 
         file.close()

--- a/Source/WebCore/platform/LogMessages.in
+++ b/Source/WebCore/platform/LogMessages.in
@@ -104,23 +104,23 @@ HTMLMEDIAELEMENT_MEDIAPLAYERRATECHANGED, "HTMLMediaElement::mediaPlayerRateChang
 HTMLMEDIAELEMENT_MEDIAPLAYERTIMECHANGED, "HTMLMediaElement::mediaPlayerTimeChanged(%" PRIX64 ")", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_MEDIAPLAYERTIMECHANGED_LOOPING, "HTMLMediaElement::mediaPlayerTimeChanged(%" PRIX64 ") current time (%f) is greater then duration (%f), looping", (uint64_t, double, double), DEFAULT, Media
 HTMLMEDIAELEMENT_SETSHOULDDELAYLOADEVENT, "HTMLMediaElement::setShouldDelayLoadEvent(%" PRIX64 ") %" PRIu8, (uint64_t, uint8_t), DEFAULT, Media
-HTMLMEDIAELEMENT_MEDIAPLAYERENGINEUPDATED, "HTMLMediaElement::mediaPlayerEngineUpdated(%" PRIX64 ") %{public}s", (uint64_t, CString), DEFAULT, Media
+HTMLMEDIAELEMENT_MEDIAPLAYERENGINEUPDATED, "HTMLMediaElement::mediaPlayerEngineUpdated(%" PRIX64 ") %" PUBLIC_LOG_STRING "", (uint64_t, CString), DEFAULT, Media
 HTMLMEDIAELEMENT_CURRENTMEDIATIME_SEEKING, "HTMLMediaElement::currentMediaTime(%" PRIX64 ") seeking, returning %f", (uint64_t, float), DEFAULT, Media
 HTMLMEDIAELEMENT_UPDATEPLAYSTATE, "HTMLMediaElement::updatePlayState(%" PRIX64 ") shouldBePlaying = %d, playerPaused = %d", (uint64_t, int, int), DEFAULT, Media
 HTMLMEDIAELEMENT_VISIBILITYSTATECHANGED, "HTMLMediaElement::visibilityStateChanged(%" PRIX64 ") visible = %d", (uint64_t, int), DEFAULT, Media
 HTMLMEDIAELEMENT_CREATEMEDIAPLAYER, "HTMLMediaElement::createMediaPlayer(%" PRIX64 ")", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_PLAY, "HTMLMediaElement::play(%" PRIX64 ")", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_PLAYINTERNAL, "HTMLMediaElement::playInternal(%" PRIX64 ")", (uint64_t), DEFAULT, Media
-HTMLMEDIAELEMENT_ADDAUDIOTRACK, "HTMLMediaElement::addAudioTrack(%" PRIX64 ") id: %{public}s, %{public}s", (uint64_t, CString, CString), DEFAULT, Media
-HTMLMEDIAELEMENT_ADDVIDEOTRACK, "HTMLMediaElement::addVideoTrack(%" PRIX64 ") id: %{public}s, %{public}s", (uint64_t, CString, CString), DEFAULT, Media
-HTMLMEDIAELEMENT_CANPLAYTYPE, "HTMLMediaElement::canPlayType(%" PRIX64 ") %{public}s: %{public}s", (uint64_t, CString, CString), DEFAULT, Media
+HTMLMEDIAELEMENT_ADDAUDIOTRACK, "HTMLMediaElement::addAudioTrack(%" PRIX64 ") id: %" PUBLIC_LOG_STRING ", %" PUBLIC_LOG_STRING "", (uint64_t, CString, CString), DEFAULT, Media
+HTMLMEDIAELEMENT_ADDVIDEOTRACK, "HTMLMediaElement::addVideoTrack(%" PRIX64 ") id: %" PUBLIC_LOG_STRING ", %" PUBLIC_LOG_STRING "", (uint64_t, CString, CString), DEFAULT, Media
+HTMLMEDIAELEMENT_CANPLAYTYPE, "HTMLMediaElement::canPlayType(%" PRIX64 ") %" PUBLIC_LOG_STRING ": %" PUBLIC_LOG_STRING "", (uint64_t, CString, CString), DEFAULT, Media
 HTMLMEDIAELEMENT_CANTRANSITIONFROMAUTOPLAYTOPLAY_NOT_ENOUGH_DATA, "HTMLMediaElement::canTransitionFromAutoplayToPlay(%" PRIX64 ") not enough data", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_CANTRANSITIONFROMAUTOPLAYTOPLAY_NOT_AUTOPLAYING, "HTMLMediaElement::canTransitionFromAutoplayToPlay(%" PRIX64 ") not autoplaying", (uint64_t), DEFAULT, Media
-HTMLMEDIAELEMENT_CONFIGURETEXTTRACKDISPLAY, "HTMLMediaElement::configureTextTrackDisplay(%" PRIX64 ") %{public}s", (uint64_t, CString), DEFAULT, Media
-HTMLMEDIAELEMENT_CONFIGURETEXTTRACKGROUP, "HTMLMediaElement::configureTextTrackGroup(%" PRIX64 ") %{public}s track with language %{public}s and BCP 47 language %{public}s has score %d", (uint64_t, CString, CString, CString, int), DEFAULT, Media
+HTMLMEDIAELEMENT_CONFIGURETEXTTRACKDISPLAY, "HTMLMediaElement::configureTextTrackDisplay(%" PRIX64 ") %" PUBLIC_LOG_STRING "", (uint64_t, CString), DEFAULT, Media
+HTMLMEDIAELEMENT_CONFIGURETEXTTRACKGROUP, "HTMLMediaElement::configureTextTrackGroup(%" PRIX64 ") %" PUBLIC_LOG_STRING " track with language %" PUBLIC_LOG_STRING " and BCP 47 language %" PUBLIC_LOG_STRING " has score %d", (uint64_t, CString, CString, CString, int), DEFAULT, Media
 HTMLMEDIAELEMENT_FINISHSEEK, "HTMLMediaElement::finishSeek(%" PRIX64 ") current time = %f, pending seek = %d", (uint64_t, double, int), DEFAULT, Media
 HTMLMEDIAELEMENT_MEDIAENGINEWASUPDATED, "HTMLMediaElement::mediaEngineWasUpdated(%" PRIX64 ")", (uint64_t), DEFAULT, Media
-HTMLMEDIAELEMENT_MEDIAPLAYERCHARACTERISTICSCHANGED, "HTMLMediaElement::mediaPlayerCharacteristicChanged(%" PRIX64 ") %{public}s", (uint64_t, CString), DEFAULT, Media
+HTMLMEDIAELEMENT_MEDIAPLAYERCHARACTERISTICSCHANGED, "HTMLMediaElement::mediaPlayerCharacteristicChanged(%" PRIX64 ") %" PUBLIC_LOG_STRING "", (uint64_t, CString), DEFAULT, Media
 HTMLMEDIAELEMENT_MEDIAPLAYERCHARACTERISTICSCHANGED_NO_MEDIASESSION, "HTMLMediaElement::mediaPlayerCharacteristicChanged(%" PRIX64 ") no media session", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_MEDIAPLAYERDURATIONCHANGED, "HTMLMediaElement::mediaPlayerDurationChanged(%" PRIX64 ") duration = %f, current time = %f", (uint64_t, float, float), DEFAULT, Media
 HTMLMEDIAELEMENT_MEDIAPLAYERSIZECHANGED, "HTMLMediaElement::mediaPlayerSizeChanged(%" PRIX64 ") w = %f, h = %f", (uint64_t, float, float), DEFAULT, Media
@@ -128,14 +128,14 @@ HTMLMEDIAELEMENT_MEDIAPLAYERSEEKED, "HTMLMediaElement::mediaPlayerSeeked(%" PRIX
 HTMLMEDIAELEMENT_PAUSE, "HTMLMediaElement::pause(%" PRIX64 ")", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_PAUSEINTERNAL, "HTMLMediaElement::pauseInternal(%" PRIX64 ")", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_PREPAREFORLOAD, "HTMLMediaElement::prepareForLoad(%" PRIX64 ") gesture = %d", (uint64_t, int), DEFAULT, Media
-HTMLMEDIAELEMENT_REMOVEAUDIOTRACK, "HTMLMediaElement::removeAudioTrack(%" PRIX64 ") id: %{public}s, %{public}s", (uint64_t, CString, CString), DEFAULT, Media
-HTMLMEDIAELEMENT_SCENEIDENTIFIERDIDCHANGE, "HTMLMediaElement::sceneIdentifierDidChange(%" PRIX64 ") %{public}s", (uint64_t, CString), DEFAULT, Media
+HTMLMEDIAELEMENT_REMOVEAUDIOTRACK, "HTMLMediaElement::removeAudioTrack(%" PRIX64 ") id: %" PUBLIC_LOG_STRING ", %" PUBLIC_LOG_STRING "", (uint64_t, CString, CString), DEFAULT, Media
+HTMLMEDIAELEMENT_SCENEIDENTIFIERDIDCHANGE, "HTMLMediaElement::sceneIdentifierDidChange(%" PRIX64 ") %" PUBLIC_LOG_STRING "", (uint64_t, CString), DEFAULT, Media
 HTMLMEDIAELEMENT_SCHEDULECONFIGURETEXTTRACKS_TASK_SCHEDULED, "HTMLMediaElement::scheduleConfigureTextTracks(%" PRIX64 ") task scheduled", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_SCHEDULECONFIGURETEXTTRACKS_LAMBDA_TASK_FIRED, "HTMLMediaElement::scheduleConfigureTextTracks(%" PRIX64 ") lambda(), task fired", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_SCHEDULEMEDIAENGINEWASUPDATED_TASK_SCHEDULED, "HTMLMediaElement::scheduleMediaEngineWasUpdated(%" PRIX64 ") task scheduled", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_SCHEDULEMEDIAENGINEWASUPDATED_LAMBDA_TASK_FIRED, "HTMLMediaElement::scheduleMediaEngineWasUpdated(%" PRIX64 ") lambda(), task fired", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_SEEKINTERNAL, "HTMLMediaElement::seekInternal(%" PRIX64 ") %f", (uint64_t, double), DEFAULT, Media
-HTMLMEDIAELEMENT_SEEKWITHTOLERANCE, "HTMLMediaElement::seekWithTolerance(%" PRIX64 ") SeekTarget = %{public}s", (uint64_t, CString), DEFAULT, Media
+HTMLMEDIAELEMENT_SEEKWITHTOLERANCE, "HTMLMediaElement::seekWithTolerance(%" PRIX64 ") SeekTarget = %" PUBLIC_LOG_STRING "", (uint64_t, CString), DEFAULT, Media
 HTMLMEDIAELEMENT_SELECTMEDIARESOURCE_LAMBDA_TASK_FIRED, "HTMLMediaElement::selectMediaResource(%" PRIX64 ") lambda(), task fired", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_SELECTMEDIARESOURCE_NOTHING_TO_LOAD, "HTMLMediaElement::selectMediaResource(%" PRIX64 ") nothing to load", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_SELECTMEDIARESOURCE_HAS_SRCATTR_PLAYER_NOT_CREATED, "HTMLMediaElement::selectMediaResource(%" PRIX64 ") has srcAttr but m_player is not created", (uint64_t), DEFAULT, Media
@@ -143,11 +143,11 @@ HTMLMEDIAELEMENT_SELECTMEDIARESOURCE_ATTEMPTING_USE_OF_UNATTACHED_MEDIASOURCEHAN
 HTMLMEDIAELEMENT_SELECTMEDIARESOURCE_USING_SRCOBJECT_PROPERTY, "HTMLMediaElement::selectMediaResource(%" PRIX64 ") using 'srcObject' property", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_SELECTMEDIARESOURCE_USING_SRC_ATTRIBUTE_URL, "HTMLMediaElement::selectMediaResource(%" PRIX64 ") using 'src' attribute url", (uint64_t), DEFAULT, Media
 HTMLMEDIAELEMENT_SELECTMEDIARESOURCE_EMPTY_SRC, "HTMLMediaElement::selectMediaResource(%" PRIX64 ") empty 'src'", (uint64_t), DEFAULT, Media
-HTMLMEDIAELEMENT_SETAUTOPLAYEVENTPLAYBACKSTATE, "HTMLMediaElement::setAutoplayEventPlaybackState(%" PRIX64 ") %{public}s", (uint64_t, CString), DEFAULT, Media
+HTMLMEDIAELEMENT_SETAUTOPLAYEVENTPLAYBACKSTATE, "HTMLMediaElement::setAutoplayEventPlaybackState(%" PRIX64 ") %" PUBLIC_LOG_STRING "", (uint64_t, CString), DEFAULT, Media
 HTMLMEDIAELEMENT_SETMUTEDINTERNAL, "HTMLMediaElement::setMutedInternal(%" PRIX64 ") %d", (uint64_t, int), DEFAULT, Media
-HTMLMEDIAELEMENT_SETNETWORKSTATE, "HTMLMediaElement::setNetworkState(%" PRIX64 ") new state = %{public}s, current state = %{public}s", (uint64_t, CString, CString), DEFAULT, Media
+HTMLMEDIAELEMENT_SETNETWORKSTATE, "HTMLMediaElement::setNetworkState(%" PRIX64 ") new state = %" PUBLIC_LOG_STRING ", current state = %" PUBLIC_LOG_STRING "", (uint64_t, CString, CString), DEFAULT, Media
 HTMLMEDIAELEMENT_SETPLAYBACKRATE, "HTMLMediaElement::setPlaybackRate(%" PRIX64 ") %f", (uint64_t, double), DEFAULT, Media
-HTMLMEDIAELEMENT_SETREADYSTATE, "HTMLMediaElement::setReadyState(%" PRIX64 ") new state = %{public}s, current state = %{public}s, tracks ready = %d", (uint64_t, CString, CString, bool), DEFAULT, Media
+HTMLMEDIAELEMENT_SETREADYSTATE, "HTMLMediaElement::setReadyState(%" PRIX64 ") new state = %" PUBLIC_LOG_STRING ", current state = %" PUBLIC_LOG_STRING ", tracks ready = %d", (uint64_t, CString, CString, bool), DEFAULT, Media
 HTMLMEDIAELEMENT_SETSHOWPOSTERFLAG, "HTMLMediaElement::setShowPosterFlag(%" PRIX64 ") %d", (uint64_t, int), DEFAULT, Media
 HTMLMEDIAELEMENT_SETVOLUME, "HTMLMediaElement::setVolume(%" PRIX64 ") %f", (uint64_t, double), DEFAULT, Media
 
@@ -155,36 +155,36 @@ HTMLVIDEOELEMENT_MEDIAPLAYERRENDERINGMODECHANGED, "HTMLVideoElement::mediaPlayer
 HTMLVIDEOELEMENT_MEDIAPLAYERFIRSTVIDEOFRAMEAVAILABLE, "HTMLVideoElement::mediaPlayerFirstVideoFrameAvailable(%" PRIX64 ") m_showPoster = %d", (uint64_t, int), DEFAULT, Media
 HTMLVIDEOELEMENT_SCHEDULERESIZEEVENT, "HTMLMediaElement::scheduleResizeEvent(%" PRIX64 ") width: %f height: %f", (uint64_t, float, float), DEFAULT, Media
 
-PERFORMANCELOGGING_MEMORY_USAGE_INFO, "Memory usage info dump at %{public}s:", (CString), DEFAULT, PerformanceLogging
-PERFORMANCELOGGING_MEMORY_USAGE_FOR_KEY, "  %{public}s: %" PRIu64, (CString, uint64_t), DEFAULT, PerformanceLogging
+PERFORMANCELOGGING_MEMORY_USAGE_INFO, "Memory usage info dump at %" PUBLIC_LOG_STRING ":", (CString), DEFAULT, PerformanceLogging
+PERFORMANCELOGGING_MEMORY_USAGE_FOR_KEY, "  %" PUBLIC_LOG_STRING ": %" PRIu64, (CString, uint64_t), DEFAULT, PerformanceLogging
 
 PERFORMANCEMONITOR_MEASURE_POSTLOAD_CPUUSAGE, "PerformanceMonitor::measurePostLoadCPUUsage: Process was using %.1f%% CPU after the page load.", (double), DEFAULT, PerformanceLogging
 PERFORMANCEMONITOR_MEASURE_POSTLOAD_MEMORYUSAGE, "PerformanceMonitor::measurePostLoadMemoryUsage: Process was using %" PRIu64 " bytes of memory after the page load.", (uint64_t), DEFAULT, PerformanceLogging
 PERFORMANCEMONITOR_MEASURE_POSTBACKGROUND_MEMORYUSAGE, "PerformanceMonitor:measurePostBackgroundingMemoryUsage: Process was using %" PRIu64 " bytes of memory after becoming non visible.", (uint64_t), DEFAULT, PerformanceLogging
 PERFORMANCEMONITOR_MEASURE_POSTBACKGROUND_CPUUSAGE, "PerformanceMonitor::measurePostBackgroundingCPUUsage: Process was using %.1f%% CPU after becoming non visible.", (double), DEFAULT, PerformanceLogging
-PERFORMANCEMONITOR_MEASURE_CPUUSAGE_IN_ACTIVITYSTATE, "PerformanceMonitor::measureCPUUsageInActivityState: Process is using %.1f%% CPU in state: %{public}s", (double, CString), DEFAULT, PerformanceLogging
+PERFORMANCEMONITOR_MEASURE_CPUUSAGE_IN_ACTIVITYSTATE, "PerformanceMonitor::measureCPUUsageInActivityState: Process is using %.1f%% CPU in state: %" PUBLIC_LOG_STRING "", (double, CString), DEFAULT, PerformanceLogging
 
 POLICYCHECKER_CHECKNAVIGATIONPOLICY_CONTINUE_LOAD_IN_ANOTHER_PROCESS, "[pageID=%" PRIu64 ", frameID=%" PRIu64 "] PolicyChecker::checkNavigationPolicy: stopping because policyAction from dispatchDecidePolicyForNavigationAction is LoadWillContinueInAnotherProcess", (uint64_t, uint64_t), DEFAULT, Loading
 POLICYCHECKER_CHECKNAVIGATIONPOLICY_CONTINUE_INITIAL_EMPTY_DOCUMENT, "[pageID=%" PRIu64 ", frameID=%" PRIu64 "] PolicyChecker::checkNavigationPolicy: continuing because this is an initial empty document", (uint64_t, uint64_t), DEFAULT, Loading
 POLICYCHECKER_CHECKNAVIGATIONPOLICY_CONTINUE_POLICYACTION_IS_USE, "[pageID=%" PRIu64 ", frameID=%" PRIu64 "] PolicyChecker::checkNavigationPolicy: continuing because this policyAction from dispatchDecidePolicyForNavigationAction is Use", (uint64_t, uint64_t), DEFAULT, Loading
 
-LIBWEBRTCMEDIAENDPOINT_ONSTATSDELIVERED, "RTCStats (%" PRIu64 ") %{public}s", (uint64_t, CString), DEFAULT, WebRTCStats
-LIBWEBRTC_LOG_ERROR, "LibWebRTC error: %{public}s", (CString), DEFAULT, WebRTC
-LIBWEBRTC_LOG_MESSAGE, "LibWebRTC message: %{public}s", (CString), DEFAULT, WebRTC
+LIBWEBRTCMEDIAENDPOINT_ONSTATSDELIVERED, "RTCStats (%" PRIu64 ") %" PUBLIC_LOG_STRING "", (uint64_t, CString), DEFAULT, WebRTCStats
+LIBWEBRTC_LOG_ERROR, "LibWebRTC error: %" PUBLIC_LOG_STRING "", (CString), DEFAULT, WebRTC
+LIBWEBRTC_LOG_MESSAGE, "LibWebRTC message: %" PUBLIC_LOG_STRING "", (CString), DEFAULT, WebRTC
 
 LOCALFRAMEVIEW_FIRING_FIRST_VISUALLY_NON_EMPTY_LAYOUT_MILESTONE, "[pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] LocalFrameView::fireLayoutRelatedMilestonesIfNeeded: Firing first visually non-empty layout milestone on the main frame", (uint64_t, uint64_t, int), DEFAULT, Layout
 LOCALFRAMEVIEW_FIRING_RESIZE_EVENTS_DISABLED_FOR_PAGE, "[pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] LocalFrameView::scheduleResizeEventIfNeeded: Not firing resize events because they are temporarily disabled for this page", (uint64_t, uint64_t, int), DEFAULT, Events
 LOCALFRAMEVIEW_NOT_PAINTING_LAYOUT_NEEDED, "    [pageID=%" PRIu64 ", frameID=%" PRIu64 ", isMainFrame=%d] LocalFrameView::paintContents: Not painting because render tree needs layout", (uint64_t, uint64_t, int), DEFAULT, Layout
 
-PEERCONNECTIONBACKEND_CREATEOFFERSUCCEEDED, "PeerConnectionBackend::createOfferSucceeded (%" PRIu64 ") to: '%{public}s'", (uint64_t, CString), DEFAULT, WebRTC
-PEERCONNECTIONBACKEND_CREATEANSWERSUCCEEDED, "PeerConnectionBackend::createAnswerSucceeded (%" PRIu64 ") to: '%{public}s'", (uint64_t, CString), DEFAULT, WebRTC
+PEERCONNECTIONBACKEND_CREATEOFFERSUCCEEDED, "PeerConnectionBackend::createOfferSucceeded (%" PRIu64 ") to: '%" PUBLIC_LOG_STRING "'", (uint64_t, CString), DEFAULT, WebRTC
+PEERCONNECTIONBACKEND_CREATEANSWERSUCCEEDED, "PeerConnectionBackend::createAnswerSucceeded (%" PRIu64 ") to: '%" PUBLIC_LOG_STRING "'", (uint64_t, CString), DEFAULT, WebRTC
 
-RTCPEERCONNECTION_SETLOCALDESCRIPTION, "RTCPeerConnection::setLocalDescription (%" PRIu64 ") to: '%{public}s'", (uint64_t, CString), DEFAULT, WebRTC
-RTCPEERCONNECTION_SETREMOTEDESCRIPTION, "RTCPeerConnection::setRemoteDescription (%" PRIu64 ") to: '%{public}s'", (uint64_t, CString), DEFAULT, WebRTC
+RTCPEERCONNECTION_SETLOCALDESCRIPTION, "RTCPeerConnection::setLocalDescription (%" PRIu64 ") to: '%" PUBLIC_LOG_STRING "'", (uint64_t, CString), DEFAULT, WebRTC
+RTCPEERCONNECTION_SETREMOTEDESCRIPTION, "RTCPeerConnection::setRemoteDescription (%" PRIu64 ") to: '%" PUBLIC_LOG_STRING "'", (uint64_t, CString), DEFAULT, WebRTC
 
 SERVICEWORKERTHREADPROXY_REMOVEFETCH, "ServiceWorkerThreadProxy::removeFetch %" PRIu64, (uint64_t), DEFAULT, ServiceWorker
 
 FONTCACHECORETEXT_REGISTER_FONT, "Registering font %" PRIVATE_LOG_STRING " with fontURL %" PRIVATE_LOG_STRING, (CString, CString), DEFAULT, Fonts
-FONTCACHECORETEXT_REGISTER_ERROR, "Could not register font %" PRIVATE_LOG_STRING ", error %" PUBLIC_LOG_STRING, (CString, CString), DEFAULT, Fonts
+FONTCACHECORETEXT_REGISTER_ERROR, "Could not register font %" PRIVATE_LOG_STRING ", error %" PUBLIC_LOG_STRING "", (CString, CString), DEFAULT, Fonts
 
 WEBCORE_TEST_LOG, "WebCore log message for testing (%u)", (unsigned), DEFAULT, Testing


### PR DESCRIPTION
#### bbae6b54aba58e4b8ec999a89a1ca1eba98af678
<pre>
[WPE][GTK] Setting WEBKIT_DEBUG=Media triggers WebProcess crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=310020">https://bugs.webkit.org/show_bug.cgi?id=310020</a>

Reviewed by Adrian Perez de Castro.

The %{public}s format specifier is not cross-platform, PUBLIC_LOG_STRING should be used instead.

* Source/WebCore/platform/LogMessages.in:

Canonical link: <a href="https://commits.webkit.org/309330@main">https://commits.webkit.org/309330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09b669ab8e9d2ef6bf7460bb665ffc618e8ae33f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159045 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23221 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115986 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96718 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17196 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15140 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6889 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126811 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/12785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161519 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4646 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123988 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19187 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124192 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33714 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22877 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134580 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79257 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19314 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11337 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22491 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86290 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22204 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22258 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->