### PR TITLE
AX: use test helper for client-side accessibility tests

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -126,6 +126,7 @@ webkit.org/b/306558 accessibility/mac/style-range.html [ Failure ]
 # Skip accessibility tests that use the accessibility client API on most builders;
 # requires an extra permission for WKTR
 accessibility/mac/client [ Skip ]
+accessibility/mac/client/button.html [ Pass ]
 
 # Skip glib-only combobox accessibility tests.
 accessibility/combobox/gtk [ Skip ]

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -554,6 +554,8 @@ public:
     static void enableAccessibility();
     static void disableAccessibility();
 #if PLATFORM(MAC)
+    WEBCORE_EXPORT static void ensureAccessibilityInitialized();
+    WEBCORE_EXPORT static unsigned primaryScreenHeight();
     WEBCORE_EXPORT static bool isAppleInternalInstall();
 #endif
     static bool forceDeferredSpellChecking();

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -40,6 +40,7 @@
 #import "DeprecatedGlobalSettings.h"
 #import "DocumentView.h"
 #import "LocalFrameView.h"
+#import "PlatformScreen.h"
 #import "RenderObject.h"
 #import "RenderView.h"
 #import "WebAccessibilityObjectWrapperMac.h"
@@ -794,6 +795,31 @@ void AXObjectCache::initializeAXThreadIfNeeded()
 bool AXObjectCache::isAXThreadInitialized()
 {
     return axThreadInitialized;
+}
+
+static std::atomic<bool> webPageAccessibilityInitialized { false };
+static std::atomic<unsigned> cachedPrimaryScreenHeight { 0 };
+
+void AXObjectCache::ensureAccessibilityInitialized()
+{
+    ASSERT(isMainRunLoop());
+
+    if (webPageAccessibilityInitialized)
+        return;
+
+    if (!accessibilityEnabled())
+        enableAccessibility();
+
+    float roundedHeight = std::round(screenRectForPrimaryScreen().size().height());
+    cachedPrimaryScreenHeight = std::max(0u, static_cast<unsigned>(roundedHeight));
+
+    webPageAccessibilityInitialized = true;
+}
+
+unsigned AXObjectCache::primaryScreenHeight()
+{
+    ASSERT(webPageAccessibilityInitialized);
+    return cachedPrimaryScreenHeight;
 }
 
 bool AXObjectCache::shouldSpellCheck()

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -348,3 +348,10 @@ void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frameRef)
     RefPtr root = cache ? cache->rootObjectForFrame(*protect(protect(WebKit::toImpl(frameRef))->coreLocalFrame())) : nullptr;
     return root ? root->wrapper() : nullptr;
 }
+
+#if PLATFORM(MAC)
+void _WKAccessibilityEnsureInitialized()
+{
+    WebCore::AXObjectCache::ensureAccessibilityInitialized();
+}
+#endif

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h
@@ -58,6 +58,13 @@ WK_EXPORT void _WKBundleFrameGenerateTestReport(WKBundleFrameRef, WKStringRef me
 
 WK_EXPORT void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frame);
 
+#ifdef __APPLE__
+#include <TargetConditionals.h>
+#if TARGET_OS_MAC && !TARGET_OS_IPHONE
+WK_EXPORT void _WKAccessibilityEnsureInitialized(void);
+#endif
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm
@@ -161,22 +161,24 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 - (id)accessibilityAttributeValue:(NSString *)attribute
 ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
-    static std::atomic<bool> didInitialize { false };
-    static std::atomic<unsigned> screenHeight { 0 };
-    if (!didInitialize) [[unlikely]] {
-        didInitialize = true;
-        callOnMainRunLoopAndWait([protectedSelf = retainPtr(self)] {
-            if (!WebCore::AXObjectCache::accessibilityEnabled())
-                [protectedSelf enableAccessibilityForAllProcesses];
+    if (!WebCore::AXObjectCache::accessibilityEnabled()) {
+        // If accessibility hasn't been initialized yet (e.g. not via
+        // ensureAccessibilityInitialized), do the lazy init. This path
+        // uses callOnMainRunLoopAndWait and may deadlock if the main thread is
+        // blocked, but is kept for the non-test code path.
+        static std::atomic<bool> didInitialize { false };
+        if (!didInitialize) [[unlikely]] {
+            didInitialize = true;
+            callOnMainRunLoopAndWait([protectedSelf = retainPtr(self)] {
+                if (!WebCore::AXObjectCache::accessibilityEnabled())
+                    [protectedSelf enableAccessibilityForAllProcesses];
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-            if (WebCore::AXObjectCache::isIsolatedTreeEnabled())
-                [protectedSelf _buildIsolatedTreeIfNeeded];
+                if (WebCore::AXObjectCache::isIsolatedTreeEnabled())
+                    [protectedSelf _buildIsolatedTreeIfNeeded];
 #endif // ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-
-            float roundedHeight = std::round(WebCore::screenRectForPrimaryScreen().size().height());
-            screenHeight = std::max(0u, static_cast<unsigned>(roundedHeight));
-        });
+            });
+        }
     }
 
     // The following attributes can be handled off the main thread.
@@ -205,8 +207,16 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if ([attribute isEqualToString:NSAccessibilityParentAttribute])
         return [self accessibilityAttributeParentValue].autorelease();
 
-    if ([attribute isEqualToString:NSAccessibilityPrimaryScreenHeightAttribute])
+    if ([attribute isEqualToString:NSAccessibilityPrimaryScreenHeightAttribute]) {
+        static std::atomic<unsigned> screenHeight { 0 };
+        if (!screenHeight) {
+            callOnMainRunLoopAndWait([&] {
+                float roundedHeight = std::round(WebCore::screenRectForPrimaryScreen().size().height());
+                screenHeight = std::max(0u, static_cast<unsigned>(roundedHeight));
+            });
+        }
         return @(screenHeight.load());
+    }
 
     if ([attribute isEqualToString:NSAccessibilityWindowAttribute])
         return [self accessibilityAttributeWindowValue].autorelease();

--- a/Tools/WebKitTestRunner/Configurations/WebKitAccessibilityTestHelper.entitlements
+++ b/Tools/WebKitTestRunner/Configurations/WebKitAccessibilityTestHelper.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.private.tcc.allow</key>
+	<array>
+		<string>kTCCServiceAccessibility</string>
+	</array>
+</dict>
+</plist>

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
@@ -248,6 +248,13 @@ void AccessibilityController::platformInitializeClientAccessibility()
 {
     setIsolatedTreeMode(true);
 
+    // Pre-initialize accessibility state on the main thread before any sync IPC
+    // calls that would block the main thread. Without this, the first external
+    // AX query would trigger callOnMainRunLoopAndWait in
+    // WKAccessibilityWebPageObject, which deadlocks because the main thread is
+    // blocked on the sync IPC from the test.
+    _WKAccessibilityEnsureInitialized();
+
     // This triggers WebKit's normal accessibility initialization flow via IPC
     WTR::postSynchronousMessage("InitializeWebProcessAccessibility");
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -94,6 +94,7 @@
 #include <wtf/CompletionHandler.h>
 #include <wtf/CryptographicallyRandomNumber.h>
 #include <wtf/FileSystem.h>
+#include <wtf/JSONValues.h>
 #include <wtf/Logging.h>
 #include <wtf/MainThread.h>
 #include <wtf/MallocSpan.h>
@@ -5418,132 +5419,64 @@ void TestController::setHasMouseDeviceForTesting(bool)
 #endif
 
 #if PLATFORM(MAC)
-// Client accessibility IPC implementation
+// Client accessibility: forward requests to WebKitAccessibilityTestHelper subprocess
+// via stdin/stdout JSON; that process uses Mac client accessibility APIs to query the
+// accessibility tree similarly to how AT such as VoiceOver does.
 
-// Private API for creating an AXUIElement from a remote token
-extern "C" AXUIElementRef _AXUIElementCreateWithRemoteToken(CFDataRef remoteToken);
-
-uint64_t TestController::storeAXElement(CFTypeRef element)
+static Ref<JSON::Object> buildHelperCommand(const char* command, WKDictionaryRef messageBody = nullptr)
 {
-    if (!element)
-        return 0;
-
-    uint64_t token = m_nextAXElementToken++;
-    m_axElementTokens.set(token, element);
-    return token;
-}
-
-CFTypeRef TestController::getAXElement(uint64_t token)
-{
-    if (!token)
-        return nullptr;
-
-    auto tokenIterator = m_axElementTokens.find(token);
-    if (tokenIterator == m_axElementTokens.end())
-        return nullptr;
-
-    return tokenIterator->value.get();
-}
-
-WKRetainPtr<WKTypeRef> TestController::handleAXGetRoot()
-{
-    CFDataRef remoteToken = getRemoteAccessibilityToken();
-    if (!remoteToken)
-        return nullptr;
-
-    AXUIElementRef webContentElement = _AXUIElementCreateWithRemoteToken(remoteToken);
-    if (!webContentElement)
-        return nullptr;
-
-    // Try to get children
-    CFTypeRef childrenValue = nullptr;
-    AXError error = AXUIElementCopyAttributeValue(webContentElement, kAXChildrenAttribute, &childrenValue);
-    RetainPtr adoptedChildren = adoptCF(childrenValue);
-
-    if (error != kAXErrorSuccess || !childrenValue)
-        return nullptr;
-
-    CFArrayRef children = static_cast<CFArrayRef>(childrenValue);
-    CFIndex childCount = CFArrayGetCount(children);
-    if (!childCount)
-        return nullptr;
-
-    AXUIElementRef child = static_cast<AXUIElementRef>(const_cast<void*>(CFArrayGetValueAtIndex(children, 0)));
-
-    uint64_t token = storeAXElement(child);
-    return adoptWK(WKUInt64Create(token));
-}
-
-RetainPtr<CFTypeRef> TestController::axCopyAttributeValue(WKDictionaryRef messageBody)
-{
-    uint64_t elementToken = uint64Value(messageBody, "elementToken");
-    WKStringRef attributeName = stringValue(messageBody, "attributeName");
-
-    AXUIElementRef element = static_cast<AXUIElementRef>(getAXElement(elementToken));
-    if (!element)
-        return nullptr;
-
-    RetainPtr attributeNameCF = adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, toSTD(attributeName).c_str(), kCFStringEncodingUTF8));
-    CFTypeRef value = nullptr;
-    AXError error = AXUIElementCopyAttributeValue(element, attributeNameCF.get(), &value);
-
-    if (error != kAXErrorSuccess || !value)
-        return nullptr;
-
-    return adoptCF(value);
+    auto json = JSON::Object::create();
+    json->setString("command"_s, String::fromLatin1(command));
+    if (messageBody) {
+        json->setInteger("elementId"_s, uint64Value(messageBody, "elementToken"));
+        json->setString("attribute"_s, toWTFString(stringValue(messageBody, "attributeName")));
+    }
+    return json;
 }
 
 WKRetainPtr<WKTypeRef> TestController::handleAXCopyAttributeValueAsString(WKDictionaryRef messageBody)
 {
-    RetainPtr value = axCopyAttributeValue(messageBody);
+    auto response = sendAccessibilityHelperCommand(buildHelperCommand("copyAttributeValueAsString", messageBody));
+    if (!response)
+        return nullptr;
+
+    auto value = response->getString("value"_s);
     if (!value)
         return nullptr;
 
-    if (CFGetTypeID(value.get()) != CFStringGetTypeID())
-        return nullptr;
-
-    return toWK(String(static_cast<CFStringRef>(value.get())));
+    return toWK(value);
 }
 
 WKRetainPtr<WKTypeRef> TestController::handleAXCopyAttributeValueAsElement(WKDictionaryRef messageBody)
 {
-    RetainPtr value = axCopyAttributeValue(messageBody);
-    if (!value)
+    auto response = sendAccessibilityHelperCommand(buildHelperCommand("copyAttributeValueAsElement", messageBody));
+    if (!response)
         return nullptr;
 
-    if (CFGetTypeID(value.get()) != AXUIElementGetTypeID())
+    auto elementId = response->getInteger("elementId"_s);
+    if (!elementId)
         return nullptr;
 
-    uint64_t token = storeAXElement(value.get());
-    return adoptWK(WKUInt64Create(token));
+    return adoptWK(WKUInt64Create(*elementId));
 }
 
 WKRetainPtr<WKTypeRef> TestController::handleAXCopyAttributeValueAsElementArray(WKDictionaryRef messageBody)
 {
-    RetainPtr value = axCopyAttributeValue(messageBody);
-    if (!value)
+    auto response = sendAccessibilityHelperCommand(buildHelperCommand("copyAttributeValueAsElementArray", messageBody));
+    if (!response)
         return nullptr;
 
-    if (CFGetTypeID(value.get()) != CFArrayGetTypeID())
+    auto elementIds = response->getArray("elementIds"_s);
+    if (!elementIds)
         return nullptr;
 
-    CFArrayRef elementArray = static_cast<CFArrayRef>(value.get());
-    CFIndex count = CFArrayGetCount(elementArray);
-
-    Vector<WKTypeRef> tokens;
-    tokens.reserveInitialCapacity(count);
-
-    for (CFIndex i = 0; i < count; i++) {
-        CFTypeRef childElement = CFArrayGetValueAtIndex(elementArray, i);
-        if (CFGetTypeID(childElement) == AXUIElementGetTypeID()) {
-            uint64_t token = storeAXElement(childElement);
-            tokens.append(WKUInt64Create(token));
-        }
-    }
-
-    // Build array from individual elements since Vector::data() is private
     WKRetainPtr result = adoptWK(WKMutableArrayCreate());
-    for (WKTypeRef token : tokens) {
+    for (unsigned i = 0; i < elementIds->length(); i++) {
+        auto value = elementIds->get(i);
+        auto intValue = value->asInteger();
+        if (!intValue)
+            continue;
+        auto token = WKUInt64Create(*intValue);
         WKArrayAppendItem(result.get(), token);
         WKRelease(token);
     }
@@ -5553,152 +5486,99 @@ WKRetainPtr<WKTypeRef> TestController::handleAXCopyAttributeValueAsElementArray(
 
 WKRetainPtr<WKTypeRef> TestController::handleAXCopyAttributeValueAsNumber(WKDictionaryRef messageBody)
 {
-    RetainPtr value = axCopyAttributeValue(messageBody);
+    auto response = sendAccessibilityHelperCommand(buildHelperCommand("copyAttributeValueAsNumber", messageBody));
+    if (!response)
+        return nullptr;
+
+    auto value = response->getDouble("value"_s);
     if (!value)
         return nullptr;
 
-    if (CFGetTypeID(value.get()) != CFNumberGetTypeID())
-        return nullptr;
-
-    double doubleValue;
-    CFNumberGetValue(static_cast<CFNumberRef>(value.get()), kCFNumberDoubleType, &doubleValue);
-
-    return adoptWK(WKDoubleCreate(doubleValue));
+    return adoptWK(WKDoubleCreate(*value));
 }
 
 WKRetainPtr<WKTypeRef> TestController::handleAXCopyAttributeValueAsBoolean(WKDictionaryRef messageBody)
 {
-    RetainPtr value = axCopyAttributeValue(messageBody);
+    auto response = sendAccessibilityHelperCommand(buildHelperCommand("copyAttributeValueAsBoolean", messageBody));
+    if (!response)
+        return nullptr;
+
+    auto value = response->getBoolean("value"_s);
     if (!value)
         return nullptr;
 
-    if (CFGetTypeID(value.get()) != CFBooleanGetTypeID())
-        return nullptr;
-
-    bool boolValue = CFBooleanGetValue(static_cast<CFBooleanRef>(value.get()));
-
-    return adoptWK(WKBooleanCreate(boolValue));
+    return adoptWK(WKBooleanCreate(*value));
 }
 
 WKRetainPtr<WKTypeRef> TestController::handleAXCopyAttributeValueAsPoint(WKDictionaryRef messageBody)
 {
-    RetainPtr value = axCopyAttributeValue(messageBody);
-    if (!value)
+    auto response = sendAccessibilityHelperCommand(buildHelperCommand("copyAttributeValueAsPoint", messageBody));
+    if (!response)
         return nullptr;
 
-    if (CFGetTypeID(value.get()) != AXValueGetTypeID())
-        return nullptr;
-
-    CGPoint point;
-    if (!AXValueGetValue(static_cast<AXValueRef>(value.get()), static_cast<AXValueType>(kAXValueCGPointType), &point))
+    auto x = response->getDouble("x"_s);
+    auto y = response->getDouble("y"_s);
+    if (!x || !y)
         return nullptr;
 
     WKRetainPtr dictionary = adoptWK(WKMutableDictionaryCreate());
-    setValue(dictionary, "x", point.x);
-    setValue(dictionary, "y", point.y);
+    setValue(dictionary, "x", *x);
+    setValue(dictionary, "y", *y);
     return dictionary;
 }
 
 WKRetainPtr<WKTypeRef> TestController::handleAXCopyAttributeValueAsSize(WKDictionaryRef messageBody)
 {
-    RetainPtr value = axCopyAttributeValue(messageBody);
-    if (!value)
+    auto response = sendAccessibilityHelperCommand(buildHelperCommand("copyAttributeValueAsSize", messageBody));
+    if (!response)
         return nullptr;
 
-    if (CFGetTypeID(value.get()) != AXValueGetTypeID())
-        return nullptr;
-
-    CGSize size;
-    if (!AXValueGetValue(static_cast<AXValueRef>(value.get()), static_cast<AXValueType>(kAXValueCGSizeType), &size))
+    auto width = response->getDouble("width"_s);
+    auto height = response->getDouble("height"_s);
+    if (!width || !height)
         return nullptr;
 
     WKRetainPtr dictionary = adoptWK(WKMutableDictionaryCreate());
-    setValue(dictionary, "width", size.width);
-    setValue(dictionary, "height", size.height);
+    setValue(dictionary, "width", *width);
+    setValue(dictionary, "height", *height);
     return dictionary;
 }
 
 WKRetainPtr<WKTypeRef> TestController::handleAXSearchPredicate(WKDictionaryRef messageBody)
 {
-    uint64_t elementToken = uint64Value(messageBody, "elementToken");
-    uint64_t startElementToken = uint64Value(messageBody, "startElementToken");
-    bool isDirectionNext = booleanValue(messageBody, "isDirectionNext");
-    uint64_t resultsLimit = uint64Value(messageBody, "resultsLimit");
-    bool visibleOnly = booleanValue(messageBody, "visibleOnly");
-    bool immediateDescendantsOnly = booleanValue(messageBody, "immediateDescendantsOnly");
-    WKStringRef searchKey = stringValue(messageBody, "searchKey");
-    WKStringRef searchText = stringValue(messageBody, "searchText");
+    auto command = JSON::Object::create();
+    command->setString("command"_s, "searchPredicate"_s);
+    command->setInteger("elementId"_s, uint64Value(messageBody, "elementToken"));
+    command->setInteger("startElementId"_s, uint64Value(messageBody, "startElementToken"));
+    command->setBoolean("isDirectionNext"_s, booleanValue(messageBody, "isDirectionNext"));
+    command->setInteger("resultsLimit"_s, uint64Value(messageBody, "resultsLimit"));
+    command->setBoolean("visibleOnly"_s, booleanValue(messageBody, "visibleOnly"));
+    command->setBoolean("immediateDescendantsOnly"_s, booleanValue(messageBody, "immediateDescendantsOnly"));
+    if (auto key = stringValue(messageBody, "searchKey"))
+        command->setString("searchKey"_s, toWTFString(key));
+    if (auto text = stringValue(messageBody, "searchText"))
+        command->setString("searchText"_s, toWTFString(text));
 
-    AXUIElementRef element = static_cast<AXUIElementRef>(getAXElement(elementToken));
-    if (!element)
+    auto response = sendAccessibilityHelperCommand(command);
+    if (!response)
         return nullptr;
 
-    // Build the search predicate parameter dictionary using CF APIs.
-    RetainPtr paramDictionary = adoptCF(CFDictionaryCreateMutable(kCFAllocatorDefault, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
-
-    if (startElementToken) {
-        if (AXUIElementRef startElement = static_cast<AXUIElementRef>(getAXElement(startElementToken)))
-            CFDictionarySetValue(paramDictionary.get(), CFSTR("AXStartElement"), startElement);
-    }
-
-    CFDictionarySetValue(paramDictionary.get(), CFSTR("AXDirection"),
-        isDirectionNext ? CFSTR("AXDirectionNext") : CFSTR("AXDirectionPrevious"));
-
-    int resultsLimitInt = static_cast<int>(resultsLimit);
-    RetainPtr resultsLimitNum = adoptCF(CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &resultsLimitInt));
-    CFDictionarySetValue(paramDictionary.get(), CFSTR("AXResultsLimit"), resultsLimitNum.get());
-
-    if (searchKey) {
-        RetainPtr searchKeyCF = adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, toSTD(searchKey).c_str(), kCFStringEncodingUTF8));
-        CFDictionarySetValue(paramDictionary.get(), CFSTR("AXSearchKey"), searchKeyCF.get());
-    }
-
-    if (searchText) {
-        auto searchTextStd = toSTD(searchText);
-        if (!searchTextStd.empty()) {
-            RetainPtr searchTextCF = adoptCF(CFStringCreateWithCString(kCFAllocatorDefault, searchTextStd.c_str(), kCFStringEncodingUTF8));
-            CFDictionarySetValue(paramDictionary.get(), CFSTR("AXSearchText"), searchTextCF.get());
-        }
-    }
-
-    CFDictionarySetValue(paramDictionary.get(), CFSTR("AXVisibleOnly"), visibleOnly ? kCFBooleanTrue : kCFBooleanFalse);
-    CFDictionarySetValue(paramDictionary.get(), CFSTR("AXImmediateDescendantsOnly"), immediateDescendantsOnly ? kCFBooleanTrue : kCFBooleanFalse);
-
-    CFTypeRef resultValue = nullptr;
-    AXError error = AXUIElementCopyParameterizedAttributeValue(element, CFSTR("AXUIElementsForSearchPredicate"), paramDictionary.get(), &resultValue);
-
-    if (error != kAXErrorSuccess || !resultValue)
+    auto elementIds = response->getArray("elementIds"_s);
+    if (!elementIds)
         return nullptr;
 
-    RetainPtr result = adoptCF(resultValue);
-
-    if (CFGetTypeID(result.get()) != CFArrayGetTypeID())
-        return nullptr;
-
-    CFArrayRef resultArray = static_cast<CFArrayRef>(result.get());
-    CFIndex count = CFArrayGetCount(resultArray);
-
-    WKRetainPtr tokenArray = adoptWK(WKMutableArrayCreate());
-    for (CFIndex i = 0; i < count; i++) {
-        CFTypeRef item = CFArrayGetValueAtIndex(resultArray, i);
-
-        AXUIElementRef resultElement = nullptr;
-        if (CFGetTypeID(item) == AXUIElementGetTypeID())
-            resultElement = static_cast<AXUIElementRef>(const_cast<void*>(item));
-        else if (CFGetTypeID(item) == CFDictionaryGetTypeID()) {
-            CFTypeRef searchResultElement = CFDictionaryGetValue(static_cast<CFDictionaryRef>(item), CFSTR("AXSearchResultElement"));
-            if (searchResultElement && CFGetTypeID(searchResultElement) == AXUIElementGetTypeID())
-                resultElement = static_cast<AXUIElementRef>(const_cast<void*>(searchResultElement));
-        }
-
-        if (resultElement) {
-            uint64_t token = storeAXElement(resultElement);
-            WKRetainPtr tokenRef = adoptWK(WKUInt64Create(token));
-            WKArrayAppendItem(tokenArray.get(), tokenRef.get());
-        }
+    WKRetainPtr result = adoptWK(WKMutableArrayCreate());
+    for (unsigned i = 0; i < elementIds->length(); i++) {
+        auto value = elementIds->get(i);
+        auto intValue = value->asInteger();
+        if (!intValue)
+            continue;
+        auto token = WKUInt64Create(*intValue);
+        WKArrayAppendItem(result.get(), token);
+        WKRelease(token);
     }
 
-    return tokenArray;
+    return result;
 }
 
 #endif // PLATFORM(MAC)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -36,6 +36,7 @@
 #include <vector>
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
+#include <wtf/JSONValues.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Seconds.h>
 #include <wtf/Vector.h>
@@ -481,6 +482,8 @@ public:
 #if PLATFORM(MAC)
     // Client accessibility testing support
     void initializeWebProcessAccessibility();
+    void launchAccessibilityHelper();
+    void shutdownAccessibilityHelper();
 #endif
 
 #if !PLATFORM(COCOA)
@@ -581,11 +584,9 @@ private:
 
 #if PLATFORM(MAC)
     // Client accessibility testing support
-    uint64_t storeAXElement(CFTypeRef);
-    CFTypeRef getAXElement(uint64_t token);
+    RefPtr<JSON::Object> sendAccessibilityHelperCommand(Ref<JSON::Object>);
     CFDataRef getRemoteAccessibilityToken();
     WKRetainPtr<WKTypeRef> handleAXGetRoot();
-    RetainPtr<CFTypeRef> axCopyAttributeValue(WKDictionaryRef);
     WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsString(WKDictionaryRef);
     WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsElement(WKDictionaryRef);
     WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsElementArray(WKDictionaryRef);
@@ -889,9 +890,11 @@ private:
     bool m_useWorkQueue { false };
 
 #if PLATFORM(MAC)
-    // Client accessibility testing support
-    std::atomic<uint64_t> m_nextAXElementToken { 1 };
-    HashMap<uint64_t, RetainPtr<CFTypeRef>> m_axElementTokens;
+    // Client accessibility testing support - helper process
+    RetainPtr<id> m_axHelperTask; // NSTask
+    RetainPtr<id> m_axHelperStdinPipe; // NSPipe
+    RetainPtr<id> m_axHelperStdoutPipe; // NSPipe
+    RetainPtr<id> m_axHelperStdoutHandle; // NSFileHandle
 #endif
 
 #if ENABLE(WPE_PLATFORM)

--- a/Tools/WebKitTestRunner/WebKitAccessibilityTestHelper.xcconfig
+++ b/Tools/WebKitTestRunner/WebKitAccessibilityTestHelper.xcconfig
@@ -1,0 +1,45 @@
+//
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#include "Configurations/BaseTarget.xcconfig"
+
+PRODUCT_NAME = WebKitAccessibilityTestHelper;
+PRODUCT_BUNDLE_IDENTIFIER = org.webkit.WebKitAccessibilityTestHelper;
+SUPPORTED_PLATFORMS = macosx;
+CODE_SIGN_ENTITLEMENTS = Configurations/WebKitAccessibilityTestHelper.entitlements;
+CODE_SIGN_IDENTITY = -;
+CODE_SIGN_IDENTITY[sdk=macosx*] = $(WK_ACCESSIBILITY_HELPER_CODE_SIGN_IDENTITY_$(USE_INTERNAL_SDK));
+WK_ACCESSIBILITY_HELPER_CODE_SIGN_IDENTITY_ = -;
+WK_ACCESSIBILITY_HELPER_CODE_SIGN_IDENTITY_YES = $(WK_ENGINEERING_CODE_SIGN_IDENTITY);
+CODE_SIGN_STYLE = Manual;
+SWIFT_VERSION = 5.0;
+SWIFT_INCLUDE_PATHS = $(SRCROOT)/WebKitAccessibilityTestHelper;
+
+// Only build on macOS; exclude all sources on other platforms.
+EXCLUDED_SOURCE_FILE_NAMES = *;
+EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*] = ;
+
+SKIP_INSTALL = YES;
+SKIP_INSTALL[sdk=macosx*] = NO;

--- a/Tools/WebKitTestRunner/WebKitAccessibilityTestHelper/AccessibilityPrivate/AccessibilityPrivate.h
+++ b/Tools/WebKitTestRunner/WebKitAccessibilityTestHelper/AccessibilityPrivate/AccessibilityPrivate.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <ApplicationServices/ApplicationServices.h>
+
+AXUIElementRef _Nonnull _AXUIElementCreateWithRemoteToken(CFDataRef _Nonnull remoteToken);

--- a/Tools/WebKitTestRunner/WebKitAccessibilityTestHelper/AccessibilityPrivate/module.modulemap
+++ b/Tools/WebKitTestRunner/WebKitAccessibilityTestHelper/AccessibilityPrivate/module.modulemap
@@ -1,0 +1,8 @@
+module AccessibilityPrivate [system] {
+    explicit module AccessibilityPrivate {
+        header "AccessibilityPrivate.h"
+        export *
+    }
+
+    export *
+}

--- a/Tools/WebKitTestRunner/WebKitAccessibilityTestHelper/WebKitAccessibilityTestHelper.swift
+++ b/Tools/WebKitTestRunner/WebKitAccessibilityTestHelper/WebKitAccessibilityTestHelper.swift
@@ -1,0 +1,310 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+// WebKitAccessibilityTestHelper
+//
+// A small helper tool that calls macOS client-side accessibility APIs
+// (AXUIElement) on behalf of WebKitTestRunner.
+//
+// Communication protocol: reads JSON commands from stdin (one per line),
+// writes JSON responses to stdout (one per line).
+
+import AccessibilityPrivate.AccessibilityPrivate
+import ApplicationServices
+import Foundation
+
+// MARK: - Request / Response types
+
+struct HelperRequest: Decodable {
+    let command: String
+    var token: String?
+    var elementId: UInt64?
+    var attribute: String?
+    var startElementId: UInt64?
+    var isDirectionNext: Bool?
+    var resultsLimit: Int?
+    var visibleOnly: Bool?
+    var immediateDescendantsOnly: Bool?
+    var searchKey: String?
+    var searchText: String?
+}
+
+struct ElementResponse: Encodable { let elementId: UInt64 }
+struct ElementArrayResponse: Encodable { let elementIds: [UInt64] }
+struct StringResponse: Encodable { let value: String }
+struct NumberResponse: Encodable { let value: Double }
+struct BooleanResponse: Encodable { let value: Bool }
+struct PointResponse: Encodable {
+    let x: Double
+    let y: Double
+}
+struct SizeResponse: Encodable {
+    let width: Double
+    let height: Double
+}
+struct ErrorResponse: Encodable { let error: String }
+struct OkResponse: Encodable { let ok: Bool }
+
+// MARK: - Element storage
+
+var nextElementID: UInt64 = 1
+var elementMap: [UInt64: AXUIElement] = [:]
+
+func storeElement(_ element: AXUIElement) -> UInt64 {
+    let id = nextElementID
+    nextElementID += 1
+    elementMap[id] = element
+    return id
+}
+
+// MARK: - AX helpers
+
+func createRootElement(fromTokenBase64 base64String: String) -> UInt64? {
+    guard let tokenData = Data(base64Encoded: base64String) else {
+        return nil
+    }
+    let element = unsafe _AXUIElementCreateWithRemoteToken(tokenData as CFData).takeRetainedValue()
+    return storeElement(element)
+}
+
+func copyAttributeValue(elementID: UInt64, attribute: String) -> (CFTypeRef?, AXError) {
+    guard let element = elementMap[elementID] else {
+        return (nil, .invalidUIElement)
+    }
+    var value: CFTypeRef?
+    let error = unsafe AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+    return (value, error)
+}
+
+// MARK: - Command handling
+
+func handleCommand(_ request: HelperRequest) -> any Encodable {
+    switch request.command {
+    case "wirecheck":
+        return OkResponse(ok: true)
+
+    case "getRoot":
+        guard let token = request.token else {
+            return ErrorResponse(error: "missing token")
+        }
+        if let elementID = createRootElement(fromTokenBase64: token) {
+            return ElementResponse(elementId: elementID)
+        }
+        return ErrorResponse(error: "failed to create root element from token")
+
+    case "copyAttributeValueAsString":
+        guard let elementID = request.elementId, let attribute = request.attribute else {
+            return ErrorResponse(error: "missing elementId or attribute")
+        }
+        let (value, error) = copyAttributeValue(elementID: elementID, attribute: attribute)
+        if error == .success, let stringValue = value as? String {
+            return StringResponse(value: stringValue)
+        }
+        return ErrorResponse(error: "AXError \(error.rawValue)")
+
+    case "copyAttributeValueAsElementArray":
+        guard let elementID = request.elementId, let attribute = request.attribute else {
+            return ErrorResponse(error: "missing elementId or attribute")
+        }
+        let (value, error) = copyAttributeValue(elementID: elementID, attribute: attribute)
+        if error == .success, let elements = value as? [AXUIElement] {
+            return ElementArrayResponse(elementIds: elements.map { storeElement($0) })
+        }
+        if error == .success, let value, CFGetTypeID(value) == AXUIElementGetTypeID() {
+            let element: AXUIElement = unsafe unsafeBitCast(value, to: AXUIElement.self)
+            return ElementArrayResponse(elementIds: [storeElement(element)])
+        }
+        return ErrorResponse(error: "AXError \(error.rawValue)")
+
+    case "copyAttributeValueAsElement":
+        guard let elementID = request.elementId, let attribute = request.attribute else {
+            return ErrorResponse(error: "missing elementId or attribute")
+        }
+        let (value, error) = copyAttributeValue(elementID: elementID, attribute: attribute)
+        if error == .success, let value, CFGetTypeID(value) == AXUIElementGetTypeID() {
+            let element: AXUIElement = unsafe unsafeBitCast(value, to: AXUIElement.self)
+            return ElementResponse(elementId: storeElement(element))
+        }
+        return ErrorResponse(error: "AXError \(error.rawValue)")
+
+    case "copyAttributeValueAsNumber":
+        guard let elementID = request.elementId, let attribute = request.attribute else {
+            return ErrorResponse(error: "missing elementId or attribute")
+        }
+        let (value, error) = copyAttributeValue(elementID: elementID, attribute: attribute)
+        if error == .success, let number = value as? NSNumber {
+            return NumberResponse(value: number.doubleValue)
+        }
+        return ErrorResponse(error: "AXError \(error.rawValue)")
+
+    case "copyAttributeValueAsBoolean":
+        guard let elementID = request.elementId, let attribute = request.attribute else {
+            return ErrorResponse(error: "missing elementId or attribute")
+        }
+        let (value, error) = copyAttributeValue(elementID: elementID, attribute: attribute)
+        if error == .success, let number = value as? NSNumber {
+            return BooleanResponse(value: number.boolValue)
+        }
+        return ErrorResponse(error: "AXError \(error.rawValue)")
+
+    case "copyAttributeValueAsPoint":
+        guard let elementID = request.elementId, let attribute = request.attribute else {
+            return ErrorResponse(error: "missing elementId or attribute")
+        }
+        let (value, error) = copyAttributeValue(elementID: elementID, attribute: attribute)
+        if error == .success, let value, CFGetTypeID(value) == AXValueGetTypeID() {
+            var point = CGPoint.zero
+            // AXValue type verified by CFGetTypeID check above.
+            unsafe AXValueGetValue(unsafe unsafeBitCast(value, to: AXValue.self), .cgPoint, &point)
+            return PointResponse(x: point.x, y: point.y)
+        }
+        return ErrorResponse(error: "AXError \(error.rawValue)")
+
+    case "copyAttributeValueAsSize":
+        guard let elementID = request.elementId, let attribute = request.attribute else {
+            return ErrorResponse(error: "missing elementId or attribute")
+        }
+        let (value, error) = copyAttributeValue(elementID: elementID, attribute: attribute)
+        if error == .success, let value, CFGetTypeID(value) == AXValueGetTypeID() {
+            var size = CGSize.zero
+            // AXValue type verified by CFGetTypeID check above.
+            unsafe AXValueGetValue(unsafe unsafeBitCast(value, to: AXValue.self), .cgSize, &size)
+            return SizeResponse(width: size.width, height: size.height)
+        }
+        return ErrorResponse(error: "AXError \(error.rawValue)")
+
+    case "searchPredicate":
+        guard let elementID = request.elementId else {
+            return ErrorResponse(error: "missing elementId")
+        }
+        guard let element = elementMap[elementID] else {
+            return ErrorResponse(error: "invalid elementId")
+        }
+        return handleSearchPredicate(request: request, element: element)
+
+    case "releaseElement":
+        if let elementID = request.elementId {
+            elementMap.removeValue(forKey: elementID)
+        }
+        return OkResponse(ok: true)
+
+    case "releaseAll":
+        elementMap.removeAll()
+        nextElementID = 1
+        return OkResponse(ok: true)
+
+    default:
+        return ErrorResponse(error: "unknown command: \(request.command)")
+    }
+}
+
+func handleSearchPredicate(request: HelperRequest, element: AXUIElement) -> any Encodable {
+    let paramDict = NSMutableDictionary()
+
+    if let startElementID = request.startElementId, startElementID != 0,
+        let startElement = elementMap[startElementID]
+    {
+        paramDict["AXStartElement"] = startElement
+    }
+
+    let isDirectionNext = request.isDirectionNext ?? true
+    paramDict["AXDirection"] = isDirectionNext ? "AXDirectionNext" : "AXDirectionPrevious"
+
+    paramDict["AXResultsLimit"] = NSNumber(value: request.resultsLimit ?? 1)
+
+    if let searchKey = request.searchKey {
+        paramDict["AXSearchKey"] = searchKey
+    }
+    if let searchText = request.searchText, !searchText.isEmpty {
+        paramDict["AXSearchText"] = searchText
+    }
+
+    paramDict["AXVisibleOnly"] = NSNumber(value: request.visibleOnly ?? false)
+    paramDict["AXImmediateDescendantsOnly"] = NSNumber(value: request.immediateDescendantsOnly ?? false)
+
+    var resultValue: CFTypeRef?
+    let searchError = unsafe AXUIElementCopyParameterizedAttributeValue(
+        element,
+        "AXUIElementsForSearchPredicate" as CFString,
+        paramDict as CFDictionary,
+        &resultValue
+    )
+
+    if searchError != .success || resultValue == nil {
+        return ErrorResponse(error: "AXError \(searchError.rawValue)")
+    }
+
+    var resultIds: [UInt64] = []
+    if let resultArray = resultValue as? [Any] {
+        for item in resultArray {
+            if CFGetTypeID(item as CFTypeRef) == AXUIElementGetTypeID() {
+                resultIds.append(storeElement(unsafe unsafeBitCast(item, to: AXUIElement.self)))
+            } else if let dict = item as? NSDictionary,
+                let searchResultElement = dict["AXSearchResultElement"],
+                CFGetTypeID(searchResultElement as CFTypeRef) == AXUIElementGetTypeID()
+            {
+                resultIds.append(
+                    storeElement(unsafe unsafeBitCast(searchResultElement, to: AXUIElement.self))
+                )
+            }
+        }
+    }
+
+    return ElementArrayResponse(elementIds: resultIds)
+}
+
+// MARK: - Entry point
+
+@main
+enum WebKitAccessibilityTestHelper {
+    static func main() {
+        unsafe fputs("WebKitAccessibilityTestHelper: started, pid \(ProcessInfo.processInfo.processIdentifier)\n", stderr)
+
+        // Disable stdout buffering so each response line is flushed immediately.
+        unsafe setbuf(stdout, nil)
+
+        let decoder = JSONDecoder()
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys
+
+        while let line = readLine() {
+            guard let data = line.data(using: .utf8),
+                let request = try? decoder.decode(HelperRequest.self, from: data)
+            else {
+                if let errorData = try? encoder.encode(ErrorResponse(error: "invalid JSON")),
+                    let errorString = String(data: errorData, encoding: .utf8)
+                {
+                    print(errorString)
+                }
+                continue
+            }
+
+            let response = handleCommand(request)
+            if let responseData = try? encoder.encode(response),
+                let responseString = String(data: responseData, encoding: .utf8)
+            {
+                print(responseString)
+            }
+        }
+    }
+}

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 70;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -24,6 +24,7 @@
 			buildPhases = (
 			);
 			dependencies = (
+				80D1077F2F67CBFB004FE853 /* PBXTargetDependency */,
 				E3D8A94E2CC69CAF006B43E3 /* PBXTargetDependency */,
 				A115CCBC1B9D76C400E89159 /* PBXTargetDependency */,
 				A115CCBA1B9D76BF00E89159 /* PBXTargetDependency */,
@@ -46,7 +47,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		00E43E412D9781430060461A /* WebContentCaptivePortalExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = 00E43E3F2D977FC70060461A /* WebContentCaptivePortalExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		00E43E412D9781430060461A /* WebContentCaptivePortalExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = 00E43E3F2D977FC70060461A /* WebContentCaptivePortalExtension.appex */; platformFilters = (ios, xros, ); settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		0F18E6E51D6B9B9E0027E547 /* UIScriptContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F18E6DD1D6B9AAF0027E547 /* UIScriptContext.cpp */; };
 		0F18E6E61D6B9BA20027E547 /* UIScriptControllerShared.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F18E6DF1D6B9AAF0027E547 /* UIScriptControllerShared.cpp */; };
 		0F18E7181D6BC4560027E547 /* JSWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F18E7151D6BC4560027E547 /* JSWrapper.cpp */; };
@@ -132,6 +133,7 @@
 		7CFF9BCB2534AF1D0008009F /* TestCommand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7CFF9BC72534AF1D0008009F /* TestCommand.cpp */; };
 		8034C6621487636400AC32E9 /* AccessibilityControllerMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8034C6611487636400AC32E9 /* AccessibilityControllerMac.mm */; };
 		8097338A14874A5A008156D9 /* AccessibilityNotificationHandler.mm in Sources */ = {isa = PBXBuildFile; fileRef = 8097338914874A5A008156D9 /* AccessibilityNotificationHandler.mm */; };
+		80D107642F64A62F004FE853 /* WebKitAccessibilityTestHelper.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 80D107632F64A62F004FE853 /* WebKitAccessibilityTestHelper.xcconfig */; };
 		932BB9C0270E27000094CC33 /* ModifierKeys.mm in Sources */ = {isa = PBXBuildFile; fileRef = 932BB9BE270E27000094CC33 /* ModifierKeys.mm */; };
 		9376417A210D737200A3DAAE /* WebKitTestRunnerWindow.mm in Sources */ = {isa = PBXBuildFile; fileRef = 93764176210D736000A3DAAE /* WebKitTestRunnerWindow.mm */; };
 		93C78823250C6C2E00C0AA24 /* WPTFunctions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93C7881F250C69E400C0AA24 /* WPTFunctions.cpp */; };
@@ -170,9 +172,9 @@
 		E132AA3A17CD5F1000611DF0 /* WebKitTestRunnerDraggingInfo.mm in Sources */ = {isa = PBXBuildFile; fileRef = E132AA3817CD5F1000611DF0 /* WebKitTestRunnerDraggingInfo.mm */; };
 		E132AA3D17CE776F00611DF0 /* WebKitTestRunnerEvent.mm in Sources */ = {isa = PBXBuildFile; fileRef = E132AA3B17CE776F00611DF0 /* WebKitTestRunnerEvent.mm */; };
 		E1C642C617CBCD4C00D66A3C /* WebKitTestRunnerPasteboard.mm in Sources */ = {isa = PBXBuildFile; fileRef = E1C642C417CBCD4C00D66A3C /* WebKitTestRunnerPasteboard.mm */; };
-		E372BC362C08E29C006DFE67 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC352C08E29C006DFE67 /* NetworkingExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		E372BC382C08EB01006DFE67 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC372C08EB01006DFE67 /* GPUExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		E372BC3A2C08F323006DFE67 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC392C08F323006DFE67 /* WebContentExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E372BC362C08E29C006DFE67 /* NetworkingExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC352C08E29C006DFE67 /* NetworkingExtension.appex */; platformFilters = (ios, xros, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E372BC382C08EB01006DFE67 /* GPUExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC372C08EB01006DFE67 /* GPUExtension.appex */; platformFilters = (ios, xros, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E372BC3A2C08F323006DFE67 /* WebContentExtension.appex in Embed Extensions */ = {isa = PBXBuildFile; fileRef = E372BC392C08F323006DFE67 /* WebContentExtension.appex */; platformFilters = (ios, xros, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E3D8A94C2CC4B003006B43E3 /* main.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E3E17D422CC4447B0077C3AE /* main.cpp */; };
 		F4010B7E24DA205300A876E2 /* PoseAsClass.mm in Sources */ = {isa = PBXBuildFile; fileRef = F4010B7C24DA204800A876E2 /* PoseAsClass.mm */; };
 		F415C22C27AF52D30028F505 /* UIPasteboardConsistencyEnforcer.h in Headers */ = {isa = PBXBuildFile; fileRef = F415C22A27AF52D30028F505 /* UIPasteboardConsistencyEnforcer.h */; };
@@ -204,6 +206,13 @@
 /* End PBXBuildRule section */
 
 /* Begin PBXContainerItemProxy section */
+		80D1077E2F67CBFB004FE853 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 80D1075A2F64A4CF004FE853;
+			remoteInfo = WebKitAccessibilityTestHelper;
+		};
 		A115CCB91B9D76BF00E89159 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
@@ -263,6 +272,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		80D107592F64A4CF004FE853 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = /usr/share/man/man1/;
+			dstSubfolderSpec = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 1;
+		};
 		CEC209031D36E36A00261596 /* Copy Plug-Ins */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -436,6 +454,8 @@
 		8097338914874A5A008156D9 /* AccessibilityNotificationHandler.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AccessibilityNotificationHandler.mm; path = mac/AccessibilityNotificationHandler.mm; sourceTree = "<group>"; };
 		80A359B02F2945980018924A /* AccessibilityUIElementClientMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccessibilityUIElementClientMac.h; sourceTree = "<group>"; };
 		80A359B12F2945A20018924A /* AccessibilityUIElementMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccessibilityUIElementMac.h; sourceTree = "<group>"; };
+		80D1075B2F64A4CF004FE853 /* WebKitAccessibilityTestHelper */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = WebKitAccessibilityTestHelper; sourceTree = BUILT_PRODUCTS_DIR; };
+		80D107632F64A62F004FE853 /* WebKitAccessibilityTestHelper.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = WebKitAccessibilityTestHelper.xcconfig; sourceTree = "<group>"; };
 		841CC00D181185BF0042E9B6 /* Options.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Options.cpp; sourceTree = "<group>"; };
 		841CC00E181185BF0042E9B6 /* Options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Options.h; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* WebKitTestRunner */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = WebKitTestRunner; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -531,6 +551,10 @@
 		F4FED3222358215E003C139C /* NSPasteboardAdditions.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = NSPasteboardAdditions.mm; path = ../TestRunnerShared/mac/NSPasteboardAdditions.mm; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		80D1075C2F64A4CF004FE853 /* WebKitAccessibilityTestHelper */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = WebKitAccessibilityTestHelper; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
 /* Begin PBXFrameworksBuildPhase section */
 		2EE52CDD1890A9A80010ED21 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
@@ -538,6 +562,13 @@
 			files = (
 				D2D99AFC2AA27BA800000BBF /* Network.framework in Frameworks */,
 				57A0062F22976EF800AD08BD /* Security.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		80D107582F64A4CF004FE853 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -601,8 +632,10 @@
 				BC25194411D15DBE002EBC01 /* Resources */,
 				2EE52CE81890A9A80010ED21 /* WebKitTestRunnerApp */,
 				7C8A1F5425351EC600C5291E /* Scripts */,
+				80D1075C2F64A4CF004FE853 /* WebKitAccessibilityTestHelper */,
 				2EE52CE11890A9A80010ED21 /* Frameworks */,
 				1AB674ADFE9D54B511CA2CBB /* Products */,
+				80D107632F64A62F004FE853 /* WebKitAccessibilityTestHelper.xcconfig */,
 			);
 			name = WebKitTestRunner;
 			sourceTree = "<group>";
@@ -761,6 +794,7 @@
 				2EE52CE01890A9A80010ED21 /* WebKitTestRunnerApp.app */,
 				BC25186211D15D54002EBC01 /* WebKitTestRunnerInjectedBundle.bundle */,
 				E3D8A94A2CC4AFB3006B43E3 /* WebKitEligibilityUtil */,
+				80D1075B2F64A4CF004FE853 /* WebKitAccessibilityTestHelper */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1145,6 +1179,28 @@
 			productReference = 2EE52CE01890A9A80010ED21 /* WebKitTestRunnerApp.app */;
 			productType = "com.apple.product-type.application";
 		};
+		80D1075A2F64A4CF004FE853 /* WebKitAccessibilityTestHelper */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 80D107622F64A4CF004FE853 /* Build configuration list for PBXNativeTarget "WebKitAccessibilityTestHelper" */;
+			buildPhases = (
+				80D107572F64A4CF004FE853 /* Sources */,
+				80D107582F64A4CF004FE853 /* Frameworks */,
+				80D107592F64A4CF004FE853 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				80D1075C2F64A4CF004FE853 /* WebKitAccessibilityTestHelper */,
+			);
+			name = WebKitAccessibilityTestHelper;
+			packageProductDependencies = (
+			);
+			productName = WebKitAccessibilityTestHelper;
+			productReference = 80D1075B2F64A4CF004FE853 /* WebKitAccessibilityTestHelper */;
+			productType = "com.apple.product-type.tool";
+		};
 		8DD76F960486AA7600D96B5E /* WebKitTestRunner */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1DEB927408733DD40010E9CD /* Build configuration list for PBXNativeTarget "WebKitTestRunner" */;
@@ -1258,6 +1314,7 @@
 				A18510261B9ADE4800744AEB /* WebKitTestRunner (Library) */,
 				5325BDD921DFF4F500A0DEE1 /* Apply Configuration to XCFileLists */,
 				E3D8A9332CC4AFB3006B43E3 /* WebKitEligibilityUtil */,
+				80D1075A2F64A4CF004FE853 /* WebKitAccessibilityTestHelper */,
 			);
 		};
 /* End PBXProject section */
@@ -1268,6 +1325,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0F4B08731D5BE88D00EC1B78 /* Launch.storyboard in Resources */,
+				80D107642F64A62F004FE853 /* WebKitAccessibilityTestHelper.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1399,6 +1457,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		80D107572F64A4CF004FE853 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8DD76F990486AA7600D96B5E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1517,6 +1582,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		80D1077F2F67CBFB004FE853 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 80D1075A2F64A4CF004FE853 /* WebKitAccessibilityTestHelper */;
+			targetProxy = 80D1077E2F67CBFB004FE853 /* PBXContainerItemProxy */;
+		};
 		A115CCBA1B9D76BF00E89159 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 8DD76F960486AA7600D96B5E /* WebKitTestRunner */;
@@ -1666,6 +1736,30 @@
 			baseConfigurationReference = A18510381B9ADF2200744AEB /* WebKitTestRunner.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Production;
+		};
+		80D1075F2F64A4CF004FE853 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 80D107632F64A62F004FE853 /* WebKitAccessibilityTestHelper.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		80D107602F64A4CF004FE853 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 80D107632F64A62F004FE853 /* WebKitAccessibilityTestHelper.xcconfig */;
+			buildSettings = {
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		80D107612F64A4CF004FE853 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 80D107632F64A62F004FE853 /* WebKitAccessibilityTestHelper.xcconfig */;
+			buildSettings = {
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Production;
@@ -1832,6 +1926,16 @@
 				5325BDDA21DFF4F500A0DEE1 /* Debug */,
 				5325BDDB21DFF4F500A0DEE1 /* Release */,
 				5325BDDC21DFF4F500A0DEE1 /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		80D107622F64A4CF004FE853 /* Build configuration list for PBXNativeTarget "WebKitAccessibilityTestHelper" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				80D1075F2F64A4CF004FE853 /* Debug */,
+				80D107602F64A4CF004FE853 /* Release */,
+				80D107612F64A4CF004FE853 /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;

--- a/Tools/WebKitTestRunner/mac/TestControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/TestControllerMac.mm
@@ -36,7 +36,9 @@
 #import "WebKitTestRunnerPasteboard.h"
 #import <WebCore/RunLoopObserver.h>
 #import <WebKit/WKContextPrivate.h>
+#import <WebKit/WKNumber.h>
 #import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKRetainPtr.h>
 #import <WebKit/WKStringCF.h>
 #import <WebKit/WKURLCF.h>
 #import <WebKit/WKUserContentControllerPrivate.h>
@@ -46,7 +48,9 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <mach-o/dyld.h>
 #import <pal/spi/mac/NSApplicationSPI.h>
+#import <wtf/JSONValues.h>
 #import <wtf/darwin/DispatchExtras.h>
+#import <wtf/text/CString.h>
 
 @interface NSMenu ()
 - (id)_menuImpl;
@@ -522,6 +526,162 @@ void TestController::initializeWebProcessAccessibility()
     // WebProcessPool::initializeAccessibilityIfNecessary() to send the InitializeAccessibility
     // IPC message to the web content process.
     [platformView accessibilityAttributeValue:NSAccessibilityRoleAttribute];
+}
+
+WKRetainPtr<WKTypeRef> TestController::handleAXGetRoot()
+{
+    WTFLogAlways("handleAXGetRoot: entering");
+    CFDataRef remoteToken = getRemoteAccessibilityToken();
+    if (!remoteToken) {
+        WTFLogAlways("handleAXGetRoot: no remote token");
+        return nullptr;
+    }
+
+    launchAccessibilityHelper();
+
+    RetainPtr nsData = (__bridge NSData *)remoteToken;
+    String base64Token = String::fromUTF8([nsData base64EncodedStringWithOptions:0].UTF8String);
+
+    // Get the remote element from the helper.
+    auto getRoot = JSON::Object::create();
+    getRoot->setString("command"_s, "getRoot"_s);
+    getRoot->setString("token"_s, base64Token);
+
+    auto rootResponse = sendAccessibilityHelperCommand(getRoot);
+    if (!rootResponse)
+        return nullptr;
+
+    auto remoteElementId = rootResponse->getInteger("elementId"_s);
+    if (!remoteElementId)
+        return nullptr;
+
+    // The remote token element is the WKAccessibilityWebPageObject (AXGroup),
+    // which wraps the actual web content. Get its first child to return the
+    // real root of the accessibility tree.
+    auto getChildren = JSON::Object::create();
+    getChildren->setString("command"_s, "copyAttributeValueAsElementArray"_s);
+    getChildren->setInteger("elementId"_s, *remoteElementId);
+    getChildren->setString("attribute"_s, "AXChildren"_s);
+
+    auto childrenResponse = sendAccessibilityHelperCommand(getChildren);
+    if (!childrenResponse)
+        return nullptr;
+
+    auto elementIds = childrenResponse->getArray("elementIds"_s);
+    if (!elementIds || !elementIds->length())
+        return nullptr;
+
+    auto firstChildId = elementIds->get(0)->asInteger();
+    if (!firstChildId)
+        return nullptr;
+
+    return adoptWK(WKUInt64Create(*firstChildId));
+}
+
+void TestController::launchAccessibilityHelper()
+{
+    if (m_axHelperTask)
+        return;
+
+    // Find the helper binary next to the WKTR binary.
+    NSString *wktrPath = [[NSBundle mainBundle] executablePath];
+    NSString *helperPath = [[wktrPath stringByDeletingLastPathComponent] stringByAppendingPathComponent:@"WebKitAccessibilityTestHelper"];
+    WTFLogAlways("launchAccessibilityHelper: looking for %s", [helperPath UTF8String]);
+
+    if (![[NSFileManager defaultManager] isExecutableFileAtPath:helperPath]) {
+        WTFLogAlways("launchAccessibilityHelper: helper binary not found");
+        return;
+    }
+
+    auto stdinPipe = adoptNS([[NSPipe alloc] init]);
+    auto stdoutPipe = adoptNS([[NSPipe alloc] init]);
+
+    auto task = adoptNS([[NSTask alloc] init]);
+    [task setExecutableURL:[NSURL fileURLWithPath:helperPath]];
+    [task setStandardInput:stdinPipe.get()];
+    [task setStandardOutput:stdoutPipe.get()];
+    [task setStandardError:[NSFileHandle fileHandleWithStandardError]];
+
+    NSError *error = nil;
+    if (![task launchAndReturnError:&error]) {
+        WTFLogAlways("launchAccessibilityHelper: failed to launch: %s", [[error description] UTF8String]);
+        return;
+    }
+
+    WTFLogAlways("launchAccessibilityHelper: launched pid %d", [task processIdentifier]);
+
+    m_axHelperTask = task;
+    m_axHelperStdinPipe = stdinPipe;
+    m_axHelperStdoutPipe = stdoutPipe;
+    m_axHelperStdoutHandle = [stdoutPipe fileHandleForReading];
+
+    // Verify the helper is running and responsive.
+    auto wirecheck = JSON::Object::create();
+    wirecheck->setString("command"_s, "wirecheck"_s);
+    auto response = sendAccessibilityHelperCommand(wirecheck);
+    if (!response) {
+        WTFLogAlways("launchAccessibilityHelper: wirecheck failed, helper may have crashed");
+        shutdownAccessibilityHelper();
+        return;
+    }
+    WTFLogAlways("launchAccessibilityHelper: wirecheck succeeded");
+}
+
+void TestController::shutdownAccessibilityHelper()
+{
+    if (!m_axHelperTask)
+        return;
+
+    // Close stdin to signal the helper to exit.
+    [[m_axHelperStdinPipe fileHandleForWriting] closeFile];
+    [m_axHelperTask waitUntilExit];
+
+    m_axHelperTask = nil;
+    m_axHelperStdinPipe = nil;
+    m_axHelperStdoutPipe = nil;
+    m_axHelperStdoutHandle = nil;
+}
+
+RefPtr<JSON::Object> TestController::sendAccessibilityHelperCommand(Ref<JSON::Object> command)
+{
+    if (!m_axHelperTask) {
+        WTFLogAlways("sendAccessibilityHelperCommand: no helper task running");
+        return nullptr;
+    }
+
+    // Serialize to JSON and write a single line to the helper's stdin.
+    String jsonString = command->toJSONString();
+    CString utf8 = jsonString.utf8();
+    WTFLogAlways("sendAccessibilityHelperCommand: sending %s", utf8.data());
+
+    NSFileHandle *stdinHandle = [m_axHelperStdinPipe fileHandleForWriting];
+    NSMutableData *lineData = [NSMutableData dataWithBytes:utf8.data() length:utf8.length()];
+    [lineData appendBytes:"\n" length:1];
+    [stdinHandle writeData:lineData];
+
+    // Read one line of response from stdout.
+    // We read byte-by-byte to find the newline delimiter, since NSFileHandle
+    // doesn't have line-oriented reading.
+    NSMutableData *responseData = [NSMutableData data];
+    while (true) {
+        NSData *byte = [m_axHelperStdoutHandle readDataOfLength:1];
+        if (!byte || ![byte length]) {
+            WTFLogAlways("sendAccessibilityHelperCommand: EOF reading response (helper may have crashed)");
+            return nullptr;
+        }
+        const char c = static_cast<const char *>([byte bytes])[0];
+        if (c == '\n')
+            break;
+        [responseData appendData:byte];
+    }
+
+    String responseString = String::fromUTF8(std::span { static_cast<const char*>([responseData bytes]), [responseData length] });
+    WTFLogAlways("sendAccessibilityHelperCommand: received %s", responseString.utf8().data());
+    auto parsed = JSON::Value::parseJSON(responseString);
+    if (!parsed)
+        return nullptr;
+
+    return parsed->asObject();
 }
 
 } // namespace WTR


### PR DESCRIPTION
#### cef89c65ad8c29b7d0fc574629a71eabd3450a32
<pre>
AX: use test helper for client-side accessibility tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=310044">https://bugs.webkit.org/show_bug.cgi?id=310044</a>
<a href="https://rdar.apple.com/172687684">rdar://172687684</a>

Reviewed by NOBODY (OOPS!).

(NOTE: WIP - currently has debugging logs to see why this fails on WebKit test infrastructure but not locally.)

Calling AXUIElement APIs from WebKitTestRunner directly led to permission errors
on WebKit test infrastructure; use a separate test helper instead.

Re-enables a test that was previously skipped.

* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::ensureAccessibilityInitialized):
(WebCore::AXObjectCache::primaryScreenHeight):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(_WKAccessibilityEnsureInitialized):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFramePrivate.h:
* Source/WebKit/WebProcess/WebPage/mac/WKAccessibilityWebPageObjectMac.mm:
(-[WKAccessibilityWebPageObject accessibilityAttributeValue:]):
* Tools/WebKitTestRunner/Configurations/WebKitAccessibilityTestHelper.entitlements: Added.
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm:
(WTR::AccessibilityController::platformInitializeClientAccessibility):
* Tools/WebKitTestRunner/TestController.cpp:
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/WebKitAccessibilityTestHelper.xcconfig: Added.
* Tools/WebKitTestRunner/WebKitAccessibilityTestHelper/AccessibilityPrivate/AccessibilityPrivate.h: Added.
* Tools/WebKitTestRunner/WebKitAccessibilityTestHelper/AccessibilityPrivate/module.modulemap: Added.
* Tools/WebKitTestRunner/WebKitAccessibilityTestHelper/WebKitAccessibilityTestHelper.swift: Added.
(HelperRequest.token):
(HelperRequest.elementId):
(HelperRequest.attribute):
(HelperRequest.startElementId):
(HelperRequest.isDirectionNext):
(HelperRequest.resultsLimit):
(HelperRequest.visibleOnly):
(HelperRequest.immediateDescendantsOnly):
(HelperRequest.searchKey):
(HelperRequest.searchText):
(nextElementID):
(elementMap):
(storeElement(_:)):
(createRootElement(fromTokenBase64:)):
(copyAttributeValue(_:attribute:AXError:)):
(handleCommand(_:)):
(handleSearchPredicate(_:element:)):
(WebKitAccessibilityTestHelper.main):
* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj:
* Tools/WebKitTestRunner/mac/TestControllerMac.mm:
(WTR::TestController::handleAXGetRoot):
(WTR::TestController::launchAccessibilityHelper):
(WTR::TestController::shutdownAccessibilityHelper):
(WTR::TestController::sendAccessibilityHelperCommand):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cef89c65ad8c29b7d0fc574629a71eabd3450a32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150969 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159697 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104405 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116546 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82739 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135447 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97266 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17753 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15705 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7543 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127371 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162170 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5295 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14935 "Found 1 new test failure: accessibility/mac/client/button.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124554 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23533 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19755 "Found 1 new test failure: accessibility/mac/client/button.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124741 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23523 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135161 "Exiting early after 10 failures. 10 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79930 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19801 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11926 "Found 1 new test failure: accessibility/mac/client/button.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23133 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87334 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22845 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22997 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->