### PR TITLE
Bindings generator spends a lot of time launching Perl and re-parsing the same files needlessly

### DIFF
--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -2683,29 +2683,23 @@ $(IDL_INTERMEDIATE_PATTERNS) : $(PREPROCESS_IDLS_SCRIPTS) $(IDL_ATTRIBUTES_FILE)
 vpath %.idl $(ADDITIONAL_BINDING_IDLS_PATHS) $(WebCore)/bindings/scripts
 
 # -------------------------------------------------
-define GENERATE_BINDINGS_template
+JS_DOM_HEADERS_PATTERNS = $(subst .h,%h,$(JS_DOM_HEADERS))
+JS_DOM_IMPLEMENTATIONS_PATTERNS = $(subst .cpp,%cpp,$(JS_DOM_IMPLEMENTATIONS))
 
-JS$(call get_bare_name,$(1)).cpp JS$(call get_bare_name,$(1)).h: $(1) $$(JS_BINDINGS_SCRIPTS) $$(IDL_ATTRIBUTES_FILE) $$(IDL_INTERMEDIATE_FILES) $$(FEATURE_AND_PLATFORM_FLAGS_RESPONSE_FILE) | $(IDL_FILE_NAMES_LIST)
-	$$(PERL) $$(WebCore)/bindings/scripts/generate-bindings.pl \
-		$$(IDL_COMMON_ARGS) \
-		--defines "$$(FEATURE_AND_PLATFORM_DEFINES) LANGUAGE_JAVASCRIPT" \
+$(JS_DOM_HEADERS_PATTERNS) $(JS_DOM_IMPLEMENTATIONS_PATTERNS): $(JS_BINDING_IDLS) $(JS_BINDINGS_SCRIPTS) \
+        $(IDL_ATTRIBUTES_FILE) $(IDL_INTERMEDIATE_FILES) \
+        $(FEATURE_AND_PLATFORM_FLAGS_RESPONSE_FILE) \
+        | $(IDL_FILE_NAMES_LIST)
+	$(PERL) $(WebCore)/bindings/scripts/generate-bindings-all.pl \
+		--outputDir . \
+		--idlFilesList $(IDL_FILE_NAMES_LIST) \
+		--supplementalDependencyFile $(SUPPLEMENTAL_DEPENDENCY_FILE) \
+		--idlAttributesFile $(IDL_ATTRIBUTES_FILE) \
+		--defines "$(FEATURE_AND_PLATFORM_DEFINES) LANGUAGE_JAVASCRIPT" \
 		--generator JS \
-		--idlAttributesFile $$(IDL_ATTRIBUTES_FILE) \
-		--idlFileNamesList $(IDL_FILE_NAMES_LIST) \
-		--supplementalDependencyFile $$(SUPPLEMENTAL_DEPENDENCY_FILE) \
-		$$<
-endef
+		$(addprefix --generatorDependency ,$(JS_BINDINGS_SCRIPTS)) \
+		--exclude EventListener.idl
 # -------------------------------------------------
-
-$(foreach IDL_FILE,$(JS_BINDING_IDLS),$(eval $(call GENERATE_BINDINGS_template,$(IDL_FILE))))
-
-ifneq ($(NO_SUPPLEMENTAL_FILES),1)
--include $(SUPPLEMENTAL_MAKEFILE_DEPS)
-endif
-
-ifneq ($(NO_SUPPLEMENTAL_FILES),1)
--include $(JS_DOM_HEADERS:.h=.dep)
-endif
 
 # WebCore JS Builtins
 

--- a/Source/WebCore/bindings/scripts/generate-bindings-all.pl
+++ b/Source/WebCore/bindings/scripts/generate-bindings-all.pl
@@ -45,9 +45,10 @@ my $preprocessor;
 my $supplementalDependencyFile;
 my @ppExtraOutput;
 my @ppExtraArgs;
-my $numOfJobs = 1;
+my $numOfJobs;
 my $idlAttributesFile;
 my $showProgress;
+my @exclude;
 
 GetOptions('outputDir=s' => \$outputDirectory,
            'idlFilesList=s' => \$idlFilesList,
@@ -62,7 +63,15 @@ GetOptions('outputDir=s' => \$outputDirectory,
            'ppExtraArgs=s@' => \@ppExtraArgs,
            'idlAttributesFile=s' => \$idlAttributesFile,
            'numOfJobs=i' => \$numOfJobs,
+           'exclude=s@' => \@exclude,
            'showProgress' => \$showProgress);
+
+if (!defined $numOfJobs) {
+    $numOfJobs = `sysctl -n hw.activecpu 2>/dev/null` || `nproc 2>/dev/null` || 4;
+    chomp $numOfJobs;
+}
+
+$idlFileNamesList = $idlFilesList if !defined $idlFileNamesList;
 
 $| = 1;
 my @idlFiles;
@@ -70,26 +79,35 @@ open(my $fh, '<', $idlFilesList) or die "Cannot open $idlFilesList";
 @idlFiles = map { CygwinPathIfNeeded(s/\r?\n?$//r) } <$fh>;
 close($fh) or die;
 
+if (@exclude) {
+    my %excluded = map { $_ => 1 } @exclude;
+    @idlFiles = grep { !$excluded{basename($_)} } @idlFiles;
+}
+
 my @ppIDLFiles;
-open($fh, '<', $ppIDLFilesList) or die "Cannot open $ppIDLFilesList";
-@ppIDLFiles = map { CygwinPathIfNeeded(s/\r?\n?$//r) } <$fh>;
-close($fh) or die;
+if ($ppIDLFilesList) {
+    open($fh, '<', $ppIDLFilesList) or die "Cannot open $ppIDLFilesList";
+    @ppIDLFiles = map { CygwinPathIfNeeded(s/\r?\n?$//r) } <$fh>;
+    close($fh) or die;
+}
 
 my %oldSupplements;
 my %newSupplements;
 if ($supplementalDependencyFile) {
-    my @output = ($supplementalDependencyFile, @ppExtraOutput);
-    my @deps = ($ppIDLFilesList, @ppIDLFiles, @generatorDependency);
-    if (needsUpdate(\@output, \@deps)) {
-        readSupplementalDependencyFile($supplementalDependencyFile, \%oldSupplements) if -e $supplementalDependencyFile;
-        my @args = (File::Spec->catfile($scriptDir, 'preprocess-idls.pl'),
-                    '--defines', $defines,
-                    '--idlFileNamesList', $ppIDLFilesList,
-                    '--supplementalDependencyFile', $supplementalDependencyFile,
-                    '--idlAttributesFile', $idlAttributesFile,
-                    @ppExtraArgs);
-        printProgress("Preprocess IDL");
-        executeCommand($perl, @args) == 0 or die;
+    if ($ppIDLFilesList) {
+        my @output = ($supplementalDependencyFile, @ppExtraOutput);
+        my @deps = ($ppIDLFilesList, @ppIDLFiles, @generatorDependency);
+        if (needsUpdate(\@output, \@deps)) {
+            readSupplementalDependencyFile($supplementalDependencyFile, \%oldSupplements) if -e $supplementalDependencyFile;
+            my @args = (File::Spec->catfile($scriptDir, 'preprocess-idls.pl'),
+                        '--defines', $defines,
+                        '--idlFileNamesList', $ppIDLFilesList,
+                        '--supplementalDependencyFile', $supplementalDependencyFile,
+                        '--idlAttributesFile', $idlAttributesFile,
+                        @ppExtraArgs);
+            printProgress("Preprocess IDL");
+            executeCommand($perl, @args) == 0 or die;
+        }
     }
     readSupplementalDependencyFile($supplementalDependencyFile, \%newSupplements);
 }
@@ -98,10 +116,10 @@ my @args = (File::Spec->catfile($scriptDir, 'generate-bindings.pl'),
             '--defines', $defines,
             '--generator', $generator,
             '--outputDir', $outputDirectory,
-            '--preprocessor', $preprocessor,
             '--idlAttributesFile', $idlAttributesFile,
             '--idlFileNamesList', $idlFileNamesList,
             '--write-dependencies');
+push @args, '--preprocessor', $preprocessor if $preprocessor;
 push @args, '--supplementalDependencyFile', $supplementalDependencyFile if $supplementalDependencyFile;
 
 my %directoryCache;

--- a/Source/WebCore/bindings/scripts/generate-bindings.pl
+++ b/Source/WebCore/bindings/scripts/generate-bindings.pl
@@ -79,6 +79,38 @@ if (!$outputHeadersDirectory) {
     $outputHeadersDirectory = $outputDirectory;
 }
 
+# Parse supplemental dependencies and IDL attributes once, shared across all files.
+my %supplementalDependencies;
+if ($supplementalDependencyFile) {
+    # The format of a supplemental dependency file:
+    #
+    # DOMWindow.idl P.idl Q.idl R.idl
+    # Document.idl S.idl
+    # Event.idl
+    # ...
+    #
+    # The above indicates that DOMWindow.idl is supplemented by P.idl, Q.idl and R.idl,
+    # Document.idl is supplemented by S.idl, and Event.idl is supplemented by no IDLs.
+    open FH, "< $supplementalDependencyFile" or die "Cannot open $supplementalDependencyFile\n";
+    while (my $line = <FH>) {
+        my ($idlFile, @followingIdlFiles) = split(/\s+/, $line);
+        $supplementalDependencies{fileparse($idlFile)} = [sort @followingIdlFiles] if $idlFile;
+    }
+    close FH;
+}
+
+my $idlAttributes;
+{
+    local $INPUT_RECORD_SEPARATOR;
+    open(JSON, "<", $idlAttributesFile) or die "Couldn't open $idlAttributesFile: $!";
+    my $input = <JSON>;
+    close(JSON);
+
+    my $jsonDecoder = JSON::PP->new->utf8;
+    my $jsonHashRef = $jsonDecoder->decode($input);
+    $idlAttributes = $jsonHashRef->{attributes};
+}
+
 generateBindings($_) for (@ARGV);
 
 sub generateBindings
@@ -90,38 +122,6 @@ sub generateBindings
         print "$generator: $targetIdlFile\n";
     }
     my $targetInterfaceName = fileparse($targetIdlFile, ".idl");
-
-    my $idlFound = 0;
-    my %supplementalDependencies;
-    if ($supplementalDependencyFile) {
-        # The format of a supplemental dependency file:
-        #
-        # DOMWindow.idl P.idl Q.idl R.idl
-        # Document.idl S.idl
-        # Event.idl
-        # ...
-        #
-        # The above indicates that DOMWindow.idl is supplemented by P.idl, Q.idl and R.idl,
-        # Document.idl is supplemented by S.idl, and Event.idl is supplemented by no IDLs.
-        open FH, "< $supplementalDependencyFile" or die "Cannot open $supplementalDependencyFile\n";
-        while (my $line = <FH>) {
-            my ($idlFile, @followingIdlFiles) = split(/\s+/, $line);
-            $supplementalDependencies{fileparse($idlFile)} = [sort @followingIdlFiles] if $idlFile;
-        }
-        close FH;
-    }
-
-    my $input;
-    {
-        local $INPUT_RECORD_SEPARATOR;
-        open(JSON, "<", $idlAttributesFile) or die "Couldn't open $idlAttributesFile: $!";
-        $input = <JSON>;
-        close(JSON);
-    }
-
-    my $jsonDecoder = JSON::PP->new->utf8;
-    my $jsonHashRef = $jsonDecoder->decode($input);
-    my $idlAttributes = $jsonHashRef->{attributes};
 
     # Parse the target IDL file.
     my $targetParser = IDLParser->new(!$verbose);


### PR DESCRIPTION
#### e331c09641345277aa6f2ef1ba7147466028c40f
<pre>
Bindings generator spends a lot of time launching Perl and re-parsing the same files needlessly
<a href="https://bugs.webkit.org/show_bug.cgi?id=310049">https://bugs.webkit.org/show_bug.cgi?id=310049</a>
<a href="https://rdar.apple.com/172693536">rdar://172693536</a>

Reviewed by Darin Adler, Megan Gardner, and Abrar Rahman Protyasha.

There is a significant amount of clean build overhead when generating derived sources,
from launching a Perl instance per IDL file.

It turns out that the CMake build uses a wrapper which first determines the set
of stale IDLs, then shards them between a small number of Perl instances. Adopt
this wrapper in the Xcode build, and make a few adjustments to it to make that
work:

- Make it possible to exclude generation for given hand-written implementations (EventListener)
- Default the number of shards to the number of CPUs, instead of 1
- Make the preprocess-idls step optional, because the Xcode build does it separately

Also, drive-by hoist shared work (parsing supplemental dependency files) out of the
inner loop, which makes the win from sharing a process even bigger.

This cuts a full minute (almost 5%) off clean builds for me, and has no measurable impact
on incremental builds that touch IDL files.

* Source/WebCore/DerivedSources.make:
* Source/WebCore/bindings/scripts/generate-bindings-all.pl:
* Source/WebCore/bindings/scripts/generate-bindings.pl:
(generateBindings):

Canonical link: <a href="https://commits.webkit.org/309433@main">https://commits.webkit.org/309433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac5878de08b022685e2e6b451bccd9458a66a87c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150597 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159319 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df052bf3-bf6e-4803-b3e0-94ceef58b096) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152470 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23786 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116222 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96950 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ed9e3074-c869-41ca-8fa4-8e3fad03a5c4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17427 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15379 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7167 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127041 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13028 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161793 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4913 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14582 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124220 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19426 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124418 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33783 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23145 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134823 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79534 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19510 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11584 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22759 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86557 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22471 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22623 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22525 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->