### PR TITLE
Add test to verify MessagePort transfer bug (webkit.org/b/310041)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webmessaging/Channel_postMessage_transfer_during_dispatch.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webmessaging/Channel_postMessage_transfer_during_dispatch.any-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL Transferring a port during message dispatch preserves remaining queued messages assert_unreached: Timed out. Received at old: [first], received at new: []. Total: 1/3. Messages were likely lost during transfer. Reached unreachable code
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webmessaging/Channel_postMessage_transfer_during_dispatch.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webmessaging/Channel_postMessage_transfer_during_dispatch.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/webmessaging/Channel_postMessage_transfer_during_dispatch.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/webmessaging/Channel_postMessage_transfer_during_dispatch.any.js
@@ -1,0 +1,52 @@
+// META: title=Transfer port during message dispatch preserves remaining messages
+// META: timeout=long
+
+async_test(function(t) {
+  var channel1 = new MessageChannel();
+  var channel2 = new MessageChannel();
+
+  // Post multiple messages to port2 via port1.
+  channel1.port1.postMessage("first");
+  channel1.port1.postMessage("second");
+  channel1.port1.postMessage("third");
+
+  var receivedAtOld = [];
+  var receivedAtNew = [];
+
+  // Start port2. In the handler for the first message, transfer port2.
+  channel1.port2.onmessage = t.step_func(function(evt) {
+    receivedAtOld.push(evt.data);
+    // Transfer port2 upon receiving the first message.
+    // Per spec, remaining messages in the port message queue should
+    // move to the new location.
+    channel2.port1.postMessage("transfer", [channel1.port2]);
+  });
+
+  // At the receiving end, set up a handler on the transferred port.
+  channel2.port2.onmessage = t.step_func(function(evt) {
+    var transferred = evt.ports[0];
+    transferred.onmessage = t.step_func(function(evt) {
+      receivedAtNew.push(evt.data);
+      if (receivedAtNew.length + receivedAtOld.length === 3) {
+        // All three messages accounted for.
+        assert_equals(receivedAtOld.length, 1,
+          "Only the first message should be received at the old location");
+        assert_equals(receivedAtOld[0], "first");
+        assert_equals(receivedAtNew.length, 2,
+          "Remaining messages should be received at the new location");
+        assert_equals(receivedAtNew[0], "second");
+        assert_equals(receivedAtNew[1], "third");
+        t.done();
+      }
+    });
+  });
+
+  // Timeout if messages are lost.
+  t.step_timeout(function() {
+    assert_unreached(
+      "Timed out. Received at old: [" + receivedAtOld + "], " +
+      "received at new: [" + receivedAtNew + "]. " +
+      "Total: " + (receivedAtOld.length + receivedAtNew.length) + "/3. " +
+      "Messages were likely lost during transfer.");
+  }, 2000);
+}, "Transferring a port during message dispatch preserves remaining queued messages");

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -314,7 +314,11 @@ void MessagePort::dispatchEvent(Event& event)
     if (m_isDetached)
         return;
 
-    if (RefPtr globalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext())) {
+    RefPtr context = scriptExecutionContext();
+    if (!context)
+        return;
+
+    if (RefPtr globalScope = dynamicDowncast<WorkerGlobalScope>(context.get())) {
         if (globalScope->isClosing())
             return;
     }


### PR DESCRIPTION
#### e80b7c8ebc4f5e42a905cc021199c8b1d5e961ee
<pre>
Add test to verify MessagePort transfer bug (webkit.org/b/310041)
<a href="https://bugs.webkit.org/show_bug.cgi?id=310042">https://bugs.webkit.org/show_bug.cgi?id=310042</a>
<a href="https://rdar.apple.com/172687204">rdar://172687204</a>

Reviewed by NOBODY (OOPS!).

Adds a test to verify that a port transfer can cause messages to be
lost, as described in webkit.org/b/310041. The added test causes a port
transfer to be performed during the handler for a message while extra
messages are waiting to be serviced.

A simple crash fix was also added, as the test originally does not run
to completion.

Tests:
* LayoutTests/imported/w3c/web-platform-tests/webmessaging/Channel_postMessage_transfer_during_dispatch.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webmessaging/Channel_postMessage_transfer_during_dispatch.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webmessaging/Channel_postMessage_transfer_during_dispatch.any.js: Added.

Crash fix:
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::dispatchEvent):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e80b7c8ebc4f5e42a905cc021199c8b1d5e961ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159117 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103829 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152268 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116049 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82462 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153355 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134916 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96777 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17255 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15198 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6965 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126870 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12840 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161591 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4711 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124049 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22955 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19245 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124247 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22942 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134635 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79322 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19361 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11392 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22556 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86355 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22269 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22421 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->