### PR TITLE
[css-anchor-position-1] Media queries may fail to resolve in presence of viewport units and anchors

### DIFF
--- a/LayoutTests/fast/css/anchor-position-media-query-viewport-units-expected.html
+++ b/LayoutTests/fast/css/anchor-position-media-query-viewport-units-expected.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>Anchor positioning with media query toggle and viewport units - reference</title>
+<style>
+    body { margin: 0; overflow: hidden; }
+    .box {
+        width: 100px;
+        height: 100px;
+        background: green;
+    }
+</style>
+<body>
+<div class="box"></div>
+</body>
+<script>
+    window.testRunner?.waitUntilDone();
+
+    const raf = () => new Promise(resolve => requestAnimationFrame(resolve));
+
+    (async () => {
+        window.resizeTo(600, 600);
+        await raf();
+        await raf();
+        window.testRunner?.notifyDone();
+    })();
+</script>

--- a/LayoutTests/fast/css/anchor-position-media-query-viewport-units.html
+++ b/LayoutTests/fast/css/anchor-position-media-query-viewport-units.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<title>Anchor positioning with media query toggle and viewport units</title>
+<style>
+    body { margin: 0; overflow: hidden; }
+    .container {
+        height: 100dvh;
+    }
+    .anchor {
+        width: 100px;
+        height: 100px;
+        background: red;
+        anchor-name: --a;
+    }
+    .target {
+        display: none;
+        position: absolute;
+        position-anchor: --a;
+        position-area: center;
+        width: 100px;
+        height: 100px;
+        background: green;
+    }
+    @media (min-width: 300px) {
+        .target {
+            display: block;
+        }
+    }
+</style>
+<body>
+<!-- Red box is always visible. Green box covers it when media query matches. -->
+<div class="anchor"></div>
+<div class="container">
+    <div class="target"></div>
+</div>
+<script>
+    window.testRunner?.waitUntilDone();
+
+    const raf = () => new Promise(resolve => requestAnimationFrame(resolve));
+
+    (async () => {
+        await raf();
+        await raf();
+        window.resizeTo(200, 600);
+        await raf();
+        await raf();
+        window.resizeTo(600, 600);
+        await raf();
+        await raf();
+        window.testRunner?.notifyDone();
+    })();
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2836,6 +2836,9 @@ void Document::resolveStyle(ResolveStyleType type)
                 documentElement->invalidateStyleForSubtree();
         }
 
+        // Size media queries are affected by zoom which is read from root style set in resolveForDocument above.
+        styleScope().evaluateMediaQueriesForViewportChange();
+
         {
             Style::TreeResolver resolver(*this, WTF::move(m_pendingRenderTreeUpdate));
             auto styleUpdate = resolver.resolve();


### PR DESCRIPTION
#### 5c614d46912aa58bb34efc59108a926158b05806
<pre>
[css-anchor-position-1] Media queries may fail to resolve in presence of viewport units and anchors
<a href="https://bugs.webkit.org/show_bug.cgi?id=310086">https://bugs.webkit.org/show_bug.cgi?id=310086</a>
<a href="https://rdar.apple.com/172385594">rdar://172385594</a>

Reviewed by Alan Baradlay.

On window resize the presence of viewport units invalidates style. We enter style resolution
where the anchor positioning triggers interleaved layout. Media query evaluation is not performed in
during these nested layouts. We then exit style resolution with layout clean but
the media queries still have not been evaluated.

Without viewport units we would just invalidate layout and resolve media queries before that.
Without anchor positioning we would do a normal layout after style resolution also resolving media queries.

Test: fast/css/anchor-position-media-query-viewport-units.html
* LayoutTests/fast/css/anchor-position-media-query-viewport-units-expected.html: Added.
* LayoutTests/fast/css/anchor-position-media-query-viewport-units.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveStyle):

Fix by ensuring we evalute media queries when already before entering style resolution, not just before layout.

Canonical link: <a href="https://commits.webkit.org/309470@main">https://commits.webkit.org/309470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23d565ced3841dfe1c92ba8ce1b38da1e58c3fe7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23549 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159513 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afdd6613-882f-4460-ac26-216945da93f9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23755 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116385 "Found 1 new test failure: fast/css/anchor-position-media-query-viewport-units.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97113 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7580d830-017e-42a9-8b4d-c268294a61dd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7361 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161987 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5108 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14756 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124387 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19590 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124584 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33808 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134994 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79728 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19663 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11756 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22953 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/86753 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22665 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22817 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22719 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->