### PR TITLE
Restore functionality of LayoutTest `touch-event-radius.html`

### DIFF
--- a/LayoutTests/fast/events/touch/ios/touch-event-radius-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-radius-expected.txt
@@ -1,3 +1,6 @@
-PASS: radiusX is correct.
-PASS: radiusY is correct.
+PASS radiusX is expected
+PASS radiusY is expected
+PASS successfullyParsed is true
+
+TEST COMPLETE
 

--- a/LayoutTests/fast/events/touch/ios/touch-event-radius.html
+++ b/LayoutTests/fast/events/touch/ios/touch-event-radius.html
@@ -1,92 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
-
 <html>
 <head>
-    <script>
-        if (window.testRunner) {
-            testRunner.dumpAsText();
-            testRunner.waitUntilDone();
-        }
-
-        function getUIScript()
-        {
-            return `
-            (function() {
-                var eventStream = {
-                    events : [
-                        {
-                            inputType : "hand",
-                            timeOffset : 0,
-                            touches : [
-                                {
-                                    inputType : "finger",
-                                    phase : "began",
-                                    id : 1,
-                                    x : 20,
-                                    y : 40,
-                                    majorRadius: 0.10,
-                                    minorRadius: 0.10,
-                                }
-                            ]
-                        },
-                        {
-                            inputType : "hand",
-                            timeOffset : 0.0005,
-                            touches : [
-                                {
-                                    inputType : "finger",
-                                    phase : "ended",
-                                    id : 1,
-                                    x : 20,
-                                    y : 40,
-                                    majorRadius: 0.10,
-                                    minorRadius: 0.10,
-                                }
-                            ]
-                        },
-                    ]
-                };
-
-                uiController.sendEventStream(JSON.stringify(eventStream), function() {
-                    uiController.uiScriptComplete();
-                });
-            })();`
-        }
-
-        function runTest()
-        {
-            if (!testRunner.runUIScript)
-                return;
-
-            var output = '';
-            var target = document.getElementById('target');
-            var forces = [];
-            
-            target.addEventListener('touchstart', function(event) {
-                var expected = Math.round(0.10 * window.screen.height * 10) / 10;
-                var radiusX = Math.round(event.touches[0].radiusX * 10) / 10;
-                if (radiusX == expected)
-                    output += 'PASS: radiusX is correct.<br>';
-                else
-                    output += 'FAIL: radiusX should be ' + expected + ', was ' + radiusX + '<br>';
-
-                var radiusY = Math.round(event.touches[0].radiusY * 10) / 10;
-                if (radiusY == expected)
-                    output += 'PASS: radiusY is correct.<br>';
-                else
-                    output += 'FAIL: radiusY should be ' + expected + ', was ' + radiusY + '<br>';
-            });
-            
-            if (testRunner.runUIScript) {
-                testRunner.runUIScript(getUIScript(), function(result) {
-                    document.getElementById('target').innerHTML = output;
-                    testRunner.notifyDone();
-               });
-            }
-        }
-
-        window.addEventListener('load', runTest, false);
-    </script>
+    <script src="../../../../resources/js-test.js"></script>
     <style>
         #target {
             height: 100px;
@@ -100,5 +15,29 @@
 <div id="target">
     This test requires UIScriptController to run.
 </div>
+<script>
+    jsTestIsAsync = true;
+
+    let target = document.getElementById("target");
+    target.addEventListener('touchstart', function(event) {
+        radiusX = Math.round(event.touches[0].radiusX * 10) / 10;
+        radiusY = Math.round(event.touches[0].radiusY * 10) / 10;
+        expected = Math.round(0.1 * window.screen.height * 10) / 10;
+        shouldBe("radiusX", "expected");
+        shouldBe("radiusY", "expected");
+        target.remove();
+        finishJSTest();
+    });
+
+    window.addEventListener('load', () => {
+        if (!testRunner.runUIScript)
+            return;
+
+        testRunner.runUIScript(`
+            uiController.touchDownAtPointWithMajorRadius(20, 40, 0.1, 0.01, function() {
+                uiController.uiScriptComplete();
+            });`);
+    });
+</script>
 </body>
 </html>

--- a/Source/WebCore/PAL/pal/spi/ios/IOKitSPIIOS.h
+++ b/Source/WebCore/PAL/pal/spi/ios/IOKitSPIIOS.h
@@ -110,6 +110,7 @@ enum {
     kIOHIDEventFieldDigitizerMajorRadius = kIOHIDEventFieldDigitizerX + 20,
     kIOHIDEventFieldDigitizerMinorRadius,
     kIOHIDEventFieldDigitizerIsDisplayIntegrated = kIOHIDEventFieldDigitizerMajorRadius + 5,
+    kIOHIDEventFieldDigitizerQualityRadiiAccuracy,
 };
 
 enum {

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -89,6 +89,7 @@ interface UIScriptController {
     // These functions post events asynchronously. The callback is fired when the events have been dispatched, but any
     // resulting behavior may also be asynchronous. Points are in "global" (WKWebView) coordinates.
     undefined touchDownAtPoint(long x, long y, long touchCount, object callback);
+    undefined touchDownAtPointWithMajorRadius(long x, long y, float majorRadius, float majorRadiusTolerance, object callback);
     undefined liftUpAtPoint(long x, long y, long touchCount, object callback);
     undefined singleTapAtPoint(long x, long y, object callback);
     undefined singleTapAtPointWithModifiers(long x, long y, object modifierArray, object callback);

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -217,6 +217,7 @@ public:
     // Touches
 
     virtual void touchDownAtPoint(long, long, long, JSValueRef) { notImplemented(); }
+    virtual void touchDownAtPointWithMajorRadius(long, long, float, float, JSValueRef) { notImplemented(); }
     virtual void liftUpAtPoint(long, long, long, JSValueRef) { notImplemented(); }
     virtual void singleTapAtPoint(long, long, JSValueRef) { notImplemented(); }
     virtual void singleTapAtPointWithModifiers(long, long, JSValueRef, JSValueRef) { notImplemented(); }

--- a/Tools/WebKitTestRunner/ios/HIDEventGenerator.h
+++ b/Tools/WebKitTestRunner/ios/HIDEventGenerator.h
@@ -79,6 +79,7 @@ RetainPtr<IOHIDEventRef> createHIDKeyEvent(NSString *, uint64_t timestamp, bool 
 
 // Touches
 - (void)touchDown:(CGPoint)location touchCount:(NSUInteger)count completionBlock:(void (^)(void))completionBlock;
+- (void)touchDown:(CGPoint)location majorRadius:(CGFloat)majorRadius majorRadiusTolerance:(CGFloat)majorRadiusTolerance completionBlock:(void (^)(void))completionBlock;
 - (void)liftUp:(CGPoint)location touchCount:(NSUInteger)count completionBlock:(void (^)(void))completionBlock;
 
 // Stylus

--- a/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
+++ b/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
@@ -139,6 +139,7 @@ static const NSTimeInterval multiTapInterval = 0.15;
 static const NSTimeInterval fingerMoveInterval = 0.016;
 static const NSTimeInterval longPressHoldDelay = 2.0;
 static const IOHIDFloat defaultMajorRadius = 5;
+static const IOHIDFloat defaultMajorRadiusTolerance = 0;
 static const IOHIDFloat defaultPathPressure = 0;
 static const long nanosecondsPerSecond = 1e9;
 
@@ -169,6 +170,7 @@ typedef struct {
     int identifier;
     CGPoint point;
     IOHIDFloat pathMajorRadius;
+    IOHIDFloat pathMajorRadiusTolerance;
     IOHIDFloat pathPressure;
     UInt8 pathProximity;
     BOOL isStylus;
@@ -447,6 +449,8 @@ static InterpolationType interpolationFromString(NSString *string)
         if (eventType == HandEventTouched) {
             if (!pointInfo->pathMajorRadius)
                 pointInfo->pathMajorRadius = defaultMajorRadius;
+            if (!pointInfo->pathMajorRadiusTolerance)
+                pointInfo->pathMajorRadiusTolerance = defaultMajorRadiusTolerance;
             if (!pointInfo->pathPressure)
                 pointInfo->pathPressure = defaultPathPressure;
             if (!pointInfo->pathProximity)
@@ -506,6 +510,7 @@ static InterpolationType interpolationFromString(NSString *string)
 
         IOHIDEventSetFloatValue(subEvent.get(), kIOHIDEventFieldDigitizerMajorRadius, pointInfo->pathMajorRadius);
         IOHIDEventSetFloatValue(subEvent.get(), kIOHIDEventFieldDigitizerMinorRadius, pointInfo->pathMajorRadius);
+        IOHIDEventSetFloatValue(subEvent.get(), kIOHIDEventFieldDigitizerQualityRadiiAccuracy, pointInfo->pathMajorRadiusTolerance);
 
         IOHIDEventAppendEvent(eventRef.get(), subEvent.get(), 0);
     }
@@ -625,6 +630,26 @@ static InterpolationType interpolationFromString(NSString *string)
 - (void)touchDown:(CGPoint)location
 {
     [self touchDownAtPoints:&location touchCount:1];
+}
+
+- (void)touchDown:(CGPoint)location majorRadius:(CGFloat)majorRadius majorRadiusTolerance:(CGFloat)majorRadiusTolerance
+{
+    _activePointCount = 1;
+    _activePoints[0].point = location;
+    _activePoints[0].isStylus = NO;
+    _activePoints[0].pathMajorRadius = majorRadius;
+    _activePoints[0].pathMajorRadiusTolerance = majorRadiusTolerance;
+
+    [[GeneratedTouchesDebugWindow sharedGeneratedTouchesDebugWindow] updateDebugIndicatorForTouch:0 withPointInWindowCoordinates:location isTouching:YES];
+
+    RetainPtr eventRef = adoptCF([self _createIOHIDEventType:HandEventTouched]);
+    [self _sendHIDEvent:eventRef.get()];
+}
+
+- (void)touchDown:(CGPoint)location majorRadius:(CGFloat)majorRadius majorRadiusTolerance:(CGFloat)majorRadiusTolerance completionBlock:(void (^)(void))completionBlock
+{
+    [self touchDown:location majorRadius:majorRadius majorRadiusTolerance:majorRadiusTolerance];
+    [self sendMarkerHIDEventWithCompletionBlock:completionBlock];
 }
 
 - (void)liftUpAtPoints:(CGPoint*)locations touchCount:(NSUInteger)touchCount

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -64,6 +64,7 @@ private:
     void simulateAccessibilitySettingsChangeNotification(JSValueRef) override;
     double zoomScale() const override;
     void touchDownAtPoint(long x, long y, long touchCount, JSValueRef) override;
+    void touchDownAtPointWithMajorRadius(long x, long y, float majorRadius, float majorRadiusTolerance, JSValueRef) override;
     void liftUpAtPoint(long x, long y, long touchCount, JSValueRef) override;
     void singleTapAtPoint(long x, long y, JSValueRef) override;
     void singleTapAtPointWithModifiers(long x, long y, JSValueRef modifierArray, JSValueRef) override;

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -337,6 +337,18 @@ void UIScriptControllerIOS::touchDownAtPoint(long x, long y, long touchCount, JS
     }).get()];
 }
 
+void UIScriptControllerIOS::touchDownAtPointWithMajorRadius(long x, long y, float majorRadius, float majorRadiusTolerance, JSValueRef callback)
+{
+    unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
+
+    auto location = globalToContentCoordinates(webView(), x, y);
+    [[HIDEventGenerator sharedHIDEventGenerator] touchDown:location majorRadius:majorRadius majorRadiusTolerance:majorRadiusTolerance completionBlock:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
+        if (!m_context)
+            return;
+        m_context->asyncTaskComplete(callbackID);
+    }).get()];
+}
+
 void UIScriptControllerIOS::liftUpAtPoint(long x, long y, long touchCount, JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);


### PR DESCRIPTION
#### 07f9bb3ce12652212db136d35ee34d06aa93425b
<pre>
Restore functionality of LayoutTest `touch-event-radius.html`
<a href="https://bugs.webkit.org/show_bug.cgi?id=310039">https://bugs.webkit.org/show_bug.cgi?id=310039</a>
<a href="https://rdar.apple.com/171567543">rdar://171567543</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Add new UIScriptController method `touchDownAtPointWithMajorRadius`
which simulates a touch with a specific major radius and major radius
tolerance. Update layout test `touch-event-radius.html` to use this new
method instead, thus restoring its functionality.

* LayoutTests/fast/events/touch/ios/touch-event-radius-expected.txt:
* LayoutTests/fast/events/touch/ios/touch-event-radius.html:
* Source/WebCore/PAL/pal/spi/ios/IOKitSPIIOS.h:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::touchDownAtPointWithMajorRadius):
* Tools/WebKitTestRunner/ios/HIDEventGenerator.h:
* Tools/WebKitTestRunner/ios/HIDEventGenerator.mm:
(-[HIDEventGenerator _createIOHIDEventType:]):
(-[HIDEventGenerator touchDown:majorRadius:majorRadiusTolerance:]):
(-[HIDEventGenerator touchDown:majorRadius:majorRadiusTolerance:completionBlock:]):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::touchDownAtPointWithMajorRadius):

Canonical link: <a href="https://commits.webkit.org/309369@main">https://commits.webkit.org/309369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b65b9c2c1e9b5006876109063f331b0e69cf5fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159115 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103827 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23582 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116047 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82461 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153353 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18152 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134915 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96775 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17251 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15197 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6963 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161589 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4709 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14392 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124047 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22953 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124245 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33742 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134634 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79320 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19356 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11391 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22554 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86353 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22267 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22419 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22321 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->