### PR TITLE
[WKTR] HIDEventGenerator InterpolationType should be a scoped enum

### DIFF
--- a/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
+++ b/Tools/WebKitTestRunner/ios/HIDEventGenerator.mm
@@ -145,14 +145,9 @@ static const long nanosecondsPerSecond = 1e9;
 
 NSUInteger const HIDMaxTouchCount = 5;
 
-
-
 static int fingerIdentifiers[HIDMaxTouchCount] = { 2, 3, 4, 5, 1 };
 
-typedef enum {
-    InterpolationTypeLinear,
-    InterpolationTypeSimpleCurve,
-} InterpolationType;
+enum class InterpolationType : uint8_t { Linear, SimpleCurve };
 
 typedef enum {
     HandEventNull,
@@ -183,27 +178,37 @@ static CFTimeInterval secondsSinceAbsoluteTime(CFAbsoluteTime startTime)
     return (CFAbsoluteTimeGetCurrent() - startTime);
 }
 
-static double linearInterpolation(double a, double b, double t)
-{
-    return (a + (b - a) * t );
-}
+using PressureInterpolationFunction = Function<double(double, double, CFTimeInterval)>;
 
-static double simpleCurveInterpolation(double a, double b, double t)
-{
-    return (a + (b - a) * sin(sin(t * std::numbers::pi / 2) * t * std::numbers::pi / 2));
-}
+static const PressureInterpolationFunction linearInterpolation {
+    [](double a, double b, double t) {
+        return std::lerp(a, b, t);
+    }
+};
 
+static const PressureInterpolationFunction simpleCurveInterpolation {
+    [](double a, double b, double t) {
+        return (a + (b - a) * sin(sin(t * std::numbers::pi / 2) * t * std::numbers::pi / 2));
+    }
+};
 
 static CGPoint calculateNextCurveLocation(CGPoint a, CGPoint b, CFTimeInterval t)
 {
     return CGPointMake(simpleCurveInterpolation(a.x, b.x, t), simpleCurveInterpolation(a.y, b.y, t));
 }
 
-typedef double(*pressureInterpolationFunction)(double, double, CFTimeInterval);
-static pressureInterpolationFunction interpolations[] = {
-    linearInterpolation,
-    simpleCurveInterpolation,
-};
+static const PressureInterpolationFunction& interpolationFunctor(InterpolationType type)
+{
+    using enum InterpolationType;
+    switch (type) {
+    case Linear:
+        return linearInterpolation;
+    case SimpleCurve:
+        return simpleCurveInterpolation;
+    }
+    ASSERT_NOT_REACHED();
+    return linearInterpolation;
+}
 
 static void delayBetweenMove(int eventIndex, double elapsed)
 {
@@ -304,13 +309,14 @@ static UITouchPhase phaseFromString(NSString *string)
 
 static InterpolationType interpolationFromString(NSString *string)
 {
+    using enum InterpolationType;
     if ([string isEqualToString:HIDEventInterpolationTypeLinear])
-        return InterpolationTypeLinear;
-    
+        return Linear;
+
     if ([string isEqualToString:HIDEventInterpolationTypeSimpleCurve])
-        return InterpolationTypeSimpleCurve;
-    
-    return InterpolationTypeLinear;
+        return SimpleCurve;
+
+    return Linear;
 }
 
 - (IOHIDDigitizerEventMask)eventMaskFromEventInfo:(NSDictionary *)info
@@ -1132,8 +1138,8 @@ RetainPtr<IOHIDEventRef> createHIDKeyEvent(NSString *character, uint64_t timesta
     NSDictionary *startEvent = interpolationsDictionary[HIDEventStartEventKey];
     NSDictionary *endEvent = interpolationsDictionary[HIDEventEndEventKey];
     NSTimeInterval timeStep = [interpolationsDictionary[HIDEventTimestepKey] doubleValue];
-    InterpolationType interpolationType = interpolationFromString(interpolationsDictionary[HIDEventInterpolateKey]);
-    
+    auto interpolationType = interpolationFromString(interpolationsDictionary[HIDEventInterpolateKey]);
+
     NSMutableArray *interpolatedEvents = [NSMutableArray arrayWithObject:startEvent];
     
     NSTimeInterval startTime = [startEvent[HIDEventTimeOffsetKey] doubleValue];
@@ -1163,14 +1169,14 @@ RetainPtr<IOHIDEventRef> createHIDKeyEvent(NSString *character, uint64_t timesta
                 auto newTouch = adoptNS([endTouch mutableCopy]);
                 
                 if (newTouch.get()[HIDEventXKey] != startTouch[HIDEventXKey])
-                    newTouch.get()[HIDEventXKey] = @(interpolations[interpolationType]([startTouch[HIDEventXKey] doubleValue], [endTouch[HIDEventXKey] doubleValue], timeRatio));
-                
+                    newTouch.get()[HIDEventXKey] = @(interpolationFunctor(interpolationType)([startTouch[HIDEventXKey] doubleValue], [endTouch[HIDEventXKey] doubleValue], timeRatio));
+
                 if (newTouch.get()[HIDEventYKey] != startTouch[HIDEventYKey])
-                    newTouch.get()[HIDEventYKey] = @(interpolations[interpolationType]([startTouch[HIDEventYKey] doubleValue], [endTouch[HIDEventYKey] doubleValue], timeRatio));
-                
+                    newTouch.get()[HIDEventYKey] = @(interpolationFunctor(interpolationType)([startTouch[HIDEventYKey] doubleValue], [endTouch[HIDEventYKey] doubleValue], timeRatio));
+
                 if (newTouch.get()[HIDEventPressureKey] != startTouch[HIDEventPressureKey])
-                    newTouch.get()[HIDEventPressureKey] = @(interpolations[interpolationType]([startTouch[HIDEventPressureKey] doubleValue], [endTouch[HIDEventPressureKey] doubleValue], timeRatio));
-                
+                    newTouch.get()[HIDEventPressureKey] = @(interpolationFunctor(interpolationType)([startTouch[HIDEventPressureKey] doubleValue], [endTouch[HIDEventPressureKey] doubleValue], timeRatio));
+
                 [newTouches addObject:newTouch.get()];
             } else
                 NSLog(@"Missing End Touch with ID: %ld", (long)startTouchID);


### PR DESCRIPTION
#### 3d11a2d1d35380ba4ca144506f430f04910c98ed
<pre>
[WKTR] HIDEventGenerator InterpolationType should be a scoped enum
<a href="https://bugs.webkit.org/show_bug.cgi?id=310071">https://bugs.webkit.org/show_bug.cgi?id=310071</a>
<a href="https://rdar.apple.com/172715161">rdar://172715161</a>

Reviewed by Lily Spiniolas.

This is a fairly mechanical change to take InterpolationType in the HID
event generator from a C-style enum to a scoped enum class.

We make some changes to how interpolation types are associated with
interpolation functors. Instead of storing the function pointers in a
C-style array and using enum value-based indices for access, we instead
provide an `interpolationFunctor` method that takes in an interpolation
type value and spits out the associated function.

Also, some drive-by whitespace cleanup here and there.

No tests because no change in behavior.

* Tools/WebKitTestRunner/ios/HIDEventGenerator.mm:
(linearInterpolation):
(interpolationFunctor):
(interpolationFromString):
(-[HIDEventGenerator interpolatedEvents:]):

Canonical link: <a href="https://commits.webkit.org/309434@main">https://commits.webkit.org/309434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69f3e5bcf365727e40c2652aa59d677dffff6dc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150523 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159245 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103957 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23712 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23426 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116155 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82522 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6b9604f-ddd0-4e77-ad0c-5dce6b062a56) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96883 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2a180be-198e-4f43-9fed-47614c257e21) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17362 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15311 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7093 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161719 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14508 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124151 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23083 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19358 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124349 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134750 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79450 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23150 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19448 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11510 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22685 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22397 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22549 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22451 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->