### PR TITLE
AX: Fix LocalFrame hit testing in layout tests

### DIFF
--- a/LayoutTests/accessibility-isolated-tree/TestExpectations
+++ b/LayoutTests/accessibility-isolated-tree/TestExpectations
@@ -65,7 +65,6 @@ accessibility/textarea-insertion-point-line-number.html [ Failure ]
 accessibility/mac/html5-input-number.html [ Timeout ]
 
 # Regressions from ENABLE(ACCESSIBILITY_LOCAL_FRAME).
-accessibility/mac/iframe-hit-testing.html [ Failure ]
 accessibility/scroll-to-global-point-main-window.html [ Failure ]
 accessibility/scroll-to-make-visible-iframe-offscreen.html [ Timeout ]
 

--- a/LayoutTests/accessibility/button-hit-test.html
+++ b/LayoutTests/accessibility/button-hit-test.html
@@ -14,12 +14,18 @@ var output = "This test ensures that hit testing a button works.\n\n";
 if (window.accessibilityController) {
     window.jsTestIsAsync = true;
 
-    var button = document.getElementById("button");
-    var buttonRect = button.getBoundingClientRect();
-    var hitTestResult = accessibilityController.elementAtPoint(buttonRect.x + buttonRect.width / 2, buttonRect.y + buttonRect.height / 2);
-    output += expect("hitTestResult.role.toLowerCase().includes('button')", "true");
+    var rootElement, button, buttonRect, hitTestResult;
+
+    button = document.getElementById("button");
+    buttonRect = button.getBoundingClientRect();
 
     setTimeout(async function() {
+        rootElement = accessibilityController.rootElement;
+        await waitForFrameGeometryReady();
+
+        hitTestResult = accessibilityController.elementAtPoint(buttonRect.x + buttonRect.width / 2, buttonRect.y + buttonRect.height / 2);
+        output += expect("hitTestResult.role.toLowerCase().includes('button')", "true");
+
         button.style.marginTop = "100px";
         button.style.marginLeft = "230px";
 

--- a/LayoutTests/accessibility/dynamic-changes-update-position.html
+++ b/LayoutTests/accessibility/dynamic-changes-update-position.html
@@ -16,14 +16,12 @@
 <script>
 var output = "This test ensures that an AX element's position is updated after a dynamic page change.\n\n";
 
-var link, expectsZeroOrigin, startY, endY;
+var link, startY, endY;
 if (window.accessibilityController) {
     window.jsTestIsAsync = true;
 
-    expectsZeroOrigin = accessibilityController.platformName == "mac";
-
     setTimeout(async function() {
-        await waitFor(() => accessibilityController.rootElement.x != 0 || !expectsZeroOrigin);
+        await waitForFrameGeometryReady();
 
         link = accessibilityController.accessibleElementById("link");
         startY = link.y;

--- a/LayoutTests/accessibility/hit-test-on-stitched-text.html
+++ b/LayoutTests/accessibility/hit-test-on-stitched-text.html
@@ -20,11 +20,21 @@
 var output = "This test ensures that when we hit test onto text stitched into other text, that we return the sitch-group owner object.\n\n";
 
 if (window.accessibilityController) {
-    var targetRect = document.getElementById("target-span").getBoundingClientRect();
-    var hitTestResult = accessibilityController.elementAtPoint(targetRect.x + targetRect.width / 2, targetRect.y + targetRect.height / 2);
-    output += expect("platformStaticTextValue(hitTestResult)", "'AXValue: Hello world! How are you doing on this fine day?'");
+    window.jsTestIsAsync = true;
 
-    debug(output);
+    var hitTestResult;
+
+    setTimeout(async function() {
+        var rootElement = accessibilityController.rootElement;
+        await waitForFrameGeometryReady();
+
+        var targetRect = document.getElementById("target-span").getBoundingClientRect();
+        hitTestResult = accessibilityController.elementAtPoint(targetRect.x + targetRect.width / 2, targetRect.y + targetRect.height / 2);
+        output += expect("platformStaticTextValue(hitTestResult)", "'AXValue: Hello world! How are you doing on this fine day?'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
 }
 </script>
 </body>

--- a/LayoutTests/accessibility/mac/imagemap-hittest.html
+++ b/LayoutTests/accessibility/mac/imagemap-hittest.html
@@ -1,4 +1,5 @@
 <html>
+<script src="../../resources/accessibility-helper.js"></script>
 <script>
     if (window.testRunner)
         testRunner.dumpAsText();
@@ -6,35 +7,45 @@
 <body id="body">
 
 <html>
- 
-    <!-- This test makes sure that an image map can be hit tested -->
- 
-    <IMG src="resources/cake.png" ismap="" usemap="#IHIP_NEW" width="190" height="260">
 
-    <MAP name="IHIP_NEW"><AREA shape="rect" coords="20,25,84,113" href="rectangle.html">
-    <AREA shape="polygon" coords="90,25,162,26,163,96,89,25,90,24" href="triangle.html">
-    <AREA shape="circle" coords="130,114,29" href="circle.html">
-    <AREA shape="default" href="test.html">
-    </MAP>
-    
-    <div id="result"></div>
-     
-    <script>
-        if (window.accessibilityController) {
-            var result = document.getElementById("result");
+<!-- This test makes sure that an image map can be hit tested -->
 
-            var body = document.getElementById("body");
-            body.focus();
+<IMG src="resources/cake.png" ismap="" usemap="#IHIP_NEW" width="190" height="260">
 
-            var imageMapLink = accessibilityController.focusedElement.elementAtPoint(30, 100);
-            var pattern = "AXRole: AXLink";
-            if (imageMapLink.allAttributes().indexOf(pattern) != -1) {
-                result.innerText += "Test passed\n";
-            }
-            else {
-                 result.innerText += "Test failed\n" + imageMapLink.allAttributes();
-            }
+<MAP name="IHIP_NEW"><AREA shape="rect" coords="20,25,84,113" href="rectangle.html">
+<AREA shape="polygon" coords="90,25,162,26,163,96,89,25,90,24" href="triangle.html">
+<AREA shape="circle" coords="130,114,29" href="circle.html">
+<AREA shape="default" href="test.html">
+</MAP>
+
+<div id="result"></div>
+
+<script>
+if (window.accessibilityController) {
+    testRunner.waitUntilDone();
+
+    setTimeout(async function() {
+        var rootElement = accessibilityController.rootElement;
+        await waitForFrameGeometryReady();
+
+        var result = document.getElementById("result");
+
+        var body = document.getElementById("body");
+        body.focus();
+
+        var imageMapLink = accessibilityController.focusedElement.elementAtPoint(30, 100);
+        var pattern = "AXRole: AXLink";
+        if (imageMapLink.allAttributes().indexOf(pattern) != -1) {
+            result.innerText += "Test passed\n";
         }
-    </script>
+        else {
+             result.innerText += "Test failed\n" + imageMapLink.allAttributes();
+        }
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+}
+</script>
 </body>
 </html>

--- a/LayoutTests/accessibility/mac/line-range-for-text-marker.html
+++ b/LayoutTests/accessibility/mac/line-range-for-text-marker.html
@@ -33,7 +33,7 @@ if (window.accessibilityController) {
     window.jsTestIsAsync = true;
 
     setTimeout(async function() {
-        await waitFor(() => accessibilityController.rootElement.x != 0);
+        await waitForFrameGeometryReady();
 
         var line = accessibilityController.accessibleElementById("line");
         // Line text from first text marker (add one to make sure we get the first marker for THIS line).

--- a/LayoutTests/accessibility/mac/scroll-to-visible-action.html
+++ b/LayoutTests/accessibility/mac/scroll-to-visible-action.html
@@ -36,9 +36,7 @@ if (window.accessibilityController) {
     window.jsTestIsAsync = true;
 
     setTimeout(async function() {
-        await waitFor(() => {
-            return accessibilityController.rootElement.x != 0;
-        });
+        await waitForFrameGeometryReady();
 
         var button = accessibilityController.accessibleElementById("button");
         initialButtonX = button.x;

--- a/LayoutTests/accessibility/mac/text-marker-for-bounds.html
+++ b/LayoutTests/accessibility/mac/text-marker-for-bounds.html
@@ -16,9 +16,7 @@ if (window.accessibilityController) {
     window.jsTestIsAsync = true;
 
     setTimeout(async function() {
-        await waitFor(() => {
-            return accessibilityController.rootElement.childAtIndex(0).x != 0;
-        });
+        await waitForFrameGeometryReady();
 
         var text = accessibilityController.accessibleElementById("text");
         startMarker = text.startTextMarkerForBounds(text.x, text.y, text.width, text.height);

--- a/LayoutTests/accessibility/table-cell-hit-test-not-column.html
+++ b/LayoutTests/accessibility/table-cell-hit-test-not-column.html
@@ -21,23 +21,33 @@
 var output = "This test ensures that hit testing a table cell returns the cell contents, not a table column.\n\n";
 
 if (window.accessibilityController) {
-    var cell1 = document.getElementById("cell1");
-    var rect1 = cell1.getBoundingClientRect();
-    var hitTestResult = accessibilityController.elementAtPoint(rect1.x + rect1.width / 2, rect1.y + rect1.height / 2);
+    window.jsTestIsAsync = true;
 
-    output += `Hit test on cell 1: ${hitTestResult.role}\n`;
-    output += expect("hitTestResult.role.toLowerCase().includes('column')", "false");
-    output += expect("hitTestResult.role.toLowerCase().includes('statictext')", "true");
+    var hitTestResult;
 
-    var cell4 = document.getElementById("cell4");
-    var rect4 = cell4.getBoundingClientRect();
-    hitTestResult = accessibilityController.elementAtPoint(rect4.x + rect4.width / 2, rect4.y + rect4.height / 2);
+    setTimeout(async function() {
+        var rootElement = accessibilityController.rootElement;
+        await waitForFrameGeometryReady();
 
-    output += `Hit test on cell 4: ${hitTestResult.role}\n`;
-    output += expect("hitTestResult.role.toLowerCase().includes('column')", "false");
-    output += expect("hitTestResult.role.toLowerCase().includes('statictext')", "true");
+        var cell1 = document.getElementById("cell1");
+        var rect1 = cell1.getBoundingClientRect();
+        hitTestResult = accessibilityController.elementAtPoint(rect1.x + rect1.width / 2, rect1.y + rect1.height / 2);
 
-    debug(output);
+        output += `Hit test on cell 1: ${hitTestResult.role}\n`;
+        output += expect("hitTestResult.role.toLowerCase().includes('column')", "false");
+        output += expect("hitTestResult.role.toLowerCase().includes('statictext')", "true");
+
+        var cell4 = document.getElementById("cell4");
+        var rect4 = cell4.getBoundingClientRect();
+        hitTestResult = accessibilityController.elementAtPoint(rect4.x + rect4.width / 2, rect4.y + rect4.height / 2);
+
+        output += `Hit test on cell 4: ${hitTestResult.role}\n`;
+        output += expect("hitTestResult.role.toLowerCase().includes('column')", "false");
+        output += expect("hitTestResult.role.toLowerCase().includes('statictext')", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
 }
 </script>
 </body>

--- a/LayoutTests/accessibility/text-input-hit-test.html
+++ b/LayoutTests/accessibility/text-input-hit-test.html
@@ -14,14 +14,24 @@ var output = "This test ensures that hit testing a text input yields the text in
 // element (e.g. a div inside the UA shadow tree created by <input type="text">).
 
 if (window.accessibilityController) {
-    const rect = document.getElementById("text-input").getBoundingClientRect();
-    const horizontalMidpoint = rect.left + rect.width / 2;
-    const verticalMidpoint = rect.top + rect.height / 2;
+    window.jsTestIsAsync = true;
 
-    var hitTestResult = accessibilityController.elementAtPoint(horizontalMidpoint, verticalMidpoint);
-    output += expect("hitTestResult.role.toLowerCase().includes('textfield')", "true");
+    var hitTestResult;
 
-    debug(output);
+    setTimeout(async function() {
+        var rootElement = accessibilityController.rootElement;
+        await waitForFrameGeometryReady();
+
+        const rect = document.getElementById("text-input").getBoundingClientRect();
+        const horizontalMidpoint = rect.left + rect.width / 2;
+        const verticalMidpoint = rect.top + rect.height / 2;
+
+        hitTestResult = accessibilityController.elementAtPoint(horizontalMidpoint, verticalMidpoint);
+        output += expect("hitTestResult.role.toLowerCase().includes('textfield')", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
 }
 </script>
 </body>

--- a/LayoutTests/resources/accessibility-helper.js
+++ b/LayoutTests/resources/accessibility-helper.js
@@ -275,6 +275,12 @@ function waitFor(condition)
     });
 }
 
+async function waitForFrameGeometryReady() {
+    await waitFor(() => {
+        return accessibilityController.rootElement.isFrameGeometryInitialized;
+    });
+}
+
 async function waitForElementById(id) {
     let element;
     await waitFor(() => {

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -994,6 +994,7 @@ public:
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     virtual IntPoint frameScreenPosition() const = 0;
     virtual AffineTransform frameScreenTransform() const = 0;
+    virtual bool isFrameGeometryInitialized() const { return true; }
 #endif
 
     virtual FloatRect convertFrameToSpace(const FloatRect&, AccessibilityConversionSpace) const = 0;

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -307,6 +307,12 @@ AXObjectCache::AXObjectCache(LocalFrame& localFrame, Document* document)
 #endif
 
     AXTreeStore::add(m_id, WeakPtr { this });
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    // This is the first time this frame has its cache initialized, so it has no geometry. Kick off a request to initialize it asynchronously.
+    if (RefPtr page = localFrame.page())
+        page->chrome().client().requestFrameScreenPosition(m_frameID);
+#endif
 }
 
 AXObjectCache::~AXObjectCache()

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -590,6 +590,16 @@ AccessibilityObject* AccessibilityScrollView::crossFrameChildObject() const
     return nullptr;
 }
 
+bool AccessibilityScrollView::isFrameGeometryInitialized() const
+{
+    if (isRoot()) {
+        if (CheckedPtr cache = axObjectCache())
+            return cache->frameGeometry().has_value();
+        return false;
+    }
+    return true;
+}
+
 FrameGeometry AccessibilityScrollView::frameGeometry() const
 {
     if (CheckedPtr cache = axObjectCache()) {

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -66,6 +66,8 @@ public:
     IntPoint frameScreenPosition() const final { return frameGeometry().screenPosition; }
     AffineTransform frameScreenTransform() const final { return frameGeometry().screenTransform; }
 
+    bool isFrameGeometryInitialized() const final;
+
     void setInheritedFrameState(InheritedFrameState);
     const InheritedFrameState& inheritedFrameState() const LIFETIME_BOUND { return m_inheritedFrameState; }
     bool isARIAHidden() const final;

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -3039,6 +3039,18 @@ static RenderObject* rendererForView(WAKView* view)
     return ancestorWithRole(*self.axBackingObject, { AccessibilityRole::Mark }) != nullptr;
 }
 
+- (BOOL)_accessibilityIsFrameGeometryInitialized
+{
+    if (![self _prepareAccessibilityCall])
+        return NO;
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    return self.axBackingObject->isFrameGeometryInitialized();
+#else
+    return YES;
+#endif
+}
+
 - (BOOL)_accessibilityIsSwitch
 {
     if (![self _prepareAccessibilityCall])

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -582,8 +582,21 @@ RefPtr<AXCoreObject> AXIsolatedObject::accessibilityHitTest(const IntPoint& poin
 {
     // For layout tests, we want to exercise hit testing using the accessibility thread, so don't
     // use any caching or main-thread calls in testing contexts.
-    if (AXObjectCache::clientIsInTestMode()) [[unlikely]]
+    if (AXObjectCache::clientIsInTestMode()) [[unlikely]] {
+        // In layout tests, we pass page-relative coordinates. Convert to screen for approximateHitTest, which works in screen-space.
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME) && PLATFORM(MAC)
+        if (RefPtr root = tree().rootNode()) {
+            auto rootPosition = root->screenRelativePosition();
+            auto rootSize = root->size();
+            IntPoint screenPoint(rootPosition.x() + point.x(), rootPosition.y() + rootSize.height() - point.y());
+            return approximateHitTest(screenPoint);
+        }
+#else
+        // If ITM exists on non-macOS platforms, the coordinate conversion above (using a bottom-left origin) will be incorrect.
+        AX_ASSERT_NOT_REACHED();
+#endif // ENABLE(ACCESSIBILITY_LOCAL_FRAME) && PLATFORM(MAC)
         return approximateHitTest(point);
+    }
 
     // Check if we have a cached result for this point.
     RefPtr geometryManager = tree().geometryManager();
@@ -645,6 +658,10 @@ RefPtr<AXCoreObject> AXIsolatedObject::accessibilityHitTest(const IntPoint& poin
 RefPtr<AXIsolatedObject> AXIsolatedObject::approximateHitTest(const IntPoint& point) const
 {
     FloatRect bounds;
+    IntPoint adjustedPoint = point;
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    bounds = screenRelativeRect();
+#else
     if (!AXObjectCache::clientIsInTestMode()) [[likely]] {
         // For "real" off-main-thread hit tests (i.e. those forwarded to us by WKAccessibilityWebPageObjectMac),
         // the coordinates are in the screen space. Note this may not be true for non-Mac platforms when we
@@ -655,8 +672,6 @@ RefPtr<AXIsolatedObject> AXIsolatedObject::approximateHitTest(const IntPoint& po
         bounds = relativeFrame();
     }
 
-    IntPoint adjustedPoint = point;
-#if !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     adjustedPoint.moveBy(-remoteFrameOffset());
 #endif
 
@@ -685,6 +700,22 @@ RefPtr<AXIsolatedObject> AXIsolatedObject::approximateHitTest(const IntPoint& po
             // cell (or cell contents) instead, which is typically more useful for ATs like Hover Text.
             continue;
         }
+
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+        if (child->role() == AccessibilityRole::LocalFrame) {
+            // LocalFrames have no unique platform wrapper (they delegate to the child tree), so we must explicitly
+            // cross into the child tree here.
+            // RemoteFrames don't have this problem since they have a wrapper that points to the remote accessibility
+            // object, and the frameworks recursively hit test in the bridged process.
+            // This also helps guard against potential frame wrapper issues, like the one noted in
+            // AXIsolatedTree::applyPendingChangesLocked.
+            if (RefPtr crossFrameChild = child->crossFrameChildObject()) {
+                if (RefPtr hitChild = crossFrameChild->approximateHitTest(point))
+                    return hitChild;
+            }
+            continue;
+        }
+#endif
 
         if (RefPtr hitChild = child->approximateHitTest(point))
             return hitChild;
@@ -1184,15 +1215,19 @@ IntPoint AXIsolatedObject::remoteFrameOffset() const
 
 FloatPoint AXIsolatedObject::screenRelativePosition() const
 {
+#if !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     if (auto point = optionalAttributeValue<FloatPoint>(AXProperty::ScreenRelativePosition))
         return *point;
+#endif
     return convertFrameToSpace(relativeFrame(), AccessibilityConversionSpace::Screen).location();
 }
 
 FloatRect AXIsolatedObject::screenRelativeRect() const
 {
+#if !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     if (auto point = optionalAttributeValue<FloatPoint>(AXProperty::ScreenRelativePosition))
         return { *point, size() };
+#endif
     return convertFrameToSpace(relativeFrame(), AccessibilityConversionSpace::Screen);
 }
 
@@ -1831,6 +1866,11 @@ AXIsolatedObject* AXIsolatedObject::crossFrameChildObject() const
         return childTree->rootNode();
     }
     return nullptr;
+}
+
+bool AXIsolatedObject::isFrameGeometryInitialized() const
+{
+    return tree().isFrameGeometryInitialized();
 }
 
 #endif // ENABLE_ACCESSIBILITY_LOCAL_FRAME

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -89,6 +89,7 @@ public:
     // Returns the child or parent object that crosses a local frame boundary.
     AXIsolatedObject* crossFrameParentObject() const final;
     AXIsolatedObject* crossFrameChildObject() const final;
+    bool isFrameGeometryInitialized() const final;
 #endif
 
     const AXTextRuns* textRuns() const;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -130,7 +130,11 @@ void AXIsolatedTree::createEmptyContent(AccessibilityObject& axRoot)
 
     // Create the IsolatedObjects for the root/ScrollView and WebArea.
     auto rootData = createIsolatedObjectData(axRoot, *this);
+#if !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+    // When ACCESSIBILITY_LOCAL_FRAME is enabled, the root's screen-relative position is
+    // derived dynamically from the tree's frame geometry, so we don't need to cache it.
     rootData.setProperty(AXProperty::ScreenRelativePosition, axRoot.screenRelativePosition());
+#endif
     NodeChange rootAppend { WTF::move(rootData), axRoot.wrapper() };
 
     RefPtr axWebArea = Accessibility::findUnignoredChild(axRoot, [] (auto& object) {
@@ -1553,8 +1557,10 @@ void AXIsolatedTree::applyPendingChangesLocked()
         m_selectedTextMarkerRange = std::exchange(m_pendingSelectedTextMarkerRange, std::nullopt).value();
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
-    if (m_pendingFrameGeometry)
+    if (m_pendingFrameGeometry) {
         m_frameGeometry = std::exchange(m_pendingFrameGeometry, std::nullopt).value();
+        m_hasReceivedFrameGeometry = true;
+    }
 #endif
 
     // Do this at the end because it requires looking up the root node by ID, so doing it at the end
@@ -2070,7 +2076,12 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
             // Eagerly cache the screen relative position for the root. AXIsolatedObject::screenRelativePosition()
             // of non-root objects depend on the root object's screen relative position, so make sure it's there
             // from the start. We keep this up-to-date via AXIsolatedTree::updateRootScreenRelativePosition().
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+            // When ACCESSIBILITY_LOCAL_FRAME is enabled, the root's screen-relative position is
+            // derived dynamically from the tree's frame geometry via convertFrameToSpace().
+#else
             setProperty(AXProperty::ScreenRelativePosition, axObject->screenRelativePosition());
+#endif
 #if !ENABLE(ACCESSIBILITY_LOCAL_FRAME)
             setProperty(AXProperty::RemoteFrameOffset, object.remoteFrameOffset());
 #endif //

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -442,6 +442,7 @@ public:
 
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     FrameGeometry frameGeometry() const { return m_frameGeometry; }
+    bool isFrameGeometryInitialized() const { return m_hasReceivedFrameGeometry; }
     void setFrameGeometry(FrameGeometry&&);
 #endif
 
@@ -690,6 +691,7 @@ private:
     HashMap<AXID, AXRelations> m_relations;
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     FrameGeometry m_frameGeometry;
+    bool m_hasReceivedFrameGeometry { false };
 #endif
 
     // Set to true by the AXObjectCache and false by AXIsolatedTree.

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -2568,6 +2568,14 @@ id attributeValueForTesting(const RefPtr<AXCoreObject>& backingObject, NSString 
     if ([attributeName isEqualToString:@"_AXDebugDescription"])
         return debugDescriptionFrom(backingObject.get()).createNSString().autorelease();
 
+    if ([attributeName isEqualToString:@"_AXFrameGeometryInitialized"]) {
+#if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
+        return [NSNumber numberWithBool:backingObject->isFrameGeometryInitialized()];
+#else
+        return @YES;
+#endif
+    }
+
     if ([attributeName isEqualToString:@"_AXRawRoleForTesting"])
         return roleToString(backingObject->role()).createNSString().autorelease();
 

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -416,6 +416,7 @@ public:
     virtual bool isRemoteFrame() const;
     // True if the element backing |this| is a platform remote element (e.g. NSAccessibilityRemoteUIElement on macOS).
     virtual bool isRemotePlatformElement() const { return false; }
+    virtual bool isFrameGeometryInitialized() const { return true; }
 
     virtual bool isMarkAnnotation() const;
 protected:

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -129,6 +129,7 @@ interface AccessibilityUIElement {
     readonly attribute boolean isLastItemInSuggestion;
     readonly attribute boolean isRemoteFrame;
     readonly attribute boolean isRemotePlatformElement;
+    readonly attribute boolean isFrameGeometryInitialized;
 
     readonly attribute long pageX;
     readonly attribute long pageY;

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h
@@ -307,6 +307,7 @@ public:
     bool isFirstItemInSuggestion() const override;
     bool isLastItemInSuggestion() const override;
     bool isMarkAnnotation() const override;
+    bool isFrameGeometryInitialized() const override;
 
     // Text input
     bool insertText(JSStringRef) override;

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
@@ -137,6 +137,7 @@ typedef void (*AXPostedNotificationCallback)(id element, NSString* notification,
 - (BOOL)accessibilityIsFirstItemInSuggestion;
 - (BOOL)accessibilityIsLastItemInSuggestion;
 - (BOOL)accessibilityIsMarkAnnotation;
+- (BOOL)_accessibilityIsFrameGeometryInitialized;
 
 // TextMarker related
 - (NSArray *)textMarkerRange;
@@ -1643,6 +1644,11 @@ bool AccessibilityUIElementIOS::isLastItemInSuggestion() const
 bool AccessibilityUIElementIOS::isMarkAnnotation() const
 {
     return [m_element accessibilityIsMarkAnnotation];
+}
+
+bool AccessibilityUIElementIOS::isFrameGeometryInitialized() const
+{
+    return [m_element _accessibilityIsFrameGeometryInitialized];
 }
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h
@@ -338,6 +338,7 @@ public:
     bool isLastItemInSuggestion() const override;
     bool isRemoteFrame() const override;
     bool isRemotePlatformElement() const final;
+    bool isFrameGeometryInitialized() const final;
 
 private:
     AccessibilityUIElementMac(PlatformUIElement);

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -231,6 +231,7 @@ static id attributeValue(id element, NSString *attribute)
         @"AXOwns",
         @"AXPopupValue",
         @"AXRelativeFrame", // Continue to support this for testing purposes with ENABLE(ACCESSIBILITY_LOCAL_FRAME).
+        @"_AXFrameGeometryInitialized",
         @"AXValue",
     ];
 
@@ -3203,6 +3204,11 @@ bool AccessibilityUIElementMac::isRemotePlatformElement() const
     BEGIN_AX_OBJC_EXCEPTIONS
     return [m_element isKindOfClass:NSAccessibilityRemoteUIElement.class];
     END_AX_OBJC_EXCEPTIONS
+}
+
+bool AccessibilityUIElementMac::isFrameGeometryInitialized() const
+{
+    return boolAttributeValueNS(@"_AXFrameGeometryInitialized");
 }
 
 } // namespace WTR


### PR DESCRIPTION
#### ca8a934ed7061e80cc605100d29bdcb392586560
<pre>
AX: Fix LocalFrame hit testing in layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=310080">https://bugs.webkit.org/show_bug.cgi?id=310080</a>
<a href="https://rdar.apple.com/172721343">rdar://172721343</a>

Reviewed by Tyler Wilcock.

With ACCESSIBILITY_LOCAL_FRAME enabled, relative frames are no longer supported. This
is an issue for layout tests, since all coordinates for hit testing are expected to
be in page-relative position. This patch fixes that by converting page to screen coords
only when in test mode.

The other core fix here is recursively calling approximateHitTest on local frames. This
allows us to pass through a hit test seemlessly, and gets around some of the
complications with wrappers + LocalFrame.

To support tests, a new method, isFrameGeometryInitialized, was added. This will allow
layout tests to wait on initialization before performing any geometry-related actions
or queries.

* LayoutTests/accessibility-isolated-tree/TestExpectations:
* LayoutTests/accessibility/button-hit-test.html:
* LayoutTests/accessibility/dynamic-changes-update-position.html:
* LayoutTests/accessibility/hit-test-on-stitched-text.html:
* LayoutTests/accessibility/mac/imagemap-hittest.html:
* LayoutTests/accessibility/mac/line-range-for-text-marker.html:
* LayoutTests/accessibility/mac/scroll-to-visible-action.html:
* LayoutTests/accessibility/mac/text-marker-for-bounds.html:
* LayoutTests/accessibility/table-cell-hit-test-not-column.html:
* LayoutTests/accessibility/text-input-hit-test.html:
* LayoutTests/resources/accessibility-helper.js:
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::isFrameGeometryInitialized const):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::AXObjectCache):
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::isFrameGeometryInitialized const):
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper _accessibilityIsFrameGeometryInitialized]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::accessibilityHitTest const):
(WebCore::AXIsolatedObject::approximateHitTest const):
(WebCore::AXIsolatedObject::screenRelativePosition const):
(WebCore::AXIsolatedObject::screenRelativeRect const):
(WebCore::AXIsolatedObject::isFrameGeometryInitialized const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::createEmptyContent):
(WebCore::AXIsolatedTree::applyPendingChangesLocked):
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::isFrameGeometryInitialized const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(attributeValueForTesting):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
(WTR::AccessibilityUIElement::isFrameGeometryInitialized const):
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h:
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
(WTR::AccessibilityUIElementIOS::isFrameGeometryInitialized const):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::attributeValue):
(WTR::AccessibilityUIElementMac::isFrameGeometryInitialized const):

Canonical link: <a href="https://commits.webkit.org/309535@main">https://commits.webkit.org/309535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9432874c212cb7cfbe47c926ba128a19dcaf2c46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159610 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104319 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36a73ee7-20eb-43c5-9ca3-20c0aaa5fa6c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152756 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24076 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116471 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82700 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0aa5ae48-31a8-4fb8-899d-bf789cad9400) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153843 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97191 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/967cba26-a5fa-4fc1-9d38-db27fdbc96b1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17682 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15633 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7457 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162084 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5209 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14856 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124480 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124667 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33848 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23437 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135085 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79844 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19733 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11850 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23047 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/87131 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22759 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22911 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22813 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->