### PR TITLE
Unreviewed, revert 297750@main

### DIFF
--- a/Source/JavaScriptCore/builtins/TypedArrayPrototype.js
+++ b/Source/JavaScriptCore/builtins/TypedArrayPrototype.js
@@ -26,58 +26,6 @@
 // Note that the intrisic @typedArrayLength checks that the argument passed is a typed array
 // and throws if it is not.
 
-function reduce(callback /* [, initialValue] */)
-{
-    // 22.2.3.19
-    "use strict";
-
-    var length = @typedArrayLength(this);
-
-    if (!@isCallable(callback))
-        @throwTypeError("TypedArray.prototype.reduce callback must be a function");
-
-    var argumentCount = @argumentCount();
-    if (length === 0 && argumentCount < 2)
-        @throwTypeError("TypedArray.prototype.reduce of empty array with no initial value");
-
-    var accumulator, k = 0;
-    if (argumentCount > 1)
-        accumulator = @argument(1);
-    else
-        accumulator = this[k++];
-
-    for (; k < length; k++)
-        accumulator = callback.@call(@undefined, accumulator, this[k], k, this);
-
-    return accumulator;
-}
-
-function reduceRight(callback /* [, initialValue] */)
-{
-    // 22.2.3.20
-    "use strict";
-
-    var length = @typedArrayLength(this);
-
-    if (!@isCallable(callback))
-        @throwTypeError("TypedArray.prototype.reduceRight callback must be a function");
-
-    var argumentCount = @argumentCount();
-    if (length === 0 && argumentCount < 2)
-        @throwTypeError("TypedArray.prototype.reduceRight of empty array with no initial value");
-
-    var accumulator, k = length - 1;
-    if (argumentCount > 1)
-        accumulator = @argument(1);
-    else
-        accumulator = this[k--];
-
-    for (; k >= 0; k--)
-        accumulator = callback.@call(@undefined, accumulator, this[k], k, this);
-
-    return accumulator;
-}
-
 function toLocaleString(/* locale, options */)
 {
     "use strict";

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -1460,6 +1460,157 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSome(VM& vm, JSGlobal
 }
 
 template<typename ViewClass>
+ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncReduce(VM& vm, JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    // https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduce
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    validateTypedArray(globalObject, thisObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    const size_t length = thisObject->length();
+
+    JSValue callback = callFrame->argument(0);
+    auto callData = JSC::getCallData(callback);
+    if (callData.type == CallData::Type::None) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "TypedArray.prototype.reduce callback must be a function"_s);
+
+    const bool hasInitialValue = callFrame->argumentCount() > 1;
+
+    if (!hasInitialValue && !length) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "TypedArray.prototype.reduce of empty array with no initial value"_s);
+
+    JSValue accumulator = hasInitialValue ? callFrame->uncheckedArgument(1) : jsUndefined();
+
+    bool initialized = hasInitialValue;
+    if (callData.type == CallData::Type::JS) [[likely]] {
+        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(callback), 4);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        scope.release();
+        typedArrayViewForEachImpl<ForEachDirection::Forward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index, auto) -> IterationStatus {
+            if (!initialized) {
+                accumulator = element;
+                initialized  = true;
+                return IterationStatus::Continue;
+            }
+
+            accumulator = cachedCall.callWithArguments(globalObject, jsUndefined(), accumulator, element, jsNumber(index), thisObject);
+            return IterationStatus::Continue;
+        });
+        return JSValue::encode(accumulator);
+    }
+
+    MarkedArgumentBuffer args;
+
+    scope.release();
+
+    typedArrayViewForEachImpl<ForEachDirection::Forward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index, auto) -> IterationStatus {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
+        if (!initialized) {
+            accumulator = element;
+            initialized  = true;
+            return IterationStatus::Continue;
+        }
+
+        args.clear();
+
+        args.append(accumulator);
+        args.append(element);
+        args.append(jsNumber(index));
+        args.append(thisObject);
+        if (args.hasOverflowed()) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return IterationStatus::Continue;
+        }
+
+        scope.release();
+        accumulator = call(globalObject, callback, callData, jsUndefined(), args);
+        return IterationStatus::Continue;
+    });
+
+    return JSValue::encode(accumulator);
+}
+
+template<typename ViewClass>
+ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncReduceRight(VM& vm, JSGlobalObject* globalObject, CallFrame* callFrame)
+{
+    // https://tc39.es/ecma262/#sec-%typedarray%.prototype.reduceright
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* thisObject = jsCast<ViewClass*>(callFrame->thisValue());
+    validateTypedArray(globalObject, thisObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    const size_t length = thisObject->length();
+
+    JSValue callback = callFrame->argument(0);
+    auto callData = JSC::getCallData(callback);
+    if (callData.type == CallData::Type::None) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "TypedArray.prototype.reduceRight callback must be a function"_s);
+
+    const bool hasInitialValue = callFrame->argumentCount() > 1;
+
+    if (!hasInitialValue && !length) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "TypedArray.prototype.reduceRight of empty array with no initial value"_s);
+
+    JSValue accumulator = hasInitialValue ? callFrame->uncheckedArgument(1) : jsUndefined();
+
+    bool initialized = hasInitialValue;
+    if (callData.type == CallData::Type::JS) [[likely]] {
+        CachedCall cachedCall(globalObject, jsCast<JSFunction*>(callback), 4);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        scope.release();
+        typedArrayViewForEachImpl<ForEachDirection::Backward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index, auto) -> IterationStatus {
+            if (!initialized) {
+                accumulator = element;
+                initialized  = true;
+                return IterationStatus::Continue;
+            }
+
+            accumulator = cachedCall.callWithArguments(globalObject, jsUndefined(), accumulator, element, jsNumber(index), thisObject);
+            return IterationStatus::Continue;
+        });
+
+        return JSValue::encode(accumulator);
+    }
+
+    MarkedArgumentBuffer args;
+
+    scope.release();
+
+    typedArrayViewForEachImpl<ForEachDirection::Backward>(globalObject, vm, thisObject, length, [&](JSValue element, size_t index, auto) -> IterationStatus {
+        auto scope = DECLARE_THROW_SCOPE(vm);
+
+        if (!initialized) {
+            accumulator = element;
+            initialized  = true;
+            return IterationStatus::Continue;
+        }
+
+        args.clear();
+
+        args.append(accumulator);
+        args.append(element);
+        args.append(jsNumber(index));
+        args.append(thisObject);
+        if (args.hasOverflowed()) [[unlikely]] {
+            throwOutOfMemoryError(globalObject, scope);
+            return IterationStatus::Continue;
+        }
+
+        scope.release();
+        accumulator = call(globalObject, callback, callData, jsUndefined(), args);
+        return IterationStatus::Continue;
+    });
+
+    return JSValue::encode(accumulator);
+}
+
+template<typename ViewClass>
 ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncReverse(VM& vm, JSGlobalObject* globalObject, CallFrame* callFrame)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);

--- a/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp
@@ -68,6 +68,8 @@ static JSC_DECLARE_HOST_FUNCTION(typedArrayViewProtoGetterFuncToStringTag);
 static JSC_DECLARE_HOST_FUNCTION(typedArrayViewProtoFuncToReversed);
 static JSC_DECLARE_HOST_FUNCTION(typedArrayViewProtoFuncToSorted);
 static JSC_DECLARE_HOST_FUNCTION(typedArrayViewProtoFuncWith);
+static JSC_DECLARE_HOST_FUNCTION(typedArrayViewProtoFuncReduce);
+static JSC_DECLARE_HOST_FUNCTION(typedArrayViewProtoFuncReduceRight);
 
 #define CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION_ON_TYPE(type, functionName) do {             \
     switch ((type)) {                                                                             \
@@ -552,6 +554,28 @@ JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncWith, (JSGlobalObject* globalObj
     CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncWith);
 }
 
+JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncReduce, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    if (!thisValue.isObject()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
+    scope.release();
+    CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncReduce);
+}
+
+JSC_DEFINE_HOST_FUNCTION(typedArrayViewProtoFuncReduceRight, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue thisValue = callFrame->thisValue();
+    if (!thisValue.isObject()) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "Receiver should be a typed array view but was not an object"_s);
+    scope.release();
+    CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION(genericTypedArrayViewProtoFuncReduceRight);
+}
+
 #undef CALL_GENERIC_TYPEDARRAY_PROTOTYPE_FUNCTION
 
 JSTypedArrayViewPrototype::JSTypedArrayViewPrototype(VM& vm, Structure* structure)
@@ -592,8 +616,8 @@ void JSTypedArrayViewPrototype::finishCreation(VM& vm, JSGlobalObject* globalObj
     putDirectNonIndexAccessorWithoutTransition(vm, vm.propertyNames->length, lengthGetterSetter, PropertyAttribute::DontEnum | PropertyAttribute::ReadOnly | PropertyAttribute::Accessor);
 
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().mapPublicName(), typedArrayViewProtoFuncMap, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
-    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("reduce"_s, typedArrayPrototypeReduceCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
-    JSC_BUILTIN_FUNCTION_WITHOUT_TRANSITION("reduceRight"_s, typedArrayPrototypeReduceRightCodeGenerator, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().reducePublicName(), typedArrayViewProtoFuncReduce, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().reduceRightPublicName(), typedArrayViewProtoFuncReduceRight, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("reverse"_s, typedArrayViewProtoFuncReverse, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->set, typedArrayViewProtoFuncSet, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->slice, typedArrayViewProtoFuncSlice, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MemoryFootprintThreshold.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MemoryFootprintThreshold.mm
@@ -48,7 +48,7 @@ function touchBytes(len)
     const array = new Uint8Array(len);
     for (let i = 0; i < len; i += 4096)
         array[i] = Math.random() * 256;
-    return array.reduce((accumulator, element) => accumulator + element, 0);
+    return array.fill(42);
 }
 </script>
 )HTML"_s;
@@ -72,7 +72,6 @@ function touchBytes(len)
 }
 
 @end
-
 TEST(MemoryFootprintThreshold, TestDelegateMethod)
 {
     TestWebKitAPI::HTTPServer server({


### PR DESCRIPTION
#### 1b67131e8c4cac7b2ad8b386685158e83bac3489
<pre>
Unreviewed, revert 297750@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=310056">https://bugs.webkit.org/show_bug.cgi?id=310056</a>
<a href="https://rdar.apple.com/172700945">rdar://172700945</a>

Now callWithArguments support up to 6 arguments. This covers enough for
reduce / reduceRight use. Also callWithArguments is supported in x64
too, which is the original reason of test timeout environment.

But still, debug build is slow because C++ gets slower while JS does not
get affected with debug build configuration. We use fill function
instead of reduce for the debug api test.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/MemoryFootprintThreshold.mm

* Source/JavaScriptCore/builtins/TypedArrayPrototype.js:
(reduce): Deleted.
(reduceRight): Deleted.
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::genericTypedArrayViewProtoFuncReduce):
(JSC::genericTypedArrayViewProtoFuncReduceRight):
* Source/JavaScriptCore/runtime/JSTypedArrayViewPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSTypedArrayViewPrototype::finishCreation):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/MemoryFootprintThreshold.mm:
(touchBytes):

Canonical link: <a href="https://commits.webkit.org/309588@main">https://commits.webkit.org/309588@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/737906c6592ef1cd9e229e135e58698e0dad4bf0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150802 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17131 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104236 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/780bf0cd-f236-4fa7-b80a-76cdb7a59d06) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152675 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23766 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116399 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82647 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153762 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18508 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135290 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97127 "Passed tests") | | ⏳ 🛠 vision-apple 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/150123 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17605 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15555 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7372 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142785 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127219 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13214 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161999 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11600 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5119 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124401 "Passed tests") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124597 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23353 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135009 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79739 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23224 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19665 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11771 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182327 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22964 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86764 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46587 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22676 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22828 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22730 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->