### PR TITLE
Enhanced <select>: suppress focus visibility for mouse-focused option

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -639,10 +639,6 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-select-element/customizable-select/min-size-empty-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/rendering/replaced-elements/the-select-element/customizable-select/min-size-empty-002.html [ ImageOnlyFailure ]
 
-# <option> focus outline causes test to fail.
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-option.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-button-after-span.html [ ImageOnlyFailure ]
-
 # Picker fallback positioning failures (potentially related to the max-block-size).
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left-scroller.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-bottom-left.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-focus-visible-with-mouse-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-focus-visible-with-mouse-expected.txt
@@ -1,5 +1,6 @@
 
-option
 
-FAIL Select should not match :focus-visible when using mouse. assert_equals: Nothing should be :focus-visible after opening select with mouse. expected null but got Element node <option>option</option>
+FAIL Select should not match :focus-visible when using mouse. assert_equals: Nothing should be :focus-visible after picking an option. expected null but got Element node <select>
+  <option>option</option>
+</select>
 

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -1588,7 +1588,7 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
             if (!clickedInsidePopover)
                 hidePickerPopoverElement();
         } else
-            openPickerForUserInteraction();
+            openPickerForUserInteraction(false);
 
         event.setDefaultHandled();
         return;
@@ -2025,7 +2025,7 @@ void HTMLSelectElement::showPickerInternal()
     }
 }
 
-void HTMLSelectElement::openPickerForUserInteraction()
+void HTMLSelectElement::openPickerForUserInteraction(std::optional<bool> focusVisible)
 {
     // Save the selection so it can be compared to the new selection when
     // dispatching change events during selectOption, which gets called from
@@ -2041,10 +2041,10 @@ void HTMLSelectElement::openPickerForUserInteraction()
     int listIndex = optionToListIndex(selectedIndex());
     if (listIndex < 0)
         listIndex = firstSelectableListIndex();
-    focusOptionAtIndex(listIndex);
+    focusOptionAtIndex(listIndex, focusVisible);
 }
 
-void HTMLSelectElement::focusOptionAtIndex(int listIndex)
+void HTMLSelectElement::focusOptionAtIndex(int listIndex, std::optional<bool> focusVisible)
 {
     if (!usesBaseAppearancePicker())
         return;
@@ -2059,6 +2059,7 @@ void HTMLSelectElement::focusOptionAtIndex(int listIndex)
 
     FocusOptions focusOptions;
     focusOptions.preventScroll = false;
+    focusOptions.focusVisible = focusVisible;
     option->focus(focusOptions);
 }
 

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -194,7 +194,7 @@ public:
     };
     NavigationKeyIdentifiers pickerNavigationKeyIdentifiers() const;
     int computeNavigationIndex(const String& keyIdentifier, int currentListIndex, NavigationKeyIdentifiers) const;
-    void focusOptionAtIndex(int listIndex);
+    void focusOptionAtIndex(int listIndex, std::optional<bool> focusVisible = std::nullopt);
     int typeAheadMatchIndex(KeyboardEvent&);
 
 protected:
@@ -281,7 +281,7 @@ private:
     void didAddUserAgentShadowRoot(ShadowRoot&) final;
 
     void showPickerInternal();
-    void openPickerForUserInteraction();
+    void openPickerForUserInteraction(std::optional<bool> focusVisible = std::nullopt);
 
     // TypeAheadDataSource functions.
     int indexOfSelectedOption() const final;


### PR DESCRIPTION
#### 1f0a62657577f4e8d76a519e962c74c907db4b0c
<pre>
Enhanced &lt;select&gt;: suppress focus visibility for mouse-focused option
<a href="https://bugs.webkit.org/show_bug.cgi?id=310109">https://bugs.webkit.org/show_bug.cgi?id=310109</a>

Reviewed by Tim Nguyen.

We decided that when a picker is opened with the mouse focus does not
need to be visible. It will remain visible when focus moves back to the
select element for consistency across auto and base appearance.

imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-focus-visible-with-mouse.html
asserting it should not be visible in the latter case seems likely a
test issue that will be resolved separately.

Canonical link: <a href="https://commits.webkit.org/309448@main">https://commits.webkit.org/309448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62e9bc4927518255f4e5fd7d8181cc02420cb43b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159326 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104038 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152477 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23516 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116227 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82562 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d7ac37c-a7a2-4ed5-a1f3-59fb9005c071) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18336 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135113 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96955 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17435 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15386 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7174 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Running compile-webkit") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161800 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4920 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14591 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124225 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124423 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134832 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79541 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23157 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19522 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11593 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22766 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86564 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22478 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22630 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22532 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->