### PR TITLE
[WTF] Remove useless `WTF::ref` and `WTF::deref` functions

### DIFF
--- a/Source/WTF/wtf/RefCounted.h
+++ b/Source/WTF/wtf/RefCounted.h
@@ -88,18 +88,6 @@ protected:
     ~RefCounted() = default;
 } SWIFT_RETURNED_AS_UNRETAINED_BY_DEFAULT;
 
-template<typename T>
-inline void ref(T* obj)
-{
-    obj->ref();
-}
-
-template<typename T>
-inline void deref(T* obj)
-{
-    obj->deref();
-}
-
 inline void adopted(RefCountedBase* object)
 {
     if (!object)

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -192,12 +192,12 @@ private:
 
 inline void refBuffer(WebGPU::Buffer* obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefBuffer(WebGPU::Buffer* obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }
 
 IGNORE_CLANG_WARNINGS_END

--- a/Source/WebGPU/WebGPU/CommandBuffer.h
+++ b/Source/WebGPU/WebGPU/CommandBuffer.h
@@ -99,10 +99,10 @@ private:
 
 inline void refCommandBuffer(WebGPU::CommandBuffer* obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefCommandBuffer(WebGPU::CommandBuffer* obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -218,12 +218,12 @@ private:
 
 inline void refCommandEncoder(WebGPU::CommandEncoder* obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefCommandEncoder(WebGPU::CommandEncoder* obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }
 
 IGNORE_CLANG_WARNINGS_END

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -115,10 +115,10 @@ private:
 
 inline void refComputePassEncoder(WebGPU::ComputePassEncoder* obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefComputePassEncoder(WebGPU::ComputePassEncoder* obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -349,12 +349,12 @@ private:
 
 inline void refDevice(WebGPU::Device* obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefDevice(WebGPU::Device* obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }
 
 IGNORE_CLANG_WARNINGS_END

--- a/Source/WebGPU/WebGPU/QuerySet.h
+++ b/Source/WebGPU/WebGPU/QuerySet.h
@@ -124,10 +124,10 @@ private:
 
 inline void refQuerySet(WebGPU::QuerySet* obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefQuerySet(WebGPU::QuerySet* obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }

--- a/Source/WebGPU/WebGPU/Queue.h
+++ b/Source/WebGPU/WebGPU/Queue.h
@@ -147,12 +147,12 @@ private:
 
 inline void refQueue(WebGPU::Queue* obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefQueue(WebGPU::Queue* obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }
 
 IGNORE_CLANG_WARNINGS_END

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -230,10 +230,10 @@ private:
 
 inline void refRenderPassEncoder(WebGPU::RenderPassEncoder* obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefRenderPassEncoder(WebGPU::RenderPassEncoder* obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }

--- a/Source/WebGPU/WebGPU/Texture.h
+++ b/Source/WebGPU/WebGPU/Texture.h
@@ -190,10 +190,10 @@ private:
 
 inline void refTexture(WebGPU::Texture* obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefTexture(WebGPU::Texture* obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }

--- a/Source/WebGPU/WebGPU/TextureView.h
+++ b/Source/WebGPU/WebGPU/TextureView.h
@@ -111,10 +111,10 @@ private:
 
 inline void refTextureView(WebGPU::TextureView* obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefTextureView(WebGPU::TextureView* obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -1163,10 +1163,10 @@ inline void markCurrentlyDispatchedMessageAsInvalid(const RefPtr<Connection>& co
 
 inline void refConnection(IPC::Connection* WTF_NONNULL obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefConnection(IPC::Connection* WTF_NONNULL obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }

--- a/Source/WebKit/Shared/API/APIArray.h
+++ b/Source/WebKit/Shared/API/APIArray.h
@@ -96,12 +96,12 @@ using RefAPIArray = Ref<Array>;
 
 inline void refArray(API::Array* WTF_NONNULL obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefArray(API::Array* WTF_NONNULL obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }
 
 SPECIALIZE_TYPE_TRAITS_API_OBJECT(Array);

--- a/Source/WebKit/Shared/API/APIObject.h
+++ b/Source/WebKit/Shared/API/APIObject.h
@@ -329,20 +329,12 @@ using RefPtrAPIObject = RefPtr<Object>;
 
 inline void refObject(API::Object* WTF_NONNULL obj)
 {
-#if DELEGATE_REF_COUNTING_TO_COCOA
     obj->ref();
-#else
-    WTF::ref(obj);
-#endif
 }
 
 inline void derefObject(API::Object* WTF_NONNULL obj)
 {
-#if DELEGATE_REF_COUNTING_TO_COCOA
     obj->deref();
-#else
-    WTF::deref(obj);
-#endif
 }
 
 #undef DELEGATE_REF_COUNTING_TO_COCOA

--- a/Source/WebKit/Shared/SessionState.h
+++ b/Source/WebKit/Shared/SessionState.h
@@ -181,10 +181,10 @@ using VectorRefFrameState = Vector<Ref<FrameState>>;
 
 inline void refFrameState(WebKit::FrameState* obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefFrameState(WebKit::FrameState* obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -92,10 +92,10 @@ private:
 
 inline void refWebBackForwardListFrameItem(WebKit::WebBackForwardListFrameItem* obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefWebBackForwardListFrameItem(WebKit::WebBackForwardListFrameItem* obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -144,12 +144,12 @@ inline API::Object* WTF_NONNULL toAPIObject(WebBackForwardListItem* WTF_NONNULL 
 
 inline void refBackForwardListItem(WebKit::WebBackForwardListItem* WTF_NONNULL obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefBackForwardListItem(WebKit::WebBackForwardListItem* WTF_NONNULL obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebBackForwardListItem)

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -404,10 +404,10 @@ inline AuxiliaryProcessProxy::State AuxiliaryProcessProxy::state() const
 
 inline void refAuxiliaryProcessProxy(WebKit::AuxiliaryProcessProxy* WTF_NONNULL obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefAuxiliaryProcessProxy(WebKit::AuxiliaryProcessProxy* WTF_NONNULL obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }

--- a/Source/WebKit/UIProcess/BrowsingContextGroup.h
+++ b/Source/WebKit/UIProcess/BrowsingContextGroup.h
@@ -100,10 +100,10 @@ private:
 
 inline void refBrowsingContextGroup(WebKit::BrowsingContextGroup* WTF_NONNULL obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefBrowsingContextGroup(WebKit::BrowsingContextGroup* WTF_NONNULL obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.h
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.h
@@ -143,10 +143,10 @@ private:
 
 inline void refSuspendedPageProxy(WebKit::SuspendedPageProxy* WTF_NONNULL obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefSuspendedPageProxy(WebKit::SuspendedPageProxy* WTF_NONNULL obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
@@ -72,10 +72,10 @@ private:
 
 inline void refWebBackForwardCacheEntry(WebKit::WebBackForwardCacheEntry* WTF_NONNULL obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefWebBackForwardCacheEntry(WebKit::WebBackForwardCacheEntry* WTF_NONNULL obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -361,12 +361,12 @@ private:
 
 inline void refWebFrameProxy(WebKit::WebFrameProxy* WTF_NONNULL obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefWebFrameProxy(WebKit::WebFrameProxy* WTF_NONNULL obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebFrameProxy)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -4241,12 +4241,12 @@ using WeakPtrWebPageProxy = WeakPtr<WebPageProxy>;
 
 inline void refWebPageProxy(WebKit::WebPageProxy* WTF_NONNULL obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefWebPageProxy(WebKit::WebPageProxy* WTF_NONNULL obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebPageProxy)

--- a/Source/WebKit/UIProcess/WebPreferences.h
+++ b/Source/WebKit/UIProcess/WebPreferences.h
@@ -159,12 +159,12 @@ private:
 
 inline void refPrefs(WebKit::WebPreferences* WTF_NONNULL obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefPrefs(WebKit::WebPreferences* WTF_NONNULL obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebPreferences)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -976,12 +976,12 @@ inline RefPtr<WebProcessProxy> downcastToWebProcessProxy(AuxiliaryProcessProxy* 
 
 inline void refWebProcessProxy(WebKit::WebProcessProxy* WTF_NONNULL obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefWebProcessProxy(WebKit::WebProcessProxy* WTF_NONNULL obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebProcessProxy)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -701,12 +701,12 @@ private:
 
 inline void refDataStore(WebKit::WebsiteDataStore* WTF_NONNULL obj)
 {
-    WTF::ref(obj);
+    obj->ref();
 }
 
 inline void derefDataStore(WebKit::WebsiteDataStore* WTF_NONNULL obj)
 {
-    WTF::deref(obj);
+    obj->deref();
 }
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::WebsiteDataStore)


### PR DESCRIPTION
#### a2d09e310875d86bb0497edd0c712430114faa43
<pre>
[WTF] Remove useless `WTF::ref` and `WTF::deref` functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=310066">https://bugs.webkit.org/show_bug.cgi?id=310066</a>
<a href="https://rdar.apple.com/172708498">rdar://172708498</a>

Reviewed by Mike Wyrzykowski and Abrar Rahman Protyasha.

These no longer serve any purpose after 287320@main, and just lead to confusion.

* Source/WTF/wtf/RefCounted.h:
(WTF::ref): Deleted.
(WTF::deref): Deleted.
* Source/WebGPU/WebGPU/Buffer.h:
(refBuffer):
(derefBuffer):
* Source/WebGPU/WebGPU/CommandBuffer.h:
(refCommandBuffer):
(derefCommandBuffer):
* Source/WebGPU/WebGPU/CommandEncoder.h:
(refCommandEncoder):
(derefCommandEncoder):
* Source/WebGPU/WebGPU/ComputePassEncoder.h:
(refComputePassEncoder):
(derefComputePassEncoder):
* Source/WebGPU/WebGPU/Device.h:
(refDevice):
(derefDevice):
* Source/WebGPU/WebGPU/QuerySet.h:
(refQuerySet):
(derefQuerySet):
* Source/WebGPU/WebGPU/Queue.h:
(refQueue):
(derefQueue):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
(refRenderPassEncoder):
(derefRenderPassEncoder):
* Source/WebGPU/WebGPU/Texture.h:
(refTexture):
(derefTexture):
* Source/WebGPU/WebGPU/TextureView.h:
(refTextureView):
(derefTextureView):
* Source/WebKit/Platform/IPC/Connection.h:
(refConnection):
(derefConnection):
* Source/WebKit/Shared/API/APIArray.h:
(refArray):
(derefArray):
* Source/WebKit/Shared/API/APIObject.h:
(refObject):
(derefObject):
* Source/WebKit/Shared/SessionState.h:
(refFrameState):
(derefFrameState):
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
(refWebBackForwardListFrameItem):
(derefWebBackForwardListFrameItem):
* Source/WebKit/Shared/WebBackForwardListItem.h:
(refBackForwardListItem):
(derefBackForwardListItem):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(refAuxiliaryProcessProxy):
(derefAuxiliaryProcessProxy):
* Source/WebKit/UIProcess/BrowsingContextGroup.h:
(refBrowsingContextGroup):
(derefBrowsingContextGroup):
* Source/WebKit/UIProcess/SuspendedPageProxy.h:
(refSuspendedPageProxy):
(derefSuspendedPageProxy):
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.h:
(refWebBackForwardCacheEntry):
(derefWebBackForwardCacheEntry):
* Source/WebKit/UIProcess/WebFrameProxy.h:
(refWebFrameProxy):
(derefWebFrameProxy):
* Source/WebKit/UIProcess/WebPageProxy.h:
(refWebPageProxy):
(derefWebPageProxy):
* Source/WebKit/UIProcess/WebPreferences.h:
(refPrefs):
(derefPrefs):
* Source/WebKit/UIProcess/WebProcessProxy.h:
(refWebProcessProxy):
(derefWebProcessProxy):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(refDataStore):
(derefDataStore):

Canonical link: <a href="https://commits.webkit.org/309393@main">https://commits.webkit.org/309393@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90e559f6a86e3e014fc5560bda89faa5b9011ce0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150475 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23233 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16794 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159197 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103909 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c7ac7b37-45d9-4100-93ec-df0d8b05cd5a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23664 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23371 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116108 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82494 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/761ef99b-8f9a-487c-97cc-8bc774c91d0f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18216 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/134984 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96836 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17315 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15264 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7045 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142458 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12908 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161671 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11273 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4791 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14461 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124108 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124306 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33760 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134703 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79402 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19415 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11460 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181907 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22636 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86435 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46527 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22349 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22501 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22403 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->