### PR TITLE
[JSC] Improve the performance of maps in VariableEnvironments

### DIFF
--- a/JSTests/stress/can-declare-global-var-invoked-before-any-binding-is-created-eval.js
+++ b/JSTests/stress/can-declare-global-var-invoked-before-any-binding-is-created-eval.js
@@ -10,7 +10,6 @@ Object.preventExtensions(globalThis);
 let didThrow = false;
 try {
     eval(`
-        var d = 4;
         function a() {}
         function b() {}
         var c = 3;

--- a/JSTests/stress/can-declare-global-var-invoked-before-any-binding-is-created-global.js
+++ b/JSTests/stress/can-declare-global-var-invoked-before-any-binding-is-created-global.js
@@ -10,7 +10,6 @@ Object.preventExtensions(globalThis);
 let didThrow = false;
 try {
     $262.evalScript(`
-        var d = 4;
         function a() {}
         function b() {}
         var c = 3;

--- a/JSTests/stress/eval-func-decl-in-global-of-eval.js
+++ b/JSTests/stress/eval-func-decl-in-global-of-eval.js
@@ -67,16 +67,14 @@ assertThrow(() => g, "ReferenceError: Can't find variable: g");
 (function() {
     try {
         let b;
-        let c;
-        eval('var a; var b; var c;');
+        eval('var a; var b;');
     } catch (e) {
         var error = e;
     }
 
-    assert(error.toString(), "SyntaxError: Can't create duplicate variable in eval: 'c'");
+    assert(error.toString(), "SyntaxError: Can't create duplicate variable in eval: 'b'");
     assertThrow(() => a, "ReferenceError: Can't find variable: a");
     assertThrow(() => b, "ReferenceError: Can't find variable: b");
-    assertThrow(() => c, "ReferenceError: Can't find variable: c");
 })();
 
 (function() {

--- a/Source/JavaScriptCore/parser/VariableEnvironment.h
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.h
@@ -28,6 +28,7 @@
 #include <JavaScriptCore/Identifier.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/InlineMap.h>
 #include <wtf/IteratorRange.h>
 #include <wtf/PackedRefPtr.h>
 #include <wtf/TZoneMalloc.h>
@@ -145,8 +146,12 @@ typedef UncheckedKeyHashMap<PackedRefPtr<UniquedStringImpl>, PrivateNameEntry, I
 
 class VariableEnvironment {
     WTF_MAKE_TZONE_ALLOCATED(VariableEnvironment);
+
+public:
+    static constexpr unsigned inlineMapCapacity = 9;
+
 private:
-    typedef UncheckedKeyHashMap<PackedRefPtr<UniquedStringImpl>, VariableEnvironmentEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>, VariableEnvironmentEntryHashTraits> Map;
+    typedef InlineMap<PackedRefPtr<UniquedStringImpl>, VariableEnvironmentEntry, inlineMapCapacity, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>, VariableEnvironmentEntryHashTraits> Map;
 
 public:
 

--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -43,6 +43,7 @@
 #include "UnlinkedModuleProgramCodeBlock.h"
 #include "UnlinkedProgramCodeBlock.h"
 #include <wtf/FileHandle.h>
+#include <wtf/InlineMap.h>
 #include <wtf/MallocPtr.h>
 #include <wtf/MallocSpan.h>
 #include <wtf/Packed.h>
@@ -701,6 +702,35 @@ private:
 template<typename Key, typename Value, typename HashArg = DefaultHash<SourceType<Key>>, typename KeyTraitsArg = HashTraits<SourceType<Key>>, typename MappedTraitsArg = HashTraits<SourceType<Value>>>
 using CachedMemoryCompactLookupOnlyRobinHoodHashMap = CachedHashMap<Key, Value, HashArg, KeyTraitsArg, MappedTraitsArg, WTF::MemoryCompactLookupOnlyRobinHoodHashTableTraits>;
 
+template<typename Key, typename Value, unsigned Capacity, typename HashArg = DefaultHash<SourceType<Key>>, typename KeyTraitsArg = HashTraits<SourceType<Key>>, typename MappedTraitsArg = HashTraits<SourceType<Value>>>
+class CachedInlineMap : public VariableLengthObject<InlineMap<SourceType<Key>, SourceType<Value>, Capacity, HashArg, KeyTraitsArg, MappedTraitsArg>> {
+
+    using Map = InlineMap<SourceType<Key>, SourceType<Value>, Capacity, HashArg, KeyTraitsArg, MappedTraitsArg>;
+
+public:
+
+    void encode(Encoder& encoder, const Map& map)
+    {
+        SourceType<decltype(m_entries)> entriesVector(map.size());
+        unsigned i = 0;
+        for (const auto& it : map)
+            entriesVector[i++] = { it.key, it.value };
+        m_entries.encode(encoder, entriesVector);
+    }
+
+    void decode(Decoder& decoder, Map& map) const
+    {
+        SourceType<decltype(m_entries)> decodedEntries;
+        m_entries.decode(decoder, decodedEntries);
+        map.reserveInitialCapacity(decodedEntries.size());
+        for (const auto& pair : decodedEntries)
+            map.add(pair.first, pair.second);
+    }
+
+private:
+    CachedVector<CachedPair<Key, Value>> m_entries;
+};
+
 template<typename T>
 class CachedUniquedStringImplBase : public VariableLengthObject<T> {
 public:
@@ -1091,7 +1121,7 @@ public:
 private:
     bool m_isEverythingCaptured;
     bool m_hasAwaitUsingDeclaration;
-    CachedHashMap<CachedRefPtr<CachedUniquedStringImpl, UniquedStringImpl, WTF::PackedPtrTraits<UniquedStringImpl>>, VariableEnvironmentEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>, VariableEnvironmentEntryHashTraits> m_map;
+    CachedInlineMap<CachedRefPtr<CachedUniquedStringImpl, UniquedStringImpl, WTF::PackedPtrTraits<UniquedStringImpl>>, VariableEnvironmentEntry, VariableEnvironment::inlineMapCapacity, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>, VariableEnvironmentEntryHashTraits> m_map;
     CachedPtr<CachedVariableEnvironmentRareData> m_rareData;
 };
 

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		1CFD5D3D2851AB3E00A0E30B /* EnumeratedArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CFD5D3B2851AB3E00A0E30B /* EnumeratedArray.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1FA47C8A152502DA00568D1B /* WebCoreThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1FA47C88152502DA00568D1B /* WebCoreThread.cpp */; };
 		231829062EF0B0D00078588C /* MemoryDump.h in Headers */ = {isa = PBXBuildFile; fileRef = 231829052EF0B0D00078588C /* MemoryDump.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		23626E7D2F42D7330007FAB7 /* InlineMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 23626E7C2F42D7330007FAB7 /* InlineMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		27C793CF2C40909D000E1BE8 /* PlatformEnableWin.h in Headers */ = {isa = PBXBuildFile; fileRef = 27C793CE2C40909D000E1BE8 /* PlatformEnableWin.h */; };
 		2A0CF001302E77880086000B /* CFTypeTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A0CF001302E77880086000A /* CFTypeTraits.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2B70468D2C6BC5F600318C0A /* StdMultimap.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B70468C2C6BC5F600318C0A /* StdMultimap.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1281,6 +1282,7 @@
 		1FA47C88152502DA00568D1B /* WebCoreThread.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebCoreThread.cpp; sourceTree = "<group>"; };
 		1FA47C89152502DA00568D1B /* WebCoreThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebCoreThread.h; sourceTree = "<group>"; };
 		231829052EF0B0D00078588C /* MemoryDump.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MemoryDump.h; sourceTree = "<group>"; };
+		23626E7C2F42D7330007FAB7 /* InlineMap.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InlineMap.h; sourceTree = "<group>"; };
 		24F1B248619F412296D1C19C /* RandomDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RandomDevice.h; sourceTree = "<group>"; };
 		26147B0815DDCCDC00DDB907 /* IntegerToStringConversion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntegerToStringConversion.h; sourceTree = "<group>"; };
 		26299B6D17A9E5B800ADEBE5 /* Ref.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Ref.h; sourceTree = "<group>"; };
@@ -2482,6 +2484,7 @@
 				3137E1D7DBD84AC38FAE4D34 /* IndexSet.h */,
 				2684D4351C000D400081D663 /* IndexSparseSet.h */,
 				A8A472BC151A825A004123FF /* InlineASM.h */,
+				23626E7C2F42D7330007FAB7 /* InlineMap.h */,
 				146C6C1C2ED51D9400956BE7 /* InlineWeakPtr.h */,
 				146C6C1E2ED51D9C00956BE7 /* InlineWeakRef.h */,
 				A70DA0821799F04D00529A9B /* Insertion.h */,
@@ -3635,6 +3638,7 @@
 				DD3DC93F27A4BF8E007E5B61 /* IndexSet.h in Headers */,
 				DD3DC96627A4BF8E007E5B61 /* IndexSparseSet.h in Headers */,
 				DD3DC97227A4BF8E007E5B61 /* InlineASM.h in Headers */,
+				23626E7D2F42D7330007FAB7 /* InlineMap.h in Headers */,
 				146C6C1D2ED51D9400956BE7 /* InlineWeakPtr.h in Headers */,
 				146C6C1F2ED51D9C00956BE7 /* InlineWeakRef.h in Headers */,
 				DD3DC91327A4BF8E007E5B61 /* Insertion.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -138,6 +138,7 @@ set(WTF_PUBLIC_HEADERS
     IndexSparseSet.h
     IndexedContainerIterator.h
     InlineASM.h
+    InlineMap.h
     InlineWeakPtr.h
     InlineWeakRef.h
     Insertion.h

--- a/Source/WTF/wtf/InlineMap.h
+++ b/Source/WTF/wtf/InlineMap.h
@@ -1,0 +1,655 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <memory>
+#include <wtf/Assertions.h>
+#include <wtf/FastMalloc.h>
+#include <wtf/HashFunctions.h>
+#include <wtf/HashTraits.h>
+#include <wtf/KeyValuePair.h>
+#include <wtf/MathExtras.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/StdLibExtras.h>
+
+namespace WTF {
+
+template<typename IteratorType> struct InlineMapAddResult {
+    IteratorType iterator;
+    bool isNewEntry;
+};
+
+// An unchecked key map that stores entries inline with linear lookup for small sizes and
+// switches to hashed heap storage only after growing past a certain point. The switchover
+// happens when the map size exceeds the InlineCapacity template parameter. InlineCapacity
+// does not need to be any special value such as a power of 2.
+//
+// InlineMap is to a large extent compatible with UncheckedKeyHashMap. Inserted keys are
+// only checked for not being empty or deleted values in debug builds. In release builds
+// such insertions would corrupt the map.
+
+template<typename KeyArg, typename ValueArg, unsigned InlineCapacity, typename HashArg = PtrHash<KeyArg>, typename KeyTraitsArg = HashTraits<KeyArg>, typename MappedTraitsArg = HashTraits<ValueArg>>
+class InlineMap {
+public:
+    using KeyType = KeyArg;
+    using KeyTraits = KeyTraitsArg;
+    using MappedType = ValueArg;
+    using MappedTraits = MappedTraitsArg;
+    using Entry = KeyValuePair<KeyType, MappedType>;
+    using EntryTraits = KeyValuePairHashTraits<KeyTraits, MappedTraits>;
+
+    InlineMap()
+        : m_size(0)
+        , m_capacity(InlineCapacity)
+    {
+    }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+    InlineMap(InlineMap&& other)
+        : m_size(other.m_size)
+        , m_capacity(other.m_capacity)
+    {
+        if (isInline()) {
+            for (unsigned i = 0; i < m_size; ++i)
+                std::construct_at(&inlineStorage()[i], WTF::move(other.inlineStorage()[i]));
+        } else {
+            m_storage.heapEntries = other.m_storage.heapEntries;
+            other.m_storage.heapEntries = nullptr;
+        }
+        other.m_size = 0;
+        other.m_capacity = InlineCapacity;
+    }
+
+    InlineMap(const InlineMap& other)
+        : m_size(other.m_size)
+        , m_capacity(other.m_capacity)
+    {
+        if (isInline()) {
+            for (unsigned i = 0; i < m_size; ++i)
+                std::construct_at(&inlineStorage()[i], other.inlineStorage()[i]);
+            return;
+        }
+
+        m_storage.heapEntries = allocateAndInitializeStorage(m_capacity);
+        Entry* srcEntries = other.m_storage.heapEntries;
+        Entry* destEntries = m_storage.heapEntries;
+
+        for (unsigned i = 0; i < m_capacity; ++i) {
+            if (isEmptyEntry(srcEntries[i]))
+                continue;
+            if constexpr (!EntryTraits::emptyValueIsZero)
+                std::destroy_at(&destEntries[i]);
+            if (isDeletedEntry(srcEntries[i]))
+                constructDeletedEntry(destEntries[i]);
+            else
+                std::construct_at(&destEntries[i], srcEntries[i]);
+        }
+    }
+
+    InlineMap& operator=(InlineMap&& other)
+    {
+        if (this != &other) {
+            std::destroy_at(this);
+            std::construct_at(this, WTF::move(other));
+        }
+        return *this;
+    }
+
+    InlineMap& operator=(const InlineMap& other)
+    {
+        if (this != &other) {
+            InlineMap temp(other);
+            swap(temp);
+        }
+        return *this;
+    }
+
+    ~InlineMap()
+    {
+        if (isInline()) {
+            std::destroy_n(inlineStorage(), m_size);
+        } else if (m_storage.heapEntries) {
+            for (unsigned i = 0; i < m_capacity; ++i) {
+                if (!isEmptyOrDeletedEntry(m_storage.heapEntries[i]))
+                    std::destroy_at(&m_storage.heapEntries[i]);
+            }
+            FastMalloc::free(m_storage.heapEntries);
+        }
+    }
+
+    class ValuesIterator;
+
+    class iterator {
+        friend class ValuesIterator;
+    public:
+        iterator() = default;
+
+        iterator(Entry* current, Entry* end)
+            : m_current(current)
+            , m_end(end)
+        {
+            skipEmpty();
+        }
+
+        Entry& operator*() const { return *m_current; }
+        Entry* operator->() const { return m_current; }
+
+        iterator& operator++()
+        {
+            ++m_current;
+            skipEmpty();
+            return *this;
+        }
+
+        bool operator==(const iterator& other) const { return m_current == other.m_current; }
+
+        ValuesIterator values() const { return ValuesIterator(*this); }
+
+    private:
+        void skipEmpty()
+        {
+            while (m_current != m_end && isEmptyOrDeletedEntry(*m_current))
+                ++m_current;
+        }
+
+        Entry* m_current { nullptr };
+        Entry* m_end { nullptr };
+    };
+
+    class ValuesIterator {
+    public:
+        ValuesIterator() = default;
+        ValuesIterator(const iterator& it)
+            : m_impl(it)
+        { }
+
+        MappedType& operator*() const { return m_impl.m_current->value; }
+        MappedType* operator->() const { return &m_impl.m_current->value; }
+
+        ValuesIterator& operator++()
+        {
+            ++m_impl;
+            return *this;
+        }
+
+        bool operator==(const ValuesIterator& other) const { return m_impl == other.m_impl; }
+
+    private:
+        iterator m_impl;
+    };
+
+    struct ValuesRange {
+        ValuesIterator m_begin;
+        ValuesIterator m_end;
+
+        ValuesIterator begin() const { return m_begin; }
+        ValuesIterator end() const { return m_end; }
+    };
+
+    using const_iterator = iterator;
+
+    using AddResult = InlineMapAddResult<iterator>;
+
+    template<typename K, typename V>
+    AddResult add(K&& key, V&& value) LIFETIME_BOUND
+    {
+        ASSERT(!isEmptyKey(key));
+        ASSERT(!KeyTraits::isDeletedValue(key));
+
+        unsigned size = m_size;
+        if (isInline()) [[likely]] {
+            Entry* entryStorage = inlineStorage();
+            Entry* end = entryStorage + size;
+            for (unsigned i = 0; i < size; ++i) {
+                if (HashArg::equal(entryStorage[i].key, key))
+                    return { iterator { &entryStorage[i], end }, false };
+            }
+
+            if (size < m_capacity) {
+                Entry* slot = &entryStorage[size];
+                std::construct_at(slot, std::forward<K>(key), std::forward<V>(value));
+                ++m_size;
+                return { iterator { slot, entriesEnd() }, true };
+            }
+
+            // At capacity in linear mode: become hashed and fall through to the hashed add
+            transitionToHashed();
+        }
+
+        if (m_size * loadFactorDenominator >= m_capacity * loadFactorNumerator) [[unlikely]]
+            grow();
+
+        Entry* end = entriesEnd();
+        Entry* slot = findKeyOrEmptyOrDeleted(key);
+        if (!isEmptyOrDeletedEntry(*slot))
+            return { iterator { slot, end }, false };
+
+        // Slot is either empty or deleted - we can insert here
+        std::construct_at(slot, std::forward<K>(key), std::forward<V>(value));
+        ++m_size;
+        return { iterator { slot, end }, true };
+    }
+
+    template<typename K>
+    bool contains(const K& key) const
+    {
+        if (!m_size)
+            return false;
+
+        if (isInline()) [[likely]] {
+            Entry* entryStorage = const_cast<InlineMap*>(this)->inlineStorage();
+            for (unsigned i = 0; i < m_size; ++i) {
+                if (HashArg::equal(entryStorage[i].key, key))
+                    return true;
+            }
+            return false;
+        }
+
+        return !isEmptyOrDeletedEntry(*findKeyOrEmpty(key));
+    }
+
+    template<typename K>
+    iterator find(const K& key) LIFETIME_BOUND
+    {
+        if (!m_size)
+            return iterator { nullptr, nullptr };
+
+        if (isInline()) [[likely]] {
+            Entry* entryStorage = inlineStorage();
+            Entry* end = entryStorage + m_size;
+            for (unsigned i = 0; i < m_size; ++i) {
+                if (HashArg::equal(entryStorage[i].key, key))
+                    return iterator { &entryStorage[i], end };
+            }
+            return iterator { end, end };
+        }
+
+        Entry* slot = findKeyOrEmpty(key);
+        Entry* end = m_storage.heapEntries + m_capacity;
+        if (isEmptyOrDeletedEntry(*slot))
+            return iterator { end, end };
+        return iterator { slot, end };
+    }
+
+    template<typename K>
+    const_iterator find(const K& key) const LIFETIME_BOUND
+    {
+        return const_cast<InlineMap*>(this)->find(key);
+    }
+
+    template<typename K>
+    bool remove(const K& key)
+    {
+        if (!m_size) [[unlikely]]
+            return false;
+
+        Entry* entryStorage = entries();
+
+        if (isInline()) {
+            // Find and swap with last entry. Inline mode should not use deleted entries.
+            for (unsigned i = 0; i < m_size; ++i) {
+                if (HashArg::equal(entryStorage[i].key, key)) [[unlikely]] {
+                    std::destroy_at(&entryStorage[i]);
+                    --m_size;
+                    if (i != m_size) {
+                        // Move last entry to fill the gap
+                        std::construct_at(&entryStorage[i], WTF::move(entryStorage[m_size]));
+                        // Assuming the moved-from entry is trivially destructible
+                    }
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        // Hashed mode - mark as deleted
+        Entry* slot = findKeyOrEmpty(key);
+        if (isEmptyOrDeletedEntry(*slot))
+            return false;
+
+        std::destroy_at(slot);
+        constructDeletedEntry(*slot);
+        --m_size;
+        return true;
+    }
+
+    iterator begin() LIFETIME_BOUND
+    {
+        if (!m_size)
+            return iterator { nullptr, nullptr };
+
+        return iterator { entries(), entriesEnd() };
+    }
+
+    const_iterator begin() const LIFETIME_BOUND
+    {
+        return const_cast<InlineMap*>(this)->begin();
+    }
+
+    iterator end() LIFETIME_BOUND
+    {
+        if (!m_size)
+            return iterator { nullptr, nullptr };
+        Entry* end = entriesEnd();
+        return iterator { end, end };
+    }
+
+    const_iterator end() const LIFETIME_BOUND
+    {
+        return const_cast<InlineMap*>(this)->end();
+    }
+
+    ValuesRange values() LIFETIME_BOUND
+    {
+        return { begin().values(), end().values() };
+    }
+
+    ValuesRange values() const LIFETIME_BOUND
+    {
+        return const_cast<InlineMap*>(this)->values();
+    }
+
+    ALWAYS_INLINE unsigned size() const
+    {
+        return m_size;
+    }
+
+    ALWAYS_INLINE bool isEmpty() const { return !m_size; }
+
+    void clear()
+    {
+        if (!m_size)
+            return;
+
+        Entry* entryStorage = entries();
+        if (isInline())
+            std::destroy_n(entryStorage, m_size);
+        else {
+            for (unsigned i = 0; i < m_capacity; ++i) {
+                if (isEmptyEntry(entryStorage[i]))
+                    continue;
+                if constexpr (EntryTraits::emptyValueIsZero) {
+                    // If emptyValueIsZero, deleted entries don't have live values and shouldn't be destroyed
+                    if (!isDeletedEntry(entryStorage[i]))
+                        std::destroy_at(&entryStorage[i]);
+                } else
+                    std::destroy_at(&entryStorage[i]);
+                constructEmptyEntry(entryStorage[i]);
+            }
+        }
+        m_size = 0;
+    }
+
+    ALWAYS_INLINE void swap(InlineMap& other)
+    {
+        // For now, implement as three moves
+        InlineMap temp(WTF::move(*this));
+        *this = WTF::move(other);
+        other = WTF::move(temp);
+    }
+
+    void reserveInitialCapacity(unsigned keyCount)
+    {
+        RELEASE_ASSERT(!m_size && m_capacity == InlineCapacity); // expecting a brand new map
+
+        if (keyCount <= InlineCapacity)
+            return;
+
+        unsigned capacity = roundUpToPowerOfTwo(keyCount * loadFactorDenominator / loadFactorNumerator + 1);
+        m_capacity = capacity;
+        m_storage.heapEntries = allocateAndInitializeStorage(capacity);
+    }
+
+private:
+    friend class InlineMapAccessForTesting;
+
+    ALWAYS_INLINE bool isInline() const { return m_capacity == InlineCapacity; }
+
+    ALWAYS_INLINE Entry* inlineStorage()
+    {
+        return reinterpret_cast<Entry*>(&m_storage.inlineEntries);
+    }
+
+    ALWAYS_INLINE const Entry* inlineStorage() const
+    {
+        return reinterpret_cast<const Entry*>(&m_storage.inlineEntries);
+    }
+
+    ALWAYS_INLINE Entry* entries()
+    {
+        return isInline() ? inlineStorage() : m_storage.heapEntries;
+    }
+
+    ALWAYS_INLINE const Entry* entries() const
+    {
+        return isInline() ? inlineStorage() : m_storage.heapEntries;
+    }
+
+    ALWAYS_INLINE Entry* entriesEnd()
+    {
+        Entry* entryStorage = entries();
+        return isInline()
+            ? entryStorage + m_size
+            : entryStorage + m_capacity;
+    }
+
+    ALWAYS_INLINE const Entry* entriesEnd() const
+    {
+        const Entry* entryStorage = entries();
+        return isInline()
+            ? entryStorage + m_size
+            : entryStorage + m_capacity;
+    }
+
+    ALWAYS_INLINE static constexpr size_t allocationSizeForCapacity(size_t capacity)
+    {
+        return sizeof(Entry) * capacity;
+    }
+
+    ALWAYS_INLINE static bool isEmptyKey(const KeyType& key)
+    {
+        return isHashTraitsEmptyValue<HashTraits<KeyType>>(key);
+    }
+
+    ALWAYS_INLINE static bool isEmptyEntry(const Entry& entry)
+    {
+        return isEmptyKey(entry.key);
+    }
+
+    ALWAYS_INLINE static bool isDeletedEntry(const Entry& entry)
+    {
+        return HashTraits<KeyType>::isDeletedValue(entry.key);
+    }
+
+    ALWAYS_INLINE static bool isEmptyOrDeletedEntry(const Entry& entry)
+    {
+        return isEmptyEntry(entry) || isDeletedEntry(entry);
+    }
+
+    ALWAYS_INLINE static void constructDeletedEntry(Entry& entry)
+    {
+        if constexpr (EntryTraits::emptyValueIsZero) {
+            // For zero-initialized types, we can zero the memory first, then set the deleted marker
+            zeroBytes(entry);
+            KeyTraits::constructDeletedValue(entry.key);
+        } else {
+            // Create the deleted key value separately to avoid construction/destruction cycle
+            typename KeyTraits::TraitType deletedKey = KeyTraits::emptyValue();
+            KeyTraits::constructDeletedValue(deletedKey);
+
+            // Construct the Entry directly with the deleted key and empty value
+            // This avoids constructing an empty Entry first and then overwriting it
+            std::construct_at(std::addressof(entry), WTF::move(deletedKey), MappedTraits::emptyValue());
+        }
+    }
+
+    ALWAYS_INLINE static void constructEmptyEntry(Entry& entry)
+    {
+        if constexpr (EntryTraits::emptyValueIsZero)
+            zeroBytes(entry);
+        else
+            std::construct_at(std::addressof(entry), KeyTraits::emptyValue(), MappedTraits::emptyValue());
+    }
+
+    static constexpr unsigned loadFactorNumerator = 3;
+    static constexpr unsigned loadFactorDenominator = 4;
+
+    ALWAYS_INLINE static Entry* allocateAndInitializeStorage(unsigned capacity)
+    {
+        if constexpr (EntryTraits::emptyValueIsZero)
+            return static_cast<Entry*>(FastMalloc::zeroedMalloc(allocationSizeForCapacity(capacity)));
+
+        Entry* storage = static_cast<Entry*>(FastMalloc::malloc(allocationSizeForCapacity(capacity)));
+        for (unsigned i = 0; i < capacity; ++i)
+            constructEmptyEntry(storage[i]);
+        return storage;
+    }
+
+    ALWAYS_INLINE void rehashTo(unsigned newCapacity)
+    {
+        bool wasInline = isInline();
+        unsigned oldIterCount = wasInline ? m_size : m_capacity;
+        Entry* oldEntries = entries();
+
+        Entry* newEntries = allocateAndInitializeStorage(newCapacity);
+
+        for (unsigned i = 0; i < oldIterCount; ++i) {
+            if (wasInline || !isEmptyOrDeletedEntry(oldEntries[i])) {
+                Entry* slot = findKeyOrEmptyInStorage(oldEntries[i].key, newEntries, newCapacity);
+                ASSERT(isEmptyEntry(*slot));
+                std::construct_at(slot, WTF::move(oldEntries[i]));
+            }
+        }
+
+        Entry* toFree = wasInline ? nullptr : oldEntries;
+        m_capacity = newCapacity;
+        m_storage.heapEntries = newEntries;
+        if (toFree)
+            FastMalloc::free(toFree);
+    }
+
+    void transitionToHashed()
+    {
+        ASSERT(isInline());
+        rehashTo(roundUpToPowerOfTwo(m_size * 2 * loadFactorDenominator / loadFactorNumerator));
+    }
+
+    void grow()
+    {
+        ASSERT(!isInline());
+        rehashTo(m_capacity * 2);
+    }
+
+    template<typename K>
+    ALWAYS_INLINE static Entry* findKeyOrEmptyInStorage(const K& key, Entry* data, unsigned capacity)
+    {
+        ASSERT(isPowerOfTwo(capacity));
+
+        unsigned hash = HashArg::hash(key);
+        unsigned mask = capacity - 1;
+        unsigned bucket = hash & mask;
+        unsigned probe = 0;
+
+        while (true) {
+            Entry* entry = &data[bucket];
+            if (isEmptyEntry(*entry)) [[likely]]
+                return entry;
+            if (!isDeletedEntry(*entry) && HashArg::equal(entry->key, key))
+                return entry;
+            ++probe;
+            bucket = (bucket + probe) & mask;
+        }
+    }
+
+    // If the key is not found, returns the empty slot where the search ended even if
+    // there were deleted slots along the way.
+    template<typename K>
+    Entry* findKeyOrEmpty(const K& key) const
+    {
+        ASSERT(!isInline());
+        return findKeyOrEmptyInStorage(key, m_storage.heapEntries, m_capacity);
+    }
+
+    Entry* findKeyOrEmptyOrDeleted(const KeyType& key) const
+    {
+        ASSERT(!isInline());
+        ASSERT(isPowerOfTwo(m_capacity));
+
+        Entry* data = m_storage.heapEntries;
+        unsigned hash = HashArg::hash(key);
+        unsigned mask = m_capacity - 1;
+        unsigned bucket = hash & mask;
+        unsigned probe = 0;
+        Entry* firstDeletedSlot = nullptr;
+
+        while (true) {
+            Entry* entry = &data[bucket];
+            if (isEmptyEntry(*entry)) [[likely]]
+                return firstDeletedSlot ? firstDeletedSlot : entry;
+            if (isDeletedEntry(*entry)) {
+                if (!firstDeletedSlot)
+                    firstDeletedSlot = entry;
+            } else if (HashArg::equal(entry->key, key))
+                return entry;
+            ++probe;
+            bucket = (bucket + probe) & mask;
+        }
+    }
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+    unsigned m_size;
+    unsigned m_capacity;
+    union Storage {
+        struct alignas(Entry) EntryBytes {
+            std::byte data[sizeof(Entry)];
+        };
+        std::array<EntryBytes, InlineCapacity> inlineEntries;
+        Entry* heapEntries;
+    } m_storage;
+};
+
+class InlineMapAccessForTesting {
+public:
+    template<typename KeyArg, typename ValueArg, unsigned InlineCapacity, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg>
+    static bool isInline(InlineMap<KeyArg, ValueArg, InlineCapacity, HashArg, KeyTraitsArg, MappedTraitsArg>& map)
+    {
+        return map.isInline();
+    }
+
+    template<typename KeyArg, typename ValueArg, unsigned InlineCapacity, typename HashArg, typename KeyTraitsArg, typename MappedTraitsArg>
+    static unsigned capacity(InlineMap<KeyArg, ValueArg, InlineCapacity, HashArg, KeyTraitsArg, MappedTraitsArg>& map)
+    {
+        return map.m_capacity;
+    }
+};
+
+} // namespace WTF
+
+using WTF::InlineMap;

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -62,6 +62,7 @@ set(TestWTF_SOURCES
     Tests/WTF/Hasher.cpp
     Tests/WTF/HexNumber.cpp
     Tests/WTF/IndexSparseSet.cpp
+    Tests/WTF/InlineMap.cpp
     Tests/WTF/Int128.cpp
     Tests/WTF/IntegerToStringConversion.cpp
     Tests/WTF/IntervalSet.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		1FEF15102D7A2AA900D29B57 /* SkipAdInPictureInPicture.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1FEF150F2D7A2A9800D29B57 /* SkipAdInPictureInPicture.html */; };
 		1FEF15112D7B69DB00D29B57 /* SkipAdInPictureInPicture.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1FEF15072D7A151900D29B57 /* SkipAdInPictureInPicture.mm */; };
 		231829092EF0E3140078588C /* MemoryDump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 231829082EF0E3140078588C /* MemoryDump.cpp */; };
+		23626E742F42D45A0007FAB7 /* InlineMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 23626E732F42D45A0007FAB7 /* InlineMap.cpp */; };
 		23CB493B2DFEAD81006E424B /* PreciseSum.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 23CB493A2DFEAD7B006E424B /* PreciseSum.cpp */; };
 		272A691022F012DA000FDABB /* PageLoadState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 272A690F22F012C7000FDABB /* PageLoadState.cpp */; };
 		278E3E1923CD842F005A6B80 /* KeyedCoding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 278E3E1823CD82FA005A6B80 /* KeyedCoding.cpp */; };
@@ -2692,6 +2693,7 @@
 		1FEF15072D7A151900D29B57 /* SkipAdInPictureInPicture.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = SkipAdInPictureInPicture.mm; sourceTree = "<group>"; };
 		1FEF150F2D7A2A9800D29B57 /* SkipAdInPictureInPicture.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = SkipAdInPictureInPicture.html; sourceTree = "<group>"; };
 		231829082EF0E3140078588C /* MemoryDump.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MemoryDump.cpp; sourceTree = "<group>"; };
+		23626E732F42D45A0007FAB7 /* InlineMap.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = InlineMap.cpp; sourceTree = "<group>"; };
 		23CB493A2DFEAD7B006E424B /* PreciseSum.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PreciseSum.cpp; sourceTree = "<group>"; };
 		260BA5781B1D2E7B004FA07C /* DFACombiner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DFACombiner.cpp; sourceTree = "<group>"; };
 		260BA57A1B1D2EE2004FA07C /* DFAHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DFAHelpers.h; sourceTree = "<group>"; };
@@ -6562,6 +6564,7 @@
 				26B2DFF815BDE599004F691D /* HashSet.cpp */,
 				7C8BFF7023C0106700C009B3 /* HexNumber.cpp */,
 				33976D8224DC479B00812304 /* IndexSparseSet.cpp */,
+				23626E732F42D45A0007FAB7 /* InlineMap.cpp */,
 				F6D67D3626F90206006E0349 /* Int128.cpp */,
 				266FAFD215E5775200F61D5B /* IntegerToStringConversion.cpp */,
 				A4EC3A782E305163002E3744 /* IntervalSet.cpp */,
@@ -7752,6 +7755,7 @@
 				7C83DED41D0A590C00FEBCF3 /* HashSet.cpp in Sources */,
 				7C8BFF7123C0107A00C009B3 /* HexNumber.cpp in Sources */,
 				33976D8324DC479B00812304 /* IndexSparseSet.cpp in Sources */,
+				23626E742F42D45A0007FAB7 /* InlineMap.cpp in Sources */,
 				F6D67D3826F90206006E0349 /* Int128.cpp in Sources */,
 				7C83DEE01D0A590C00FEBCF3 /* IntegerToStringConversion.cpp in Sources */,
 				A4EC3A792E305163002E3744 /* IntervalSet.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/InlineMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/InlineMap.cpp
@@ -1,0 +1,1875 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/InlineMap.h>
+
+#include "MoveOnly.h"
+#include "RefLogger.h"
+#include "Test.h"
+#include <wtf/HashSet.h>
+#include <wtf/PackedRefPtr.h>
+#include <wtf/Ref.h>
+#include <wtf/RefPtr.h>
+#include <wtf/Vector.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/text/StringHash.h>
+
+namespace TestWebKitAPI {
+
+TEST(WTF_InlineMap, Empty)
+{
+    // A freshly constructed map is empty and all queries return no results.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_EQ(map.size(), 0u);
+    EXPECT_FALSE(map.contains(1));
+    EXPECT_FALSE(map.contains(2));
+    EXPECT_TRUE(map.find(1) == map.end());
+    EXPECT_TRUE(map.begin() == map.end());
+}
+
+TEST(WTF_InlineMap, BasicAddAndFind)
+{
+    // Adding a single entry makes it findable; missing keys return end().
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    auto result = map.add(1, 100);
+    EXPECT_TRUE(result.isNewEntry);
+    EXPECT_EQ(result.iterator->key, 1u);
+    EXPECT_EQ(result.iterator->value, 100u);
+
+    EXPECT_FALSE(map.isEmpty());
+    EXPECT_EQ(map.size(), 1u);
+    EXPECT_TRUE(map.contains(1));
+    EXPECT_FALSE(map.contains(2));
+
+    auto it = map.find(1);
+    EXPECT_FALSE(it == map.end());
+    EXPECT_EQ(it->key, 1u);
+    EXPECT_EQ(it->value, 100u);
+
+    it = map.find(2);
+    EXPECT_TRUE(it == map.end());
+}
+
+TEST(WTF_InlineMap, DuplicateAdd)
+{
+    // Adding a key that already exists preserves the original value.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    auto result1 = map.add(1, 100);
+    EXPECT_TRUE(result1.isNewEntry);
+
+    auto result2 = map.add(1, 200);
+    EXPECT_FALSE(result2.isNewEntry);
+    EXPECT_EQ(result2.iterator->value, 100u); // Original value preserved
+
+    EXPECT_EQ(map.size(), 1u);
+}
+
+TEST(WTF_InlineMap, StorageModeTransitions)
+{
+    // Map transitions from inline to hashed storage when inline capacity is exceeded.
+    // Explicitly specify InitialCapacity=3 and InitialHashedCapacity=8
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    // New map starts empty
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // First add transitions to linear mode
+    map.add(1, 10);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Stays linear through capacity (3 entries)
+    map.add(2, 20);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    map.add(3, 30);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Fourth entry triggers transition to hashed mode
+    map.add(4, 40);
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Stays hashed as more entries are added
+    map.add(5, 50);
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // All entries should be accessible
+    EXPECT_EQ(map.size(), 5u);
+    for (unsigned i = 1; i <= 5; ++i) {
+        auto it = map.find(i);
+        ASSERT_FALSE(it == map.end());
+        EXPECT_EQ(it->value, i * 10);
+    }
+}
+
+TEST(WTF_InlineMap, LinearMode)
+{
+    // Entries within inline capacity are stored inline and are all findable.
+    // Explicitly specify InitialCapacity=3 to test linear storage behavior
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    for (unsigned i = 1; i <= 3; ++i) {
+        auto result = map.add(i, i * 10);
+        EXPECT_TRUE(result.isNewEntry);
+        EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+    }
+
+    EXPECT_EQ(map.size(), 3u);
+
+    for (unsigned i = 1; i <= 3; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        auto it = map.find(i);
+        EXPECT_FALSE(it == map.end());
+        EXPECT_EQ(it->value, i * 10);
+    }
+
+    EXPECT_FALSE(map.contains(4));
+}
+
+TEST(WTF_InlineMap, GrowToHashedMode)
+{
+    // Growing well past inline capacity preserves all entries in hashed mode.
+    // Explicitly specify InitialCapacity=3 and InitialHashedCapacity=8
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Fill linear capacity (3 entries)
+    for (unsigned i = 1; i <= 3; ++i) {
+        map.add(i, i * 10);
+        EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+    }
+
+    // Adding one more should trigger transition to hashed mode
+    map.add(4, 40);
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Fill beyond initial capacity to trigger growth
+    for (unsigned i = 5; i <= 100; ++i) {
+        auto result = map.add(i, i * 10);
+        EXPECT_TRUE(result.isNewEntry);
+        EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    }
+
+    EXPECT_EQ(map.size(), 100u);
+
+    // Verify all entries are still accessible
+    for (unsigned i = 1; i <= 100; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        auto it = map.find(i);
+        EXPECT_FALSE(it == map.end());
+        EXPECT_EQ(it->value, i * 10);
+    }
+
+    EXPECT_FALSE(map.contains(101));
+}
+
+TEST(WTF_InlineMap, Iteration)
+{
+    // Range-based for visits every entry exactly once.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, i * 10);
+
+    HashSet<unsigned, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> seenKeys;
+    unsigned count = 0;
+
+    for (auto& entry : map) {
+        seenKeys.add(entry.key);
+        EXPECT_EQ(entry.value, entry.key * 10);
+        ++count;
+    }
+
+    EXPECT_EQ(count, 10u);
+    EXPECT_EQ(seenKeys.size(), 10u);
+
+    for (unsigned i = 1; i <= 10; ++i)
+        EXPECT_TRUE(seenKeys.contains(i));
+}
+
+TEST(WTF_InlineMap, IterationAfterGrowth)
+{
+    // Iteration works correctly after the map has grown to hashed mode.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 100; ++i)
+        map.add(i, i * 10);
+
+    HashSet<unsigned, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> seenKeys;
+    unsigned count = 0;
+
+    for (auto& entry : map) {
+        seenKeys.add(entry.key);
+        EXPECT_EQ(entry.value, entry.key * 10);
+        ++count;
+    }
+
+    EXPECT_EQ(count, 100u);
+    EXPECT_EQ(seenKeys.size(), 100u);
+}
+
+TEST(WTF_InlineMap, MoveConstruction)
+{
+    // Move constructor transfers all entries and leaves the source empty.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map1;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map1.add(i, i * 10);
+
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map2(WTF::move(map1));
+
+    EXPECT_TRUE(map1.isEmpty());
+    EXPECT_EQ(map2.size(), 10u);
+
+    for (unsigned i = 1; i <= 10; ++i) {
+        EXPECT_TRUE(map2.contains(i));
+        EXPECT_EQ(map2.find(i)->value, i * 10);
+    }
+}
+
+TEST(WTF_InlineMap, MoveAssignment)
+{
+    // Move assignment replaces the target's content and leaves the source empty.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map1;
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map2;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map1.add(i, i * 10);
+
+    map2.add(100, 1000);
+
+    map2 = WTF::move(map1);
+
+    EXPECT_TRUE(map1.isEmpty());
+    EXPECT_EQ(map2.size(), 10u);
+    EXPECT_FALSE(map2.contains(100));
+
+    for (unsigned i = 1; i <= 10; ++i)
+        EXPECT_TRUE(map2.contains(i));
+}
+
+TEST(WTF_InlineMap, CopyConstructionEmpty)
+{
+    // Copy-constructing from an empty map produces another empty map.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map1;
+
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map2(map1);
+
+    EXPECT_TRUE(map1.isEmpty());
+    EXPECT_TRUE(map2.isEmpty());
+    EXPECT_EQ(map1.size(), 0u);
+    EXPECT_EQ(map2.size(), 0u);
+}
+
+TEST(WTF_InlineMap, CopyConstructionLinearMode)
+{
+    // Copy-constructing a map in inline mode produces an independent copy.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map1;
+
+    map1.add(1, 10);
+    map1.add(2, 20);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map1));
+
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map2(map1);
+
+    // Original should be unchanged
+    EXPECT_EQ(map1.size(), 2u);
+    EXPECT_TRUE(map1.contains(1));
+    EXPECT_TRUE(map1.contains(2));
+    EXPECT_EQ(map1.find(1)->value, 10u);
+    EXPECT_EQ(map1.find(2)->value, 20u);
+
+    // Copy should have same content
+    EXPECT_EQ(map2.size(), 2u);
+    EXPECT_TRUE(map2.contains(1));
+    EXPECT_TRUE(map2.contains(2));
+    EXPECT_EQ(map2.find(1)->value, 10u);
+    EXPECT_EQ(map2.find(2)->value, 20u);
+
+    // Modifying copy should not affect original
+    map2.add(3, 30);
+    EXPECT_EQ(map1.size(), 2u);
+    EXPECT_EQ(map2.size(), 3u);
+    EXPECT_FALSE(map1.contains(3));
+    EXPECT_TRUE(map2.contains(3));
+}
+
+TEST(WTF_InlineMap, CopyConstructionHashedMode)
+{
+    // Copy-constructing a map in hashed mode produces an independent copy.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map1;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map1.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map1));
+
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map2(map1);
+
+    // Original should be unchanged
+    EXPECT_EQ(map1.size(), 20u);
+    for (unsigned i = 1; i <= 20; ++i) {
+        EXPECT_TRUE(map1.contains(i));
+        EXPECT_EQ(map1.find(i)->value, i * 10);
+    }
+
+    // Copy should have same content
+    EXPECT_EQ(map2.size(), 20u);
+    for (unsigned i = 1; i <= 20; ++i) {
+        EXPECT_TRUE(map2.contains(i));
+        EXPECT_EQ(map2.find(i)->value, i * 10);
+    }
+
+    // Modifying copy should not affect original
+    map2.add(100, 1000);
+    EXPECT_EQ(map1.size(), 20u);
+    EXPECT_EQ(map2.size(), 21u);
+    EXPECT_FALSE(map1.contains(100));
+    EXPECT_TRUE(map2.contains(100));
+}
+
+TEST(WTF_InlineMap, CopyAssignment)
+{
+    // Copy assignment replaces the target's content with a copy of the source.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map1;
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map2;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map1.add(i, i * 10);
+
+    map2.add(100, 1000);
+
+    map2 = map1;
+
+    // Original should be unchanged
+    EXPECT_EQ(map1.size(), 10u);
+    for (unsigned i = 1; i <= 10; ++i)
+        EXPECT_TRUE(map1.contains(i));
+
+    // Assigned map should have same content, old content replaced
+    EXPECT_EQ(map2.size(), 10u);
+    EXPECT_FALSE(map2.contains(100));
+    for (unsigned i = 1; i <= 10; ++i) {
+        EXPECT_TRUE(map2.contains(i));
+        EXPECT_EQ(map2.find(i)->value, i * 10);
+    }
+}
+
+TEST(WTF_InlineMap, CopyAssignmentToSelf)
+{
+    // Self-assignment is a no-op and preserves the map's content.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, i * 10);
+
+    // Use a reference to avoid -Wself-assign-overloaded warning
+    auto& ref = map;
+    map = ref;
+
+    // Map should be unchanged after self-assignment
+    EXPECT_EQ(map.size(), 10u);
+    for (unsigned i = 1; i <= 10; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
+}
+
+TEST(WTF_InlineMap, CopyConstructionWithStrings)
+{
+    // Copy construction works correctly with String key/value types.
+    InlineMap<String, String, 5, StringHash> map1;
+
+    map1.add("key1"_s, "value1"_s);
+    map1.add("key2"_s, "value2"_s);
+    map1.add("key3"_s, "value3"_s);
+
+    InlineMap<String, String, 5, StringHash> map2(map1);
+
+    EXPECT_EQ(map1.size(), 3u);
+    EXPECT_EQ(map2.size(), 3u);
+
+    EXPECT_EQ(map1.find("key1"_s)->value, "value1"_s);
+    EXPECT_EQ(map2.find("key1"_s)->value, "value1"_s);
+    EXPECT_EQ(map1.find("key2"_s)->value, "value2"_s);
+    EXPECT_EQ(map2.find("key2"_s)->value, "value2"_s);
+    EXPECT_EQ(map1.find("key3"_s)->value, "value3"_s);
+    EXPECT_EQ(map2.find("key3"_s)->value, "value3"_s);
+}
+
+TEST(WTF_InlineMap, RemoveFromEmpty)
+{
+    // Removing from an empty map returns false.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    EXPECT_FALSE(map.remove(1));
+    EXPECT_TRUE(map.isEmpty());
+}
+
+TEST(WTF_InlineMap, RemoveLinearMode)
+{
+    // Removing entries in inline mode works and the map can be emptied completely.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    map.add(1, 10);
+    map.add(2, 20);
+    map.add(3, 30);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 3u);
+
+    // Remove middle entry
+    EXPECT_TRUE(map.remove(2));
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_TRUE(map.contains(1));
+    EXPECT_FALSE(map.contains(2));
+    EXPECT_TRUE(map.contains(3));
+    EXPECT_EQ(map.find(1)->value, 10u);
+    EXPECT_EQ(map.find(3)->value, 30u);
+
+    // Remove first entry
+    EXPECT_TRUE(map.remove(1));
+    EXPECT_EQ(map.size(), 1u);
+    EXPECT_FALSE(map.contains(1));
+    EXPECT_TRUE(map.contains(3));
+
+    // Remove last entry
+    EXPECT_TRUE(map.remove(3));
+    EXPECT_EQ(map.size(), 0u);
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_FALSE(map.contains(3));
+
+    // Remove from empty should return false
+    EXPECT_FALSE(map.remove(1));
+}
+
+TEST(WTF_InlineMap, RemoveNonexistentLinearMode)
+{
+    // Removing a key not present in inline mode returns false and changes nothing.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    map.add(1, 10);
+    map.add(2, 20);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    EXPECT_FALSE(map.remove(3));
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_TRUE(map.contains(1));
+    EXPECT_TRUE(map.contains(2));
+}
+
+TEST(WTF_InlineMap, RemoveHashedMode)
+{
+    // Removing entries in hashed mode leaves the remaining entries intact.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 20u);
+
+    // Remove several entries
+    EXPECT_TRUE(map.remove(5));
+    EXPECT_TRUE(map.remove(10));
+    EXPECT_TRUE(map.remove(15));
+
+    EXPECT_EQ(map.size(), 17u);
+    EXPECT_FALSE(map.contains(5));
+    EXPECT_FALSE(map.contains(10));
+    EXPECT_FALSE(map.contains(15));
+
+    // Other entries should still be accessible
+    for (unsigned i = 1; i <= 20; ++i) {
+        if (i == 5 || i == 10 || i == 15)
+            continue;
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
+
+    // Remove nonexistent should return false
+    EXPECT_FALSE(map.remove(5));
+    EXPECT_FALSE(map.remove(100));
+}
+
+TEST(WTF_InlineMap, RemoveAndReaddHashedMode)
+{
+    // A removed key can be re-added with a different value.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Remove and re-add with different value
+    EXPECT_TRUE(map.remove(5));
+    EXPECT_FALSE(map.contains(5));
+
+    auto result = map.add(5, 500);
+    EXPECT_TRUE(result.isNewEntry);
+    EXPECT_TRUE(map.contains(5));
+    EXPECT_EQ(map.find(5)->value, 500u);
+    EXPECT_EQ(map.size(), 10u);
+}
+
+TEST(WTF_InlineMap, RemoveAllHashedMode)
+{
+    // Removing all entries one by one leaves the map empty.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Remove all entries
+    for (unsigned i = 1; i <= 10; ++i)
+        EXPECT_TRUE(map.remove(i));
+
+    EXPECT_EQ(map.size(), 0u);
+    EXPECT_TRUE(map.isEmpty());
+
+    // All entries should be gone
+    for (unsigned i = 1; i <= 10; ++i)
+        EXPECT_FALSE(map.contains(i));
+}
+
+TEST(WTF_InlineMap, IterationAfterRemove)
+{
+    // Iteration skips removed entries and visits only live ones.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, i * 10);
+
+    // Remove some entries
+    map.remove(2);
+    map.remove(5);
+    map.remove(8);
+
+    // Iteration should only visit non-removed entries
+    HashSet<unsigned, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> seenKeys;
+    unsigned count = 0;
+
+    for (auto& entry : map) {
+        seenKeys.add(entry.key);
+        EXPECT_EQ(entry.value, entry.key * 10);
+        ++count;
+    }
+
+    EXPECT_EQ(count, 7u);
+    EXPECT_EQ(seenKeys.size(), 7u);
+    EXPECT_FALSE(seenKeys.contains(2));
+    EXPECT_FALSE(seenKeys.contains(5));
+    EXPECT_FALSE(seenKeys.contains(8));
+}
+
+TEST(WTF_InlineMap, RemoveWithStrings)
+{
+    // Remove works correctly with String keys.
+    InlineMap<String, unsigned, 5, StringHash> map;
+
+    map.add("one"_s, 1);
+    map.add("two"_s, 2);
+    map.add("three"_s, 3);
+
+    EXPECT_TRUE(map.remove("two"_s));
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_TRUE(map.contains("one"_s));
+    EXPECT_FALSE(map.contains("two"_s));
+    EXPECT_TRUE(map.contains("three"_s));
+
+    EXPECT_FALSE(map.remove("four"_s));
+    EXPECT_FALSE(map.remove("two"_s));
+}
+
+TEST(WTF_InlineMap, GrowAfterRemove)
+{
+    // The hash table can grow correctly after entries have been removed.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    // Fill to trigger hashed mode
+    for (unsigned i = 1; i <= 4; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Remove some entries
+    map.remove(2);
+    map.remove(3);
+    EXPECT_EQ(map.size(), 2u);
+
+    // Add more entries to trigger growth
+    for (unsigned i = 5; i <= 20; ++i)
+        map.add(i, i * 10);
+
+    // Verify all expected entries are present
+    EXPECT_TRUE(map.contains(1));
+    EXPECT_FALSE(map.contains(2));
+    EXPECT_FALSE(map.contains(3));
+    EXPECT_TRUE(map.contains(4));
+    for (unsigned i = 5; i <= 20; ++i)
+        EXPECT_TRUE(map.contains(i));
+}
+
+TEST(WTF_InlineMap, PointerKeys)
+{
+    // Raw pointers work as map keys.
+    InlineMap<int*, int, 5> map;
+
+    constexpr unsigned arraySize = 50;
+    int array[arraySize];
+
+    for (unsigned i = 0; i < arraySize; ++i) {
+        array[i] = i;
+        int* ptr = &array[i];
+        EXPECT_FALSE(map.contains(ptr));
+        auto result = map.add(ptr, i * 10);
+        EXPECT_TRUE(result.isNewEntry);
+        EXPECT_TRUE(map.contains(ptr));
+    }
+
+    EXPECT_EQ(map.size(), arraySize);
+
+    for (unsigned i = 0; i < arraySize; ++i) {
+        int* ptr = &array[i];
+        auto it = map.find(ptr);
+        EXPECT_FALSE(it == map.end());
+        EXPECT_EQ(it->value, static_cast<int>(i * 10));
+    }
+}
+
+TEST(WTF_InlineMap, ConstIteration)
+{
+    // Iteration works through a const reference to the map.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, i * 10);
+
+    const auto& constMap = map;
+    unsigned count = 0;
+
+    for (const auto& entry : constMap) {
+        EXPECT_EQ(entry.value, entry.key * 10);
+        ++count;
+    }
+
+    EXPECT_EQ(count, 10u);
+}
+
+TEST(WTF_InlineMap, ConstFind)
+{
+    // find() works through a const reference to the map.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+    map.add(1, 100);
+
+    const auto& constMap = map;
+
+    auto it = constMap.find(1);
+    EXPECT_FALSE(it == constMap.end());
+    EXPECT_EQ(it->value, 100u);
+
+    it = constMap.find(2);
+    EXPECT_TRUE(it == constMap.end());
+}
+
+TEST(WTF_InlineMap, MoveOnlyValues)
+{
+    // Move-only types work as map values.
+    InlineMap<unsigned, MoveOnly, 5, IntHash<unsigned>> map;
+
+    for (size_t i = 0; i < 100; ++i) {
+        MoveOnly moveOnly(i + 1);
+        auto result = map.add(static_cast<unsigned>(i + 1), WTF::move(moveOnly));
+        EXPECT_TRUE(result.isNewEntry);
+    }
+
+    EXPECT_EQ(map.size(), 100u);
+
+    for (size_t i = 0; i < 100; ++i) {
+        auto it = map.find(static_cast<unsigned>(i + 1));
+        ASSERT_FALSE(it == map.end());
+        EXPECT_EQ(it->value.value(), i + 1);
+    }
+}
+
+TEST(WTF_InlineMap, MoveOnlyKeys)
+{
+    // Move-only types work as map keys, including duplicate detection.
+    InlineMap<MoveOnly, unsigned, 5, DefaultHash<MoveOnly>> map;
+
+    for (size_t i = 0; i < 100; ++i) {
+        MoveOnly moveOnly(i + 1);
+        auto result = map.add(WTF::move(moveOnly), static_cast<unsigned>(i + 1));
+        EXPECT_TRUE(result.isNewEntry);
+    }
+
+    EXPECT_EQ(map.size(), 100u);
+
+    for (size_t i = 0; i < 100; ++i) {
+        auto it = map.find(MoveOnly(i + 1));
+        ASSERT_FALSE(it == map.end());
+        EXPECT_EQ(it->value, static_cast<unsigned>(i + 1));
+    }
+
+    // Verify duplicate add doesn't insert
+    for (size_t i = 0; i < 100; ++i)
+        EXPECT_FALSE(map.add(MoveOnly(i + 1), static_cast<unsigned>(i + 1)).isNewEntry);
+}
+
+namespace {
+
+template<typename T> struct ZeroHash : public IntHash<T> {
+    static unsigned hash(const T&) { return 0; }
+};
+
+} // anonymous namespace
+
+TEST(WTF_InlineMap, HashCollisions)
+{
+    // All entries remain accessible even when every key hashes to the same bucket.
+    // Use a hash that always returns 0 to force all entries into the same bucket
+    InlineMap<unsigned, unsigned, 5, ZeroHash<unsigned>> map;
+
+    // Add enough entries to trigger hashed mode
+    for (unsigned i = 1; i <= 20; ++i) {
+        auto result = map.add(i, i * 10);
+        EXPECT_TRUE(result.isNewEntry);
+    }
+
+    EXPECT_EQ(map.size(), 20u);
+
+    // Verify all entries are still accessible despite hash collisions
+    for (unsigned i = 1; i <= 20; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        auto it = map.find(i);
+        ASSERT_FALSE(it == map.end());
+        EXPECT_EQ(it->value, i * 10);
+    }
+
+    // Verify non-existent key lookup
+    EXPECT_FALSE(map.contains(100));
+}
+
+TEST(WTF_InlineMap, IteratorComparison)
+{
+    // Iterator == and \!= operators work correctly, including const conversions.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+    map.add(1, 100);
+
+    ASSERT_TRUE(map.begin() != map.end());
+    ASSERT_FALSE(map.begin() == map.end());
+
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>>::const_iterator begin = map.begin();
+    ASSERT_TRUE(begin == map.begin());
+    ASSERT_TRUE(map.begin() == begin);
+    ASSERT_TRUE(begin != map.end());
+    ASSERT_TRUE(map.end() != begin);
+    ASSERT_FALSE(begin != map.begin());
+    ASSERT_FALSE(map.begin() != begin);
+    ASSERT_FALSE(begin == map.end());
+    ASSERT_FALSE(map.end() == begin);
+}
+
+namespace {
+
+class DestructorCounter {
+public:
+    static unsigned destructorCount;
+
+    struct TestingScope {
+        TestingScope() { destructorCount = 0; }
+    };
+
+    DestructorCounter() = default;
+    DestructorCounter(unsigned value)
+        : m_value(value)
+    { }
+
+    DestructorCounter(DestructorCounter&& other)
+        : m_value(other.m_value)
+    {
+        other.m_value = 0;
+    }
+
+    DestructorCounter& operator=(DestructorCounter&& other)
+    {
+        m_value = other.m_value;
+        other.m_value = 0;
+        return *this;
+    }
+
+    ~DestructorCounter()
+    {
+        if (m_value != emptyValue())
+            ++destructorCount;
+    }
+
+    unsigned value() const { return m_value; }
+
+    static constexpr unsigned emptyValue() { return std::numeric_limits<unsigned>::max(); }
+
+private:
+    unsigned m_value { emptyValue() };
+};
+
+unsigned DestructorCounter::destructorCount = 0;
+
+} // anonymous namespace
+
+TEST(WTF_InlineMap, DestructorCalledOnClear)
+{
+    // Value destructors are called when the map is destroyed (inline mode).
+    DestructorCounter::TestingScope scope;
+
+    {
+        InlineMap<unsigned, DestructorCounter, 5, IntHash<unsigned>> map;
+
+        for (unsigned i = 1; i <= 3; ++i)
+            map.add(i, DestructorCounter(i));
+
+        EXPECT_EQ(map.size(), 3u);
+        EXPECT_EQ(DestructorCounter::destructorCount, 3u); // Moved-from temporaries
+    }
+
+    // Destructor should be called for all 3 entries when map is destroyed
+    EXPECT_EQ(DestructorCounter::destructorCount, 6u);
+}
+
+TEST(WTF_InlineMap, DestructorCalledOnClearAfterGrowth)
+{
+    // Value destructors are called for all live entries after growth (hashed mode).
+    DestructorCounter::TestingScope scope;
+    unsigned countBeforeDestruction = 0;
+
+    {
+        InlineMap<unsigned, DestructorCounter, 5, IntHash<unsigned>> map;
+
+        for (unsigned i = 1; i <= 100; ++i)
+            map.add(i, DestructorCounter(i));
+
+        EXPECT_EQ(map.size(), 100u);
+
+        // Record the count before map destruction. This includes temporaries from add()
+        // calls as well as internal temporaries created during hash table growth.
+        countBeforeDestruction = DestructorCounter::destructorCount;
+    }
+
+    // Map destruction should destroy exactly 100 live entries
+    EXPECT_EQ(DestructorCounter::destructorCount, countBeforeDestruction + 100u);
+}
+
+TEST(WTF_InlineMap, StringKeys)
+{
+    // String objects work as map keys.
+    InlineMap<String, unsigned, 5, StringHash> map;
+
+    map.add("one"_s, 1);
+    map.add("two"_s, 2);
+    map.add("three"_s, 3);
+
+    EXPECT_EQ(map.size(), 3u);
+    EXPECT_TRUE(map.contains("one"_s));
+    EXPECT_TRUE(map.contains("two"_s));
+    EXPECT_TRUE(map.contains("three"_s));
+    EXPECT_FALSE(map.contains("four"_s));
+
+    EXPECT_EQ(map.find("one"_s)->value, 1u);
+    EXPECT_EQ(map.find("two"_s)->value, 2u);
+    EXPECT_EQ(map.find("three"_s)->value, 3u);
+}
+
+TEST(WTF_InlineMap, StringValues)
+{
+    // String objects work as map values.
+    InlineMap<unsigned, String, 5, IntHash<unsigned>> map;
+
+    map.add(1, "one"_s);
+    map.add(2, "two"_s);
+    map.add(3, "three"_s);
+
+    EXPECT_EQ(map.size(), 3u);
+    EXPECT_EQ(map.find(1)->value, "one"_s);
+    EXPECT_EQ(map.find(2)->value, "two"_s);
+    EXPECT_EQ(map.find(3)->value, "three"_s);
+}
+
+TEST(WTF_InlineMap, StringKeysAndValues)
+{
+    // String-to-String map works, and duplicate add preserves the original value.
+    InlineMap<String, String, 5, StringHash> map;
+
+    map.add("key1"_s, "value1"_s);
+    map.add("key2"_s, "value2"_s);
+    map.add("key3"_s, "value3"_s);
+
+    EXPECT_EQ(map.size(), 3u);
+    EXPECT_EQ(map.find("key1"_s)->value, "value1"_s);
+    EXPECT_EQ(map.find("key2"_s)->value, "value2"_s);
+    EXPECT_EQ(map.find("key3"_s)->value, "value3"_s);
+
+    // Duplicate add should not overwrite
+    auto result = map.add("key1"_s, "newvalue"_s);
+    EXPECT_FALSE(result.isNewEntry);
+    EXPECT_EQ(map.find("key1"_s)->value, "value1"_s);
+}
+
+TEST(WTF_InlineMap, StringKeysGrowth)
+{
+    // String keys survive growth from inline to hashed mode.
+    InlineMap<String, unsigned, 5, StringHash> map;
+
+    // Add enough entries to trigger growth to hashed mode
+    for (unsigned i = 1; i <= 100; ++i)
+        map.add(makeString("key"_s, i), i);
+
+    EXPECT_EQ(map.size(), 100u);
+
+    // Verify all entries are still accessible
+    for (unsigned i = 1; i <= 100; ++i) {
+        auto key = makeString("key"_s, i);
+        EXPECT_TRUE(map.contains(key));
+        auto it = map.find(key);
+        ASSERT_FALSE(it == map.end());
+        EXPECT_EQ(it->value, i);
+    }
+
+    EXPECT_FALSE(map.contains("key101"_s));
+}
+
+TEST(WTF_InlineMap, RefPtrKeys)
+{
+    // RefPtr objects work as map keys, looked up by raw pointer.
+    DerivedRefLogger a("a");
+    DerivedRefLogger b("b");
+    DerivedRefLogger c("c");
+
+    InlineMap<RefPtr<RefLogger>, int, 5> map;
+
+    map.add(RefPtr<RefLogger>(&a), 1);
+    map.add(RefPtr<RefLogger>(&b), 2);
+    map.add(RefPtr<RefLogger>(&c), 3);
+
+    EXPECT_EQ(map.size(), 3u);
+    EXPECT_TRUE(map.contains(&a));
+    EXPECT_TRUE(map.contains(&b));
+    EXPECT_TRUE(map.contains(&c));
+
+    EXPECT_EQ(map.find(&a)->value, 1);
+    EXPECT_EQ(map.find(&b)->value, 2);
+    EXPECT_EQ(map.find(&c)->value, 3);
+}
+
+TEST(WTF_InlineMap, RefPtrValues)
+{
+    // RefPtr objects work as map values.
+    DerivedRefLogger a("a");
+    DerivedRefLogger b("b");
+
+    InlineMap<unsigned, RefPtr<RefLogger>, 5, IntHash<unsigned>> map;
+
+    map.add(1, RefPtr<RefLogger>(&a));
+    map.add(2, RefPtr<RefLogger>(&b));
+
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_EQ(map.find(1)->value.get(), &a);
+    EXPECT_EQ(map.find(2)->value.get(), &b);
+}
+
+TEST(WTF_InlineMap, RefKeys)
+{
+    // Ref objects work as map keys and are properly deref'd on destruction.
+    RefLogger a("a");
+
+    {
+        InlineMap<Ref<RefLogger>, int, 5> map;
+
+        Ref<RefLogger> ref(a);
+        map.add(WTF::move(ref), 1);
+
+        EXPECT_EQ(map.size(), 1u);
+
+        // Verify through iteration since we don't have translator support
+        bool found = false;
+        for (auto& entry : map) {
+            if (entry.key.ptr() == &a) {
+                EXPECT_EQ(entry.value, 1);
+                found = true;
+            }
+        }
+        EXPECT_TRUE(found);
+    }
+
+    EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
+}
+
+TEST(WTF_InlineMap, RefValues)
+{
+    // Ref objects work as map values and are properly deref'd on destruction.
+    RefLogger a("a");
+
+    {
+        InlineMap<unsigned, Ref<RefLogger>, 5, IntHash<unsigned>> map;
+
+        Ref<RefLogger> ref(a);
+        map.add(1, WTF::move(ref));
+
+        EXPECT_EQ(map.size(), 1u);
+        EXPECT_EQ(map.find(1)->value.ptr(), &a);
+    }
+
+    EXPECT_STREQ("ref(a) deref(a) ", takeLogStr().c_str());
+}
+
+TEST(WTF_InlineMap, RefKeysGrowth)
+{
+    // Ref keys work correctly through growth transitions.
+    // Test that Ref keys work correctly through growth transitions
+    Vector<Ref<RefLogger>> loggers;
+    for (int i = 0; i < 50; ++i)
+        loggers.append(adoptRef(*new RefLogger("a")));
+
+    {
+        InlineMap<Ref<RefLogger>, int, 5> map;
+
+        for (int i = 0; i < 50; ++i) {
+            Ref<RefLogger> ref = loggers[i].copyRef();
+            map.add(WTF::move(ref), i + 1);
+        }
+
+        EXPECT_EQ(map.size(), 50u);
+
+        // Verify all entries through iteration
+        unsigned count = 0;
+        for (auto& entry : map) {
+            ++count;
+            // Just verify values are in expected range
+            EXPECT_GE(entry.value, 1);
+            EXPECT_LE(entry.value, 50);
+        }
+        EXPECT_EQ(count, 50u);
+    }
+}
+
+TEST(WTF_InlineMap, ClearEmpty)
+{
+    // Clearing an already-empty map is a no-op.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.clear();
+
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_EQ(map.size(), 0u);
+}
+
+TEST(WTF_InlineMap, ClearLinearMode)
+{
+    // Clearing in inline mode removes entries but preserves inline storage.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    map.add(1, 10);
+    map.add(2, 20);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 2u);
+
+    map.clear();
+
+    // Storage is preserved, just cleared
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_EQ(map.size(), 0u);
+
+    // Should be able to add entries again after clear
+    map.add(3, 30);
+    EXPECT_EQ(map.size(), 1u);
+    EXPECT_TRUE(map.contains(3));
+    EXPECT_FALSE(map.contains(1));
+    EXPECT_FALSE(map.contains(2));
+}
+
+TEST(WTF_InlineMap, ClearHashedMode)
+{
+    // Clearing in hashed mode removes entries but preserves hashed storage.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 20u);
+
+    map.clear();
+
+    // Storage is preserved, just cleared
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_EQ(map.size(), 0u);
+
+    // Should be able to add entries again after clear
+    for (unsigned i = 100; i <= 105; ++i)
+        map.add(i, i);
+
+    EXPECT_EQ(map.size(), 6u);
+    for (unsigned i = 100; i <= 105; ++i)
+        EXPECT_TRUE(map.contains(i));
+    EXPECT_FALSE(map.contains(1));
+}
+
+TEST(WTF_InlineMap, ClearWithStrings)
+{
+    // Clearing works correctly with String key/value types.
+    InlineMap<String, String, 5, StringHash> map;
+
+    map.add("key1"_s, "value1"_s);
+    map.add("key2"_s, "value2"_s);
+    map.add("key3"_s, "value3"_s);
+
+    EXPECT_EQ(map.size(), 3u);
+
+    map.clear();
+
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_FALSE(map.contains("key1"_s));
+}
+
+TEST(WTF_InlineMap, ReserveInitialCapacityZero)
+{
+    // Reserving zero capacity keeps the map in inline mode.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.reserveInitialCapacity(0);
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_TRUE(map.isEmpty());
+}
+
+TEST(WTF_InlineMap, ReserveInitialCapacityLinear)
+{
+    // Reserving within inline capacity keeps inline storage.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    map.reserveInitialCapacity(2);
+
+    // Should allocate linear storage
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_TRUE(map.isEmpty());
+
+    // Should be able to add entries
+    map.add(1, 10);
+    map.add(2, 20);
+    EXPECT_EQ(map.size(), 2u);
+    EXPECT_TRUE(map.contains(1));
+    EXPECT_TRUE(map.contains(2));
+}
+
+TEST(WTF_InlineMap, ReserveInitialCapacityHashed)
+{
+    // Reserving beyond inline capacity switches directly to hashed storage.
+    InlineMap<unsigned, unsigned, 3, IntHash<unsigned>> map;
+
+    map.reserveInitialCapacity(10);
+
+    // Should allocate hashed storage directly
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_TRUE(map.isEmpty());
+
+    // Should be able to add entries without triggering growth
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_EQ(map.size(), 10u);
+    for (unsigned i = 1; i <= 10; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i * 10);
+    }
+}
+
+TEST(WTF_InlineMap, ReserveInitialCapacityLarge)
+{
+    // Reserving a large capacity pre-allocates hashed storage for many entries.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.reserveInitialCapacity(100);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_TRUE(map.isEmpty());
+
+    // Add all 100 entries
+    for (unsigned i = 1; i <= 100; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_EQ(map.size(), 100u);
+    for (unsigned i = 1; i <= 100; ++i)
+        EXPECT_TRUE(map.contains(i));
+}
+
+TEST(WTF_InlineMap, ValuesIteration)
+{
+    // The values() range visits every value exactly once.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 10; ++i)
+        map.add(i, i * 10);
+
+    unsigned sum = 0;
+    unsigned count = 0;
+    for (auto& value : map.values()) {
+        sum += value;
+        ++count;
+    }
+
+    EXPECT_EQ(count, 10u);
+    // Sum of 10 + 20 + ... + 100 = 550
+    EXPECT_EQ(sum, 550u);
+}
+
+TEST(WTF_InlineMap, ValuesIterationModify)
+{
+    // Values can be modified in-place through the values() iterator.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 5; ++i)
+        map.add(i, i);
+
+    // Modify values through the values iterator
+    for (auto& value : map.values())
+        value *= 10;
+
+    // Verify modifications
+    for (unsigned i = 1; i <= 5; ++i)
+        EXPECT_EQ(map.find(i)->value, i * 10);
+}
+
+TEST(WTF_InlineMap, ValuesIterationEmpty)
+{
+    // The values() range on an empty map produces zero iterations.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    unsigned count = 0;
+    for (auto& value : map.values()) {
+        UNUSED_PARAM(value);
+        ++count;
+    }
+
+    EXPECT_EQ(count, 0u);
+}
+
+TEST(WTF_InlineMap, ValuesIterationConst)
+{
+    // The values() range works through a const reference.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 5; ++i)
+        map.add(i, i * 10);
+
+    const auto& constMap = map;
+    unsigned sum = 0;
+    for (const auto& value : constMap.values())
+        sum += value;
+
+    EXPECT_EQ(sum, 150u); // 10 + 20 + 30 + 40 + 50
+}
+
+TEST(WTF_InlineMap, SwapBothEmpty)
+{
+    // Swapping two empty maps is a no-op.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map1;
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map2;
+
+    map1.swap(map2);
+
+    EXPECT_TRUE(map1.isEmpty());
+    EXPECT_TRUE(map2.isEmpty());
+}
+
+TEST(WTF_InlineMap, SwapOneEmpty)
+{
+    // Swapping a populated map with an empty one exchanges their contents.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map1;
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map2;
+
+    for (unsigned i = 1; i <= 5; ++i)
+        map1.add(i, i * 10);
+
+    EXPECT_EQ(map1.size(), 5u);
+    EXPECT_TRUE(map2.isEmpty());
+
+    map1.swap(map2);
+
+    EXPECT_TRUE(map1.isEmpty());
+    EXPECT_EQ(map2.size(), 5u);
+    for (unsigned i = 1; i <= 5; ++i) {
+        EXPECT_TRUE(map2.contains(i));
+        EXPECT_EQ(map2.find(i)->value, i * 10);
+    }
+}
+
+TEST(WTF_InlineMap, SwapBothPopulated)
+{
+    // Swapping two populated maps exchanges their contents.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map1;
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map2;
+
+    for (unsigned i = 1; i <= 5; ++i)
+        map1.add(i, i * 10);
+
+    for (unsigned i = 100; i <= 103; ++i)
+        map2.add(i, i);
+
+    EXPECT_EQ(map1.size(), 5u);
+    EXPECT_EQ(map2.size(), 4u);
+
+    map1.swap(map2);
+
+    EXPECT_EQ(map1.size(), 4u);
+    EXPECT_EQ(map2.size(), 5u);
+
+    // Verify map1 now has map2's original content
+    for (unsigned i = 100; i <= 103; ++i) {
+        EXPECT_TRUE(map1.contains(i));
+        EXPECT_EQ(map1.find(i)->value, i);
+    }
+    EXPECT_FALSE(map1.contains(1));
+
+    // Verify map2 now has map1's original content
+    for (unsigned i = 1; i <= 5; ++i) {
+        EXPECT_TRUE(map2.contains(i));
+        EXPECT_EQ(map2.find(i)->value, i * 10);
+    }
+    EXPECT_FALSE(map2.contains(100));
+}
+
+TEST(WTF_InlineMap, SwapWithStrings)
+{
+    // Swap works correctly with String key/value types.
+    InlineMap<String, String, 5, StringHash> map1;
+    InlineMap<String, String, 5, StringHash> map2;
+
+    map1.add("key1"_s, "value1"_s);
+    map1.add("key2"_s, "value2"_s);
+
+    map2.add("other"_s, "data"_s);
+
+    map1.swap(map2);
+
+    EXPECT_EQ(map1.size(), 1u);
+    EXPECT_EQ(map2.size(), 2u);
+
+    EXPECT_TRUE(map1.contains("other"_s));
+    EXPECT_EQ(map1.find("other"_s)->value, "data"_s);
+
+    EXPECT_TRUE(map2.contains("key1"_s));
+    EXPECT_TRUE(map2.contains("key2"_s));
+}
+
+// --- PackedRefPtr key tests (matching production use in VariableEnvironment) ---
+
+TEST(WTF_InlineMap, PackedRefPtrKeysBasic)
+{
+    // PackedRefPtr<StringImpl> keys work for basic add/find/contains.
+    Vector<String> strings;
+    strings.append("alpha"_s);
+    strings.append("beta"_s);
+    strings.append("gamma"_s);
+
+    InlineMap<PackedRefPtr<StringImpl>, unsigned, 5> map;
+
+    for (unsigned i = 0; i < strings.size(); ++i) {
+        auto result = map.add(strings[i].impl(), i + 1);
+        EXPECT_TRUE(result.isNewEntry);
+    }
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 3u);
+
+    for (unsigned i = 0; i < strings.size(); ++i) {
+        EXPECT_TRUE(map.contains(strings[i].impl()));
+        auto it = map.find(strings[i].impl());
+        ASSERT_FALSE(it == map.end());
+        EXPECT_EQ(it->value, i + 1);
+    }
+
+    EXPECT_FALSE(map.contains(String("delta"_s).impl()));
+}
+
+TEST(WTF_InlineMap, PackedRefPtrKeysGrowth)
+{
+    // PackedRefPtr keys survive growth from inline to hashed mode.
+    constexpr unsigned count = 50;
+    Vector<String> strings;
+    for (unsigned i = 0; i < count; ++i)
+        strings.append(makeString("key_"_s, i));
+
+    InlineMap<PackedRefPtr<StringImpl>, unsigned, 5> map;
+
+    for (unsigned i = 0; i < count; ++i) {
+        auto result = map.add(strings[i].impl(), i * 10);
+        EXPECT_TRUE(result.isNewEntry);
+    }
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), count);
+
+    for (unsigned i = 0; i < count; ++i) {
+        EXPECT_TRUE(map.contains(strings[i].impl()));
+        auto it = map.find(strings[i].impl());
+        ASSERT_FALSE(it == map.end());
+        EXPECT_EQ(it->value, i * 10);
+    }
+
+    EXPECT_FALSE(map.contains(String("nonexistent"_s).impl()));
+}
+
+TEST(WTF_InlineMap, PackedRefPtrKeysRemoveAndReinsert)
+{
+    // PackedRefPtr keys can be removed and re-inserted with new values.
+    constexpr unsigned count = 20;
+    Vector<String> strings;
+    for (unsigned i = 0; i < count; ++i)
+        strings.append(makeString("var_"_s, i));
+
+    InlineMap<PackedRefPtr<StringImpl>, unsigned, 5> map;
+
+    for (unsigned i = 0; i < count; ++i)
+        map.add(strings[i].impl(), i);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    // Remove even-indexed entries
+    for (unsigned i = 0; i < count; i += 2)
+        EXPECT_TRUE(map.remove(strings[i].impl()));
+
+    EXPECT_EQ(map.size(), count / 2);
+
+    // Verify odd-indexed entries are still present
+    for (unsigned i = 1; i < count; i += 2) {
+        EXPECT_TRUE(map.contains(strings[i].impl()));
+        EXPECT_EQ(map.find(strings[i].impl())->value, i);
+    }
+
+    // Re-add even-indexed entries with new values
+    for (unsigned i = 0; i < count; i += 2) {
+        auto result = map.add(strings[i].impl(), i + 1000);
+        EXPECT_TRUE(result.isNewEntry);
+    }
+
+    EXPECT_EQ(map.size(), count);
+
+    // Verify all entries
+    for (unsigned i = 0; i < count; ++i) {
+        EXPECT_TRUE(map.contains(strings[i].impl()));
+        unsigned expectedValue = (i % 2) ? i : i + 1000;
+        EXPECT_EQ(map.find(strings[i].impl())->value, expectedValue);
+    }
+}
+
+TEST(WTF_InlineMap, PackedRefPtrKeysCopy)
+{
+    // Copying a map with PackedRefPtr keys produces an independent copy.
+    constexpr unsigned count = 20;
+    Vector<String> strings;
+    for (unsigned i = 0; i < count; ++i)
+        strings.append(makeString("name_"_s, i));
+
+    InlineMap<PackedRefPtr<StringImpl>, unsigned, 5> map1;
+
+    for (unsigned i = 0; i < count; ++i)
+        map1.add(strings[i].impl(), i);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map1));
+
+    InlineMap<PackedRefPtr<StringImpl>, unsigned, 5> map2(map1);
+
+    EXPECT_EQ(map1.size(), count);
+    EXPECT_EQ(map2.size(), count);
+
+    for (unsigned i = 0; i < count; ++i) {
+        EXPECT_TRUE(map1.contains(strings[i].impl()));
+        EXPECT_TRUE(map2.contains(strings[i].impl()));
+        EXPECT_EQ(map1.find(strings[i].impl())->value, i);
+        EXPECT_EQ(map2.find(strings[i].impl())->value, i);
+    }
+
+    // Modifying copy should not affect original
+    map2.add(String("extra"_s).impl(), 999);
+    EXPECT_EQ(map1.size(), count);
+    EXPECT_EQ(map2.size(), count + 1);
+}
+
+// --- Stress tests ---
+
+TEST(WTF_InlineMap, StressInsertions)
+{
+    // Inserting 1000 entries works and all are retrievable.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 1000; ++i) {
+        auto result = map.add(i, i * 10);
+        EXPECT_TRUE(result.isNewEntry);
+    }
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 1000u);
+
+    for (unsigned i = 1; i <= 1000; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        auto it = map.find(i);
+        ASSERT_FALSE(it == map.end());
+        EXPECT_EQ(it->value, i * 10);
+    }
+
+    EXPECT_FALSE(map.contains(1001));
+}
+
+TEST(WTF_InlineMap, StressInsertRemoveReinsert)
+{
+    // Bulk remove of odd keys and re-insert with new values preserves integrity.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    // Add 200 entries
+    for (unsigned i = 1; i <= 200; ++i)
+        map.add(i, i);
+
+    EXPECT_EQ(map.size(), 200u);
+
+    // Remove odd-keyed entries
+    for (unsigned i = 1; i <= 200; i += 2)
+        EXPECT_TRUE(map.remove(i));
+
+    EXPECT_EQ(map.size(), 100u);
+
+    // Verify even entries remain, odd entries gone
+    for (unsigned i = 1; i <= 200; ++i) {
+        if (!(i % 2)) {
+            EXPECT_TRUE(map.contains(i));
+            EXPECT_EQ(map.find(i)->value, i);
+        } else
+            EXPECT_FALSE(map.contains(i));
+    }
+
+    // Re-add odd entries with new values
+    for (unsigned i = 1; i <= 200; i += 2) {
+        auto result = map.add(i, i + 1000);
+        EXPECT_TRUE(result.isNewEntry);
+    }
+
+    EXPECT_EQ(map.size(), 200u);
+
+    // Verify all entries
+    for (unsigned i = 1; i <= 200; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        unsigned expectedValue = (i % 2) ? i + 1000 : i;
+        EXPECT_EQ(map.find(i)->value, expectedValue);
+    }
+}
+
+TEST(WTF_InlineMap, StressRemoveAll)
+{
+    // Removing all 500 entries then re-adding them works correctly.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    // Add 500 entries
+    for (unsigned i = 1; i <= 500; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_EQ(map.size(), 500u);
+
+    // Remove all one by one
+    for (unsigned i = 1; i <= 500; ++i)
+        EXPECT_TRUE(map.remove(i));
+
+    EXPECT_EQ(map.size(), 0u);
+    EXPECT_TRUE(map.isEmpty());
+
+    for (unsigned i = 1; i <= 500; ++i)
+        EXPECT_FALSE(map.contains(i));
+
+    // Re-add 500 entries with different values
+    for (unsigned i = 1; i <= 500; ++i) {
+        auto result = map.add(i, i + 5000);
+        EXPECT_TRUE(result.isNewEntry);
+    }
+
+    EXPECT_EQ(map.size(), 500u);
+
+    for (unsigned i = 1; i <= 500; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i + 5000);
+    }
+}
+
+TEST(WTF_InlineMap, DuplicateAddHashedMode)
+{
+    // Duplicate adds in hashed mode preserve original values.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 20u);
+
+    // Attempt duplicate adds
+    for (unsigned i = 1; i <= 20; ++i) {
+        auto result = map.add(i, i * 100);
+        EXPECT_FALSE(result.isNewEntry);
+        EXPECT_EQ(result.iterator->value, i * 10); // Original value preserved
+    }
+
+    EXPECT_EQ(map.size(), 20u);
+}
+
+TEST(WTF_InlineMap, IterationInlineMode)
+{
+    // Iteration visits all entries while still in inline mode.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 3; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+
+    HashSet<unsigned, IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> seenKeys;
+    unsigned count = 0;
+
+    for (auto& entry : map) {
+        seenKeys.add(entry.key);
+        EXPECT_EQ(entry.value, entry.key * 10);
+        ++count;
+    }
+
+    EXPECT_EQ(count, 3u);
+    EXPECT_EQ(seenKeys.size(), 3u);
+    for (unsigned i = 1; i <= 3; ++i)
+        EXPECT_TRUE(seenKeys.contains(i));
+}
+
+TEST(WTF_InlineMap, MoveConstructionInlineMode)
+{
+    // Move construction in inline mode transfers entries and preserves inline storage.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map1;
+
+    for (unsigned i = 1; i <= 3; ++i)
+        map1.add(i, i * 10);
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map1));
+
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map2(WTF::move(map1));
+
+    EXPECT_TRUE(map1.isEmpty());
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map1));
+    EXPECT_EQ(map2.size(), 3u);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map2));
+
+    for (unsigned i = 1; i <= 3; ++i) {
+        EXPECT_TRUE(map2.contains(i));
+        EXPECT_EQ(map2.find(i)->value, i * 10);
+    }
+}
+
+TEST(WTF_InlineMap, MoveConstructionHashedMode)
+{
+    // Move construction in hashed mode steals the heap pointer.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map1;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map1.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map1));
+
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map2(WTF::move(map1));
+
+    EXPECT_TRUE(map1.isEmpty());
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map1)); // Reset to inline after move
+    EXPECT_EQ(map2.size(), 20u);
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map2)); // Stole heap pointer
+
+    for (unsigned i = 1; i <= 20; ++i) {
+        EXPECT_TRUE(map2.contains(i));
+        EXPECT_EQ(map2.find(i)->value, i * 10);
+    }
+}
+
+TEST(WTF_InlineMap, MoveAssignmentInlineToInline)
+{
+    // Move assignment between two inline maps works correctly.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map1;
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map2;
+
+    for (unsigned i = 1; i <= 3; ++i)
+        map1.add(i, i * 10);
+
+    map2.add(100, 1000);
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map1));
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map2));
+
+    map2 = WTF::move(map1);
+
+    EXPECT_TRUE(map1.isEmpty());
+    EXPECT_EQ(map2.size(), 3u);
+    EXPECT_FALSE(map2.contains(100));
+
+    for (unsigned i = 1; i <= 3; ++i) {
+        EXPECT_TRUE(map2.contains(i));
+        EXPECT_EQ(map2.find(i)->value, i * 10);
+    }
+}
+
+TEST(WTF_InlineMap, SwapInlineAndHashed)
+{
+    // Swapping an inline map with a hashed map exchanges both content and storage mode.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> inlineMap;
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> hashedMap;
+
+    for (unsigned i = 1; i <= 3; ++i)
+        inlineMap.add(i, i * 10);
+
+    for (unsigned i = 100; i <= 120; ++i)
+        hashedMap.add(i, i);
+
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(inlineMap));
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(hashedMap));
+
+    inlineMap.swap(hashedMap);
+
+    // inlineMap now has hashed content
+    EXPECT_EQ(inlineMap.size(), 21u);
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(inlineMap));
+    for (unsigned i = 100; i <= 120; ++i) {
+        EXPECT_TRUE(inlineMap.contains(i));
+        EXPECT_EQ(inlineMap.find(i)->value, i);
+    }
+    EXPECT_FALSE(inlineMap.contains(1));
+
+    // hashedMap now has inline content
+    EXPECT_EQ(hashedMap.size(), 3u);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(hashedMap));
+    for (unsigned i = 1; i <= 3; ++i) {
+        EXPECT_TRUE(hashedMap.contains(i));
+        EXPECT_EQ(hashedMap.find(i)->value, i * 10);
+    }
+    EXPECT_FALSE(hashedMap.contains(100));
+}
+
+TEST(WTF_InlineMap, ClearThenGrow)
+{
+    // A cleared map can grow beyond its original capacity.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map));
+    unsigned capacityAfterFirstGrowth = WTF::InlineMapAccessForTesting::capacity(map);
+
+    map.clear();
+
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map)); // Storage preserved
+
+    // Add enough entries to trigger growth beyond the cleared capacity
+    for (unsigned i = 1; i <= 100; ++i)
+        map.add(i, i + 100);
+
+    EXPECT_EQ(map.size(), 100u);
+    EXPECT_GT(WTF::InlineMapAccessForTesting::capacity(map), capacityAfterFirstGrowth);
+
+    for (unsigned i = 1; i <= 100; ++i) {
+        EXPECT_TRUE(map.contains(i));
+        EXPECT_EQ(map.find(i)->value, i + 100);
+    }
+}
+
+TEST(WTF_InlineMap, CopyWithDeletedEntries)
+{
+    // Copying a map with deleted tombstones produces a clean copy without them.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map1;
+
+    for (unsigned i = 1; i <= 20; ++i)
+        map1.add(i, i * 10);
+
+    EXPECT_FALSE(WTF::InlineMapAccessForTesting::isInline(map1));
+
+    // Remove some entries to create deleted tombstones
+    map1.remove(3);
+    map1.remove(7);
+    map1.remove(11);
+    map1.remove(15);
+    map1.remove(19);
+
+    EXPECT_EQ(map1.size(), 15u);
+
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map2(map1);
+
+    EXPECT_EQ(map2.size(), 15u);
+
+    // Verify copy has exactly the right entries
+    for (unsigned i = 1; i <= 20; ++i) {
+        if (i == 3 || i == 7 || i == 11 || i == 15 || i == 19)
+            EXPECT_FALSE(map2.contains(i));
+        else {
+            EXPECT_TRUE(map2.contains(i));
+            EXPECT_EQ(map2.find(i)->value, i * 10);
+        }
+    }
+
+    // Adding to copy should not affect original
+    map2.add(3, 999);
+    EXPECT_TRUE(map2.contains(3));
+    EXPECT_FALSE(map1.contains(3));
+}
+
+TEST(WTF_InlineMap, RemoveLastInlineEntry)
+{
+    // Removing the sole inline entry leaves the map empty and still usable.
+    InlineMap<unsigned, unsigned, 5, IntHash<unsigned>> map;
+
+    map.add(42, 420);
+    EXPECT_TRUE(WTF::InlineMapAccessForTesting::isInline(map));
+    EXPECT_EQ(map.size(), 1u);
+
+    EXPECT_TRUE(map.remove(42));
+    EXPECT_EQ(map.size(), 0u);
+    EXPECT_TRUE(map.isEmpty());
+    EXPECT_FALSE(map.contains(42));
+
+    // Map should still be usable
+    map.add(99, 990);
+    EXPECT_EQ(map.size(), 1u);
+    EXPECT_TRUE(map.contains(99));
+    EXPECT_EQ(map.find(99)->value, 990u);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 577296de6a91c6458c2dabfd2ceb83dec93c82ed
<pre>
[JSC] Improve the performance of maps in VariableEnvironments
<a href="https://bugs.webkit.org/show_bug.cgi?id=310108">https://bugs.webkit.org/show_bug.cgi?id=310108</a>
<a href="https://rdar.apple.com/172755753">rdar://172755753</a>

Reviewed by Yusuke Suzuki.

This patch improves the performance of JavaScript parser.
Key changes:

    * Source/WTF/wtf/InlineMap.h: Added.
    * Tools/TestWebKitAPI/Tests/WTF/InlineMap.cpp: Added.

Introduces a new map implementation, largely compatible with the existing
UncheckedKeyHashMap. The map stores entries inline using a flat array with linear lookup
when the number of entries is at or below the InlineCapacity parameter value.
This is implemented as a new class rather than a change to the existing
UncheckedKeyHashMap / HashMap / HashTable class group to keep the change localized.
Changing the base HashTable to allow linear inline storage might be an interesting
exercise, but it would be touching many use cases and is better done as a separate
project.

    * Source/JavaScriptCore/parser/VariableEnvironment.h:
    * Source/JavaScriptCore/runtime/CachedTypes.cpp:

Class VariableEnvironment is changed to use the new map for its bindings.

Testing: The new class comes with unit tests. The parser is covered by existing tests.
The patch changes 3 of them:

    * JSTests/stress/can-declare-global-var-invoked-before-any-binding-is-created-eval.js:
    * JSTests/stress/can-declare-global-var-invoked-before-any-binding-is-created-global.js:
    * JSTests/stress/eval-func-decl-in-global-of-eval.js:

These tests were relying on the specific iteration order of the original hash map by
assuming which of the two problematic bindings was visited and detected first. The purpose
of the tests is to verify that a problematic binding prevents valid bindings in the same
eval unit from taking effect.

In this context, it actually makes sense to only have one problematic binding in the test.
This both avoids the non-determinism of which binding is detected first, and reduces the
chances of a false negative (having the valid bindings not take effect simply because the
invalid one was processed first). The patch removes the second problematic definition in
each test.

Canonical link: <a href="https://commits.webkit.org/309506@main">https://commits.webkit.org/309506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/092cd7b33e0692affd5ffc4ff6ad635feac85fe1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159384 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104096 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e9094f20-dbc4-4051-a10d-fc5ea0ac790b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152535 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116282 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82588 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9b53556-2cab-4b0c-bfdf-6e81e0424c28) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135162 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97010 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e6f17b3f-4926-4a60-bb89-11b6f97189db) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17483 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15431 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7232 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/142645 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127097 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161858 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/11460 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4978 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14640 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124276 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19478 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124474 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33830 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23210 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134881 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79599 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19562 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11643 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/182144 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22824 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86623 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46563 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22536 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22688 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22590 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->