### PR TITLE
[Navigation API] navigation.back() inside of onnavigate should reject

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate-should-reject-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate-should-reject-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Test that await navigation.back().finished during onnavigate should reject Test timed out
+PASS Test that await navigation.back().finished during onnavigate should reject
 

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate-should-reject.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate-should-reject.html
@@ -9,7 +9,7 @@ promise_test(async t => {
   await new Promise(resolve => w.onload = resolve);
 
   await test_driver.bless("navigate", async function() {
-    w.navigation.navigate("resources/navigate-during-onnavigate-should-reject-helper.html");
+    w.navigation.navigate("../navigation-api/navigate-event/resources/navigate-during-onnavigate-should-reject-helper.html");
   });
 
   await new Promise(resolve => onmessage = resolve);


### PR DESCRIPTION
#### f8b0bb18f195f632e4f5f3058546e2d952197fad
<pre>
[Navigation API] navigation.back() inside of onnavigate should reject
<a href="https://bugs.webkit.org/show_bug.cgi?id=308750">https://bugs.webkit.org/show_bug.cgi?id=308750</a>
<a href="https://rdar.apple.com/171808756">rdar://171808756</a>

Reviewed by Anne van Kesteren.

The test times out because it&apos;s written incorrectly:

It calls w.navigation.navigate(&quot;resources/...&quot;), which resolves against the
popup&apos;s document URL &quot;/common/blank.html&quot;. This results in
&quot;/common/resources/navigate-during-onnavigate-should-reject-helper.html&quot;,
which doesn&apos;t exist. So the navigation fails.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate-should-reject-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-history-traversal-during-onnavigate-should-reject.html:

Canonical link: <a href="https://commits.webkit.org/309408@main">https://commits.webkit.org/309408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ec05469872ede0862edff942d391b34cf39f16e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23276 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159240 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103952 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/665e7b39-49dd-4cd8-b143-eac077189879) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23707 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116148 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82519 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13c7a9ee-61f5-4e38-9a7a-12a0d15d5df5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18259 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135026 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96876 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/870d246f-1c6e-4813-bd0c-c97bd1dfe04b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17358 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15309 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7088 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12950 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161714 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14503 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124146 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124344 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23066 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134745 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79445 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23138 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19446 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11505 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22680 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22392 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22544 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22446 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->