### PR TITLE
com.apple.WebKit.WebContent at WebCore:  unsigned int JSC::DataView::get<unsigned int>

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -39,16 +39,14 @@
 #import "SharedBuffer.h"
 #import "WebMAudioUtilitiesCocoa.h"
 #import <CoreMedia/CMFormatDescription.h>
-#import <JavaScriptCore/ArrayBuffer.h>
-#import <JavaScriptCore/DataView.h>
 #import <pal/avfoundation/MediaTimeAVFoundation.h>
 #import <pal/cf/CoreAudioExtras.h>
 #import <pal/spi/cocoa/AudioToolboxSPI.h>
 #import <wtf/Expected.h>
 #import <wtf/Scope.h>
-#import <wtf/SharedTask.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cf/TypeCastsCF.h>
+#import <wtf/cf/VectorCF.h>
 
 #import "CoreVideoSoftLink.h"
 #import "VideoToolboxSoftLink.h"
@@ -903,14 +901,8 @@ Vector<Ref<SharedBuffer>> getKeyIDs(CMFormatDescriptionRef description)
         // AVStreamDataParser will attach the 'tenc' box to each sample, not including the leading
         // size and boxType data. Extract the 'tenc' box and use that box to derive the sample's
         // keyID.
-        auto length = CFDataGetLength(trackEncryptionData.get());
-        auto ptr = (void*)(CFDataGetBytePtr(trackEncryptionData.get()));
-        Ref destructorFunction = createSharedTask<void(void*)>([data = WTF::move(trackEncryptionData)] (void*) { UNUSED_PARAM(data); });
-        Ref trackEncryptionDataBuffer = ArrayBuffer::create(JSC::ArrayBufferContents(ptr, length, std::nullopt, WTF::move(destructorFunction)));
-
         ISOTrackEncryptionBox trackEncryptionBox;
-        auto trackEncryptionView = JSC::DataView::create(WTF::move(trackEncryptionDataBuffer), 0, length);
-        if (!trackEncryptionBox.parseWithoutTypeAndSize(trackEncryptionView))
+        if (!trackEncryptionBox.parseWithoutTypeAndSize(span(trackEncryptionData.get())))
             return { };
         return { SharedBuffer::create(trackEncryptionBox.defaultKID()) };
     }

--- a/Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.cpp
@@ -50,9 +50,11 @@ bool ISOSchemeInformationBox::parse(DataView& view, unsigned& offset)
         if (localOffset + schemeSpecificBoxType.value().second > offset + m_size)
             return false;
 
-        m_schemeSpecificData = makeUnique<ISOTrackEncryptionBox>();
-        if (!m_schemeSpecificData->read(view, localOffset))
+        auto tencBox = makeUnique<ISOTrackEncryptionBox>();
+        if (!tencBox->read(view, localOffset))
             return false;
+
+        m_schemeSpecificData = WTF::move(tencBox);
     }
 
     return true;

--- a/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ISOTrackEncryptionBox.h"
 
+#include "BitReader.h"
 #include <JavaScriptCore/DataView.h>
 #include <wtf/StdLibExtras.h>
 
@@ -35,14 +36,6 @@ namespace WebCore {
 
 ISOTrackEncryptionBox::ISOTrackEncryptionBox() = default;
 ISOTrackEncryptionBox::~ISOTrackEncryptionBox() = default;
-
-bool ISOTrackEncryptionBox::parseWithoutTypeAndSize(DataView& view)
-{
-    // Clients may want to parse the contents of a `tenc` box without the
-    // leading size and name fields.
-    unsigned offset = 0;
-    return parseVersionAndFlags(view, offset) && parsePayload(view, offset);
-}
 
 bool ISOTrackEncryptionBox::parse(DataView& view, unsigned& offset)
 {
@@ -103,6 +96,67 @@ bool ISOTrackEncryptionBox::parsePayload(DataView& view, unsigned& offset)
             defaultConstantIV.append(character);
         }
         m_defaultConstantIV = WTF::move(defaultConstantIV);
+    }
+
+    return true;
+}
+
+bool ISOTrackEncryptionBox::parseWithoutTypeAndSize(std::span<const uint8_t> data)
+{
+    BitReader reader(data);
+
+    // parseVersionAndFlags: 1 byte version + 3 bytes flags
+    auto version = reader.read<uint8_t>();
+    if (!version)
+        return false;
+    m_version = *version;
+
+    auto flags = reader.read(24);
+    if (!flags)
+        return false;
+    m_flags = static_cast<uint32_t>(*flags);
+
+    // unsigned int(8) reserved = 0;
+    if (!reader.skipBytes(1))
+        return false;
+
+    if (!m_version) {
+        // unsigned int(8) reserved = 0;
+        if (!reader.skipBytes(1))
+            return false;
+    } else {
+        auto cryptAndSkip = reader.read<uint8_t>();
+        if (!cryptAndSkip)
+            return false;
+        m_defaultCryptByteBlock = static_cast<int8_t>(*cryptAndSkip) >> 4;
+        m_defaultSkipByteBlock = static_cast<int8_t>(*cryptAndSkip) & 0xF;
+    }
+
+    auto defaultIsProtected = reader.read<uint8_t>();
+    if (!defaultIsProtected)
+        return false;
+    m_defaultIsProtected = static_cast<int8_t>(*defaultIsProtected);
+
+    auto defaultPerSampleIVSize = reader.read<uint8_t>();
+    if (!defaultPerSampleIVSize)
+        return false;
+    m_defaultPerSampleIVSize = static_cast<int8_t>(*defaultPerSampleIVSize);
+
+    auto kIDOffset = reader.byteOffset();
+    if (data.size() < kIDOffset + 16)
+        return false;
+    m_defaultKID = data.subspan(kIDOffset, 16);
+    if (!reader.skipBytes(16))
+        return false;
+
+    if (m_defaultIsProtected == 1 && !m_defaultPerSampleIVSize) {
+        auto ivSize = reader.read<uint8_t>();
+        if (!ivSize)
+            return false;
+        auto ivOffset = reader.byteOffset();
+        if (data.size() < ivOffset + *ivSize)
+            return false;
+        m_defaultConstantIV = data.subspan(ivOffset, *ivSize);
     }
 
     return true;

--- a/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/ISOBox.h>
+#include <span>
 
 namespace WebCore {
 
@@ -43,13 +44,12 @@ public:
     Vector<uint8_t> defaultKID() const { return m_defaultKID; }
     Vector<uint8_t> defaultConstantIV() const { return m_defaultConstantIV; }
 
-    bool parseWithoutTypeAndSize(JSC::DataView&);
+    bool parseWithoutTypeAndSize(std::span<const uint8_t>);
 
     bool parse(JSC::DataView&, unsigned& offset) override;
 
 private:
     bool parsePayload(JSC::DataView&, unsigned& offset);
-
     std::optional<int8_t> m_defaultCryptByteBlock;
     std::optional<int8_t> m_defaultSkipByteBlock;
     int8_t m_defaultIsProtected { 0 };

--- a/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CoreMediaUtilities.mm
+++ b/Tools/TestWebKitAPI/Tests/WebCore/cocoa/CoreMediaUtilities.mm
@@ -27,7 +27,13 @@
 
 #if USE(AVFOUNDATION)
 
-#include <pal/avfoundation/MediaTimeAVFoundation.h>
+#import <CoreMedia/CMFormatDescription.h>
+#import <JavaScriptCore/JavaScriptCore.h>
+#import <WebCore/CMUtilities.h>
+#import <pal/avfoundation/MediaTimeAVFoundation.h>
+#import <wtf/RetainPtr.h>
+
+#import <pal/cf/CoreMediaSoftLink.h>
 
 namespace TestWebKitAPI {
 
@@ -36,5 +42,89 @@ TEST(PAL, MediaTime)
     EXPECT_EQ(PAL::toMediaTime(PAL::toCMTime(MediaTime::invalidTime())), MediaTime::invalidTime());
 }
 
+#if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
+
+static RetainPtr<CMFormatDescriptionRef> makeFormatDescriptionWithTencData(std::span<const uint8_t> tencData)
+{
+    auto data = adoptCF(CFDataCreate(kCFAllocatorDefault, tencData.data(), tencData.size()));
+    auto extensions = adoptNS([[NSDictionary alloc] initWithObjectsAndKeys:(__bridge NSData *)data.get(), @"CommonEncryptionTrackEncryptionBox", nil]);
+    CMFormatDescriptionRef desc = nullptr;
+    PAL::CMVideoFormatDescriptionCreate(kCFAllocatorDefault, kCMVideoCodecType_H264, 1920, 1080, (__bridge CFDictionaryRef)extensions.get(), &desc);
+    return adoptCF(desc);
+}
+
+TEST(CMUtilities, GetKeyIDsEmptyTencData)
+{
+    auto desc = makeFormatDescriptionWithTencData({ });
+    ASSERT_TRUE(desc);
+    EXPECT_TRUE(WebCore::getKeyIDs(desc.get()).isEmpty());
+}
+
+TEST(CMUtilities, GetKeyIDsTruncatedTencData)
+{
+    // 3 bytes — not enough to read the 4-byte version+flags field.
+    constexpr uint8_t truncated[] = { 0x00, 0x00, 0x00 };
+    auto desc = makeFormatDescriptionWithTencData(truncated);
+    ASSERT_TRUE(desc);
+    EXPECT_TRUE(WebCore::getKeyIDs(desc.get()).isEmpty());
+}
+
+TEST(CMUtilities, GetKeyIDsValidTencData)
+{
+    // Minimal v0 tenc box payload (no size/type prefix):
+    // version(1) + flags(3) + reserved(1) + reserved(1) + defaultIsProtected(1)
+    // + defaultPerSampleIVSize(1) + KID(16).
+    constexpr uint8_t validTenc[] = {
+        0x00, // version = 0
+        0x00, 0x00, 0x00, // flags
+        0x00, // reserved
+        0x00, // reserved (v0)
+        0x01, // defaultIsProtected = 1
+        0x08, // defaultPerSampleIVSize = 8
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // defaultKID (16 bytes)
+        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+    };
+    auto desc = makeFormatDescriptionWithTencData(validTenc);
+    ASSERT_TRUE(desc);
+    auto keyIDs = WebCore::getKeyIDs(desc.get());
+    ASSERT_EQ(keyIDs.size(), 1u);
+    ASSERT_EQ(keyIDs[0]->size(), 16u);
+    auto span = keyIDs[0]->span();
+    for (size_t i = 0; i < 16; ++i)
+        EXPECT_EQ(span[i], uint8_t(i));
+}
+
+TEST(CMUtilities, GetKeyIDsWithActiveGigacage)
+{
+    // Creating a JSContext initialises a JSC VM, which calls Gigacage::ensureGigacage()
+    // and sets g_gigacageConfig.isEnabled = true — the same state as WebContent.
+    @autoreleasepool {
+        JSContext * jsContext = [[JSContext alloc] init];
+        (void)jsContext;
+
+        constexpr uint8_t validTenc[] = {
+            0x00, // version = 0
+            0x00, 0x00, 0x00, // flags
+            0x00, // reserved
+            0x00, // reserved (v0)
+            0x01, // defaultIsProtected = 1
+            0x08, // defaultPerSampleIVSize = 8
+            0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, // defaultKID (16 bytes)
+            0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+        };
+        auto desc = makeFormatDescriptionWithTencData(validTenc);
+        ASSERT_TRUE(desc);
+        auto keyIDs = WebCore::getKeyIDs(desc.get());
+        ASSERT_EQ(keyIDs.size(), 1u);
+        ASSERT_EQ(keyIDs[0]->size(), 16u);
+        auto span = keyIDs[0]->span();
+        for (size_t i = 0; i < 16; ++i)
+            EXPECT_EQ(span[i], uint8_t(i));
+    }
+}
+
+#endif // ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
+
 } // namespace TestWebKitAPI
-#endif
+
+#endif // USE(AVFOUNDATION)


### PR DESCRIPTION
#### 77c68ec71672e3060e7f251645bc1429377ae4df
<pre>
com.apple.WebKit.WebContent at WebCore:  unsigned int JSC::DataView::get&lt;unsigned int&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=310089">https://bugs.webkit.org/show_bug.cgi?id=310089</a>
<a href="https://rdar.apple.com/171573373">rdar://171573373</a>

Reviewed by Youenn Fablet.

getKeyIDs parsed a CommonEncryptionTrackEncryptionBox CMFormatDescription
extension by wrapping the raw CFDataGetBytePtr() result in a JSC::ArrayBufferContents
and reading it via JSC::DataView.
0This caused an EXC_BAD_ACCESS (SIGBUS / KERN_PROTECTION_FAILURE) in WebContent processes.

The root cause is JSC&apos;s Gigacage security mitigation: DataView::baseAddress()
routes through CagedPtr::getMayBeNull() → Gigacage::caged(), which computes:
result = gigacageBasePtr + (ptr &amp; gigacageMask)

CFData memory is allocated outside the Gigacage, so after masking the result
falls in the Gigacage&apos;s reserved-but-inaccessible virtual address region.
Any read from that address crashes with SIGBUS.
In a WebContent process JSC is always initialised, so the Gigacage is always active;
When the AVStreamDataParser was run in the GPUP, the gigacage wasn&apos;t active
which prevented this bug from occurring.

Fix: avoid involving JSC at all.
ISOTrackEncryptionBox gains a new parseWithoutTypeAndSize(std::span&lt;const uint8_t&gt;)
overload that uses BitReader instead of JSC::DataView. getKeyIDs is updated to use span instead,
eliminating the ArrayBuffer, DataView, and their associated SharedTask destructor trampoline entirely.

Tests: Tools/TestWebKitAPI/Tests/WebCore/cocoa/CoreMediaUtilities.mm adds four API tests:

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::getKeyIDs):
* Source/WebCore/platform/graphics/iso/ISOSchemeInformationBox.cpp:
(WebCore::ISOSchemeInformationBox::parse):
* Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp:
(WebCore::ISOTrackEncryptionBox::parseWithoutTypeAndSize):
* Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.h:
* Tools/TestWebKitAPI/Tests/WebCore/cocoa/CoreMediaUtilities.mm:
(TestWebKitAPI::makeFormatDescriptionWithTencData):
(TestWebKitAPI::TEST(CMUtilities, GetKeyIDsEmptyTencData)):
(TestWebKitAPI::TEST(CMUtilities, GetKeyIDsTruncatedTencData)):
(TestWebKitAPI::TEST(CMUtilities, GetKeyIDsValidTencData)):
(TestWebKitAPI::TEST(CMUtilities, GetKeyIDsWithActiveGigacage)):

Canonical link: <a href="https://commits.webkit.org/309465@main">https://commits.webkit.org/309465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9227441d1f40c93f7b69c602d9bb273543a50038

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23480 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159444 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104156 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f73d4b1-99e7-4d25-ba9d-a21d1b0b6428) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116328 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82613 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/253ef3f9-3156-40e4-8ab3-ddd4c9ad3042) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135220 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97056 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff7cc517-90ad-44a0-bc18-d53e61657cd5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17534 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15485 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7292 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127148 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13144 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161918 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5039 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14699 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124328 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23282 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19532 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124526 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33804 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23270 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134939 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79659 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19602 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11701 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22884 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86684 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22596 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22748 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22650 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->