### PR TITLE
[macOS arm64] inspector/unit-tests/array-utilities.html is a flaky text/timeout failure

### DIFF
--- a/LayoutTests/inspector/unit-tests/array-utilities-expected.txt
+++ b/LayoutTests/inspector/unit-tests/array-utilities-expected.txt
@@ -186,5 +186,5 @@ Node:
 
 Object (doesn't have [Symbol.iterator]):
 PASS: Should produce an exception.
-TypeError: {} is not iterable
+PASS: Exception should be a TypeError.
 

--- a/LayoutTests/inspector/unit-tests/array-utilities.html
+++ b/LayoutTests/inspector/unit-tests/array-utilities.html
@@ -434,9 +434,13 @@ function test()
             InspectorTest.newline();
 
             InspectorTest.log("Object (doesn't have [Symbol.iterator]):");
-            InspectorTest.expectException(() => {
+            try {
                 test(object);
-            });
+                InspectorTest.fail("Should produce an exception.");
+            } catch (e) {
+                InspectorTest.pass("Should produce an exception.");
+                InspectorTest.expectThat(e instanceof TypeError, "Exception should be a TypeError.");
+            }
         },
     });
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2399,8 +2399,7 @@ webkit.org/b/305581 http/tests/workers/service/shownotification-allowed.html [ P
 
 webkit.org/b/303348 http/tests/site-isolation/remote-frame-loaded-while-hidden.html [ ImageOnlyFailure ]
 
-webkit.org/b/310052 [ Tahoe Release arm64 ] inspector/unit-tests/array-utilities.html [ Pass Failure ]
-webkit.org/b/310052 [ Tahoe Debug arm64 ] inspector/unit-tests/array-utilities.html [ Pass Timeout ]
+webkit.org/b/310052 [ Tahoe Debug arm64 ] inspector/unit-tests/array-utilities.html [ Slow ]
 
 webkit.org/b/305660 [ Debug ] http/tests/cache-storage/cache-clearing-all.https.html [ Pass Failure ]
 


### PR DESCRIPTION
#### f765be186673ecf1ee09c0e3c3c9f1b339b7e036
<pre>
[macOS arm64] inspector/unit-tests/array-utilities.html is a flaky text/timeout failure
<a href="https://rdar.apple.com/172695961">rdar://172695961</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=310052">https://bugs.webkit.org/show_bug.cgi?id=310052</a>

Reviewed by BJ Burg.

Inconsistent logging from expectException() is causing flaky text failures on
release, looks like this is timing related since it occurs on tests ran with --run-singly.
Test also times out on debug due to large amounts of allocations.

Both:
- TypeError: {} is not iterable - Expected
- TypeError: undefined is not a function (near &apos;...item of iterable...&apos;) - Actual
Are valid outputs since they raise TypeError however, the test harness does not account for this.

Fixes:
- Manual try/catch that asserts e instanceof TypeError, validating the error type programmatically
rather than matching the message string.
- Mark test slow on debug to address timeouts

* LayoutTests/inspector/unit-tests/array-utilities-expected.txt:
* LayoutTests/inspector/unit-tests/array-utilities.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/309385@main">https://commits.webkit.org/309385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4ab95ea95b80dd3c570d2861ce54553f0292816

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159185 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103897 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23652 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116098 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82487 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134968 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96826 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17303 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15253 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7033 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126918 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161659 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124096 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19300 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124294 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33753 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134687 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79390 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19406 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11444 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22624 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22337 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22489 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22391 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->