### PR TITLE
Remove system from clang modules

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCore_Private.modulemap
+++ b/Source/JavaScriptCore/JavaScriptCore_Private.modulemap
@@ -1,4 +1,4 @@
-framework module JavaScriptCore_Private [system] {
+framework module JavaScriptCore_Private {
     // These ad-hoc explicit modules are the exhaustive set of headers that are both private and compatible
     // with both C and C++.
 

--- a/Source/WTF/wtf/module.modulemap
+++ b/Source/WTF/wtf/module.modulemap
@@ -1,4 +1,4 @@
-module wtf [system] {
+module wtf {
     explicit module Assertions {
         header "Assertions.h"
         export *

--- a/Source/WebCore/PAL/pal/module.modulemap
+++ b/Source/WebCore/PAL/pal/module.modulemap
@@ -1,4 +1,4 @@
-module pal [system] {
+module pal {
     explicit module ExportMacros {
         header "ExportMacros.h"
         export *

--- a/Source/WebCore/WebCore.modulemap
+++ b/Source/WebCore/WebCore.modulemap
@@ -1,2 +1,2 @@
-framework module WebCore [system] {
+framework module WebCore {
 }

--- a/Source/WebCore/WebCore_Private.modulemap
+++ b/Source/WebCore/WebCore_Private.modulemap
@@ -1,4 +1,4 @@
-framework module WebCore_Private [system] {
+framework module WebCore_Private {
     module PlatformExportMacros {
         header "PlatformExportMacros.h"
         export *

--- a/Source/WebGPU/WebGPU/Internal/module.modulemap
+++ b/Source/WebGPU/WebGPU/Internal/module.modulemap
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-module WebGPU_Internal [system] {
+module WebGPU_Internal {
     explicit module APIConversions {
         header "../APIConversions.h"
         export *

--- a/Source/WebGPU/WebGPU/WebGPU.modulemap
+++ b/Source/WebGPU/WebGPU/WebGPU.modulemap
@@ -1,2 +1,2 @@
-framework module WebGPU [system] {
+framework module WebGPU {
 }

--- a/Source/WebGPU/WebGPU/WebGPU_Private.modulemap
+++ b/Source/WebGPU/WebGPU/WebGPU_Private.modulemap
@@ -1,4 +1,4 @@
-framework module WebGPU_Private [system] {
+framework module WebGPU_Private {
     umbrella "PrivateHeaders"
 
     explicit module * {

--- a/Source/WebKit/Modules/Internal/module.modulemap
+++ b/Source/WebKit/Modules/Internal/module.modulemap
@@ -1,4 +1,4 @@
-module WebKit_Internal [system] {
+module WebKit_Internal {
     module AppKitSPI {
         requires cplusplus20
         header "../../Platform/spi/mac/AppKitSPI.h"

--- a/Source/WebKit/Modules/MacCatalyst.modulemap
+++ b/Source/WebKit/Modules/MacCatalyst.modulemap
@@ -1,4 +1,4 @@
-framework module WebKit [system] {
+framework module WebKit {
   umbrella header "WebKit.h"
   // Use <WebKitLegacy/WebKit.h> if available.
   exclude header "WebKitLegacy.h"

--- a/Source/WebKit/Modules/OSX.modulemap
+++ b/Source/WebKit/Modules/OSX.modulemap
@@ -1,4 +1,4 @@
-framework module WebKit [system] {
+framework module WebKit {
   umbrella header "WebKit.h"
   module * { export * }
   export *

--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -1,4 +1,4 @@
-framework module WebKit_Private [system] {
+framework module WebKit_Private {
   umbrella header "WebKitPrivate.h"
   export *
 

--- a/Source/WebKit/Modules/iOS.modulemap
+++ b/Source/WebKit/Modules/iOS.modulemap
@@ -1,4 +1,4 @@
-framework module WebKit [system] {
+framework module WebKit {
   umbrella header "WebKit.h"
   module * { export * }
   export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -1,6 +1,6 @@
 #include <TargetConditionals.h>
 
-framework module WebKit_Private [system] {
+framework module WebKit_Private {
   umbrella header "WebKitPrivate.h"
   export *
 

--- a/Source/WebKit/Platform/spi/Cocoa/Modules/WritingToolsUI_Private_SPI/module.modulemap
+++ b/Source/WebKit/Platform/spi/Cocoa/Modules/WritingToolsUI_Private_SPI/module.modulemap
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-module WritingToolsUI_Private_SPI [system] {
+module WritingToolsUI_Private_SPI {
     umbrella header "WritingToolsUISPI.h"
     link framework "WritingToolsUI"
     export *

--- a/Source/WebKit/Platform/spi/Cocoa/Modules/WritingTools_SPI/module.modulemap
+++ b/Source/WebKit/Platform/spi/Cocoa/Modules/WritingTools_SPI/module.modulemap
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-module WritingTools_SPI [system] {
+module WritingTools_SPI {
     umbrella header "WritingToolsSPI.h"
     link framework "WritingTools"
     export *

--- a/Source/WebKit/WebKitSwift/module.modulemap
+++ b/Source/WebKit/WebKitSwift/module.modulemap
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-module WebKitSwift [system] {
+module WebKitSwift {
     header "WebKitSwift.h"
     export *
 }

--- a/Source/WebKitLegacy/Modules/WebKitLegacy.private.modulemap
+++ b/Source/WebKitLegacy/Modules/WebKitLegacy.private.modulemap
@@ -1,4 +1,4 @@
-framework module WebKitLegacy [system] {
+framework module WebKitLegacy {
   umbrella "PrivateHeaders"
 
   explicit module * { export * }

--- a/Source/bmalloc/Configurations/module.modulemap
+++ b/Source/bmalloc/Configurations/module.modulemap
@@ -1,4 +1,4 @@
-module bmalloc [system] {
+module bmalloc {
     config_macros OS_UNFAIR_LOCK_INLINE
 
     explicit module pas_simple_free_heap_declarations_def {


### PR DESCRIPTION
#### 72e8a4e7e9ff29ca09ef2a1872f293f53d358780
<pre>
Remove system from clang modules
<a href="https://bugs.webkit.org/show_bug.cgi?id=310100">https://bugs.webkit.org/show_bug.cgi?id=310100</a>
<a href="https://rdar.apple.com/170129992">rdar://170129992</a>

Reviewed by NOBODY (OOPS!).

The [system] attribute is believed to inhibit the build process from
recognizing when Swift code needs to be rebuilt due to C++ header changes.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72e8a4e7e9ff29ca09ef2a1872f293f53d358780

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150568 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23326 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16894 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159290 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104002 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ccf33b2-b956-4b1a-9d4c-eb1afcc60c5a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152441 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23757 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23478 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116196 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82538 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3e0b1f0-274d-4235-8d5f-cd3f55c8ee60) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153528 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/23757 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/16894 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96924 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8146f35a-66e8-4919-96fc-07775778c489) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/23757 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/23478 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7138 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142551 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/23757 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/16894 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161764 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11366 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4884 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/16894 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124194 "Passed tests") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23128 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/23478 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124392 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23116 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/16894 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79505 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/23116 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/16894 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182050 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22730 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86528 "Failed to build and analyze WebKit") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46548 "Passed tests") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22442 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22594 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22496 "Hash 72e8a4e7 for PR 60769 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->