### PR TITLE
[WIP] GRA: restrict coalescing of const def to preserve property

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -1522,18 +1522,21 @@ private:
     class AffinityGroup {
         WTF_MAKE_NONCOPYABLE(AffinityGroup);
     public:
-        AffinityGroup(Tmp tmp0, const LiveRange& range0, Tmp tmp1, const LiveRange& range1)
+        AffinityGroup(Tmp tmp0, const LiveRange& range0, bool isConstDef0, bool isSingleDef0,
+            Tmp tmp1, const LiveRange& range1, bool isConstDef1, bool isSingleDef1)
         {
-            addMember(tmp0, range0);
-            addMember(tmp1, range1);
+            addMember(tmp0, range0, isConstDef0, isSingleDef0);
+            addMember(tmp1, range1, isConstDef1, isSingleDef1);
         }
         AffinityGroup(AffinityGroup&&) = default;
         AffinityGroup& operator=(AffinityGroup&&) = default;
 
-        void addMember(Tmp tmp, const LiveRange& range)
+        void addMember(Tmp tmp, const LiveRange& range, bool isConstDef, bool isSingleDef)
         {
             m_members.append(tmp);
             m_liveness.add(tmp, range);
+            m_hasConstDef |= isConstDef;
+            m_allMembersSingleDef &= isSingleDef;
         }
 
         // Merges the other group into this one.
@@ -1541,8 +1544,12 @@ private:
         {
             m_liveness.merge(WTF::move(other.m_liveness));
             m_members.appendVector(other.m_members);
+            m_hasConstDef |= other.m_hasConstDef;
+            m_allMembersSingleDef &= other.m_allMembersSingleDef;
             other.m_members.clear();
         }
+
+        bool canPropagateConstDef() const { return m_hasConstDef && m_allMembersSingleDef; }
 
         const Vector<Tmp>& members() const { return m_members; }
         size_t size() const { return m_members.size(); }
@@ -1569,6 +1576,8 @@ private:
         }
 
         Tmp m_representative; // Only set for non-empty groups at finalization
+        bool m_hasConstDef { false };
+        bool m_allMembersSingleDef { true };
 
     private:
         Vector<Tmp> m_members;
@@ -1584,8 +1593,20 @@ private:
     void coalesceSingletons(Tmp tmp0, Tmp tmp1, Vector<AffinityGroup<bank>>& groups, TmpGroupMap<bank>& tmpToGroup)
     {
         ASSERT(isInCoalescables<bank>(tmp1, m_map.get<bank>(tmp0).coalescables) && isInCoalescables<bank>(tmp0, m_map.get<bank>(tmp1).coalescables));
+        auto idx0 = AbsoluteTmpMapper<bank>::absoluteIndex(tmp0);
+        auto idx1 = AbsoluteTmpMapper<bank>::absoluteIndex(tmp1);
+        bool isConstDef0 = m_useCounts.isConstDef<bank>(idx0);
+        bool isConstDef1 = m_useCounts.isConstDef<bank>(idx1);
+        bool isSingleDef0 = m_useCounts.isSingleDef<bank>(idx0);
+        bool isSingleDef1 = m_useCounts.isSingleDef<bank>(idx1);
+        if ((isConstDef0 && !isSingleDef1) || (isConstDef1 && !isSingleDef0)) {
+            m_stats[bank].numGroupConstDefPreserved++;
+            dataLogLnIf(verbose(), "Skipping coalesce: const def ", tmp0, " ", tmp1);
+            return;
+        }
         auto newIndex = groups.size();
-        groups.constructAndAppend(tmp0, m_map.get<bank>(tmp0).liveRange, tmp1, m_map.get<bank>(tmp1).liveRange);
+        groups.constructAndAppend(tmp0, m_map.get<bank>(tmp0).liveRange, isConstDef0, isSingleDef0,
+            tmp1, m_map.get<bank>(tmp1).liveRange, isConstDef1, isSingleDef1);
         tmpToGroup[tmp0] = newIndex;
         tmpToGroup[tmp1] = newIndex;
         dataLogLnIf(verbose(), "Created group ", newIndex, ": ", groups[newIndex]);
@@ -1594,8 +1615,18 @@ private:
     template<Bank bank>
     bool tryCoalesceSingletonWithGroup(Tmp singleton, GroupIndex groupIndex, Vector<AffinityGroup<bank>>& groups, TmpGroupMap<bank>& tmpToGroup)
     {
-        const auto& group = groups[groupIndex];
+        auto& group = groups[groupIndex];
         TmpData& singletonData = m_map.get<bank>(singleton);
+        auto singletonIdx = AbsoluteTmpMapper<bank>::absoluteIndex(singleton);
+        bool singletonIsConstDef = m_useCounts.isConstDef<bank>(singletonIdx);
+        bool singletonIsSingleDef = m_useCounts.isSingleDef<bank>(singletonIdx);
+
+        if ((singletonIsConstDef && !group.m_allMembersSingleDef)
+            || (group.m_hasConstDef && !singletonIsSingleDef)) {
+            m_stats[bank].numGroupConstDefPreserved++;
+            dataLogLnIf(verbose(), "Skipping coalesce: const def ", singleton, " with group ", groupIndex);
+            return false;
+        }
 
         bool conflict = false;
         group.forEachOverlap(singletonData.liveRange, [&](const auto& tmpList) {
@@ -1614,7 +1645,7 @@ private:
         if (conflict)
             return false;
 
-        groups[groupIndex].addMember(singleton, singletonData.liveRange);
+        groups[groupIndex].addMember(singleton, singletonData.liveRange, singletonIsConstDef, singletonIsSingleDef);
         tmpToGroup[singleton] = groupIndex;
         dataLogLnIf(verbose(), "Added ", singleton, " to group ", groupIndex);
         return true;
@@ -1623,8 +1654,15 @@ private:
     template<Bank bank>
     bool tryCoalesceGroups(GroupIndex groupIndex0, GroupIndex groupIndex1, Vector<AffinityGroup<bank>>& groups, TmpGroupMap<bank>& tmpToGroup)
     {
-        const auto& group0 = groups[groupIndex0];
-        const auto& group1 = groups[groupIndex1];
+        auto& group0 = groups[groupIndex0];
+        auto& group1 = groups[groupIndex1];
+
+        if ((group0.m_hasConstDef && !group1.m_allMembersSingleDef)
+            || (group1.m_hasConstDef && !group0.m_allMembersSingleDef)) {
+            m_stats[bank].numGroupConstDefPreserved++;
+            dataLogLnIf(verbose(), "Skipping coalesce: const def between groups ", groupIndex0, " and ", groupIndex1);
+            return false;
+        }
 
         bool conflict = false;
         AffinityGroup<bank>::forEachPairwiseOverlap(group0, group1, [&](const auto& tmpListA, const auto& tmpListB) {
@@ -1827,6 +1865,31 @@ private:
                 memberData.stage = Stage::Coalesced;
             }
             m_tmpWidth.setWidths(representative, useWidth, defWidth);
+
+            // Propagate const def property to the representative. When a group has exactly one
+            // const def member and all other members are single-def (their only def is the
+            // coalescable move that gets deleted), the representative's sole remaining def after
+            // move elimination is the const def's Move imm, representative.
+            if (group.canPropagateConstDef()) {
+                auto representativeAbsIdx = AbsoluteTmpMapper<bank>::absoluteIndex(representative);
+                for (Tmp member : group.members()) {
+                    auto memberIdx = AbsoluteTmpMapper<bank>::absoluteIndex(member);
+                    if (m_useCounts.isConstDef<bank>(memberIdx)) {
+                        if constexpr (bank == GP)
+                            m_useCounts.registerGPConstDef(representativeAbsIdx, m_useCounts.constant<GP>(memberIdx));
+                        else
+                            m_useCounts.registerFPConstDef(representativeAbsIdx, m_useCounts.constant<FP>(memberIdx), m_useCounts.constantWidth<FP>(memberIdx));
+                        // Recompute cost with the 0.1x const def multiplier applied to total raw uses.
+                        float rawUses = 0;
+                        for (Tmp m : group.members())
+                            rawUses += m_useCounts.numWarmUsesAndDefs<bank>(AbsoluteTmpMapper<bank>::absoluteIndex(m));
+                        cost = rawUses * 0.1;
+                        m_stats[bank].numGroupConstDefPropagated++;
+                        dataLogLnIf(verbose(), "Propagated const def from ", member, " to representative ", representative);
+                        break;
+                    }
+                }
+            }
 
             m_map.append(representative, TmpData());
             TmpData& representativeData = m_map.get<bank>(representative);
@@ -2685,6 +2748,8 @@ private:
                                 arg = imm;
                                 if (inst.isValidForm()) {
                                     m_stats[bank].numRematerializeConst++;
+                                    if (m_useCounts.isRegisteredConstDef<bank>(tmpIndex))
+                                        m_stats[bank].numGroupConstDefRematerialized++;
                                     dataLogLnIf(verbose(), "Rematerialized (direct imm), BB", *block, " arg=", oldArg, ", inst=", inst);
                                     return;
                                 }
@@ -2781,12 +2846,16 @@ private:
                                 if (Arg::isValidImmForm(value) && isValidForm(Move, Arg::Imm, Arg::Tmp)) {
                                     m_insertionSets[block].insert(instIndex, spillLoad, Move, inst.origin, Arg::imm(value), tmp);
                                     m_stats[bank].numRematerializeConst++;
+                                    if (m_useCounts.isRegisteredConstDef<bank>(tmpIndex))
+                                        m_stats[bank].numGroupConstDefRematerialized++;
                                     dataLogLnIf(verbose(), "Rematerialized (imm) BB", *block, " ", originalTmp, ": ", tmp, " <- ", WTF::RawHex(value));
                                     return true;
                                 }
                                 RELEASE_ASSERT(isValidForm(Move, Arg::BigImm, Arg::Tmp));
                                 m_insertionSets[block].insert(instIndex, spillLoad, Move, inst.origin, Arg::bigImm(value), tmp);
                                 m_stats[bank].numRematerializeConst++;
+                                if (m_useCounts.isRegisteredConstDef<bank>(tmpIndex))
+                                    m_stats[bank].numGroupConstDefRematerialized++;
                                 dataLogLnIf(verbose(), "Rematerialized (bigImm) BB", *block, " ", originalTmp, ": ", tmp, " <- ", WTF::RawHex(value));
                                 return true;
                             } else {
@@ -2817,6 +2886,8 @@ private:
                                 if (imm && isValidForm(constMove, imm.kind(), Arg::Tmp)) {
                                     m_insertionSets[block].insert(instIndex, spillLoad, constMove, inst.origin, imm, tmp);
                                     m_stats[bank].numRematerializeConst++;
+                                    if (m_useCounts.isRegisteredConstDef<bank>(tmpIndex))
+                                        m_stats[bank].numGroupConstDefRematerialized++;
                                     dataLogLnIf(verbose(), "Rematerialized (FP) BB", *block, " ", originalTmp, ": ", tmp);
                                     return true;
                                 }

--- a/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
+++ b/Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h
@@ -64,6 +64,9 @@ namespace JSC { namespace B3 { namespace Air {
     macro(numGroupsCreated)                     \
     macro(numGroupMovesCoalesced)               \
     macro(numGroupConstDefMerged)               \
+    macro(numGroupConstDefPreserved)            \
+    macro(numGroupConstDefPropagated)           \
+    macro(numGroupConstDefRematerialized)       \
     macro(maxGroupSize)                         \
     macro(numInsts)                             \
 

--- a/Source/JavaScriptCore/b3/air/AirUseCounts.h
+++ b/Source/JavaScriptCore/b3/air/AirUseCounts.h
@@ -33,6 +33,7 @@
 #include "AirInstInlines.h"
 #include "AirTmpInlines.h"
 #include <wtf/CommaPrinter.h>
+#include <wtf/HashMap.h>
 #include <wtf/Vector.h>
 
 namespace JSC { namespace B3 { namespace Air {
@@ -59,15 +60,16 @@ public:
         unsigned gpArraySize = AbsoluteTmpMapper<GP>::absoluteIndex(code.numTmps(GP));
         m_gpNumWarmUsesAndDefs = FixedVector<float>(gpArraySize, 0);
         m_gpConstDefs.ensureSize(gpArraySize);
-        BitVector gpNonConstDefs = m_gpConstDefs;
-        m_gpConstants = FixedVector<int64_t>(gpArraySize, 0);
+        m_gpHasMultipleDefs.ensureSize(gpArraySize);
+        BitVector gpHasAnyDef;
+        gpHasAnyDef.ensureSize(gpArraySize);
 
         unsigned fpArraySize = AbsoluteTmpMapper<FP>::absoluteIndex(code.numTmps(FP));
         m_fpNumWarmUsesAndDefs = FixedVector<float>(fpArraySize, 0);
         m_fpConstDefs.ensureSize(fpArraySize);
-        BitVector fpNonConstDefs = m_fpConstDefs;
-        m_fpConstants = FixedVector<v128_t>(fpArraySize, v128_t { });
-        m_fpConstantWidths = FixedVector<Width>(fpArraySize, Width8);
+        m_fpHasMultipleDefs.ensureSize(fpArraySize);
+        BitVector fpHasAnyDef;
+        fpHasAnyDef.ensureSize(fpArraySize);
 
         auto extractGPConstant = [&](Air::Opcode opcode, const Air::Arg& arg) -> int64_t {
             return opcode == Move32 ? static_cast<int64_t>(static_cast<uint64_t>(static_cast<uint32_t>(static_cast<uint64_t>(arg.value())))) : arg.value();
@@ -82,6 +84,10 @@ public:
             return v;
         };
 
+        // Per-tmp state machine: on every def, if hasAnyDef then hasMultipleDefs.
+        // On const-style defs (Move imm, tmp), additionally set hasConstDef and store
+        // the constant (only on first def, since it's only useful if there are no other defs).
+        // At the end: isConstDef = hasConstDef && !hasMultipleDefs.
         for (BasicBlock* block : code) {
             double frequency = block->frequency();
             if (!fastWorklist.saw(block))
@@ -94,11 +100,13 @@ public:
                         Tmp tmp = inst.args[1].as<Tmp>();
                         if (tmp.bank() == GP) {
                             auto index = AbsoluteTmpMapper<GP>::absoluteIndex(tmp);
-                            if (!m_gpConstDefs.quickGet(index)) {
+                            if (gpHasAnyDef.quickGet(index))
+                                m_gpHasMultipleDefs.quickSet(index);
+                            else {
+                                gpHasAnyDef.quickSet(index);
                                 m_gpConstDefs.quickSet(index);
-                                m_gpConstants[index] = extractGPConstant(inst.kind.opcode, inst.args[0]);
-                            } else
-                                gpNonConstDefs.quickSet(index);
+                                m_gpConstants.set(index, extractGPConstant(inst.kind.opcode, inst.args[0]));
+                            }
                             m_gpNumWarmUsesAndDefs[index] += frequency;
                             continue;
                         }
@@ -112,24 +120,26 @@ public:
                         Tmp tmp = inst.args[1].as<Tmp>();
                         if (tmp.bank() == FP) {
                             auto index = AbsoluteTmpMapper<FP>::absoluteIndex(tmp);
-                            if (!m_fpConstDefs.quickGet(index)) {
+                            if (fpHasAnyDef.quickGet(index))
+                                m_fpHasMultipleDefs.quickSet(index);
+                            else {
+                                fpHasAnyDef.quickSet(index);
                                 m_fpConstDefs.quickSet(index);
-                                m_fpConstants[index] = extractFPConstant(inst.kind.opcode, inst.args[0]);
+                                m_fpConstants.set(index, extractFPConstant(inst.kind.opcode, inst.args[0]));
                                 switch (inst.kind.opcode) {
                                 case MoveFloat:
-                                    m_fpConstantWidths[index] = Width32;
+                                    m_fpConstantWidths.set(index, Width32);
                                     break;
                                 case MoveDouble:
-                                    m_fpConstantWidths[index] = Width64;
+                                    m_fpConstantWidths.set(index, Width64);
                                     break;
                                 case MoveVector:
-                                    m_fpConstantWidths[index] = Width128;
+                                    m_fpConstantWidths.set(index, Width128);
                                     break;
                                 default:
                                     RELEASE_ASSERT_NOT_REACHED();
                                 }
-                            } else
-                                fpNonConstDefs.quickSet(index);
+                            }
                             m_fpNumWarmUsesAndDefs[index] += frequency;
                             continue;
                         }
@@ -146,21 +156,29 @@ public:
                             if (bank == GP) {
                                 auto index = AbsoluteTmpMapper<GP>::absoluteIndex(tmp);
                                 m_gpNumWarmUsesAndDefs[index] += frequency;
-                                if (Arg::isAnyDef(role))
-                                    gpNonConstDefs.quickSet(index);
+                                if (Arg::isAnyDef(role)) {
+                                    if (gpHasAnyDef.quickGet(index))
+                                        m_gpHasMultipleDefs.quickSet(index);
+                                    else
+                                        gpHasAnyDef.quickSet(index);
+                                }
                             } else {
                                 auto index = AbsoluteTmpMapper<FP>::absoluteIndex(tmp);
                                 m_fpNumWarmUsesAndDefs[index] += frequency;
-                                if (Arg::isAnyDef(role))
-                                    fpNonConstDefs.quickSet(index);
+                                if (Arg::isAnyDef(role)) {
+                                    if (fpHasAnyDef.quickGet(index))
+                                        m_fpHasMultipleDefs.quickSet(index);
+                                    else
+                                        fpHasAnyDef.quickSet(index);
+                                }
                             }
                         }
                     });
             }
         }
 
-        m_gpConstDefs.exclude(gpNonConstDefs);
-        m_fpConstDefs.exclude(fpNonConstDefs);
+        m_gpConstDefs.exclude(m_gpHasMultipleDefs);
+        m_fpConstDefs.exclude(m_fpHasMultipleDefs);
     }
 
     template<Bank bank>
@@ -175,10 +193,15 @@ public:
     template<Bank bank>
     decltype(auto) constant(unsigned absoluteIndex) const
     {
-        if constexpr (bank == GP)
-            return m_gpConstants[absoluteIndex];
-        else
-            return m_fpConstants[absoluteIndex];
+        if constexpr (bank == GP) {
+            auto it = m_gpConstants.find(absoluteIndex);
+            ASSERT(it != m_gpConstants.end());
+            return it->value;
+        } else {
+            auto it = m_fpConstants.find(absoluteIndex);
+            ASSERT(it != m_fpConstants.end());
+            return it->value;
+        }
     }
 
     template<Bank bank>
@@ -194,16 +217,51 @@ public:
     Width constantWidth(unsigned absoluteIndex) const
     {
         static_assert(bank == FP, "constantWidth only valid for FP bank");
-        return m_fpConstantWidths[absoluteIndex];
+        auto it = m_fpConstantWidths.find(absoluteIndex);
+        ASSERT(it != m_fpConstantWidths.end());
+        return it->value;
+    }
+
+    template<Bank bank>
+    bool isSingleDef(unsigned absoluteIndex) const
+    {
+        if constexpr (bank == GP)
+            return !m_gpHasMultipleDefs.get(absoluteIndex);
+        else
+            return !m_fpHasMultipleDefs.get(absoluteIndex);
+    }
+
+    template<Bank bank>
+    bool isRegisteredConstDef(unsigned absoluteIndex) const
+    {
+        if constexpr (bank == GP)
+            return m_gpRegisteredConstDefs.get(absoluteIndex);
+        else
+            return m_fpRegisteredConstDefs.get(absoluteIndex);
+    }
+
+    void registerGPConstDef(unsigned absoluteIndex, int64_t value)
+    {
+        m_gpConstDefs.set(absoluteIndex);
+        m_gpRegisteredConstDefs.set(absoluteIndex);
+        m_gpConstants.set(absoluteIndex, value);
+    }
+
+    void registerFPConstDef(unsigned absoluteIndex, v128_t value, Width width)
+    {
+        m_fpConstDefs.set(absoluteIndex);
+        m_fpRegisteredConstDefs.set(absoluteIndex);
+        m_fpConstants.set(absoluteIndex, value);
+        m_fpConstantWidths.set(absoluteIndex, width);
     }
 
     void dump(PrintStream& out) const
     {
         CommaPrinter comma(", "_s);
         for (unsigned i = 0; i < m_gpNumWarmUsesAndDefs.size(); ++i)
-            out.print(comma, AbsoluteTmpMapper<GP>::tmpFromAbsoluteIndex(i), "=> {numWarmUsesAndDefs="_s, m_gpNumWarmUsesAndDefs[i], ", isConstDef="_s, m_gpConstDefs.quickGet(i), "}"_s);
+            out.print(comma, AbsoluteTmpMapper<GP>::tmpFromAbsoluteIndex(i), "=> {numWarmUsesAndDefs="_s, m_gpNumWarmUsesAndDefs[i], ", isConstDef="_s, isConstDef<GP>(i), "}"_s);
         for (unsigned i = 0; i < m_fpNumWarmUsesAndDefs.size(); ++i)
-            out.print(comma, AbsoluteTmpMapper<FP>::tmpFromAbsoluteIndex(i), "=> {numWarmUsesAndDefs="_s, m_fpNumWarmUsesAndDefs[i], ", isConstDef="_s, m_fpConstDefs.quickGet(i), "}"_s);
+            out.print(comma, AbsoluteTmpMapper<FP>::tmpFromAbsoluteIndex(i), "=> {numWarmUsesAndDefs="_s, m_fpNumWarmUsesAndDefs[i], ", isConstDef="_s, isConstDef<FP>(i), "}"_s);
     }
 
 private:
@@ -211,9 +269,13 @@ private:
     FixedVector<float> m_fpNumWarmUsesAndDefs;
     BitVector m_gpConstDefs;
     BitVector m_fpConstDefs;
-    FixedVector<int64_t> m_gpConstants;
-    FixedVector<v128_t> m_fpConstants;
-    FixedVector<Width> m_fpConstantWidths;
+    BitVector m_gpHasMultipleDefs;
+    BitVector m_fpHasMultipleDefs;
+    BitVector m_gpRegisteredConstDefs;
+    BitVector m_fpRegisteredConstDefs;
+    HashMap<unsigned, int64_t> m_gpConstants;
+    HashMap<unsigned, v128_t> m_fpConstants;
+    HashMap<unsigned, Width> m_fpConstantWidths;
 };
 
 } } } // namespace JSC::B3::Air


### PR DESCRIPTION
#### d71cc095bf072e1975c548a9e41a20093cdc170e
<pre>
[WIP] GRA: restrict coalescing of const def to preserve property
<a href="https://bugs.webkit.org/show_bug.cgi?id=310105">https://bugs.webkit.org/show_bug.cgi?id=310105</a>
<a href="https://rdar.apple.com/172751802">rdar://172751802</a>

Reviewed by NOBODY (OOPS!).

Prototype: merge const def only with single def tmp/group in order
to preserve const def property and propagate const def to group.

No new tests (OOPS!).

* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::AffinityGroup::AffinityGroup):
(JSC::B3::Air::Greedy::GreedyAllocator::AffinityGroup::addMember):
(JSC::B3::Air::Greedy::GreedyAllocator::AffinityGroup::merge):
(JSC::B3::Air::Greedy::GreedyAllocator::AffinityGroup::canPropagateConstDef const):
(JSC::B3::Air::Greedy::GreedyAllocator::coalesceSingletons):
(JSC::B3::Air::Greedy::GreedyAllocator::tryCoalesceSingletonWithGroup):
(JSC::B3::Air::Greedy::GreedyAllocator::tryCoalesceGroups):
(JSC::B3::Air::Greedy::GreedyAllocator::createGroupRepresentatives):
(JSC::B3::Air::Greedy::GreedyAllocator::emitSpillCodeAndEnqueueNewTmps):
* Source/JavaScriptCore/b3/air/AirRegisterAllocatorStats.h:
* Source/JavaScriptCore/b3/air/AirUseCounts.h:
(JSC::B3::Air::UseCounts::UseCounts):
(JSC::B3::Air::UseCounts::constant const):
(JSC::B3::Air::UseCounts::constantWidth const):
(JSC::B3::Air::UseCounts::isSingleDef const):
(JSC::B3::Air::UseCounts::isRegisteredConstDef const):
(JSC::B3::Air::UseCounts::registerGPConstDef):
(JSC::B3::Air::UseCounts::registerFPConstDef):
(JSC::B3::Air::UseCounts::dump const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d71cc095bf072e1975c548a9e41a20093cdc170e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104030 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b8ca166-7a84-4084-a51f-6fa19c4d35ab) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116220 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82556 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/87311cd9-e0e6-4b7c-83c1-ec0f03246533) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135103 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96948 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db32aea8-51f4-4a88-80c1-0e9b86c794e4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17426 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15377 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7166 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142579 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127040 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13027 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161792 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11394 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4912 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124218 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23156 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124416 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23144 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134822 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79533 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19508 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11583 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182078 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22758 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86556 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46554 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22470 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22622 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22524 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->