### PR TITLE
[JSC] Fix spec conformance bugs in Explicit Resource Management builtins

### DIFF
--- a/JSTests/stress/async-disposable-stack-adopt-awaits-result.js
+++ b/JSTests/stress/async-disposable-stack-adopt-awaits-result.js
@@ -1,0 +1,90 @@
+//@ requireOptions("--useExplicitResourceManagement=1")
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${JSON.stringify(b)} but got ${JSON.stringify(a)}`);
+}
+
+// AsyncDisposableStack.prototype.adopt step 6: the closure returns the result
+// of Call(onDisposeAsync, undefined, « value »). disposeAsync must await that
+// result. If the closure swallows the return value, disposeAsync resolves
+// before the onDisposeAsync promise settles.
+
+// Ordering: disposeAsync must not resolve before onDisposeAsync's promise.
+{
+    const events = [];
+    const stack = new AsyncDisposableStack();
+    const slow = () => Promise.resolve()
+        .then(() => {})
+        .then(() => {})
+        .then(() => {})
+        .then(() => {})
+        .then(() => events.push("slow-done"));
+
+    stack.adopt("R", () => {
+        events.push("adopt-called");
+        return slow();
+    });
+    stack.disposeAsync().then(() => events.push("dispose-resolved"));
+    drainMicrotasks();
+
+    shouldBe(events.join(","), "adopt-called,slow-done,dispose-resolved");
+}
+
+// onDisposeAsync returns a rejected promise → SuppressedError chain works,
+// and disposeAsync still waits for it.
+{
+    const events = [];
+    const stack = new AsyncDisposableStack();
+    stack.adopt("A", () => {
+        events.push("A-called");
+        return Promise.resolve().then(() => {}).then(() => { throw new Error("A-fail"); });
+    });
+    stack.adopt("B", () => {
+        events.push("B-called");
+        return Promise.resolve().then(() => {}).then(() => { events.push("B-done"); });
+    });
+    let caught;
+    stack.disposeAsync().then(
+        () => events.push("resolved"),
+        (e) => { events.push("rejected"); caught = e; }
+    );
+    drainMicrotasks();
+
+    // LIFO: B first (succeeds), then A (fails). A's rejection is the only error.
+    shouldBe(events.join(","), "B-called,B-done,A-called,rejected");
+    shouldBe(caught.message, "A-fail");
+}
+
+// onDisposeAsync returning a thenable (not a real Promise)
+{
+    const events = [];
+    const stack = new AsyncDisposableStack();
+    stack.adopt("R", () => {
+        events.push("called");
+        return {
+            then(onFulfilled) {
+                Promise.resolve().then(() => {}).then(() => {
+                    events.push("thenable-resolved");
+                    onFulfilled();
+                });
+            }
+        };
+    });
+    stack.disposeAsync().then(() => events.push("dispose-resolved"));
+    drainMicrotasks();
+    shouldBe(events.join(","), "called,thenable-resolved,dispose-resolved");
+}
+
+// onDisposeAsync returning a non-promise primitive → resolved immediately
+{
+    const events = [];
+    const stack = new AsyncDisposableStack();
+    stack.adopt("R", (v) => {
+        events.push("called:" + v);
+        return 42;
+    });
+    stack.disposeAsync().then(() => events.push("resolved"));
+    drainMicrotasks();
+    shouldBe(events.join(","), "called:R,resolved");
+}

--- a/JSTests/stress/async-disposable-stack-use-null-await.js
+++ b/JSTests/stress/async-disposable-stack-use-null-await.js
@@ -1,0 +1,100 @@
+//@ requireOptions("--useExplicitResourceManagement=1")
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${JSON.stringify(b)} but got ${JSON.stringify(a)}`);
+}
+
+// AddDisposableResource step 1.a returns unused only when hint is sync-dispose.
+// For async-dispose with V = null/undefined, CreateDisposableResource produces
+// { undefined, undefined, async-dispose }, which causes DisposeResources to
+// set needsAwait=true (step 3.f), resulting in one trailing Await(undefined)
+// (step 6) if no other resource was awaited.
+
+// Measure relative timing: disposeAsync with use(null) resolves later than empty.
+function probe(setup) {
+    const events = [];
+    const stack = new AsyncDisposableStack();
+    setup(stack);
+    stack.disposeAsync().then(() => events.push("D"));
+    Promise.resolve()
+        .then(() => events.push("1"))
+        .then(() => events.push("2"))
+        .then(() => events.push("3"));
+    drainMicrotasks();
+    return events.join("");
+}
+
+const empty = probe(() => {});
+const one = probe(s => s.use(null));
+const two = probe(s => { s.use(null); s.use(null); });
+const three = probe(s => { s.use(null); s.use(null); s.use(null); });
+const undef = probe(s => s.use(undefined));
+
+// Empty stack: finish() immediately, no Await.
+// use(null): loop sets needsAwait, finish via @promiseResolve(undefined).then → one tick later.
+shouldBe(empty !== one, true);
+
+// Multiple use(null) → only one Await(undefined) (needsAwait is boolean).
+shouldBe(one, two);
+shouldBe(two, three);
+
+// use(undefined) behaves the same as use(null).
+shouldBe(one, undef);
+
+// use(null) mixed with a real resource: the real resource's Await sets
+// hasAwaited=true, so the trailing Await(undefined) is skipped.
+{
+    let disposed = false;
+    const log = [];
+    const stack = new AsyncDisposableStack();
+    stack.use(null);
+    stack.use({ [Symbol.asyncDispose]() { disposed = true; } });
+    stack.use(null);
+    stack.disposeAsync().then(() => log.push("D"));
+    Promise.resolve()
+        .then(() => log.push("1"))
+        .then(() => log.push("2"))
+        .then(() => log.push("3"));
+    drainMicrotasks();
+    shouldBe(disposed, true);
+    // The real resource already provides a microtask boundary; timing should not
+    // be delayed by an additional Await(undefined).
+    const realOnly = probe(s => s.use({ [Symbol.asyncDispose]() {} }));
+    shouldBe(log.join(""), realOnly);
+}
+
+// use(null) + defer: defer's closure has a defined method, so hasAwaited
+// becomes true and the trailing Await is skipped.
+{
+    const stack = new AsyncDisposableStack();
+    let deferred = false;
+    stack.use(null);
+    stack.defer(() => { deferred = true; });
+    let resolved = false;
+    stack.disposeAsync().then(() => { resolved = true; });
+    drainMicrotasks();
+    shouldBe(deferred, true);
+    shouldBe(resolved, true);
+}
+
+// use(null) + error in another resource: error still propagates correctly.
+{
+    const stack = new AsyncDisposableStack();
+    stack.use(null);
+    stack.use({ [Symbol.asyncDispose]() { throw new Error("fail"); } });
+    stack.use(null);
+    let caught;
+    stack.disposeAsync().catch(e => { caught = e; });
+    drainMicrotasks();
+    shouldBe(caught.message, "fail");
+}
+
+// Sync DisposableStack.use(null) is still a no-op (existing behavior).
+{
+    const stack = new DisposableStack();
+    stack.use(null);
+    stack.use(undefined);
+    stack.dispose();
+    shouldBe(stack.disposed, true);
+}

--- a/JSTests/stress/asynciterator-prototype-symbol-async-dispose-return-argument.js
+++ b/JSTests/stress/asynciterator-prototype-symbol-async-dispose-return-argument.js
@@ -1,0 +1,55 @@
+//@ requireOptions("--useExplicitResourceManagement=1")
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+// %AsyncIteratorPrototype%[@@asyncDispose] step 6.a:
+//   Let result be Completion(Call(return.[[Value]], O, « undefined »)).
+// The return method must be called with exactly one argument (undefined),
+// matching for-await-of abrupt completion semantics. The sync
+// %IteratorPrototype%[@@dispose] calls return with no arguments (« »).
+
+async function* ag() {}
+const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(Object.getPrototypeOf(ag())));
+
+{
+    let argsLength, arg0;
+    const iter = Object.create(AsyncIteratorPrototype);
+    iter.return = function(...args) {
+        argsLength = args.length;
+        arg0 = args[0];
+        return {};
+    };
+    iter[Symbol.asyncDispose]();
+    drainMicrotasks();
+    shouldBe(argsLength, 1);
+    shouldBe(arg0, undefined);
+}
+
+// Sync @@dispose should still call return with no arguments
+{
+    const IteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
+    let argsLength;
+    const iter = Object.create(IteratorPrototype);
+    iter.return = function(...args) {
+        argsLength = args.length;
+        return {};
+    };
+    iter[Symbol.dispose]();
+    shouldBe(argsLength, 0);
+}
+
+// Observable via `arguments` object (no rest)
+{
+    let argsLength;
+    const iter = Object.create(AsyncIteratorPrototype);
+    iter.return = function() {
+        argsLength = arguments.length;
+        return {};
+    };
+    iter[Symbol.asyncDispose]();
+    drainMicrotasks();
+    shouldBe(argsLength, 1);
+}

--- a/JSTests/stress/asynciterator-prototype-symbol-async-dispose-return-null.js
+++ b/JSTests/stress/asynciterator-prototype-symbol-async-dispose-return-null.js
@@ -1,0 +1,60 @@
+//@ requireOptions("--useExplicitResourceManagement=1")
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+function shouldResolve(p, expected) {
+    let status, value;
+    p.then(v => { status = "resolved"; value = v; }, e => { status = "rejected"; value = e; });
+    drainMicrotasks();
+    if (status !== "resolved")
+        throw new Error(`Expected resolved but got ${status}: ${value}`);
+    shouldBe(value, expected);
+}
+
+// %AsyncIteratorPrototype%[@@asyncDispose] uses GetMethod(O, "return"),
+// which treats null the same as undefined. When `return` is null, the
+// promise should resolve with undefined rather than rejecting.
+
+async function* ag() {}
+const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(Object.getPrototypeOf(ag())));
+
+// return: null → resolved undefined
+{
+    const iter = Object.create(AsyncIteratorPrototype);
+    iter.return = null;
+    shouldResolve(iter[Symbol.asyncDispose](), undefined);
+}
+
+// return: undefined → resolved undefined (existing)
+{
+    const iter = Object.create(AsyncIteratorPrototype);
+    iter.return = undefined;
+    shouldResolve(iter[Symbol.asyncDispose](), undefined);
+}
+
+// return: callable → still invoked
+{
+    let called = false;
+    const iter = Object.create(AsyncIteratorPrototype);
+    iter.return = function() { called = true; return {}; };
+    shouldResolve(iter[Symbol.asyncDispose](), undefined);
+    shouldBe(called, true);
+}
+
+// await using with async iterator whose return is null
+{
+    let caught;
+    (async () => {
+        async function* gen() { yield 1; yield 2; }
+        const iter = gen();
+        iter.return = null;
+        {
+            await using x = iter;
+        }
+    })().catch(e => caught = e);
+    drainMicrotasks();
+    shouldBe(caught, undefined);
+}

--- a/JSTests/stress/iterator-prototype-symbol-dispose-return-null.js
+++ b/JSTests/stress/iterator-prototype-symbol-dispose-return-null.js
@@ -1,0 +1,54 @@
+//@ requireOptions("--useExplicitResourceManagement=1")
+
+function shouldBe(a, b) {
+    if (a !== b)
+        throw new Error(`Expected ${b} but got ${a}`);
+}
+
+// %IteratorPrototype%[@@dispose] uses GetMethod(O, "return"), which treats
+// null the same as undefined (ECMA-262 7.3.10 step 3). When `return` is null,
+// the method should no-op rather than attempting to call null.
+
+const IteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
+
+// return: null → no-op, no throw
+{
+    const iter = Object.create(IteratorPrototype);
+    iter.return = null;
+    iter[Symbol.dispose]();
+}
+
+// return: undefined → no-op (existing behavior)
+{
+    const iter = Object.create(IteratorPrototype);
+    iter.return = undefined;
+    iter[Symbol.dispose]();
+}
+
+// return: callable → still invoked (no regression)
+{
+    let called = false;
+    const iter = Object.create(IteratorPrototype);
+    iter.return = function() { called = true; return {}; };
+    iter[Symbol.dispose]();
+    shouldBe(called, true);
+}
+
+// return: non-callable non-null → still TypeError (not GetMethod's job, Call throws)
+{
+    const iter = Object.create(IteratorPrototype);
+    iter.return = 42;
+    let threw = false;
+    try { iter[Symbol.dispose](); } catch (e) { threw = e instanceof TypeError; }
+    shouldBe(threw, true);
+}
+
+// `using` declaration with an iterator whose return is null → dispose succeeds
+{
+    function* gen() { yield 1; yield 2; }
+    const iter = gen();
+    iter.return = null;
+    {
+        using x = iter;
+    }
+}

--- a/Source/JavaScriptCore/builtins/AsyncDisposableStackPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncDisposableStackPrototype.js
@@ -37,7 +37,7 @@ function adopt(value, onAsyncDispose)
     if (!@isCallable(onAsyncDispose))
         @throwTypeError("AsyncDisposableStack.prototype.adopt requires that onAsyncDispose argument be a callable");
 
-    var closure = () => { onAsyncDispose.@call(@undefined, value); }
+    var closure = () => onAsyncDispose.@call(@undefined, value);
     @addDisposableResource(@getAsyncDisposableStackInternalField(this, @asyncDisposableStackFieldCapability), @undefined, /* isAsync */ true, closure);
 
     return value;
@@ -88,6 +88,8 @@ function disposeAsync()
     var i = stack.length;
     var thrown = false;
     var suppressed;
+    var needsAwait = false;
+    var hasAwaited = false;
 
     var handleError = (result) => {
         if (thrown)
@@ -99,20 +101,35 @@ function disposeAsync()
         loop();
     };
 
+    var finish = () => {
+        if (thrown)
+            @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, suppressed);
+        else
+            @resolvePromiseWithFirstResolvingFunctionCallCheck(promise, @undefined);
+    };
+
     var loop = () => {
-        if (i) {
+        while (i) {
             var resource = stack[--i];
+            if (resource.method === @undefined) {
+                needsAwait = true;
+                continue;
+            }
+            var result;
             try {
-                @promiseResolve(@Promise, resource.method.@call(resource.value)).@then(loop, handleError);
+                result = resource.method.@call(resource.value);
             } catch (error) {
                 handleError(error);
+                return;
             }
-        } else {
-            if (thrown)
-                @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, suppressed);
-            else
-               @resolvePromiseWithFirstResolvingFunctionCallCheck(promise, @undefined);
+            hasAwaited = true;
+            @promiseResolve(@Promise, result).@then(loop, handleError);
+            return;
         }
+        if (needsAwait && !hasAwaited)
+            @promiseResolve(@Promise, @undefined).@then(finish, finish);
+        else
+            finish();
     };
 
     loop();
@@ -153,7 +170,7 @@ function use(value)
     if (@getAsyncDisposableStackInternalField(this, @asyncDisposableStackFieldState) === @AsyncDisposableStackStateDisposed)
         throw new @ReferenceError("AsyncDisposableStack.prototype.use requires that |this| be a pending AsyncDisposableStack object");
 
-    @addDisposableResource(@getDisposableStackInternalField(this, @disposableStackFieldCapability), value, /* isAsync */ true);
+    @addDisposableResource(@getAsyncDisposableStackInternalField(this, @asyncDisposableStackFieldCapability), value, /* isAsync */ true);
 
     return value;
 }

--- a/Source/JavaScriptCore/builtins/AsyncIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncIteratorPrototype.js
@@ -46,12 +46,12 @@ function asyncDispose()
         return promise;
     }
 
-    if (returnMethod === @undefined)
+    if (@isUndefinedOrNull(returnMethod))
         @resolvePromiseWithFirstResolvingFunctionCallCheck(promise, @undefined);
     else {
         var result;
         try {
-            result = returnMethod.@call(this);
+            result = returnMethod.@call(this, @undefined);
         } catch (e) {
             @rejectPromiseWithFirstResolvingFunctionCallCheck(promise, e);
             return promise;

--- a/Source/JavaScriptCore/builtins/DisposableStackPrototype.js
+++ b/Source/JavaScriptCore/builtins/DisposableStackPrototype.js
@@ -119,7 +119,7 @@ function addDisposableResource(disposeCapability, value, isAsync /* , method */)
 
     var resource;
     if (@argumentCount() < 4) {
-        if (@isUndefinedOrNull(value))
+        if (@isUndefinedOrNull(value) && !isAsync)
             return;
         resource = @createDisposableResource(value, isAsync);
     } else {

--- a/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
@@ -479,6 +479,6 @@ function dispose()
     "use strict";
 
     var returnMethod = this.return;
-    if (returnMethod !== @undefined)
+    if (!@isUndefinedOrNull(returnMethod))
         returnMethod.@call(this);
 }


### PR DESCRIPTION
#### 064f2d4d90abd572fe29f12254d95b58e8b43a65
<pre>
[JSC] Fix spec conformance bugs in Explicit Resource Management builtins
<a href="https://bugs.webkit.org/show_bug.cgi?id=310091">https://bugs.webkit.org/show_bug.cgi?id=310091</a>

Reviewed by Yusuke Suzuki.

Fixes in the runtime builtins (syntax implementation is unaffected):

1. AsyncDisposableStack.prototype.adopt: the closure discarded the
   onDisposeAsync return value, so disposeAsync never awaited it.
2. %IteratorPrototype%[@@dispose] / %AsyncIteratorPrototype%[@@asyncDispose]:
   GetMethod treats null as undefined; `return: null` should be a no-op.
3. %AsyncIteratorPrototype%[@@asyncDispose]: spec passes undefined as the
   sole argument to return (step 6.a).
4. AsyncDisposableStack.prototype.use(null): AddDisposableResource step 1.a
   only short-circuits for sync-dispose. The disposeAsync loop now handles
   method=undefined resources per DisposeResources steps 3.f and 6.
5. AsyncDisposableStack.prototype.use was calling the DisposableStack
   internal-field intrinsic; worked by coincidence (same enum offset).

Tests: JSTests/stress/async-disposable-stack-adopt-awaits-result.js
       JSTests/stress/async-disposable-stack-use-null-await.js
       JSTests/stress/asynciterator-prototype-symbol-async-dispose-return-argument.js
       JSTests/stress/asynciterator-prototype-symbol-async-dispose-return-null.js
       JSTests/stress/iterator-prototype-symbol-dispose-return-null.js

* JSTests/stress/async-disposable-stack-adopt-awaits-result.js: Added.
(shouldBe):
(const.slow.Promise.resolve.then):
(then):
(shouldBe.events.join):
* JSTests/stress/async-disposable-stack-use-null-await.js: Added.
(shouldBe):
(probe):
(const.empty.probe):
* JSTests/stress/asynciterator-prototype-symbol-async-dispose-return-argument.js: Added.
(shouldBe):
(async ag):
(const.AsyncIteratorPrototype.Object.getPrototypeOf.Object.getPrototypeOf.Object.getPrototypeOf.ag.iter.return):
(const.AsyncIteratorPrototype.Object.getPrototypeOf.Object.getPrototypeOf.Object.getPrototypeOf.ag):
(shouldBe.iter.return):
* JSTests/stress/asynciterator-prototype-symbol-async-dispose-return-null.js: Added.
(shouldBe):
(shouldResolve):
(async ag):
(const.AsyncIteratorPrototype.Object.getPrototypeOf.Object.getPrototypeOf.Object.getPrototypeOf.ag):
(shouldResolve.iter.return):
(shouldBe.):
* JSTests/stress/iterator-prototype-symbol-dispose-return-null.js: Added.
(shouldBe):
(const.IteratorPrototype.Object.getPrototypeOf.Object.getPrototypeOf.Symbol.iterator):
(iter.Symbol.dispose):
(iter.Symbol.dispose.iter.return):
(shouldBe.gen):
* Source/JavaScriptCore/builtins/AsyncDisposableStackPrototype.js:
(adopt):
(disposeAsync):
(use):
* Source/JavaScriptCore/builtins/AsyncIteratorPrototype.js:
(overriddenName.string_appeared_here.asyncDispose):
* Source/JavaScriptCore/builtins/DisposableStackPrototype.js:
(linkTimeConstant.addDisposableResource):
* Source/JavaScriptCore/builtins/JSIteratorPrototype.js:
(overriddenName.string_appeared_here.dispose):

Canonical link: <a href="https://commits.webkit.org/309462@main">https://commits.webkit.org/309462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9f9e18e9e5c8cecc698771fd980039c50463a7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150536 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159258 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/103970 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116164 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82526 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153496 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18274 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135044 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96892 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17373 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15323 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7106 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142519 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/126987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/12968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161732 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11334 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4852 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124162 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23096 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124360 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33801 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23084 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134763 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79463 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19455 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11523 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182018 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22698 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86496 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46544 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22410 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22562 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22464 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->