### PR TITLE
[WebVTT] Support text-decoration-{text,color,style} on CSS ::cue pseudo-element

### DIFF
--- a/LayoutTests/media/track/track-cue-text-decoration-expected.txt
+++ b/LayoutTests/media/track/track-cue-text-decoration-expected.txt
@@ -1,0 +1,11 @@
+
+EVENT(canplaythrough)
+EVENT(seeked)
+Test that text-decoration properties are applied to ::cue pseudo-element.
+
+EXPECTED (cueStyle.textDecorationLine == 'underline') OK
+EXPECTED (cueStyle.textDecorationStyle == 'dashed') OK
+EXPECTED (cueStyle.textDecorationColor == 'rgb(0, 255, 255)') OK
+EXPECTED (cueStyle.textDecorationThickness == '3px') OK
+END OF TEST
+

--- a/LayoutTests/media/track/track-cue-text-decoration.html
+++ b/LayoutTests/media/track/track-cue-text-decoration.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Test that text-decoration properties on ::cue are applied correctly</title>
+    <script src=../media-file.js></script>
+    <script src=../video-test.js></script>
+    <style>
+    video::cue {
+        text-decoration-line: underline;
+        text-decoration-style: dashed;
+        text-decoration-color: cyan;
+        text-decoration-thickness: 3px;
+    }
+    </style>
+    <script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    function cueElement() {
+        return internals.shadowRoot(video).querySelector('[useragentpart="cue"]');
+    }
+
+    window.addEventListener('load', function() {
+        findMediaElement();
+        video.src = findMediaFile('video', '../content/test');
+        video.textTracks[0].mode = 'showing';
+
+        waitForEvent('canplaythrough', function() {
+            video.currentTime = 0.5;
+        });
+
+        waitForEvent('seeked', function() {
+            var cue = cueElement();
+            if (!cue) {
+                consoleWrite("FAIL: Could not find cue element in shadow root.");
+                endTest();
+                return;
+            }
+
+            window.cueStyle = getComputedStyle(cue);
+            consoleWrite("Test that text-decoration properties are applied to ::cue pseudo-element.");
+            consoleWrite("");
+            testExpected("cueStyle.textDecorationLine", "underline");
+            testExpected("cueStyle.textDecorationStyle", "dashed");
+            testExpected("cueStyle.textDecorationColor", "rgb(0, 255, 255)");
+            testExpected("cueStyle.textDecorationThickness", "3px");
+            endTest();
+        });
+    });
+    </script>
+</head>
+<body>
+    <video>
+        <track src="captions-webvtt/captions.vtt" kind="captions" default>
+    </video>
+</body>
+</html>

--- a/Source/WebCore/style/PropertyAllowlist.cpp
+++ b/Source/WebCore/style/PropertyAllowlist.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -141,7 +141,10 @@ bool isValidCueStyleProperty(CSSPropertyID id)
     case CSSPropertyWhiteSpace:
     case CSSPropertyWhiteSpaceCollapse:
     case CSSPropertyTextCombineUpright:
+    case CSSPropertyTextDecorationColor:
     case CSSPropertyTextDecorationLine:
+    case CSSPropertyTextDecorationStyle:
+    case CSSPropertyTextDecorationThickness:
     case CSSPropertyTextShadow:
     case CSSPropertyTextWrapMode:
     case CSSPropertyTextWrapStyle:
@@ -193,7 +196,10 @@ bool isValidCueSelectorStyleProperty(CSSPropertyID id)
     case CSSPropertyWhiteSpace:
     case CSSPropertyWhiteSpaceCollapse:
     case CSSPropertyTextCombineUpright:
+    case CSSPropertyTextDecorationColor:
     case CSSPropertyTextDecorationLine:
+    case CSSPropertyTextDecorationStyle:
+    case CSSPropertyTextDecorationThickness:
     case CSSPropertyTextShadow:
     case CSSPropertyTextWrapMode:
     case CSSPropertyTextWrapStyle:


### PR DESCRIPTION
#### 659a9e578eb17fa5e758a10bccdfce411d9ddfc8
<pre>
[WebVTT] Support text-decoration-{text,color,style} on CSS ::cue pseudo-element
<a href="https://bugs.webkit.org/show_bug.cgi?id=118915">https://bugs.webkit.org/show_bug.cgi?id=118915</a>
<a href="https://rdar.apple.com/172728187">rdar://172728187</a>

Reviewed by Eric Carlson.

The ::cue pseudo-element spec [1] defines that the properties
corresponding to the text-decoration shorthand apply to ::cue.
Previously only text-decoration-line was allowed. Add the missing
text-decoration-color, text-decoration-style and
text-decoration-thickness properties to the ::cue and ::cue()
allowlists.

[1] <a href="https://w3c.github.io/webvtt/#the-cue-pseudo-element">https://w3c.github.io/webvtt/#the-cue-pseudo-element</a>

* LayoutTests/media/track/track-cue-text-decoration-expected.txt: Added.
* LayoutTests/media/track/track-cue-text-decoration.html: Added.
* Source/WebCore/style/PropertyAllowlist.cpp:
(WebCore::Style::isValidCueStyleProperty):
(WebCore::Style::isValidCueSelectorStyleProperty):

Canonical link: <a href="https://commits.webkit.org/309425@main">https://commits.webkit.org/309425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae89a469e5aa6084d51ce3fc56896942cc2d1799

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23396 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16967 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159360 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4c9b947-4ad1-47b3-abba-0d64a0214c5d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23552 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/116256 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb1aef83-80cc-4d54-9191-9249e84cfa3a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153598 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/18370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96984 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5064e37a-3e23-40da-9759-34b1a9c4e8b1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7208 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161834 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/4954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14610 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/124253 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23198 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/19458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124451 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33777 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/23186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/134851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79575 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/23186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/11612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22800 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/86598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/22512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22664 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/22566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->