### PR TITLE
[WPE] Fix breakpad support broken since 303476@main

### DIFF
--- a/Source/WebKit/Shared/unix/BreakpadExceptionHandler.cpp
+++ b/Source/WebKit/Shared/unix/BreakpadExceptionHandler.cpp
@@ -29,8 +29,6 @@
 #if ENABLE(BREAKPAD)
 
 #include <breakpad/client/linux/handler/exception_handler.h>
-#include <mutex>
-#include <signal.h>
 #include <wtf/FileSystem.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -42,7 +40,7 @@ void installBreakpadExceptionHandler()
 
 #ifdef BREAKPAD_MINIDUMP_DIR
     if (breakpadMinidumpDir.isEmpty())
-        breakpadMinidumpDir = StringImpl::createFromCString(BREAKPAD_MINIDUMP_DIR);
+        breakpadMinidumpDir = String::fromUTF8(BREAKPAD_MINIDUMP_DIR);
 #endif
 
     if (breakpadMinidumpDir.isEmpty())
@@ -53,12 +51,10 @@ void installBreakpadExceptionHandler()
         return;
     }
 
-    static MainRunLoopNeverDestroyed<google_breakpad::ExceptionHandler> exceptionHandler = google_breakpad::MinidumpDescriptor(breakpadMinidumpDir.utf8().data()), nullptr,
+    static NeverDestroyed<google_breakpad::ExceptionHandler> exceptionHandler(google_breakpad::MinidumpDescriptor(breakpadMinidumpDir.utf8().data()), nullptr,
         [](const google_breakpad::MinidumpDescriptor&, void*, bool succeeded) -> bool {
             return succeeded;
         }, nullptr, true, -1);
-    });
-}
 }
 #endif
 


### PR DESCRIPTION
#### 936727f2151494a6c02c711f9b0a6a9738302e54
<pre>
[WPE] Fix breakpad support broken since 303476@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=310098">https://bugs.webkit.org/show_bug.cgi?id=310098</a>

Reviewed by Philippe Normand.

This replaces StringImpl::createFromCString with String::fromUTF8 when
getting the minidump directory from the environment, and then
MainRunLoopNeverDestroyed with NeverDestroyed, as the former asserts
when used before the run loop is created.

Tested by disabling the sandbox, as otherwise the directory access is
restricted.

* Source/WebKit/Shared/unix/BreakpadExceptionHandler.cpp:
(WebKit::installBreakpadExceptionHandler):

Canonical link: <a href="https://commits.webkit.org/309414@main">https://commits.webkit.org/309414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89d5b8734a510f2f4e018379f549a15f69e3dafd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23328 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16896 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159292 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104004 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116197 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/82539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96925 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17403 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15351 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7140 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127017 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161766 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4886 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14549 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124197 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19398 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124395 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33774 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23118 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134791 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79507 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19498 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11551 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22732 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86530 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22444 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22596 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->