### PR TITLE
MediaStreamTrack may have wrong settings if source settings change while track is transferred

### DIFF
--- a/LayoutTests/http/wpt/mediastream/videotrackgenerator-track-settings-after-transfer-expected.txt
+++ b/LayoutTests/http/wpt/mediastream/videotrackgenerator-track-settings-after-transfer-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Transfer VideoTrackGenerator right before writing the first frame
+

--- a/LayoutTests/http/wpt/mediastream/videotrackgenerator-track-settings-after-transfer.html
+++ b/LayoutTests/http/wpt/mediastream/videotrackgenerator-track-settings-after-transfer.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Transfer MediaStreamTrack to dedicated worker</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+
+async function createWorker(script)
+{
+    script += "self.postMessage('ready');";
+    const blob = new Blob([script], { type: 'text/javascript' });
+    const url = URL.createObjectURL(blob);
+    const worker = new Worker(url);
+    await new Promise(resolve => worker.onmessage = () => {
+        resolve();
+    });
+    URL.revokeObjectURL(url);
+    return worker;
+}
+
+async function waitForSettings(track, width, height)
+{
+    let counter = 0;
+    while (++counter < 100) {
+        const settings = track.getSettings();
+        if (settings.width === width && settings.height === height)
+            return;
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+}
+
+promise_test(async test => {
+    const worker = await createWorker(`
+        function makeOffscreenCanvasVideoFrame(width, height) {
+            let canvas = new OffscreenCanvas(width, height);
+            let ctx = canvas.getContext('2d');
+            ctx.fillStyle = 'rgba(50, 100, 150, 255)';
+            ctx.fillRect(0, 0, width, height);
+            return new VideoFrame(canvas, { timestamp: 1 });
+        }
+        self.onmessage = async (event) => {
+            const generator = new VideoTrackGenerator();
+            const writer = generator.writable.getWriter();
+            writer.write(makeOffscreenCanvasVideoFrame(100, 100));
+            self.postMessage({ track : generator.track }, [generator.track]);
+        }
+    `);
+    test.add_cleanup(() => worker.terminate());
+
+    const tracks = [];
+    for (let i = 0; i < 10; ++i) {
+        worker.postMessage("track");
+        tracks.push(await new Promise(resolve => worker.onmessage = e => resolve(e.data.track)));
+    }
+
+    for (const track of tracks) {
+      await waitForSettings(track, 100, 100);
+      assert_equals(track.getSettings().width, 100, "width");
+      assert_equals(track.getSettings().height, 100, "height");
+    }
+}, "Transfer VideoTrackGenerator right before writing the first frame");
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp
@@ -81,7 +81,7 @@ private:
     std::unique_ptr<PreventSourceFromEndingObserver> m_observer;
 };
 
-MediaStreamTrackDataHolder::MediaStreamTrackDataHolder(String&& trackId, String&& label, RealtimeMediaSource::Type type, CaptureDevice::DeviceType deviceType, bool isEnabled, bool isEnded, MediaStreamTrackHintValue contentHint, bool isProducingData, bool isMuted, bool isInterrupted, RealtimeMediaSourceSettings settings, RealtimeMediaSourceCapabilities capabilities, Ref<RealtimeMediaSource>&& source)
+MediaStreamTrackDataHolder::MediaStreamTrackDataHolder(String&& trackId, String&& label, RealtimeMediaSource::Type type, CaptureDevice::DeviceType deviceType, bool isEnabled, bool isEnded, MediaStreamTrackHintValue contentHint, bool isProducingData, bool isMuted, bool isInterrupted, RealtimeMediaSourceSettings settings, RealtimeMediaSourceCapabilities capabilities, size_t settingsCapabilitiesUpdateCount, Ref<RealtimeMediaSource>&& source)
     : trackId(WTF::move(trackId))
     , label(WTF::move(label))
     , type(type)
@@ -94,6 +94,7 @@ MediaStreamTrackDataHolder::MediaStreamTrackDataHolder(String&& trackId, String&
     , isInterrupted(isInterrupted)
     , settings(WTF::move(settings))
     , capabilities(WTF::move(capabilities))
+    , settingsCapabilitiesUpdateCount(settingsCapabilitiesUpdateCount)
     , source(source.get())
     , preventSourceFromEndingObserverWrapper(PreventSourceFromEndingObserverWrapper::create(WTF::move(source)))
 {

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.h
@@ -38,7 +38,7 @@ class PreventSourceFromEndingObserverWrapper;
 struct MediaStreamTrackDataHolder {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(MediaStreamTrackDataHolder);
 
-    WEBCORE_EXPORT MediaStreamTrackDataHolder(String&& trackId, String&& label, RealtimeMediaSource::Type, CaptureDevice::DeviceType, bool isEnabled, bool isEnded, MediaStreamTrackHintValue, bool isProducingData, bool isMuted, bool isInterrupted, RealtimeMediaSourceSettings, RealtimeMediaSourceCapabilities, Ref<RealtimeMediaSource>&&);
+    WEBCORE_EXPORT MediaStreamTrackDataHolder(String&& trackId, String&& label, RealtimeMediaSource::Type, CaptureDevice::DeviceType, bool isEnabled, bool isEnded, MediaStreamTrackHintValue, bool isProducingData, bool isMuted, bool isInterrupted, RealtimeMediaSourceSettings, RealtimeMediaSourceCapabilities, size_t, Ref<RealtimeMediaSource>&&);
     WEBCORE_EXPORT ~MediaStreamTrackDataHolder();
 
     MediaStreamTrackDataHolder(const MediaStreamTrackDataHolder &) = delete;
@@ -56,6 +56,7 @@ struct MediaStreamTrackDataHolder {
     bool isInterrupted { false };
     RealtimeMediaSourceSettings settings;
     RealtimeMediaSourceCapabilities capabilities;
+    size_t settingsCapabilitiesUpdateCount { 0 };
     Ref<RealtimeMediaSource> source;
 
     Ref<PreventSourceFromEndingObserverWrapper> preventSourceFromEndingObserverWrapper;

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -94,7 +94,7 @@ public:
         return m_postTask;
     }
 
-    void initialize(bool interrupted, bool muted)
+    void initialize(bool interrupted, bool muted, size_t settingsCapabilitiesUpdateCount)
     {
         ASSERT(isMainThread());
         if (m_source->isEnded()) {
@@ -105,7 +105,8 @@ public:
         if (muted != m_source->muted() || interrupted != m_source->interrupted())
             sourceMutedChanged();
 
-        // FIXME: We should check for settings capabilities changes.
+        if (settingsCapabilitiesUpdateCount != m_source->settingsCapabilitiesUpdateCount())
+            sourceSettingsChanged();
 
         m_isStarted = true;
         m_source->addObserver(*this);
@@ -185,15 +186,15 @@ private:
 
     void sourceSettingsChanged() final
     {
-        sendToMediaStreamTrackPrivate([settings = crossThreadCopy(m_source->settings()), capabilities = crossThreadCopy(m_source->capabilities())] (auto& privateTrack) mutable {
-            privateTrack.sourceSettingsChanged(WTF::move(settings), WTF::move(capabilities));
+        sendToMediaStreamTrackPrivate([settings = crossThreadCopy(m_source->settings()), capabilities = crossThreadCopy(m_source->capabilities()), settingsCapabilitiesUpdateCount = m_source->settingsCapabilitiesUpdateCount()] (auto& privateTrack) mutable {
+            privateTrack.sourceSettingsChanged(WTF::move(settings), WTF::move(capabilities), settingsCapabilitiesUpdateCount);
         });
     }
 
     void sourceConfigurationChanged() final
     {
-        sendToMediaStreamTrackPrivate([name = crossThreadCopy(m_source->name()), settings = crossThreadCopy(m_source->settings()), capabilities = crossThreadCopy(m_source->capabilities())] (auto& privateTrack) mutable {
-            privateTrack.sourceConfigurationChanged(WTF::move(name), WTF::move(settings), WTF::move(capabilities));
+        sendToMediaStreamTrackPrivate([name = crossThreadCopy(m_source->name()), settings = crossThreadCopy(m_source->settings()), capabilities = crossThreadCopy(m_source->capabilities()), settingsCapabilitiesUpdateCount = m_source->settingsCapabilitiesUpdateCount()] (auto& privateTrack) mutable {
+            privateTrack.sourceConfigurationChanged(WTF::move(name), WTF::move(settings), WTF::move(capabilities), settingsCapabilitiesUpdateCount);
         });
     }
 
@@ -234,9 +235,9 @@ MediaStreamTrackPrivateSourceObserver::~MediaStreamTrackPrivateSourceObserver() 
 
 void MediaStreamTrackPrivateSourceObserver::initialize(MediaStreamTrackPrivate& privateTrack)
 {
-    ensureOnMainThread([this, protectedThis = Ref { *this }, privateTrack = WeakPtr { privateTrack }, postTask = m_postTask, source = m_source, interrupted = privateTrack.interrupted(), muted = privateTrack.muted()] () mutable {
+    ensureOnMainThread([this, protectedThis = Ref { *this }, privateTrack = WeakPtr { privateTrack }, postTask = m_postTask, source = m_source, interrupted = privateTrack.interrupted(), muted = privateTrack.muted(), settingsCapabilitiesUpdateCount = privateTrack.settingsCapabilitiesUpdateCount()] () mutable {
         lazyInitialize(m_sourceProxy, makeUnique<MediaStreamTrackPrivateSourceObserverSourceProxy>(WTF::move(privateTrack), WTF::move(source), WTF::move(postTask)));
-        m_sourceProxy->initialize(interrupted, muted);
+        m_sourceProxy->initialize(interrupted, muted, settingsCapabilitiesUpdateCount);
     });
 }
 
@@ -307,6 +308,7 @@ MediaStreamTrackPrivate::MediaStreamTrackPrivate(Ref<const Logger>&& trackLogger
     , m_isInterrupted(m_sourceObserver->source().interrupted())
     , m_settings(m_sourceObserver->source().settings())
     , m_capabilities(m_sourceObserver->source().capabilities())
+    , m_settingsCapabilitiesUpdateCount(m_sourceObserver->source().settingsCapabilitiesUpdateCount())
 #if ASSERT_ENABLED
     , m_creationThreadId(isMainThread() ? 0 : Thread::currentSingleton().uid())
 #endif
@@ -341,6 +343,7 @@ MediaStreamTrackPrivate::MediaStreamTrackPrivate(Ref<const Logger>&& logger, Uni
     , m_isInterrupted(dataHolder->isInterrupted)
     , m_settings(WTF::move(dataHolder->settings))
     , m_capabilities(WTF::move(dataHolder->capabilities))
+    , m_settingsCapabilitiesUpdateCount(dataHolder->settingsCapabilitiesUpdateCount)
 #if ASSERT_ENABLED
     , m_creationThreadId(isMainThread() ? 0 : Thread::currentSingleton().uid())
 #endif
@@ -601,18 +604,20 @@ void MediaStreamTrackPrivate::sourceMutedChanged(bool interrupted, bool muted)
     });
 }
 
-void MediaStreamTrackPrivate::sourceSettingsChanged(RealtimeMediaSourceSettings&& settings, RealtimeMediaSourceCapabilities&& capabilities)
+void MediaStreamTrackPrivate::sourceSettingsChanged(RealtimeMediaSourceSettings&& settings, RealtimeMediaSourceCapabilities&& capabilities, size_t settingsCapabilitiesUpdateCount)
 {
     ASSERT(isOnCreationThread());
     ALWAYS_LOG(LOGIDENTIFIER);
 
     m_settings = WTF::move(settings);
     m_capabilities = WTF::move(capabilities);
+    m_settingsCapabilitiesUpdateCount = settingsCapabilitiesUpdateCount;
     forEachObserver([this](auto& observer) {
         observer.trackSettingsChanged(*this);
     });
 }
-void MediaStreamTrackPrivate::sourceConfigurationChanged(String&& label, RealtimeMediaSourceSettings&& settings, RealtimeMediaSourceCapabilities&& capabilities)
+
+void MediaStreamTrackPrivate::sourceConfigurationChanged(String&& label, RealtimeMediaSourceSettings&& settings, RealtimeMediaSourceCapabilities&& capabilities, size_t settingsCapabilitiesUpdateCount)
 {
     ASSERT(isOnCreationThread());
     ALWAYS_LOG(LOGIDENTIFIER);
@@ -620,6 +625,7 @@ void MediaStreamTrackPrivate::sourceConfigurationChanged(String&& label, Realtim
     m_label = WTF::move(label);
     m_settings = WTF::move(settings);
     m_capabilities = WTF::move(capabilities);
+    m_settingsCapabilitiesUpdateCount = settingsCapabilitiesUpdateCount;
     forEachObserver([this](auto& observer) {
         observer.trackConfigurationChanged(*this);
     });
@@ -671,6 +677,7 @@ UniqueRef<MediaStreamTrackDataHolder> MediaStreamTrackPrivate::toDataHolder(Shou
         m_isInterrupted,
         m_settings.isolatedCopy(),
         m_capabilities.isolatedCopy(),
+        m_settingsCapabilitiesUpdateCount,
         shouldClone == ShouldClone::Yes ? m_sourceObserver->source().clone() : Ref { m_sourceObserver->source() });
 }
 

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -185,6 +185,7 @@ public:
     void updateLabelIfRemoteTrack();
 
     MediaStreamTrackPrivateSourceObserver& sourceObserver() { return m_sourceObserver; }
+    size_t settingsCapabilitiesUpdateCount() const { return m_settingsCapabilitiesUpdateCount; }
 
 private:
     MediaStreamTrackPrivate(Ref<const Logger>&&, Ref<RealtimeMediaSource>&&, String&& id, std::function<void(Function<void()>&&)>&&);
@@ -197,8 +198,8 @@ private:
 
     void sourceStopped(bool captureDidFail);
     void sourceMutedChanged(bool interrupted, bool muted);
-    void sourceSettingsChanged(RealtimeMediaSourceSettings&&, RealtimeMediaSourceCapabilities&&);
-    void sourceConfigurationChanged(String&&, RealtimeMediaSourceSettings&&, RealtimeMediaSourceCapabilities&&);
+    void sourceSettingsChanged(RealtimeMediaSourceSettings&&, RealtimeMediaSourceCapabilities&&, size_t);
+    void sourceConfigurationChanged(String&&, RealtimeMediaSourceSettings&&, RealtimeMediaSourceCapabilities&&, size_t);
 
     void updateReadyState();
 
@@ -236,6 +237,7 @@ private:
     bool m_isInterrupted { false };
     RealtimeMediaSourceSettings m_settings;
     RealtimeMediaSourceCapabilities m_capabilities;
+    size_t m_settingsCapabilitiesUpdateCount { 0 };
 #if ASSERT_ENABLED
     uint32_t m_creationThreadId { 0 };
 #endif

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -248,6 +248,7 @@ void RealtimeMediaSource::notifySettingsDidChangeObservers(OptionSet<RealtimeMed
 {
     ASSERT(isMainThread());
 
+    ++m_settingsCapabilitiesUpdateCount;
     settingsDidChange(flags);
 
     if (m_pendingSettingsDidChangeNotification)

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -311,6 +311,8 @@ public:
 
     virtual void configurationChanged();
 
+    size_t settingsCapabilitiesUpdateCount() const;
+
 protected:
     RealtimeMediaSource(const CaptureDevice&, MediaDeviceHashSalts&& hashSalts = { }, std::optional<PageIdentifier> = std::nullopt);
 
@@ -427,6 +429,7 @@ private:
     bool m_hasStartedProducingData { false };
     std::atomic<bool> m_isApplyingRotation { false };
 
+    size_t m_settingsCapabilitiesUpdateCount { 0 };
     unsigned m_videoFrameObserversWithAdaptors { 0 };
 };
 
@@ -499,6 +502,11 @@ inline void RealtimeMediaSource::setCanUseIOSurface()
 inline const AudioStreamDescription* RealtimeMediaSource::audioStreamDescription() const
 {
     return nullptr;
+}
+
+inline size_t RealtimeMediaSource::settingsCapabilitiesUpdateCount() const
+{
+    return m_settingsCapabilitiesUpdateCount;
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### c7f5f3f3145ecc0b648168c2e3f2d19741363e92
<pre>
MediaStreamTrack may have wrong settings if source settings change while track is transferred
<a href="https://rdar.apple.com/172657570">rdar://172657570</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310017">https://bugs.webkit.org/show_bug.cgi?id=310017</a>

Reviewed by Jean-Yves Avenard.

When transferring a track, we take a snapshot of settings, that is used to initialize the track created from the transfer.
That track is then registering to the source to get updates on settings changes.
If settings change between the start of the transfer and the end of the transfer, the track will not be notified of those changes.

To fix that issue, we keep track in RealtimeMediaSource and MediaStreamTrackPrivate of a counter of settings change.
Whenever settings change, RealtimeMediaSource increments its counter and notifies its observer, including MediaStreamTrackPrivate that will update its counter as well.

Whenever transferring, we store the current counter and initialize the newly created MediaStreamTrackPrivate counter with that counter.
When registering the MediaStreamTrackPrivate to the source, in  MediaStreamTrackPrivateSourceObserverSourceProxy::initialize, we compare the track and source counters.
If they do not match, we automatically update the MediaStreamTrackPrivate settings.

Covered by added test.

Canonical link: <a href="https://commits.webkit.org/309458@main">https://commits.webkit.org/309458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a81b659ac2de6e33d2b29b291beb09c14824e14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159069 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103781 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e013210d-bb9e-402d-966b-37ed60c2a50c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116008 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82433 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134870 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96738 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b874ae32-2866-44df-8f5f-dc924f22a6d9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17211 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15155 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6916 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126826 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12794 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161555 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4663 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14347 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124020 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22907 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19202 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124218 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33799 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134589 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79274 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19329 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11346 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22508 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86307 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22221 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22373 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22275 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->