### PR TITLE
[OpenXR] Crash when closing a session with hit testing

### DIFF
--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp
@@ -44,7 +44,6 @@ std::unique_ptr<OpenXRHitTestManager> OpenXRHitTestManager::create(XrInstance in
 }
 
 OpenXRHitTestManager::OpenXRHitTestManager(XrInstance instance, XrSystemId systemId, XrSession session)
-    : m_session(session)
 {
 #if defined(XR_ANDROID_trackables) && defined(XR_ANDROID_raycast)
     uint32_t trackableTypeCapacity = 0;
@@ -67,8 +66,6 @@ OpenXRHitTestManager::OpenXRHitTestManager(XrInstance instance, XrSystemId syste
             break;
         }
     }
-#else
-    UNUSED_VARIABLE(m_session);
 #endif
 }
 
@@ -80,7 +77,7 @@ OpenXRHitTestManager::~OpenXRHitTestManager()
 #endif
 }
 
-Vector<PlatformXR::FrameData::HitTestResult> OpenXRHitTestManager::requestHitTest(const PlatformXR::Ray& ray, XrSpace space, XrTime time)
+Vector<PlatformXR::FrameData::HitTestResult> OpenXRHitTestManager::requestHitTest(XrSession session, const PlatformXR::Ray& ray, XrSpace space, XrTime time)
 {
 #if defined(XR_ANDROID_raycast)
     if (space == XR_NULL_HANDLE)
@@ -101,7 +98,7 @@ Vector<PlatformXR::FrameData::HitTestResult> OpenXRHitTestManager::requestHitTes
     xrHitResults.resultsCountOutput = 0;
     xrHitResults.results = nullptr;
 
-    CHECK_XRCMD(OpenXRExtensions::singleton().methods().xrRaycastANDROID(m_session, &raycastInfo, &xrHitResults));
+    CHECK_XRCMD(OpenXRExtensions::singleton().methods().xrRaycastANDROID(session, &raycastInfo, &xrHitResults));
     if (!xrHitResults.resultsCountOutput)
         return { };
 
@@ -110,7 +107,7 @@ Vector<PlatformXR::FrameData::HitTestResult> OpenXRHitTestManager::requestHitTes
     xrHitResults.resultsCapacityInput = xrHitResults.resultsCountOutput;
     xrHitResults.results = xrResults.mutableSpan().data();
 
-    CHECK_XRCMD(OpenXRExtensions::singleton().methods().xrRaycastANDROID(m_session, &raycastInfo, &xrHitResults));
+    CHECK_XRCMD(OpenXRExtensions::singleton().methods().xrRaycastANDROID(session, &raycastInfo, &xrHitResults));
 
     return xrResults.map([](auto& result) -> PlatformXR::FrameData::HitTestResult {
         return { XrPosefToPose(result.pose) };

--- a/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.h
+++ b/Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.h
@@ -35,10 +35,9 @@ public:
     static std::unique_ptr<OpenXRHitTestManager> create(XrInstance, XrSystemId, XrSession);
     OpenXRHitTestManager(XrInstance, XrSystemId, XrSession);
     ~OpenXRHitTestManager();
-    Vector<PlatformXR::FrameData::HitTestResult> requestHitTest(const PlatformXR::Ray&, XrSpace, XrTime);
+    Vector<PlatformXR::FrameData::HitTestResult> requestHitTest(XrSession, const PlatformXR::Ray&, XrSpace, XrTime);
 
 private:
-    XrSession m_session { XR_NULL_HANDLE };
 #if defined(XR_ANDROID_trackables)
     Vector<XrTrackableTrackerANDROID> m_trackableTrackers;
 #endif

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -67,7 +67,6 @@ struct OpenXRCoordinator::RenderState {
 #if ENABLE(WEBXR_HIT_TEST)
     HashMap<PlatformXR::HitTestSource, UniqueRef<PlatformXR::HitTestOptions>> hitTestSources;
     HashMap<PlatformXR::TransientInputHitTestSource, UniqueRef<PlatformXR::TransientInputHitTestOptions>> transientInputHitTestSources;
-    std::unique_ptr<OpenXRHitTestManager> hitTestManager;
 #endif
 };
 
@@ -401,9 +400,9 @@ void OpenXRCoordinator::requestHitTestSource(WebPageProxy& page, const PlatformX
 
             auto copiedOptions = makeUniqueRef<PlatformXR::HitTestOptions>(options);
             active.renderQueue->dispatch([this, renderState = active.renderState, options = WTF::move(copiedOptions), completionHandler = WTF::move(completionHandler)]() mutable {
-                if (!renderState->hitTestManager)
-                    renderState->hitTestManager = OpenXRHitTestManager::create(m_instance, m_systemId, m_session);
-                if (!renderState->hitTestManager) {
+                if (!m_hitTestManager)
+                    m_hitTestManager = OpenXRHitTestManager::create(m_instance, m_systemId, m_session);
+                if (!m_hitTestManager) {
                     callOnMainRunLoop([completionHandler = WTF::move(completionHandler)] mutable {
                         completionHandler(WebCore::Exception { WebCore::ExceptionCode::NotSupportedError });
                     });
@@ -464,9 +463,9 @@ void OpenXRCoordinator::requestTransientInputHitTestSource(WebPageProxy& page, c
 
             auto copiedOptions = makeUniqueRef<PlatformXR::TransientInputHitTestOptions>(options);
             active.renderQueue->dispatch([this, renderState = active.renderState, options = WTF::move(copiedOptions), completionHandler = WTF::move(completionHandler)]() mutable {
-                if (!renderState->hitTestManager)
-                    renderState->hitTestManager = OpenXRHitTestManager::create(m_instance, m_systemId, m_session);
-                if (!renderState->hitTestManager) {
+                if (!m_hitTestManager)
+                    m_hitTestManager = OpenXRHitTestManager::create(m_instance, m_systemId, m_session);
+                if (!m_hitTestManager) {
                     callOnMainRunLoop([completionHandler = WTF::move(completionHandler)] mutable {
                         completionHandler(WebCore::Exception { WebCore::ExceptionCode::NotSupportedError });
                     });
@@ -806,6 +805,9 @@ void OpenXRCoordinator::cleanupSessionAndAssociatedResources()
     m_layers.clear();
     m_views.clear();
     m_input.reset();
+#if ENABLE(WEBXR_HIT_TEST)
+    m_hitTestManager.reset();
+#endif
 
     if (m_session != XR_NULL_HANDLE) {
         CHECK_XRCMD(xrDestroySession(m_session));
@@ -1005,14 +1007,14 @@ PlatformXR::FrameData OpenXRCoordinator::populateFrameData(Box<RenderState> rend
 
 #if ENABLE(WEBXR_HIT_TEST)
     for (auto& pair : renderState->hitTestSources)
-        frameData.hitTestResults.add(pair.key, renderState->hitTestManager->requestHitTest(pair.value->offsetRay, spaceForHitTest(pair.value->nativeOrigin), renderState->frameState.predictedDisplayTime));
+        frameData.hitTestResults.add(pair.key, m_hitTestManager->requestHitTest(m_session, pair.value->offsetRay, spaceForHitTest(pair.value->nativeOrigin), renderState->frameState.predictedDisplayTime));
     for (auto& pair : renderState->transientInputHitTestSources) {
         Vector<PlatformXR::FrameData::TransientInputHitTestResult> results;
         for (const auto& inputSource : m_input->inputSources()) {
             if (inputSource->profiles().contains(pair.value->profile)) {
                 PlatformXR::FrameData::TransientInputHitTestResult result = {
                     inputSource->handle(),
-                    renderState->hitTestManager->requestHitTest(pair.value->offsetRay, inputSource->aimSpace(), renderState->frameState.predictedDisplayTime)
+                    m_hitTestManager->requestHitTest(m_session, pair.value->offsetRay, inputSource->aimSpace(), renderState->frameState.predictedDisplayTime)
                 };
                 results.append(WTF::move(result));
             }

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h
@@ -37,6 +37,9 @@ class GLDisplay;
 
 namespace WebKit {
 
+#if ENABLE(WEBXR_HIT_TEST)
+class OpenXRHitTestManager;
+#endif
 class OpenXRInput;
 class OpenXRLayer;
 class OpenXRSwapchain;
@@ -137,6 +140,10 @@ private:
     XrSpace m_floorSpace { XR_NULL_HANDLE };
 
     PlatformXR::LayerHandle m_nextLayerHandle { 1 };
+
+#if ENABLE(WEBXR_HIT_TEST)
+    std::unique_ptr<OpenXRHitTestManager> m_hitTestManager;
+#endif
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### a35addd14f70c012ca29dff8cd48ebc398dbebe2
<pre>
[OpenXR] Crash when closing a session with hit testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=310092">https://bugs.webkit.org/show_bug.cgi?id=310092</a>

Reviewed by Fujii Hironori.

Cleaning up all the associated resources to the session was not freeing
the hit test manager which stored the handle of the OpenXR session. That
was causing crashes when exiting sessions with hit test enabled as the
session might be freed without the manager ever noticing.

We&apos;re implementing a multi-level solution
* Move the hit test manager from the RenderState to an attribute of the
  coordinator, makes sense as it&apos;s associated to the session.
* Remove the XrSession handle from the manager, we better pass it when
  required, that way the manager won&apos;t ever use an already freed session
* Clean up the hit test manager when exiting the session.

No new tests as this was failing only on devices with hit testing
enabled when using OpenXR backend.

* Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.cpp:
(WebKit::OpenXRHitTestManager::OpenXRHitTestManager):
(WebKit::OpenXRHitTestManager::requestHitTest):
* Source/WebKit/UIProcess/XR/openxr/OpenXRHitTestManager.h:
(): Deleted.
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::requestHitTestSource):
(WebKit::OpenXRCoordinator::requestTransientInputHitTestSource):
(WebKit::OpenXRCoordinator::cleanupSessionAndAssociatedResources):
(WebKit::OpenXRCoordinator::populateFrameData):
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.h:

Canonical link: <a href="https://commits.webkit.org/309403@main">https://commits.webkit.org/309403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7d56ef69aebfcd79414019e5589674d1ffe39822

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159270 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/103982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116177 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/103982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18286 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96905 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17385 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15335 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7118 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/126999 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161744 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4864 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14531 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124175 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124373 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33765 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23096 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/134773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79475 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19466 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11533 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22710 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86508 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22422 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22574 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22476 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->