### PR TITLE
[JSC] Check for all indexed accessors in Array.p.concat

### DIFF
--- a/JSTests/stress/concat-spreadable-own-indexed-accessor.js
+++ b/JSTests/stress/concat-spreadable-own-indexed-accessor.js
@@ -1,0 +1,16 @@
+let firstArray = [];
+firstArray[0] = 1;
+
+let secondArray = [3, 4, 5];
+
+Object.defineProperty(firstArray, 1, {
+    get: function() {
+        secondArray[Symbol.isConcatSpreadable] = false;
+        return 2;
+    }
+});
+
+let result = firstArray.concat(secondArray);
+if (result.length !== 3) {
+    throw new Error("secondArray should not be spread");
+}

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1436,7 +1436,7 @@ static JSArray* concatAppendOne(JSGlobalObject* globalObject, VM& vm, JSArray* f
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     ASSERT(!isJSArray(second));
-    ASSERT(!shouldUseSlowPut(first->indexingType()));
+    ASSERT(!first->mayInterceptIndexedAccesses());
     Butterfly* firstButterfly = first->butterfly();
     unsigned firstArraySize = firstButterfly->publicLength();
 
@@ -1604,7 +1604,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncConcat, (JSGlobalObject* globalObject, Ca
                 // This code assumes that neither array has set Symbol.isConcatSpreadable. If the first array
                 // has indexed accessors then one of those accessors might change the value of Symbol.isConcatSpreadable
                 // on the second argument.
-                if (!shouldUseSlowPut(firstArray->indexingType())) [[likely]] {
+                if (!firstArray->mayInterceptIndexedAccesses()) [[likely]] {
                     if (!argumentValue.isObject()) {
                         auto* result = concatAppendOne(globalObject, vm, firstArray, argumentValue);
                         RETURN_IF_EXCEPTION(scope, { });


### PR DESCRIPTION
#### 131349b225e396d47790e262dcd50d4129f54998
<pre>
[JSC] Check for all indexed accessors in Array.p.concat
<a href="https://bugs.webkit.org/show_bug.cgi?id=310065">https://bugs.webkit.org/show_bug.cgi?id=310065</a>
<a href="https://rdar.apple.com/172237596">rdar://172237596</a>

Reviewed by Yusuke Suzuki.

Array.prototype.concat has a fast path that assumes the `this` array, if not
concat-spreadable, stays non-concat-spreadable. This is invalidated if it can
have indexed accessors. The current code guards against indexed accessors
incorrectly by using `shouldUseSlowPut`, which only checks against indexed
accessors on the prototype chain for the put case. This PR fixes it by using
`mayInterceptIndexedAccesses` which also considers own indexed accessors.

Test: JSTests/stress/concat-spreadable-own-indexed-accessor.js
* JSTests/stress/concat-spreadable-own-indexed-accessor.js: Added.
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::concatAppendOne):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/309423@main">https://commits.webkit.org/309423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a36f06f8ef055283ef030d0f75293bfda8054de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23224 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159188 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103900 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23655 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116101 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82490 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c994084-a7c3-41b9-80d4-5608ac838405) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153426 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96829 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b804801-81d4-428f-a2e6-b9ca16c37e61) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17309 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15256 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7036 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142449 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126924 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12899 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161662 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11264 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4782 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14452 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124099 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23026 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19303 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124297 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134694 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79393 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23148 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19409 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11451 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181898 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22627 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86426 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46525 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22340 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22492 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22394 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->