### PR TITLE
Find in Page match index is not being populated

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -361,11 +361,14 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
     if (found && !options.contains(FindOptions::DoNotSetSelection)) {
         m_findIndicator->didFindString(frameWithSelection(protect(m_webPage->corePage()).get()));
 
-        if (!foundStringStartsAfterSelection && m_foundStringMatchIndex) {
-            if (options.contains(FindOptions::Backwards))
-                (*m_foundStringMatchIndex)--;
-            else if (!options.contains(FindOptions::NoIndexChange))
-                (*m_foundStringMatchIndex)++;
+        if (!foundStringStartsAfterSelection && options.contains(FindOptions::DetermineMatchIndex)) {
+            if (m_foundStringMatchIndex) {
+                if (options.contains(FindOptions::Backwards))
+                    (*m_foundStringMatchIndex)--;
+                else if (!options.contains(FindOptions::NoIndexChange))
+                    (*m_foundStringMatchIndex)++;
+            } else
+                m_foundStringMatchIndex = 0;
         }
     }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewFindString.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewFindString.mm
@@ -147,4 +147,32 @@ TEST(WKWebViewFindString, DoNotUpdateMatchIndexWhenGivenNoIndexChangeOption)
     EXPECT_EQ(0, [findDelegate matchIndex]);
 }
 
+TEST(WKWebViewFindString, MatchIndexIsCorrectWhenNavigatingForwardAndBackward)
+{
+    auto findDelegate = adoptNS([[WKWebViewFindStringFindDelegate alloc] init]);
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 300, 200) configuration:configuration.get() addToWindow:YES]);
+    [webView synchronouslyLoadHTMLString:@"<p>hello</p><p>hello</p><p>hello</p>"];
+    [webView _setFindDelegate:findDelegate.get()];
+
+    [webView _findString:@"hello" options:_WKFindOptionsDetermineMatchIndex maxCount:maxCount];
+    Util::run(&isDone);
+    EXPECT_EQ(0, [findDelegate matchIndex]);
+
+    isDone = false;
+    [webView _findString:@"hello" options:_WKFindOptionsDetermineMatchIndex maxCount:maxCount];
+    Util::run(&isDone);
+    EXPECT_EQ(1, [findDelegate matchIndex]);
+
+    isDone = false;
+    [webView _findString:@"hello" options:_WKFindOptionsDetermineMatchIndex maxCount:maxCount];
+    Util::run(&isDone);
+    EXPECT_EQ(2, [findDelegate matchIndex]);
+
+    isDone = false;
+    [webView _findString:@"hello" options:_WKFindOptionsBackwards | _WKFindOptionsDetermineMatchIndex  maxCount:maxCount];
+    Util::run(&isDone);
+    EXPECT_EQ(1, [findDelegate matchIndex]);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 58cdc35fd9f7095e246ecb853be71886bba6aeb5
<pre>
Find in Page match index is not being populated
<a href="https://bugs.webkit.org/show_bug.cgi?id=310120">https://bugs.webkit.org/show_bug.cgi?id=310120</a>
<a href="https://rdar.apple.com/172760529">rdar://172760529</a>

Reviewed by Megan Gardner.

This was some fallout from this refactor:
<a href="https://commits.webkit.org/309268@main">https://commits.webkit.org/309268@main</a>

The FindController index was not being populated. I also added
an API test to ensure this does not happen again.

* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::findString):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewFindString.mm:
(TestWebKitAPI::TEST(WKWebViewFindString, MatchIndexIsCorrectWhenNavigatingForwardAndBackward)):

Canonical link: <a href="https://commits.webkit.org/309485@main">https://commits.webkit.org/309485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/975d9a6389bf58cc45e4597ee994126d82b3b6f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104129 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c925bd2b-6521-4cd8-aaf8-e3ee5ef71ecc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23655 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116304 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82599 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/febc6ac3-eac9-44eb-9489-413e7fdb7b8b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153655 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18413 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135189 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97032 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19ea8652-c00e-45d5-960b-00dbd54d0656) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17510 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15459 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7265 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161891 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5012 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14667 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124303 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23255 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19506 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124501 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33816 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134908 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79632 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19582 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11670 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22857 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86657 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22569 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22721 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22623 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->