### PR TITLE
ResizeObserver is still sluggish over time

### DIFF
--- a/Source/WebCore/page/ResizeObserver.cpp
+++ b/Source/WebCore/page/ResizeObserver.cpp
@@ -67,43 +67,23 @@ ResizeObserver::~ResizeObserver()
         m_document->removeResizeObserver(*this);
 }
 
-ResizeObservation* ResizeObserver::observationForElement(Element& target)
-{
-    auto* data = target.resizeObserverDataIfExists();
-    if (!data)
-        return nullptr;
-
-    // There tend to be more elements to be observed than there are observers.
-    // Check if this observer appears in node's observer data first to avoid a linear search over m_observations.
-    if (data->observers.size() * 2 < m_observations.size() && data->observers.contains(this))
-        return nullptr;
-
-    auto position = m_observations.findIf([&](auto& observation) {
-        return observation->target() == &target;
-    });
-
-    if (position == notFound)
-        return nullptr;
-
-    return m_observations[position].ptr();
-}
-
 void ResizeObserver::observeInternal(Element& target, const ResizeObserverBoxOptions boxOptions)
 {
     ASSERT(!m_JSOrNativeCallback.valueless_by_exception());
 
-    if (RefPtr existingObservation = observationForElement(target)) {
+    auto addResult = m_observationMap.ensure(target, [&]() {
+        return ResizeObservation::create(target, boxOptions);
+    });
+    if (!addResult.isNewEntry) {
         // The spec suggests unconditionally unobserving here, but that causes a test failure:
         // https://github.com/web-platform-tests/wpt/issues/30708
-        if (existingObservation->observedBox() == boxOptions)
+        if (addResult.iterator->value->observedBox() == boxOptions)
             return;
         unobserve(target);
     }
-
     auto& observerData = target.ensureResizeObserverData();
     observerData.observers.append(*this);
-
-    m_observations.append(ResizeObservation::create(target, boxOptions));
+    m_observations.add(addResult.iterator->value.copyRef());
 
     // Per the specification, we should dispatch at least one observation for the target. For this reason, we make sure to keep the
     // target alive until this first observation. This, in turn, will keep the ResizeObserver's JS wrapper alive via
@@ -276,6 +256,7 @@ void ResizeObserver::removeAllTargets()
     }
     m_activeObservations.clear();
     m_observations.clear();
+    m_observationMap.clear();
 }
 
 bool ResizeObserver::removeObservation(const Element& target)
@@ -286,9 +267,11 @@ bool ResizeObserver::removeObservation(const Element& target)
             return pendingTarget.get() == &target;
         });
     }
-    return m_observations.removeFirstMatching([&target](auto& observation) {
-        return observation->target() == &target;
-    });
+    RefPtr observation = m_observationMap.take(target);
+    if (!observation)
+        return false;
+    m_observations.remove(observation);
+    return true;
 }
 
 bool ResizeObserver::isJSCallback()
@@ -315,7 +298,7 @@ ResizeObserverCallback* ResizeObserver::callbackConcurrently()
 
 void ResizeObserver::resetObservationSize(Element& target)
 {
-    if (RefPtr observation = observationForElement(target))
+    if (RefPtr observation = m_observationMap.get(target))
         observation->resetObservationSize();
 }
 

--- a/Source/WebCore/page/ResizeObserver.h
+++ b/Source/WebCore/page/ResizeObserver.h
@@ -28,8 +28,10 @@
 #include "GCReachableRef.h"
 #include "ResizeObservation.h"
 #include "ResizeObserverCallback.h"
+#include <wtf/ListHashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/WeakHashMap.h>
 #include <wtf/WeakPtr.h>
 
 namespace JSC {
@@ -86,7 +88,6 @@ public:
 private:
     ResizeObserver(Document&, JSOrNativeResizeObserverCallback&&);
 
-    ResizeObservation* observationForElement(Element&);
     bool removeTarget(Element&);
     void removeAllTargets();
     bool removeObservation(const Element&);
@@ -94,9 +95,24 @@ private:
     bool NODELETE isNativeCallback();
     bool NODELETE isJSCallback();
 
+    struct ResizeObservationHashFunctions {
+        using T = Ref<ResizeObservation>;
+        using PtrType = const ResizeObservation*;
+
+        static unsigned hash(const PtrType observation) { return PtrHash<Element*>::hash(observation->target()); }
+        static bool equal(const PtrType a, const PtrType b) { return a->target() == b->target(); }
+        static const bool safeToCompareToEmptyOrDeleted = true;
+
+        static unsigned hash(const T& observation) { return hash(observation.ptr()); }
+        static bool equal(const T& a, const T& b) { return equal(a.ptr(), b.ptr()); }
+        static bool equal(const PtrType a, const T& b) { return equal(a, b.ptr()); }
+        static bool equal(const T& a, const PtrType b) { return equal(a.ptr(), b); }
+    };
+
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     const JSOrNativeResizeObserverCallback m_JSOrNativeCallback;
-    Vector<Ref<ResizeObservation>> m_observations;
+    ListHashSet<Ref<ResizeObservation>, ResizeObservationHashFunctions> m_observations;
+    WeakHashMap<Element, Ref<ResizeObservation>, WeakPtrImplWithEventTargetData> m_observationMap;
 
     Vector<Ref<ResizeObservation>> m_activeObservations;
     Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> m_activeObservationTargets WTF_GUARDED_BY_LOCK(m_observationTargetsLock);


### PR DESCRIPTION
#### 89c4bdc2aba0b1f857a7a954ae04beda5acf045f
<pre>
ResizeObserver is still sluggish over time
<a href="https://bugs.webkit.org/show_bug.cgi?id=310050">https://bugs.webkit.org/show_bug.cgi?id=310050</a>

Reviewed by Geoffrey Garen.

Use a combination of HashMap and ListHashSet to further optimize ResizeObserver.

No new tests since there should be no behavioral changes other than the improved perf.

* Source/WebCore/page/ResizeObserver.cpp:
(WebCore::ResizeObserver::observeInternal):
(WebCore::ResizeObserver::removeAllTargets):
(WebCore::ResizeObserver::removeObservation):
(WebCore::ResizeObserver::resetObservationSize):
(WebCore::ResizeObserver::observationForElement): Deleted.
* Source/WebCore/page/ResizeObserver.h:
(WebCore::ResizeObserver::ResizeObservationHashFunctions::hash):
(WebCore::ResizeObserver::ResizeObservationHashFunctions::equal):

Canonical link: <a href="https://commits.webkit.org/309376@main">https://commits.webkit.org/309376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/617576bd8bbcb2a7129b734c2b99d3b9a2e1c66b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16766 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159169 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103881 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/727526e8-7112-4f55-8c5a-03714defe108) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23636 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23342 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116081 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6930fc6-1e4b-494b-8ee9-209687f15568) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134948 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96809 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17288 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15235 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7017 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12872 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161643 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4763 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14425 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124078 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23007 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19282 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124276 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22994 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134667 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79374 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23126 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19393 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11424 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22608 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86407 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22321 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22473 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22375 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->