### PR TITLE
WebModelPlayer should support resizing

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.cpp
@@ -110,6 +110,12 @@ Vector<MachSendRight> MeshImpl::ioSurfaceHandles()
         return renderBuffer->createSendRight();
     });
 }
+
+void MeshImpl::updateRenderBuffers(WebModel::ResizeMeshDescriptor&& descriptor)
+{
+    m_backing->updateRenderBuffers(descriptor);
+    m_renderBuffers = WTF::move(descriptor.renderBuffers);
+}
 #endif
 
 }

--- a/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/MeshImpl.h
@@ -51,6 +51,7 @@ public:
 
 #if PLATFORM(COCOA)
     Vector<MachSendRight> ioSurfaceHandles() final;
+    void updateRenderBuffers(WebModel::ResizeMeshDescriptor&&) final;
 #endif
 
 private:

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -31,6 +31,7 @@
 #include <WebKit/Float4x4.h>
 #include <wtf/ExportMacros.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 #include <wtf/text/WTFString.h>
 #endif
@@ -452,6 +453,7 @@ NS_HEADER_AUDIT_END(nullability, sendability)
 #ifdef __cplusplus
 
 namespace WebCore {
+class IOSurface;
 class ProcessIdentity;
 }
 
@@ -690,6 +692,13 @@ struct UpdateMeshDescriptor {
     Vector<String> materialPrims;
     std::optional<DeformationData> deformationData;
 };
+
+struct ResizeMeshDescriptor {
+    unsigned width;
+    unsigned height;
+    Vector<UniqueRef<WebCore::IOSurface>> renderBuffers;
+};
+
 }
 
 typedef struct WebModelCreateMeshDescriptor {

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
@@ -127,6 +127,20 @@ void RemoteMesh::setEnvironmentMap(const WebModel::ImageAsset& imageAsset)
     m_backing->setEnvironmentMap(imageAsset);
 }
 
+void RemoteMesh::updateRenderBuffers(unsigned width, unsigned height, CompletionHandler<void(Vector<MachSendRight>&&)>&& completionHandler)
+{
+    auto gpuProcessConnection = m_gpuConnectionToWebProcess.get();
+    if (!gpuProcessConnection) {
+        completionHandler({ });
+        return;
+    }
+
+    auto renderBuffers = RemoteGPU::createRenderBuffers(width, height, gpuProcessConnection->webProcessIdentity());
+    WebModel::ResizeMeshDescriptor descriptor { width, height, WTF::move(renderBuffers) };
+    m_backing->updateRenderBuffers(WTF::move(descriptor));
+    completionHandler(m_backing->ioSurfaceHandles());
+}
+
 } // namespace WebKit
 
 #undef MESSAGE_CHECK

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h
@@ -99,6 +99,7 @@ private:
     void setBackgroundColor(const WebModel::Float3&);
     void play(bool);
     void setEnvironmentMap(const WebModel::ImageAsset&);
+    void updateRenderBuffers(unsigned, unsigned, CompletionHandler<void(Vector<MachSendRight>&&)>&&);
 
     void render();
 

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in
@@ -40,5 +40,6 @@ messages -> RemoteMesh Stream {
     void SetBackgroundColor(struct WebModel::Float3 color)
     void Play(bool playing)
     void SetEnvironmentMap(struct WebModel::ImageAsset imageAsset)
+    void UpdateRenderBuffers(unsigned width, unsigned height) -> (Vector<MachSendRight> renderBuffers) NotStreamEncodableReply
 }
 #endif

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h
@@ -44,6 +44,7 @@ struct WebModelCreateMeshDescriptor;
 
 namespace WebModel {
 struct ImageAsset;
+struct ResizeMeshDescriptor;
 struct UpdateMaterialDescriptor;
 struct UpdateMeshDescriptor;
 struct UpdateTextureDescriptor;
@@ -71,6 +72,7 @@ public:
     void NODELETE setBackgroundColor(const simd_float3&);
     void NODELETE setEnvironmentMap(const WebModel::ImageAsset&);
     void NODELETE play(bool);
+    void NODELETE updateRenderBuffers(const WebModel::ResizeMeshDescriptor&);
 
 private:
     WebMesh(const WebModelCreateMeshDescriptor&);

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
@@ -28,6 +28,7 @@
 
 #import "ModelTypes.h"
 
+#import <WebCore/IOSurface.h>
 #import <WebCore/ProcessIdentity.h>
 #import <wtf/CheckedArithmetic.h>
 #import <wtf/MathExtras.h>
@@ -563,15 +564,21 @@ static WKBridgeMaterialGraph *convert(const MaterialGraph& material)
 
 namespace WebKit {
 
+static RetainPtr<NSMutableArray> createMetalTextures(id<MTLDevice> device, const Vector<RetainPtr<IOSurfaceRef>>& ioSurfaces, unsigned width, unsigned height)
+{
+    MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatRGBA16Float width:width height:height mipmapped:NO];
+    RetainPtr textures = adoptNS([[NSMutableArray alloc] init]);
+    for (auto& ioSurface : ioSurfaces)
+        [textures addObject:[device newTextureWithDescriptor:textureDescriptor iosurface:ioSurface.get() plane:0]];
+    return textures;
+}
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebMesh);
 
 WebMesh::WebMesh(const WebModelCreateMeshDescriptor& descriptor)
 {
     id<MTLDevice> device = MTLCreateSystemDefaultDevice();
-    MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatRGBA16Float width:descriptor.width height:descriptor.height mipmapped:NO];
-    m_textures = [NSMutableArray array];
-    for (RetainPtr ioSurface : descriptor.ioSurfaces)
-        [m_textures addObject:[device newTextureWithDescriptor:textureDescriptor iosurface:ioSurface.get() plane:0]];
+    m_textures = createMetalTextures(device, descriptor.ioSurfaces, descriptor.width, descriptor.height);
 
 #if ENABLE(GPU_PROCESS_MODEL)
     WKBridgeUSDConfiguration *configuration = [WebKit::allocWKBridgeUSDConfigurationInstance() initWithDevice:device memoryOwner:descriptor.processIdentity ? descriptor.processIdentity->taskIdToken() : 0];
@@ -738,6 +745,19 @@ void WebMesh::play(bool play)
     [m_receiver setPlaying:play];
 #else
     UNUSED_PARAM(play);
+#endif
+}
+
+void WebMesh::updateRenderBuffers(const WebModel::ResizeMeshDescriptor& descriptor)
+{
+#if ENABLE(GPU_PROCESS_MODEL)
+    auto ioSurfaces = descriptor.renderBuffers.map([](auto& buffer) -> RetainPtr<IOSurfaceRef> {
+        return buffer->surface();
+    });
+    m_textures = createMetalTextures(MTLCreateSystemDefaultDevice(), ioSurfaces, descriptor.width, descriptor.height);
+    m_currentTexture = 0;
+#else
+    UNUSED_PARAM(descriptor);
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -271,7 +271,7 @@ void RemoteGPU::paintNativeImageToImageBuffer(WebCore::NativeImage& nativeImage,
 
 
 #if ENABLE(GPU_PROCESS_MODEL)
-static Vector<UniqueRef<WebCore::IOSurface>> createIOSurfaces(unsigned width, unsigned height)
+Vector<UniqueRef<WebCore::IOSurface>> RemoteGPU::createRenderBuffers(unsigned width, unsigned height, const WebCore::ProcessIdentity& processIdentity)
 {
     const auto colorFormat = WebCore::IOSurface::Format::RGBA16F;
     const auto colorSpace = WebCore::DestinationColorSpace::LinearDisplayP3();
@@ -280,8 +280,10 @@ static Vector<UniqueRef<WebCore::IOSurface>> createIOSurfaces(unsigned width, un
 
     constexpr auto surfaceCount = 3;
     for (auto i = 0; i < surfaceCount; ++i) {
-        if (auto buffer = WebCore::IOSurface::create(nullptr, WebCore::IntSize(width, height), colorSpace, WebCore::IOSurface::Name::WebGPU, colorFormat))
+        if (auto buffer = WebCore::IOSurface::create(nullptr, WebCore::IntSize(width, height), colorSpace, WebCore::IOSurface::Name::WebGPU, colorFormat)) {
+            buffer->setOwnershipIdentity(processIdentity);
             ioSurfaces.append(makeUniqueRefFromNonNullUniquePtr(WTF::move(buffer)));
+        }
     }
 
     return ioSurfaces;
@@ -291,12 +293,10 @@ static Vector<UniqueRef<WebCore::IOSurface>> createIOSurfaces(unsigned width, un
 #if ENABLE(GPU_PROCESS_MODEL)
 static RefPtr<WebKit::Mesh> createModelBackingInternal(unsigned width, unsigned height, const WebModel::ImageAsset& diffuseTexture, const WebModel::ImageAsset& specularTexture, const WebCore::ProcessIdentity& processIdentity, CompletionHandler<void(Vector<MachSendRight>&&)>&& callback)
 {
-    auto ioSurfaceVector = createIOSurfaces(width, height);
+    auto ioSurfaceVector = RemoteGPU::createRenderBuffers(width, height, processIdentity);
     Vector<RetainPtr<IOSurfaceRef>> ioSurfaces;
-    for (UniqueRef<WebCore::IOSurface>& ioSurface : ioSurfaceVector) {
+    for (auto& ioSurface : ioSurfaceVector)
         ioSurfaces.append(ioSurface->surface());
-        ioSurface->setOwnershipIdentity(processIdentity);
-    }
 
     WebModelCreateMeshDescriptor backingDescriptor {
         .width = width,

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -58,8 +58,10 @@ class Connection;
 }
 
 namespace WebCore {
+class IOSurface;
 class MediaPlayer;
 class NativeImage;
+class ProcessIdentity;
 class VideoFrame;
 }
 
@@ -96,6 +98,8 @@ public:
 
     void paintNativeImageToImageBuffer(WebCore::NativeImage&, WebCore::RenderingResourceIdentifier);
     RefPtr<GPUConnectionToWebProcess> gpuConnectionToWebProcess() const;
+
+    static Vector<UniqueRef<WebCore::IOSurface>> createRenderBuffers(unsigned width, unsigned height, const WebCore::ProcessIdentity&);
 
 private:
     friend class WebGPU::ObjectHeap;

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -341,6 +341,7 @@
 
     [NotSentFromWebContent] MessageParamReply RemoteCompositorIntegration.RecreateRenderBuffers renderBuffers
     [NotSentFromWebContent] MessageParamReply RemoteGPU.CreateModelBacking renderBuffers
+    [NotSentFromWebContent] MessageParamReply RemoteMesh.UpdateRenderBuffers renderBuffers
 }
 
 [UnsafeWrapper] std::optional<MachSendRightAnnotated> {

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
@@ -242,6 +242,18 @@ void RemoteMeshProxy::setEnvironmentMap(const WebModel::ImageAsset& imageAsset)
 }
 
 #if PLATFORM(COCOA)
+void RemoteMeshProxy::sizeDidChange(unsigned width, unsigned height, CompletionHandler<void(Vector<MachSendRight>&&)>&& callback)
+{
+#if ENABLE(GPU_PROCESS_MODEL)
+    auto sendResult = sendWithAsyncReply(Messages::RemoteMesh::UpdateRenderBuffers(width, height), WTF::move(callback));
+    UNUSED_PARAM(sendResult);
+#else
+    UNUSED_PARAM(width);
+    UNUSED_PARAM(height);
+    callback({ });
+#endif
+}
+
 std::optional<WebModel::Float4x4> RemoteMeshProxy::entityTransform() const
 {
     return m_transform;

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
@@ -93,6 +93,7 @@ private:
     void updateMaterial(const WebModel::UpdateMaterialDescriptor&) final;
 #if PLATFORM(COCOA)
     std::pair<simd_float4, simd_float4> getCenterAndExtents() const final;
+    void sizeDidChange(unsigned, unsigned, CompletionHandler<void(Vector<MachSendRight>&&)>&&) final;
 #endif
     void play(bool) final;
 

--- a/Source/WebKit/WebProcess/Model/Mesh.h
+++ b/Source/WebKit/WebProcess/Model/Mesh.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
@@ -35,6 +36,10 @@
 #include <simd/simd.h>
 #include <wtf/MachSendRight.h>
 #endif
+
+namespace WebModel {
+struct ResizeMeshDescriptor;
+}
 
 namespace WebCore {
 class TransformationMatrix;
@@ -85,6 +90,8 @@ public:
 #if PLATFORM(COCOA)
     virtual std::optional<WebModel::Float4x4> entityTransform() const = 0;
     virtual Vector<MachSendRight> ioSurfaceHandles() { return { }; }
+    virtual void updateRenderBuffers(WebModel::ResizeMeshDescriptor&&) { }
+    virtual void sizeDidChange(unsigned, unsigned, CompletionHandler<void(Vector<MachSendRight>&&)>&& callback) { callback({ }); }
     virtual std::pair<simd_float4, simd_float4> getCenterAndExtents() const { return std::make_pair(simd_make_float4(0.f), simd_make_float4(0.f)); }
 #endif
 

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.h
@@ -128,6 +128,7 @@ private:
     uint32_t m_currentTexture { 0 };
     WebCore::StageModeOperation m_stageMode { WebCore::StageModeOperation::None };
     float m_currentScale { 1.f };
+    WebCore::IntSize m_currentPixelSize;
     bool m_didFinishLoading { false };
     enum class PauseState {
         None,

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -262,6 +262,8 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
         return;
 
     size.scale(document->deviceScaleFactor());
+    m_currentPixelSize = WebCore::IntSize(size.width().toUnsigned(), size.height().toUnsigned());
+
     WebModel::ImageAsset diffuseTexture {
         .data = loadData(adoptCF(static_cast<CFStringRef>(@"modelDefaultDiffuseData"))),
         .width = 64,
@@ -289,7 +291,7 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
         .swizzle = { }
     };
 
-    m_currentModel = static_cast<RemoteGPUProxy&>(gpu->backing()).createModelBacking(size.width().toUnsigned(), size.height().toUnsigned(), diffuseTexture, specularTexture, [protectedThis = Ref { *this }] (Vector<MachSendRight>&& surfaceHandles) {
+    m_currentModel = static_cast<RemoteGPUProxy&>(gpu->backing()).createModelBacking(m_currentPixelSize.width(), m_currentPixelSize.height(), diffuseTexture, specularTexture, [protectedThis = Ref { *this }] (Vector<MachSendRight>&& surfaceHandles) {
         if (surfaceHandles.size())
             protectedThis->m_displayBuffers = WTF::move(surfaceHandles);
     });
@@ -359,9 +361,38 @@ void WebModelPlayer::notifyEntityTransformUpdated()
     client->didUpdateEntityTransform(*this, WebCore::TransformationMatrix(static_cast<simd_float4x4>(scaledTransform)));
 }
 
-void WebModelPlayer::sizeDidChange(WebCore::LayoutSize layoutSize)
+void WebModelPlayer::sizeDidChange(WebCore::LayoutSize size)
 {
-    m_currentScale = static_cast<float>(layoutSize.minDimension());
+    RefPtr currentModel = m_currentModel;
+    if (!currentModel)
+        return;
+
+    RefPtr corePage = m_page.get();
+    if (!corePage)
+        return;
+    RefPtr document = corePage->localTopDocument();
+    if (!document)
+        return;
+
+    size.scale(document->deviceScaleFactor());
+    auto newPixelSize = WebCore::IntSize(size.width().toUnsigned(), size.height().toUnsigned());
+    if (newPixelSize == m_currentPixelSize)
+        return;
+
+    m_currentPixelSize = newPixelSize;
+
+    currentModel->sizeDidChange(newPixelSize.width(), newPixelSize.height(), [protectedThis = Ref { *this }](Vector<MachSendRight>&& newBuffers) {
+        if (newBuffers.isEmpty())
+            return;
+
+        protectedThis->m_displayBuffers = WTF::move(newBuffers);
+        protectedThis->m_currentTexture = 0;
+        if (protectedThis->m_contentsDisplayDelegate)
+            RefPtr { protectedThis->m_contentsDisplayDelegate }->setDisplayBuffer(*protectedThis->displayBuffer());
+    });
+
+    m_currentScale = static_cast<float>(size.minDimension());
+    notifyEntityTransformUpdated();
 }
 
 void WebModelPlayer::enterFullscreen()


### PR DESCRIPTION
#### 3fcfb8dbae92dbd836f42310986a8592eb3b2266
<pre>
WebModelPlayer should support resizing
<a href="https://bugs.webkit.org/show_bug.cgi?id=310058">https://bugs.webkit.org/show_bug.cgi?id=310058</a>
&lt;<a href="https://rdar.apple.com/172312511">rdar://172312511</a>&gt;

Reviewed by Mike Wyrzykowski.

When the layout size of the model changes, create new render buffers and
update the existing Mesh to use them.

* Source/WebKit/GPUProcess/graphics/Model/MeshImpl.cpp:
(WebKit::MeshImpl::updateRenderBuffers):
* Source/WebKit/GPUProcess/graphics/Model/MeshImpl.h:
* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp:
(WebKit::RemoteMesh::updateRenderBuffers):
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h:
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.messages.in:
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h:
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm:
(WebKit::createMetalTextures):
Extract the metal texture creation code in a static so it can be shared
between the initial creation and the resize code paths.

(WebKit::WebMesh::WebMesh):
(WebKit::WebMesh::updateRenderBuffers):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::createRenderBuffers):
Extract the render buffer creation code so it can be shared, add the
memory attribution to this new function.

(WebKit::createModelBackingInternal):
(WebKit::createIOSurfaces): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h:
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp:
(WebKit::RemoteMeshProxy::sizeDidChange):
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h:
* Source/WebKit/WebProcess/Model/Mesh.h:
(WebKit::Mesh::updateRenderBuffers):
(WebKit::Mesh::sizeDidChange):
* Source/WebKit/WebProcess/Model/WebModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::load):
Keep track of the initial pixel size.
(WebKit::WebModelPlayer::sizeDidChange):
On size change, signal the mesh and configure the display delegate to
use the new buffers.

Canonical link: <a href="https://commits.webkit.org/309410@main">https://commits.webkit.org/309410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44a76b78c9e8822ff9212a1cf713df20a9ab98a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159278 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103990 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116185 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135065 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96913 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13eafdad-730f-460b-ad83-824c47e6834a) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/149877 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17393 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15341 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7126 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127007 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161752 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4872 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124183 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124381 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33771 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134784 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79484 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19475 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11544 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22718 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86516 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22430 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22582 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22484 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->