### PR TITLE
AX: VoiceOver next element searches loop when encountering the end of a container (e.g. a list) inside a site-isolated iframe

### DIFF
--- a/LayoutTests/http/tests/site-isolation/accessibility/client/search-immediate-descendants-in-remote-frame-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/search-immediate-descendants-in-remote-frame-expected.txt
@@ -1,0 +1,18 @@
+Tests that immediateDescendantsOnly search inside a remote frame's list does not return results from the parent frame (which is very obviously not an immediate descendant).
+Without the fix, the parent search returns the main page's ScrollBar, causing VoiceOver to loop.
+
+PASS: list !== null === true
+PASS: list.role.includes('List') === true
+PASS: listChildCount === 3
+PASS: lastListItem != null === true
+
+Search forward from last list item (immediateDescendantsOnly=true):
+PASS: results.length === 0
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Content Before Iframe
+
+
+Content After Iframe

--- a/LayoutTests/http/tests/site-isolation/accessibility/client/search-immediate-descendants-in-remote-frame.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/search-immediate-descendants-in-remote-frame.html
@@ -1,0 +1,86 @@
+<html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+<script src="/js-test-resources/accessibility-helper.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
+<style>
+/* Force the page to be tall enough to produce a vertical ScrollBar, which
+   becomes a child of the root ScrollArea alongside the WebArea. Without a
+   ScrollBar, the parent search returns 0 results trivially. */
+body { height: 5000px; }
+</style>
+</head>
+<body>
+
+<h1 id="heading-before">Content Before Iframe</h1>
+
+<iframe id="iframe" src="http://localhost:8000/site-isolation/accessibility/resources/iframe-with-list-mock-parent-search.html"></iframe>
+
+<h2 id="heading-after">Content After Iframe</h2>
+
+<script>
+var output = "Tests that immediateDescendantsOnly search inside a remote frame's list does not return results from the parent frame (which is very obviously not an immediate descendant).\n";
+output += "Without the fix, the parent search returns the main page's ScrollBar, causing VoiceOver to loop.\n\n";
+
+window.jsTestIsAsync = true;
+accessibilityController.setClientAccessibilityMode(true);
+
+function findElementByRole(element, roleSubstring, maxDepth) {
+    if (!element || maxDepth <= 0)
+        return null;
+    if (element.role && element.role.includes(roleSubstring))
+        return element;
+
+    var count = element.childrenCount;
+    for (var i = 0; i < count; i++) {
+        var result = findElementByRole(element.childAtIndex(i), roleSubstring, maxDepth - 1);
+        if (result)
+            return result;
+    }
+    return null;
+}
+
+var list, lastListItem, results, resultCount, listChildCount;
+async function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    await waitForElements([
+        (element) => element.role && element.role.includes("List"),
+    ]);
+
+    var root = accessibilityController.rootElement;
+    var webArea = root.childAtIndex(0);
+
+    // Find the list inside the remote iframe by traversing the AX tree.
+    list = findElementByRole(webArea, "List", 6);
+    output += expect("list !== null", "true");
+    output += expect("list.role.includes('List')", "true");
+
+    // Get the last item in the list.
+    listChildCount = list.childrenCount;
+    lastListItem = list.childAtIndex(listChildCount - 1);
+    output += expect("listChildCount", "3");
+    output += expect("lastListItem != null", "true");
+
+    // Search forward from the last list item with immediateDescendantsOnly=true.
+    // The anchor is the list, the start element is the last item.
+    // Without the fix, the parent frame search returns a ScrollBar, which leaks
+    // into the results. With the fix, the parent search is skipped entirely,
+    // and the search correctly returns 0 results (the list has no more immediate descendants).
+    results = list.uiElementsForSearchPredicate(lastListItem, true, "AXAnyTypeSearchKey", "", false, true, 10);
+    output += "\nSearch forward from last list item (immediateDescendantsOnly=true):\n";
+    // Verify no results were returned, as the list has no more immediate descendants.
+    output += expect("results.length", "0");
+    for (var i = 0; i < results.length; i++) {
+        // If we did erroneously get results, let's log what they were to help debugging.
+        output += `  ${i + 1}: ${results[i].role}\n`;
+    }
+
+    debug(output);
+    finishJSTest();
+}
+
+document.getElementById("iframe").onload = runTest;
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/accessibility/resources/iframe-with-list-mock-parent-search.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/resources/iframe-with-list-mock-parent-search.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Iframe with List (Mock Parent Search)</title>
+</head>
+<body>
+<h2>Dog Breeds</h2>
+<ul>
+    <li>Golden Retriever</li>
+    <li>Labrador</li>
+    <li>Poodle</li>
+</ul>
+<script>
+if (window.internals)
+    internals.setShouldMockParentSearchResultsForTesting(true);
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AXCrossProcessSearch.cpp
+++ b/Source/WebCore/accessibility/AXCrossProcessSearch.cpp
@@ -50,6 +50,18 @@
 
 namespace WebCore {
 
+static bool s_shouldMockParentSearchResults = false;
+
+void setShouldMockParentSearchResultsForTesting(bool enabled)
+{
+    s_shouldMockParentSearchResults = enabled;
+}
+
+bool shouldMockParentSearchResultsForTesting()
+{
+    return s_shouldMockParentSearchResults;
+}
+
 static bool NODELETE canDoRemoteSearch(const std::optional<AXTreeID>& treeID)
 {
 #if PLATFORM_SUPPORTS_REMOTE_SEARCH
@@ -413,13 +425,26 @@ AccessibilitySearchResults performSearchWithParentCoordination(AXCoreObject& anc
         RefPtr frame = document ? document->frame() : nullptr;
         RefPtr page = frame ? frame->page() : nullptr;
 
-        if (!frame || !page || frame->isMainFrame() || !page->settings().siteIsolationEnabled()) {
-            // Not in a child frame, or site isolation is disabled (so no cross-process coordination needed).
+        if (!frame || !page || frame->isMainFrame() || !page->settings().siteIsolationEnabled() || criteriaForParent.immediateDescendantsOnly) {
+            // Not in a child frame, site isolation is disabled, or this is an
+            // immediateDescendantsOnly search. In the latter case, the search is scoped
+            // to a specific container in the child frame, so the parent frame has nothing
+            // to contribute — skip the parent search to match non-site-isolation behavior
+            // and avoid returning unrelated elements (like the parent's ScrollBar).
             context->signal();
             return;
         }
 
         context->markParentDispatched();
+
+        if (shouldMockParentSearchResultsForTesting()) [[unlikely]] {
+            // Testing: provide a mock parent result instead of dispatching
+            // real IPC (which deadlocks in the test runner). This lets tests
+            // verify that the parent search is correctly skipped for
+            // immediateDescendantsOnly searches (i.e. the if just above).
+            context->signal();
+            return;
+        }
 
         // Use the provided frameID if available, otherwise use the frame's own ID.
         FrameIdentifier frameIDToUse = currentFrameID.value_or(frame->frameID());
@@ -440,8 +465,16 @@ AccessibilitySearchResults performSearchWithParentCoordination(AXCoreObject& anc
         context->waitWithTimeout(*remainingTimeout);
 
     // Merge parent results with local results based on search direction.
-    if (context->didDispatchParent())
+    if (context->didDispatchParent()) {
         searchResults = mergeParentSearchResults(WTF::move(searchResults), context->takeParentTokens(), isForward, originalLimit);
+
+        if (shouldMockParentSearchResultsForTesting()) [[unlikely]] {
+            // Inject the anchor as a mock parent result. Tests should not rely on
+            // this being any specific object — just that *something* is returned
+            // from the parent search.
+            searchResults.append(AccessibilitySearchResult::local(anchorObject));
+        }
+    }
 
     return searchResults;
 #else

--- a/Source/WebCore/accessibility/AXCrossProcessSearch.h
+++ b/Source/WebCore/accessibility/AXCrossProcessSearch.h
@@ -154,4 +154,29 @@ WEBCORE_EXPORT AccessibilitySearchResults mergeParentSearchResults(Accessibility
 // re-searching this frame during parent continuation.
 WEBCORE_EXPORT AccessibilitySearchResults performSearchWithParentCoordination(AXCoreObject& anchorObject, AccessibilitySearchCriteria&&, std::optional<FrameIdentifier> currentFrameID = std::nullopt);
 
+// Testing support: when enabled, performSearchWithParentCoordination injects a
+// mock parent search result if the parent search was dispatched. This allows
+// tests to verify that the parent search is correctly skipped (e.g., for
+// immediateDescendantsOnly searches) without relying on real cross-process IPC,
+// which deadlocks in the test runner purely due to a limitation in our testing
+// infrastructure.
+//
+// The deadlock occurs because the test runner (UI process) initiates accessibility
+// searches via AXUIElementCopyParameterizedAttributeValue, which is a synchronous
+// Mach IPC call that blocks the UI process main thread until the child web content
+// process returns a result. However, the child's search dispatches a parent search
+// via WebKit IPC (child -> UI process -> parent process), and the UI process must
+// process this IPC on its main thread to forward it to the parent. Since the main
+// thread is blocked waiting for the AXUIElementCopyParameterizedAttributeValue
+// reply, the parent search IPC cannot be forwarded, and the child eventually times
+// out waiting for parent results.
+//
+// In production, VoiceOver uses the system accessibility framework which does not
+// block the UI process in the same way, so this deadlock is test-infrastructure-
+// specific. If the test infrastructure is updated to avoid blocking the UI process
+// main thread during accessibility searches, this mock can be removed and tests
+// can rely on real cross-process parent search results instead.
+WEBCORE_EXPORT void setShouldMockParentSearchResultsForTesting(bool);
+WEBCORE_EXPORT bool shouldMockParentSearchResultsForTesting();
+
 } // namespace WebCore

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "Internals.h"
 
+#include "AXCrossProcessSearch.h"
 #include "AXObjectCacheInlines.h"
 #include "AnimationTimeline.h"
 #include "AnimationTimelinesController.h"
@@ -668,6 +669,7 @@ void Internals::resetToConsistentState(Page& page)
 #endif
     AXObjectCache::setEnhancedUserInterfaceAccessibility(false);
     AXObjectCache::disableAccessibility();
+    WebCore::setShouldMockParentSearchResultsForTesting(false);
 
     MockPageOverlayClient::singleton().uninstallAllOverlays();
 
@@ -4595,6 +4597,11 @@ void Internals::forceAXObjectCacheUpdate() const
         if (CheckedPtr cache = document->axObjectCache())
             cache->performDeferredCacheUpdate(ForceLayout::Yes);
     }
+}
+
+void Internals::setShouldMockParentSearchResultsForTesting(bool enabled)
+{
+    WebCore::setShouldMockParentSearchResultsForTesting(enabled);
 }
 
 void Internals::forceReload(bool endToEnd)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -771,6 +771,7 @@ public:
     String toolTipFromElement(Element&) const;
 
     void forceAXObjectCacheUpdate() const;
+    void setShouldMockParentSearchResultsForTesting(bool);
     void forceReload(bool endToEnd);
     void reloadExpiredOnly();
 

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -995,6 +995,7 @@ enum ContentsFormat {
     undefined setUsesOverlayScrollbars(boolean enabled);
 
     undefined forceAXObjectCacheUpdate();
+    undefined setShouldMockParentSearchResultsForTesting(boolean enabled);
     undefined forceReload(boolean endToEnd);
     undefined reloadExpiredOnly();
 


### PR DESCRIPTION
#### bf8ea4b7402a86e47e7734bd03d1d210ac4ae9d8
<pre>
AX: VoiceOver next element searches loop when encountering the end of a container (e.g. a list) inside a site-isolated iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=309453">https://bugs.webkit.org/show_bug.cgi?id=309453</a>
<a href="https://rdar.apple.com/172029151">rdar://172029151</a>

Reviewed by Joshua Hoffman.

When a cross-origin child frame performs an immediateDescendantsOnly search
(e.g. like VoiceOver when navigating the children of a ul), the parent frame
has nothing to contribute, as it&apos;s clearly not an immediate descendant. But
prior to this fix, we returned the results of the parent search, causing
VoiceOver to loop infinitely thinking the ul-container was never exhausted.

The fix is simple: skip the parent dispatch when immediateDescendantsOnly is set.

Add mock-parent-search testing infrastructure to verify this without real
cross-process IPC (which deadlocks in the test runner).

* LayoutTests/http/tests/site-isolation/accessibility/client/search-immediate-descendants-in-remote-frame-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/accessibility/client/search-immediate-descendants-in-remote-frame.html: Added.
* LayoutTests/http/tests/site-isolation/accessibility/resources/iframe-with-list-mock-parent-search.html: Added.
* Source/WebCore/accessibility/AXCrossProcessSearch.cpp:
(WebCore::setShouldMockParentSearchResultsForTesting):
(WebCore::shouldMockParentSearchResultsForTesting):
(WebCore::performSearchWithParentCoordination):
* Source/WebCore/accessibility/AXCrossProcessSearch.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resetToConsistentState):
(WebCore::Internals::setShouldMockParentSearchResultsForTesting):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/309426@main">https://commits.webkit.org/309426@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5f1510f083a547b954115a87e3ef594f8a475a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16784 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159187 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103899 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59152deb-c883-41fd-9046-fbdd693fce63) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23361 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116100 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82489 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bd8cdb9f-6434-4dbd-bcbf-9b5dc6fc4757) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96828 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8eefd23-3f21-4dd6-8c59-7dfaac98a3a6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17311 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15255 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7035 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126926 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161661 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4781 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14451 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124098 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19302 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124296 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33778 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134693 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79392 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19408 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11450 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22626 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86425 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22339 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22491 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22393 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->