### PR TITLE
Enhanced <select>: make appearance change detection actually work

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -658,9 +658,7 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-starting-style.html [ Skip ]
 
 # Untriaged.
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-switching-invalidation.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-restore.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance.html [ Skip ]
 
 # List boxes/<select multiple>.
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select-listbox/ [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-disabled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-disabled-expected.txt
@@ -1,4 +1,4 @@
-
+  button
 
 PASS defaultbutton: <select disabled> should prevent focus and activation with appearance:base-select.
 PASS custombutton: <select disabled> should prevent focus and activation with appearance:base-select.

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance-expected.txt
@@ -7,10 +7,10 @@ option three
 PASS Basic functionality of select picker and appearance
 PASS Basic functionality of select picker with appearance:auto
 PASS Basic functionality of select picker with appearance:none
-FAIL Switching appearance in :open should close the picker assert_false: Switching appearance in :open should re-close the picker expected false got true
-FAIL Switching appearance in JS after picker is open should close the picker assert_false: changing appearance while the picker is open should close it expected false got true
+PASS Switching appearance in :open should close the picker
+PASS Switching appearance in JS after picker is open should close the picker
 PASS Test of the test harness
 PASS The select picker is closed if the <select> appearance value is changed via CSS while the picker is open
-FAIL The select picker is closed if the ::picker() appearance value is changed via CSS while the picker is open assert_false: picker should get closed when the appearance value changes expected false got true
-FAIL The select picker is closed if the <select> inline appearance value is changed while the picker is open assert_false: setup expected false got true
+PASS The select picker is closed if the ::picker() appearance value is changed via CSS while the picker is open
+PASS The select picker is closed if the <select> inline appearance value is changed while the picker is open
 

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -42,6 +42,7 @@
 #include "ElementChildIteratorInlines.h"
 #include "ElementTraversal.h"
 #include "EventHandler.h"
+#include "EventLoop.h"
 #include "EventNames.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FormController.h"
@@ -214,6 +215,11 @@ HTMLSelectElement* HTMLSelectElement::findOwnerSelect(ContainerNode* startNode, 
     return findOwnerSelect(startNode->parentNode(), excludeOptGroup);
 }
 
+static bool hasBaseAppearance(const RenderStyle* style)
+{
+    return style && style->usedAppearance() == StyleAppearance::Base;
+}
+
 void HTMLSelectElement::didRecalcStyle(OptionSet<Style::Change> styleChange)
 {
     // Even though the options didn't necessarily change, we will call setOptionsChangedOnRenderer for its side effect
@@ -228,6 +234,11 @@ void HTMLSelectElement::didRecalcStyle(OptionSet<Style::Change> styleChange)
                 fallbackButton->invalidateStyle();
         }
     }
+
+    bool newIsBaseAppearance = hasBaseAppearance(existingComputedStyle());
+    if (m_wasBaseAppearance && !newIsBaseAppearance && m_popupIsVisible)
+        queuePickerCloseForAppearanceChange();
+    m_wasBaseAppearance = newIsBaseAppearance;
 
     HTMLFormControlElement::didRecalcStyle(styleChange);
 }
@@ -361,6 +372,18 @@ void HTMLSelectElement::hidePickerPopoverElement()
 
     setPopupIsVisible(false);
     popover->hidePopover();
+}
+
+void HTMLSelectElement::queuePickerCloseForAppearanceChange()
+{
+    protect(protect(document())->eventLoop())->queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
+        RefPtr select = weakThis.get();
+        if (!select)
+            return;
+        protect(select->document())->addConsoleMessage(MessageSource::Other, MessageLevel::Warning,
+            "The select element's appearance property changed while its picker was open. The picker has been closed."_s);
+        select->hidePickerPopoverElement();
+    });
 }
 
 static inline auto navigationKeyIdentifiersForWritingMode(const RenderElement* renderer) -> HTMLSelectElement::NavigationKeyIdentifiers
@@ -553,7 +576,7 @@ bool HTMLSelectElement::isMouseFocusable() const
 RenderPtr<RenderElement> HTMLSelectElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& position)
 {
     if (usesMenuList()) {
-        if (style.usedAppearance() == StyleAppearance::Base)
+        if (hasBaseAppearance(&style))
             return HTMLElement::createElementRenderer(WTF::move(style), position);
         return createRenderer<RenderMenuList>(*this, WTF::move(style));
     }
@@ -572,6 +595,19 @@ bool HTMLSelectElement::childShouldCreateRenderer(const Node& child) const
         return true;
     if (child.isBeforePseudoElement() || child.isAfterPseudoElement())
         return true;
+    // When the first-child author button has display:contents, its descendant nodes become
+    // rendering children of the select. Allow those through based on the select's own
+    // appearance rather than usesBaseAppearancePicker(), because during render tree updates
+    // the popover may not have its updated style yet (it comes after the button slot in the
+    // composed tree).
+    if (hasBaseAppearance(existingComputedStyle())) {
+        for (auto* ancestor = child.parentElement(); ancestor && ancestor != this; ancestor = ancestor->parentElement()) {
+            if (isFirstElementChildButton(*ancestor))
+                return true;
+            if (!ancestor->hasDisplayContents())
+                break;
+        }
+    }
     if (usesBaseAppearancePicker())
         return true;
     return validationMessageShadowTreeContains(child);
@@ -1442,6 +1478,23 @@ bool HTMLSelectElement::platformHandleKeydownEvent(KeyboardEvent* event)
 
 #endif
 
+static bool isClickInsidePopover(SelectPopoverElement* popover, Event& event)
+{
+    if (!popover)
+        return false;
+    RefPtr targetNode = dynamicDowncast<Node>(event.target());
+    if (!targetNode)
+        return false;
+    RefPtr select = popover->selectElement();
+    for (RefPtr element = dynamicDowncast<Element>(targetNode); element; element = element->parentElementInComposedTree()) {
+        if (element == popover)
+            return true;
+        if (element == select)
+            return false;
+    }
+    return false;
+}
+
 void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
 {
     ASSERT(renderer());
@@ -1568,24 +1621,13 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
             event.setDefaultHandled();
             return;
         }
-        ASSERT(usesBaseAppearancePicker() || !m_popupIsVisible);
         if (m_popupIsVisible) {
-            bool clickedInsidePopover = [&] {
-                RefPtr popover = m_popover;
-                if (!popover)
-                    return false;
-                RefPtr targetNode = dynamicDowncast<Node>(event.target());
-                if (!targetNode)
-                    return false;
-                for (RefPtr element = dynamicDowncast<Element>(targetNode); element; element = element->parentElementInComposedTree()) {
-                    if (element == popover)
-                        return true;
-                    if (element == this)
-                        return false;
-                }
-                return false;
-            }();
-            if (!clickedInsidePopover)
+            if (!usesBaseAppearancePicker()) {
+#if !PLATFORM(IOS_FAMILY)
+                hidePopup();
+#endif
+                hidePickerPopoverElement();
+            } else if (!isClickInsidePopover(protect(m_popover), event))
                 hidePickerPopoverElement();
         } else
             openPickerForUserInteraction(false);
@@ -2038,6 +2080,14 @@ void HTMLSelectElement::openPickerForUserInteraction(std::optional<bool> focusVi
         return;
 
     protect(document())->updateStyleIfNeeded();
+
+    // If the appearance changed due to :open (e.g., a rule switching appearance away from
+    // base-select), close the picker.
+    if (!usesBaseAppearancePicker()) {
+        hidePickerPopoverElement();
+        return;
+    }
+
     int listIndex = optionToListIndex(selectedIndex());
     if (listIndex < 0)
         listIndex = firstSelectableListIndex();
@@ -2081,7 +2131,17 @@ ExceptionOr<void> HTMLSelectElement::showPicker()
     if (!window || !window->consumeTransientActivation())
         return Exception { ExceptionCode::NotAllowedError, "Select showPicker() requires a user gesture."_s };
 
+    protect(document())->updateStyleIfNeeded();
+    bool openedBaseAppearancePicker = usesBaseAppearancePicker();
     showPickerInternal(); // showPickerInternal() may run JS and cause the renderer to get destroyed.
+
+    // Resolve styles with :open now matching. If the appearance changed (e.g., due to a
+    // :open rule switching appearance away from base-select), close the picker immediately.
+    if (openedBaseAppearancePicker && m_popupIsVisible) {
+        protect(document())->updateStyleIfNeeded();
+        if (!usesBaseAppearancePicker())
+            hidePickerPopoverElement();
+    }
 
     return { };
 }

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -187,6 +187,7 @@ public:
     WEBCORE_EXPORT bool usesBaseAppearancePicker() const;
     SelectPopoverElement* NODELETE pickerPopoverElement() const;
     void hidePickerPopoverElement();
+    void queuePickerCloseForAppearanceChange();
 
     struct NavigationKeyIdentifiers {
         ASCIILiteral next;
@@ -313,6 +314,7 @@ private:
     RefPtr<PopupMenu> m_popup;
 #endif
     bool m_popupIsVisible { false };
+    bool m_wasBaseAppearance { false };
 };
 
 } // namespace

--- a/Source/WebCore/html/shadow/SelectPopoverElement.cpp
+++ b/Source/WebCore/html/shadow/SelectPopoverElement.cpp
@@ -27,11 +27,9 @@
 #include "SelectPopoverElement.h"
 
 #include "Document.h"
-#include "EventLoop.h"
 #include "HTMLSelectElement.h"
 #include "RenderStyle.h"
 #include "ShadowRoot.h"
-#include <JavaScriptCore/ConsoleTypes.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -44,7 +42,7 @@ Ref<SelectPopoverElement> SelectPopoverElement::create(Document& document)
 }
 
 SelectPopoverElement::SelectPopoverElement(Document& document)
-    : HTMLDivElement(document)
+    : HTMLDivElement(document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 
@@ -56,37 +54,19 @@ HTMLSelectElement* SelectPopoverElement::selectElement() const
     return dynamicDowncast<HTMLSelectElement>(shadowRoot->host());
 }
 
-void SelectPopoverElement::didRecalcStyle(OptionSet<Style::Change> change)
+void SelectPopoverElement::didAttachRenderers()
 {
-    HTMLDivElement::didRecalcStyle(change);
+    HTMLDivElement::didAttachRenderers();
 
     CheckedPtr style = computedStyle();
-    if (!style)
-        return;
+    bool newIsAppearanceBase = style && style->usedAppearance() == StyleAppearance::Base;
 
-    auto usedAppearance = style->usedAppearance();
-    bool newIsAppearanceBase = (usedAppearance == StyleAppearance::Base);
-
-    RefPtr select = selectElement();
-    if (!select) {
-        m_isAppearanceBase = newIsAppearanceBase;
-        return;
+    if (m_wasBaseAppearancePicker && !newIsAppearanceBase) {
+        if (RefPtr select = selectElement(); select && select->popupIsVisible())
+            select->queuePickerCloseForAppearanceChange();
     }
 
-#if !PLATFORM(IOS_FAMILY)
-    if (m_isAppearanceBase != newIsAppearanceBase && select->popupIsVisible()) {
-        protect(protect(document())->eventLoop())->queueTask(TaskSource::DOMManipulation, [weakSelect = WeakPtr { select }] {
-            RefPtr select = weakSelect.get();
-            if (!select)
-                return;
-            protect(select->document())->addConsoleMessage(MessageSource::Other, MessageLevel::Warning,
-                "The select element's appearance property changed while its picker was open. The picker has been closed."_s);
-            select->hidePopup();
-        });
-    }
-#endif
-
-    m_isAppearanceBase = newIsAppearanceBase;
+    m_wasBaseAppearancePicker = newIsAppearanceBase;
 }
 
 void SelectPopoverElement::popoverWasHidden()

--- a/Source/WebCore/html/shadow/SelectPopoverElement.h
+++ b/Source/WebCore/html/shadow/SelectPopoverElement.h
@@ -44,10 +44,10 @@ private:
 
     bool isSelectPopoverElement() const final { return true; }
 
-    void didRecalcStyle(OptionSet<Style::Change>) final;
+    void didAttachRenderers() final;
     void popoverWasHidden() final;
 
-    bool m_isAppearanceBase { false };
+    bool m_wasBaseAppearancePicker { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 153d2003e537f9e3f499ce2fcd14d2210f1a1b1e
<pre>
Enhanced &lt;select&gt;: make appearance change detection actually work
<a href="https://bugs.webkit.org/show_bug.cgi?id=310028">https://bugs.webkit.org/show_bug.cgi?id=310028</a>

Reviewed by Ryosuke Niwa.

The old code wasn&apos;t even passing
TypeFlag::HasCustomStyleResolveCallbacks. Now we do, we handle the
equivalent case for the select element itself, it all works across
ports, and we pass the relevant tests.

Canonical link: <a href="https://commits.webkit.org/309684@main">https://commits.webkit.org/309684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c7f5261eed5a3e656f1ab5086c62f385ada91fc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160151 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104857 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78404550-9f45-49d4-8c98-463564a3b6c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153292 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116909 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82990 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/885a4b47-3460-4b73-8bc0-478a9814d538) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/19050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97627 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18141 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/16086 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7995 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127763 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162622 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5755 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124926 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/125109 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33941 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23974 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135574 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80470 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20166 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12344 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23585 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87887 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23295 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23448 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23350 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->