### PR TITLE
[audit-spi] Swift symbols can change between SDK builds, breaking allowlists

### DIFF
--- a/Source/WebKit/Configurations/AllowedSPI-legacy.toml
+++ b/Source/WebKit/Configurations/AllowedSPI-legacy.toml
@@ -10,10 +10,10 @@ classes = [
 classes = [
     "WTTextSuggestion",
 ]
-symbols = [
-    "$s5UIKit16UITextEffectViewC09PonderingC0C2idAC0C2IDVvgTj",
-    "$s5UIKit16UITextEffectViewC0C2IDVSHAAMc",
-    "$s5UIKit16UITextEffectViewC16removeAllEffectsyyFTj",
+swift-decls = [
+    { name = "UIKit.UITextEffectView.EffectID", type_kinds = { "EffectID" = "struct" } },
+    { name = "UIKit.UITextEffectView.PonderingEffect.id" },
+    { name = "UIKit.UITextEffectView.removeAllEffects" },
 ]
 
 [[legacy]]
@@ -715,25 +715,6 @@ selectors = [
     { name = "sharedTextEffectsWindowForWindowScene:", class = "?" },
     ]
 symbols = [
-    "$s5UIKit16UITextEffectViewC015ReplacementTextC0C2idAC0C2IDVvgTj",
-    "$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegateMp",
-    "$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegateP011replacementC11DidCompleteyyAEFTq",
-    "$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegateP07performE18AndGeneratePreview3for6effect9animationSo010UITargetedK0CSgAA0bcF5ChunkC_A2E19AnimationParametersVtYaFTq",
-    "$s5UIKit16UITextEffectViewC015ReplacementTextC0CAC0fC0AAWP",
-    "$s5UIKit16UITextEffectViewC015ReplacementTextC0CMa",
-    "$s5UIKit16UITextEffectViewC03addC0yAC0C2IDVAC04TextC0_pFTj",
-    "$s5UIKit16UITextEffectViewC06removeC0yyAC0C2IDVFTj",
-    "$s5UIKit16UITextEffectViewC09PonderingC0CAC04TextC0AAWP",
-    "$s5UIKit16UITextEffectViewC09PonderingC0CMa",
-    "$s5UIKit16UITextEffectViewC0C2IDV2eeoiySbAE_AEtFZ",
-    "$s5UIKit16UITextEffectViewC0C2IDVMa",
-    "$s5UIKit16UITextEffectViewC0C2IDVMn",
-    "$s5UIKit16UITextEffectViewCMa",
-    "$s5UIKit16UITextEffectViewCMn",
-    "$s5UIKit21UITextEffectTextChunkCMn",
-    "$s5UIKit28UIDirectionalLightEffectViewC13ConfigurationV9fillColorSo7UIColorCvg",
-    "$s5UIKit28UIDirectionalLightEffectViewC13ConfigurationV9ponderingAEvgZ",
-    "$s5UIKit28UIDirectionalLightEffectViewC13ConfigurationVMa",
     "APSEnvironmentProduction",
     "ASCAuthorizationErrorDomain",
     "BKSDisplayBrightnessGetCurrent",
@@ -920,33 +901,48 @@ symbols = [
     "kAXSEnhanceTextLegibilityChangedNotification",
     "kGSEventHardwareKeyboardAvailabilityChangedNotification",
 ]
+swift-decls = [
+    { name = "UIKit.UIDirectionalLightEffectView.Configuration", type_kinds = { "Configuration" = "struct" } },
+    { name = "UIKit.UIDirectionalLightEffectView.Configuration.fillColor", type_kinds = { "Configuration" = "struct" } },
+    { name = "UIKit.UIDirectionalLightEffectView.Configuration.pondering", type_kinds = { "Configuration" = "struct" } },
+    { name = "UIKit.UITextEffectTextChunk" },
+    { name = "UIKit.UITextEffectView" },
+    { name = "UIKit.UITextEffectView.EffectID", type_kinds = { "EffectID" = "struct" } },
+    { name = "UIKit.UITextEffectView.PonderingEffect" },
+    { name = "UIKit.UITextEffectView.ReplacementTextEffect" },
+    { name = "UIKit.UITextEffectView.ReplacementTextEffect.Delegate", type_kinds = { "Delegate" = "protocol" } },
+    { name = "UIKit.UITextEffectView.ReplacementTextEffect.Delegate.performReplacementAndGeneratePreview(for:effect:animation:)", type_kinds = { "Delegate" = "protocol" } },
+    { name = "UIKit.UITextEffectView.ReplacementTextEffect.Delegate.replacementEffectDidComplete(_:)", type_kinds = { "Delegate" = "protocol" } },
+    { name = "UIKit.UITextEffectView.ReplacementTextEffect.id" },
+    { name = "UIKit.UITextEffectView.addEffect(_:)" },
+    { name = "UIKit.UITextEffectView.removeEffect(_:)" },
+]
 
 # Some of the TextEffectView SPI symbols WebKit uses change between Debug and Release builds. This appears to be an
 # implementation detail of Swift's ABI in different optimization modes. Perhaps
 # audit-spi should have a higher level way to declare usage of Swift types that
 # allows use of both kinds of symbols. (rdar://158963645)
 [[legacy]]
-symbols = [
-    "$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegateP015performAnimatedE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaFTq",
-    "$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegateP07performE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaFTq",
-    "$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegatePAAE015performAnimatedE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaF",
-    "$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegatePAAE015performAnimatedE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaFTu",
-    "$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegatePAAE07performE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaF",
-    "$s5UIKit16UITextEffectViewC015ReplacementTextC0C8DelegatePAAE07performE03for6effect9animationyAA0bcF5ChunkC_A2E19AnimationParametersVtYaFTu",
+swift-decls = [
+    { name = "UIKit.UITextEffectView.ReplacementTextEffect" },
+    { name = "UIKit.UITextEffectView.ReplacementTextEffect.Delegate.performAnimatedReplacement(for:effect:animation:)", type_kinds = { "Delegate" = "protocol" } },
+    { name = "UIKit.UITextEffectView.ReplacementTextEffect.Delegate.performAnimatedReplacement(for:effect:animation:)", type_kinds = { "Delegate" = "protocol" }, extension = "UIKit", extension_base_depth = 3 },
+    { name = "UIKit.UITextEffectView.ReplacementTextEffect.Delegate.performReplacement(for:effect:animation:)", type_kinds = { "Delegate" = "protocol" } },
+    { name = "UIKit.UITextEffectView.ReplacementTextEffect.Delegate.performReplacement(for:effect:animation:)", type_kinds = { "Delegate" = "protocol" }, extension = "UIKit", extension_base_depth = 3 },
 ]
 [[legacy]]
-symbols = [
-    "$s5UIKit16UITextEffectViewC015ReplacementTextC0C5chunk4view8delegate9fromColorAeA0bcF5ChunkC_AcE8Delegate_pSo7UIColorCtcfC",
-    "$s5UIKit16UITextEffectViewC09PonderingC0C5chunk4view18lightConfigurationAeA0bC9TextChunkC_AcA018UIDirectionalLightcD0C0I0VtcfC",
-    "$s5UIKit16UITextEffectViewC6sourceAcA0bcD6Source_p_tcfC",
+swift-decls = [
+    { name = "UIKit.UITextEffectView.PonderingEffect.init(chunk:view:lightConfiguration:)" },
+    { name = "UIKit.UITextEffectView.ReplacementTextEffect.init(chunk:view:delegate:fromColor:)" },
+    { name = "UIKit.UITextEffectView.init(source:)" },
 ]
 requires = ["!NDEBUG"]
 [[legacy]]
-symbols = [
-    "$s5UIKit16UITextEffectViewC015ReplacementTextC0C5chunk4view8delegate9fromColorAeA0bcF5ChunkC_AcE8Delegate_pSo7UIColorCtcfc",
-    "$s5UIKit16UITextEffectViewC09PonderingC0C5chunk4view18lightConfigurationAeA0bC9TextChunkC_AcA018UIDirectionalLightcD0C0I0Vtcfc",
-    "$s5UIKit16UITextEffectViewC0C2IDVSQAAMc",
-    "$s5UIKit16UITextEffectViewC6sourceAcA0bcD6Source_p_tcfc",
+swift-decls = [
+    { name = "UIKit.UITextEffectView.EffectID", type_kinds = { "EffectID" = "struct" } },
+    { name = "UIKit.UITextEffectView.PonderingEffect.init(chunk:view:lightConfiguration:)" },
+    { name = "UIKit.UITextEffectView.ReplacementTextEffect.init(chunk:view:delegate:fromColor:)" },
+    { name = "UIKit.UITextEffectView.init(source:)" },
 ]
 requires = ["NDEBUG"]
 
@@ -1083,37 +1079,29 @@ selectors = [
 ]
 requires = ["!SDKDB_HAS_148943382"]
 
+
 [[legacy]]
 requires = ["!SDKDB_HAS_164901718", "HAVE_UIINTELLIGENCESUPPORT_FRAMEWORK"]
-symbols = [
-    "$s21UIIntelligenceSupport0A16ElementCollectorC7collectyyAA012IntelligenceC0V7ContentOF",
-    "$s21UIIntelligenceSupport0A16ElementCollectorC7contextAA29IntelligenceCollectionContext_pvg",
-    "$s21UIIntelligenceSupport0A30CollectionRemoteContextWrapperCMn",
-    "$s21UIIntelligenceSupport17IntelligenceImageVMa",
-    "$s21UIIntelligenceSupport17IntelligenceImageVMn",
-    "$s21UIIntelligenceSupport19IntelligenceElementV11boundingBox7content11subelementsACSo6CGRectV_AC7ContentOSayACGtcfC",
-    "$s21UIIntelligenceSupport19IntelligenceElementV11subelementsSayACGvs",
-    "$s21UIIntelligenceSupport19IntelligenceElementV4TextV010attributedE08editable11textOptionsAE10Foundation16AttributedStringV_AE8EditableVSgAA0C17CollectionRequestV0eI0VSgtcfC",
-    "$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesV17SelectedAttributeV10Foundation19AttributedStringKeyAAMc",
-    "$s21UIIntelligenceSupport19IntelligenceElementV4TextV10AttributesV17SelectedAttributeVMa",
-    "$s21UIIntelligenceSupport19IntelligenceElementV4TextV8EditableV5label6prompt11contentType8isSecure0K7FocusedAGSSSg_A2MS2btcfC",
-    "$s21UIIntelligenceSupport19IntelligenceElementV4TextV8EditableVMa",
-    "$s21UIIntelligenceSupport19IntelligenceElementV4TextV8EditableVMn",
-    "$s21UIIntelligenceSupport19IntelligenceElementV5ImageV4name15textDescription5imageAESSSg_AiA0cE0VSgtcfC",
-    "$s21UIIntelligenceSupport19IntelligenceElementV7ContentO4baseyA2EmFWC",
-    "$s21UIIntelligenceSupport19IntelligenceElementV7ContentO4textyAeC4TextVcAEmFWC",
-    "$s21UIIntelligenceSupport19IntelligenceElementV7ContentO5imageyAeC5ImageVcAEmFWC",
-    "$s21UIIntelligenceSupport19IntelligenceElementV7ContentO6remoteyAeA0C8FragmentV13RemoteContextVcAEmFWC",
-    "$s21UIIntelligenceSupport19IntelligenceElementV7ContentOMa",
-    "$s21UIIntelligenceSupport19IntelligenceElementVMa",
-    "$s21UIIntelligenceSupport19IntelligenceElementVMn",
-    "$s21UIIntelligenceSupport20IntelligenceFragmentV13RemoteContextVMa",
-    "$s21UIIntelligenceSupport29IntelligenceCollectionContextP012createRemoteE011descriptionAA0C8FragmentV0gE0VSS_tFTj",
-    "$s21UIIntelligenceSupport29IntelligenceCollectionRequestV11TextOptionsVMa",
-    "$s21UIIntelligenceSupport29IntelligenceCollectionRequestV11TextOptionsVMn",
-    "$s21UIIntelligenceSupport29IntelligenceFragmentCollectorC7collectyyAA0C7ElementVF",
-    "$s21UIIntelligenceSupport33IntelligenceCollectionCoordinatorC06finishD0yyAA0C17FragmentCollectorCF",
-    "$s21UIIntelligenceSupport33IntelligenceCollectionCoordinatorC15createCollector20remoteContextWrapperAA0c8FragmentG0CAA0ad6RemoteiJ0C_tF",
-    "$s21UIIntelligenceSupport33IntelligenceCollectionCoordinatorC6sharedACvgZ",
-    "$s21UIIntelligenceSupport33IntelligenceCollectionCoordinatorCMa",
+swift-decls = [
+    { name = "UIIntelligenceSupport.IntelligenceCollectionContext.createRemoteContext(description:)", type_kinds = { "IntelligenceCollectionContext" = "protocol" } },
+    { name = "UIIntelligenceSupport.IntelligenceCollectionCoordinator" },
+    { name = "UIIntelligenceSupport.IntelligenceCollectionCoordinator.createCollector(remoteContextWrapper:)" },
+    { name = "UIIntelligenceSupport.IntelligenceCollectionCoordinator.finishCollection(_:)" },
+    { name = "UIIntelligenceSupport.IntelligenceCollectionCoordinator.shared" },
+    { name = "UIIntelligenceSupport.IntelligenceCollectionRequest.TextOptions", type_kinds = { "IntelligenceCollectionRequest" = "struct", "TextOptions" = "struct" } },
+    { name = "UIIntelligenceSupport.IntelligenceElement", type_kinds = { "IntelligenceElement" = "struct" } },
+    { name = "UIIntelligenceSupport.IntelligenceElement.Content", type_kinds = { "Content" = "enum", "IntelligenceElement" = "struct" } },
+    { name = "UIIntelligenceSupport.IntelligenceElement.Image.init(name:textDescription:image:)", type_kinds = { "Image" = "struct", "IntelligenceElement" = "struct" } },
+    { name = "UIIntelligenceSupport.IntelligenceElement.Text.Attributes.SelectedAttribute", type_kinds = { "Attributes" = "struct", "IntelligenceElement" = "struct", "SelectedAttribute" = "struct", "Text" = "struct" } },
+    { name = "UIIntelligenceSupport.IntelligenceElement.Text.Editable", type_kinds = { "Editable" = "struct", "IntelligenceElement" = "struct", "Text" = "struct" } },
+    { name = "UIIntelligenceSupport.IntelligenceElement.Text.Editable.init(label:prompt:contentType:isSecure:isFocused:)", type_kinds = { "Editable" = "struct", "IntelligenceElement" = "struct", "Text" = "struct" } },
+    { name = "UIIntelligenceSupport.IntelligenceElement.Text.init(attributedText:editable:textOptions:)", type_kinds = { "IntelligenceElement" = "struct", "Text" = "struct" } },
+    { name = "UIIntelligenceSupport.IntelligenceElement.init(boundingBox:content:subelements:)", type_kinds = { "IntelligenceElement" = "struct" } },
+    { name = "UIIntelligenceSupport.IntelligenceElement.subelements", type_kinds = { "IntelligenceElement" = "struct" } },
+    { name = "UIIntelligenceSupport.IntelligenceFragment.RemoteContext", type_kinds = { "IntelligenceFragment" = "struct", "RemoteContext" = "struct" } },
+    { name = "UIIntelligenceSupport.IntelligenceFragmentCollector.collect(_:)" },
+    { name = "UIIntelligenceSupport.IntelligenceImage", type_kinds = { "IntelligenceImage" = "struct" } },
+    { name = "UIIntelligenceSupport.UIIntelligenceCollectionRemoteContextWrapper" },
+    { name = "UIIntelligenceSupport.UIIntelligenceElementCollector.collect(_:)" },
+    { name = "UIIntelligenceSupport.UIIntelligenceElementCollector.context" },
 ]

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/allow.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/allow.py
@@ -29,7 +29,7 @@ from dataclasses import dataclass, field
 from decimal import Decimal
 from pathlib import Path
 from enum import Enum
-from typing import Any, NamedTuple, Optional, Union
+from typing import Any, Mapping, NamedTuple, Optional, Union
 
 if sys.version_info < (3, 11):
     from webkitapipy._vendor import tomli as tomllib
@@ -54,6 +54,8 @@ class AllowedSPI:
     symbols: list[str]
     selectors: list[Selector]
     classes: list[str]
+    swift_decls: list[SwiftDecl] = field(default_factory=list)
+
     requires: list[str] = field(default_factory=list)
     requires_os: list[RequiredVersion] = field(default_factory=list)
     requires_sdk: list[RequiredVersion] = field(default_factory=list)
@@ -72,6 +74,12 @@ class AllowedSPI:
         operator: str
         version: str
 
+    @dataclass(frozen=True)
+    class SwiftDecl:
+        name: str
+        type_kinds: Optional[Mapping[str, str]] = None
+        extension: Optional[str] = None
+        extension_base_depth: Optional[int] = None
 
 class AllowedReason(StrEnum):
     LEGACY = 'legacy'
@@ -142,6 +150,11 @@ class AllowList:
                 for sym in entry.pop('symbols', []):
                     syms.append(f'_{sym}')
 
+                swift_decls = []
+                for decl in entry.pop('swift-decls', []):
+                    decl = AllowedSPI.SwiftDecl(**decl)
+                    swift_decls.append(decl)
+
                 bugs = AllowedSPI.Bugs(entry.pop('request', None),
                                        entry.pop('cleanup', None))
                 allow_unused = bool(entry.pop('allow-unused', False))
@@ -167,7 +180,8 @@ class AllowList:
                             AllowedSPI.RequiredVersion(platform, op,
                                                        version))
                 allow = AllowedSPI(reason=reason, bugs=bugs, symbols=syms,
-                                   selectors=sels, classes=clss, requires=reqs,
+                                   selectors=sels, classes=clss,
+                                   swift_decls=swift_decls, requires=reqs,
                                    allow_unused=allow_unused,
                                    requires_os=requires_os,
                                    requires_sdk=requires_sdk)

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/allow_unittest.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/allow_unittest.py
@@ -32,6 +32,7 @@ Toml = b'''
 request = "rdar://123456789"
 cleanup = "rdar://123456790"
 symbols = ["TemporarilyAllowedSymbol"]
+swift-decls = [{ name = "UIKit._SomeSPIClass" }]
 selectors = [{ name = "_initWithTemporarilyAllowedData:", class = "?" }]
 classes = ["NSTemporarilyAllowed"]
 
@@ -48,7 +49,8 @@ A1 = AllowedSPI(reason=AllowedReason.TEMPORARY_USAGE,
                                      cleanup='rdar://123456790'),
                 symbols=['_TemporarilyAllowedSymbol'],
                 selectors=[AllowedSPI.Selector('_initWithTemporarilyAllowedData:', None)],
-                classes=['NSTemporarilyAllowed'])
+                classes=['NSTemporarilyAllowed'],
+                swift_decls=[AllowedSPI.SwiftDecl(name='UIKit._SomeSPIClass')])
 A2 = AllowedSPI(reason=AllowedReason.NOT_WEB_ESSENTIAL,
                 bugs=AllowedSPI.Bugs(request='rdar://234567890', cleanup=None),
                 symbols=['_Permanent1', '_Permanent2'],

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/program.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/program.py
@@ -151,6 +151,13 @@ def get_parser() -> argparse.ArgumentParser:
     output.add_argument('--errors',
                         action=argparse.BooleanOptionalAction, default=True,
                         help='whether to report SPI use as an error')
+
+    debug = parser.add_argument_group('debugging options')
+    debug.add_argument('--backup-temp-data', dest='sdkdb_temp', type=Path,
+                       help='dump internal sqlite database (including temp data) to this path')
+    debug.add_argument('--explain-query-plan', action='store_true',
+                       help='instead of performing the audit query, print its query plan')
+
     return parser
 
 
@@ -310,7 +317,10 @@ def main(argv: Optional[list[str]] = None):
         add_corresponding_sdkdb(binary_path)
         db.add_binary(use_input(binary_path), arch=args.arch_name,
                       for_auditing=True)
-    for diagnostic in db.audit():
+    if args.sdkdb_temp:
+        with db:
+            db.backup_temp_data(args.sdkdb_temp)
+    for diagnostic in db.audit(debug_query_plan=args.explain_query_plan):
         reporter.emit_diagnostic(diagnostic)
 
     reporter.finished()

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
-import sys
 from enum import Enum
 from fnmatch import fnmatch
 from typing import Any, Callable, Iterable, Mapping, NamedTuple, Optional, Union
@@ -35,10 +34,11 @@ from pathlib import Path
 from .macho import APIReport, objc_fully_qualified_method
 from .tbd import TBD
 from .allow import AllowList
+from .swift_mangle import mangle_partial
 
 # Increment this number to force clients to rebuild from scratch, to
 # accomodate schema changes or fix caching bugs.
-VERSION = 9
+VERSION = 10
 
 
 class DeclarationKind(Enum):
@@ -182,15 +182,16 @@ class SDKDB:
             return
         cur.execute('CREATE TABLE input_file(path PRIMARY KEY, hash)')
         cur.execute('CREATE TABLE exports('
-                    '   name, class_name, kind DeclarationKind, '
+                    '   name TEXT, class_name, kind DeclarationKind, '
                     '   input_file REFERENCES input_file(path) '
                     '              ON DELETE CASCADE)')
         cur.execute('CREATE INDEX export_names ON exports (name, kind)')
         cur.execute('CREATE TABLE allow('
-                    '   name, class_name, allow_unused, kind DeclarationKind, '
+                    '   name TEXT, is_prefix, class_name, allow_unused, '
+                    '   kind DeclarationKind, '
                     '   cond_id, input_file REFERENCES input_file(path) '
                     '                       ON DELETE CASCADE)')
-        cur.execute('CREATE INDEX allow_names ON allow (name, kind)')
+        cur.execute('CREATE INDEX allow_names ON allow (name, kind, is_prefix)')
         cur.execute('CREATE TABLE condition_chain(name, '
                     "   op CHECK (op IN ('==', '!=', '<', '<=', '>', '>=')), "
                     '   operand, nextid, '
@@ -203,10 +204,11 @@ class SDKDB:
         cur = self.con.cursor()
         cur.execute('CREATE TEMPORARY TABLE window(input_file)')
         cur.execute('CREATE INDEX selected_files ON window(input_file)')
-        cur.execute('CREATE TEMPORARY TABLE imports(name, '
+        cur.execute('CREATE TEMPORARY TABLE imports(name TEXT, '
                     '   kind DeclarationKind, input_file, arch)')
         cur.execute('CREATE INDEX import_names ON imports(name, kind)')
         cur.execute('CREATE TEMPORARY TABLE condition(name UNIQUE, value)')
+        cur.execute('CREATE TEMPORARY TABLE active_cond(nextid, name TEXT)')
         self.con.commit()
 
     def __del__(self):
@@ -315,16 +317,23 @@ class SDKDB:
     class InsertionKind(Enum):
         EXPORTS = 1
         ALLOW = 2
+        ALLOW_PREFIX = 3
 
         @property
         def statement(self) -> str:
             if self == self.EXPORTS:
-                return (f'INSERT INTO exports VALUES (:name, :class_name, '
-                        '                             :kind, :file)')
-            else:  # self.ALLOW
-                return (f'INSERT INTO allow VALUES (:name, :class_name, '
+                return ('INSERT INTO exports VALUES (:name, :class_name, '
+                        '                            :kind, :file)')
+            elif self == self.ALLOW:
+                return ('INSERT INTO allow VALUES (:name, 0, :class_name, '
                         '                           :allow_unused, :kind, '
                         '                           :cond, :file)')
+            elif self == self.ALLOW_PREFIX:
+                return ('INSERT INTO allow VALUES (:name, 1, :class_name, '
+                        '                          :allow_unused, :kind, '
+                        '                          :cond, :file)')
+            else:
+                raise RuntimeError('unreachable')
 
     def _add_api_report(self, report: APIReport, binary: Path,
                         dest=InsertionKind.EXPORTS):
@@ -416,6 +425,16 @@ class SDKDB:
                                         dest=self.InsertionKind.ALLOW,
                                         cond_id=cond_id,
                                         allow_unused=entry.allow_unused)
+            for decl in entry.swift_decls:
+                mangled = mangle_partial(decl.name, type_kinds=decl.type_kinds,
+                                         extension_module=decl.extension,
+                                         extension_base_depth=decl.extension_base_depth)
+                assert all(c != '*' and c != '?' for c in mangled), \
+                    'Mangled Swift symbol "{mangled}" contains glob characters'
+                self._add_symbol(mangled, allowlist,
+                                 dest=self.InsertionKind.ALLOW_PREFIX,
+                                 cond_id=cond_id,
+                                 allow_unused=entry.allow_unused)
 
     def add_conditions(self, conditions: Mapping[str, ConditionVariable]):
         cur = self.con.cursor()
@@ -450,92 +469,141 @@ class SDKDB:
                         ((sel, OBJC_SEL, path, report.arch)
                          for sel in report.selrefs))
 
-    def audit(self) -> Iterable[Diagnostic]:
-        cur = self.con.cursor()
-        # First compute the "-D" defines that are active by traversing the
-        # `condition_chain` graph structure. Start with rows that have no
-        # `nextid` edge, and keep only the ones whose names are active (or
-        # inactive, if the condition is inverted). Repeat the process with rows
-        # whose nextid is in the table, until no rows are added.
-        cur.execute('WITH RECURSIVE active_cond AS ('
+    def backup_temp_data(self, file: Path) -> None:
+        backup = sqlite3.connect(file)
+        self.con.commit()
+        self.con.backup(backup, pages=1, name='temp')
+        backup.close()
+
+    def _materialize_active_conditions(self, cur) -> None:
+        """Populate a temp table by traversing the condition_chain graph to
+        find allowlist entries whose conditions are all satisfied."""
+        cur.execute('DELETE FROM active_cond')
+        cur.execute('INSERT INTO active_cond '
+                    'WITH RECURSIVE ac AS ('
                     '   SELECT cc.rowid AS nextid, name '
                     '   FROM condition_chain AS cc NATURAL LEFT JOIN condition '
-                    '   WHERE nextid IS NULL AND '
+                    '   WHERE cc.nextid IS NULL AND '
                     f'        {apply_operator_sql("cc.op", "condition.value", "cc.operand")}'
                     '   UNION ALL '
                     '   SELECT cc.rowid AS nextid, cc.name '
-                    '   FROM condition_chain AS cc JOIN active_cond USING (nextid) '
+                    '   FROM condition_chain AS cc JOIN ac USING (nextid) '
                     '   NATURAL LEFT JOIN condition '
                     f'  WHERE {apply_operator_sql("cc.op", "condition.value", "cc.operand")}'
-                    ') '
-                    # Then cross-check imports and allowed declarations against
-                    # exports.
-                    'SELECT i.arch, i.kind, i.input_file, i.name, '
-                    '       a.kind, group_concat(aw.input_file), a.name, '
-                    '           min(a.allow_unused), '
-                    '       group_concat(ew.input_file), '
+                    ') SELECT * FROM ac')
+
+    def _query_missing_imports(self, cur) -> list:
+        """Find imported names that have no matching export in any loaded file."""
+        cur.execute('SELECT i.arch, i.kind, i.input_file, i.name, '
                     '       sum(e.name IS NOT NULL AND '
-                    '           ew.input_file IS NOT NULL) as export_found, '
-                    '       sum(a.name IS NOT NULL AND '
-                    '           a.cond_id IS c.nextid AND '
-                    '           (ew.input_file IS NULL OR '
-                    '            a.class_name = e.class_name IS NOT FALSE) AND '
-                    '           aw.input_file IS NOT NULL) as allow_found '
+                    '           ew.input_file IS NOT NULL) as export_found '
                     'FROM imports AS i '
                     'LEFT JOIN exports AS e USING (name, kind) '
-                    'FULL JOIN allow AS a USING (name, kind) '
-                    # The `input_file` columns added by these joins will be
-                    # NULL if the respective export or allowed declaration is
-                    # not loaded (i.e. it's in the cache from some other
-                    # invocation).
                     'FULL JOIN window AS ew ON ew.input_file = e.input_file '
+                    'GROUP BY i.kind, i.name, i.input_file '
+                    'HAVING i.name IS NOT NULL AND export_found = 0 '
+                    'ORDER BY i.input_file, i.kind, i.name')
+        return cur.fetchall()
+
+    # Note on prefix matching: The below queries use range lookups instead of
+    # LIKE or GLOB to match names in allowlist entries. Plain LIKE and GLOB
+    # cannot be optimized because the query planner doesn't know whether the
+    # pattern string is a prefix match or not, so the LIKE optimization
+    # <https://sqlite.org/optoverview.html#the_like_optimization> does not
+    # apply.
+    #
+    # The range lookup (q >= p AND q < p||X'FF') is equivalent to what the LIKE
+    # optimization would expand to. The upper bound of the range works because
+    # 0xFF is larger than any starting UTF-8 byte, so it sorts after `name` but
+    # before the next possible UTF-8 string.
+
+    def _query_allowed_imports(self, cur) -> list:
+        """Find imported names that match a loaded allowlist entry."""
+        cur.execute('SELECT i.kind, i.name, '
+                    '       a.kind, group_concat(aw.input_file), a.name, a.class_name, '
+                    '           max(a.is_prefix), min(a.allow_unused), '
+                    '       sum(a.name IS NOT NULL AND '
+                    '           a.cond_id IS c.nextid AND '
+                    '           aw.input_file IS NOT NULL) as allow_found '
+                    'FROM allow AS a '
+                    'LEFT JOIN imports AS i '
+                    '     ON (i.name = a.name '
+                    '         OR (a.is_prefix AND i.name >= a.name '
+                    '             AND i.name < a.name||X\'FF\')) '
+                    '        AND i.kind = a.kind '
                     'FULL JOIN window AS aw ON aw.input_file = a.input_file '
                     'LEFT JOIN active_cond AS c ON a.cond_id = c.nextid '
-                    # There may be multiple entries for the same name in the
-                    # cache (multiple binaries that implement the same
-                    # selector, or different allowlists that allow the same
-                    # name. Coalesce the results and only return entries where
-                    # an import name has *no* exports found, or an allowed name
-                    # comes from at least one loaded file. Ignore ObjC methods
-                    # in allowlists which partially match an exported method
-                    # (i.e. selector matches but class does not).
-                    #
-                    # This is sufficient to remove all rows in the common
-                    # case--imported API that matches an exported delcaration.
-                    # The remaining logic to identify problem is done in Python
-                    # below.
                     'GROUP BY i.kind, a.kind, i.name, a.name, i.input_file '
-                    'HAVING export_found = 0 OR '
-                    '   (allow_found > 0 AND '
-                    '    e.class_name = a.class_name IS NOT FALSE) '
+                    'HAVING allow_found > 0 '
                     'ORDER BY i.input_file, i.kind, a.kind, i.name, a.name')
-        for (arch, import_kind, input_path, import_name,
-             allowed_kind, allowlist_paths, allowed_name, allow_unused,
-             export_paths, export_found, allow_found) in cur.fetchall():
-            if import_name and not export_found and not allow_found:
-                # Imported but neither exported nor allowed => possible SPI.
-                yield MissingName(name=import_name, file=Path(input_path),
-                                  arch=arch, kind=import_kind)
-            elif not import_name and allow_found and not allow_unused:
-                # Not imported but allowed => unused allowlist entry to remove.
-                # FIXME: split(',') falls apart if an allowlist path contains a
-                # comma. We could improve this by using quote() in the query
-                # and unquoting here.
-                for path in sorted(set(allowlist_paths.split(','))):
-                    yield UnusedAllowedName(name=allowed_name, file=Path(path),
-                                            kind=allowed_kind)
-            elif allow_found and export_found:
-                # Allowed but also exported => unnecessary allowlist entry to
-                # remove.
-                for path in sorted(set(allowlist_paths.split(','))):
-                    # Normally, a declaration would only be exported from one
-                    # library in the SDK. If the cache sees multiple sources,
-                    # just pick one.
-                    export_path = min(export_paths.split(','))
-                    yield UnnecessaryAllowedName(name=allowed_name,
-                                                 file=Path(path),
-                                                 kind=allowed_kind,
-                                                 exported_in=Path(export_path))
+        return cur.fetchall()
+
+    def _find_export_sources(self, cur, allowed_name: str, allowed_kind: DeclarationKind,
+                             allowed_class: Optional[str], is_prefix: bool) -> list:
+        """Look up which loaded files export a given name."""
+        params = {'name': allowed_name, 'kind': allowed_kind, 'class': allowed_class}
+        where_clause = ('e.name >= :name AND e.name < :name||X\'FF\''
+                        if is_prefix else 'e.name = :name')
+        cur.execute('SELECT DISTINCT e.input_file FROM exports AS e '
+                    'JOIN window AS ew ON ew.input_file = e.input_file '
+                    f'WHERE {where_clause} AND e.kind = :kind '
+                    # For ObjC selectors, ignore mismatching classes if the
+                    # allowlist entry has a class.
+                    'AND (e.class_name = :class OR :class IS NULL) '
+                    'ORDER BY e.input_file ', params)
+        return cur.fetchall()
+
+    def audit(self, debug_query_plan=False) -> Iterable[Diagnostic]:
+        cur = self.con.cursor()
+
+        self._materialize_active_conditions(cur)
+        # Maps from a name-kind pair representing an imported declaration to
+        # the file-arch slice that it appears in.
+        missing = {}
+        for arch, kind, path, name, _ in self._query_missing_imports(cur):
+            missing[(name, kind)] = (arch, path)
+
+        # Tracks when a prefix symbol for a swift declaration has been
+        # encountered, to avoid reporting issues for the same entry multiple
+        # times.
+        seen_prefixes: set[str] = set()
+
+        for (import_kind, import_name,
+             allowed_kind, allowlist_paths, allowed_name, allowed_class,
+             is_prefix, allow_unused, _) in self._query_allowed_imports(cur):
+            display_name = allowed_name + ('*' if is_prefix else '')
+            allowlist_files = sorted(set(allowlist_paths.split(',')))
+
+            if import_name is None:
+                # Not imported: allowlist entry can be cleaned up.
+                if allow_unused:
+                    continue
+                for path in allowlist_files:
+                    yield UnusedAllowedName(name=display_name,
+                                            file=Path(path), kind=allowed_kind)
+            else:
+                if missing.pop((import_name, import_kind), None):
+                    # Matches a missing declaration: SPI allowed.
+                    continue
+                # Imported, allowed, and present in the exports table:
+                # allowlist entry can be cleaned up.
+                if is_prefix:
+                    if allowed_name in seen_prefixes:
+                        continue
+                    seen_prefixes.add(allowed_name)
+                for export_file, in self._find_export_sources(
+                        cur, allowed_name, allowed_kind,
+                        allowed_class, is_prefix):
+                    for path in allowlist_files:
+                        yield UnnecessaryAllowedName(
+                            name=display_name, file=Path(path),
+                            kind=allowed_kind, exported_in=Path(export_file))
+
+        # Any remaining missing entries are not covered by active allowlist
+        # entries.
+        for (name, kind), (arch, input_file) in missing.items():
+            yield MissingName(name=name, file=Path(input_file),
+                              arch=arch, kind=kind)
 
     def stats(self):
         cur = self.con.cursor()

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/sdkdb_unittest.py
@@ -35,7 +35,9 @@ F_NonNormalized = Path('/foo/../libdoesntexist.dylib')
 R_Selector = APIReport.Selector('initWithData:', 'WKDoesntExist')
 R = APIReport(
     file=F, arch='arm64e',
-    exports={'_WKDoesntExistLibraryVersion', '_OBJC_CLASS_$_WKDoesntExist'},
+    exports={'_WKDoesntExistLibraryVersion', '_OBJC_CLASS_$_WKDoesntExist',
+             # class WKTest { func foo() { ... } }
+             '_$s4Test6WKTestCMF', '_$s4Test6WKTestC3fooyyF'},
     methods={R_Selector},
     platform='iOS', min_os='1.0', sdk='1.0'
 )
@@ -43,12 +45,17 @@ R = APIReport(
 F_Client = Path('/libdoesntexist_client.dylib')
 R_Client = APIReport(
     file=F_Client, arch='arm64e',
-    imports={'_WKDoesntExistLibraryVersion', '_OBJC_CLASS_$_WKDoesntExist'},
+    imports={'_WKDoesntExistLibraryVersion', '_OBJC_CLASS_$_WKDoesntExist',
+             '_$s4Test6WKTestCMF', '_$s4Test6WKTestC3fooyyF'},
     selrefs={'initWithData:'},
     platform='iOS', min_os='1.0', sdk='1.0'
 )
 R_MissingSymbol = MissingName(name='_WKDoesntExistLibraryVersion',
                               file=F_Client, arch='arm64e', kind=SYMBOL)
+R_MissingSwiftSymbol1 = MissingName(name='_$s4Test6WKTestCMF',
+                                    file=F_Client, arch='arm64e', kind=SYMBOL)
+R_MissingSwiftSymbol2 = MissingName(name='_$s4Test6WKTestC3fooyyF',
+                                    file=F_Client, arch='arm64e', kind=SYMBOL)
 R_MissingClass = MissingName(name='WKDoesntExist', file=F_Client, arch='arm64e', kind=OBJC_CLS)
 R_MissingSelector = MissingName(name='initWithData:', file=F_Client, arch='arm64e', kind=OBJC_SEL)
 
@@ -57,7 +64,8 @@ A = AllowList.from_dict({'temporary-usage': [
      'cleanup': 'rdar://12346',
      'classes': ['WKDoesntExist'],
      'selectors': [{'name': 'initWithData:', 'class': '?'}],
-     'symbols': ['WKDoesntExistLibraryVersion']}
+     'symbols': ['WKDoesntExistLibraryVersion'],
+     'swift-decls': [{'name': 'Test.WKTest'}]}
 ]})
 A_File = Path('/allowed.toml')
 A_Hash = 23456
@@ -67,6 +75,7 @@ A_ExplicitlyAllowUnused = AllowList.from_dict({'temporary-usage': [
      'classes': ['WKDoesntExist'],
      'selectors': [{'name': 'initWithData:', 'class': '?'}],
      'symbols': ['WKDoesntExistLibraryVersion'],
+     'swift-decls': [{'name': 'Test.WKTest'}],
      'allow-unused': True}
 ]})
 
@@ -74,6 +83,8 @@ A_UnusedAllow = UnusedAllowedName(name='WKDoesntExist', file=A_File,
                                   kind=OBJC_CLS)
 A_AllowedAPI = UnnecessaryAllowedName(name='WKDoesntExist', file=A_File,
                                       kind=OBJC_CLS, exported_in=F)
+A_AllowedSwift = UnusedAllowedName(name='_$s4Test6WKTest*', file=A_File,
+                                   kind=SYMBOL)
 
 R_Uses_Own_Selector = APIReport(
     file=F_Client, arch='arm64e',
@@ -88,6 +99,7 @@ A_Conditional = AllowList.from_dict({'temporary-usage': [
      'classes': ['WKDoesntExist'],
      'selectors': [{'name': 'initWithData:', 'class': '?'}],
      'symbols': ['WKDoesntExistLibraryVersion'],
+     'swift-decls': [{'name': 'Test.WKTest'}],
      'requires': ['ENABLE_FEATURE'],
      'requires-os': ['iOS>=1.0'],
      'requires-sdk': ['iOS < 99']}
@@ -99,6 +111,7 @@ A_NegatedConditional = AllowList.from_dict({'temporary-usage': [
      'classes': ['WKDoesntExist'],
      'selectors': [{'name': 'initWithData:', 'class': '?'}],
      'symbols': ['WKDoesntExistLibraryVersion'],
+     'swift-decls': [{'name': 'Test.WKTest'}],
      'requires': ['!ENABLE_FEATURE']}
 ]})
 
@@ -108,6 +121,7 @@ A_MultipleConditions = AllowList.from_dict({'temporary-usage': [
      'classes': ['WKDoesntExist'],
      'selectors': [{'name': 'initWithData:', 'class': '?'}],
      'symbols': ['WKDoesntExistLibraryVersion'],
+     'swift-decls': [{'name': 'Test.WKTest'}],
      'requires': ['ENABLE_A', 'ENABLE_B', '!ENABLE_C']}
 ]})
 
@@ -116,7 +130,8 @@ A_QualifiedSelector = AllowList.from_dict({'temporary-usage': [
      'cleanup': 'rdar://12346',
      'classes': ['WKDoesntExist'],
      'selectors': [{'name': 'initWithData:', 'class': 'WKDoesntExist'}],
-     'symbols': ['WKDoesntExistLibraryVersion']}
+     'symbols': ['WKDoesntExistLibraryVersion'],
+     'swift-decls': [{'name': 'Test.WKTest'}]}
 ]})
 
 A_NonmatchingOS = AllowList.from_dict({'temporary-usage': [
@@ -125,6 +140,7 @@ A_NonmatchingOS = AllowList.from_dict({'temporary-usage': [
      'classes': ['WKDoesntExist'],
      'selectors': [{'name': 'initWithData:', 'class': '?'}],
      'symbols': ['WKDoesntExistLibraryVersion'],
+     'swift-decls': [{'name': 'Test.WKTest'}],
      'requires': ['ENABLE_FEATURE'],
      'requires-os': ['iOS>=99.0']}
 ]})
@@ -141,9 +157,21 @@ S = {
         }]
     }]
 }
+S_SwiftSymbols = {
+    'PublicSDKContentRoot': [{
+        'target': 'arm64-apple-ios18.5',
+        'globals': [
+            {'access': 'public', 'name': '_$s4Test6WKTestCMF'},
+            {'access': 'public', 'name': '_$s4Test6WKTestC3fooyyF'},
+        ]
+    }]
+}
 S_File = Path('/Foundation.partial.sdkdb')
 S_Hash = 3456789
 S_UnnecessarySelector = UnnecessaryAllowedName(name='initWithData:', file=A_File, kind=OBJC_SEL, exported_in=S_File)
+S_UnnecessarySwiftDecl = UnnecessaryAllowedName(name="_$s4Test6WKTest*",
+                                                file=A_File, kind=SYMBOL,
+                                                exported_in=S_File)
 
 class TestSDKDB(TestCase):
     def setUp(self):
@@ -158,10 +186,10 @@ class TestSDKDB(TestCase):
             self.sdkdb._cache_hit_preparing_to_insert(file, file_hash)
             self.sdkdb._add_api_report(fixture, file)
 
-    def add_partial_sdkdb(self):
+    def add_partial_sdkdb(self, fixture=S, file=S_File, file_hash=S_Hash):
         with self.sdkdb:
-            self.sdkdb._cache_hit_preparing_to_insert(S_File, S_Hash)
-            self.sdkdb._add_partial_sdkdb(S, S_File, spi=False, abi=False)
+            self.sdkdb._cache_hit_preparing_to_insert(file, file_hash)
+            self.sdkdb._add_partial_sdkdb(fixture, file, spi=False, abi=False)
 
     def add_allowlist(self, fixture=A, file=A_File, hash=A_Hash):
         with self.sdkdb:
@@ -215,7 +243,9 @@ class TestSDKDB(TestCase):
 
         # ...the old exports should be removed:
         diagnostics = set(self.audit_with(R_Client))
-        self.assertEqual({R_MissingSymbol, R_MissingClass, R_MissingSelector},
+        self.assertEqual({R_MissingSymbol, R_MissingSwiftSymbol1,
+                          R_MissingSwiftSymbol2, R_MissingClass,
+                          R_MissingSelector},
                          diagnostics)
 
     def test_audit_missing_name_from_spi(self):
@@ -298,6 +328,13 @@ class TestSDKDB(TestCase):
         self.add_allowlist()
         self.assertIn(S_UnnecessarySelector, self.audit_with(R_Client))
 
+    def test_audit_unnecessary_allow_from_swift_partial_symbol(self):
+        self.add_partial_sdkdb(S_SwiftSymbols)
+        self.add_allowlist()
+        diagnostics = list(self.audit_with(R_Client))
+        self.assertIn(S_UnnecessarySwiftDecl, diagnostics)
+        self.assertEqual(1, diagnostics.count(S_UnnecessarySwiftDecl))
+
     def test_audit_allowed_fully_qualified_selector(self):
         self.add_partial_sdkdb()
         self.add_allowlist(A_QualifiedSelector)
@@ -340,6 +377,10 @@ class TestSDKDB(TestCase):
         self.add_allowlist()
         self.add_allowlist(A_ExplicitlyAllowUnused)
         self.assertIn(A_UnusedAllow, self.sdkdb.audit())
+
+    def test_audit_unused_allow_from_swift_decl(self):
+        self.add_allowlist()
+        self.assertIn(A_AllowedSwift, list(self.sdkdb.audit()))
 
     def test_audit_no_unused_allow_from_unloaded_allowlist(self):
         self.add_allowlist()

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/swift_mangle.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/swift_mangle.py
@@ -1,0 +1,675 @@
+"""Partial Swift name mangling.
+
+Produces mangled symbol *prefixes* for Swift declarations.
+Given a simplified declaration string like ``ModuleName.TypeName.foo(bar:)``,
+produces ``_$s10ModuleName04TypeB0C3foo3bar`` — containing module, nominal
+types, function name, and argument labels, but **not** type information.
+
+This enables prefix-matching against real Swift symbols.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Mapping
+
+# Portions of this code are based the Swift compiler:
+# https://github.com/swiftlang/swift, retrieved January 2026.
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+# ---------------------------------------------------------------------------
+# Standard-type substitution tables (from StandardTypesMangling.def)
+# ---------------------------------------------------------------------------
+
+# Swift module standard types: name -> mangling char
+# Emitted as "S<char>"
+STANDARD_TYPES: Mapping[str, str] = {
+    # Structures
+    "AutoreleasingUnsafeMutablePointer": "A",
+    "Array": "a",
+    "Bool": "b",
+    "Dictionary": "D",
+    "Double": "d",
+    "Float": "f",
+    "Set": "h",
+    "DefaultIndices": "I",
+    "Int": "i",
+    "Character": "J",
+    "ClosedRange": "N",
+    "Range": "n",
+    "ObjectIdentifier": "O",
+    "UnsafePointer": "P",
+    "UnsafeMutablePointer": "p",
+    "UnsafeBufferPointer": "R",
+    "UnsafeMutableBufferPointer": "r",
+    "String": "S",
+    "Substring": "s",
+    "UInt": "u",
+    "UnsafeRawPointer": "V",
+    "UnsafeMutableRawPointer": "v",
+    "UnsafeRawBufferPointer": "W",
+    "UnsafeMutableRawBufferPointer": "w",
+    # Enums
+    "Optional": "q",
+    # Protocols
+    "BinaryFloatingPoint": "B",
+    "Encodable": "E",
+    "Decodable": "e",
+    "FloatingPoint": "F",
+    "RandomNumberGenerator": "G",
+    "Hashable": "H",
+    "Numeric": "j",
+    "BidirectionalCollection": "K",
+    "RandomAccessCollection": "k",
+    "Comparable": "L",
+    "Collection": "l",
+    "MutableCollection": "M",
+    "RangeReplaceableCollection": "m",
+    "Equatable": "Q",
+    "Sequence": "T",
+    "IteratorProtocol": "t",
+    "UnsignedInteger": "U",
+    "RangeExpression": "X",
+    "Strideable": "x",
+    "RawRepresentable": "Y",
+    "StringProtocol": "y",
+    "SignedInteger": "Z",
+    "BinaryInteger": "z",
+}
+
+# Concurrency standard types: name -> mangling char
+# Emitted as "Sc<char>"
+STANDARD_TYPES_CONCURRENCY: Mapping[str, str] = {
+    "Actor": "A",
+    "CheckedContinuation": "C",
+    "UnsafeContinuation": "c",
+    "CancellationError": "E",
+    "UnownedSerialExecutor": "e",
+    "Executor": "F",
+    "SerialExecutor": "f",
+    "TaskGroup": "G",
+    "ThrowingTaskGroup": "g",
+    "TaskExecutor": "h",
+    "AsyncIteratorProtocol": "I",
+    "AsyncSequence": "i",
+    "UnownedJob": "J",
+    "MainActor": "M",
+    "TaskPriority": "P",
+    "AsyncStream": "S",
+    "AsyncThrowingStream": "s",
+    "Task": "T",
+    "UnsafeCurrentTask": "t",
+}
+
+# Kind operators for nominal types
+KIND_OPERATORS: dict[str, str] = {
+    "class": "C",
+    "struct": "V",
+    "enum": "O",
+    "protocol": "P",
+}
+
+# ---------------------------------------------------------------------------
+# Word-boundary helpers (ports isWordStart / isWordEnd from ManglingUtils.h)
+# ---------------------------------------------------------------------------
+
+
+def _is_word_start(ch: str) -> bool:
+    """A word starts at a non-digit, non-underscore, non-NUL character."""
+    return ch != "\0" and ch != "_" and not ch.isdigit()
+
+
+def _is_word_end(ch: str, prev: str) -> bool:
+    """A word ends when we hit underscore, NUL, or a lowercase->uppercase transition."""
+    if ch == "_" or ch == "\0":
+        return True
+    if not prev.isupper() and ch.isupper():
+        return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Substitution merging (ports SubstitutionMerging from ManglingUtils.h)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SubstitutionMerging:
+    last_subst_position: int = 0
+    last_subst_size: int = 0
+    last_num_substs: int = 0
+    last_subst_is_standard: bool = False
+
+    MAX_REPEAT_COUNT: int = 2048
+
+    def try_merge_subst(
+        self, buffer: list[str], subst: str, is_standard_subst: bool
+    ) -> bool:
+        buf_len = len(buffer)
+        if (
+            self.last_num_substs > 0
+            and self.last_num_substs < self.MAX_REPEAT_COUNT
+            and buf_len == self.last_subst_position + self.last_subst_size
+            and self.last_subst_is_standard == is_standard_subst
+        ):
+            # Get the last substitution mangling (drop leading digits)
+            last_raw = "".join(buffer[-self.last_subst_size:])
+            last_subst = last_raw.lstrip("0123456789")
+
+            if last_subst != subst and not is_standard_subst:
+                # Merge with a different 'A' substitution: AB -> AbC
+                self.last_subst_position = buf_len
+                self.last_num_substs = 1
+                # Replace last char (uppercase) with lowercase version
+                old_char = buffer[-1]
+                buffer[-1] = old_char.lower()
+                buffer.extend(subst)
+                self.last_subst_size = len(subst)
+                return True
+
+            if last_subst == subst:
+                # Merge with the same substitution: AB -> A2B, S3i -> S4i
+                self.last_num_substs += 1
+                del buffer[self.last_subst_position:]
+                count_str = str(self.last_num_substs)
+                buffer.extend(count_str)
+                buffer.extend(subst)
+                self.last_subst_size = len(buffer) - self.last_subst_position
+                return True
+
+        # Can't merge; caller will mangle it. Record for future merging.
+        self.last_subst_position = buf_len + 1  # +1 for the 'A' or 'S' prefix
+        self.last_subst_size = len(subst)
+        self.last_num_substs = 1
+        self.last_subst_is_standard = is_standard_subst
+        return False
+
+
+# ---------------------------------------------------------------------------
+# WordReplacement helper
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WordReplacement:
+    string_pos: int
+    word_idx: int
+
+
+@dataclass
+class SubstitutionWord:
+    start: int
+    length: int
+
+
+# ---------------------------------------------------------------------------
+# Mangler
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Mangler:
+    """Stateful Swift name mangler for producing symbol prefixes."""
+
+    buffer: list[str] = field(default_factory=list)
+
+    # Word substitutions (up to 26 words shared across identifiers in one symbol)
+    words: list[SubstitutionWord] = field(default_factory=list)
+
+    # Entity/string substitutions share a single index counter
+    string_substitutions: dict[str, int] = field(default_factory=dict)
+    entity_substitutions: dict[str, int] = field(default_factory=dict)
+    next_substitution_index: int = 0
+
+    subst_merging: SubstitutionMerging = field(default_factory=SubstitutionMerging)
+
+    def _get_buffer_str(self) -> str:
+        return "".join(self.buffer)
+
+    def _reset_buffer(self, pos: int) -> None:
+        del self.buffer[pos:]
+
+    # -------------------------------------------------------------------
+    # Index encoding (from Mangler.h)
+    # -------------------------------------------------------------------
+
+    @staticmethod
+    def _encode_index(n: int) -> str:
+        """Encode an index: Index(0) = '_', Index(1) = '0_', Index(k) = '{k-1}_'."""
+        if n == 0:
+            return "_"
+        return f"{n - 1}_"
+
+    # -------------------------------------------------------------------
+    # Entity/string substitution management
+    # -------------------------------------------------------------------
+
+    def _add_substitution(self, key: str, is_entity: bool = False) -> None:
+        value = self.next_substitution_index
+        self.next_substitution_index += 1
+        if is_entity:
+            self.entity_substitutions[key] = value
+        else:
+            self.string_substitutions[key] = value
+
+    def _try_substitution(self, key: str, is_entity: bool = False) -> bool:
+        subs = self.entity_substitutions if is_entity else self.string_substitutions
+        if key in subs:
+            self._mangle_substitution(subs[key])
+            return True
+        return False
+
+    def _mangle_substitution(self, idx: int) -> None:
+        """Emit a substitution encoding for the given index (ports mangleSubstitution)."""
+        if idx >= 26:
+            # Large substitution: A + Index(idx - 26)
+            self.buffer.extend("A")
+            self.buffer.extend(self._encode_index(idx - 26))
+            return
+
+        subst_char = chr(idx + ord("A"))
+        subst = subst_char
+        if self.subst_merging.try_merge_subst(self.buffer, subst, False):
+            pass  # merged
+        else:
+            self.buffer.extend("A")
+            self.buffer.append(subst_char)
+
+    # -------------------------------------------------------------------
+    # Identifier encoding (word substitution algorithm)
+    # Faithful port of ManglingUtils.h mangleIdentifier()
+    # -------------------------------------------------------------------
+
+    def _mangle_identifier(self, ident: str) -> None:
+        """Core word-substitution encoding of an identifier."""
+        words_in_buffer = len(self.words)
+        subst_words: list[WordReplacement] = []
+
+        NOT_INSIDE_WORD = -1
+        word_start_pos = NOT_INSIDE_WORD
+
+        for pos in range(len(ident) + 1):
+            ch = ident[pos] if pos < len(ident) else "\0"
+
+            if word_start_pos != NOT_INSIDE_WORD and _is_word_end(
+                ch, ident[pos - 1]
+            ):
+                word_len = pos - word_start_pos
+                word = ident[word_start_pos:word_start_pos + word_len]
+
+                # Look up word in buffer-sourced words first
+                word_idx = -1
+                buf_str = self._get_buffer_str()
+                for i in range(0, words_in_buffer):
+                    w = self.words[i]
+                    existing = buf_str[w.start:w.start + w.length]
+                    if word == existing:
+                        word_idx = i
+                        break
+
+                # Then look in identifier-sourced words
+                if word_idx < 0:
+                    for i in range(words_in_buffer, len(self.words)):
+                        w = self.words[i]
+                        existing = ident[w.start:w.start + w.length]
+                        if word == existing:
+                            word_idx = i
+                            break
+
+                if word_idx >= 0:
+                    assert word_idx < 26
+                    subst_words.append(WordReplacement(word_start_pos, word_idx))
+                elif word_len >= 2 and len(self.words) < 26:
+                    # New word — position relative to identifier for now
+                    self.words.append(SubstitutionWord(word_start_pos, word_len))
+
+                word_start_pos = NOT_INSIDE_WORD
+
+            if word_start_pos == NOT_INSIDE_WORD and _is_word_start(ch):
+                word_start_pos = pos
+
+        # If we have word substitutions, prefix with '0'
+        if subst_words:
+            self.buffer.append("0")
+
+        pos = 0
+        # Add sentinel
+        subst_words.append(WordReplacement(len(ident), -1))
+
+        for idx in range(len(subst_words)):
+            repl = subst_words[idx]
+            if pos < repl.string_pos:
+                # Emit literal substring length
+                first = True
+                self.buffer.extend(str(repl.string_pos - pos))
+                while pos < repl.string_pos:
+                    # Update start positions of new words
+                    if (
+                        words_in_buffer < len(self.words)
+                        and self.words[words_in_buffer].start == pos
+                    ):
+                        self.words[words_in_buffer].start = len(self.buffer)
+                        words_in_buffer += 1
+
+                    if first and ident[pos].isdigit():
+                        self.buffer.append("X")
+                    else:
+                        self.buffer.append(ident[pos])
+                    pos += 1
+                    first = False
+
+            if repl.word_idx >= 0:
+                assert repl.word_idx <= words_in_buffer
+                pos += self.words[repl.word_idx].length
+                if idx < len(subst_words) - 2:
+                    # Non-last: lowercase
+                    self.buffer.append(chr(repl.word_idx + ord("a")))
+                else:
+                    # Last: uppercase
+                    self.buffer.append(chr(repl.word_idx + ord("A")))
+                    if pos == len(ident):
+                        self.buffer.append("0")
+
+    # -------------------------------------------------------------------
+    # appendIdentifier — string-substitution wrapper
+    # -------------------------------------------------------------------
+
+    def _append_identifier(self, ident: str) -> None:
+        """Append an identifier with string-substitution check."""
+        if ident in self.string_substitutions:
+            self._mangle_substitution(self.string_substitutions[ident])
+            return
+
+        self._add_substitution(ident, is_entity=False)
+        self._mangle_identifier(ident)
+
+    # -------------------------------------------------------------------
+    # Module encoding
+    # -------------------------------------------------------------------
+
+    def _mangle_module(self, name: str) -> None:
+        if name == "Swift":
+            self.buffer.append("s")
+            return
+        if name == "__C" or name == "ObjectiveC":
+            self.buffer.extend("So")
+            return
+        if name == "__C_Synthesized":
+            self.buffer.extend("SC")
+            return
+        self._append_identifier(name)
+
+    # -------------------------------------------------------------------
+    # Standard type substitution
+    # -------------------------------------------------------------------
+
+    def _try_standard_type_subst(self, module: str, name: str) -> bool:
+        """Try emitting a standard type substitution. Returns True if emitted."""
+        if module != "Swift":
+            return False
+
+        if name in STANDARD_TYPES:
+            ch = STANDARD_TYPES[name]
+            subst = ch
+            if self.subst_merging.try_merge_subst(self.buffer, subst, True):
+                pass
+            else:
+                self.buffer.append("S")
+                self.buffer.append(ch)
+            return True
+
+        if name in STANDARD_TYPES_CONCURRENCY:
+            ch = STANDARD_TYPES_CONCURRENCY[name]
+            self.buffer.extend("Sc")
+            self.buffer.append(ch)
+            return True
+
+        return False
+
+    # -------------------------------------------------------------------
+    # Nominal type encoding
+    # -------------------------------------------------------------------
+
+    def _mangle_nominal_type(
+        self,
+        module: str,
+        type_chain: list[str],
+        type_idx: int,
+        type_kinds: Mapping[str, str],
+        extension_module: str | None = None,
+        extension_base_depth: int | None = None,
+    ) -> None:
+        """Mangle a nominal type at position type_idx in the chain."""
+        name = type_chain[type_idx]
+        kind = type_kinds.get(name, "class")
+        kind_op = KIND_OPERATORS[kind]
+
+        # Build entity key
+        if type_idx == 0:
+            entity_key = f"{module}.{name}"
+        else:
+            parts = [module] + [type_chain[i] for i in range(type_idx + 1)]
+            entity_key = ".".join(parts)
+
+        # Check standard type substitution
+        if type_idx == 0 and self._try_standard_type_subst(module, name):
+            self.entity_substitutions[entity_key] = self.next_substitution_index
+            self.next_substitution_index += 1
+            return
+
+        # Check entity substitution
+        if entity_key in self.entity_substitutions:
+            self._mangle_substitution(self.entity_substitutions[entity_key])
+            return
+
+        # Mangle context (module or parent type)
+        if type_idx == 0:
+            self._mangle_module(module)
+        else:
+            self._mangle_nominal_type(
+                module, type_chain, type_idx - 1, type_kinds,
+                extension_module, extension_base_depth,
+            )
+
+        # Extension boundary: emit extension context between base types
+        # and types defined within the extension.
+        if (
+            extension_module is not None
+            and extension_base_depth is not None
+            and type_idx == extension_base_depth
+        ):
+            self._mangle_extension_context(extension_module)
+
+        # Mangle the type name
+        self._append_identifier(name)
+
+        # Kind operator
+        self.buffer.append(kind_op)
+
+        # Register entity substitution
+        self.entity_substitutions[entity_key] = self.next_substitution_index
+        self.next_substitution_index += 1
+
+    # -------------------------------------------------------------------
+    # Label encoding (from appendFunction)
+    # -------------------------------------------------------------------
+
+    def _mangle_labels(self, labels: list[str]) -> None:
+        """Encode parameter labels."""
+        if not labels:
+            # No parameters at all — emit nothing
+            return
+
+        has_any_label = any(n != "_" and n != "" for n in labels)
+        if has_any_label:
+            for label in labels:
+                if label == "_" or label == "":
+                    self.buffer.append("_")
+                else:
+                    self._append_identifier(label)
+        else:
+            # All unlabeled
+            self.buffer.append("y")
+
+    # -------------------------------------------------------------------
+    # Input parsing
+    # -------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_decl(decl: str) -> tuple[str, list[str], str | None, list[str] | None]:
+        """Parse a declaration string.
+
+        Returns (module, type_chain, member_name, labels).
+        - member_name is None for bare types
+        - labels is None for properties, list of strings for functions
+        """
+        components = decl.split(".")
+        module = components[0]
+        if len(components) == 1:
+            return (module, [], None, None)
+
+        last = components[-1]
+        type_chain = list(components[1:-1])
+
+        # Check if last component has parentheses (function/init)
+        paren_match = re.match(r"^(\w+)\((.*)\)$", last)
+        if paren_match:
+            member_name = paren_match.group(1)
+            label_str = paren_match.group(2)
+            # Normalize __allocating_init -> init
+            if member_name == "__allocating_init":
+                member_name = "init"
+            if label_str:
+                # "bar:baz:" -> ["bar", "baz"]
+                # "_:foo:" -> ["_", "foo"]
+                raw_labels = label_str.rstrip(":").split(":")
+                labels = [n.strip() if n.strip() else "_" for n in raw_labels]
+            else:
+                labels = []
+            return (module, type_chain, member_name, labels)
+        elif last == "subscript":
+            # subscript is special — not mangled as an identifier
+            return (module, type_chain, "subscript", None)
+        else:
+            return (module, type_chain, last, None)
+
+    # -------------------------------------------------------------------
+    # Extension context
+    # -------------------------------------------------------------------
+
+    def _mangle_extension_context(self, module: str) -> None:
+        """Emit extension module + E operator."""
+        self._mangle_module(module)
+        self.buffer.append("E")
+
+    # -------------------------------------------------------------------
+    # Top-level API
+    # -------------------------------------------------------------------
+
+    def mangle(
+        self,
+        decl: str,
+        type_kinds: Mapping[str, str] | None = None,
+        extension_module: str | None = None,
+        extension_base_depth: int | None = None,
+    ) -> str:
+        """Mangle a declaration to its prefix form.
+
+        Args:
+            extension_module: Module where the extension is defined.
+            extension_base_depth: Number of types in the base type chain
+                (before the extension). Types at index >= this value are
+                defined within the extension. Defaults to len(type_chain)
+                (all types are base types, extension adds only members).
+        """
+        if type_kinds is None:
+            type_kinds = {}
+
+        module, type_chain, member_name, labels = self._parse_decl(decl)
+
+        self.buffer.extend("$s")
+
+        # Resolve extension_base_depth: default = all types are base types.
+        if extension_module and extension_base_depth is None:
+            extension_base_depth = len(type_chain)
+
+        # Determine whether extension context is threaded into the type chain
+        # (nested types defined in extension) or appended after it (members only).
+        ext_in_chain = (
+            extension_module is not None
+            and extension_base_depth is not None
+            and extension_base_depth < len(type_chain)
+        )
+
+        # 1. Module + type chain
+        if type_chain:
+            self._mangle_nominal_type(
+                module, type_chain, len(type_chain) - 1, type_kinds,
+                extension_module=extension_module if ext_in_chain else None,
+                extension_base_depth=extension_base_depth if ext_in_chain else None,
+            )
+        else:
+            self._mangle_module(module)
+
+        # 2. Extension context after full type chain (simple case: no nested
+        #    types in extension, only members/properties).
+        if extension_module and not ext_in_chain:
+            self._mangle_extension_context(extension_module)
+
+        # 3. Member
+        if member_name is not None:
+            if member_name == "init":
+                # Constructor — labels only, no member name identifier
+                if labels is not None:
+                    self._mangle_labels(labels)
+            elif member_name == "subscript":
+                # Subscript — not encoded as an identifier name
+                # Labels would follow if provided, but subscript labels
+                # are part of the type signature we don't emit
+                pass
+            elif labels is not None:
+                # Function/method
+                self._append_identifier(member_name)
+                self._mangle_labels(labels)
+            else:
+                # Property
+                self._append_identifier(member_name)
+
+        return "_" + "".join(self.buffer)
+
+
+def mangle_partial(
+    decl: str,
+    type_kinds: Mapping[str, str] | None = None,
+    extension_module: str | None = None,
+    extension_base_depth: int | None = None,
+) -> str:
+    """Compute the mangled symbol prefix for a Swift declaration.
+
+    Args:
+        decl: Simplified declaration like ``"Module.Type.func(label:)"``
+        type_kinds: Optional map from type name to kind
+                    (``"class"``, ``"struct"``, ``"enum"``, ``"protocol"``).
+                    Defaults to ``"class"`` for unknown types.
+        extension_module: If the declaration is in an extension defined in
+                    a different module, the name of that module (e.g.
+                    ``"Foundation"``).  Emits the extension context
+                    (``<module>E``) between the type chain and the member.
+        extension_base_depth: Number of types in the base type chain
+                    (before the extension). Types at index >= this value
+                    are defined within the extension. Defaults to
+                    ``len(type_chain)`` (all types are base, extension
+                    adds only members).
+
+    Returns:
+        Mangled prefix string like ``"_$s10ModuleName..."``
+    """
+    m = Mangler()
+    return m.mangle(decl, type_kinds, extension_module, extension_base_depth)

--- a/Tools/Scripts/libraries/webkitapipy/webkitapipy/swift_mangle_unittest.py
+++ b/Tools/Scripts/libraries/webkitapipy/webkitapipy/swift_mangle_unittest.py
@@ -1,0 +1,428 @@
+"""Tests for swift_mangling module."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import unittest
+
+from .swift_mangle import Mangler, mangle_partial
+
+
+class TestIdentifierEncoding(unittest.TestCase):
+    """Test the word-substitution identifier encoding algorithm."""
+
+    def _mangle(self, ident: str) -> str:
+        m = Mangler()
+        m._mangle_identifier(ident)
+        return "".join(m.buffer)
+
+    def test_simple_word(self):
+        self.assertEqual(self._mangle("foo"), "3foo")
+
+    def test_single_char(self):
+        self.assertEqual(self._mangle("x"), "1x")
+
+    def test_camel_case_splits(self):
+        # "ModuleName" -> words: Module, Name -> no prior words -> just literal
+        self.assertEqual(self._mangle("ModuleName"), "10ModuleName")
+
+    def test_word_substitution_same_ident(self):
+        # "abcabc" has word "abc" starting at pos 0, repeated at pos 3
+        # First "abc" is new (idx 0), second matches -> substitution
+        result = self._mangle("AbcAbc")
+        # "Abc" at pos 0 (new, word 0), "Abc" at pos 3 (matches word 0)
+        # Substitutions: [(3, 0)], prefix '0', then literal "3Abc" + last subst 'A0'
+        self.assertEqual(result, "03AbcA0")
+
+    def test_word_substitution_across_identifiers(self):
+        # Mangling "ModuleName" then "TypeName" should reuse "Name"
+        m = Mangler()
+        m._mangle_identifier("ModuleName")
+        buf_after_first = "".join(m.buffer)
+        self.assertEqual(buf_after_first, "10ModuleName")
+
+        m._mangle_identifier("TypeName")
+        buf_after_second = "".join(m.buffer)
+        # "TypeName": Type is new (word 2), Name matches word 1 from buffer
+        # Substitutions: [(4, 1)] -> prefix '0', literal "4Type", last subst 'B0'
+        self.assertEqual(buf_after_second, "10ModuleName04TypeB0")
+
+    def test_underscore_prefix(self):
+        # Identifiers starting with _ should work
+        self.assertEqual(self._mangle("_arg"), "4_arg")
+
+    def test_digit_first_literal(self):
+        result = self._mangle("a1b")
+        # "a" not word (len < 2), "1b" not word start (digit)
+        # No substitutions -> just emit "3a1b"
+        self.assertEqual(result, "3a1b")
+
+
+class TestAppendIdentifier(unittest.TestCase):
+    """Test string-substitution wrapping of identifier encoding."""
+
+    def test_first_use_encodes(self):
+        m = Mangler()
+        m._append_identifier("Hello")
+        self.assertEqual("".join(m.buffer), "5Hello")
+
+    def test_second_use_substitutes(self):
+        m = Mangler()
+        m._append_identifier("Hello")
+        m._append_identifier("Hello")
+        result = "".join(m.buffer)
+        # First: encodes "5Hello", registers subst idx 0
+        # Second: emits substitution for idx 0 -> "AA"
+        self.assertEqual(result, "5HelloAA")
+
+
+class TestModuleEncoding(unittest.TestCase):
+    def test_swift_module(self):
+        m = Mangler()
+        m._mangle_module("Swift")
+        self.assertEqual("".join(m.buffer), "s")
+
+    def test_objc_module(self):
+        m = Mangler()
+        m._mangle_module("__C")
+        self.assertEqual("".join(m.buffer), "So")
+
+    def test_clang_importer(self):
+        m = Mangler()
+        m._mangle_module("__C_Synthesized")
+        self.assertEqual("".join(m.buffer), "SC")
+
+    def test_regular_module(self):
+        m = Mangler()
+        m._mangle_module("Foundation")
+        self.assertEqual("".join(m.buffer), "10Foundation")
+
+
+class TestStandardTypes(unittest.TestCase):
+    def test_swift_int(self):
+        result = mangle_partial("Swift.Int.bitWidth", type_kinds={"Int": "struct"})
+        # Swift -> s, Int -> Si (standard), bitWidth -> identifier
+        self.assertTrue(result.startswith("_$sSi"))
+
+    def test_swift_string(self):
+        result = mangle_partial("Swift.String.count", type_kinds={"String": "struct"})
+        self.assertTrue(result.startswith("_$sSS"))
+
+    def test_swift_array(self):
+        result = mangle_partial("Swift.Array.count", type_kinds={"Array": "struct"})
+        self.assertTrue(result.startswith("_$sSa"))
+
+    def test_swift_optional(self):
+        result = mangle_partial("Swift.Optional.map", type_kinds={"Optional": "enum"})
+        self.assertTrue(result.startswith("_$sSq"))
+
+    def test_swift_bool(self):
+        result = mangle_partial("Swift.Bool.toggle", type_kinds={"Bool": "struct"})
+        self.assertTrue(result.startswith("_$sSb"))
+
+
+class TestLabelEncoding(unittest.TestCase):
+    def test_single_label(self):
+        m = Mangler()
+        m._mangle_labels(["bar"])
+        self.assertEqual("".join(m.buffer), "3bar")
+
+    def test_multiple_labels(self):
+        m = Mangler()
+        m._mangle_labels(["from", "to"])
+        result = "".join(m.buffer)
+        self.assertEqual(result, "4from2to")
+
+    def test_unlabeled_params(self):
+        m = Mangler()
+        m._mangle_labels(["_", "_"])
+        self.assertEqual("".join(m.buffer), "y")
+
+    def test_mixed_labels(self):
+        m = Mangler()
+        m._mangle_labels(["_", "by"])
+        result = "".join(m.buffer)
+        self.assertEqual(result, "_2by")
+
+    def test_no_params(self):
+        m = Mangler()
+        m._mangle_labels([])
+        self.assertEqual("".join(m.buffer), "")
+
+
+class TestNominalTypes(unittest.TestCase):
+    def test_struct(self):
+        result = mangle_partial(
+            "Foundation.URLRequest.url",
+            type_kinds={"URLRequest": "struct"},
+        )
+        self.assertEqual(result, "_$s10Foundation10URLRequestV3url")
+
+    def test_class(self):
+        result = mangle_partial(
+            "Foundation.JSONDecoder.decode",
+            type_kinds={"JSONDecoder": "class"},
+        )
+        self.assertTrue(result.startswith("_$s10Foundation11JSONDecoderC"))
+
+    def test_enum(self):
+        result = mangle_partial(
+            "Foundation.CocoaError.Code.fileNoSuchFile",
+            type_kinds={"CocoaError": "struct", "Code": "struct"},
+        )
+        self.assertTrue(result.startswith("_$s10Foundation10CocoaErrorV4CodeV"))
+
+    def test_protocol(self):
+        result = mangle_partial(
+            "Foundation._LocaleProtocol.identifier",
+            type_kinds={"_LocaleProtocol": "protocol"},
+        )
+        self.assertTrue(result.startswith("_$s10Foundation15_LocaleProtocolP"))
+
+
+class TestWorkedExample(unittest.TestCase):
+    """Test the worked example from the design plan."""
+
+    def test_module_type_func_label(self):
+        result = mangle_partial("ModuleName.TypeName.foo(bar:)")
+        self.assertEqual(result, "_$s10ModuleName04TypeB0C3foo3bar")
+
+    def test_step_by_step(self):
+        m = Mangler()
+        m.buffer.extend("$s")
+
+        # Step 1: Module "ModuleName"
+        m._mangle_module("ModuleName")
+        self.assertEqual("".join(m.buffer), "$s10ModuleName")
+        # Words should now include "Module" and "Name"
+        self.assertEqual(len(m.words), 2)
+
+        # Step 2: Type "TypeName" — "Name" should match word 1
+        m._mangle_nominal_type("ModuleName", ["TypeName"], 0, {})
+        buf = "".join(m.buffer)
+        # Module was already mangled, but _mangle_nominal_type calls _mangle_module again
+        # which hits string substitution for "ModuleName" (index 0)
+        # Then "TypeName" is mangled as "04TypeB0" (Type=new word, Name=subst for word 1)
+        # Kind C
+        self.assertTrue(buf.endswith("04TypeB0C"), f"Buffer: {buf}")
+
+
+class TestInit(unittest.TestCase):
+    def test_init_with_labels(self):
+        result = mangle_partial(
+            "Foundation.URLRequest.init(url:)",
+            type_kinds={"URLRequest": "struct"},
+        )
+        self.assertEqual(result, "_$s10Foundation10URLRequestV3url")
+
+    def test_init_no_labels(self):
+        result = mangle_partial(
+            "Foundation.Data.init()",
+            type_kinds={"Data": "struct"},
+        )
+        self.assertEqual(result, "_$s10Foundation4DataV")
+
+    def test_allocating_init(self):
+        # __allocating_init should be treated as init
+        result = mangle_partial(
+            "SomeModule.SomeClass.__allocating_init()",
+            type_kinds={"SomeClass": "class"},
+        )
+        # Should not contain "__allocating_init" as identifier
+        self.assertNotIn("allocating", result)
+
+
+class TestSubscript(unittest.TestCase):
+    def test_subscript_not_encoded(self):
+        result = mangle_partial(
+            "Foundation.AttributeContainer.subscript",
+            type_kinds={"AttributeContainer": "struct"},
+        )
+        # subscript should not appear as an identifier
+        self.assertNotIn("subscript", result)
+        self.assertTrue(result.startswith("_$s10Foundation18AttributeContainerV"))
+
+
+class TestEntitySubstitution(unittest.TestCase):
+    def test_repeated_type_context(self):
+        # When we mangle nested types, entity substitution fires for parent types
+        result = mangle_partial(
+            "Foundation.CocoaError.Code.fileNoSuchFile",
+            {"CocoaError": "struct", "Code": "struct"},
+        )
+        buf = result[len("_"):]  # strip leading _
+        # CocoaError entity sub should be used when mangling Code's context
+        self.assertIn("V4CodeV", buf)
+
+
+class TestSubstitutionMerging(unittest.TestCase):
+    def test_different_subst_merging(self):
+        # Two consecutive different A-substitutions should merge
+        # AA + AB -> AaB
+        m = Mangler()
+        m._mangle_substitution(0)  # AA
+        m._mangle_substitution(1)  # AB -> merged to AaB
+        result = "".join(m.buffer)
+        self.assertEqual(result, "AaB")
+
+    def test_same_subst_merging(self):
+        # Two consecutive same A-substitutions should merge
+        # AA + AA -> A2A
+        m = Mangler()
+        m._mangle_substitution(0)  # AA
+        m._mangle_substitution(0)  # AA -> merged to A2A
+        result = "".join(m.buffer)
+        self.assertEqual(result, "A2A")
+
+    def test_large_substitution(self):
+        # Index 26 -> A + Index(0) = A_
+        m = Mangler()
+        m._mangle_substitution(26)
+        result = "".join(m.buffer)
+        self.assertEqual(result, "A_")
+
+    def test_large_substitution_27(self):
+        # Index 27 -> A + Index(1) = A0_
+        m = Mangler()
+        m._mangle_substitution(27)
+        result = "".join(m.buffer)
+        self.assertEqual(result, "A0_")
+
+
+class TestEndToEnd(unittest.TestCase):
+    """End-to-end tests verified against xcrun swift-demangle."""
+
+    def _verify_prefix(self, decl, type_kinds, expected_prefix):
+        result = mangle_partial(decl, type_kinds)
+        self.assertEqual(
+            result, expected_prefix,
+            f"mangle_partial({decl!r}) = {result!r}, expected {expected_prefix!r}"
+        )
+
+    def test_foundation_url_request(self):
+        self._verify_prefix(
+            "Foundation.URLRequest.init(url:)",
+            {"URLRequest": "struct"},
+            "_$s10Foundation10URLRequestV3url",
+        )
+
+    def test_foundation_calendar_method(self):
+        # Calendar.nextDate(after:matching:matchingPolicy:repeatedTimePolicy:direction:)
+        result = mangle_partial(
+            "Foundation.Calendar.nextDate(after:matching:matchingPolicy:repeatedTimePolicy:direction:)",
+            {"Calendar": "struct"},
+        )
+        # Verify it starts with Foundation + Calendar struct
+        self.assertTrue(result.startswith("_$s10Foundation8CalendarV"))
+        # Verify it contains "nextDate"
+        self.assertIn("8nextDate", result)
+
+    def test_nested_types(self):
+        result = mangle_partial(
+            "Foundation.CocoaError.Code.fileNoSuchFile",
+            {"CocoaError": "struct", "Code": "struct"},
+        )
+        self.assertTrue(result.startswith("_$s10Foundation10CocoaErrorV4CodeV"))
+
+    def test_no_label_function(self):
+        result = mangle_partial(
+            "Foundation.Date.ISO8601FormatStyle.day()",
+            {"Date": "struct", "ISO8601FormatStyle": "struct"},
+        )
+        self.assertTrue(result.startswith("_$s10Foundation4DateV18ISO8601FormatStyleV3day"))
+
+    def test_swift_standard_type_member(self):
+        result = mangle_partial(
+            "Swift.Array.append(_:)",
+            {"Array": "struct"},
+        )
+        # Array -> Sa, append identifier, _ label
+        self.assertTrue(result.startswith("_$sSa"))
+        self.assertIn("6append", result)
+
+
+class TestDemanglerVerification(unittest.TestCase):
+    """Verify mangled prefixes demangle to expected components."""
+
+    def _demangle(self, symbol: str) -> str | None:
+        """Demangle a symbol using xcrun swift-demangle."""
+        try:
+            result = subprocess.run(
+                ["xcrun", "swift-demangle"],
+                input=symbol.lstrip("_"),
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            output = result.stdout.strip()
+            return output if output != symbol.lstrip("_") else None
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return None
+
+    def test_foundation_type_demangles(self):
+        prefix = mangle_partial(
+            "Foundation.URLRequest.init(url:)",
+            {"URLRequest": "struct"},
+        )
+        # The prefix alone may not fully demangle, but adding a simple
+        # type suffix should give us something containing the expected parts
+        demangled = self._demangle(prefix.lstrip("_") + "SgvpMV")
+        # Even partial, the prefix should be recognizable
+        if demangled:
+            self.assertIn("Foundation", demangled)
+
+
+class TestExtension(unittest.TestCase):
+    """Test extension context mangling."""
+
+    def test_cross_module_swift_type(self):
+        # Swift.Int._arg (ext in Foundation)
+        result = mangle_partial(
+            "Swift.Int._arg",
+            type_kinds={"Int": "struct"},
+            extension_module="Foundation",
+        )
+        self.assertEqual(result, "_$sSi10FoundationE4_arg")
+
+    def test_cross_module_objc_type(self):
+        # __C.NSScanner.currentIndex (ext in Foundation)
+        result = mangle_partial(
+            "__C.NSScanner.currentIndex",
+            extension_module="Foundation",
+        )
+        self.assertTrue(result.startswith("_$sSo9NSScannerC10FoundationE"))
+
+    def test_cross_module_init(self):
+        # Swift.String.init(_characters:) (ext in Foundation)
+        result = mangle_partial(
+            "Swift.String.init(_characters:)",
+            type_kinds={"String": "struct"},
+            extension_module="Foundation",
+        )
+        self.assertTrue(result.startswith("_$sSS10FoundationE"))
+        self.assertIn("_characters", result)
+
+    def test_no_extension(self):
+        # Without extension_module, no E should be emitted
+        result = mangle_partial(
+            "Swift.Int.bitWidth",
+            type_kinds={"Int": "struct"},
+        )
+        self.assertNotIn("E", result.replace("_$s", ""))
+
+    def test_nested_type_in_extension(self):
+        # __C.NSUndoManager.DidCloseUndoGroupMessage.groupIsDiscardable (ext in Foundation)
+        # E goes after NSUndoManager (base_depth=1), before DidCloseUndoGroupMessage
+        result = mangle_partial(
+            "__C.NSUndoManager.DidCloseUndoGroupMessage.groupIsDiscardable",
+            type_kinds={"NSUndoManager": "class", "DidCloseUndoGroupMessage": "struct"},
+            extension_module="Foundation",
+            extension_base_depth=1,
+        )
+        self.assertTrue(
+            result.startswith("_$sSo13NSUndoManagerC10FoundationE"),
+            f"got: {result}",
+        )
+        self.assertIn("24DidCloseUndoGroupMessageV", result)


### PR DESCRIPTION
#### 8a4f2c1e10436b245de90ca58cb16b4740d43ccc
<pre>
[audit-spi] Swift symbols can change between SDK builds, breaking allowlists
<a href="https://bugs.webkit.org/show_bug.cgi?id=309970">https://bugs.webkit.org/show_bug.cgi?id=309970</a>
<a href="https://rdar.apple.com/172677139">rdar://172677139</a>

Reviewed by Mike Wyrzykowski and Sam Sneddon.

Swift makes it relatively easy for library authors to make
source-compatible but ABI-breaking changes, and for SPI (where there is
no implicit contract to retain binary compatibility) we observe changes
to symbol names in between SDK builds, as OS frameworks submit new
versions. This causes our allowlists to go out of date despite no change
in our SPI footprint, disrupting CI and driving frustration with the
tools.

Work towards improving how we declare Swift SPI in allowlists by
supporting a higher-level syntax for naming the Swift declarations we
use. Instead of needing to declare the exact mangled symbol used,
allowlists recognize a &quot;swift-decl&quot; section that lists nominal types and
method names that we are using. For example, instead of writing:

    symbols = [&quot;$s5UIKit16UITextEffectViewC015ReplacementTextC0C5chunk4view8delegate9fromColorAeA0bcF5ChunkC_AcE8Delegate_pSo7UIColorCtcfC&quot;]

we can write:

    swift-decls = [
        { name = &quot;UIKit.UITextEffectView.PonderingEffect.init(chunk:view:lightConfiguration:)&quot; }
    ]

A &quot;partial name mangler&quot; based on the Swift compiler&apos;s own name mangling
spec &lt;<a href="https://github.com/swiftlang/swift/blob/main/docs/ABI/Mangling.rst">https://github.com/swiftlang/swift/blob/main/docs/ABI/Mangling.rst</a>&gt;
parses these nominal types and produces the expected *prefix* that the
real symbol starts with.

Objects which are fully SPI can be matched by only writing the type
name. This entry matches the SomeSPIClass type and all its member
functions:

    { name = &quot;ModuleName.SomeSPIClass&quot; }

Additionally, function declarations can omit their parameter names to
match functions/initializers with arbitrary parameters:

    { name = &quot;UIKit.UITextEffectView.PonderingEffect.init()&quot; }

Entries support some additional fields which customize the partial
symbol generated. A complete example:

    { name = &quot;UIKit.UITextEffectView.ReplacementTextEffect.Delegate.performAnimatedReplacement(for:effect:animation:)&quot;,

      # Maps components of the nominal type to their declaration kinds (struct, protocol, enum, class).
      type_kinds = { &quot;Delegate&quot; = &quot;protocol&quot; },

      # If the declaration is an extension, the extension is part of
      # this module.
      extension = &quot;UIKit&quot;,

      # How deeply nested in the nominal type the extension occurs. For example, this entry matches a symbol
      # `performAnimatedReplacement` on an `extension UIKitCore.UITextEffectView.ReplacementTextEffect.Delegate { ... }` declaration.
      extension_base_depth = 3 },

The sdkdb engine uses these partial symbols to make prefix queries
against the table of imported symbols. The same rules about unused
allowlist entries still apply; a Swift declaration that does not match
against any imported symbols is flagged.

For performance reasons, refactor SDKDB.audit() and split the query into
multiple steps:

1. First, it prepares the table of active conditions.
2. Then, it subtracts the `exports` from `imports` to find potential SPI
   in imported binaries.
3. Then, it joins allowlist entries to `imports` to find potential SPI
   which are covered by an allowlist.
4. The results of steps 2 and 3 are compared to produce the different
   diagnostic classes.

Canonical link: <a href="https://commits.webkit.org/310820@main">https://commits.webkit.org/310820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e205d274f3925c8282f5a05f24569778cc468d39

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28375 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163875 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/108629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e8835ba4-fef5-480c-94ea-a011d0a0da7d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/156988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28223 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120011 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/108629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2a3c26ed-f8b6-4b5c-ba83-cf1089e3fa1e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139294 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100704 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/154435 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/21349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/19397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11701 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/131011 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/17136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166353 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18745 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128112 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128250 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27843 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138929 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/84552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23636 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23121 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/15724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27536 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/91639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/27114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/27344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27187 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->