### PR TITLE
[libpas] Disable and rename PAS_USE_COMPACT_ONLY_TZONE_HEAP

### DIFF
--- a/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
+++ b/Source/bmalloc/bmalloc/TZoneHeapManager.cpp
@@ -627,7 +627,7 @@ BINLINE pas_heap_ref* TZoneHeapManager::heapRefForTZoneType(const TZoneSpecifica
     else
         group = populateGroupBuckets(lock, spec);
 
-    if (spec.allocationMode == CompactAllocationMode::NonCompact && PAS_USE_COMPACT_ONLY_TZONE_HEAP)
+    if (spec.allocationMode == CompactAllocationMode::NonCompact && PAS_BYPASS_TZONE_FOR_NONCOMPACT_OBJECTS)
         return &group->nonCompactBucket.heapref;
 
     unsigned bucket = bucketForKey(spec, group->numberOfBuckets, lock);

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap.c
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap.c
@@ -61,14 +61,14 @@ pas_allocator_counts bmalloc_allocator_counts;
 
 PAS_NEVER_INLINE void* bmalloc_try_allocate_casual(size_t size, pas_allocation_mode allocation_mode)
 {
-    if (allocation_mode == pas_always_compact_allocation_mode && PAS_USE_COMPACT_ONLY_HEAP)
+    if (allocation_mode == pas_always_compact_allocation_mode)
         return (void*)bmalloc_try_allocate_auxiliary(&bmalloc_compact_primitive_heap_ref, size, allocation_mode);
     return (void*)bmalloc_try_allocate_impl_casual_case(size, 1, allocation_mode).begin;
 }
 
 PAS_NEVER_INLINE void* bmalloc_allocate_casual(size_t size, pas_allocation_mode allocation_mode)
 {
-    if (allocation_mode == pas_always_compact_allocation_mode && PAS_USE_COMPACT_ONLY_HEAP)
+    if (allocation_mode == pas_always_compact_allocation_mode)
         return (void*)bmalloc_allocate_auxiliary(&bmalloc_compact_primitive_heap_ref, size, allocation_mode);
     return (void*)bmalloc_allocate_impl_casual_case(size, 1, allocation_mode).begin;
 }

--- a/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
+++ b/Source/bmalloc/libpas/src/libpas/bmalloc_heap_inlines.h
@@ -267,7 +267,7 @@ PAS_API void* bmalloc_allocate_casual(size_t size, pas_allocation_mode allocatio
 
 static PAS_ALWAYS_INLINE void* bmalloc_try_allocate_inline(size_t size, pas_allocation_mode allocation_mode)
 {
-    if (allocation_mode == pas_always_compact_allocation_mode && PAS_USE_COMPACT_ONLY_HEAP)
+    if (allocation_mode == pas_always_compact_allocation_mode)
         return (void*)bmalloc_try_allocate_auxiliary_inline(&bmalloc_compact_primitive_heap_ref, size, allocation_mode);
     pas_allocation_result result;
     result = bmalloc_try_allocate_impl_inline_only(size, 1, allocation_mode);
@@ -282,7 +282,7 @@ static PAS_ALWAYS_INLINE void* bmalloc_try_allocate_inline(size_t size, pas_allo
 static PAS_ALWAYS_INLINE void*
 bmalloc_try_allocate_with_alignment_inline(size_t size, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    if (allocation_mode == pas_always_compact_allocation_mode && PAS_USE_COMPACT_ONLY_HEAP)
+    if (allocation_mode == pas_always_compact_allocation_mode)
         return (void*)bmalloc_try_allocate_auxiliary_with_alignment_inline(&bmalloc_compact_primitive_heap_ref, size, alignment, allocation_mode);
     return (void*)bmalloc_try_allocate_with_alignment_impl(size, alignment, allocation_mode).begin;
 }
@@ -290,7 +290,7 @@ bmalloc_try_allocate_with_alignment_inline(size_t size, size_t alignment, pas_al
 static PAS_ALWAYS_INLINE void*
 bmalloc_try_allocate_zeroed_with_alignment_inline(size_t size, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    if (allocation_mode == pas_always_compact_allocation_mode && PAS_USE_COMPACT_ONLY_HEAP)
+    if (allocation_mode == pas_always_compact_allocation_mode)
         return (void*)bmalloc_try_allocate_auxiliary_zeroed_with_alignment_inline(&bmalloc_compact_primitive_heap_ref, size, alignment, allocation_mode);
     return (void*)pas_allocation_result_zero(
         bmalloc_try_allocate_with_alignment_impl(size, alignment, allocation_mode),
@@ -300,7 +300,7 @@ bmalloc_try_allocate_zeroed_with_alignment_inline(size_t size, size_t alignment,
 static PAS_ALWAYS_INLINE void* bmalloc_try_allocate_zeroed_inline(size_t size, pas_allocation_mode allocation_mode)
 {
     pas_allocation_result result;
-    if (allocation_mode == pas_always_compact_allocation_mode && PAS_USE_COMPACT_ONLY_HEAP)
+    if (allocation_mode == pas_always_compact_allocation_mode)
         return (void*)bmalloc_try_allocate_auxiliary_zeroed_inline(&bmalloc_compact_primitive_heap_ref, size, allocation_mode);
 
     result = bmalloc_try_allocate_impl(size, 1, allocation_mode);
@@ -312,7 +312,7 @@ static PAS_ALWAYS_INLINE void* bmalloc_try_allocate_zeroed_inline(size_t size, p
 static PAS_ALWAYS_INLINE void* bmalloc_allocate_inline(size_t size, pas_allocation_mode allocation_mode)
 {
     pas_allocation_result result;
-    if (allocation_mode == pas_always_compact_allocation_mode && PAS_USE_COMPACT_ONLY_HEAP)
+    if (allocation_mode == pas_always_compact_allocation_mode)
         return (void*)bmalloc_allocate_auxiliary_inline(&bmalloc_compact_primitive_heap_ref, size, allocation_mode);
 
     result = bmalloc_allocate_impl_inline_only(size, 1, allocation_mode);
@@ -324,14 +324,14 @@ static PAS_ALWAYS_INLINE void* bmalloc_allocate_inline(size_t size, pas_allocati
 static PAS_ALWAYS_INLINE void*
 bmalloc_allocate_with_alignment_inline(size_t size, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    if (allocation_mode == pas_always_compact_allocation_mode && PAS_USE_COMPACT_ONLY_HEAP)
+    if (allocation_mode == pas_always_compact_allocation_mode)
         return (void*)bmalloc_allocate_auxiliary_with_alignment_inline(&bmalloc_compact_primitive_heap_ref, size, alignment, allocation_mode);
     return (void*)bmalloc_allocate_with_alignment_impl(size, alignment, allocation_mode).begin;
 }
 
 static PAS_ALWAYS_INLINE void* bmalloc_allocate_zeroed_inline(size_t size, pas_allocation_mode allocation_mode)
 {
-    if (allocation_mode == pas_always_compact_allocation_mode && PAS_USE_COMPACT_ONLY_HEAP)
+    if (allocation_mode == pas_always_compact_allocation_mode)
         return (void*)bmalloc_allocate_auxiliary_zeroed_inline(&bmalloc_compact_primitive_heap_ref, size, allocation_mode);
     return (void*)pas_allocation_result_zero(
         bmalloc_allocate_impl(size, 1, allocation_mode),
@@ -341,7 +341,7 @@ static PAS_ALWAYS_INLINE void* bmalloc_allocate_zeroed_inline(size_t size, pas_a
 static PAS_ALWAYS_INLINE void*
 bmalloc_allocate_zeroed_with_alignment_inline(size_t size, size_t alignment, pas_allocation_mode allocation_mode)
 {
-    if (allocation_mode == pas_always_compact_allocation_mode && PAS_USE_COMPACT_ONLY_HEAP)
+    if (allocation_mode == pas_always_compact_allocation_mode)
         return (void*)bmalloc_allocate_auxiliary_zeroed_with_alignment_inline(&bmalloc_compact_primitive_heap_ref, size, alignment, allocation_mode);
     return (void*)pas_allocation_result_zero(
         bmalloc_allocate_with_alignment_impl(size, alignment, allocation_mode),
@@ -353,7 +353,7 @@ bmalloc_try_reallocate_inline(void* old_ptr, size_t new_size,
                               pas_allocation_mode allocation_mode,
                               pas_reallocate_free_mode free_mode)
 {
-    if (allocation_mode == pas_always_compact_allocation_mode && PAS_USE_COMPACT_ONLY_HEAP)
+    if (allocation_mode == pas_always_compact_allocation_mode)
         return (void*)bmalloc_try_reallocate_auxiliary_inline(old_ptr, &bmalloc_compact_primitive_heap_ref, new_size, allocation_mode, free_mode);
     return (void*)pas_try_reallocate_intrinsic(
         old_ptr,
@@ -371,7 +371,7 @@ bmalloc_reallocate_inline(void* old_ptr, size_t new_size,
                           pas_allocation_mode allocation_mode,
                           pas_reallocate_free_mode free_mode)
 {
-    if (allocation_mode == pas_always_compact_allocation_mode && PAS_USE_COMPACT_ONLY_HEAP)
+    if (allocation_mode == pas_always_compact_allocation_mode)
         return (void*)bmalloc_reallocate_auxiliary_inline(old_ptr, &bmalloc_compact_primitive_heap_ref, new_size, allocation_mode, free_mode);
     return (void*)pas_try_reallocate_intrinsic(
         old_ptr,

--- a/Source/bmalloc/libpas/src/libpas/pas_allocation_mode.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_allocation_mode.h
@@ -30,11 +30,6 @@
 
 PAS_BEGIN_EXTERN_C;
 
-#ifndef PAS_USE_COMPACT_ONLY_HEAP
-#define PAS_USE_COMPACT_ONLY_HEAP 0
-#define PAS_USE_COMPACT_ONLY_TZONE_HEAP 0
-#endif
-
 enum pas_allocation_mode {
     /* We are allocating an object from ordinary memory and don't plan on
        compacting its address. */

--- a/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_mte_config.h
@@ -104,20 +104,27 @@ PAS_ALLOW_UNSAFE_BUFFER_USAGE_END;
 
 #define PAS_MTE_SHOULD_STORE_TAG 1
 
-#ifndef PAS_USE_COMPACT_ONLY_HEAP
 /*
- * The reason we make TZone compact-only heaps reliant on runtime PAS_MTE
- * enablement, and not the general compact-only heap, is that lumping all
- * non-compact objects into the same heap is a security regression for TZone,
- * but not a security regression for the general bmalloc heap where we already
- * expect all allocations to come out of the same singular intrinsic heap.
- * By avoiding checking PAS_USE_MTE, we save an additional check in the malloc
- * fast path for ordinary allocations, while the corresponding check for TZone
- * heaps only occurs during heap selection - it's not as significant.
+ * This setting would force all non-compact TZone allocations into a single bucket.
+ * Normally this would be a security regression, as it effectively bypasses the
+ * iso-heap mechanism that TZone relies on for its security guarantees.
+ * Normally, this would be a security regression, as it effectively removes the
+ * randomness at the heart of the TZone security feature by putting all classes
+ * from the same TZone into a single iso-heap.
+
+ * However, MTE provides the same security benefits as TZone, and as such it's
+ * OK to bypass TZone for objects we know will be MTE-tagged.
+ * Presently, the main reason for doing so would be performance, but as MTE
+ * is currently (c. 2026) only enabled in non-performant processes, there's no
+ * reason to have it on. If it is re-enabled it should be set to PAS_USE_MTE
+ * so as to preserve the security properties of non-MTE processes.
+ *
+ * Astute observers may notice that in bmalloc we do the converse, i.e. allocating
+ * always-compact objects from a single heap-ref. This is OK since in that heap,
+ * we already expect all allocations to come out of the same singular intrinsic
+ * heap.
  */
-#define PAS_USE_COMPACT_ONLY_HEAP 1
-#define PAS_USE_COMPACT_ONLY_TZONE_HEAP PAS_USE_MTE
-#endif
+#define PAS_BYPASS_TZONE_FOR_NONCOMPACT_OBJECTS 0
 
 #define PAS_MTE_FEATURE_RETAG_ON_SCAVENGE 0
 #define PAS_MTE_FEATURE_LOG_ON_TAG 1
@@ -193,6 +200,7 @@ PAS_ALLOW_UNSAFE_BUFFER_USAGE_END;
 #define PAS_MTE_CHECK_TAG_AND_SET_TCO(ptr) do { (void)ptr; } while (0)
 #define PAS_MTE_SET_TCO_UNCHECKED do { } while (0)
 #define PAS_MTE_CLEAR_TCO do { } while (0)
+#define PAS_BYPASS_TZONE_FOR_NONCOMPACT_OBJECTS 0
 #endif // PAS_ENABLE_MTE
 
 #ifdef __cplusplus


### PR DESCRIPTION
#### 824037e6445b151e2d3c2aefe7a87e0196a43cf9
<pre>
[libpas] Disable and rename PAS_USE_COMPACT_ONLY_TZONE_HEAP
<a href="https://bugs.webkit.org/show_bug.cgi?id=310115">https://bugs.webkit.org/show_bug.cgi?id=310115</a>
<a href="https://rdar.apple.com/172759337">rdar://172759337</a>

Reviewed by Mark Lam.

This was previously enabled as a performance optimization,
which no longer applies now that we distinguish between
hardened and non-hardened WebContent processes.
As such, we can incrementally harden our security posture by
re-enabling size segregation for non-compact objects in
+MTE processes.

This also renames PAS_USE_COMPACT_ONLY_TZONE_HEAP to
PAS_BYPASS_TZONE_FOR_NONCOMPACT_OBJECTS to be explicit about what the
macro actually does -- beforehand it was vague and the most direct
implication was actually the opposite of what it does.

Further, it removes PAS_USE_COPMACT_ONLY_HEAP altogether, as there&apos;s
no benefit to leaving that in now that we&apos;re locked in to using MTE.

Canonical link: <a href="https://commits.webkit.org/309583@main">https://commits.webkit.org/309583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39bf4f33ef5cf999464a3d7560a45053647c5746

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23886 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/17457 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159852 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ed959aeb-2825-437e-a887-c1d9d124ce90) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24317 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24112 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/116677 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3016223-068d-425e-aba4-7653c80a9fb2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154084 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/18795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97398 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/631bdd1c-96d3-4c58-9f04-d2bf321feddc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7698 "Built successfully") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/143108 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162325 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11923 "Built successfully and passed tests") | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/124685 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23688 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19891 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124873 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33872 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23678 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/135311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/80122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/19938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182733 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23288 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46634 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23000 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23152 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/23054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->