### PR TITLE
REGRESSION(308411@main): [macOS Debug] TestWebKitAPI.EditorStateTests.TypingAttributesTextAlignmentDirectionalText is flaky failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm
@@ -200,12 +200,7 @@ TEST(EditorStateTests, TypingAttributesTextAlignmentAbsoluteAlignmentOptions)
     EXPECT_WK_STREQ("right\njustified\ncenter\nleft", [webView stringByEvaluatingJavaScript:@"getSelection().toString()"]);
 }
 
-// FIXME when webkit.org/b/309007 is resolved.
-#if PLATFORM(MAC) && !defined(NDEBUG)
-TEST(EditorStateTests, DISABLED_TypingAttributesTextAlignmentStartEnd)
-#else
 TEST(EditorStateTests, TypingAttributesTextAlignmentStartEnd)
-#endif
 {
     auto testHarness = setUpEditorStateTestHarness();
     TestWKWebView *webView = [testHarness webView];
@@ -228,12 +223,7 @@ TEST(EditorStateTests, TypingAttributesTextAlignmentStartEnd)
     [testHarness insertParagraphAndExpectEditorStateWith:@{ @"text-alignment": @(NSTextAlignmentRight) }];
 }
 
-// FIXME when webkit.org/b/309007 is resolved.
-#if PLATFORM(MAC) && !defined(NDEBUG)
-TEST(EditorStateTests, DISABLED_TypingAttributesTextAlignmentDirectionalText)
-#else
 TEST(EditorStateTests, TypingAttributesTextAlignmentDirectionalText)
-#endif
 {
     auto testHarness = setUpEditorStateTestHarness();
     [[testHarness webView] stringByEvaluatingJavaScript:@"document.body.setAttribute('dir', 'auto')"];

--- a/Tools/TestWebKitAPI/cocoa/app/AppCommon.mm
+++ b/Tools/TestWebKitAPI/cocoa/app/AppCommon.mm
@@ -46,7 +46,10 @@ static void registerTestClasses()
 
 void initializeApp()
 {
-    [NSUserDefaults.standardUserDefaults removePersistentDomainForName:@"TestWebKitAPI"];
+    RetainPtr standardDefaults = [NSUserDefaults standardUserDefaults];
+    [standardDefaults removePersistentDomainForName:@"TestWebKitAPI"];
+    [standardDefaults removeObjectForKey:@"WebCoreLogging"];
+    [standardDefaults removeObjectForKey:@"WebKit2Logging"];
 
     // Set up user defaults.
     NSMutableDictionary *argumentDomain = [[NSUserDefaults.standardUserDefaults volatileDomainForName:NSArgumentDomain] mutableCopy];


### PR DESCRIPTION
#### ae5f3fc8a4f1f83c4b3b9c04018fd15cd3f3be71
<pre>
REGRESSION(308411@main): [macOS Debug] TestWebKitAPI.EditorStateTests.TypingAttributesTextAlignmentDirectionalText is flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=309007">https://bugs.webkit.org/show_bug.cgi?id=309007</a>
<a href="https://rdar.apple.com/171554884">rdar://171554884</a>

Reviewed by Aditya Keerthi.

The logging previously added in <a href="https://commits.webkit.org/308411@main">https://commits.webkit.org/308411@main</a> caused some subsequent tests
to fail with `EXCEEDED LOG LINE THRESHOLD OF 250`. When `ScrollingTreeAfterDetachReattach` times
out, we never actually got to the `-removeObjectForKey:` calls in the bottom of the test; as a
result, the logging channels would be enabled for subsequent tests, causing spurious failures if a
downstream test happened to trigger lots of debug logging.

Since the scrolling test was already disabled in 308806@main, we can actually just reenable these
two otherwise-unrelated `EditorState` API tests. I&apos;m also adding a bit of logic in this patch to
prevent similar issues in the future, by having `initializeApp()` force the logging channels off at
the start of each test.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm:
(TestWebKitAPI::TEST(EditorStateTests, TypingAttributesTextAlignmentStartEnd)):
(TestWebKitAPI::TEST(EditorStateTests, TypingAttributesTextAlignmentDirectionalText)):
* Tools/TestWebKitAPI/cocoa/app/AppCommon.mm:
(TestWebKitAPI::initializeApp):

Canonical link: <a href="https://commits.webkit.org/309365@main">https://commits.webkit.org/309365@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2e93bf39dc431005cc3771d9e6e94670d7d886d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159158 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103870 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac593ce0-5904-4fb0-bcca-ff2784ecfd5a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23625 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23331 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116074 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7429cc39-9798-420b-96a3-2b50a2ee05d1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153396 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18180 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96802 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d099ed84-b0e2-4f2f-9a73-5901d7c1c63b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17279 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15230 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7006 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161632 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124072 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/22996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124270 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33741 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/22983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134672 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79363 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19387 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11429 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22597 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22310 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22462 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22364 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->