### PR TITLE
Move RenderBlock overflow relayout logic out of RenderLayerScrollableArea.

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2980,6 +2980,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/PaintPhase.h
     rendering/PathOperation.h
     rendering/RegionContext.h
+    rendering/RelayoutScopeForScrollbarChange
     rendering/RenderAttachment.h
     rendering/RenderBlock.h
     rendering/RenderBlockFlow.h
@@ -3000,6 +3001,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/RenderImageResource.h
     rendering/RenderInline.h
     rendering/RenderLayer.h
+    rendering/ScrollbarUpdateScope.h
     rendering/RenderLayerBacking.h
     rendering/RenderLayerCompositor.h
     rendering/RenderLayerModelObject.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2902,6 +2902,8 @@ rendering/InlineBoxPainter.cpp
 rendering/LayerAncestorClippingStack.cpp
 rendering/LayerOverlapMap.cpp
 rendering/LayoutScope.cpp
+rendering/RelayoutScopeForScrollbarChange.cpp
+rendering/ScrollbarUpdateScope.cpp
 rendering/LayoutDisallowedScope.cpp
 rendering/LayoutRepainter.cpp
 rendering/LegacyInlineBox.cpp

--- a/Source/WebCore/rendering/LayoutScope.cpp
+++ b/Source/WebCore/rendering/LayoutScope.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "LayoutScope.h"
 
+#include "RelayoutScopeForScrollbarChange.h"
 #include "RenderBlock.h"
 
 namespace WebCore {
@@ -35,10 +36,16 @@ LayoutScope::LayoutScope(RenderElement& renderer)
 {
 }
 
+LayoutScope::LayoutScope(RenderBlock& renderBlock, InOverflowRelayout inOverflowRelayout)
+    : m_renderer(renderBlock)
+    , m_inOverflowRelayout(inOverflowRelayout)
+{
+}
+
 LayoutScope::~LayoutScope()
 {
     if (CheckedPtr block = dynamicDowncast<RenderBlock>(m_renderer))
-        block->updateScrollInfoAfterLayout();
+        RelayoutScopeForScrollbarChange relayoutScope { *block, m_inOverflowRelayout };
 
     m_renderer->setScrollAnchoringSuppressionStyleChanged(false);
     m_renderer->clearNeedsLayout();

--- a/Source/WebCore/rendering/LayoutScope.h
+++ b/Source/WebCore/rendering/LayoutScope.h
@@ -30,13 +30,19 @@
 
 namespace WebCore {
 
+class RenderBlock;
+
+enum class InOverflowRelayout : bool { No, Yes };
+
 class LayoutScope {
 public:
     LayoutScope(RenderElement& renderer);
+    LayoutScope(RenderBlock&, InOverflowRelayout);
     ~LayoutScope();
 
 private:
     const CheckedRef<RenderElement> m_renderer;
+    InOverflowRelayout m_inOverflowRelayout { InOverflowRelayout::No };
 };
 
 }

--- a/Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp
+++ b/Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "RelayoutScopeForScrollbarChange.h"
+
+#include "LayoutScope.h"
+#include "RenderBlock.h"
+#include "RenderFlexibleBox.h"
+#include "RenderObjectInlines.h"
+
+namespace WebCore {
+
+RelayoutScopeForScrollbarChange::RelayoutScopeForScrollbarChange(RenderBlock& renderBlock, InOverflowRelayout inOverflowRelayout)
+    : m_renderBlock(renderBlock)
+    , m_inOverflowRelayout(inOverflowRelayout)
+    , m_scrollbarUpdateScope(renderBlock.updateScrollInfoAfterLayout())
+{
+}
+
+RelayoutScopeForScrollbarChange::~RelayoutScopeForScrollbarChange()
+{
+    if (!m_scrollbarUpdateScope)
+        return;
+
+    using ScrollbarChange = ScrollbarUpdateScope::ScrollbarChange;
+    auto& scrollbarChanges = m_scrollbarUpdateScope->scrollbarChanges();
+    if (scrollbarChanges.isEmpty())
+        return;
+
+    // Scrollbars with auto behavior may need to lay out again if scrollbars got added or removed.
+    m_renderBlock->repaint();
+
+    if (m_renderBlock->style().overflowX() == Overflow::Auto || m_renderBlock->style().overflowY() == Overflow::Auto) {
+        if (m_inOverflowRelayout == InOverflowRelayout::No) {
+            m_renderBlock->setNeedsLayout(MarkingBehavior::MarkOnlyThis);
+            auto scope = LayoutScope { m_renderBlock.get(), InOverflowRelayout::Yes };
+            m_renderBlock->scrollbarsChanged(scrollbarChanges.contains(ScrollbarChange::AutoHorizontalScrollbarChanged), scrollbarChanges.contains(ScrollbarChange::AutoVerticalScrollBarChanged));
+            m_renderBlock->layoutBlock(RelayoutChildren::Yes);
+        }
+    }
+
+    // FIXME: This does not belong here.
+    CheckedPtr parent = m_renderBlock->parent();
+    if (CheckedPtr parentFlexibleBox = dynamicDowncast<RenderFlexibleBox>(parent); parentFlexibleBox)
+        parentFlexibleBox->clearCachedMainSizeForFlexItem(m_renderBlock.get());
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/RelayoutScopeForScrollbarChange.h
+++ b/Source/WebCore/rendering/RelayoutScopeForScrollbarChange.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/ScrollbarUpdateScope.h>
+#include <wtf/CheckedPtr.h>
+
+namespace WebCore {
+
+class RenderBlock;
+
+enum class InOverflowRelayout : bool;
+
+// When a renderer goes through layout it may gain or lose a scrollbar which may
+// affect the layout of its contents. We learn from ScrollbarUpdaterScope if this
+// happens and use this scope to potentially relayout the renderer in response.
+class RelayoutScopeForScrollbarChange {
+public:
+    RelayoutScopeForScrollbarChange(RenderBlock&, InOverflowRelayout);
+    ~RelayoutScopeForScrollbarChange();
+
+    RelayoutScopeForScrollbarChange(const RelayoutScopeForScrollbarChange&) = delete;
+    RelayoutScopeForScrollbarChange& operator=(const RelayoutScopeForScrollbarChange&) = delete;
+    RelayoutScopeForScrollbarChange(RelayoutScopeForScrollbarChange&&) = default;
+
+private:
+    const CheckedRef<RenderBlock> m_renderBlock;
+    InOverflowRelayout m_inOverflowRelayout;
+
+    // When |this| is being destroyed, whichs means we may have ran layout on
+    // the renderer again, ScrollbarUpdateScope's destructor will know that
+    // the associated renderer's geometry and content's geometry may have changed.
+    std::optional<ScrollbarUpdateScope> m_scrollbarUpdateScope;
+};
+
+}

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -54,6 +54,7 @@
 #include "PaintInfo.h"
 #include "PaintInfoInlines.h"
 #include "PositionedLayoutConstraints.h"
+#include "RelayoutScopeForScrollbarChange.h"
 #include "RenderBlockFlow.h"
 #include "RenderBlockInlines.h"
 #include "RenderBoxFragmentInfo.h"
@@ -81,6 +82,7 @@
 #include "RenderTreeBuilder.h"
 #include "RenderTreePosition.h"
 #include "RenderView.h"
+#include "ScrollbarUpdateScope.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
 #include "ShapeOutsideInfo.h"
@@ -477,7 +479,7 @@ void RenderBlock::endAndCommitUpdateScrollInfoAfterLayoutTransaction()
         if (block->hasControlClip() && block->hasRenderOverflow())
             block->clearLayoutOverflow();
         if (block->hasNonVisibleOverflow())
-            block->layer()->updateScrollInfoAfterLayout();
+            RelayoutScopeForScrollbarChange relayoutScope { *block, InOverflowRelayout::No };
     }
 }
 
@@ -491,7 +493,7 @@ static inline bool NODELETE isDelayingUpdateScrollInfoAfterLayout(const RenderBl
     return transaction && transaction->nestedCount && !renderer.writingMode().isBlockFlipped();
 };
 
-void RenderBlock::updateScrollInfoAfterLayout()
+std::optional<ScrollbarUpdateScope> RenderBlock::updateScrollInfoAfterLayout()
 {
     auto hasNonVisibleOverflow = this->hasNonVisibleOverflow();
 
@@ -499,12 +501,14 @@ void RenderBlock::updateScrollInfoAfterLayout()
         auto shouldUpdate = hasNonVisibleOverflow || hasControlClip();
         if (shouldUpdate) {
             view().frameView().layoutContext().updateScrollInfoAfterLayoutTransactionIfExists()->blocks.add(*this);
-            return;
+            return { };
         }
     }
 
     if (hasNonVisibleOverflow && layer())
-        layer()->updateScrollInfoAfterLayout();
+        return layer()->updateScrollInfoAfterLayout();
+
+    return { };
 }
 
 void RenderBlock::layout()
@@ -735,8 +739,9 @@ bool RenderBlock::simplifiedLayout()
 
     updateLayerTransform();
 
-    updateScrollInfoAfterLayout();
-
+    {
+        RelayoutScopeForScrollbarChange relayoutScope { *this, InOverflowRelayout::No };
+    }
     clearNeedsLayout();
     return true;
 }

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -33,8 +33,10 @@ namespace WebCore {
 
 class LayoutScope;
 class LogicalSelectionOffsetCaches;
+class RelayoutScopeForScrollbarChange;
 class RenderInline;
 class RenderText;
+class ScrollbarUpdateScope;
 
 struct PaintInfo;
 struct RenderBlockRareData;
@@ -55,6 +57,7 @@ typedef unsigned TextRunFlags;
 class RenderBlock : public RenderBox {
     WTF_MAKE_TZONE_ALLOCATED(RenderBlock);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderBlock);
+    friend class RelayoutScopeForScrollbarChange;
 public:
     // FIXME: This is temporary to allow us to move code from RenderBlock into RenderBlockFlow that accesses member variables that we haven't moved out of
     // RenderBlock yet.
@@ -291,7 +294,7 @@ protected:
 
     void removeFromUpdateScrollInfoAfterLayoutTransaction();
 
-    void updateScrollInfoAfterLayout();
+    std::optional<ScrollbarUpdateScope> updateScrollInfoAfterLayout();
 
     void styleWillChange(Style::Difference, const RenderStyle& newStyle) override;
     void styleDidChange(Style::Difference, const RenderStyle* oldStyle) override;

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -144,6 +144,7 @@
 #include "ScrollSnapOffsetsInfo.h"
 #include "Scrollbar.h"
 #include "ScrollbarTheme.h"
+#include "ScrollbarUpdateScope.h"
 #include "ScrollingCoordinator.h"
 #include "Settings.h"
 #include "ShadowRoot.h"
@@ -3157,11 +3158,12 @@ int RenderLayer::scrollHeight() const
     return roundToInt(overflowRect.maxY() - overflowRect.y());
 }
 
-void RenderLayer::updateScrollInfoAfterLayout()
+std::optional<ScrollbarUpdateScope> RenderLayer::updateScrollInfoAfterLayout()
 {
     updateLayerScrollableArea();
     if (m_scrollableArea)
-        m_scrollableArea->updateScrollInfoAfterLayout();
+        return m_scrollableArea->updateScrollInfoAfterLayout();
+    return { };
 }
 
 void RenderLayer::updateScrollbarSteps()

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -510,7 +510,7 @@ public:
     bool isPointInResizeControl(IntPoint localPoint) const;
     IntSize offsetFromResizeCorner(const IntPoint& localPoint) const;
 
-    void updateScrollInfoAfterLayout();
+    std::optional<ScrollbarUpdateScope> updateScrollInfoAfterLayout();
     void updateScrollbarSteps();
 
     // Returns true if this RenderLayer is a candidate for scrolling during scrollIntoView operations.

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -84,6 +84,7 @@
 #include "ScrollAnchoringController.h"
 #include "ScrollAnimator.h"
 #include "ScrollbarTheme.h"
+#include "ScrollbarUpdateScope.h"
 #include "ScrollbarsController.h"
 #include "ScrollingCoordinator.h"
 #include "ShadowRoot.h"
@@ -1287,108 +1288,12 @@ void RenderLayerScrollableArea::updateScrollbarsAfterStyleChange(const RenderSty
     }
 }
 
-void RenderLayerScrollableArea::updateScrollbarsAfterLayout()
-{
-    CheckedPtr box = m_layer.renderBox();
-    ASSERT(box);
-
-    // List box parts handle the scrollbars by themselves so we have nothing to do.
-    if (box->style().usedAppearance() == StyleAppearance::Listbox)
-        return;
-
-    bool hadHorizontalScrollbar = hasHorizontalScrollbar();
-    bool hadVerticalScrollbar = hasVerticalScrollbar();
-
-    bool hasHorizontalOverflow = this->hasHorizontalOverflow();
-    bool hasVerticalOverflow = this->hasVerticalOverflow();
-
-    updateScrollbarPresenceAndState(hasHorizontalOverflow, hasVerticalOverflow);
-
-    // Scrollbars with auto behavior may need to lay out again if scrollbars got added or removed.
-    bool autoHorizontalScrollBarChanged = box->hasAutoScrollbar(ScrollbarOrientation::Horizontal) && (hadHorizontalScrollbar != hasHorizontalScrollbar());
-    bool autoVerticalScrollBarChanged = box->hasAutoScrollbar(ScrollbarOrientation::Vertical) && (hadVerticalScrollbar != hasVerticalScrollbar());
-
-    if (autoHorizontalScrollBarChanged || autoVerticalScrollBarChanged) {
-        if (autoVerticalScrollBarChanged && shouldPlaceVerticalScrollbarOnLeft())
-            computeScrollOrigin();
-
-        m_layer.updateSelfPaintingLayer();
-
-        auto& renderer = m_layer.renderer();
-        renderer.repaint();
-
-        if (renderer.style().overflowX() == Overflow::Auto || renderer.style().overflowY() == Overflow::Auto) {
-            if (!m_inOverflowRelayout) {
-                SetForScope inOverflowRelayoutScope(m_inOverflowRelayout, true);
-                renderer.setNeedsLayout(MarkingBehavior::MarkOnlyThis);
-                if (CheckedPtr block = dynamicDowncast<RenderBlock>(renderer)) {
-                    // FIXME: Calling layoutBlock here is a bit of a layering violation.
-                    auto scope = LayoutScope { *block };
-                    block->scrollbarsChanged(autoHorizontalScrollBarChanged, autoVerticalScrollBarChanged);
-                    block->layoutBlock(RelayoutChildren::Yes);
-                } else
-                    renderer.layout();
-            }
-        }
-
-        // FIXME: This does not belong here.
-        auto* parent = renderer.parent();
-        if (CheckedPtr parentFlexibleBox = dynamicDowncast<RenderFlexibleBox>(parent); parentFlexibleBox && renderer.isRenderBox())
-            parentFlexibleBox->clearCachedMainSizeForFlexItem(*m_layer.renderBox());
-    }
-
-    // Set up the range.
-    if (RefPtr hBar = m_hBar)
-        hBar->setProportion(roundToInt(box->clientWidth()), m_scrollWidth);
-    if (RefPtr vBar = m_vBar)
-        vBar->setProportion(roundToInt(box->clientHeight()), m_scrollHeight);
-
-    updateScrollbarSteps();
-
-    auto hasScrollableOverflow = [&]() {
-        if (hasVerticalOverflow && m_layer.renderBox()->scrollsOverflowY())
-            return true;
-
-        if (hasHorizontalOverflow && m_layer.renderBox()->scrollsOverflowX())
-            return true;
-
-        return false;
-    };
-
-    updateScrollableAreaSet(hasScrollableOverflow());
-
-    if (CheckedPtr scrollAnchoringController = this->scrollAnchoringController())
-        scrollAnchoringController->scrollerDidLayout();
-}
-
-void RenderLayerScrollableArea::updateScrollbarSteps()
-{
-    if (!m_hBar && !m_vBar)
-        return;
-
-    CheckedPtr box = m_layer.renderBox();
-    ASSERT(box);
-
-    LayoutRect paddedLayerBounds(0_lu, 0_lu, box->clientWidth(), box->clientHeight());
-    paddedLayerBounds.contract(box->scrollPaddingForViewportRect(paddedLayerBounds));
-
-    // Set up the  page step/line step.
-    if (RefPtr hBar = m_hBar) {
-        int width = roundToInt(paddedLayerBounds.width());
-        hBar->setSteps(Scrollbar::pixelsPerLineStep(width), Scrollbar::pageStep(width));
-    }
-    if (RefPtr vBar = m_vBar) {
-        int height = roundToInt(paddedLayerBounds.height());
-        vBar->setSteps(Scrollbar::pixelsPerLineStep(height), Scrollbar::pageStep(height));
-    }
-}
-
 // This is called from layout code (before updateLayerPositions).
-void RenderLayerScrollableArea::updateScrollInfoAfterLayout()
+std::optional<ScrollbarUpdateScope> RenderLayerScrollableArea::updateScrollInfoAfterLayout()
 {
-    RenderBox* box = m_layer.renderBox();
+    CheckedPtr box = m_layer.renderBox();
     if (!box)
-        return;
+        return { };
 
     m_scrollDimensionsDirty = true;
     auto originalScrollPosition = scrollPosition();
@@ -1411,25 +1316,55 @@ void RenderLayerScrollableArea::updateScrollInfoAfterLayout()
         }
     }
 
-    updateScrollbarsAfterLayout();
+    // List box parts handle the scrollbars by themselves so we have nothing to do.
+    if (box->style().usedAppearance() == StyleAppearance::Listbox)
+        return { };
 
-    LOG_WITH_STREAM(Scrolling, stream << "RenderLayerScrollableArea [" << scrollingNodeID() << "] updateScrollInfoAfterLayout - new scroll width " << m_scrollWidth << " scroll height " << m_scrollHeight
-        << " rubber banding " << isRubberBandInProgress() << " user scrolling " << isUserScrollInProgress() << " scroll position updated from " << originalScrollPosition << " to " << scrollPosition());
+    bool hadHorizontalScrollbar = hasHorizontalScrollbar();
+    bool hadVerticalScrollbar = hasVerticalScrollbar();
 
-    if (originalScrollPosition != scrollPosition())
-        scrollToPositionWithoutAnimation(IntPoint(scrollPosition()));
+    bool hasHorizontalOverflow = this->hasHorizontalOverflow();
+    bool hasVerticalOverflow = this->hasVerticalOverflow();
 
-    if (m_layer.isComposited()) {
-        m_layer.setNeedsCompositingGeometryUpdate();
-        m_layer.setNeedsCompositingConfigurationUpdate();
+    updateScrollbarPresenceAndState(hasHorizontalOverflow, hasVerticalOverflow);
+
+    // Scrollbars with auto behavior may need to lay out again if scrollbars got added or removed.
+    OptionSet<ScrollbarUpdateScope::ScrollbarChange> scrollbarChanges;
+    if (box->hasAutoScrollbar(ScrollbarOrientation::Horizontal) && (hadHorizontalScrollbar != hasHorizontalScrollbar()))
+        scrollbarChanges.add(ScrollbarUpdateScope::ScrollbarChange::AutoHorizontalScrollbarChanged);
+
+    if (box->hasAutoScrollbar(ScrollbarOrientation::Vertical) && (hadVerticalScrollbar != hasVerticalScrollbar()))
+        scrollbarChanges.add(ScrollbarUpdateScope::ScrollbarChange::AutoVerticalScrollBarChanged);
+
+    if (!scrollbarChanges.isEmpty()) {
+        if (scrollbarChanges.contains(ScrollbarUpdateScope::ScrollbarChange::AutoVerticalScrollBarChanged) && shouldPlaceVerticalScrollbarOnLeft())
+            computeScrollOrigin();
+        m_layer.updateSelfPaintingLayer();
     }
 
-    if (canUseCompositedScrolling())
-        m_layer.setNeedsPostLayoutCompositingUpdate();
+    return ScrollbarUpdateScope { *this, originalScrollPosition, scrollbarChanges, hasHorizontalOverflow ? HasHorizontalOverflow::Yes : HasHorizontalOverflow::No, hasVerticalOverflow ? HasVerticalOverflow::Yes : HasVerticalOverflow::No };
+}
 
-    resnapAfterLayout();
+void RenderLayerScrollableArea::updateScrollbarSteps()
+{
+    if (!m_hBar && !m_vBar)
+        return;
 
-    InspectorInstrumentation::didAddOrRemoveScrollbars(m_layer.renderer());
+    CheckedPtr box = m_layer.renderBox();
+    ASSERT(box);
+
+    LayoutRect paddedLayerBounds(0_lu, 0_lu, box->clientWidth(), box->clientHeight());
+    paddedLayerBounds.contract(box->scrollPaddingForViewportRect(paddedLayerBounds));
+
+    // Set up the  page step/line step.
+    if (RefPtr hBar = m_hBar) {
+        int width = roundToInt(paddedLayerBounds.width());
+        hBar->setSteps(Scrollbar::pixelsPerLineStep(width), Scrollbar::pageStep(width));
+    }
+    if (RefPtr vBar = m_vBar) {
+        int height = roundToInt(paddedLayerBounds.height());
+        vBar->setSteps(Scrollbar::pixelsPerLineStep(height), Scrollbar::pageStep(height));
+    }
 }
 
 bool RenderLayerScrollableArea::overflowControlsIntersectRect(const IntRect& localRect) const

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -56,6 +56,7 @@ class RenderMarquee;
 class RenderLayerScrollableArea final : public ScrollableArea, public CanMakeCheckedPtr<RenderLayerScrollableArea> {
     WTF_MAKE_TZONE_ALLOCATED(RenderLayerScrollableArea);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderLayerScrollableArea);
+    friend class ScrollbarUpdateScope;
 public:
     explicit RenderLayerScrollableArea(RenderLayer&);
     virtual ~RenderLayerScrollableArea();
@@ -146,8 +147,8 @@ public:
     void paintResizer(GraphicsContext&, const LayoutPoint&, const IntRect& resizerRect, const LayoutRect& damageRect);
     void paintOverlayScrollbars(GraphicsContext&, const LayoutRect& damageRect, OptionSet<PaintBehavior>, RenderObject* subtreePaintRoot = nullptr);
 
-    void updateScrollInfoAfterLayout();
     void updateScrollbarSteps();
+    std::optional<ScrollbarUpdateScope> updateScrollInfoAfterLayout();
 
     bool scroll(ScrollDirection, ScrollGranularity, unsigned stepCount = 1);
 
@@ -235,7 +236,6 @@ public:
     void setContainsDirtyOverlayScrollbars(bool dirtyScrollbars) { m_containsDirtyOverlayScrollbars = dirtyScrollbars; }
 
     void updateScrollbarsAfterStyleChange(const RenderStyle* oldStyle);
-    void updateScrollbarsAfterLayout();
 
     bool positionOverflowControls(const IntSize&);
 
@@ -305,7 +305,6 @@ private:
 
 private:
     bool m_scrollDimensionsDirty { true };
-    bool m_inOverflowRelayout { false };
     bool m_registeredScrollableArea { false };
     bool m_hasCompositedScrollableOverflow { false };
 

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -96,6 +96,10 @@
 #include <wtf/Language.h>
 #include <wtf/NeverDestroyed.h>
 
+#if PLATFORM(COCOA)
+#include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#endif
+
 #if ENABLE(SERVICE_CONTROLS)
 #include "ImageControlsMac.h"
 #endif

--- a/Source/WebCore/rendering/ScrollbarUpdateScope.cpp
+++ b/Source/WebCore/rendering/ScrollbarUpdateScope.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScrollbarUpdateScope.h"
+
+#include "InspectorInstrumentation.h"
+#include "Logging.h"
+#include "RenderLayerScrollableArea.h"
+#include "ScrollAnchoringController.h"
+
+
+namespace WebCore {
+
+ScrollbarUpdateScope::ScrollbarUpdateScope(RenderLayerScrollableArea& scrollableArea, ScrollPosition originalScrollPosition, OptionSet<ScrollbarChange> scrollbarChanges, HasHorizontalOverflow hasHorizontalOverflow, HasVerticalOverflow hasVerticalOverflow)
+    : m_renderLayerScrollableArea(scrollableArea)
+    , m_originalScrollPosition(originalScrollPosition)
+    , m_scrollbarChanges(scrollbarChanges)
+    , m_hasHorizontalOverflow(hasHorizontalOverflow)
+    , m_hasVerticalOverflow(hasVerticalOverflow)
+{
+}
+
+ScrollbarUpdateScope::~ScrollbarUpdateScope()
+{
+    CheckedPtr box = m_renderLayerScrollableArea->m_layer.renderBox();
+    ASSERT(box);
+
+    // Set up the range.
+    if (RefPtr hBar = m_renderLayerScrollableArea->m_hBar)
+        hBar->setProportion(roundToInt(box->clientWidth()), m_renderLayerScrollableArea->m_scrollWidth);
+    if (RefPtr vBar = m_renderLayerScrollableArea->m_vBar)
+        vBar->setProportion(roundToInt(box->clientHeight()), m_renderLayerScrollableArea->m_scrollHeight);
+
+    m_renderLayerScrollableArea->updateScrollbarSteps();
+
+    auto hasScrollableOverflow = [&]() {
+        if (m_hasVerticalOverflow == HasVerticalOverflow::Yes && m_renderLayerScrollableArea->m_layer.renderBox()->scrollsOverflowY())
+            return true;
+
+        if (m_hasHorizontalOverflow == HasHorizontalOverflow::Yes && m_renderLayerScrollableArea->m_layer.renderBox()->scrollsOverflowX())
+            return true;
+
+        return false;
+    };
+
+    m_renderLayerScrollableArea->updateScrollableAreaSet(hasScrollableOverflow());
+
+    if (CheckedPtr scrollAnchoringController = m_renderLayerScrollableArea->scrollAnchoringController())
+        scrollAnchoringController->scrollerDidLayout();
+
+    LOG_WITH_STREAM(Scrolling, stream << "RenderLayerScrollableArea [" << m_renderLayerScrollableArea->scrollingNodeID() << "] updateScrollInfoAfterLayout - new scroll width " << m_renderLayerScrollableArea->m_scrollWidth << " scroll height " << m_renderLayerScrollableArea->m_scrollHeight
+        << " rubber banding " << m_renderLayerScrollableArea->isRubberBandInProgress() << " user scrolling " << m_renderLayerScrollableArea->isUserScrollInProgress() << " scroll position updated from " << m_originalScrollPosition << " to " << m_renderLayerScrollableArea->scrollPosition());
+
+    if (m_originalScrollPosition != m_renderLayerScrollableArea->scrollPosition())
+        m_renderLayerScrollableArea->scrollToPositionWithoutAnimation(IntPoint(m_renderLayerScrollableArea->scrollPosition()));
+
+    if (m_renderLayerScrollableArea->m_layer.isComposited()) {
+        m_renderLayerScrollableArea->m_layer.setNeedsCompositingGeometryUpdate();
+        m_renderLayerScrollableArea->m_layer.setNeedsCompositingConfigurationUpdate();
+    }
+
+    if (m_renderLayerScrollableArea->canUseCompositedScrolling())
+        m_renderLayerScrollableArea->m_layer.setNeedsPostLayoutCompositingUpdate();
+
+    m_renderLayerScrollableArea->resnapAfterLayout();
+
+    InspectorInstrumentation::didAddOrRemoveScrollbars(m_renderLayerScrollableArea->m_layer.renderer());
+}
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/ScrollbarUpdateScope.h
+++ b/Source/WebCore/rendering/ScrollbarUpdateScope.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ScrollTypes.h"
+#include <wtf/CheckedPtr.h>
+#include <wtf/OptionSet.h>
+
+namespace WebCore {
+
+class RenderLayerScrollableArea;
+
+enum class HasHorizontalOverflow : bool { No, Yes };
+enum class HasVerticalOverflow : bool { No, Yes };
+
+// Used to inform layout of any changes to scrollbars. We capture any state associated
+// with these changes to perform any remaining work after layout has responded since it
+// may need to layout the renderer again.
+class ScrollbarUpdateScope {
+public:
+    enum class ScrollbarChange : uint8_t {
+        AutoHorizontalScrollbarChanged = 1 << 0,
+        AutoVerticalScrollBarChanged = 1 << 1
+    };
+
+    ScrollbarUpdateScope(RenderLayerScrollableArea&, ScrollPosition originalScrollPosition, OptionSet<ScrollbarChange>, HasHorizontalOverflow, HasVerticalOverflow);
+    ~ScrollbarUpdateScope();
+
+    ScrollbarUpdateScope(ScrollbarUpdateScope&&) = default;
+    ScrollbarUpdateScope(const ScrollbarUpdateScope&) = delete;
+    ScrollbarUpdateScope& operator=(const ScrollbarUpdateScope&) = delete;
+
+    const OptionSet<ScrollbarChange>& scrollbarChanges() const { return m_scrollbarChanges; }
+
+private:
+    const CheckedRef<RenderLayerScrollableArea> m_renderLayerScrollableArea;
+    const ScrollPosition m_originalScrollPosition;
+    const OptionSet<ScrollbarChange> m_scrollbarChanges;
+    HasHorizontalOverflow m_hasHorizontalOverflow;
+    HasVerticalOverflow m_hasVerticalOverflow;
+};
+
+}


### PR DESCRIPTION
#### d801bd01eb61cf3c6404099d4ba07a56eb7daf26
<pre>
Move RenderBlock overflow relayout logic out of RenderLayerScrollableArea.
<a href="https://bugs.webkit.org/show_bug.cgi?id=312392">https://bugs.webkit.org/show_bug.cgi?id=312392</a>
<a href="https://rdar.apple.com/problem/174850591">rdar://problem/174850591</a>

Reviewed by Alan Baradlay.

The way that RenderLayerScrollableArea::updateScrollInfoAfterLayout is
roughly organized, for the purposes of this change, is as follows:

1.) A preamble that computes the scroll dimensions and origin based off
the renderer&apos;s overflow rect and some styling information (e.g. writing
mode) along with some other state updates. This will have the side
effect of creating or destroying scrollbars.

2.) If there is a change in whether an automatic scrollbar is gained or
lost then we will rerun layout on the renderer. This is because a change
in the scrollbar may affect the available space for the content which
would result in a different layout.

3.) Some final updating like updating the scrollbar steps and notifying
the scroll anchoring controller.

All of this is currently done towards the end of a renderer&apos;s layout,
via the LayoutScope destructor, but this is a bit misleading since as
part of step two we may layout the renderer and its contents again. From
the perspective of the layout code this is pretty surprising since this
is very far away and hidden from the rest of layout. In this patch we
attempt to reconcile this by trying to move the logic contained within
step two outside of RenderLayerScrollableArea a bit.

This should be just a mechanical change with no changes in functional
behavior since it should be some shuffling of code that runs in the same
order but just via a couple of new mechanisms. Those two new mechanisms
are RelayoutScopeForScrollbarChange and ScrollbarUpdateScope.
The idea is that the former will hold the logic related to layout while
the latter does the work needed for RenderLayerScrollableArea. So, now
what happens is:

1.) Instead of calls to RenderBlock::updateScrollInfoAfterLayout, which
finds its way into the RenderLayerScrollableArea variant, we replace
those with a construction of RelayoutScopeForScrollbarChange.

2.) We will perform the preamble and return a ScrollbarUpdateScope
and will hold onto it in RelayoutScopeForScrollbarChange.

3.) When RelayoutScopeForScrollbarChange is destroyed we will do the work
that was included in step two of the original flow.

4.) When ScrollbarUpdateScope is destroyed it
will run the remaining work that is in step three of the original flow.

There are likely a number of ways we can improve on this but this should
hopefully be a good starting point to build off of.

* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::updateScrollInfoAfterLayout):
1.) This function, including the variants that seem to be mostly
plumbing into this, needs to return an optional to match the various
early returns that could have been hit before. This will serve as the
indicator that we returned early somewhere in this stack so we should
not try to do any of the work that got moved into RelayoutScopeForScrollbarChange.

2.) Move the logic that was in updateScrollbarsAfterLayout into this
function. So now this function should contain all of the previous code
that ran up to the point we started to perform layout on the renderer
again.

* Source/WebCore/rendering/LayoutScope.cpp:
(WebCore::LayoutScope::LayoutScope):
RelayoutScopeForScrollbarChange will need to know if we are already in an
overflow relayout so that we avoid recursion. Previously, this was
tracked via a SetForScope when we entered the RenderLayerScrollableArea
code. Instead when we create a LayoutScope there we will let it know
that we are in overflow relayout, which will pass it into the
RelayoutScopeForScrollbarChange it creates in the destructor.

* Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp: Added.
(WebCore::RelayoutScopeForScrollbarChange::RelayoutScopeForScrollbarChange):
In the constructor we will call updateScrollInfoAfterLayout which will
eventually reach RenderLayerScrollableArea. We hold onto the return
value because we want to make sure that the destructor for
ScrollbarUpdateScope only runs after we run the
code that potentially runs layout on the renderer again to make sure we
keep the same flow.

(WebCore::RelayoutScopeForScrollbarChange::~RelayoutScopeForScrollbarChange):
Contains the logic that was ripped out of RenderLayerScrollableArea
related to performing layout on the renderer. Note that the original
code contained an else layout() when the renderer was not a RenderBlock,
but that seems to have been dead code since we never called
updateScrollInfoAfterLayout on a renderer that was not a RenderBlock.

* Source/WebCore/rendering/RelayoutScopeForScrollbarChange.h: Added.
I deleted the copy constructor and assignment operator since it does not
seem like it would make sense to have copies of this object. That would
be like calling updateScrollInfoAfterLayout multiple times which I think
is a bug so this should hopefully make it harder to do accidentally.

* Source/WebCore/rendering/ScrollbarUpdateScope.cpp: Added.
(WebCore::ScrollbarUpdateScope::ScrollbarUpdateScope):
We create this at the end of RenderLayerScrollableArea::updateScrollInfoAfterLayout
right before we would run the code to layout the renderer again. This is
used mostly to hold onto some state that is needed after the renderer
has gone through layout.

(WebCore::ScrollbarUpdateScope::~ScrollbarUpdateScope):
Should just be the remaining code in updateScrollInfoAfterLayout after we
run layout on the renderer.

* Source/WebCore/rendering/ScrollbarUpdateScope.h: Added.
Same idea with the copy constructor and assignment as RelayoutScopeForScrollbarChange.

Canonical link: <a href="https://commits.webkit.org/311471@main">https://commits.webkit.org/311471@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c636c44f041172afc8067c7f83426d23d50a426

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165904 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/111163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158952 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30553 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121656 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/111163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141061 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102324 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/542c78ac-c3ce-4c20-98fa-24d7301db2f0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21188 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13676 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132643 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/18889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168389 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12548 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129782 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25266 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129890 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35180 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29942 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140683 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87763 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24724 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17487 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29653 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93667 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29175 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29405 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29302 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->