### PR TITLE
Deleting next sibling node while replacing this node stops the replacement being processed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-next-sibling-during-replace-with-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-next-sibling-during-replace-with-expected.txt
@@ -1,0 +1,4 @@
+New content
+
+PASS remove-next-sibling-during-replace-with
+

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-next-sibling-during-replace-with.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-next-sibling-during-replace-with.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta name="author" title="Ryosuke Niwa" href="mailto:rniwa@webkit.org">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="container"><div id="target"></div><b></b></div>
+<template><span>New </span><script>document.querySelector('b').remove();</script><span>content</span></template>
+
+<script>
+    test(() => {
+        target.replaceWith(document.querySelector('template').content.cloneNode(true));
+        container.querySelector('script').remove();
+        assert_equals(container.innerHTML, '<span>New </span><span>content</span>');
+    });
+</script>


### PR DESCRIPTION
#### c495217439eb8d09de3f2983b0a6885e57429b04
<pre>
Deleting next sibling node while replacing this node stops the replacement being processed
<a href="https://bugs.webkit.org/show_bug.cgi?id=309730">https://bugs.webkit.org/show_bug.cgi?id=309730</a>

Reviewed by Anne van Kesteren.

The bug has been fixed by 309388@main. Add WPT coverage for this issue.

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-next-sibling-during-replace-with-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/remove-next-sibling-during-replace-with.html: Added.

Canonical link: <a href="https://commits.webkit.org/309411@main">https://commits.webkit.org/309411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85d7a6f9a7a87893c69ce835c3fdee972759a0ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150529 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16922 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159251 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103963 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf4f7701-a617-406a-b4c7-0c23b70fcb6c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23718 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23432 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116158 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82525 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d8074d6-91d9-4419-a928-4d29adfb4f25) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18272 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96886 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3a4e827c-8417-4994-a1c8-ab71b4af478f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17371 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15317 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7099 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13025 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161725 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/14578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124157 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124355 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23077 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/134820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79456 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23139 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19461 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/11581 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22691 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22403 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22555 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22457 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->