### PR TITLE
[JSC] Crash when PhantomNewArrayWithButterfly handles exception

### DIFF
--- a/JSTests/stress/ftl-osr-exit-stack-overflow-phantom-array.js
+++ b/JSTests/stress/ftl-osr-exit-stack-overflow-phantom-array.js
@@ -1,0 +1,14 @@
+//@ runDefault("--watchdog=1000", "--watchdog-exception-ok")
+function opt() {
+    const arr = Array(10);
+    arr[0] = 0;
+    function foo() { return arr; }
+    try {
+        opt();
+        opt();
+    } catch (e) {
+    }
+}
+
+for (let i = 0; i < 100000; i++)
+    opt();

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -84,6 +84,12 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
         auto scope = DECLARE_THROW_SCOPE(vm);
         // This might be unnecessary because operationMaterializeObjectInOSR does DeferGCForAWhile but its better to be safe.
         JSArray* array = jsCast<JSArray*>(JSValue::decode(*encodedValue));
+
+        // This may be called during a GenericUnwind OSR exit (e.g. stack overflow caught by
+        // try/catch), where vm.exception() is already set. Suspend it so the assertion below
+        // only fires on new exceptions from putDirectIndex; it is restored on scope exit.
+        SuspendExceptionScope suspendException(vm);
+
         for (unsigned i = materialization->properties().size(); i--;) {
             const ExitPropertyValue& property = materialization->properties()[i];
             if (property.location().kind() != ArrayIndexedPropertyPLoc)


### PR DESCRIPTION
#### 0dbabc018f3f222e0b93def93bccb3342f707ff6
<pre>
[JSC] Crash when PhantomNewArrayWithButterfly handles exception
<a href="https://bugs.webkit.org/show_bug.cgi?id=309232">https://bugs.webkit.org/show_bug.cgi?id=309232</a>
<a href="https://rdar.apple.com/172350200">rdar://172350200</a>

Reviewed by Yusuke Suzuki.

When a stack overflow is caught by try/catch inside an FTL-compiled function,
the GenericUnwind OSR exit stub runs operationPopulateObjectInOSR to materialize
phantom array allocations before transferring control to the catch handler.
At this point vm.exception() is already set to the StackOverflow exception, causing
assertNoExceptionExceptTermination() after putDirectIndex to falsely fire on the
pre-existing exception rather than a new one from putDirectIndex itself.

Fix by adding SuspendExceptionScope before the putDirectIndex loop in the
PhantomNewArrayWithButterfly case. This temporarily nullifies vm.exception() so
the assertion correctly guards only new exceptions, then restores it on scope exit
so the catch handler can consume the original exception.

Test: JSTests/stress/ftl-osr-exit-stack-overflow-phantom-array.js
Canonical link: <a href="https://commits.webkit.org/309377@main">https://commits.webkit.org/309377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1bc31c0f70720f42a6552e8d047d839645ee8c92

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159119 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103831 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116050 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82463 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b79a2612-e954-4c79-8fa2-2de4b50ddf07) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134917 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96778 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5d2492c-fa30-4a85-8639-9c229de7c3eb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17256 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15199 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/6967 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142380 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126871 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161593 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11195 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4713 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14394 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124050 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19246 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124248 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33748 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22944 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134636 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79324 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19363 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11393 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181829 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22558 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86357 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46513 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22271 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22423 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22325 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->