### PR TITLE
Move SO authorization window check from shouldStartInternal to beginAuthorizationIfReady

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h
@@ -34,12 +34,11 @@
 
 namespace WebKit {
 
-// When the WebView, owner of the page, is not in the window, the session will then pause
-// and later resume after the WebView being moved into the window.
-// The reason to apply the above rule to the whole session instead of UI session only is UI
-// can be shown out of process, in which case WebKit will not even get notified.
-// FSM: Idle => isInWindow => Active => Completed
-//      Idle => !isInWindow => Waiting => become isInWindow => Active => Completed
+// When the WebView, owner of the page, is not in the window, the session will proceed
+// through authorization hints and policy decision, then pause before beginning authorization.
+// It will resume after the WebView is moved into the window.
+// FSM: Idle => start() => Active => decidePolicyForSOAuthorizationLoad => isInWindow => beginAuthorization => Completed
+//      Idle => start() => Active => decidePolicyForSOAuthorizationLoad => !isInWindow => Waiting => become isInWindow => beginAuthorization => Completed
 class NavigationSOAuthorizationSession : public SOAuthorizationSession, private WebViewDidMoveToWindowObserver {
 public:
     ~NavigationSOAuthorizationSession();
@@ -57,6 +56,7 @@ protected:
 private:
     // SOAuthorizationSession
     void shouldStartInternal() final;
+    void beginAuthorizationIfReady() final;
 
     // WebViewDidMoveToWindowObserver
     void webViewDidMoveToWindow() final;

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm
@@ -60,15 +60,27 @@ void NavigationSOAuthorizationSession::shouldStartInternal()
     RefPtr page = this->page();
     ASSERT(page);
     beforeStart();
+    start();
+}
+
+void NavigationSOAuthorizationSession::beginAuthorizationIfReady()
+{
+    AUTHORIZATIONSESSION_RELEASE_LOG("beginAuthorizationIfReady: m_page=%p", page());
+
+    RefPtr page = this->page();
+    if (!page)
+        return;
+
     if (!page->isInWindow()) {
-        AUTHORIZATIONSESSION_RELEASE_LOG("shouldStartInternal: Starting Extensible SSO authentication for a web view that is not attached to a window. Loading will pause until a window is attached.");
+        AUTHORIZATIONSESSION_RELEASE_LOG("beginAuthorizationIfReady: Web view is not attached to a window. Pausing authorization until a window is attached.");
         setState(State::Waiting);
         page->addDidMoveToWindowObserver(*this);
         ASSERT(page->mainFrame());
         m_waitingPageActiveURL = page->pageLoadState().activeURL();
         return;
     }
-    start();
+
+    SOAuthorizationSession::beginAuthorizationIfReady();
 }
 
 void NavigationSOAuthorizationSession::webViewDidMoveToWindow()
@@ -82,8 +94,9 @@ void NavigationSOAuthorizationSession::webViewDidMoveToWindow()
         page->removeDidMoveToWindowObserver(*this);
         return;
     }
-    start();
     page->removeDidMoveToWindowObserver(*this);
+    setState(State::Active);
+    SOAuthorizationSession::beginAuthorizationIfReady();
 }
 
 bool NavigationSOAuthorizationSession::pageActiveURLDidChangeDuringWaiting() const

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h
@@ -93,6 +93,7 @@ protected:
     SOAuthorizationSession(RetainPtr<WKSOAuthorizationDelegate>, Ref<API::NavigationAction>&&, WebPageProxy&, InitiatingAction);
 
     void start();
+    virtual void beginAuthorizationIfReady();
     WebPageProxy* page() const { return m_page.get(); }
     State state() const { return m_state; }
     ASCIILiteral stateString() const;

--- a/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
+++ b/Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm
@@ -191,7 +191,8 @@ void SOAuthorizationSession::start()
         AUTHORIZATIONSESSION_RELEASE_LOG_WITH_THIS(protectedThis, "start: Receive SOAuthorizationHints (error=%ld)", error ? error.code : 0);
 
         if (error || !authorizationHints) {
-            AUTHORIZATIONSESSION_RELEASE_LOG_WITH_THIS(protectedThis, "start (getAuthorizationHintsWithURL completion handler): Returning early due to error or lack of hints.");
+            AUTHORIZATIONSESSION_RELEASE_LOG_WITH_THIS(protectedThis, "start (getAuthorizationHintsWithURL completion handler): Falling back to web path due to error or lack of hints.");
+            protectedThis->fallBackToWebPath();
             return;
         }
 
@@ -227,9 +228,13 @@ void SOAuthorizationSession::continueStartAfterDecidePolicy(const SOAuthorizatio
     }
 
     AUTHORIZATIONSESSION_RELEASE_LOG("continueStartAfterDecidePolicy: Receive SOAuthorizationLoadPolicy::Allow");
+    beginAuthorizationIfReady();
+}
 
+void SOAuthorizationSession::beginAuthorizationIfReady()
+{
     if (!m_soAuthorization || !m_page || !m_navigationAction) {
-        AUTHORIZATIONSESSION_RELEASE_LOG("continueStartAfterGetAuthorizationHints: Early return m_soAuthorization=%d, m_page=%p, navigationAction=%p.", !!m_soAuthorization, page(), navigationAction());
+        AUTHORIZATIONSESSION_RELEASE_LOG("beginAuthorizationIfReady: Early return m_soAuthorization=%d, m_page=%p, navigationAction=%p.", !!m_soAuthorization, page(), navigationAction());
         return;
     }
 
@@ -270,7 +275,7 @@ void SOAuthorizationSession::continueStartAfterDecidePolicy(const SOAuthorizatio
 #endif
 
     RetainPtr nsRequest = m_navigationAction->request().nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody);
-    AUTHORIZATIONSESSION_RELEASE_LOG("continueStartAfterGetAuthorizationHints: Beginning authorization with AppSSO.");
+    AUTHORIZATIONSESSION_RELEASE_LOG("beginAuthorizationIfReady: Beginning authorization with AppSSO.");
     [m_soAuthorization beginAuthorizationWithURL:retainPtr(nsRequest.get().URL).get() httpHeaders:retainPtr(nsRequest.get().allHTTPHeaderFields).get() httpBody:retainPtr(nsRequest.get().HTTPBody).get()];
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm
@@ -394,6 +394,12 @@ static void overrideGetAuthorizationHintsWithURL(id, SEL, NSURL *url, NSInteger 
     completion(soAuthorizationHints.get(), nullptr);
 }
 
+static void overrideGetAuthorizationHintsWithURLNil(id, SEL, NSURL *url, NSInteger responseCode, GetAuthorizationHintsCallback completion)
+{
+    EXPECT_EQ(responseCode, 0l);
+    completion(nil, nullptr);
+}
+
 #if PLATFORM(MAC)
 using NotificationCallback = void (^)(NSNotification *note);
 static id overrideAddObserverForName(id, SEL, NSNotificationName name, id, NSOperationQueue *, NotificationCallback block)
@@ -1202,15 +1208,14 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedWithWaitingSession)
     // The session will be waiting since the web view is is not in the window.
     [webView removeFromSuperview];
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
-    Util::run(&navigationPolicyDecided);
-    EXPECT_FALSE(policyForAppSSOPerformed);
+    Util::run(&policyForAppSSOPerformed);
+    EXPECT_TRUE(policyForAppSSOPerformed);
     EXPECT_FALSE(authorizationPerformed);
 
     // Should activate the session.
     [webView addToTestWindow];
     Util::run(&authorizationPerformed);
     checkAuthorizationOptions(false, emptyString(), 0);
-    EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
@@ -1238,8 +1243,8 @@ TEST(SOAuthorizationRedirect, InterceptionAbortedWithWaitingSession)
     // The session will be waiting since the web view is is not in the window.
     [webView removeFromSuperview];
     [webView loadRequest:[NSURLRequest requestWithURL:testURL1.get()]];
-    Util::run(&navigationPolicyDecided);
-    EXPECT_FALSE(policyForAppSSOPerformed);
+    Util::run(&policyForAppSSOPerformed);
+    EXPECT_TRUE(policyForAppSSOPerformed);
     EXPECT_FALSE(authorizationPerformed);
 
     [webView loadRequest:[NSURLRequest requestWithURL:testURL2.get()]];
@@ -1248,7 +1253,6 @@ TEST(SOAuthorizationRedirect, InterceptionAbortedWithWaitingSession)
 
     // The waiting session should be aborted as the previous navigation is overwritten by a new navigation.
     Util::run(&navigationCompleted);
-    EXPECT_FALSE(policyForAppSSOPerformed);
     EXPECT_FALSE(authorizationPerformed);
 }
 
@@ -1364,22 +1368,21 @@ TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressWaitingSession)
     // The session will be waiting since the web view is is not int the window.
     [webView removeFromSuperview];
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
-    Util::run(&navigationPolicyDecided);
+    Util::run(&policyForAppSSOPerformed);
+    EXPECT_TRUE(policyForAppSSOPerformed);
     EXPECT_FALSE(authorizationPerformed);
-    EXPECT_FALSE(policyForAppSSOPerformed);
 
     // Suppress the last waiting session.
-    navigationPolicyDecided = false;
+    policyForAppSSOPerformed = false;
     [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
-    Util::run(&navigationPolicyDecided);
+    Util::run(&policyForAppSSOPerformed);
+    EXPECT_TRUE(policyForAppSSOPerformed);
     EXPECT_FALSE(authorizationPerformed);
-    EXPECT_FALSE(policyForAppSSOPerformed);
 
     // Activate the last session.
     [webView addToTestWindow];
     Util::run(&authorizationPerformed);
     checkAuthorizationOptions(false, emptyString(), 0);
-    EXPECT_TRUE(policyForAppSSOPerformed);
 
     RetainPtr<NSURL> redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
     auto response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
@@ -3194,6 +3197,165 @@ TEST(SOAuthorizationSubFrame, InterceptionSuccessMessageOrder)
     auto iframeHtmlCString = generateHTML(iframeTemplate, emptyString()).utf8();
     [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] initWithBytes:iframeHtmlCString.data() length:iframeHtmlCString.length()]).get()];
     Util::run(&allMessagesReceived);
+}
+
+TEST(SOAuthorizationRedirect, InterceptionSucceedWithWaitingSessionPolicyIgnore)
+{
+    resetState();
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
+
+    RetainPtr testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
+    [delegate setAllowSOAuthorizationLoad:false];
+
+    // Web view not in window — but policy fires and returns Ignore, so fallBackToWebPath.
+    [webView removeFromSuperview];
+    [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
+    Util::run(&navigationCompleted);
+
+    EXPECT_TRUE(policyForAppSSOPerformed);
+    EXPECT_FALSE(authorizationPerformed);
+    EXPECT_WK_STREQ(testURL.get().absoluteString, finalURL);
+}
+
+TEST(SOAuthorizationRedirect, InterceptionSucceedAsyncPolicyWindowAttachedBeforeResponse)
+{
+    resetState();
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
+
+    RetainPtr testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
+    [delegate setIsAsyncExecution:true];
+
+    [webView removeFromSuperview];
+    [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
+    Util::run(&policyForAppSSOPerformed);
+    EXPECT_FALSE(authorizationPerformed);
+
+    // Attach window before async policy response — beginAuthorizationIfReady will see
+    // isInWindow()=true and proceed directly without entering Waiting state.
+    // This simulates the Safari BackgroundLoad path where the background load is committed
+    // (attaching the webView to a window) during the decidePolicyForSOAuthorizationLoad callback.
+    [webView addToTestWindow];
+    Util::run(&authorizationPerformed);
+    checkAuthorizationOptions(false, emptyString(), 0);
+
+    RetainPtr redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
+    Util::run(&navigationCompleted);
+#if PLATFORM(IOS) || PLATFORM(VISION)
+    navigationCompleted = false;
+    Util::run(&navigationCompleted);
+#endif
+    EXPECT_WK_STREQ(redirectURL.get().absoluteString, finalURL);
+}
+
+TEST(SOAuthorizationRedirect, InterceptionSucceedAsyncPolicyEntersWaiting)
+{
+    resetState();
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
+
+    RetainPtr testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
+    [delegate setIsAsyncExecution:true];
+
+    [webView removeFromSuperview];
+    [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
+
+    // Wait for the async policy delegate to be called (sets policyForAppSSOPerformed).
+    // The async completionHandler(Allow) is queued via dispatch_async but hasn't fired yet.
+    Util::run(&policyForAppSSOPerformed);
+
+    // Spin the run loop so the async dispatch_async completionHandler fires.
+    // beginAuthorizationIfReady() will see !isInWindow() and enter Waiting state.
+    Util::spinRunLoop();
+
+    EXPECT_FALSE(authorizationPerformed);
+
+    // Now attach — webViewDidMoveToWindow should resume from Waiting.
+    [webView addToTestWindow];
+    Util::run(&authorizationPerformed);
+    checkAuthorizationOptions(false, emptyString(), 0);
+
+    RetainPtr redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
+    Util::run(&navigationCompleted);
+#if PLATFORM(IOS) || PLATFORM(VISION)
+    navigationCompleted = false;
+    Util::run(&navigationCompleted);
+#endif
+    EXPECT_WK_STREQ(redirectURL.get().absoluteString, finalURL);
+}
+
+TEST(SOAuthorizationRedirect, InterceptionSucceedWindowAttachedDuringHints)
+{
+    resetState();
+    SWIZZLE_SOAUTH(PAL::getSOAuthorizationClassSingleton());
+
+    RetainPtr testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
+
+    // Start detached, but re-attach before hints complete.
+    // Since overrideGetAuthorizationHintsWithURL calls completion synchronously,
+    // we attach between navigation policy and the hints callback by attaching
+    // right after the load starts.
+    [webView removeFromSuperview];
+    [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
+    Util::run(&navigationPolicyDecided);
+
+    // Attach now — the hints callback and policy are async but fire on main thread,
+    // so by the time beginAuthorizationIfReady checks, the window is present.
+    [webView addToTestWindow];
+    Util::run(&authorizationPerformed);
+    checkAuthorizationOptions(false, emptyString(), 0);
+    EXPECT_TRUE(policyForAppSSOPerformed);
+
+    RetainPtr redirectURL = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
+    RetainPtr response = adoptNS([[NSHTTPURLResponse alloc] initWithURL:testURL.get() statusCode:302 HTTPVersion:@"HTTP/1.1" headerFields:@{ @"Location" : [redirectURL absoluteString] }]);
+    [gDelegate authorization:gAuthorization didCompleteWithHTTPResponse:response.get() httpBody:adoptNS([[NSData alloc] init]).get()];
+    Util::run(&navigationCompleted);
+#if PLATFORM(IOS) || PLATFORM(VISION)
+    navigationCompleted = false;
+    Util::run(&navigationCompleted);
+#endif
+    EXPECT_WK_STREQ(redirectURL.get().absoluteString, finalURL);
+}
+
+TEST(SOAuthorizationRedirect, InterceptionNilHintsFallsBackToWebPath)
+{
+    resetState();
+    // Swizzle hints to return nil (no error, but nil hints).
+    ClassMethodSwizzler swizzler0(PAL::getSOAuthorizationClassSingleton(), @selector(canPerformAuthorizationWithURL:responseCode:callerBundleIdentifier:useInternalExtensions:completion:), reinterpret_cast<IMP>(overrideCanPerformAuthorizationWithURLCompletion));
+    ClassMethodSwizzler swizzler1(PAL::getSOAuthorizationClassSingleton(), @selector(canPerformAuthorizationWithURL:responseCode:), reinterpret_cast<IMP>(overrideCanPerformAuthorizationWithURL));
+    InstanceMethodSwizzler swizzler5(PAL::getSOAuthorizationClassSingleton(), @selector(getAuthorizationHintsWithURL:responseCode:completion:), reinterpret_cast<IMP>(overrideGetAuthorizationHintsWithURLNil));
+
+    RetainPtr testURL = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 500)]);
+    RetainPtr delegate = adoptNS([[TestSOAuthorizationDelegate alloc] init]);
+    configureSOAuthorizationWebView(webView.get(), delegate.get(), OpenExternalSchemesPolicy::Allow);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:testURL.get()]];
+    Util::run(&navigationCompleted);
+
+    // Policy should NOT have been performed (hints were nil, so we fell back before policy).
+    EXPECT_FALSE(policyForAppSSOPerformed);
+    EXPECT_FALSE(authorizationPerformed);
+    EXPECT_WK_STREQ(testURL.get().absoluteString, finalURL);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### ee2072d3d9d0bb6e4b0517410b24e95fa0f030c1
<pre>
Move SO authorization window check from shouldStartInternal to beginAuthorizationIfReady
<a href="https://bugs.webkit.org/show_bug.cgi?id=310054">https://bugs.webkit.org/show_bug.cgi?id=310054</a>
<a href="https://rdar.apple.com/89821910">rdar://89821910</a>

Reviewed by Abrar Rahman Protyasha and Brent Fulgham.

When a web view was not in a window, shouldStartInternal() entered Waiting
state before calling start(). This meant decidePolicyForSOAuthorizationLoad
never fired while the web view was detached — so clients had no way to learn
that SO authorization was pending. To work around this, clients were forced to
call _web_canPerformAuthorizationWithURL: synchronously in
decidePolicyForNavigationAction to detect AppSSO-eligible URLs and attach the
web view preemptively. This synchronous XPC call to the AppSSO daemon can block
the main thread indefinitely under system pressure.

This patch fires decidePolicyForSOAuthorizationLoad regardless of window state,
letting clients handle SO authorization through the proper async policy
delegate instead of synchronous URL sniffing.

Changes:

- shouldStartInternal() always calls start(). Hints are fetched and the policy
  delegate fires even when detached.

- New beginAuthorizationIfReady() override in NavigationSOAuthorizationSession
  checks isInWindow() after the policy decision. If the delegate returned Allow
  and attached the web view, authorization proceeds immediately. Otherwise the
  session enters Waiting and resumes when the web view is later attached. If
  the delegate returned Ignore, the session falls back to the web path.

- webViewDidMoveToWindow() calls beginAuthorizationIfReady() instead of
  start(), avoiding redundant hints fetching and policy re-evaluation on
  resume.

- Hints completion now calls fallBackToWebPath() on nil/error hints instead of
  silently returning, which leaked the session and hung the navigation.

Updated three existing waiting-session tests to expect
policyForAppSSOPerformed before window attachment (previously policy never
fired while detached). Added five new tests:

- InterceptionSucceedWithWaitingSessionPolicyIgnore: policy returns Ignore
  while detached, session falls back to web path without entering Waiting.

- InterceptionSucceedAsyncPolicyWindowAttachedBeforeResponse: async policy
  delegate, window attached before response completes, authorization proceeds
  directly without Waiting. This is the primary client use case — attaching the
  web view during the policy callback.

- InterceptionSucceedAsyncPolicyEntersWaiting: async policy returns Allow while
  still detached, session enters Waiting, resumes on window attachment.

- InterceptionSucceedWindowAttachedDuringHints: window attached between
  navigation policy and SO authorization start, authorization proceeds directly.

- InterceptionNilHintsFallsBackToWebPath: nil hints trigger fallBackToWebPath,
  navigation completes normally.

* Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/NavigationSOAuthorizationSession.mm:
(WebKit::NavigationSOAuthorizationSession::shouldStartInternal):
(WebKit::NavigationSOAuthorizationSession::beginAuthorizationIfReady):
(WebKit::NavigationSOAuthorizationSession::webViewDidMoveToWindow):
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.h:
* Source/WebKit/UIProcess/Cocoa/SOAuthorization/SOAuthorizationSession.mm:
(WebKit::SOAuthorizationSession::start):
(WebKit::SOAuthorizationSession::continueStartAfterDecidePolicy):
(WebKit::SOAuthorizationSession::beginAuthorizationIfReady):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SOAuthorizationTests.mm:
(overrideGetAuthorizationHintsWithURLNil):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithWaitingSession)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionAbortedWithWaitingSession)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedSuppressWaitingSession)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWithWaitingSessionPolicyIgnore)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedAsyncPolicyWindowAttachedBeforeResponse)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedAsyncPolicyEntersWaiting)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionSucceedWindowAttachedDuringHints)):
(TestWebKitAPI::TEST(SOAuthorizationRedirect, InterceptionNilHintsFallsBackToWebPath)):

Canonical link: <a href="https://commits.webkit.org/309630@main">https://commits.webkit.org/309630@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a403d9083b207ac74fc722c58ab5fc91a28fd0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151257 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159986 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104693 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24451 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24266 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116783 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82912 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135716 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97504 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/18010 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15949 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7831 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127632 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162458 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5597 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15204 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124790 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23821 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/20013 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124978 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33904 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23811 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135430 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80292 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20047 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/12195 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23421 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/87729 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23133 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23285 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23187 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->