### PR TITLE
Use a single tri-state member to distinguish between "normal", "italic" and "oblique" font-style values

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4785,7 +4785,6 @@ imported/w3c/web-platform-tests/css/css-fonts/font-variant-emoji-004.html [ Imag
 imported/w3c/web-platform-tests/css/css-fonts/font-variant-emoji-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/font-variant-position-04.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/font-variant-position-05.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-fonts/italic-oblique-fallback.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/separators.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/size-adjust-unicode-range-system-fallback.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-fonts/variation-sequences.html [ ImageOnlyFailure ]

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -232,18 +232,30 @@ void CSSFontFace::setWidth(CSSValue& style)
     });
 }
 
-static FontSelectionRange calculateItalicRange(CSSValue& value)
+struct FontFaceStyleInfo {
+    FontSelectionRange range;
+    FontStyleAxis axis;
+};
+
+static FontFaceStyleInfo calculateFontFaceStyleInfo(CSSValue& value)
 {
     auto* rangeValue = dynamicDowncast<CSSFontStyleRangeValue>(value);
-    if (!rangeValue)
-        return FontSelectionRange { Style::fontStyleFromCSSValueDeprecated(value).value_or(normalItalicValue()) };
+    if (!rangeValue) {
+        auto slope = Style::fontStyleFromCSSValueDeprecated(value);
+        if (!slope)
+            return { FontSelectionRange { normalItalicValue() }, FontStyleAxis::normal };
+        auto axis = (value.valueID() == CSSValueItalic) ? FontStyleAxis::ital : FontStyleAxis::slnt;
+        return { FontSelectionRange { *slope }, axis };
+    }
 
     auto keyword = rangeValue->fontStyleValue->valueID();
     if (!rangeValue->obliqueValues) {
         if (keyword == CSSValueNormal)
-            return FontSelectionRange { normalItalicValue() };
-        ASSERT(keyword == CSSValueItalic || keyword == CSSValueOblique);
-        return FontSelectionRange { italicValue() };
+            return { FontSelectionRange { normalItalicValue() }, FontStyleAxis::normal };
+        if (keyword == CSSValueItalic)
+            return { FontSelectionRange { italicValue() }, FontStyleAxis::ital };
+        ASSERT(keyword == CSSValueOblique);
+        return { FontSelectionRange { italicValue() }, FontStyleAxis::slnt };
     }
     ASSERT(keyword == CSSValueOblique);
     auto length = rangeValue->obliqueValues->length();
@@ -252,19 +264,20 @@ static FontSelectionRange calculateItalicRange(CSSValue& value)
         return Style::fontStyleAngleFromCSSValueDeprecated(*rangeValue->obliqueValues->itemWithoutBoundsCheck(index));
     };
     if (length == 1)
-        return FontSelectionRange { angleAtIndex(0) };
-    return { angleAtIndex(0), angleAtIndex(1) };
+        return { FontSelectionRange { angleAtIndex(0) }, FontStyleAxis::slnt };
+    return { { angleAtIndex(0), angleAtIndex(1) }, FontStyleAxis::slnt };
 }
 
 void CSSFontFace::setStyle(CSSValue& style)
 {
     mutableProperties().setProperty(CSSPropertyFontStyle, style);
 
-    auto range = calculateItalicRange(style);
-    if (m_fontSelectionCapabilities.slope == range)
+    auto [range, axis] = calculateFontFaceStyleInfo(style);
+    if (m_fontSelectionCapabilities.slope == range && m_fontSelectionCapabilities.faceAxis == axis)
         return;
 
     m_fontSelectionCapabilities.slope = range;
+    m_fontSelectionCapabilities.faceAxis = axis;
 
     iterateClients(m_clients, [&](CSSFontFaceClient& client) {
         client.fontPropertyChanged(*this);

--- a/Source/WebCore/css/FontSelectionValueInlines.h
+++ b/Source/WebCore/css/FontSelectionValueInlines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -96,9 +96,9 @@ inline std::optional<FontSelectionValue> fontWidthValue(CSSValueID value)
 
 inline std::optional<CSSValueID> fontStyleKeyword(std::optional<FontSelectionValue> style, FontStyleAxis axis)
 {
-    if (!style)
+    if (axis == FontStyleAxis::normal)
         return CSSValueNormal;
-    if (style.value() == italicValue())
+    if (style && style.value() == italicValue())
         return axis == FontStyleAxis::ital ? CSSValueItalic : CSSValueOblique;
     return std::nullopt;
 }

--- a/Source/WebCore/platform/graphics/FontCascadeCache.h
+++ b/Source/WebCore/platform/graphics/FontCascadeCache.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007-2008 Torch Mobile, Inc.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -147,10 +147,9 @@ struct FontDescriptionKey {
 private:
     static std::array<unsigned, 2> makeFlagsKey(const FontDescription& description)
     {
-        unsigned first = static_cast<unsigned>(description.script()) << 15
-            | static_cast<unsigned>(description.shouldDisableLigaturesForSpacing()) << 14
-            | static_cast<unsigned>(description.shouldAllowUserInstalledFonts()) << 13
-            | static_cast<unsigned>(description.fontStyleAxis() == FontStyleAxis::slnt) << 12
+        unsigned first = static_cast<unsigned>(description.script()) << 14
+            | static_cast<unsigned>(description.shouldDisableLigaturesForSpacing()) << 13
+            | static_cast<unsigned>(description.shouldAllowUserInstalledFonts()) << 12
             | static_cast<unsigned>(description.opticalSizing()) << 11
             | static_cast<unsigned>(description.textRenderingMode()) << 9
             | static_cast<unsigned>(description.fontSynthesisSmallCaps()) << 8

--- a/Source/WebCore/platform/graphics/FontDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontDescription.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2007 Nicholas Shanks <contact@nickshanks.com>
- * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -65,7 +65,6 @@ FontDescription::FontDescription()
     , m_variantEastAsianRuby(std::to_underlying(FontVariantEastAsianRuby::Normal))
     , m_variantEmoji(std::to_underlying(FontVariantEmoji::Normal))
     , m_opticalSizing(std::to_underlying(FontOpticalSizing::Auto))
-    , m_fontStyleAxis(std::to_underlying(FontStyleAxis::slnt))
     , m_shouldAllowUserInstalledFonts(std::to_underlying(AllowUserInstalledFonts::No))
     , m_shouldDisableLigaturesForSpacing(false)
     , m_evaluationTimeZoomEnabled(false)

--- a/Source/WebCore/platform/graphics/FontDescription.h
+++ b/Source/WebCore/platform/graphics/FontDescription.h
@@ -2,7 +2,7 @@
  * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
  *           (C) 2000 Antti Koivisto (koivisto@kde.org)
  *           (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2007 Nicholas Shanks <webkit@nickshanks.com>
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
  *
@@ -96,7 +96,7 @@ public:
     FontVariantLigaturesValues NODELETE variantLigatures() const;
     FontVariantSettings variantSettings() const;
     FontOpticalSizing opticalSizing() const { return static_cast<FontOpticalSizing>(m_opticalSizing); }
-    FontStyleAxis fontStyleAxis() const { return static_cast<FontStyleAxis>(m_fontStyleAxis); }
+    FontStyleAxis fontStyleAxis() const { return m_fontSelectionRequest.slopeAxis; }
     AllowUserInstalledFonts shouldAllowUserInstalledFonts() const { return static_cast<AllowUserInstalledFonts>(m_shouldAllowUserInstalledFonts); }
     bool shouldDisableLigaturesForSpacing() const { return m_shouldDisableLigaturesForSpacing; }
     const FontPalette& fontPalette() const LIFETIME_BOUND { return m_fontPalette; }
@@ -105,7 +105,7 @@ public:
     void setComputedSize(float s, float zoom = 1.0f) { m_computedSize = clampToFloat(s); m_usedZoomFactor = zoom; }
     void setTextSpacingTrim(TextSpacingTrim v) { m_textSpacingTrim = v; }
     void setTextAutospace(TextAutospace v) { m_textAutospace = v; }
-    void setFontStyleAxis(FontStyleAxis axis) { m_fontStyleAxis = std::to_underlying(axis); }
+    void setFontStyleAxis(FontStyleAxis axis) { m_fontSelectionRequest.slopeAxis = axis; }
     void setFontStyleSlope(std::optional<FontSelectionValue> slope) { m_fontSelectionRequest.slope = slope; }
     void setIsItalic(bool isItalic) { setFontStyleSlope(isItalic ? std::optional<FontSelectionValue> { italicValue() } : std::optional<FontSelectionValue> { }); }
     void setWeight(FontSelectionValue weight) { m_fontSelectionRequest.weight = weight; }
@@ -190,7 +190,6 @@ private:
     PREFERRED_TYPE(FontVariantEastAsianRuby) unsigned m_variantEastAsianRuby : 1;
     PREFERRED_TYPE(FontVariantEmoji) unsigned m_variantEmoji : 2;
     PREFERRED_TYPE(FontOpticalSizing) unsigned m_opticalSizing : 1;
-    PREFERRED_TYPE(FontStyleAxis) unsigned m_fontStyleAxis : 1;
     PREFERRED_TYPE(AllowUserInstalledFonts) unsigned m_shouldAllowUserInstalledFonts : 1; // If this description is allowed to match a user-installed font
     PREFERRED_TYPE(bool) unsigned m_shouldDisableLigaturesForSpacing : 1; // If letter-spacing is nonzero, we need to disable ligatures, which affects font preparation
     PREFERRED_TYPE(bool) unsigned m_evaluationTimeZoomEnabled : 1;

--- a/Source/WebCore/platform/graphics/FontSelectionAlgorithm.cpp
+++ b/Source/WebCore/platform/graphics/FontSelectionAlgorithm.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -68,6 +68,19 @@ auto FontSelectionAlgorithm::styleDistance(Capabilities capabilities) const -> D
     auto slope = capabilities.slope;
     auto requestSlope = m_request.slope.value_or(normalItalicValue());
     ASSERT(slope.isValid());
+
+    // Per CSS Fonts 4 §5.2, italic and oblique are not interchangeable when choosing
+    // faces. When requesting oblique (slnt axis), italic-labeled faces are only a last
+    // resort after both oblique and normal faces. When requesting italic (ital axis),
+    // italic-labeled faces are preferred, but oblique faces are acceptable before normal.
+    // https://drafts.csswg.org/css-fonts-4/#font-style-matching
+    //
+    // We implement this by giving mismatched faces a distance penalty large enough to
+    // always lose to any matching-category face, while still allowing last-resort use
+    // when no better face exists.
+    if (m_request.slopeAxis == FontStyleAxis::slnt && capabilities.faceAxis == FontStyleAxis::ital)
+        return { FontSelectionValue::maximumValue(), requestSlope };
+
     if (slope.includes(requestSlope))
         return { FontSelectionValue(), requestSlope };
 

--- a/Source/WebCore/platform/graphics/FontSelectionAlgorithm.h
+++ b/Source/WebCore/platform/graphics/FontSelectionAlgorithm.h
@@ -304,14 +304,8 @@ struct FontSelectionRequest {
 
     Value weight;
     Value width;
-
-    // FIXME: We are using an optional here to be able to distinguish between an explicit
-    // or implicit slope (for "italic" and "oblique") and the "normal" value which has no
-    // slope. The "italic" and "oblique" values can be distinguished by looking at the
-    // "fontStyleAxis" on the FontDescription. We should come up with a tri-state member
-    // so that it's a lot clearer whether we're dealing with a "normal", "italic" or explicit
-    // "oblique" font style. See webkit.org/b/187774.
     std::optional<Value> slope;
+    FontStyleAxis slopeAxis { FontStyleAxis::normal };
 
     friend bool operator==(const FontSelectionRequest&, const FontSelectionRequest&) = default;
 };
@@ -330,7 +324,7 @@ inline TextStream& operator<<(TextStream& ts, const std::optional<FontSelectionV
 
 inline void add(Hasher& hasher, const FontSelectionRequest& request)
 {
-    add(hasher, request.weight, request.width, request.slope);
+    add(hasher, request.weight, request.width, request.slope, std::to_underlying(request.slopeAxis));
 }
 
 struct FontSelectionCapabilities {
@@ -348,6 +342,7 @@ struct FontSelectionCapabilities {
     Range weight { normalWeightValue() };
     Range width { normalWidthValue() };
     Range slope { normalItalicValue() };
+    FontStyleAxis faceAxis { FontStyleAxis::normal };
 };
 
 struct FontSelectionSpecifiedCapabilities {
@@ -357,7 +352,7 @@ struct FontSelectionSpecifiedCapabilities {
 
     constexpr Capabilities computeFontSelectionCapabilities() const
     {
-        return { computeWeight(), computeWidth(), computeSlope() };
+        return { computeWeight(), computeWidth(), computeSlope(), faceAxis };
     }
 
     friend constexpr bool operator==(const FontSelectionSpecifiedCapabilities&, const FontSelectionSpecifiedCapabilities&) = default;
@@ -367,6 +362,7 @@ struct FontSelectionSpecifiedCapabilities {
         weight = other.weight;
         width = other.width;
         slope = other.slope;
+        faceAxis = other.faceAxis;
         return *this;
     }
 
@@ -388,11 +384,12 @@ struct FontSelectionSpecifiedCapabilities {
     OptionalRange weight;
     OptionalRange width;
     OptionalRange slope;
+    FontStyleAxis faceAxis { FontStyleAxis::normal };
 };
 
 inline void add(Hasher& hasher, const FontSelectionSpecifiedCapabilities& capabilities)
 {
-    add(hasher, capabilities.weight, capabilities.width, capabilities.slope);
+    add(hasher, capabilities.weight, capabilities.width, capabilities.slope, std::to_underlying(capabilities.faceAxis));
 }
 
 class FontSelectionAlgorithm {

--- a/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h
+++ b/Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2023-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -106,7 +106,7 @@ private:
     float m_width { 0 };
     float m_slope { 0 };
     CGFloat m_size { 0 };
-    FontStyleAxis m_fontStyleAxis { FontStyleAxis::slnt };
+    FontStyleAxis m_fontStyleAxis { FontStyleAxis::normal };
     OpticalSizingType m_opticalSizingType { OpticalSizingTypes::None { } };
     FontVariationSettings m_variationSettings;
 };

--- a/Source/WebCore/platform/text/TextFlags.h
+++ b/Source/WebCore/platform/text/TextFlags.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -379,7 +379,8 @@ enum class FontOpticalSizing : bool {
 WTF::TextStream& operator<<(WTF::TextStream&, FontOpticalSizing);
 
 // https://www.microsoft.com/typography/otspec/fvar.htm#VAT
-enum class FontStyleAxis : bool {
+enum class FontStyleAxis : uint8_t {
+    normal,
     slnt,
     ital
 };

--- a/Source/WebCore/style/StyleResolveForFont.cpp
+++ b/Source/WebCore/style/StyleResolveForFont.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2013 Google Inc. All rights reserved.
- * Copyright (C) 2014-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2020 Metrological Group B.V.
  * Copyright (C) 2020 Igalia S.L.
  * Copyright (C) 2024 Samuel Weinig <sam@webkit.org>
@@ -170,7 +170,7 @@ static ResolvedFontStyle fontStyleFromUnresolvedFontStyle(const CSSPropertyParse
             case CSSValueNormal:
                 return {
                     .slope = std::nullopt,
-                    .axis = FontStyleAxis::slnt
+                    .axis = FontStyleAxis::normal
                 };
 
             case CSSValueItalic:
@@ -190,12 +190,12 @@ static ResolvedFontStyle fontStyleFromUnresolvedFontStyle(const CSSPropertyParse
             }
 
             ASSERT_NOT_REACHED();
-            return { .slope = std::nullopt, .axis = FontStyleAxis::slnt };
+            return { .slope = std::nullopt, .axis = FontStyleAxis::normal };
         },
         [](const CSSPropertyParserHelpers::UnresolvedFontStyleObliqueAngle& angle) -> ResolvedFontStyle {
             // FIXME: Figure out correct behavior when conversion data is required.
             if (requiresConversionData(angle))
-                return { .slope = std::nullopt, .axis = FontStyleAxis::slnt };
+                return { .slope = std::nullopt, .axis = FontStyleAxis::normal };
 
             return {
                 .slope = FontSelectionValue::clampFloat(Style::toStyleNoConversionDataRequired(angle).value),

--- a/Source/WebCore/style/values/fonts/StyleFontStyle.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontStyle.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -66,7 +67,7 @@ auto CSSValueConversion<FontStyle>::operator()(BuilderState& state, const CSSVal
 
 auto CSSValueCreation<FontStyle>::operator()(CSSValuePool& pool, const RenderStyle& style, const FontStyle& value) -> Ref<CSSValue>
 {
-    if (!value.platformSlope() || !*value.platformSlope())
+    if (value.isNormal())
         return createCSSValue(pool, style, CSS::Keyword::Normal { });
 
     if (*value.platformSlope() == italicValue()) {
@@ -82,7 +83,7 @@ auto CSSValueCreation<FontStyle>::operator()(CSSValuePool& pool, const RenderSty
 
 auto Blending<FontStyle>::canBlend(const FontStyle& a, const FontStyle& b) -> bool
 {
-    return a.platformAxis() == FontStyleAxis::slnt && b.platformAxis() == FontStyleAxis::slnt;
+    return a.platformAxis() != FontStyleAxis::ital && b.platformAxis() != FontStyleAxis::ital;
 }
 
 auto Blending<FontStyle>::blend(const FontStyle& a, const FontStyle& b, const BlendingContext& context) -> FontStyle

--- a/Source/WebCore/style/values/fonts/StyleFontStyle.h
+++ b/Source/WebCore/style/values/fonts/StyleFontStyle.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,17 +36,23 @@ namespace Style {
 // https://drafts.csswg.org/css-fonts-4/#propdef-font-style
 struct FontStyle {
     using Angle = Style::Angle<CSS::Range{-90, 90}>;
+    using ZeroAngle = Style::Angle<CSS::Range{0, 0}>;
 
-    FontStyle(CSS::Keyword::Normal) : m_platformSlope { std::nullopt }, m_platformAxis { FontStyleAxis::slnt } { }
+    FontStyle(CSS::Keyword::Normal) : m_platformSlope { std::nullopt }, m_platformAxis { FontStyleAxis::normal } { }
     FontStyle(CSS::Keyword::Italic) : m_platformSlope { italicValue() }, m_platformAxis { FontStyleAxis::ital } { }
     FontStyle(CSS::Keyword::Oblique) : m_platformSlope { italicValue() }, m_platformAxis { FontStyleAxis::slnt } { }
-    FontStyle(Angle angle) : m_platformSlope { FontSelectionValue::clampFloat(angle.value) }, m_platformAxis { FontStyleAxis::slnt } { }
+    FontStyle(ZeroAngle) : m_platformSlope { std::nullopt }, m_platformAxis { FontStyleAxis::normal } { }
+    FontStyle(Angle angle)
+    {
+        auto slope = FontSelectionValue::clampFloat(angle.value);
+        *this = slope == normalItalicValue() ? FontStyle { ZeroAngle { } } : FontStyle { slope, FontStyleAxis::slnt };
+    }
 
     FontStyle(std::optional<FontSelectionValue> slope, FontStyleAxis axis) : m_platformSlope { slope }, m_platformAxis { axis } { }
 
-    bool isNormal() const { return m_platformSlope == std::nullopt && m_platformAxis == FontStyleAxis::slnt; }
+    bool isNormal() const { return m_platformAxis == FontStyleAxis::normal; }
     bool isItalic() const { return m_platformSlope == italicValue() && m_platformAxis == FontStyleAxis::ital; }
-    bool isOblique() const { return m_platformSlope != std::nullopt && m_platformAxis == FontStyleAxis::slnt; }
+    bool isOblique() const { return m_platformAxis == FontStyleAxis::slnt; }
 
     std::optional<Angle> angle() const { return m_platformSlope ? std::make_optional(Angle { static_cast<float>(*m_platformSlope) }) : std::nullopt; }
 
@@ -53,7 +60,7 @@ struct FontStyle {
     {
         auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
 
-        if (!m_platformSlope || !*m_platformSlope)
+        if (m_platformAxis == FontStyleAxis::normal)
             return visitor(CSS::Keyword::Normal { });
         if (*m_platformSlope == italicValue()) {
             if (m_platformAxis == FontStyleAxis::ital)

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h
@@ -325,6 +325,11 @@ template<CSS::Range R, typename V> struct Percentage : PrimitiveNumeric<CSS::Per
 template<CSS::Range R, typename V> struct Angle : PrimitiveNumeric<CSS::Angle<R, V>> {
     using Base = PrimitiveNumeric<CSS::Angle<R, V>>;
     using Base::Base;
+
+    constexpr Angle() requires (R.min == R.max)
+        : Base { static_cast<V>(R.min) }
+    {
+    }
 };
 template<CSS::Range R, typename V> struct Length : PrimitiveNumeric<CSS::Length<R, V>> {
     using Base = PrimitiveNumeric<CSS::Length<R, V>>;


### PR DESCRIPTION
#### b927d5607bfe96bb2008c8c70212ee8825f971cc
<pre>
Use a single tri-state member to distinguish between &quot;normal&quot;, &quot;italic&quot; and &quot;oblique&quot; font-style values
<a href="https://bugs.webkit.org/show_bug.cgi?id=187774">https://bugs.webkit.org/show_bug.cgi?id=187774</a>
<a href="https://rdar.apple.com/172702768">rdar://172702768</a>

Reviewed by Vitor Roriz.

FontStyle used a two-state flag to represent normal, slnt, and italic font
style. The combination of slnt and an angle of 0 degrees was used to represent
&apos;normal&apos; fonts. This led to some incorrect font selection behavior since in
some cases this matched against oblique fonts.

After this change we no longer store m_fontStyleAxis individually, as it is
now part of m_fontSelectionRequest.

Tests: imported/w3c/web-platform-tests/css/css-fonts/italic-oblique-fallback.html

* LayoutTests/TestExpectations:
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::calculateFontFaceStyleInfo):
(WebCore::CSSFontFace::setStyle):
(WebCore::calculateItalicRange): Deleted.
* Source/WebCore/css/FontSelectionValueInlines.h:
(WebCore::fontStyleKeyword):
* Source/WebCore/platform/graphics/FontCascadeCache.h:
(WebCore::FontDescriptionKey::makeFlagsKey):
* Source/WebCore/platform/graphics/FontDescription.cpp:
* Source/WebCore/platform/graphics/FontDescription.h:
(WebCore::FontDescription::fontStyleAxis const):
(WebCore::FontDescription::setFontStyleAxis):
* Source/WebCore/platform/graphics/FontSelectionAlgorithm.cpp:
(WebCore::FontSelectionAlgorithm::styleDistance const):
* Source/WebCore/platform/graphics/FontSelectionAlgorithm.h:
(WebCore::add):
(WebCore::FontSelectionSpecifiedCapabilities::computeFontSelectionCapabilities const):
(WebCore::FontSelectionSpecifiedCapabilities::operator=):
* Source/WebCore/platform/graphics/cocoa/UnrealizedCoreTextFont.h:
* Source/WebCore/platform/text/TextFlags.h:
* Source/WebCore/style/StyleResolveForFont.cpp:
(WebCore::Style::fontStyleFromUnresolvedFontStyle):
* Source/WebCore/style/values/fonts/StyleFontStyle.cpp:
(WebCore::Style::CSSValueCreation&lt;FontStyle&gt;::operator):
(WebCore::Style::Blending&lt;FontStyle&gt;::canBlend):
* Source/WebCore/style/values/fonts/StyleFontStyle.h:
(WebCore::Style::FontStyle::FontStyle):
(WebCore::Style::FontStyle::isNormal const):
(WebCore::Style::FontStyle::isOblique const):
(WebCore::Style::FontStyle::switchOn const):
* Source/WebCore/style/values/primitives/StylePrimitiveNumeric.h:
(WebCore::Style::Angle::requires):

Canonical link: <a href="https://commits.webkit.org/310249@main">https://commits.webkit.org/310249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23ac0f424335e2fe86badeaee0ea14d95ab6ed45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/153248 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/26030 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/19628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/161993 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/106706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/166ff63f-84c2-4ac6-9b27-19a00c0b5423) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/155121 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/26557 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/26335 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/118476 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/106706 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/156207 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/20712 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/137590 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/99189 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/173ad11b-7570-4b5c-b8b3-7f8987f06c22) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/19798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/17739 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/9828 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/129438 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/15459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/164467 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/7602 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/17053 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/126535 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/25827 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/21766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/126693 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/34364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/25829 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/137255 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/82498 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23443 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/21646 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/14034 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/25446 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/89732 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/25138 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/25296 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/25197 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->