### PR TITLE
[Win] Cross-compile ARM64 from Linux

### DIFF
--- a/Source/WTF/wtf/simde/simde.h
+++ b/Source/WTF/wtf/simde/simde.h
@@ -33,9 +33,23 @@
 #endif
 #endif
 
+// Workaround: neon.h contains MSVC-specific workarounds guarded by _MSC_VER < 1938
+// that use intrinsics not available in clang-cl. Temporarily set _MSC_VER >= 1938
+// to skip those workarounds when building with clang-cl.
+// https://developercommunity.visualstudio.com/t/In-arm64_neonh-vsqaddb_u8-vsqaddh_u16/10271747
+#if defined(_MSC_VER) && defined(__clang__)
+#pragma push_macro("_MSC_VER")
+#undef _MSC_VER
+#define _MSC_VER 1938
+#endif
+
 IGNORE_WARNINGS_BEGIN("constant-conversion")
 IGNORE_WARNINGS_BEGIN("uninitialized")
 #include <wtf/simde/arm/neon.h>
 #include <wtf/simde/arm/sve.h>
 IGNORE_WARNINGS_END
 IGNORE_WARNINGS_END
+
+#if defined(_MSC_VER) && defined(__clang__)
+#pragma pop_macro("_MSC_VER")
+#endif

--- a/Source/cmake/OptionsMSVC.cmake
+++ b/Source/cmake/OptionsMSVC.cmake
@@ -25,7 +25,12 @@ if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_NAME STREQUAL "Wind
     string(APPEND CMAKE_CXX_FLAGS " -imsvc ${WIN_CRT_INC} -imsvc ${WIN_SDK_INC}/ucrt -imsvc ${WIN_SDK_INC}/um -imsvc ${WIN_SDK_INC}/shared -imsvc ${WIN_SDK_INC}/winrt")
 
     # Set linker library path flags
-    set(WIN_CROSS_LINK_FLAGS "-libpath:${WIN_CRT_LIB}/x64 -libpath:${WIN_SDK_LIB}/ucrt/x64 -libpath:${WIN_SDK_LIB}/um/x64")
+    if (WTF_CPU_ARM64)
+        set(WIN_LIB_ARCH "arm64")
+    else ()
+        set(WIN_LIB_ARCH "x64")
+    endif ()
+    set(WIN_CROSS_LINK_FLAGS "-libpath:${WIN_CRT_LIB}/${WIN_LIB_ARCH} -libpath:${WIN_SDK_LIB}/ucrt/${WIN_LIB_ARCH} -libpath:${WIN_SDK_LIB}/um/${WIN_LIB_ARCH}")
     string(APPEND CMAKE_EXE_LINKER_FLAGS " ${WIN_CROSS_LINK_FLAGS}")
     string(APPEND CMAKE_SHARED_LINKER_FLAGS " ${WIN_CROSS_LINK_FLAGS}")
     string(APPEND CMAKE_MODULE_LINKER_FLAGS " ${WIN_CROSS_LINK_FLAGS}")

--- a/Tools/Scripts/check-win-cross-build-deps
+++ b/Tools/Scripts/check-win-cross-build-deps
@@ -28,6 +28,7 @@ Validates that all required tools for building the Windows port from a Linux hos
 """
 
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -37,6 +38,21 @@ WEBKIT_LIBRARIES_WINDOWS = os.path.join(WEBKIT_ROOT, 'WebKitLibraries', 'windows
 
 VCPKG_DIR = os.path.join(WEBKIT_LIBRARIES_WINDOWS, 'vcpkg')
 XWIN_CACHE_DIR = os.path.join(WEBKIT_LIBRARIES_WINDOWS, '.xwin')
+
+# Determine host architecture and set arch-specific constants
+HOST_MACHINE = platform.machine()
+if HOST_MACHINE == 'aarch64':
+    CLANG_RT_ARCH = 'aarch64'
+    SDK_LIB_ARCH = 'arm64'
+    XWIN_HOST_ARCH = 'aarch64-unknown-linux-musl'
+    XWIN_ARCH_FLAG = ['--arch', 'aarch64']
+    CLANG_RT_PLATFORM = 'aarch64-pc-windows-msvc'
+else:
+    CLANG_RT_ARCH = 'x86_64'
+    SDK_LIB_ARCH = 'x64'
+    XWIN_HOST_ARCH = 'x86_64-unknown-linux-musl'
+    XWIN_ARCH_FLAG = []
+    CLANG_RT_PLATFORM = 'x86_64-pc-windows-msvc'
 
 REQUIRED_EXECUTABLES = [
     ('clang-cl-20', 'LLVM MSVC-compatible C/C++ compiler driver'),
@@ -48,10 +64,9 @@ REQUIRED_EXECUTABLES = [
     ('llvm-ranlib-20', 'LLVM archive indexer'),
     ('git', 'Version control (needed for vcpkg)'),
     ('cmake', 'Build system generator (needed for vcpkg)'),
-    ('wine', 'Wine PE executor (runs Windows .exe during cross-build)'),
 ]
 
-CLANG_RT_LIBRARY = 'clang_rt.builtins-x86_64.lib'
+CLANG_RT_LIBRARY = f'clang_rt.builtins-{CLANG_RT_ARCH}.lib'
 
 INSTALLATION_INSTRUCTIONS = {
     'clang-cl-20': 'sudo apt-get install clang-20 (from https://apt.llvm.org/) - clang-cl-20 is included with clang-20',
@@ -64,9 +79,8 @@ INSTALLATION_INSTRUCTIONS = {
     'git': 'sudo apt-get install git',
     'cmake': 'sudo apt-get install cmake',
     'xwin': f'Download from https://github.com/Jake-Shadle/xwin/releases and extract to {WEBKIT_LIBRARIES_WINDOWS}/',
-    'Windows SDK': f'Run `xwin --cache-dir {WEBKIT_LIBRARIES_WINDOWS}/.xwin splat --preserve-ms-arch-notation --output {WEBKIT_LIBRARIES_WINDOWS}/` (requires xwin)',
-    CLANG_RT_LIBRARY: f"Download clang+llvm-20.1.0-x86_64-pc-windows-msvc.tar.xz from https://github.com/llvm/llvm-project/releases, extract 'lib/clang/20/lib/windows/{CLANG_RT_LIBRARY}', move to {WEBKIT_LIBRARIES_WINDOWS}/",
-    'wine': 'See https://gitlab.winehq.org/wine/wine/-/wikis/Debian-Ubuntu',
+    'Windows SDK': f'Run `xwin {" ".join(XWIN_ARCH_FLAG)} --cache-dir {WEBKIT_LIBRARIES_WINDOWS}/.xwin splat --preserve-ms-arch-notation --output {WEBKIT_LIBRARIES_WINDOWS}/` (requires xwin)',
+    CLANG_RT_LIBRARY: f"Download clang+llvm-20.1.0-{CLANG_RT_PLATFORM}.tar.xz from https://github.com/llvm/llvm-project/releases, extract 'lib/clang/20/lib/windows/{CLANG_RT_LIBRARY}', move to {WEBKIT_LIBRARIES_WINDOWS}/",
     'vcpkg': f'Clone https://github.com/microsoft/vcpkg into {VCPKG_DIR} and run bootstrap-vcpkg.sh',
 }
 
@@ -92,13 +106,11 @@ def check_xwin():
 
 
 def check_clang_rt():
-    """Check for clang_rt.builtins-x86_64.lib in WebKitLibraries/windows/. Returns the path if found, None otherwise."""
+    """Check for clang_rt builtins lib in WebKitLibraries/windows/. Returns the path if found, None otherwise."""
     path = os.path.join(WEBKIT_LIBRARIES_WINDOWS, CLANG_RT_LIBRARY)
     if os.path.isfile(path):
         return path
     return None
-
-
 
 
 
@@ -136,7 +148,7 @@ def check_windows_sdk():
     """Check if Windows SDK is present. Returns True if found, False otherwise."""
     sdk_files = [
         os.path.join(WEBKIT_LIBRARIES_WINDOWS, 'sdk', 'include', 'um', 'windows.h'),
-        os.path.join(WEBKIT_LIBRARIES_WINDOWS, 'sdk', 'lib', 'um', 'x64', 'kernel32.lib'),
+        os.path.join(WEBKIT_LIBRARIES_WINDOWS, 'sdk', 'lib', 'um', SDK_LIB_ARCH, 'kernel32.lib'),
         os.path.join(WEBKIT_LIBRARIES_WINDOWS, 'crt', 'include', 'vcruntime.h'),
     ]
     return all(os.path.isfile(f) for f in sdk_files)
@@ -149,9 +161,9 @@ def create_lib_symlinks_for_case_sensitivity():
     case than they exist on disk. We create symlinks for common patterns.
     """
     lib_dirs = [
-        os.path.join(WEBKIT_LIBRARIES_WINDOWS, 'sdk', 'lib', 'um', 'x64'),
-        os.path.join(WEBKIT_LIBRARIES_WINDOWS, 'sdk', 'lib', 'ucrt', 'x64'),
-        os.path.join(WEBKIT_LIBRARIES_WINDOWS, 'crt', 'lib', 'x64'),
+        os.path.join(WEBKIT_LIBRARIES_WINDOWS, 'sdk', 'lib', 'um', SDK_LIB_ARCH),
+        os.path.join(WEBKIT_LIBRARIES_WINDOWS, 'sdk', 'lib', 'ucrt', SDK_LIB_ARCH),
+        os.path.join(WEBKIT_LIBRARIES_WINDOWS, 'crt', 'lib', SDK_LIB_ARCH),
     ]
 
     # Known CamelCase library names that need specific symlinks
@@ -224,9 +236,8 @@ def create_lib_symlinks_for_case_sensitivity():
 def download_windows_sdk(xwin_path):
     """Download Windows SDK/CRT using xwin splat."""
     print('Downloading Windows SDK and CRT (this may take a while)...')
-    result = subprocess.run(
-        [xwin_path, '--cache-dir', XWIN_CACHE_DIR, 'splat', '--preserve-ms-arch-notation', '--include-debug-libs', '--output', WEBKIT_LIBRARIES_WINDOWS]
-    )
+    xwin_cmd = [xwin_path] + XWIN_ARCH_FLAG + ['--accept-license', '--cache-dir', XWIN_CACHE_DIR, 'splat', '--preserve-ms-arch-notation', '--include-debug-libs', '--output', WEBKIT_LIBRARIES_WINDOWS]
+    result = subprocess.run(xwin_cmd)
     if result.returncode != 0:
         print('Error downloading SDK.')
         return False
@@ -258,7 +269,7 @@ def download_xwin():
     """Download and install xwin to WebKitLibraries/windows/."""
     import tarfile
 
-    XWIN_URL = 'https://github.com/Jake-Shadle/xwin/releases/download/0.7.0/xwin-0.7.0-x86_64-unknown-linux-musl.tar.gz'
+    XWIN_URL = f'https://github.com/Jake-Shadle/xwin/releases/download/0.7.0/xwin-0.7.0-{XWIN_HOST_ARCH}.tar.gz'
     tarball_path = '/tmp/xwin.tar.gz'
 
     # Download
@@ -288,12 +299,12 @@ def download_xwin():
 
 
 def download_clang_rt():
-    """Download clang_rt.builtins-x86_64.lib from LLVM Windows release."""
+    """Download clang_rt builtins library from LLVM Windows release."""
     import tarfile
 
     LLVM_VERSION = '20.1.0'
     CLANG_MAJOR_VERSION = '20'
-    ARCHIVE_NAME = f'clang+llvm-{LLVM_VERSION}-x86_64-pc-windows-msvc'
+    ARCHIVE_NAME = f'clang+llvm-{LLVM_VERSION}-{CLANG_RT_PLATFORM}'
     LLVM_URL = f'https://github.com/llvm/llvm-project/releases/download/llvmorg-{LLVM_VERSION}/{ARCHIVE_NAME}.tar.xz'
     archive_path = '/tmp/clang-llvm-win.tar.xz'
     lib_path_in_archive = f'{ARCHIVE_NAME}/lib/clang/{CLANG_MAJOR_VERSION}/lib/windows/{CLANG_RT_LIBRARY}'
@@ -323,8 +334,8 @@ def create_dummy_pwsh():
     """Create a dummy pwsh script to satisfy vcpkg's PowerShell check.
 
     vcpkg's vcpkg_copy_tool_dependencies.cmake requires PowerShell on Windows.
-    When cross-compiling from Linux, we don't need this functionality (Wine
-    handles DLL resolution), so we provide a dummy that exits successfully.
+    When cross-compiling from Linux, we don't need this functionality, so we
+    provide a dummy that exits successfully.
 
     Returns the path to the created pwsh script.
     """

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -2872,8 +2872,8 @@ sub generateBuildSystemFromCMakeProject
 
     if (shouldUseVcpkg()) {
         push @args, '-DCMAKE_TOOLCHAIN_FILE="' . $ENV{VCPKG_ROOT} . '\\scripts\\buildsystems\\vcpkg.cmake"';
-        if (architecture() eq "ARM64") {
-            push @args, '-DVCPKG_TARGET_TRIPLET=arm64-windows-static-md';
+        if (architecture() eq "arm64") {
+            push @args, '-DVCPKG_TARGET_TRIPLET=arm64-windows-webkit';
         } else {
             push @args, '-DVCPKG_TARGET_TRIPLET=x64-windows-webkit'
         }
@@ -2900,7 +2900,8 @@ sub generateBuildSystemFromCMakeProject
             # Set linker library paths
             my $sdkLib = "$sysroot/sdk/lib";
             my $crtLib = "$sysroot/crt/lib";
-            my $linkFlags = "-libpath:$crtLib/x64 -libpath:$sdkLib/ucrt/x64 -libpath:$sdkLib/um/x64";
+            my $libArch = (architecture() eq "arm64") ? "arm64" : "x64";
+            my $linkFlags = "-libpath:$crtLib/$libArch -libpath:$sdkLib/ucrt/$libArch -libpath:$sdkLib/um/$libArch";
             push @args, "-DCMAKE_EXE_LINKER_FLAGS_INIT=\"$linkFlags\"";
             push @args, "-DCMAKE_SHARED_LINKER_FLAGS_INIT=\"$linkFlags\"";
             push @args, "-DCMAKE_MODULE_LINKER_FLAGS_INIT=\"$linkFlags\"";

--- a/Tools/TestWebKitAPI/Tests/WTF/Signals.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Signals.cpp
@@ -84,6 +84,8 @@ TEST(Signals, SignalsAccessFault)
         handlerRan = true;
 #if CPU(ARM)
         context.Pc += 2;
+#elif CPU(ARM64)
+        context.Pc += 4;
 #elif CPU(X86)
         context.Eip += 3;
 #elif CPU(X86_64)

--- a/WebKitLibraries/triplets/arm64-windows-webkit.cmake
+++ b/WebKitLibraries/triplets/arm64-windows-webkit.cmake
@@ -1,4 +1,4 @@
-set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_TARGET_ARCHITECTURE arm64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE dynamic)
 
@@ -30,11 +30,11 @@ if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
     # Pass compiler/linker flags so vcpkg port builds find the Windows SDK/CRT
     set(VCPKG_C_FLAGS "-imsvc ${CRT_INC} -imsvc ${SDK_INC}/ucrt -imsvc ${SDK_INC}/um -imsvc ${SDK_INC}/shared -imsvc ${SDK_INC}/winrt")
     set(VCPKG_CXX_FLAGS "${VCPKG_C_FLAGS}")
-    set(VCPKG_LINKER_FLAGS "/LIBPATH:${CRT_LIB}/x64 /LIBPATH:${SDK_LIB}/ucrt/x64 /LIBPATH:${SDK_LIB}/um/x64")
+    set(VCPKG_LINKER_FLAGS "/LIBPATH:${CRT_LIB}/arm64 /LIBPATH:${SDK_LIB}/ucrt/arm64 /LIBPATH:${SDK_LIB}/um/arm64")
 
     # Also set INCLUDE/LIB env vars (used by some ports' build systems directly)
     set(ENV{INCLUDE} "${CRT_INC};${SDK_INC}/ucrt;${SDK_INC}/um;${SDK_INC}/shared;${SDK_INC}/winrt")
-    set(ENV{LIB} "${CRT_LIB}/x64;${SDK_LIB}/ucrt/x64;${SDK_LIB}/um/x64")
+    set(ENV{LIB} "${CRT_LIB}/arm64;${SDK_LIB}/ucrt/arm64;${SDK_LIB}/um/arm64")
 
     # Prevent pkg-config from finding host system packages during cross-compilation.
     # set(ENV{...}) in the triplet only affects cmake's own process, not port build

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -7,15 +7,17 @@
   "registries": [
     {
       "kind": "git",
-      "baseline": "f2cc8d17478bb2bbf7ff78b3efb604dc8acf5b24",
+      "baseline": "0895db3bb0f653fab1ef3d377d2c231c971063df",
       "repository": "https://github.com/WebKitForWindows/WebKitRequirements",
       "packages": [
         "cairo",
         "curl",
         "icu",
+        "libwebp",
         "openssl",
         "vcpkg-tool-meson",
-        "zlib"
+        "zlib",
+        "zlib-ng"
       ]
     }
   ],


### PR DESCRIPTION
#### 2e7c3456cd6de1d262ac00c10501868f124526db
<pre>
[Win] Cross-compile ARM64 from Linux
<a href="https://bugs.webkit.org/show_bug.cgi?id=309681">https://bugs.webkit.org/show_bug.cgi?id=309681</a>

Reviewed by Yusuke Suzuki.

Update WebKitRequirements to pull in vcpkg fixes.

Remove wine requirement from check-win-cross-build-deps, we now build
the Linux icu tools and use those to generate the required icu files.

Fix to neon.h for clang-cl build that was previously applied downstream
by Bun on their WebKit fork.

Canonical link: <a href="https://commits.webkit.org/311670@main">https://commits.webkit.org/311670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4afca12bd1e8308e0f220b2817185729221b70c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28874 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164377 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/109430 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28724 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120439 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84913 "3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158573 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139741 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101128 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21715 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19834 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12207 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147664 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166856 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16446 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11032 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128564 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128710 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35303 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139366 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86171 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23511 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16163 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187499 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28036 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92139 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48056 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27613 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27843 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->