### PR TITLE
[JSC] Fix quick DFG tier-up causing premature jettison on OSR entry failure

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2726,20 +2726,28 @@ void CodeBlock::dontOptimizeAnytimeSoon()
         jitData->executeCounter().deferIndefinitely();
 }
 
-void CodeBlock::optimizeAfterWarmUp()
+template<CodeBlock::QuickTierUpCheck check>
+void CodeBlock::optimizeAfterWarmUpImpl()
 {
     dataLogLnIf(Options::verboseOSR(), *this, ": Optimizing after warm-up.");
 #if ENABLE(DFG_JIT)
     if (auto* jitData = baselineJITData()) {
         int32_t threshold = Options::thresholdForOptimizeAfterWarmUp();
-        if (unlinkedCodeBlock()->isQuickDFGTierUp()) {
-            threshold = static_cast<int32_t>(Options::thresholdForOptimizeAfterWarmUp() * Options::quickDFGTierUpThresholdFactor());
-            dataLogLnIf(Options::verboseOSR(), *this, ": Quick DFG tier-up enabled and code is stable, bytecodeCost=", bytecodeCost(), ", codeType=", codeType(), ", adjustedThreshold=", threshold, ", finalThreshold=", adjustedCounterValue(threshold), " optimizationDelayCounter=", m_optimizationDelayCounter);
+        if constexpr (check == QuickTierUpCheck::Apply) {
+            if (unlinkedCodeBlock()->isQuickDFGTierUp()) {
+                threshold = static_cast<int32_t>(threshold * Options::quickDFGTierUpThresholdFactor());
+                dataLogLnIf(Options::verboseOSR(), *this, ": Quick DFG tier-up enabled and code is stable, bytecodeCost=", bytecodeCost(), ", codeType=", codeType(), ", adjustedThreshold=", threshold, ", finalThreshold=", adjustedCounterValue(threshold), " optimizationDelayCounter=", m_optimizationDelayCounter);
+            }
         }
         jitData->executeCounter().setNewThreshold(adjustedCounterValue(threshold), this);
     }
 #endif
 }
+
+template void CodeBlock::optimizeAfterWarmUpImpl<CodeBlock::QuickTierUpCheck::Apply>();
+void CodeBlock::optimizeAfterWarmUp() { optimizeAfterWarmUpImpl<QuickTierUpCheck::Apply>(); }
+template void CodeBlock::optimizeAfterWarmUpImpl<CodeBlock::QuickTierUpCheck::Ignore>();
+void CodeBlock::optimizeAfterWarmUpIgnoreQuickTierUp() { optimizeAfterWarmUpImpl<QuickTierUpCheck::Ignore>(); }
 
 void CodeBlock::optimizeAfterLongWarmUp()
 {

--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -715,6 +715,7 @@ public:
     // OSR exit code is code generated, so the value of the execute
     // counter that this corresponds to is also available directly.
     void optimizeAfterWarmUp();
+    void optimizeAfterWarmUpIgnoreQuickTierUp();
 
     // Call this to force an optimization trigger to fire only after
     // a lot of warm-up.
@@ -769,6 +770,7 @@ public:
 
 #else // No JIT
     void optimizeAfterWarmUp() { }
+    void optimizeAfterWarmUpIgnoreQuickTierUp() { }
     unsigned numberOfDFGCompiles() { return 0; }
 #endif
 
@@ -925,6 +927,9 @@ private:
     friend class CodeBlockSet;
     friend class FunctionExecutable;
     friend class ScriptExecutable;
+
+    enum class QuickTierUpCheck : bool { Apply, Ignore };
+    template<QuickTierUpCheck> void optimizeAfterWarmUpImpl();
 
     template<typename Visitor> ALWAYS_INLINE void visitChildren(Visitor&);
 

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -3226,8 +3226,11 @@ JSC_DEFINE_JIT_OPERATION(operationOptimize, UGPRPair, (VM* vmPointer, uint32_t b
 
     // OSR failed this time, but it might succeed next time! Let the code run a bit
     // longer and then try again.
-    codeBlock->optimizeAfterWarmUp();
-    
+    // Use the normal threshold regardless of quickDFGTierUp: DFG is already installed,
+    // so this controls OSR retry spacing, not compilation trigger timing. Fast retries
+    // increment the exit counter on every attempt, which can cause premature jettison.
+    codeBlock->optimizeAfterWarmUpIgnoreQuickTierUp();
+
     CODEBLOCK_LOG_EVENT(codeBlock, "delayOptimizeToDFG", ("OSR failed"));
     OPERATION_RETURN(scope, encodeResult(nullptr, nullptr));
 }


### PR DESCRIPTION
#### 90a5bb45b586acd70cc05412713e4b4ba3363ed3
<pre>
[JSC] Fix quick DFG tier-up causing premature jettison on OSR entry failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=310074">https://bugs.webkit.org/show_bug.cgi?id=310074</a>
<a href="https://rdar.apple.com/172718078">rdar://172718078</a>

Reviewed by Yusuke Suzuki.

When a Baseline CodeBlock has a valid DFG replacement installed but mid-loop
OSR entry fails, operationOptimize() calls optimizeAfterWarmUp() to schedule
the next retry. With quickDFGTierUp=true the reduced threshold causes retries
to fire much more frequently. Because countOSRExit() is incremented on every
retry, the exit counter reaches the jettison threshold prematurely, triggering
an unnecessary recompile cycle.

This patch introduces optimizeAfterWarmUpIgnoreQuickTierUp(). The OSR-entry-failure
path uses the Ignore variant so the normal threshold governs retry spacing. All
other call sites keep the quick threshold since they control compilation trigger timing,
not OSR retry spacing.

Canonical link: <a href="https://commits.webkit.org/309439@main">https://commits.webkit.org/309439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c0a0d71350c5fa176766567c92f610f1d0327c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150495 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159217 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103929 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e59bb0f-2a4c-40f4-bc08-559658ea8789) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23393 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116129 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82508 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135002 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96857 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17337 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15285 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7065 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142478 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126951 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12926 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161691 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11293 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4811 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14479 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124126 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23055 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19332 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124324 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33788 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134721 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79422 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19430 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11480 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/181927 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22657 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86455 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46535 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22369 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22521 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22423 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->