### PR TITLE
[css-animations] animation-fill-mode: forwards not resolved during print

### DIFF
--- a/LayoutTests/printing/animation-fill-forwards-during-print-expected.html
+++ b/LayoutTests/printing/animation-fill-forwards-during-print-expected.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.box {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    margin: 10px;
+    opacity: 1;
+}
+</style>
+<script>
+if (window.testRunner)
+    testRunner.setPrinting();
+</script>
+</head>
+<body>
+<p>You should see two green boxes below when printed.</p>
+<div class="box"></div>
+<div class="box"></div>
+</body>
+</html>

--- a/LayoutTests/printing/animation-fill-forwards-during-print.html
+++ b/LayoutTests/printing/animation-fill-forwards-during-print.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+.animated {
+    opacity: 0;
+    animation: fadeIn 0.01s forwards;
+}
+.box {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+    margin: 10px;
+}
+</style>
+</head>
+<body>
+<p>You should see two green boxes below when printed.</p>
+<div class="box animated" id="box1"></div>
+<div class="box animated" id="box2"></div>
+<script>
+(async function () {
+    window.testRunner?.waitUntilDone();
+    await Promise.all(document.getAnimations().map(animation => animation.finished));
+    window.testRunner?.setPrinting();
+    window.testRunner?.notifyDone();
+})();
+</script>
+</body>
+</html>

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -829,7 +829,7 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
 
     WeakStyleOriginatedAnimations newStyleOriginatedAnimations;
 
-    auto updateAnimations = [&] {
+    auto updateTransitionsAndTimelines = [&] {
         if (document->backForwardCacheState() != Document::NotInBackForwardCache || document->printing())
             return;
 
@@ -849,12 +849,6 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
             CheckedRef styleOriginatedTimelinesController = protect(element->document())->ensureStyleOriginatedTimelinesController();
             styleOriginatedTimelinesController->updateNamedTimelineMapForTimelineScope(resolvedStyle.style->timelineScope(), styleable);
         }
-
-        // The order in which CSS Transitions and CSS Animations are updated matters since CSS Transitions define the after-change style
-        // to use CSS Animations as defined in the previous style change event. As such, we update CSS Animations after CSS Transitions
-        // such that when CSS Transitions are updated the CSS Animations data is the same as during the previous style change event.
-        if ((oldStyle && !oldStyle->animations().isInitial()) || !resolvedStyle.style->animations().isInitial())
-            styleable.updateCSSAnimations(oldStyle, *resolvedStyle.style, resolutionContext, newStyleOriginatedAnimations, isInDisplayNoneTree);
     };
 
     auto applyAnimations = [&]() -> std::pair<std::unique_ptr<RenderStyle>, OptionSet<AnimationImpact>> {
@@ -914,9 +908,18 @@ ElementUpdate TreeResolver::createAnimatedElementUpdate(ResolvedStyle&& resolved
     if (currentStyle && parent().needsUpdateQueryContainerDependentStyle)
         styleable.queryContainerDidChange();
 
-    // First, we need to make sure that any new CSS animation occuring on this element has a matching WebAnimation
-    // on the document timeline.
-    updateAnimations();
+    // First, update CSS Transitions and timelines (skipped when printing or in back/forward cache).
+    updateTransitionsAndTimelines();
+
+    // CSS Animations must be updated even during printing to reflect the current animation state.
+    // FIXME: CSS Transitions and scroll/view-driven animations may also need to be updated during printing.
+    // The order in which CSS Transitions and CSS Animations are updated matters since CSS Transitions define the after-change style
+    // to use CSS Animations as defined in the previous style change event. As such, we update CSS Animations after CSS Transitions
+    // such that when CSS Transitions are updated the CSS Animations data is the same as during the previous style change event.
+    if (document->backForwardCacheState() == Document::NotInBackForwardCache && !skipAnimationForAnchorPosition) {
+        if ((oldStyle && !oldStyle->animations().isInitial()) || !resolvedStyle.style->animations().isInitial())
+            styleable.updateCSSAnimations(oldStyle, *resolvedStyle.style, resolutionContext, newStyleOriginatedAnimations, isInDisplayNoneTree);
+    }
 
     // Now we can update all Web animations, which will include CSS Animations as well
     // as animations created via the JS API.


### PR DESCRIPTION
#### 06f70dafd01fd79db39f2ba1f0d033dacfb1a516
<pre>
[css-animations] animation-fill-mode: forwards not resolved during print
<a href="https://bugs.webkit.org/show_bug.cgi?id=310030">https://bugs.webkit.org/show_bug.cgi?id=310030</a>
<a href="https://rdar.apple.com/36901701">rdar://36901701</a>

Reviewed by Antti Koivisto and Antoine Quint.

When printing, CSS animations with animation-fill-mode: forwards don&apos;t
resolve to their final state. Elements that animated from opacity: 0 to
opacity: 1 remain invisible in print output.

The updateAnimations lambda in StyleTreeResolver bailed out entirely when
document-&gt;printing() was true, which skipped updateCSSAnimations(). This
meant animation objects weren&apos;t maintained across the screen-to-print
media type transition, and for test infrastructure paths where
setPrinting() is called before first render, animations were never
created at all.

Restructure the guard so that only transitions and scroll/view timelines
are skipped during print (irrelevant for paginated media), while
updateCSSAnimations() is always called. This is safe because
updateCSSAnimations() is a no-op when the animation list hasn&apos;t changed.

Test: printing/animation-fill-forwards-during-print.html

* LayoutTests/printing/animation-fill-forwards-during-print-expected.html: Added.
* LayoutTests/printing/animation-fill-forwards-during-print.html: Added.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::createAnimatedElementUpdate):

Canonical link: <a href="https://commits.webkit.org/309488@main">https://commits.webkit.org/309488@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6fa8fd9c4ec1c229b7a29649b2652c9c84aeed8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23578 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17149 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159543 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104256 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85327176-1ec5-46bf-ba97-6da1b4aeff11) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152693 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116412 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/adc328af-6cca-4ec6-b7ae-0ee9be14824d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135306 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97140 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/086c420f-03e1-4481-8641-9f26f08bf607) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17619 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15570 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7390 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127233 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13230 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162017 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5137 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14787 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124414 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19617 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124610 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33818 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23371 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135025 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79763 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19680 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11787 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22982 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86782 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22694 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22846 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22748 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->