### PR TITLE
CSS filter referencing SVG filter not invalidated when filter content changes

### DIFF
--- a/LayoutTests/css3/filters/reference-filter-update-invalidates-cache-expected.html
+++ b/LayoutTests/css3/filters/reference-filter-update-invalidates-cache-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        div {
+            width: 200px;
+            height: 200px;
+            background-color: green;
+            filter: url(#testFilter);
+        }
+    </style>
+</head>
+<body>
+    <svg style="position: absolute">
+        <filter id="testFilter">
+            <feColorMatrix type="hueRotate" values="180"/>
+        </filter>
+    </svg>
+    <div></div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/reference-filter-update-invalidates-cache.html
+++ b/LayoutTests/css3/filters/reference-filter-update-invalidates-cache.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        div {
+            width: 200px;
+            height: 200px;
+            background-color: green;
+            filter: url(#testFilter);
+        }
+    </style>
+</head>
+<body>
+    <svg style="position: absolute">
+        <filter id="testFilter">
+            <feColorMatrix type="hueRotate" values="0"/>
+        </filter>
+    </svg>
+    <div></div>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                document.getElementById("testFilter").innerHTML =
+                    `<feColorMatrix type="hueRotate" values="180"/>`;
+
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+        });
+    </script>
+</body>
+</html>

--- a/LayoutTests/css3/filters/reference-filter-update-to-invalid-expected.html
+++ b/LayoutTests/css3/filters/reference-filter-update-to-invalid-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        div {
+            width: 200px;
+            height: 200px;
+            background-color: green;
+        }
+    </style>
+</head>
+<body>
+    <div></div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/reference-filter-update-to-invalid.html
+++ b/LayoutTests/css3/filters/reference-filter-update-to-invalid.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        div {
+            width: 200px;
+            height: 200px;
+            background-color: green;
+            filter: url(#testFilter);
+        }
+    </style>
+</head>
+<body>
+    <svg style="position: absolute">
+        <filter id="testFilter">
+            <feColorMatrix type="hueRotate" values="180"/>
+        </filter>
+    </svg>
+    <div></div>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                document.getElementById("testFilter").innerHTML =
+                    `<feColorMatrix type="hueRotate" values=""/>`;
+
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+        });
+    </script>
+</body>
+</html>

--- a/LayoutTests/css3/filters/reference-filter-update-to-noop-expected.html
+++ b/LayoutTests/css3/filters/reference-filter-update-to-noop-expected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        div {
+            width: 200px;
+            height: 200px;
+            background-color: green;
+        }
+    </style>
+</head>
+<body>
+    <div></div>
+</body>
+</html>

--- a/LayoutTests/css3/filters/reference-filter-update-to-noop.html
+++ b/LayoutTests/css3/filters/reference-filter-update-to-noop.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        div {
+            width: 200px;
+            height: 200px;
+            background-color: green;
+            filter: url(#testFilter);
+        }
+    </style>
+</head>
+<body>
+    <svg style="position: absolute">
+        <filter id="testFilter">
+            <feColorMatrix type="hueRotate" values="180"/>
+        </filter>
+    </svg>
+    <div></div>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                document.getElementById("testFilter").innerHTML =
+                    `<feColorMatrix type="hueRotate" values="0"/>`;
+
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+        });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -72,6 +72,13 @@ void CSSSVGResourceElementClient::resourceChanged(SVGElement& element)
     if (m_clientRenderer->renderTreeBeingDestroyed())
         return;
 
+    if (is<SVGFilterElement>(element)) {
+        if (auto* layerModelObject = dynamicDowncast<RenderLayerModelObject>(m_clientRenderer.get())) {
+            if (CheckedPtr layer = layerModelObject->layer())
+                layer->clearFilters();
+        }
+    }
+
     if (!m_clientRenderer->document().settings().layerBasedSVGEngineEnabled()) {
         m_clientRenderer->repaint();
         return;

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -6498,6 +6498,12 @@ IntOutsets RenderLayer::filterOutsets() const
     return renderer().style().filter().calculateOutsets(renderer().style().usedZoomForLength());
 }
 
+void RenderLayer::clearFilters()
+{
+    if (m_filters)
+        m_filters->clearFilter();
+}
+
 static RenderLayer* parentLayerCrossFrame(const RenderLayer& layer)
 {
     if (auto* parent = layer.parent())

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -838,6 +838,7 @@ public:
     inline bool hasFilter() const;
     bool hasFilterOutsets() const { return !filterOutsets().isZero(); }
     IntOutsets filterOutsets() const;
+    void clearFilters();
     inline bool hasBackdropFilter() const;
 
     bool hasBackdropFilterDescendantsWithoutRoot() const { return m_hasBackdropFilterDescendantsWithoutRoot; }


### PR DESCRIPTION
#### 18dd142a5ae79c3aef10fdaff68c0f878ce97f8e
<pre>
CSS filter referencing SVG filter not invalidated when filter content changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=247397">https://bugs.webkit.org/show_bug.cgi?id=247397</a>
<a href="https://rdar.apple.com/101870430">rdar://101870430</a>

Reviewed by Said Abou-Hallawa.

When an SVG filter element&apos;s content is dynamically modified (via innerHTML),
elements using that filter through CSS `filter: url(#id)` don&apos;t visually update.

RenderLayerFilters caches the built CSSFilterRenderer and only rebuilds
it when geometry or compositing mode changes. Since a filter content
change doesn&apos;t alter geometry, the repaint reuses the stale cached filter.

The fix invalidates the cached CSSFilterRenderer when resource changes.

* LayoutTests/css3/filters/reference-filter-update-invalidates-cache-expected.html: Added.
* LayoutTests/css3/filters/reference-filter-update-invalidates-cache.html: Added.
* LayoutTests/css3/filters/reference-filter-update-to-invalid-expected.html: Added.
* LayoutTests/css3/filters/reference-filter-update-to-invalid.html: Added.
* LayoutTests/css3/filters/reference-filter-update-to-noop-expected.html: Added.
* LayoutTests/css3/filters/reference-filter-update-to-noop.html: Added.
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
(WebCore::CSSSVGResourceElementClient::resourceChanged):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:

Canonical link: <a href="https://commits.webkit.org/309495@main">https://commits.webkit.org/309495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db43e5775244b73bcba55e9dd3bb5c77fab02b67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17152 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159546 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104259 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4d9ee222-04e3-49c0-9b67-d11861eb2a37) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116415 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82663 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b6a5022-9f0d-4752-9652-27a9f9d3e7e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153783 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97143 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/54f47cd1-6cd6-48b2-aa98-5ef6e6f739b9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17633 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15573 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7393 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162020 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5140 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14789 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124420 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19620 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124616 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33823 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23374 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135027 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79770 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19682 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11789 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22985 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/86947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22697 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22849 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22751 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->