### PR TITLE
[Feature Request] Support HTMLVideoElement.getVideoPlaybackQuality() for MediaStream playback

### DIFF
--- a/LayoutTests/fast/mediastream/getUserMedia-and-getVideoPlaybackQuality-expected.txt
+++ b/LayoutTests/fast/mediastream/getUserMedia-and-getVideoPlaybackQuality-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Check MediaStream backed HTMLVideoElement.getVideoPlaybackQuality
+

--- a/LayoutTests/fast/mediastream/getUserMedia-and-getVideoPlaybackQuality.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-and-getVideoPlaybackQuality.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <script src="../../resources/testharness.js"></script>
+        <script src="../../resources/testharnessreport.js"></script>
+    </head>
+    <body>
+        <video id=video1 autoplay playsInline width=100px></video>
+        <video id=video2 autoplay playsInline width=100px></video>
+        <script>
+promise_test(async test => {
+    const stream1 = await navigator.mediaDevices.getUserMedia({ video: { width:640, height:480, frameRate : 30 } });
+    const stream2 = stream1.clone();
+    test.add_cleanup(() => stream1.getTracks().forEach(track => track.stop()));
+    test.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
+
+    await stream2.getVideoTracks()[0].applyConstraints({ frameRate : 1 });
+
+    video1.srcObject = stream1;
+    video2.srcObject = stream2;
+
+    await video1.play();
+    await video2.play();
+
+    const metrics1 = video1.getVideoPlaybackQuality();
+    const metrics2 = video2.getVideoPlaybackQuality();
+
+    await new Promise(resolve => setTimeout(resolve, 2000));
+
+    const metrics3 = video1.getVideoPlaybackQuality();
+    const metrics4 = video2.getVideoPlaybackQuality();
+
+    assert_greater_than(metrics3.totalVideoFrames, 0, "test2");
+    assert_greater_than(metrics4.totalVideoFrames, 0, "test3");
+
+    assert_greater_than(metrics3.totalVideoFrames, metrics1.totalVideoFrames, "test4");
+    assert_greater_than(metrics3.totalVideoFrames, metrics4.totalVideoFrames, "test5");
+
+    assert_greater_than(metrics4.totalVideoFrames, metrics4.droppedVideoFrames, "test6");
+    assert_greater_than(metrics3.totalVideoFrames, metrics3.droppedVideoFrames, "test7");
+
+    assert_greater_than(metrics3.totalVideoFrames - metrics1.totalVideoFrames, metrics4.totalVideoFrames - metrics2.totalVideoFrames, "test8");
+}, "Check MediaStream backed HTMLVideoElement.getVideoPlaybackQuality");
+        </script>
+    </body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2269,6 +2269,8 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-img-element/
 fast/mediastream/camera-powerEfficient-track.html [ Failure ]
 fast/mediastream/multi-microphone.html [ Skip ]
 
+fast/mediastream/getUserMedia-and-getVideoPlaybackQuality.html [ Skip ]
+
 webkit.org/b/208182 fast/repaint/backgroundSizeRepaint.html [ ImageOnlyFailure Pass ]
 
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
@@ -50,6 +50,7 @@ class SampleBufferDisplayLayerClient : public AbstractRefCountedAndCanMakeWeakPt
 public:
     virtual ~SampleBufferDisplayLayerClient() = default;
     virtual void sampleBufferDisplayLayerStatusDidFail() = 0;
+    virtual void updateVideoFrameCounters(uint64_t, uint64_t) = 0;
 #if PLATFORM(IOS_FAMILY)
     virtual bool canShowWhileLocked() const = 0;
 #endif

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.h
@@ -116,6 +116,7 @@ private:
 
     bool m_paused { false };
     bool m_didFail { false };
+    Seconds m_lastMetricsSampleTime WTF_GUARDED_BY_CAPABILITY(workQueue());
 #if !RELEASE_LOG_DISABLED
     uint64_t m_logIdentifier;
     FrameRateMonitor m_frameRateMonitor WTF_GUARDED_BY_CAPABILITY(workQueue());

--- a/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/LocalSampleBufferDisplayLayer.mm
@@ -427,6 +427,27 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     }
     m_frameRateMonitor.update();
 #endif
+
+    auto gatherSampleVideoMetricsIfNeeded = [&] -> RetainPtr<AVVideoPerformanceMetrics> {
+        assertIsCurrent(workQueue());
+
+        auto currentTime = MonotonicTime::now().secondsSinceEpoch();
+        const Seconds maximumPlaybackQualityMetricsSampleTimeDelta = 0.25_s;
+        if (currentTime < m_lastMetricsSampleTime + maximumPlaybackQualityMetricsSampleTimeDelta)
+            return nullptr;
+
+        m_lastMetricsSampleTime = currentTime;
+        return [m_sampleBufferDisplayLayer videoPerformanceMetrics];
+    };
+
+    RetainPtr metrics = gatherSampleVideoMetricsIfNeeded();
+    if (!metrics)
+        return;
+
+    callOnMainThread([client = m_client, totalVideoFrames = metrics.get().totalNumberOfVideoFrames, droppedVideoFrames = metrics.get().numberOfDroppedVideoFrames] {
+        if (RefPtr protectedClient = client.get())
+            protectedClient->updateVideoFrameCounters(totalVideoFrames, droppedVideoFrames);
+    });
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -179,6 +179,7 @@ private:
     void setResourceOwner(const ProcessIdentity&) final { ASSERT_NOT_REACHED(); }
     void renderVideoWillBeDestroyed() final { destroyLayers(); }
     void setShouldMaintainAspectRatio(bool) final;
+    std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() final;
 
     MediaPlayer::ReadyState currentReadyState();
     void updateReadyState();
@@ -292,6 +293,7 @@ private:
 
     // SampleBufferDisplayLayerClient
     void sampleBufferDisplayLayerStatusDidFail() final;
+    void updateVideoFrameCounters(uint64_t, uint64_t) final;
 #if PLATFORM(IOS_FAMILY)
     bool canShowWhileLocked() const final;
 #endif
@@ -317,6 +319,9 @@ private:
     uint64_t m_lastVideoFrameMetadataSampleCount { 0 };
     Seconds m_presentationTime { 0 };
     VideoFrameTimeMetadata m_sampleMetadata;
+
+    uint64_t m_totalFrameCount { 0 };
+    uint64_t m_droppedFrameCount { 0 };
 
     std::optional<CGRect> m_storedBounds;
     static NativeImageCreator m_nativeImageCreator;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -362,6 +362,20 @@ void MediaPlayerPrivateMediaStreamAVFObjC::sampleBufferDisplayLayerStatusDidFail
     updateLayersAsNeeded();
 }
 
+void MediaPlayerPrivateMediaStreamAVFObjC::updateVideoFrameCounters(uint64_t totalFrameCount, uint64_t droppedFrameCount)
+{
+    m_totalFrameCount = totalFrameCount;
+    m_droppedFrameCount = droppedFrameCount;
+}
+
+std::optional<VideoPlaybackQualityMetrics> MediaPlayerPrivateMediaStreamAVFObjC::videoPlaybackQualityMetrics()
+{
+    return VideoPlaybackQualityMetrics {
+        .totalVideoFrames = static_cast<uint32_t>(m_totalFrameCount),
+        .droppedVideoFrames = static_cast<uint32_t>(m_droppedFrameCount)
+    };
+}
+
 #if PLATFORM(IOS_FAMILY)
 bool MediaPlayerPrivateMediaStreamAVFObjC::canShowWhileLocked() const
 {

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -96,6 +96,7 @@ private:
 
     // WebCore::SampleBufferDisplayLayerClient
     void sampleBufferDisplayLayerStatusDidFail() final;
+    void updateVideoFrameCounters(uint64_t, uint64_t) final;
 #if PLATFORM(IOS_FAMILY)
     bool canShowWhileLocked() const final { return false; }
 #endif

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm
@@ -172,6 +172,11 @@ void RemoteSampleBufferDisplayLayer::sampleBufferDisplayLayerStatusDidFail()
     send(Messages::SampleBufferDisplayLayer::SetDidFail { protect(m_sampleBufferDisplayLayer)->didFail() });
 }
 
+void RemoteSampleBufferDisplayLayer::updateVideoFrameCounters(uint64_t totalFrameCount, uint64_t droppedFrameCount)
+{
+    send(Messages::SampleBufferDisplayLayer::UpdateVideoFrameCounters { totalFrameCount,  droppedFrameCount });
+}
+
 void RemoteSampleBufferDisplayLayer::setSharedVideoFrameSemaphore(IPC::Semaphore&& semaphore)
 {
     m_sharedVideoFrameReader.setSemaphore(WTF::move(semaphore));

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
@@ -163,6 +163,12 @@ void SampleBufferDisplayLayer::setDidFail(bool value)
         client->sampleBufferDisplayLayerStatusDidFail();
 }
 
+void SampleBufferDisplayLayer::updateVideoFrameCounters(uint64_t totalVideoFrames, uint64_t droppedVideoFrames)
+{
+    if (RefPtr client = m_client.get())
+        client->updateVideoFrameCounters(totalVideoFrames, droppedVideoFrames);
+}
+
 void SampleBufferDisplayLayer::gpuProcessConnectionDidClose(GPUProcessConnection&)
 {
     m_sharedVideoFrameWriter.disable();

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
@@ -79,6 +79,7 @@ private:
     void gpuProcessConnectionDidClose(GPUProcessConnection&) final;
 
     void setDidFail(bool);
+    void updateVideoFrameCounters(uint64_t, uint64_t);
 
     ThreadSafeWeakPtr<GPUProcessConnection> m_gpuProcessConnection;
     WeakPtr<SampleBufferDisplayLayerManager> m_manager;
@@ -90,6 +91,8 @@ private:
 
     SharedVideoFrameWriter m_sharedVideoFrameWriter;
     std::optional<WebCore::HostingContext> m_hostingContext;
+    uint64_t m_totalVideoFrames { 0 };
+    uint64_t m_droppedVideoFrames { 0 };
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.messages.in
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.messages.in
@@ -29,6 +29,7 @@
 ]
 messages -> SampleBufferDisplayLayer {
     SetDidFail(bool value)
+    UpdateVideoFrameCounters(uint64_t totalVideoFrames, uint64_t droppedVideoFrames)
 }
 
 #endif


### PR DESCRIPTION
#### 758ff5958ae22e5f17f2a6262f169e3276e50e01
<pre>
[Feature Request] Support HTMLVideoElement.getVideoPlaybackQuality() for MediaStream playback
<a href="https://rdar.apple.com/172649550">rdar://172649550</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310007">https://bugs.webkit.org/show_bug.cgi?id=310007</a>

Reviewed by Eric Carlson.

We implement MediaPlayerPrivateMediaStreamAVFObjC::videoPlaybackQualityMetrics by implementing counter gathering in SampleBufferDisplayLayer.
Everytime we enqueue a sample in LocalSampleBufferDisplayLayer::enqueueBufferInternal, we check the AVSBDL metrics and call the SampleBufferDisplayLayerClient callback if metrics have changed.
We send this information to WebProcess via IPC.
We limit video metrics sampling to every 0.25seconds for perf reasons.

Covered by added test.

Canonical link: <a href="https://commits.webkit.org/309540@main">https://commits.webkit.org/309540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5a77d53c7079e798ee22df8cace3e7ab264880f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104230 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/297ebfe6-d34f-40ba-85f0-81e6c6beae5c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152669 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23760 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116392 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82644 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8bcb25fc-fbfb-4597-9199-db171f486787) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153756 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97120 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f663dd1-ef77-4490-9c41-0d12e9bba772) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17602 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15549 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7366 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127216 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161993 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14768 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124394 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23358 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19596 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124590 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33851 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23347 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135006 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79733 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19660 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11768 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22958 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86758 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22670 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22822 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22724 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->