### PR TITLE
[List Marker]Collapse AnonymousBlock created when block content prevents line-box parenting.

### DIFF
--- a/LayoutTests/fast/lists/list-marker-before-content-table-expected.txt
+++ b/LayoutTests/fast/lists/list-marker-before-content-table-expected.txt
@@ -1,18 +1,18 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x160
-  RenderBlock {HTML} at (0,0) size 800x160
-    RenderBody {BODY} at (8,32) size 784x96
-      RenderBlock {UL} at (0,0) size 784x96
-        RenderListItem {LI} at (40,0) size 744x96 [color=#008000]
-          RenderBlock (anonymous) at (0,0) size 744x32
+layer at (0,0) size 800x128
+  RenderBlock {HTML} at (0,0) size 800x128
+    RenderBody {BODY} at (8,32) size 784x64
+      RenderBlock {UL} at (0,0) size 784x64
+        RenderListItem {LI} at (40,0) size 744x64 [color=#008000]
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-25,0) size 11x32: bullet
-          RenderTable at (0,32) size 128x32
+          RenderTable at (0,0) size 128x32
             RenderTableSection (anonymous) at (0,0) size 128x32
               RenderTableRow (anonymous) at (0,0) size 128x32 [color=#0000FF]
                 RenderTableCell (anonymous) at (0,0) size 128x32 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 128x32
                     text run at (0,0) width 128: "ABCD"
-          RenderBlock (anonymous) at (0,64) size 744x32
+          RenderBlock (anonymous) at (0,32) size 744x32
             RenderText {#text} at (0,0) size 128x32
               text run at (0,0) width 128: "EFGH"

--- a/LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block-expected.html
+++ b/LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block-expected.html
@@ -11,4 +11,9 @@
         <div></div>
         X
     </div>
+    <div style="display: flex">
+        <img style="width: 20px; height: 20px">
+        <div></div>
+        X
+    </div>
 </div>

--- a/LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block.html
+++ b/LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block.html
@@ -22,4 +22,11 @@
             X
         </div>
     </li>
+    <li>
+        <div style="display: flex">
+            <img style="display: block; width: 20px; height: 20px">
+            <div></div>
+            X
+        </div>
+    </li>
 </ul>

--- a/LayoutTests/platform/glib/fast/css-generated-content/table-row-group-with-before-expected.txt
+++ b/LayoutTests/platform/glib/fast/css-generated-content/table-row-group-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 220: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (220,0) size 0x18
-      RenderBlock {UL} at (0,34) size 784x54
-        RenderListItem {LI} at (40,0) size 744x54
-          RenderBlock (anonymous) at (0,0) size 744x18
+      RenderBlock {UL} at (0,34) size 784x36
+        RenderListItem {LI} at (40,0) size 744x36
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-17,0) size 7x18: bullet
-          RenderTable at (0,18) size 31x18
+          RenderTable at (0,0) size 31x18
             RenderTableSection (anonymous) at (0,0) size 31x18
               RenderTableRow (anonymous) at (0,0) size 31x18
                 RenderTableCell (anonymous) at (0,0) size 31x18 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 31x18
                     text run at (0,0) width 31: "hello"
-          RenderBlock (anonymous) at (0,36) size 744x18
+          RenderBlock (anonymous) at (0,18) size 744x18
             RenderText {#text} at (0,0) size 21x18
               text run at (0,0) width 21: "test"

--- a/LayoutTests/platform/glib/fast/css-generated-content/table-row-with-before-expected.txt
+++ b/LayoutTests/platform/glib/fast/css-generated-content/table-row-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 220: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (220,0) size 0x18
-      RenderBlock {UL} at (0,34) size 784x54
-        RenderListItem {LI} at (40,0) size 744x54
-          RenderBlock (anonymous) at (0,0) size 744x18
+      RenderBlock {UL} at (0,34) size 784x36
+        RenderListItem {LI} at (40,0) size 744x36
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-17,0) size 7x18: bullet
-          RenderTable at (0,18) size 31x18
+          RenderTable at (0,0) size 31x18
             RenderTableSection (anonymous) at (0,0) size 31x18
               RenderTableRow (anonymous) at (0,0) size 31x18
                 RenderTableCell (anonymous) at (0,0) size 31x18 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 31x18
                     text run at (0,0) width 31: "hello"
-          RenderBlock (anonymous) at (0,36) size 744x18
+          RenderBlock (anonymous) at (0,18) size 744x18
             RenderText {#text} at (0,0) size 21x18
               text run at (0,0) width 21: "test"

--- a/LayoutTests/platform/glib/fast/css-generated-content/table-with-before-expected.txt
+++ b/LayoutTests/platform/glib/fast/css-generated-content/table-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 220: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (220,0) size 0x18
-      RenderBlock {UL} at (0,34) size 784x54
-        RenderListItem {LI} at (40,0) size 744x54
-          RenderBlock (anonymous) at (0,0) size 744x18
+      RenderBlock {UL} at (0,34) size 784x36
+        RenderListItem {LI} at (40,0) size 744x36
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-17,0) size 7x18: bullet
-          RenderTable at (0,18) size 31x18
+          RenderTable at (0,0) size 31x18
             RenderTableSection (anonymous) at (0,0) size 31x18
               RenderTableRow (anonymous) at (0,0) size 31x18
                 RenderTableCell (anonymous) at (0,0) size 31x18 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 31x18
                     text run at (0,0) width 31: "hello"
-          RenderBlock (anonymous) at (0,36) size 744x18
+          RenderBlock (anonymous) at (0,18) size 744x18
             RenderText {#text} at (0,0) size 21x18
               text run at (0,0) width 21: "test"

--- a/LayoutTests/platform/glib/fast/forms/form-hides-table-expected.txt
+++ b/LayoutTests/platform/glib/fast/forms/form-hides-table-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x658
+layer at (0,0) size 785x640
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x658
-  RenderBlock {HTML} at (0,0) size 785x658
-    RenderBody {BODY} at (8,8) size 769x642
+layer at (0,0) size 785x640
+  RenderBlock {HTML} at (0,0) size 785x640
+    RenderBody {BODY} at (8,8) size 769x624
       RenderBlock {P} at (0,0) size 769x18
         RenderText {#text} at (0,0) size 551x18
           text run at (0,0) width 551: "This page has a few tables within form elements within divs with various display styles."
@@ -32,18 +32,18 @@ layer at (0,0) size 785x658
                   RenderTableCell {TD} at (2,2) size 90x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 88x18
                       text run at (1,1) width 88: "display: block"
-      RenderBlock {DIV} at (0,148) size 769x42
-        RenderListItem {DIV} at (0,0) size 769x42
-          RenderBlock (anonymous) at (0,0) size 769x18
+      RenderBlock {DIV} at (0,148) size 769x24
+        RenderListItem {DIV} at (0,0) size 769x24
+          RenderBlock (anonymous) at (0,0) size 769x0
             RenderListMarker at (-17,0) size 7x18: bullet
-          RenderBlock {FORM} at (0,18) size 769x24
+          RenderBlock {FORM} at (0,0) size 769x24
             RenderTable {TABLE} at (0,0) size 109x24
               RenderTableSection {TBODY} at (0,0) size 109x24
                 RenderTableRow {TR} at (0,2) size 109x20
                   RenderTableCell {TD} at (2,2) size 105x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 103x18
                       text run at (1,1) width 103: "display: list-item"
-      RenderBlock {DIV} at (0,206) size 769x24
+      RenderBlock {DIV} at (0,188) size 769x24
         RenderBlock {DIV} at (0,0) size 769x24
           RenderBlock {FORM} at (0,0) size 769x24
             RenderTable {TABLE} at (0,0) size 112x24
@@ -52,7 +52,7 @@ layer at (0,0) size 785x658
                   RenderTableCell {TD} at (2,2) size 108x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 106x18
                       text run at (1,1) width 106: "display: compact"
-      RenderBlock {DIV} at (0,246) size 769x40
+      RenderBlock {DIV} at (0,228) size 769x40
         RenderBlock {DIV} at (0,0) size 134x40
           RenderBlock {FORM} at (0,0) size 134x24
             RenderTable {TABLE} at (0,0) size 134x24
@@ -61,7 +61,7 @@ layer at (0,0) size 785x658
                   RenderTableCell {TD} at (2,2) size 130x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 128x18
                       text run at (1,1) width 128: "display: inline-block"
-      RenderBlock {DIV} at (0,286) size 769x40
+      RenderBlock {DIV} at (0,268) size 769x40
         RenderTable {DIV} at (0,0) size 89x40
           RenderTableSection (anonymous) at (0,0) size 89x40
             RenderTableRow (anonymous) at (0,0) size 89x40
@@ -73,7 +73,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 85x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 83x18
                             text run at (1,1) width 83: "display: table"
-      RenderBlock {DIV} at (0,326) size 769x40
+      RenderBlock {DIV} at (0,308) size 769x40
         RenderTable {DIV} at (0,0) size 129x40
           RenderTableSection (anonymous) at (0,0) size 129x40
             RenderTableRow (anonymous) at (0,0) size 129x40
@@ -85,7 +85,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 125x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 123x18
                             text run at (1,1) width 123: "display: inline-table"
-      RenderBlock {DIV} at (0,366) size 769x40
+      RenderBlock {DIV} at (0,348) size 769x40
         RenderTable at (0,0) size 161x40
           RenderTableSection {DIV} at (0,0) size 161x40
             RenderTableRow (anonymous) at (0,0) size 161x40
@@ -97,7 +97,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 157x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 155x18
                             text run at (1,1) width 155: "display: table-row-group"
-      RenderBlock {DIV} at (0,406) size 769x40
+      RenderBlock {DIV} at (0,388) size 769x40
         RenderTable at (0,0) size 178x40
           RenderTableSection {DIV} at (0,0) size 178x40
             RenderTableRow (anonymous) at (0,0) size 178x40
@@ -109,7 +109,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 174x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 172x18
                             text run at (1,1) width 172: "display: table-header-group"
-      RenderBlock {DIV} at (0,446) size 769x40
+      RenderBlock {DIV} at (0,428) size 769x40
         RenderTable at (0,0) size 173x40
           RenderTableSection {DIV} at (0,0) size 173x40
             RenderTableRow (anonymous) at (0,0) size 173x40
@@ -121,7 +121,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 169x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 167x18
                             text run at (1,1) width 167: "display: table-footer-group"
-      RenderBlock {DIV} at (0,486) size 769x40
+      RenderBlock {DIV} at (0,468) size 769x40
         RenderTable at (0,0) size 119x40
           RenderTableSection (anonymous) at (0,0) size 119x40
             RenderTableRow {DIV} at (0,0) size 119x40
@@ -133,14 +133,14 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 115x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 113x18
                             text run at (1,1) width 113: "display: table-row"
-      RenderBlock {DIV} at (0,526) size 769x0
+      RenderBlock {DIV} at (0,508) size 769x0
         RenderTable at (0,0) size 0x0
           RenderTableCol {DIV} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,526) size 769x0
+      RenderBlock {DIV} at (0,508) size 769x0
         RenderTable at (0,0) size 0x0
           RenderTableCol at (0,0) size 0x0
             RenderTableCol {DIV} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,526) size 769x40
+      RenderBlock {DIV} at (0,508) size 769x40
         RenderTable at (0,0) size 116x40
           RenderTableSection (anonymous) at (0,0) size 116x40
             RenderTableRow (anonymous) at (0,0) size 116x40
@@ -152,7 +152,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 112x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 110x18
                             text run at (1,1) width 110: "display: table-cell"
-      RenderBlock {DIV} at (0,566) size 769x76
+      RenderBlock {DIV} at (0,548) size 769x76
         RenderTable at (0,0) size 55x76
           RenderBlock {DIV} at (0,0) size 55x76
             RenderBlock {FORM} at (0,0) size 55x60

--- a/LayoutTests/platform/glib/fast/lists/ordered-list-with-no-ol-tag-expected.txt
+++ b/LayoutTests/platform/glib/fast/lists/ordered-list-with-no-ol-tag-expected.txt
@@ -1,15 +1,15 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x539
-  RenderBlock {HTML} at (0,0) size 800x539
-    RenderBody {BODY} at (8,19) size 784x512
+layer at (0,0) size 800x503
+  RenderBlock {HTML} at (0,0) size 800x503
+    RenderBody {BODY} at (8,19) size 784x476
       RenderBlock {H2} at (0,0) size 784x27
         RenderText {#text} at (0,0) size 303x27
           text run at (0,0) width 303: "A regular two level nested list"
       RenderBlock {P} at (0,46) size 784x19
         RenderText {#text} at (0,0) size 551x18
           text run at (0,0) width 551: "The outer list is numbered using decimal numerals, the inner lists with lower case letters"
-      RenderBlock {DIV} at (24,80) size 760x431 [border: (1px solid #000000)]
+      RenderBlock {DIV} at (24,80) size 760x395 [border: (1px solid #000000)]
         RenderListItem {DIV} at (33,1) size 726x20 [border: (1px solid #000000)]
           RenderListMarker at (-20,1) size 16x18: "1"
           RenderText {#text} at (33,1) size 40x18
@@ -67,15 +67,15 @@ layer at (0,0) size 800x539
           RenderListMarker at (-20,1) size 16x18: "4"
           RenderText {#text} at (33,1) size 40x18
             text run at (33,1) width 40: "Item 4"
-        RenderListItem {DIV} at (33,297) size 726x112 [border: (1px solid #000000)]
+        RenderListItem {DIV} at (33,297) size 726x76 [border: (1px solid #000000)]
           RenderBlock (anonymous) at (33,1) size 692x18
             RenderListMarker at (-53,0) size 16x18: "5"
             RenderText {#text} at (0,0) size 40x18
               text run at (0,0) width 40: "Item 5"
-          RenderListItem {TABLE} at (33,19) size 692x46 [border: (1px dashed #000000)]
-            RenderBlock (anonymous) at (1,1) size 690x18
+          RenderListItem {TABLE} at (33,19) size 692x28 [border: (1px dashed #000000)]
+            RenderBlock (anonymous) at (1,1) size 690x0
               RenderListMarker at (-20,0) size 15x18: "a"
-            RenderTable at (1,19) size 191x26
+            RenderTable at (1,1) size 191x26
               RenderTableSection {TBODY} at (0,0) size 191x26
                 RenderTableRow {TR} at (0,2) size 191x22
                   RenderTableCell {TD} at (2,2) size 93x22 [border: (1px dotted #000000)] [r=0 c=0 rs=1 cs=1]
@@ -84,10 +84,10 @@ layer at (0,0) size 800x539
                   RenderTableCell {TD} at (96,2) size 93x22 [border: (1px dotted #000000)] [r=0 c=1 rs=1 cs=1]
                     RenderText {#text} at (2,2) size 88x18
                       text run at (2,2) width 88: "Table Cell B1"
-          RenderListItem {TABLE} at (33,65) size 692x46 [border: (1px dashed #000000)]
-            RenderBlock (anonymous) at (1,1) size 690x18
+          RenderListItem {TABLE} at (33,47) size 692x28 [border: (1px dashed #000000)]
+            RenderBlock (anonymous) at (1,1) size 690x0
               RenderListMarker at (-21,0) size 16x18: "b"
-            RenderTable at (1,19) size 215x26
+            RenderTable at (1,1) size 215x26
               RenderTableSection {TBODY} at (0,0) size 215x26
                 RenderTableRow {TR} at (0,2) size 215x22
                   RenderTableCell {TD} at (2,2) size 105x22 [border: (1px dotted #000000)] [r=0 c=0 rs=1 cs=1]
@@ -96,7 +96,7 @@ layer at (0,0) size 800x539
                   RenderTableCell {TD} at (108,2) size 105x22 [border: (1px dotted #000000)] [r=0 c=1 rs=1 cs=1]
                     RenderText {#text} at (2,2) size 100x18
                       text run at (2,2) width 100: "Table 2 Cell B1"
-        RenderListItem {DIV} at (33,409) size 726x20 [border: (1px solid #000000)]
+        RenderListItem {DIV} at (33,373) size 726x20 [border: (1px solid #000000)]
           RenderListMarker at (-20,1) size 16x18: "6"
           RenderText {#text} at (33,1) size 40x18
             text run at (33,1) width 40: "Item 6"

--- a/LayoutTests/platform/ios/fast/css-generated-content/table-row-group-with-before-expected.txt
+++ b/LayoutTests/platform/ios/fast/css-generated-content/table-row-group-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 226: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (225,0) size 1x20
-      RenderBlock {UL} at (0,36) size 784x60
-        RenderListItem {LI} at (40,0) size 744x60
-          RenderBlock (anonymous) at (0,0) size 744x20
+      RenderBlock {UL} at (0,36) size 784x40
+        RenderListItem {LI} at (40,0) size 744x40
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-18,0) size 7x20: bullet
-          RenderTable at (0,20) size 32x20
+          RenderTable at (0,0) size 32x20
             RenderTableSection (anonymous) at (0,0) size 32x20
               RenderTableRow (anonymous) at (0,0) size 32x20
                 RenderTableCell (anonymous) at (0,0) size 32x20 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 32x20
                     text run at (0,0) width 32: "hello"
-          RenderBlock (anonymous) at (0,40) size 744x20
+          RenderBlock (anonymous) at (0,20) size 744x20
             RenderText {#text} at (0,0) size 23x20
               text run at (0,0) width 23: "test"

--- a/LayoutTests/platform/ios/fast/css-generated-content/table-row-with-before-expected.txt
+++ b/LayoutTests/platform/ios/fast/css-generated-content/table-row-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 226: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (225,0) size 1x20
-      RenderBlock {UL} at (0,36) size 784x60
-        RenderListItem {LI} at (40,0) size 744x60
-          RenderBlock (anonymous) at (0,0) size 744x20
+      RenderBlock {UL} at (0,36) size 784x40
+        RenderListItem {LI} at (40,0) size 744x40
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-18,0) size 7x20: bullet
-          RenderTable at (0,20) size 32x20
+          RenderTable at (0,0) size 32x20
             RenderTableSection (anonymous) at (0,0) size 32x20
               RenderTableRow (anonymous) at (0,0) size 32x20
                 RenderTableCell (anonymous) at (0,0) size 32x20 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 32x20
                     text run at (0,0) width 32: "hello"
-          RenderBlock (anonymous) at (0,40) size 744x20
+          RenderBlock (anonymous) at (0,20) size 744x20
             RenderText {#text} at (0,0) size 23x20
               text run at (0,0) width 23: "test"

--- a/LayoutTests/platform/ios/fast/css-generated-content/table-with-before-expected.txt
+++ b/LayoutTests/platform/ios/fast/css-generated-content/table-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 226: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (225,0) size 1x20
-      RenderBlock {UL} at (0,36) size 784x60
-        RenderListItem {LI} at (40,0) size 744x60
-          RenderBlock (anonymous) at (0,0) size 744x20
+      RenderBlock {UL} at (0,36) size 784x40
+        RenderListItem {LI} at (40,0) size 744x40
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-18,0) size 7x20: bullet
-          RenderTable at (0,20) size 32x20
+          RenderTable at (0,0) size 32x20
             RenderTableSection (anonymous) at (0,0) size 32x20
               RenderTableRow (anonymous) at (0,0) size 32x20
                 RenderTableCell (anonymous) at (0,0) size 32x20 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 32x20
                     text run at (0,0) width 32: "hello"
-          RenderBlock (anonymous) at (0,40) size 744x20
+          RenderBlock (anonymous) at (0,20) size 744x20
             RenderText {#text} at (0,0) size 23x20
               text run at (0,0) width 23: "test"

--- a/LayoutTests/platform/ios/fast/forms/form-hides-table-expected.txt
+++ b/LayoutTests/platform/ios/fast/forms/form-hides-table-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 800x694
+layer at (0,0) size 800x674
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x694
-  RenderBlock {HTML} at (0,0) size 800x694
-    RenderBody {BODY} at (8,8) size 784x678
+layer at (0,0) size 800x674
+  RenderBlock {HTML} at (0,0) size 800x674
+    RenderBody {BODY} at (8,8) size 784x658
       RenderBlock {P} at (0,0) size 784x20
         RenderText {#text} at (0,0) size 564x20
           text run at (0,0) width 564: "This page has a few tables within form elements within divs with various display styles."
@@ -32,18 +32,18 @@ layer at (0,0) size 800x694
                   RenderTableCell {TD} at (2,2) size 93x22 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 91x20
                       text run at (1,1) width 91: "display: block"
-      RenderBlock {DIV} at (0,156) size 784x46
-        RenderListItem {DIV} at (0,0) size 784x46
-          RenderBlock (anonymous) at (0,0) size 784x20
+      RenderBlock {DIV} at (0,156) size 784x26
+        RenderListItem {DIV} at (0,0) size 784x26
+          RenderBlock (anonymous) at (0,0) size 784x0
             RenderListMarker at (-18,0) size 7x20: bullet
-          RenderBlock {FORM} at (0,20) size 784x26
+          RenderBlock {FORM} at (0,0) size 784x26
             RenderTable {TABLE} at (0,0) size 114x26
               RenderTableSection {TBODY} at (0,0) size 114x26
                 RenderTableRow {TR} at (0,2) size 114x22
                   RenderTableCell {TD} at (2,2) size 110x22 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 108x20
                       text run at (1,1) width 108: "display: list-item"
-      RenderBlock {DIV} at (0,218) size 784x26
+      RenderBlock {DIV} at (0,198) size 784x26
         RenderBlock {DIV} at (0,0) size 784x26
           RenderBlock {FORM} at (0,0) size 784x26
             RenderTable {TABLE} at (0,0) size 115x26
@@ -52,7 +52,7 @@ layer at (0,0) size 800x694
                   RenderTableCell {TD} at (2,2) size 111x22 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 109x20
                       text run at (1,1) width 109: "display: compact"
-      RenderBlock {DIV} at (0,260) size 784x42
+      RenderBlock {DIV} at (0,240) size 784x42
         RenderBlock {DIV} at (0,0) size 138x42
           RenderBlock {FORM} at (0,0) size 138x26
             RenderTable {TABLE} at (0,0) size 138x26
@@ -61,7 +61,7 @@ layer at (0,0) size 800x694
                   RenderTableCell {TD} at (2,2) size 134x22 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 132x20
                       text run at (1,1) width 132: "display: inline-block"
-      RenderBlock {DIV} at (0,302) size 784x42
+      RenderBlock {DIV} at (0,282) size 784x42
         RenderTable {DIV} at (0,0) size 92x42
           RenderTableSection (anonymous) at (0,0) size 92x42
             RenderTableRow (anonymous) at (0,0) size 92x42
@@ -73,7 +73,7 @@ layer at (0,0) size 800x694
                         RenderTableCell {TD} at (2,2) size 88x22 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 86x20
                             text run at (1,1) width 86: "display: table"
-      RenderBlock {DIV} at (0,344) size 784x42
+      RenderBlock {DIV} at (0,324) size 784x42
         RenderTable {DIV} at (0,0) size 134x42
           RenderTableSection (anonymous) at (0,0) size 134x42
             RenderTableRow (anonymous) at (0,0) size 134x42
@@ -85,7 +85,7 @@ layer at (0,0) size 800x694
                         RenderTableCell {TD} at (2,2) size 130x22 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 128x20
                             text run at (1,1) width 128: "display: inline-table"
-      RenderBlock {DIV} at (0,386) size 784x42
+      RenderBlock {DIV} at (0,366) size 784x42
         RenderTable at (0,0) size 165x42
           RenderTableSection {DIV} at (0,0) size 165x42
             RenderTableRow (anonymous) at (0,0) size 165x42
@@ -97,7 +97,7 @@ layer at (0,0) size 800x694
                         RenderTableCell {TD} at (2,2) size 161x22 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 159x20
                             text run at (1,1) width 159: "display: table-row-group"
-      RenderBlock {DIV} at (0,428) size 784x42
+      RenderBlock {DIV} at (0,408) size 784x42
         RenderTable at (0,0) size 183x42
           RenderTableSection {DIV} at (0,0) size 183x42
             RenderTableRow (anonymous) at (0,0) size 183x42
@@ -109,7 +109,7 @@ layer at (0,0) size 800x694
                         RenderTableCell {TD} at (2,2) size 179x22 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 177x20
                             text run at (1,1) width 177: "display: table-header-group"
-      RenderBlock {DIV} at (0,470) size 784x42
+      RenderBlock {DIV} at (0,450) size 784x42
         RenderTable at (0,0) size 178x42
           RenderTableSection {DIV} at (0,0) size 178x42
             RenderTableRow (anonymous) at (0,0) size 178x42
@@ -121,7 +121,7 @@ layer at (0,0) size 800x694
                         RenderTableCell {TD} at (2,2) size 174x22 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 172x20
                             text run at (1,1) width 172: "display: table-footer-group"
-      RenderBlock {DIV} at (0,512) size 784x42
+      RenderBlock {DIV} at (0,492) size 784x42
         RenderTable at (0,0) size 122x42
           RenderTableSection (anonymous) at (0,0) size 122x42
             RenderTableRow {DIV} at (0,0) size 122x42
@@ -133,14 +133,14 @@ layer at (0,0) size 800x694
                         RenderTableCell {TD} at (2,2) size 118x22 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 116x20
                             text run at (1,1) width 116: "display: table-row"
-      RenderBlock {DIV} at (0,554) size 784x0
+      RenderBlock {DIV} at (0,534) size 784x0
         RenderTable at (0,0) size 0x0
           RenderTableCol {DIV} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,554) size 784x0
+      RenderBlock {DIV} at (0,534) size 784x0
         RenderTable at (0,0) size 0x0
           RenderTableCol at (0,0) size 0x0
             RenderTableCol {DIV} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,554) size 784x42
+      RenderBlock {DIV} at (0,534) size 784x42
         RenderTable at (0,0) size 121x42
           RenderTableSection (anonymous) at (0,0) size 121x42
             RenderTableRow (anonymous) at (0,0) size 121x42
@@ -152,7 +152,7 @@ layer at (0,0) size 800x694
                         RenderTableCell {TD} at (2,2) size 117x22 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 115x20
                             text run at (1,1) width 115: "display: table-cell"
-      RenderBlock {DIV} at (0,596) size 784x82
+      RenderBlock {DIV} at (0,576) size 784x82
         RenderTable at (0,0) size 57x82
           RenderBlock {DIV} at (0,0) size 57x82
             RenderBlock {FORM} at (0,0) size 57x66

--- a/LayoutTests/platform/ios/fast/lists/ordered-list-with-no-ol-tag-expected.txt
+++ b/LayoutTests/platform/ios/fast/lists/ordered-list-with-no-ol-tag-expected.txt
@@ -1,15 +1,15 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x586
-  RenderBlock {HTML} at (0,0) size 800x586
-    RenderBody {BODY} at (8,19) size 784x559
+layer at (0,0) size 800x546
+  RenderBlock {HTML} at (0,0) size 800x546
+    RenderBody {BODY} at (8,19) size 784x519
       RenderBlock {H2} at (0,0) size 784x30
         RenderText {#text} at (0,1) size 302x28
           text run at (0,1) width 302: "A regular two level nested list"
       RenderBlock {P} at (0,49) size 784x21
         RenderText {#text} at (0,0) size 566x20
           text run at (0,0) width 566: "The outer list is numbered using decimal numerals, the inner lists with lower case letters"
-      RenderBlock {DIV} at (24,85) size 760x473 [border: (1px solid #000000)]
+      RenderBlock {DIV} at (24,85) size 760x433 [border: (1px solid #000000)]
         RenderListItem {DIV} at (33,1) size 726x22 [border: (1px solid #000000)]
           RenderListMarker at (-21,1) size 16x20: "1"
           RenderText {#text} at (33,1) size 42x20
@@ -67,15 +67,15 @@ layer at (0,0) size 800x586
           RenderListMarker at (-21,1) size 16x20: "4"
           RenderText {#text} at (33,1) size 42x20
             text run at (33,1) width 42: "Item 4"
-        RenderListItem {DIV} at (33,327) size 726x122 [border: (1px solid #000000)]
+        RenderListItem {DIV} at (33,327) size 726x82 [border: (1px solid #000000)]
           RenderBlock (anonymous) at (33,1) size 692x20
             RenderListMarker at (-54,0) size 16x20: "5"
             RenderText {#text} at (0,0) size 42x20
               text run at (0,0) width 42: "Item 5"
-          RenderListItem {TABLE} at (33,21) size 692x50 [border: (1px dashed #000000)]
-            RenderBlock (anonymous) at (1,1) size 690x20
+          RenderListItem {TABLE} at (33,21) size 692x30 [border: (1px dashed #000000)]
+            RenderBlock (anonymous) at (1,1) size 690x0
               RenderListMarker at (-22,0) size 16x20: "a"
-            RenderTable at (1,21) size 193x28
+            RenderTable at (1,1) size 193x28
               RenderTableSection {TBODY} at (0,0) size 193x28
                 RenderTableRow {TR} at (0,2) size 193x24
                   RenderTableCell {TD} at (2,2) size 94x24 [border: (1px dotted #000000)] [r=0 c=0 rs=1 cs=1]
@@ -84,10 +84,10 @@ layer at (0,0) size 800x586
                   RenderTableCell {TD} at (97,2) size 94x24 [border: (1px dotted #000000)] [r=0 c=1 rs=1 cs=1]
                     RenderText {#text} at (2,2) size 89x20
                       text run at (2,2) width 89: "Table Cell B1"
-          RenderListItem {TABLE} at (33,71) size 692x50 [border: (1px dashed #000000)]
-            RenderBlock (anonymous) at (1,1) size 690x20
+          RenderListItem {TABLE} at (33,51) size 692x30 [border: (1px dashed #000000)]
+            RenderBlock (anonymous) at (1,1) size 690x0
               RenderListMarker at (-22,0) size 16x20: "b"
-            RenderTable at (1,21) size 217x28
+            RenderTable at (1,1) size 217x28
               RenderTableSection {TBODY} at (0,0) size 217x28
                 RenderTableRow {TR} at (0,2) size 217x24
                   RenderTableCell {TD} at (2,2) size 106x24 [border: (1px dotted #000000)] [r=0 c=0 rs=1 cs=1]
@@ -96,7 +96,7 @@ layer at (0,0) size 800x586
                   RenderTableCell {TD} at (109,2) size 106x24 [border: (1px dotted #000000)] [r=0 c=1 rs=1 cs=1]
                     RenderText {#text} at (2,2) size 101x20
                       text run at (2,2) width 101: "Table 2 Cell B1"
-        RenderListItem {DIV} at (33,449) size 726x22 [border: (1px solid #000000)]
+        RenderListItem {DIV} at (33,409) size 726x22 [border: (1px solid #000000)]
           RenderListMarker at (-21,1) size 16x20: "6"
           RenderText {#text} at (33,1) size 42x20
             text run at (33,1) width 42: "Item 6"

--- a/LayoutTests/platform/mac/fast/css-generated-content/table-row-group-with-before-expected.txt
+++ b/LayoutTests/platform/mac/fast/css-generated-content/table-row-group-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 226: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (225,0) size 1x18
-      RenderBlock {UL} at (0,34) size 784x54
-        RenderListItem {LI} at (40,0) size 744x54
-          RenderBlock (anonymous) at (0,0) size 744x18
+      RenderBlock {UL} at (0,34) size 784x36
+        RenderListItem {LI} at (40,0) size 744x36
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-17,0) size 7x18: bullet
-          RenderTable at (0,18) size 32x18
+          RenderTable at (0,0) size 32x18
             RenderTableSection (anonymous) at (0,0) size 32x18
               RenderTableRow (anonymous) at (0,0) size 32x18
                 RenderTableCell (anonymous) at (0,0) size 32x18 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 32x18
                     text run at (0,0) width 32: "hello"
-          RenderBlock (anonymous) at (0,36) size 744x18
+          RenderBlock (anonymous) at (0,18) size 744x18
             RenderText {#text} at (0,0) size 23x18
               text run at (0,0) width 23: "test"

--- a/LayoutTests/platform/mac/fast/css-generated-content/table-row-with-before-expected.txt
+++ b/LayoutTests/platform/mac/fast/css-generated-content/table-row-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 226: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (225,0) size 1x18
-      RenderBlock {UL} at (0,34) size 784x54
-        RenderListItem {LI} at (40,0) size 744x54
-          RenderBlock (anonymous) at (0,0) size 744x18
+      RenderBlock {UL} at (0,34) size 784x36
+        RenderListItem {LI} at (40,0) size 744x36
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-17,0) size 7x18: bullet
-          RenderTable at (0,18) size 32x18
+          RenderTable at (0,0) size 32x18
             RenderTableSection (anonymous) at (0,0) size 32x18
               RenderTableRow (anonymous) at (0,0) size 32x18
                 RenderTableCell (anonymous) at (0,0) size 32x18 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 32x18
                     text run at (0,0) width 32: "hello"
-          RenderBlock (anonymous) at (0,36) size 744x18
+          RenderBlock (anonymous) at (0,18) size 744x18
             RenderText {#text} at (0,0) size 23x18
               text run at (0,0) width 23: "test"

--- a/LayoutTests/platform/mac/fast/css-generated-content/table-with-before-expected.txt
+++ b/LayoutTests/platform/mac/fast/css-generated-content/table-with-before-expected.txt
@@ -9,16 +9,16 @@ layer at (0,0) size 800x600
             text run at (0,0) width 226: "This test passes if it does not crash."
         RenderText {#text} at (0,0) size 0x0
         RenderBR {BR} at (225,0) size 1x18
-      RenderBlock {UL} at (0,34) size 784x54
-        RenderListItem {LI} at (40,0) size 744x54
-          RenderBlock (anonymous) at (0,0) size 744x18
+      RenderBlock {UL} at (0,34) size 784x36
+        RenderListItem {LI} at (40,0) size 744x36
+          RenderBlock (anonymous) at (0,0) size 744x0
             RenderListMarker at (-17,0) size 7x18: bullet
-          RenderTable at (0,18) size 32x18
+          RenderTable at (0,0) size 32x18
             RenderTableSection (anonymous) at (0,0) size 32x18
               RenderTableRow (anonymous) at (0,0) size 32x18
                 RenderTableCell (anonymous) at (0,0) size 32x18 [r=0 c=0 rs=1 cs=1]
                   RenderText at (0,0) size 32x18
                     text run at (0,0) width 32: "hello"
-          RenderBlock (anonymous) at (0,36) size 744x18
+          RenderBlock (anonymous) at (0,18) size 744x18
             RenderText {#text} at (0,0) size 23x18
               text run at (0,0) width 23: "test"

--- a/LayoutTests/platform/mac/fast/forms/form-hides-table-expected.txt
+++ b/LayoutTests/platform/mac/fast/forms/form-hides-table-expected.txt
@@ -1,8 +1,8 @@
-layer at (0,0) size 785x658
+layer at (0,0) size 785x640
   RenderView at (0,0) size 785x600
-layer at (0,0) size 785x658
-  RenderBlock {HTML} at (0,0) size 785x658
-    RenderBody {BODY} at (8,8) size 769x642
+layer at (0,0) size 785x640
+  RenderBlock {HTML} at (0,0) size 785x640
+    RenderBody {BODY} at (8,8) size 769x624
       RenderBlock {P} at (0,0) size 769x18
         RenderText {#text} at (0,0) size 564x18
           text run at (0,0) width 564: "This page has a few tables within form elements within divs with various display styles."
@@ -32,18 +32,18 @@ layer at (0,0) size 785x658
                   RenderTableCell {TD} at (2,2) size 93x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 91x18
                       text run at (1,1) width 91: "display: block"
-      RenderBlock {DIV} at (0,148) size 769x42
-        RenderListItem {DIV} at (0,0) size 769x42
-          RenderBlock (anonymous) at (0,0) size 769x18
+      RenderBlock {DIV} at (0,148) size 769x24
+        RenderListItem {DIV} at (0,0) size 769x24
+          RenderBlock (anonymous) at (0,0) size 769x0
             RenderListMarker at (-17,0) size 7x18: bullet
-          RenderBlock {FORM} at (0,18) size 769x24
+          RenderBlock {FORM} at (0,0) size 769x24
             RenderTable {TABLE} at (0,0) size 114x24
               RenderTableSection {TBODY} at (0,0) size 114x24
                 RenderTableRow {TR} at (0,2) size 114x20
                   RenderTableCell {TD} at (2,2) size 110x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 108x18
                       text run at (1,1) width 108: "display: list-item"
-      RenderBlock {DIV} at (0,206) size 769x24
+      RenderBlock {DIV} at (0,188) size 769x24
         RenderBlock {DIV} at (0,0) size 769x24
           RenderBlock {FORM} at (0,0) size 769x24
             RenderTable {TABLE} at (0,0) size 115x24
@@ -52,7 +52,7 @@ layer at (0,0) size 785x658
                   RenderTableCell {TD} at (2,2) size 111x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 109x18
                       text run at (1,1) width 109: "display: compact"
-      RenderBlock {DIV} at (0,246) size 769x40
+      RenderBlock {DIV} at (0,228) size 769x40
         RenderBlock {DIV} at (0,0) size 138x40
           RenderBlock {FORM} at (0,0) size 138x24
             RenderTable {TABLE} at (0,0) size 138x24
@@ -61,7 +61,7 @@ layer at (0,0) size 785x658
                   RenderTableCell {TD} at (2,2) size 134x20 [r=0 c=0 rs=1 cs=1]
                     RenderText {#text} at (1,1) size 132x18
                       text run at (1,1) width 132: "display: inline-block"
-      RenderBlock {DIV} at (0,286) size 769x40
+      RenderBlock {DIV} at (0,268) size 769x40
         RenderTable {DIV} at (0,0) size 92x40
           RenderTableSection (anonymous) at (0,0) size 92x40
             RenderTableRow (anonymous) at (0,0) size 92x40
@@ -73,7 +73,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 88x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 86x18
                             text run at (1,1) width 86: "display: table"
-      RenderBlock {DIV} at (0,326) size 769x40
+      RenderBlock {DIV} at (0,308) size 769x40
         RenderTable {DIV} at (0,0) size 134x40
           RenderTableSection (anonymous) at (0,0) size 134x40
             RenderTableRow (anonymous) at (0,0) size 134x40
@@ -85,7 +85,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 130x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 128x18
                             text run at (1,1) width 128: "display: inline-table"
-      RenderBlock {DIV} at (0,366) size 769x40
+      RenderBlock {DIV} at (0,348) size 769x40
         RenderTable at (0,0) size 165x40
           RenderTableSection {DIV} at (0,0) size 165x40
             RenderTableRow (anonymous) at (0,0) size 165x40
@@ -97,7 +97,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 161x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 159x18
                             text run at (1,1) width 159: "display: table-row-group"
-      RenderBlock {DIV} at (0,406) size 769x40
+      RenderBlock {DIV} at (0,388) size 769x40
         RenderTable at (0,0) size 183x40
           RenderTableSection {DIV} at (0,0) size 183x40
             RenderTableRow (anonymous) at (0,0) size 183x40
@@ -109,7 +109,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 179x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 177x18
                             text run at (1,1) width 177: "display: table-header-group"
-      RenderBlock {DIV} at (0,446) size 769x40
+      RenderBlock {DIV} at (0,428) size 769x40
         RenderTable at (0,0) size 178x40
           RenderTableSection {DIV} at (0,0) size 178x40
             RenderTableRow (anonymous) at (0,0) size 178x40
@@ -121,7 +121,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 174x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 172x18
                             text run at (1,1) width 172: "display: table-footer-group"
-      RenderBlock {DIV} at (0,486) size 769x40
+      RenderBlock {DIV} at (0,468) size 769x40
         RenderTable at (0,0) size 122x40
           RenderTableSection (anonymous) at (0,0) size 122x40
             RenderTableRow {DIV} at (0,0) size 122x40
@@ -133,14 +133,14 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 118x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 116x18
                             text run at (1,1) width 116: "display: table-row"
-      RenderBlock {DIV} at (0,526) size 769x0
+      RenderBlock {DIV} at (0,508) size 769x0
         RenderTable at (0,0) size 0x0
           RenderTableCol {DIV} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,526) size 769x0
+      RenderBlock {DIV} at (0,508) size 769x0
         RenderTable at (0,0) size 0x0
           RenderTableCol at (0,0) size 0x0
             RenderTableCol {DIV} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,526) size 769x40
+      RenderBlock {DIV} at (0,508) size 769x40
         RenderTable at (0,0) size 121x40
           RenderTableSection (anonymous) at (0,0) size 121x40
             RenderTableRow (anonymous) at (0,0) size 121x40
@@ -152,7 +152,7 @@ layer at (0,0) size 785x658
                         RenderTableCell {TD} at (2,2) size 117x20 [r=0 c=0 rs=1 cs=1]
                           RenderText {#text} at (1,1) size 115x18
                             text run at (1,1) width 115: "display: table-cell"
-      RenderBlock {DIV} at (0,566) size 769x76
+      RenderBlock {DIV} at (0,548) size 769x76
         RenderTable at (0,0) size 57x76
           RenderBlock {DIV} at (0,0) size 57x76
             RenderBlock {FORM} at (0,0) size 57x60

--- a/LayoutTests/platform/mac/fast/lists/ordered-list-with-no-ol-tag-expected.txt
+++ b/LayoutTests/platform/mac/fast/lists/ordered-list-with-no-ol-tag-expected.txt
@@ -1,15 +1,15 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x540
-  RenderBlock {HTML} at (0,0) size 800x540
-    RenderBody {BODY} at (8,19) size 784x513
+layer at (0,0) size 800x504
+  RenderBlock {HTML} at (0,0) size 800x504
+    RenderBody {BODY} at (8,19) size 784x477
       RenderBlock {H2} at (0,0) size 784x28
         RenderText {#text} at (0,0) size 302x28
           text run at (0,0) width 302: "A regular two level nested list"
       RenderBlock {P} at (0,47) size 784x19
         RenderText {#text} at (0,0) size 566x18
           text run at (0,0) width 566: "The outer list is numbered using decimal numerals, the inner lists with lower case letters"
-      RenderBlock {DIV} at (24,81) size 760x431 [border: (1px solid #000000)]
+      RenderBlock {DIV} at (24,81) size 760x395 [border: (1px solid #000000)]
         RenderListItem {DIV} at (33,1) size 726x20 [border: (1px solid #000000)]
           RenderListMarker at (-20,1) size 16x18: "1"
           RenderText {#text} at (33,1) size 42x18
@@ -67,15 +67,15 @@ layer at (0,0) size 800x540
           RenderListMarker at (-20,1) size 16x18: "4"
           RenderText {#text} at (33,1) size 42x18
             text run at (33,1) width 42: "Item 4"
-        RenderListItem {DIV} at (33,297) size 726x112 [border: (1px solid #000000)]
+        RenderListItem {DIV} at (33,297) size 726x76 [border: (1px solid #000000)]
           RenderBlock (anonymous) at (33,1) size 692x18
             RenderListMarker at (-53,0) size 16x18: "5"
             RenderText {#text} at (0,0) size 42x18
               text run at (0,0) width 42: "Item 5"
-          RenderListItem {TABLE} at (33,19) size 692x46 [border: (1px dashed #000000)]
-            RenderBlock (anonymous) at (1,1) size 690x18
+          RenderListItem {TABLE} at (33,19) size 692x28 [border: (1px dashed #000000)]
+            RenderBlock (anonymous) at (1,1) size 690x0
               RenderListMarker at (-21,0) size 16x18: "a"
-            RenderTable at (1,19) size 193x26
+            RenderTable at (1,1) size 193x26
               RenderTableSection {TBODY} at (0,0) size 193x26
                 RenderTableRow {TR} at (0,2) size 193x22
                   RenderTableCell {TD} at (2,2) size 94x22 [border: (1px dotted #000000)] [r=0 c=0 rs=1 cs=1]
@@ -84,10 +84,10 @@ layer at (0,0) size 800x540
                   RenderTableCell {TD} at (97,2) size 94x22 [border: (1px dotted #000000)] [r=0 c=1 rs=1 cs=1]
                     RenderText {#text} at (2,2) size 89x18
                       text run at (2,2) width 89: "Table Cell B1"
-          RenderListItem {TABLE} at (33,65) size 692x46 [border: (1px dashed #000000)]
-            RenderBlock (anonymous) at (1,1) size 690x18
+          RenderListItem {TABLE} at (33,47) size 692x28 [border: (1px dashed #000000)]
+            RenderBlock (anonymous) at (1,1) size 690x0
               RenderListMarker at (-21,0) size 16x18: "b"
-            RenderTable at (1,19) size 217x26
+            RenderTable at (1,1) size 217x26
               RenderTableSection {TBODY} at (0,0) size 217x26
                 RenderTableRow {TR} at (0,2) size 217x22
                   RenderTableCell {TD} at (2,2) size 106x22 [border: (1px dotted #000000)] [r=0 c=0 rs=1 cs=1]
@@ -96,7 +96,7 @@ layer at (0,0) size 800x540
                   RenderTableCell {TD} at (109,2) size 106x22 [border: (1px dotted #000000)] [r=0 c=1 rs=1 cs=1]
                     RenderText {#text} at (2,2) size 101x18
                       text run at (2,2) width 101: "Table 2 Cell B1"
-        RenderListItem {DIV} at (33,409) size 726x20 [border: (1px solid #000000)]
+        RenderListItem {DIV} at (33,373) size 726x20 [border: (1px solid #000000)]
           RenderListMarker at (-20,1) size 16x18: "6"
           RenderText {#text} at (33,1) size 42x18
             text run at (33,1) width 42: "Item 6"

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp
@@ -71,9 +71,7 @@ static LineBoxParentSearchResult findParentOfEmptyOrFirstLineBox(RenderBlock& bl
             break;
 
         if (!is<RenderBlock>(child) || is<RenderTable>(child)) {
-            // FIXME: handle all block level children, not just replaced elements that got blockified.
-            if (!child.isInline() && child.style().originalDisplay().isInlineType())
-                failedDueToBlockification = true;
+            failedDueToBlockification = true;
             break;
         }
 
@@ -197,8 +195,7 @@ void RenderTreeBuilder::List::updateItemMarker(RenderListItem& listItemRenderer)
     m_builder.attach(*searchResult.parent, WTF::move(newMarkerRenderer), firstNonMarkerChild(*searchResult.parent));
     // For outside markers, if the search failed because a flex/grid container blockified a replaced
     // child (e.g., <img>), we should collapse the anonymous block's height so it doesn't inflate the list item.
-    if (shouldCollapseAnonymousBlockParent)
-        listItemRenderer.markerRenderer()->setShouldCollapseAnonymousBlockParent(true);
+    listItemRenderer.markerRenderer()->setShouldCollapseAnonymousBlockParent(shouldCollapseAnonymousBlockParent);
 }
 
 }


### PR DESCRIPTION
#### 99fee9e9322277f43c1c869cb5f8fb27ecaf6d3a
<pre>
[List Marker]Collapse AnonymousBlock created when block content prevents line-box parenting.
<a href="https://bugs.webkit.org/show_bug.cgi?id=310046">https://bugs.webkit.org/show_bug.cgi?id=310046</a>
&lt;<a href="https://rdar.apple.com/172686060">rdar://172686060</a>&gt;

Reviewed by Alan Baradlay.

309272@main fixed a bug where inline item blockification caused
findParentOfEmptyOrFirstLineBox to fail to find a valid line box parent.
This caused us to create an anonymous block to parent the list marker
which inherited line height and pushed the visual content down and
no longer next to the list marker.

This PR builds on that fix by expanding the line collapse behavior to
encompass anonymous blocks created by actual block items instead
of only inline items that were converted to block items, fixing
the behavior for &quot;display: block&quot;

This PR also fixes incorrect test expecatations for:

table-row-group-with-before.html
table-row-with-before.html
table-with-before.html
form-hides-table.html
list-marker-before-content-table.html
ordered-list-with-no-ol-tag.html

By collapsing the anonymous block to line up content with the list
marker, we now match the behavior with Chrome and Firefox.

* LayoutTests/fast/lists/list-marker-before-content-table-expected.txt:
* LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block-expected.html:
* LayoutTests/fast/lists/list-marker-outside-flex-collapse-anonymous-block.html:
* LayoutTests/platform/glib/fast/css-generated-content/table-row-group-with-before-expected.txt:
* LayoutTests/platform/glib/fast/css-generated-content/table-row-with-before-expected.txt:
* LayoutTests/platform/glib/fast/css-generated-content/table-with-before-expected.txt:
* LayoutTests/platform/glib/fast/forms/form-hides-table-expected.txt:
* LayoutTests/platform/glib/fast/lists/ordered-list-with-no-ol-tag-expected.txt:
* LayoutTests/platform/ios/fast/css-generated-content/table-row-group-with-before-expected.txt:
* LayoutTests/platform/ios/fast/css-generated-content/table-row-with-before-expected.txt:
* LayoutTests/platform/ios/fast/css-generated-content/table-with-before-expected.txt:
* LayoutTests/platform/ios/fast/forms/form-hides-table-expected.txt:
* LayoutTests/platform/ios/fast/lists/ordered-list-with-no-ol-tag-expected.txt:
* LayoutTests/platform/mac/fast/css-generated-content/table-row-group-with-before-expected.txt:
* LayoutTests/platform/mac/fast/css-generated-content/table-row-with-before-expected.txt:
* LayoutTests/platform/mac/fast/css-generated-content/table-with-before-expected.txt:
* LayoutTests/platform/mac/fast/forms/form-hides-table-expected.txt:
* LayoutTests/platform/mac/fast/lists/ordered-list-with-no-ol-tag-expected.txt:
* Source/WebCore/rendering/updating/RenderTreeBuilderList.cpp:
(WebCore::findParentOfEmptyOrFirstLineBox):
(WebCore::RenderTreeBuilder::List::updateItemMarker):

Canonical link: <a href="https://commits.webkit.org/309466@main">https://commits.webkit.org/309466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d00fe855c43feaa998a4cfd1f7e2a588710833ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23479 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159443 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104155 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23911 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116327 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82614 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135215 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97055 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17533 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15483 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7291 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161917 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5038 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124326 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23281 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124524 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33805 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23269 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134934 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79658 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19599 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11696 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22883 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86683 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22595 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22747 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22649 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->