### PR TITLE
IntersectionObserver can get sluggish over time

### DIFF
--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -184,11 +184,9 @@ bool ContentVisibilityDocumentState::checkRelevancyOfContentVisibilityElement(El
 DidUpdateAnyContentRelevancy ContentVisibilityDocumentState::updateRelevancyOfContentVisibilityElements(OptionSet<ContentRelevancy> relevancyToCheck) const
 {
     auto didUpdateAnyContentRelevancy = DidUpdateAnyContentRelevancy::No;
-    for (auto& weakTarget : m_observer->observationTargets()) {
-        if (RefPtr target = weakTarget.get()) {
-            if (checkRelevancyOfContentVisibilityElement(*target, relevancyToCheck))
-                didUpdateAnyContentRelevancy = DidUpdateAnyContentRelevancy::Yes;
-        }
+    for (Ref target : m_observer->observationTargets()) {
+        if (checkRelevancyOfContentVisibilityElement(target, relevancyToCheck))
+            didUpdateAnyContentRelevancy = DidUpdateAnyContentRelevancy::Yes;
     }
     return didUpdateAnyContentRelevancy;
 }
@@ -198,12 +196,10 @@ HadInitialVisibleContentVisibilityDetermination ContentVisibilityDocumentState::
     if (!m_observer)
         return HadInitialVisibleContentVisibilityDetermination::No;
     Vector<Ref<Element>> elementsToCheck;
-    for (auto& weakTarget : m_observer->observationTargets()) {
-        if (RefPtr target = weakTarget.get()) {
-            bool checkForInitialDetermination = !m_elementViewportProximities.contains(*target) && !target->isRelevantToUser();
-            if (checkForInitialDetermination)
-                elementsToCheck.append(target.releaseNonNull());
-        }
+    for (Ref target : m_observer->observationTargets()) {
+        bool checkForInitialDetermination = !m_elementViewportProximities.contains(target) && !target->isRelevantToUser();
+        if (checkForInitialDetermination)
+            elementsToCheck.append(target);
     }
     auto hadInitialVisibleContentVisibilityDetermination = HadInitialVisibleContentVisibilityDetermination::No;
     if (!elementsToCheck.isEmpty()) {

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.h
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.h
@@ -49,7 +49,7 @@ public:
 
     void updateContentRelevancyForScrollIfNeeded(const Element& scrollAnchor);
 
-    bool hasObservationTargets() const { return m_observer && m_observer->hasObservationTargets(); }
+    bool hasObservationTargets() const { return m_observer && protect(m_observer)->hasObservationTargets(); }
 
     DidUpdateAnyContentRelevancy updateRelevancyOfContentVisibilityElements(OptionSet<ContentRelevancy>) const;
     HadInitialVisibleContentVisibilityDetermination determineInitialVisibleContentVisibility() const;

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -241,9 +241,7 @@ String IntersectionObserver::scrollMargin() const
 
 bool IntersectionObserver::isObserving(const Element& element) const
 {
-    return m_observationTargets.findIf([&](auto& target) {
-        return target.get() == &element;
-    }) != notFound;
+    return m_observationTargets.contains(element);
 }
 
 void IntersectionObserver::observe(Element& target)
@@ -253,7 +251,7 @@ void IntersectionObserver::observe(Element& target)
 
     target.ensureIntersectionObserverData().registrations.append({ *this, std::nullopt });
     bool hadObservationTargets = hasObservationTargets();
-    m_observationTargets.append(target);
+    m_observationTargets.add(target);
 
     // Per the specification, we should dispatch at least one observation for the target. For this reason, we make sure to keep the
     // target alive until this first observation. This, in turn, will keep the IntersectionObserver's JS wrapper alive via
@@ -271,7 +269,7 @@ void IntersectionObserver::unobserve(Element& target)
     if (!removeTargetRegistration(target))
         return;
 
-    bool removed = m_observationTargets.removeFirst(&target);
+    bool removed = m_observationTargets.remove(&target);
     ASSERT_UNUSED(removed, removed);
     m_targetsWaitingForFirstObservation.removeFirstMatching([&](auto& pendingTarget) { return pendingTarget.ptr() == &target; });
 
@@ -300,7 +298,7 @@ auto IntersectionObserver::takeRecords() -> TakenRecords
 
 void IntersectionObserver::targetDestroyed(Element& target)
 {
-    m_observationTargets.removeFirst(&target);
+    m_observationTargets.remove(target);
     m_targetsWaitingForFirstObservation.removeFirstMatching([&](auto& pendingTarget) { return pendingTarget.ptr() == &target; });
     if (!hasObservationTargets()) {
         if (RefPtr document = trackingDocument())
@@ -323,7 +321,7 @@ bool IntersectionObserver::removeTargetRegistration(Element& target)
 void IntersectionObserver::removeAllTargets()
 {
     for (auto& target : m_observationTargets) {
-        bool removed = removeTargetRegistration(*target);
+        bool removed = removeTargetRegistration(target);
         ASSERT_UNUSED(removed, removed);
     }
     m_observationTargets.clear();
@@ -631,7 +629,7 @@ auto IntersectionObserver::updateObservations(const Frame& hostFrame) -> NeedNot
     auto needNotify = NeedNotify::No;
 
     for (auto& target : observationTargets()) {
-        auto& targetRegistrations = target->intersectionObserverDataIfExists()->registrations;
+        auto& targetRegistrations = target.intersectionObserverDataIfExists()->registrations;
         auto index = targetRegistrations.findIf([&](auto& registration) {
             return registration.observer.get() == this;
         });
@@ -640,12 +638,12 @@ auto IntersectionObserver::updateObservations(const Frame& hostFrame) -> NeedNot
 
         bool isSameOriginObservation = [&] () {
             if (RefPtr hostFrameSecurityOrigin = hostFrame.frameDocumentSecurityOrigin())
-                return protect(target->document().securityOrigin())->isSameOriginDomain(*hostFrameSecurityOrigin);
+                return protect(target.document().securityOrigin())->isSameOriginDomain(*hostFrameSecurityOrigin);
 
             return false;
         }();
         auto applyRootMargin = isSameOriginObservation ? ApplyRootMargin::Yes : ApplyRootMargin::No;
-        auto intersectionState = computeIntersectionState(registration, *hostFrameView, *target, applyRootMargin);
+        auto intersectionState = computeIntersectionState(registration, *hostFrameView, target, applyRootMargin);
 
         if (intersectionState.observationChanged) {
             FloatRect targetBoundingClientRect;
@@ -655,13 +653,13 @@ auto IntersectionObserver::updateObservations(const Frame& hostFrame) -> NeedNot
                 ASSERT(intersectionState.absoluteTargetRect);
                 ASSERT(intersectionState.absoluteRootBounds);
 
-                RefPtr targetFrameView = target->document().view();
-                targetBoundingClientRect = targetFrameView->absoluteToClientRect(*intersectionState.absoluteTargetRect, target->renderer()->style().usedZoom());
+                RefPtr targetFrameView = target.document().view();
+                targetBoundingClientRect = targetFrameView->absoluteToClientRect(*intersectionState.absoluteTargetRect, target.renderer()->style().usedZoom());
                 clientRootBounds = hostFrameView->absoluteToLayoutViewportRect(*intersectionState.absoluteRootBounds);
 
                 if (intersectionState.isIntersecting) {
                     ASSERT(intersectionState.absoluteIntersectionRect);
-                    clientIntersectionRect = targetFrameView->absoluteToClientRect(*intersectionState.absoluteIntersectionRect, target->renderer()->style().usedZoom());
+                    clientIntersectionRect = targetFrameView->absoluteToClientRect(*intersectionState.absoluteIntersectionRect, target.renderer()->style().usedZoom());
                 }
             }
 
@@ -682,7 +680,7 @@ auto IntersectionObserver::updateObservations(const Frame& hostFrame) -> NeedNot
                 { clientIntersectionRect.x(), clientIntersectionRect.y(), clientIntersectionRect.width(), clientIntersectionRect.height() },
                 intersectionState.thresholdIndex > 0,
                 intersectionState.intersectionRatio,
-                *target,
+                target,
             }));
 
             needNotify = NeedNotify::Yes;
@@ -749,8 +747,7 @@ void IntersectionObserver::notify()
 bool IntersectionObserver::isReachableFromOpaqueRoots(JSC::AbstractSlotVisitor& visitor) const
 {
     for (auto& target : m_observationTargets) {
-        SUPPRESS_UNCOUNTED_LOCAL auto* element = target.get();
-        if (containsWebCoreOpaqueRoot(visitor, element))
+        if (containsWebCoreOpaqueRoot(visitor, target))
             return true;
     }
     for (auto& target : m_pendingTargets) {

--- a/Source/WebCore/page/IntersectionObserver.h
+++ b/Source/WebCore/page/IntersectionObserver.h
@@ -32,6 +32,7 @@
 #include "IntersectionObserverMarginBox.h"
 #include "ReducedResolutionSeconds.h"
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/WeakListHashSet.h>
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
@@ -97,8 +98,8 @@ public:
     const IntersectionObserverMarginBox& rootMarginBox() const LIFETIME_BOUND { return m_rootMargin; }
     const IntersectionObserverMarginBox& scrollMarginBox() const LIFETIME_BOUND { return m_scrollMargin; }
     const Vector<double>& thresholds() const LIFETIME_BOUND { return m_thresholds; }
-    const Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>>& observationTargets() const LIFETIME_BOUND { return m_observationTargets; }
-    bool hasObservationTargets() const { return m_observationTargets.size(); }
+    const WeakListHashSet<Element, WeakPtrImplWithEventTargetData>& observationTargets() const LIFETIME_BOUND { return m_observationTargets; }
+    bool hasObservationTargets() const { return !m_observationTargets.isEmptyIgnoringNullReferences(); }
     bool isObserving(const Element&) const;
 
     void observe(Element&);
@@ -154,7 +155,7 @@ private:
     IntersectionObserverMarginBox m_scrollMargin;
     Vector<double> m_thresholds;
     const Ref<IntersectionObserverCallback> m_callback;
-    Vector<WeakPtr<Element, WeakPtrImplWithEventTargetData>> m_observationTargets;
+    WeakListHashSet<Element, WeakPtrImplWithEventTargetData> m_observationTargets;
     Vector<GCReachableRef<Element>> m_pendingTargets;
     Vector<Ref<IntersectionObserverEntry>> m_queuedEntries;
     Vector<GCReachableRef<Element>> m_targetsWaitingForFirstObservation;


### PR DESCRIPTION
#### 64a3b99228214a6644b0146f40d94f7139e08527
<pre>
IntersectionObserver can get sluggish over time
<a href="https://bugs.webkit.org/show_bug.cgi?id=310051">https://bugs.webkit.org/show_bug.cgi?id=310051</a>

Reviewed by Geoffrey Garen.

This PR fixes a potential performance problem in IntersectionObserver when a single
IntersectionObserver is used to observe lots of elements. Since m_observationTargets
is a Vector and requires a linear search to find a matching entry, adding lots of
elements to be observed by IntersectionObserver can end up in O(n^2) behavior.

No new tests since there should be no behavioral differences other than the improved perf.

* Source/WebCore/dom/ContentVisibilityDocumentState.cpp:
(WebCore::ContentVisibilityDocumentState::updateRelevancyOfContentVisibilityElements const):
(WebCore::ContentVisibilityDocumentState::determineInitialVisibleContentVisibility const):
* Source/WebCore/dom/ContentVisibilityDocumentState.h:
(WebCore::ContentVisibilityDocumentState::hasObservationTargets const):
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::isObserving const):
(WebCore::IntersectionObserver::observe):
(WebCore::IntersectionObserver::unobserve):
(WebCore::IntersectionObserver::targetDestroyed):
(WebCore::IntersectionObserver::removeAllTargets):
(WebCore::IntersectionObserver::updateObservations):
(WebCore::IntersectionObserver::isReachableFromOpaqueRoots const):
* Source/WebCore/page/IntersectionObserver.h:
(WebCore::IntersectionObserver::hasObservationTargets const):

Canonical link: <a href="https://commits.webkit.org/309387@main">https://commits.webkit.org/309387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ccc26060e1b43c74148d8ef2fff491ffac17006

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23249 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159213 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23388 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116122 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1243f92c-2988-4e65-8b1f-7f3c3bee6fb9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134999 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96850 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec69b398-e9cf-4f3b-8596-47fc75df825d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17328 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15281 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7061 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126943 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12923 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161687 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4807 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14476 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124120 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19328 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124318 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23038 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134718 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23128 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19422 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11477 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22653 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86451 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22365 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22517 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22419 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->