### PR TITLE
Some usdz files fail to load after recent ShaderGraph adoption

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -1406,14 +1406,19 @@ extension ShaderGraph._Proto_ShaderNodeGraph {
                     }
 
                 case .builtin, .arguments, .results:
-                    // Handle builtin nodes by looking up their definitions
+                    // Handle builtin, arguments, and results nodes
                     if let builtin = bridgeNode.builtin, !builtin.definition.isEmpty {
                         if let definition = library.definition(named: builtin.definition) {
                             let node = _Proto_ShaderNodeGraph.Node(name: nodeName, data: .definition(definition))
                             nodesDictionary[nodeName] = node
                         } else {
                             logError("Could not find builtin definition named '\(builtin.definition)' for node '\(nodeName)'")
+                            // Don't add this node to the dictionary - it will be filtered out later
                         }
+                    } else {
+                        // For arguments/results nodes without definitions, skip them
+                        // These are special node types that don't need explicit nodes in the graph
+                        logInfo("Skipping \(bridgeNode.bridgeNodeType) node '\(nodeName)' (no definition)")
                     }
 
                 @unknown default:
@@ -1421,9 +1426,31 @@ extension ShaderGraph._Proto_ShaderNodeGraph {
                 }
             }
 
-            // Convert bridge edges to edges
-            let edges = descriptor.edges.map { bridgeEdge in
-                _Proto_ShaderNodeGraph.Edge(
+            // Build a set of valid node names (excluding special nodes like arguments/results)
+            let validNodeNames = Set(nodesDictionary.keys)
+
+            // Get the names of arguments and results nodes from the descriptor fields
+            // These are stored separately in descriptor.arguments and descriptor.results, not in descriptor.nodes
+            let specialNodeNames = Set(
+                [descriptor.arguments, descriptor.results]
+                    .compactMap {
+                        $0.builtin?.name ?? $0.constant?.name
+                    }
+            )
+
+            // Convert bridge edges to edges, filtering out edges that reference truly missing nodes
+            let edges = descriptor.edges.compactMap { bridgeEdge -> _Proto_ShaderNodeGraph.Edge? in
+                let outputExists = validNodeNames.contains(bridgeEdge.outputNode) || specialNodeNames.contains(bridgeEdge.outputNode)
+                let inputExists = validNodeNames.contains(bridgeEdge.inputNode) || specialNodeNames.contains(bridgeEdge.inputNode)
+
+                guard outputExists && inputExists else {
+                    logError(
+                        "Skipping edge from '\(bridgeEdge.outputNode).\(bridgeEdge.outputPort)' to '\(bridgeEdge.inputNode).\(bridgeEdge.inputPort)' - one or both nodes not found"
+                    )
+                    return nil
+                }
+
+                return _Proto_ShaderNodeGraph.Edge(
                     outputNode: bridgeEdge.outputNode,
                     outputPort: bridgeEdge.outputPort,
                     inputNode: bridgeEdge.inputNode,


### PR DESCRIPTION
#### 77cd7914382126fba48af7155ca78b15e9d6813e
<pre>
Some usdz files fail to load after recent ShaderGraph adoption
<a href="https://bugs.webkit.org/show_bug.cgi?id=310124">https://bugs.webkit.org/show_bug.cgi?id=310124</a>
<a href="https://rdar.apple.com/172308418">rdar://172308418</a>

Reviewed by Etienne Segonzac.

Invalid nodes in the USD shader graph were not correctly handled, leading to
errors in graph reconstruction.

* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(ShaderGraph.fromWKDescriptor(_:)):

Canonical link: <a href="https://commits.webkit.org/309492@main">https://commits.webkit.org/309492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91ad02cdf2e54cddd443f9cc8b86022f5ef9580e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17175 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159570 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5b8cbd41-d291-4c9a-82c4-00dff9650366) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23811 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/116439 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/380fab50-6540-4cb3-8e5a-6f454f07c82e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135331 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97160 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19cd36b5-9097-4c47-9ff5-51d66db1af39) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/17647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15597 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7417 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127265 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162044 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5169 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14816 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/124441 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19647 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124629 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33821 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23397 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/135045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79795 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19700 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11810 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23005 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/86899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22717 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22869 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22771 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->